### PR TITLE
fix: correct typos in contrib, controllers, and misc files

### DIFF
--- a/Documentation/Emergency_User_README.txt
+++ b/Documentation/Emergency_User_README.txt
@@ -16,9 +16,9 @@ Emergency Login acl can be assigned to the users in the following screens:-
 2. Administration->ACL->User Membership
 3. Administration->ACL->Advanced->Assign ARO Group
 
-Emergency User should be de-activated initally. Activate the Emergency User only during emergency situations.
+Emergency User should be de-activated initially. Activate the Emergency User only during emergency situations.
 Emergency Login username should start with "breakglass" or "emergency".
 
-When Emergency User is activated, a notication mail is sent to the email-id configured in $GLOBALS['Emergency_Login_email_id']
+When Emergency User is activated, a notification mail is sent to the email-id configured in $GLOBALS['Emergency_Login_email_id']
 
 Emergency Login Activation mail will be sent only if "$GLOBALS['Emergency_Login_email']" and "$GLOBALS['Emergency_Login_email_id']" is configured in globals.php

--- a/Documentation/api/SMART_ON_FHIR.md
+++ b/Documentation/api/SMART_ON_FHIR.md
@@ -889,7 +889,7 @@ curl -X GET 'https://localhost:9300/apis/default/fhir/.well-known/smart-configur
 | `permission-patient`             | Patient-level scopes supported                                                 |
 | `permission-user`                | User-level scopes supported                                                    |
 | `authorize-post` | Pass data via POST directly to authorization endpoint instead of via GET ✨ NEW |
-| `permission-v1`                  | SMART v1 scopes (Backwards compatability) ✨ NEW                                |
+| `permission-v1`                  | SMART v1 scopes (Backwards compatibility) ✨ NEW                                |
 | `permission-v2`                  | SMART v2 scopes (granular permissions) ✨ NEW                                   |
 
 ### Using SMART Configuration

--- a/Documentation/help_files/adminacl_help.php
+++ b/Documentation/help_files/adminacl_help.php
@@ -122,7 +122,7 @@ use OpenEMR\Core\Header;
                             </ul>
                         <li><strong><?php echo xlt('Menus (menus)');?></strong></li>
                             <ul>
-                                <li><?php echo xlt('Modules (modle)');?></li>
+                                <li><?php echo xlt('Modules (module)');?></li>
                             </ul>
                         <li><strong><?php echo xlt('Nation Notes (nationnotes)');?></strong></li>
                             <ul>

--- a/Documentation/help_files/cms_1500_help.php
+++ b/Documentation/help_files/cms_1500_help.php
@@ -66,7 +66,7 @@ require_once("../../interface/globals.php");
 
                 <p><?php echo xlt("The information provided in the New Encounter Form and Fee Sheet in openEMR is used to generate the paper claim as well as electronic claims");?>.</p>
 
-                <p><?php echo xlt("Some global parameters on the setup and printing of the generated claims can be set in Adminstration > Globals > Billing");?>.</p>
+                <p><?php echo xlt("Some global parameters on the setup and printing of the generated claims can be set in Administration > Globals > Billing");?>.</p>
 
                 <p><i class="fa fa-exclamation-triangle oe-text-red" aria-hidden="true"></i> <strong><?php echo xlt("You need administrator privileges to perform the setup"); ?>.</strong></p>
 

--- a/Documentation/help_files/configure_orders_help.php
+++ b/Documentation/help_files/configure_orders_help.php
@@ -411,7 +411,7 @@ require_once("../../interface/globals.php");
 
                     <p><?php echo xlt("Unlike the regular Groups that were created earlier, each Custom Favorite Group has an Identifying Code that has to be unique. As this is our custom group and not a lab recognized panel we will give it our arbitrary unique Identifying Code - CFGWWT001");?>.</p>
 
-                    <p><?php echo xlt("Click Save to create a new line with a Name of Well Womans Tests preceded by a vertical line indicating that it has no descendants or children");?>.
+                    <p><?php echo xlt("Click Save to create a new line with a Name of Well Woman Tests preceded by a vertical line indicating that it has no descendants or children");?>.
                         <button type="button" class="btn btn-secondary btn-sm btn-save oe-no-float" ><?php echo xlt('Save');?></button>
                     </p>
 

--- a/Documentation/help_files/fee_sheet_help.php
+++ b/Documentation/help_files/fee_sheet_help.php
@@ -148,7 +148,7 @@ require_once("../../interface/globals.php");
 
                 <p><?php echo xlt("Another way to select an ICD code to justify the CPT4 code is to click on the label CPT4 at the beginning of the row"); ?>.</p>
 
-                <p><?php echo xlt("It will display the justify display pop-up. It has a search box that wil let you search for a ICD code.  It will also display the 10 most commonly used ICD codes. You can select any or all codes by checking the J (justify) checkbox and pressing update"); ?>.</p>
+                <p><?php echo xlt("It will display the justify display pop-up. It has a search box that will let you search for a ICD code.  It will also display the 10 most commonly used ICD codes. You can select any or all codes by checking the J (justify) checkbox and pressing update"); ?>.</p>
 
                 <p><?php echo xlt("This ICD code can be automatically added to to Problem List by checking the P (Problem) checkbox. This selected item will show up in the Issues section under Medical problems"); ?>.</p>
 
@@ -166,7 +166,7 @@ require_once("../../interface/globals.php");
                 <h4 class="oe-help-heading"><?php echo xlt("Setup the Fee Sheet"); ?><a href="#"><i class="fa fa-arrow-circle-up oe-pull-away oe-help-redirect" aria-hidden="true"></i></a></h4>
                 <p><i class="fa fa-exclamation-triangle oe-text-red" aria-hidden="true"></i> <strong><?php echo xlt("You need administrator privileges to perform the setup"); ?>.</strong></p>
 
-                <p><?php echo xlt("The very first step would be install the ICD codes. Go to Administraion > Other > External Data Loads. Select the Code sets you want to install and click Install"); ?>.</p>
+                <p><?php echo xlt("The very first step would be install the ICD codes. Go to Administration > Other > External Data Loads. Select the Code sets you want to install and click Install"); ?>.</p>
 
                 <p><?php echo xlt("For full billing functionality in the United States CPT/HCPCS codes will then need to be installed"); ?>.</p>
 
@@ -224,7 +224,7 @@ require_once("../../interface/globals.php");
 
                 <p><?php echo xlt("The third column will contain the CPT code"); ?>.</p>
 
-                <p><?php echo xlt("The first two numbers in the first and second colum will be used to determine the sort order of the buttons and the lists that are present in the popup"); ?>.</p>
+                <p><?php echo xlt("The first two numbers in the first and second column will be used to determine the sort order of the buttons and the lists that are present in the popup"); ?>.</p>
 
                 <p><?php echo xlt("Go to Administration > Lists. Select 'Fee Sheet' from the dropdown box"); ?>.</p>
 
@@ -236,13 +236,13 @@ require_once("../../interface/globals.php");
 
                 <p><?php echo xlt("Enter the category data in the appropriate fields and click 'Save'. These will be used to group the ICD codes and will be displayed on the buttons in the 'Select Codes' section"); ?>.</p>
 
-                <p><i class="fa fa-exclamation-circle oe-text-orange" aria-hidden="true"></i> <strong><?php echo xlt("Go to Adminstration > Lists and select 'Code Types' from the dropdown box. Use either ICD 9 or ICD 10, inactivate ICD 9 and select 'No' in the last dropdown box under ICD 10"); ?>.</strong></p>
+                <p><i class="fa fa-exclamation-circle oe-text-orange" aria-hidden="true"></i> <strong><?php echo xlt("Go to Administration > Lists and select 'Code Types' from the dropdown box. Use either ICD 9 or ICD 10, inactivate ICD 9 and select 'No' in the last dropdown box under ICD 10"); ?>.</strong></p>
 
-                <p><?php echo xlt("Go to Adminstration > Codes. Select ICD 10 under Type, enter ICD 10 Code, enter Description, under category select an appropriate category, this ICD 10 code will then appear when the button with that category is clicked"); ?>.</p>
+                <p><?php echo xlt("Go to Administration > Codes. Select ICD 10 under Type, enter ICD 10 Code, enter Description, under category select an appropriate category, this ICD 10 code will then appear when the button with that category is clicked"); ?>.</p>
 
                 <p><?php echo xlt("Click 'Save'"); ?>.</p>
 
-                <p><i class="fa fa-exclamation-circle oe-text-orange" aria-hidden="true"></i> <strong><?php echo xlt("After you have finished entering all the ICD 10 codes go to Adminstration > Lists and select 'Code Types' from the dropdown box. Select 'ICD10 Diagnosis' from the last dropdown box under ICD 10"); ?>.</strong></p>
+                <p><i class="fa fa-exclamation-circle oe-text-orange" aria-hidden="true"></i> <strong><?php echo xlt("After you have finished entering all the ICD 10 codes go to Administration > Lists and select 'Code Types' from the dropdown box. Select 'ICD10 Diagnosis' from the last dropdown box under ICD 10"); ?>.</strong></p>
 
                 <p><?php echo xlt("Click 'Save'. Now you will be able to use the Search feature to search all ICD 10 codes"); ?>.</p>
 

--- a/Documentation/help_files/message_center_help.php
+++ b/Documentation/help_files/message_center_help.php
@@ -355,7 +355,7 @@ require_once("../../interface/globals.php");
 
                 <p><?php echo xlt("A new tab sub menu will be visible at the top of the Message center page"); ?>.</p>
 
-                <p><?php echo xlt("Click on the File menu item on the top left of the Message center page ansd select Setup MedEx"); ?>.</p>
+                <p><?php echo xlt("Click on the File menu item on the top left of the Message center page and select Setup MedEx"); ?>.</p>
 
                 <p><?php echo xlt("It will take you to the MedEx sign-up page"); ?>.</p>
 

--- a/Documentation/help_files/openemr_installation_help.php
+++ b/Documentation/help_files/openemr_installation_help.php
@@ -631,7 +631,7 @@
 
                     <p><i class="fa fa-exclamation-circle oe-text-orange"  aria-hidden="true"></i> <?php echo ("In order to successfully copy these directories and files the 'sites' directory in the initial installation must have the user:group set to that of the webserver"); ?>.</p>
 
-                    <p><strong><?php echo ("PRE INSTALLTION"); ?> :</strong></p>
+                    <p><strong><?php echo ("PRE INSTALLATION"); ?> :</strong></p>
 
                     <p><?php echo ("To initiate the multisite process you need to install a single site or 'default' site"); ?>.</p>
 
@@ -647,7 +647,7 @@
 
                     <p><code>sudo chown -R www-data:www-data sites</code></p>
 
-                    <p><strong><?php echo ("INSTALLTION"); ?> :</strong></p>
+                    <p><strong><?php echo ("INSTALLATION"); ?> :</strong></p>
 
                     <p><?php echo ("If you are accessing the OpenEMR application from the computer/server  that it has been installed in type <code>http://localhost/openemr/admin.php</code> in the address bar of a browser. NOTE: This assumes that the OpenEMR files are in a directory called 'openemr', if not change the name to reflect the OpenEMR root directory. If you are accessing it from another computer substitute the localhost name with the IP address or domain name of the OpenEMR installation ");?>.</p>
 
@@ -716,7 +716,7 @@
 
                     <p><?php echo ("The setup script will automatically generate a code block"); ?>.</p>
 
-                    <p><?php echo ("It needs to be cut and pasted into the Apache configuration file for the webserver being used if you did not do it during the intial 'defalt' site installation"); ?>.</p>
+                    <p><?php echo ("It needs to be cut and pasted into the Apache configuration file for the webserver being used if you did not do it during the initial 'default' site installation"); ?>.</p>
 
                     <p><?php echo ("Click on 'Proceed to Select a Theme' to go to 'Step 7 Select a Theme' page"); ?>.</p>
 

--- a/Documentation/help_files/openemr_multisite_admin_help.php
+++ b/Documentation/help_files/openemr_multisite_admin_help.php
@@ -38,7 +38,7 @@
             </div>
             <div class="row">
                 <div class="col-sm-12">
-                    <p><?php echo ("This is the central location to manage multisite intallations");?>.</p>
+                    <p><?php echo ("This is the central location to manage multisite installations");?>.</p>
 
                     <p><?php echo ("It serves three functions");?>:</p>
                         <ul>

--- a/contrib/util/backup_oemr.sh
+++ b/contrib/util/backup_oemr.sh
@@ -12,7 +12,7 @@ tempdir='/var/tmp/isos/'
 installdir='/var/www/openemr'
 newerthan='2005-01-01'
 #newerthan is a workaround for when your media gets full,
-#re-edit this file and change the date to the last succesfull cd copy
+#re-edit this file and change the date to the last successful cd copy
 
 # a name for the file that is unique of that day
 file=$(date +%F)

--- a/contrib/util/billing/load_fee_schedule.php
+++ b/contrib/util/billing/load_fee_schedule.php
@@ -31,7 +31,7 @@ require_once __DIR__ . "/../../../interface/globals.php";
 
 use League\Csv\Reader;
 
-// setup a csv file with a header consiting of type, code and modifier
+// setup a csv file with a header consisting of type, code and modifier
 // at the specified location
 $filename = DIRECTORY_SEPARATOR . $argv[2];
 $filepath = $GLOBALS['temporary_files_dir'];

--- a/contrib/util/deidentification/deidentification.php
+++ b/contrib/util/deidentification/deidentification.php
@@ -38,7 +38,7 @@
 //Instructions:  Change these 4 values.  The run as a normal php script
 //Remember - there is no turning back
 
-//To run script, comment out the return line, fill out the databae credentials, and run.  Uncomment out the return statement when complete.
+//To run script, comment out the return line, fill out the database credentials, and run.  Uncomment out the return statement when complete.
 return 0;
 $host = 'localhost';
 $user = 'root';
@@ -261,7 +261,7 @@ function deIdInsuranceDataTable($con, $pid): void
 }
 
 
-//This function replaces the facility name with unqiue names so users can
+//This function replaces the facility name with unique names so users can
 //see how different facilities have their data and permissions abstracted depending on
 //which facility the user has access too.
 function deIdFacilityTable($con): void
@@ -341,7 +341,7 @@ function deIdUsersTable($con): void
         //$string = '';
     }
 
-    echo "successfuly altered user table \n ";
+    echo "successfully altered user table \n ";
 }
 
 //Clears most forms.  User must verify that this function handles all text fields that might hold personal identifying information
@@ -360,7 +360,7 @@ function deIdForms($con): void
     removeColumn($con, "onotes", "body", "Internal Office notes posted here");
     removeColumn($con, "pnotes", "body", "DATETIME (FROMUSER to USER) Note about Patient posted here");
 
-    echo "successfuly altered user forms table \n ";
+    echo "successfully altered user forms table \n ";
 }
 
 // truncates log tables to remove all hidden information

--- a/contrib/util/undelete_from_log/README.TXT
+++ b/contrib/util/undelete_from_log/README.TXT
@@ -3,7 +3,7 @@
 
 This procedure will restore all records deleted on a given date/time) that are in the log table
 
-First, you must look into the admin/logs screen and determine the date that the delete occured on.
+First, you must look into the admin/logs screen and determine the date that the delete occurred on.
 
 Adjust the time accordingly
 

--- a/contrib/util/undelete_from_log/convert_logcomments.pl
+++ b/contrib/util/undelete_from_log/convert_logcomments.pl
@@ -15,7 +15,7 @@
 #
 #
 
-# Converts openemr log ouput containing deleted records and
+# Converts openemr log output containing deleted records and
 # produces the necessary "insert into <table> values ... on duplicate key
 # update... "
 
@@ -32,7 +32,7 @@
 # Use like this:
 # This procedure will restore all records deleted on a given date/time) that are in the log table
 #
-# First, you must look into the admin/logs screen and determine the date that the delete occured on.
+# First, you must look into the admin/logs screen and determine the date that the delete occurred on.
 #
 # Adjust the time accordingly
 #

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -699,7 +699,7 @@ class C_Document extends Controller
                 header("Content-Length: " . strlen($filetext));
                 echo $filetext;
             }
-            exit;//exits only if file download from CouchDB is successfull.
+            exit; // exits only if file download from CouchDB is successful.
         }
         if ($couch_docid && $couch_revid) {
             //special case when retrieving a document from couchdb that has been converted to a jpg and not directly referenced in openemr documents table

--- a/controllers/C_InsuranceNumbers.class.php
+++ b/controllers/C_InsuranceNumbers.class.php
@@ -121,10 +121,10 @@ class C_InsuranceNumbers extends Controller
         parent::populate_object($this->insurance_numbers[0]);
 
         $this->insurance_numbers[0]->persist();
-        //insurance numbers need to be repopulated so that insurance_company_name recieves a value
+        //insurance numbers need to be repopulated so that insurance_company_name receives a value
         $this->insurance_numbers[0]->populate();
 
-        //echo "action processeed";
+        //echo "action processed";
         $_POST['process'] = "";
 
         if (!is_numeric($_POST['id'])) {//Z&H

--- a/controllers/C_Pharmacy.class.php
+++ b/controllers/C_Pharmacy.class.php
@@ -72,7 +72,7 @@ class C_Pharmacy extends Controller
         //print_r($this->pharmacies[0]);
         //echo $this->pharmacies[0]->toString(true);
         $this->pharmacies[0]->persist();
-        //echo "action processeed";
+        //echo "action processed";
         $_POST['process'] = "";
         header('Location:' . $GLOBALS['webroot'] . "/controller.php?" . "practice_settings&pharmacy&action=list");//Z&H
     }

--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -227,7 +227,7 @@ class C_Prescription extends Controller
             $this->assign("INTERACTION", $interaction);
         }
 
-        // flag to indicate the CAMOS form is regsitered and active
+        // flag to indicate the CAMOS form is registered and active
         $this->assign("CAMOS_FORM", isRegistered("CAMOS"));
 
         $vars = $this->getTemplateVars();
@@ -459,7 +459,7 @@ class C_Prescription extends Controller
     // now the doctors write those in on printed prescriptions and only when
     // necessary.  If you need to change this back, then please make it a
     // configurable option.  Faxed prescriptions were not changed.  -- Rod
-    // Now it is configureable. Change value in
+    // Now it is configurable. Change value in
     //     Administration->Globals->Rx
         if ($GLOBALS['rx_enable_DEA']) {
             if ($this->is_faxing || $GLOBALS['rx_show_DEA']) {

--- a/controllers/C_X12Partner.class.php
+++ b/controllers/C_X12Partner.class.php
@@ -80,10 +80,10 @@ class C_X12Partner extends Controller
         }
 
         $this->x12_partners[0]->persist();
-        //insurance numbers need to be repopulated so that insurance_company_name recieves a value
+        //insurance numbers need to be repopulated so that insurance_company_name receives a value
         $this->x12_partners[0]->populate();
 
-        //echo "action processeed";
+        //echo "action processed";
         $_POST['process'] = "";
         $this->_state = false;
         header('Location:' . $GLOBALS['webroot'] . "/controller.php?" . "practice_settings&x12_partner&action=list");//Z&H

--- a/custom/readme_rx_printtofax.txt
+++ b/custom/readme_rx_printtofax.txt
@@ -8,7 +8,7 @@ Changes:
 provider signature and other information that would normally be handled by hand.  The inherent in-security of this
 feature must be explained and managed at the clinic location and at the clinic's risk.
 
-* The follow text is printed on all print-to-faxes as addes security
+* The follow text is printed on all print-to-faxes as added security
 	"Please do not accept this prescription unless it was received via facsimile."
 
 Manual steps:

--- a/docker/library/couchdb-config-ssl-cert-keys/local.ini
+++ b/docker/library/couchdb-config-ssl-cert-keys/local.ini
@@ -79,7 +79,7 @@ cacert_file = /etc/ssl/ca.pem
 ;tls_versions = [tlsv1, 'tlsv1.1', 'tlsv1.2']
 
 ; To enable Virtual Hosts in CouchDB, add a vhost = path directive. All requests to
-; the Virual Host will be redirected to the path. In the example below all requests
+; the Virtual Host will be redirected to the path. In the example below all requests
 ; to http://example.com/ are redirected to /database.
 ; If you run CouchDB on a specific port, include the port number in the vhost:
 ; example.com:5984 = /database


### PR DESCRIPTION
## Summary
- Fix spelling errors in contrib utilities, controller classes, documentation help files, and docker config
- 21 files with typo corrections (excluding language_translations per codespell config)

**This is PR 2 of 11 PRs** to fix ~460 files with typos across the codebase.

All PRs in this series:
1. #10333 - Core files, CCR templates, SQL (merged)
2. #10336 - Contrib, controllers, misc files (this PR)
3. #10337 - Sites, templates
4. #10338 - FHIR
5. #10339 - Library
6. #10340 - Portal
7. #10341 - Interface, modules
8. #10342 - Interface misc
9. #10343 - Src misc
10. #10344 - (closed)
11. #10345 - Misc remaining files

Part of #7939

## Test plan
- [ ] Verify contrib utilities still function
- [ ] Verify documentation help files display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>