### PR TITLE
fix: correct typos in FHIR resources and services

### DIFF
--- a/src/FHIR/R4/FHIRDomainResource/FHIRActivityDefinition.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRActivityDefinition.php
@@ -207,7 +207,7 @@ class FHIRActivityDefinition extends FHIRDomainResource implements \JsonSerializ
     public $topic = [];
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public $author = [];
@@ -840,7 +840,7 @@ class FHIRActivityDefinition extends FHIRDomainResource implements \JsonSerializ
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public function getAuthor()
@@ -849,7 +849,7 @@ class FHIRActivityDefinition extends FHIRDomainResource implements \JsonSerializ
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail $author
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRAppointment.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRAppointment.php
@@ -83,7 +83,7 @@ class FHIRAppointment extends FHIRDomainResource implements \JsonSerializable
     public $status = null;
 
     /**
-     * The coded reason for the appointment being cancelled. This is often used in reporting/billing/futher processing to determine if further actions are required, or specific fees apply.
+     * The coded reason for the appointment being cancelled. This is often used in reporting/billing/further processing to determine if further actions are required, or specific fees apply.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
      */
     public $cancelationReason = null;
@@ -250,7 +250,7 @@ The duration (usually in minutes) could also be provided to indicate the length 
     }
 
     /**
-     * The coded reason for the appointment being cancelled. This is often used in reporting/billing/futher processing to determine if further actions are required, or specific fees apply.
+     * The coded reason for the appointment being cancelled. This is often used in reporting/billing/further processing to determine if further actions are required, or specific fees apply.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
      */
     public function getCancelationReason()
@@ -259,7 +259,7 @@ The duration (usually in minutes) could also be provided to indicate the length 
     }
 
     /**
-     * The coded reason for the appointment being cancelled. This is often used in reporting/billing/futher processing to determine if further actions are required, or specific fees apply.
+     * The coded reason for the appointment being cancelled. This is often used in reporting/billing/further processing to determine if further actions are required, or specific fees apply.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept $cancelationReason
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRContract.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRContract.php
@@ -237,7 +237,7 @@ class FHIRContract extends FHIRDomainResource implements \JsonSerializable
     public $supportingInfo = [];
 
     /**
-     * Links to Provenance records for past versions of this Contract definition, derivative, or instance, which identify key state transitions or updates that are likely to be relevant to a user looking at the current version of the Contract.  The Provence.entity indicates the target that was changed in the update. http://build.fhir.org/provenance-definitions.html#Provenance.entity.
+     * Links to Provenance records for past versions of this Contract definition, derivative, or instance, which identify key state transitions or updates that are likely to be relevant to a user looking at the current version of the Contract.  The Provenance.entity indicates the target that was changed in the update. http://build.fhir.org/provenance-definitions.html#Provenance.entity.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRReference[]
      */
     public $relevantHistory = [];
@@ -838,7 +838,7 @@ class FHIRContract extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * Links to Provenance records for past versions of this Contract definition, derivative, or instance, which identify key state transitions or updates that are likely to be relevant to a user looking at the current version of the Contract.  The Provence.entity indicates the target that was changed in the update. http://build.fhir.org/provenance-definitions.html#Provenance.entity.
+     * Links to Provenance records for past versions of this Contract definition, derivative, or instance, which identify key state transitions or updates that are likely to be relevant to a user looking at the current version of the Contract.  The Provenance.entity indicates the target that was changed in the update. http://build.fhir.org/provenance-definitions.html#Provenance.entity.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRReference[]
      */
     public function getRelevantHistory()
@@ -847,7 +847,7 @@ class FHIRContract extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * Links to Provenance records for past versions of this Contract definition, derivative, or instance, which identify key state transitions or updates that are likely to be relevant to a user looking at the current version of the Contract.  The Provence.entity indicates the target that was changed in the update. http://build.fhir.org/provenance-definitions.html#Provenance.entity.
+     * Links to Provenance records for past versions of this Contract definition, derivative, or instance, which identify key state transitions or updates that are likely to be relevant to a user looking at the current version of the Contract.  The Provenance.entity indicates the target that was changed in the update. http://build.fhir.org/provenance-definitions.html#Provenance.entity.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRReference $relevantHistory
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRDeviceRequest.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRDeviceRequest.php
@@ -210,7 +210,7 @@ class FHIRDeviceRequest extends FHIRDomainResource implements \JsonSerializable
     public $insurance = [];
 
     /**
-     * Additional clinical information about the patient that may influence the request fulfilment.  For example, this may include where on the subject's body the device will be used (i.e. the target site).
+     * Additional clinical information about the patient that may influence the request fulfillment.  For example, this may include where on the subject's body the device will be used (i.e. the target site).
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRReference[]
      */
     public $supportingInfo = [];
@@ -703,7 +703,7 @@ class FHIRDeviceRequest extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * Additional clinical information about the patient that may influence the request fulfilment.  For example, this may include where on the subject's body the device will be used (i.e. the target site).
+     * Additional clinical information about the patient that may influence the request fulfillment.  For example, this may include where on the subject's body the device will be used (i.e. the target site).
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRReference[]
      */
     public function getSupportingInfo()
@@ -712,7 +712,7 @@ class FHIRDeviceRequest extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * Additional clinical information about the patient that may influence the request fulfilment.  For example, this may include where on the subject's body the device will be used (i.e. the target site).
+     * Additional clinical information about the patient that may influence the request fulfillment.  For example, this may include where on the subject's body the device will be used (i.e. the target site).
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRReference $supportingInfo
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRDocumentManifest.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRDocumentManifest.php
@@ -107,7 +107,7 @@ class FHIRDocumentManifest extends FHIRDomainResource implements \JsonSerializab
     public $created = null;
 
     /**
-     * Identifies who is the author of the manifest. Manifest author is not necessarly the author of the references included.
+     * Identifies who is the author of the manifest. Manifest author is not necessarily the author of the references included.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRReference[]
      */
     public $author = [];
@@ -268,7 +268,7 @@ class FHIRDocumentManifest extends FHIRDomainResource implements \JsonSerializab
     }
 
     /**
-     * Identifies who is the author of the manifest. Manifest author is not necessarly the author of the references included.
+     * Identifies who is the author of the manifest. Manifest author is not necessarily the author of the references included.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRReference[]
      */
     public function getAuthor()
@@ -277,7 +277,7 @@ class FHIRDocumentManifest extends FHIRDomainResource implements \JsonSerializab
     }
 
     /**
-     * Identifies who is the author of the manifest. Manifest author is not necessarly the author of the references included.
+     * Identifies who is the author of the manifest. Manifest author is not necessarily the author of the references included.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRReference $author
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRDocumentReference.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRDocumentReference.php
@@ -65,7 +65,7 @@ namespace OpenEMR\FHIR\R4\FHIRDomainResource;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRDomainResource;
 
 /**
- * A reference to a document of any kind for any purpose. Provides metadata about the document so that the document can be discovered and managed. The scope of a document is any seralized object with a mime-type, so includes formal patient centric documents (CDA), cliical notes, scanned paper, and non-patient specific documents like policy text.
+ * A reference to a document of any kind for any purpose. Provides metadata about the document so that the document can be discovered and managed. The scope of a document is any serialized object with a mime-type, so includes formal patient centric documents (CDA), clinical notes, scanned paper, and non-patient specific documents like policy text.
  * If the element is present, it must have either a @value, an @id, or extensions
  */
 class FHIRDocumentReference extends FHIRDomainResource implements \JsonSerializable

--- a/src/FHIR/R4/FHIRDomainResource/FHIREffectEvidenceSynthesis.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIREffectEvidenceSynthesis.php
@@ -179,7 +179,7 @@ class FHIREffectEvidenceSynthesis extends FHIRDomainResource implements \JsonSer
     public $topic = [];
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public $author = [];
@@ -634,7 +634,7 @@ class FHIREffectEvidenceSynthesis extends FHIRDomainResource implements \JsonSer
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public function getAuthor()
@@ -643,7 +643,7 @@ class FHIREffectEvidenceSynthesis extends FHIRDomainResource implements \JsonSer
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail $author
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIREncounter.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIREncounter.php
@@ -197,7 +197,7 @@ class FHIREncounter extends FHIRDomainResource implements \JsonSerializable
     public $location = [];
 
     /**
-     * The organization that is primarily responsible for this Encounter's services. This MAY be the same as the organization on the Patient record, however it could be different, such as if the actor performing the services was from an external organization (which may be billed seperately) for an external consultation.  Refer to the example bundle showing an abbreviated set of Encounters for a colonoscopy.
+     * The organization that is primarily responsible for this Encounter's services. This MAY be the same as the organization on the Patient record, however it could be different, such as if the actor performing the services was from an external organization (which may be billed separately) for an external consultation.  Refer to the example bundle showing an abbreviated set of Encounters for a colonoscopy.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRReference
      */
     public $serviceProvider = null;
@@ -634,7 +634,7 @@ class FHIREncounter extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * The organization that is primarily responsible for this Encounter's services. This MAY be the same as the organization on the Patient record, however it could be different, such as if the actor performing the services was from an external organization (which may be billed seperately) for an external consultation.  Refer to the example bundle showing an abbreviated set of Encounters for a colonoscopy.
+     * The organization that is primarily responsible for this Encounter's services. This MAY be the same as the organization on the Patient record, however it could be different, such as if the actor performing the services was from an external organization (which may be billed separately) for an external consultation.  Refer to the example bundle showing an abbreviated set of Encounters for a colonoscopy.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRReference
      */
     public function getServiceProvider()
@@ -643,7 +643,7 @@ class FHIREncounter extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * The organization that is primarily responsible for this Encounter's services. This MAY be the same as the organization on the Patient record, however it could be different, such as if the actor performing the services was from an external organization (which may be billed seperately) for an external consultation.  Refer to the example bundle showing an abbreviated set of Encounters for a colonoscopy.
+     * The organization that is primarily responsible for this Encounter's services. This MAY be the same as the organization on the Patient record, however it could be different, such as if the actor performing the services was from an external organization (which may be billed separately) for an external consultation.  Refer to the example bundle showing an abbreviated set of Encounters for a colonoscopy.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRReference $serviceProvider
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIREventDefinition.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIREventDefinition.php
@@ -207,7 +207,7 @@ class FHIREventDefinition extends FHIRDomainResource implements \JsonSerializabl
     public $topic = [];
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public $author = [];
@@ -704,7 +704,7 @@ class FHIREventDefinition extends FHIRDomainResource implements \JsonSerializabl
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public function getAuthor()
@@ -713,7 +713,7 @@ class FHIREventDefinition extends FHIRDomainResource implements \JsonSerializabl
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail $author
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIREvidence.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIREvidence.php
@@ -191,7 +191,7 @@ class FHIREvidence extends FHIRDomainResource implements \JsonSerializable
     public $topic = [];
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public $author = [];
@@ -644,7 +644,7 @@ class FHIREvidence extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public function getAuthor()
@@ -653,7 +653,7 @@ class FHIREvidence extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail $author
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIREvidenceVariable.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIREvidenceVariable.php
@@ -191,7 +191,7 @@ class FHIREvidenceVariable extends FHIRDomainResource implements \JsonSerializab
     public $topic = [];
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public $author = [];
@@ -638,7 +638,7 @@ class FHIREvidenceVariable extends FHIRDomainResource implements \JsonSerializab
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public function getAuthor()
@@ -647,7 +647,7 @@ class FHIREvidenceVariable extends FHIRDomainResource implements \JsonSerializab
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail $author
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRImmunization.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRImmunization.php
@@ -225,7 +225,7 @@ class FHIRImmunization extends FHIRDomainResource implements \JsonSerializable
     public $programEligibility = [];
 
     /**
-     * Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publically purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).
+     * Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publicly purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
      */
     public $fundingSource = null;
@@ -764,7 +764,7 @@ class FHIRImmunization extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publically purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).
+     * Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publicly purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
      */
     public function getFundingSource()
@@ -773,7 +773,7 @@ class FHIRImmunization extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publically purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).
+     * Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publicly purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept $fundingSource
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRInsurancePlan.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRInsurancePlan.php
@@ -107,7 +107,7 @@ class FHIRInsurancePlan extends FHIRDomainResource implements \JsonSerializable
     public $period = null;
 
     /**
-     * The entity that is providing  the health insurance product and underwriting the risk.  This is typically an insurance carriers, other third-party payers, or health plan sponsors comonly referred to as 'payers'.
+     * The entity that is providing  the health insurance product and underwriting the risk.  This is typically an insurance carriers, other third-party payers, or health plan sponsors commonly referred to as 'payers'.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRReference
      */
     public $ownedBy = null;
@@ -280,7 +280,7 @@ class FHIRInsurancePlan extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * The entity that is providing  the health insurance product and underwriting the risk.  This is typically an insurance carriers, other third-party payers, or health plan sponsors comonly referred to as 'payers'.
+     * The entity that is providing  the health insurance product and underwriting the risk.  This is typically an insurance carriers, other third-party payers, or health plan sponsors commonly referred to as 'payers'.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRReference
      */
     public function getOwnedBy()
@@ -289,7 +289,7 @@ class FHIRInsurancePlan extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * The entity that is providing  the health insurance product and underwriting the risk.  This is typically an insurance carriers, other third-party payers, or health plan sponsors comonly referred to as 'payers'.
+     * The entity that is providing  the health insurance product and underwriting the risk.  This is typically an insurance carriers, other third-party payers, or health plan sponsors commonly referred to as 'payers'.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRReference $ownedBy
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRLibrary.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRLibrary.php
@@ -213,7 +213,7 @@ class FHIRLibrary extends FHIRDomainResource implements \JsonSerializable
     public $topic = [];
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public $author = [];
@@ -742,7 +742,7 @@ class FHIRLibrary extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public function getAuthor()
@@ -751,7 +751,7 @@ class FHIRLibrary extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail $author
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRLocation.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRLocation.php
@@ -137,7 +137,7 @@ class FHIRLocation extends FHIRDomainResource implements \JsonSerializable
     public $physicalType = null;
 
     /**
-     * The absolute geographic location of the Location, expressed using the WGS84 datum (This is the same co-ordinate system used in KML).
+     * The absolute geographic location of the Location, expressed using the WGS84 datum (This is the same coordinate system used in KML).
      * @var \OpenEMR\FHIR\R4\FHIRResource\FHIRLocation\FHIRLocationPosition
      */
     public $position = null;
@@ -398,7 +398,7 @@ class FHIRLocation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * The absolute geographic location of the Location, expressed using the WGS84 datum (This is the same co-ordinate system used in KML).
+     * The absolute geographic location of the Location, expressed using the WGS84 datum (This is the same coordinate system used in KML).
      * @return \OpenEMR\FHIR\R4\FHIRResource\FHIRLocation\FHIRLocationPosition
      */
     public function getPosition()
@@ -407,7 +407,7 @@ class FHIRLocation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * The absolute geographic location of the Location, expressed using the WGS84 datum (This is the same co-ordinate system used in KML).
+     * The absolute geographic location of the Location, expressed using the WGS84 datum (This is the same coordinate system used in KML).
      * @param \OpenEMR\FHIR\R4\FHIRResource\FHIRLocation\FHIRLocationPosition $position
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRMeasure.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRMeasure.php
@@ -207,7 +207,7 @@ class FHIRMeasure extends FHIRDomainResource implements \JsonSerializable
     public $topic = [];
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public $author = [];
@@ -782,7 +782,7 @@ class FHIRMeasure extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public function getAuthor()
@@ -791,7 +791,7 @@ class FHIRMeasure extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail $author
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRMedicinalProduct.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRMedicinalProduct.php
@@ -179,7 +179,7 @@ class FHIRMedicinalProduct extends FHIRDomainResource implements \JsonSerializab
     public $crossReference = [];
 
     /**
-     * An operation applied to the product, for manufacturing or adminsitrative purpose.
+     * An operation applied to the product, for manufacturing or administrative purpose.
      * @var \OpenEMR\FHIR\R4\FHIRResource\FHIRMedicinalProduct\FHIRMedicinalProductManufacturingBusinessOperation[]
      */
     public $manufacturingBusinessOperation = [];
@@ -556,7 +556,7 @@ class FHIRMedicinalProduct extends FHIRDomainResource implements \JsonSerializab
     }
 
     /**
-     * An operation applied to the product, for manufacturing or adminsitrative purpose.
+     * An operation applied to the product, for manufacturing or administrative purpose.
      * @return \OpenEMR\FHIR\R4\FHIRResource\FHIRMedicinalProduct\FHIRMedicinalProductManufacturingBusinessOperation[]
      */
     public function getManufacturingBusinessOperation()
@@ -565,7 +565,7 @@ class FHIRMedicinalProduct extends FHIRDomainResource implements \JsonSerializab
     }
 
     /**
-     * An operation applied to the product, for manufacturing or adminsitrative purpose.
+     * An operation applied to the product, for manufacturing or administrative purpose.
      * @param \OpenEMR\FHIR\R4\FHIRResource\FHIRMedicinalProduct\FHIRMedicinalProductManufacturingBusinessOperation $manufacturingBusinessOperation
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRMedicinalProductAuthorization.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRMedicinalProductAuthorization.php
@@ -119,7 +119,7 @@ class FHIRMedicinalProductAuthorization extends FHIRDomainResource implements \J
     public $validityPeriod = null;
 
     /**
-     * A period of time after authorization before generic product applicatiosn can be submitted.
+     * A period of time after authorization before generic product applications can be submitted.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod
      */
     public $dataExclusivityPeriod = null;
@@ -332,7 +332,7 @@ class FHIRMedicinalProductAuthorization extends FHIRDomainResource implements \J
     }
 
     /**
-     * A period of time after authorization before generic product applicatiosn can be submitted.
+     * A period of time after authorization before generic product applications can be submitted.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod
      */
     public function getDataExclusivityPeriod()
@@ -341,7 +341,7 @@ class FHIRMedicinalProductAuthorization extends FHIRDomainResource implements \J
     }
 
     /**
-     * A period of time after authorization before generic product applicatiosn can be submitted.
+     * A period of time after authorization before generic product applications can be submitted.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod $dataExclusivityPeriod
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIROrganizationAffiliation.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIROrganizationAffiliation.php
@@ -65,7 +65,7 @@ namespace OpenEMR\FHIR\R4\FHIRDomainResource;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRDomainResource;
 
 /**
- * Defines an affiliation/assotiation/relationship between 2 distinct oganizations, that is not a part-of relationship/sub-division relationship.
+ * Defines an affiliation/association/relationship between 2 distinct organizations, that is not a part-of relationship/sub-division relationship.
  * If the element is present, it must have either a @value, an @id, or extensions
  */
 class FHIROrganizationAffiliation extends FHIRDomainResource implements \JsonSerializable

--- a/src/FHIR/R4/FHIRDomainResource/FHIRPlanDefinition.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRPlanDefinition.php
@@ -213,7 +213,7 @@ class FHIRPlanDefinition extends FHIRDomainResource implements \JsonSerializable
     public $topic = [];
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public $author = [];
@@ -742,7 +742,7 @@ class FHIRPlanDefinition extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public function getAuthor()
@@ -751,7 +751,7 @@ class FHIRPlanDefinition extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail $author
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRPractitioner.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRPractitioner.php
@@ -120,7 +120,7 @@ Work addresses are not typically entered in this property as they are usually ro
     public $photo = [];
 
     /**
-     * The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice medicine within a certian locality.
+     * The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice medicine within a certain locality.
      * @var \OpenEMR\FHIR\R4\FHIRResource\FHIRPractitioner\FHIRPractitionerQualification[]
      */
     public $qualification = [];
@@ -299,7 +299,7 @@ Work addresses are not typically entered in this property as they are usually ro
     }
 
     /**
-     * The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice medicine within a certian locality.
+     * The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice medicine within a certain locality.
      * @return \OpenEMR\FHIR\R4\FHIRResource\FHIRPractitioner\FHIRPractitionerQualification[]
      */
     public function getQualification()
@@ -308,7 +308,7 @@ Work addresses are not typically entered in this property as they are usually ro
     }
 
     /**
-     * The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice medicine within a certian locality.
+     * The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice medicine within a certain locality.
      * @param \OpenEMR\FHIR\R4\FHIRResource\FHIRPractitioner\FHIRPractitionerQualification $qualification
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRResearchDefinition.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRResearchDefinition.php
@@ -219,7 +219,7 @@ class FHIRResearchDefinition extends FHIRDomainResource implements \JsonSerializ
     public $topic = [];
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public $author = [];
@@ -780,7 +780,7 @@ class FHIRResearchDefinition extends FHIRDomainResource implements \JsonSerializ
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public function getAuthor()
@@ -789,7 +789,7 @@ class FHIRResearchDefinition extends FHIRDomainResource implements \JsonSerializ
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail $author
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRResearchElementDefinition.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRResearchElementDefinition.php
@@ -219,7 +219,7 @@ class FHIRResearchElementDefinition extends FHIRDomainResource implements \JsonS
     public $topic = [];
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public $author = [];
@@ -774,7 +774,7 @@ class FHIRResearchElementDefinition extends FHIRDomainResource implements \JsonS
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public function getAuthor()
@@ -783,7 +783,7 @@ class FHIRResearchElementDefinition extends FHIRDomainResource implements \JsonS
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail $author
      * @return $this
      */

--- a/src/FHIR/R4/FHIRDomainResource/FHIRRiskEvidenceSynthesis.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRRiskEvidenceSynthesis.php
@@ -179,7 +179,7 @@ class FHIRRiskEvidenceSynthesis extends FHIRDomainResource implements \JsonSeria
     public $topic = [];
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public $author = [];
@@ -622,7 +622,7 @@ class FHIRRiskEvidenceSynthesis extends FHIRDomainResource implements \JsonSeria
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail[]
      */
     public function getAuthor()
@@ -631,7 +631,7 @@ class FHIRRiskEvidenceSynthesis extends FHIRDomainResource implements \JsonSeria
     }
 
     /**
-     * An individiual or organization primarily involved in the creation and maintenance of the content.
+     * An individual or organization primarily involved in the creation and maintenance of the content.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRContactDetail $author
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRBiologicallyDerivedProduct/FHIRBiologicallyDerivedProductProcessing.php
+++ b/src/FHIR/R4/FHIRResource/FHIRBiologicallyDerivedProduct/FHIRBiologicallyDerivedProductProcessing.php
@@ -77,7 +77,7 @@ class FHIRBiologicallyDerivedProductProcessing extends FHIRBackboneElement imple
     public $description = null;
 
     /**
-     * Procesing code.
+     * Processing code.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
      */
     public $procedure = null;
@@ -124,7 +124,7 @@ class FHIRBiologicallyDerivedProductProcessing extends FHIRBackboneElement imple
     }
 
     /**
-     * Procesing code.
+     * Processing code.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
      */
     public function getProcedure()
@@ -133,7 +133,7 @@ class FHIRBiologicallyDerivedProductProcessing extends FHIRBackboneElement imple
     }
 
     /**
-     * Procesing code.
+     * Processing code.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept $procedure
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRContract/FHIRContractTerm.php
+++ b/src/FHIR/R4/FHIRResource/FHIRContract/FHIRContractTerm.php
@@ -122,7 +122,7 @@ class FHIRContractTerm extends FHIRBackboneElement implements \JsonSerializable
     public $securityLabel = [];
 
     /**
-     * The matter of concern in the context of this provision of the agrement.
+     * The matter of concern in the context of this provision of the agreement.
      * @var \OpenEMR\FHIR\R4\FHIRResource\FHIRContract\FHIRContractOffer
      */
     public $offer = null;
@@ -327,7 +327,7 @@ class FHIRContractTerm extends FHIRBackboneElement implements \JsonSerializable
     }
 
     /**
-     * The matter of concern in the context of this provision of the agrement.
+     * The matter of concern in the context of this provision of the agreement.
      * @return \OpenEMR\FHIR\R4\FHIRResource\FHIRContract\FHIRContractOffer
      */
     public function getOffer()
@@ -336,7 +336,7 @@ class FHIRContractTerm extends FHIRBackboneElement implements \JsonSerializable
     }
 
     /**
-     * The matter of concern in the context of this provision of the agrement.
+     * The matter of concern in the context of this provision of the agreement.
      * @param \OpenEMR\FHIR\R4\FHIRResource\FHIRContract\FHIRContractOffer $offer
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRCoverageEligibilityRequest/FHIRCoverageEligibilityRequestSupportingInfo.php
+++ b/src/FHIR/R4/FHIRResource/FHIRCoverageEligibilityRequest/FHIRCoverageEligibilityRequestSupportingInfo.php
@@ -82,7 +82,7 @@ class FHIRCoverageEligibilityRequestSupportingInfo extends FHIRBackboneElement i
     public $information = null;
 
     /**
-     * The supporting materials are applicable for all detail items, product/servce categories and specific billing codes.
+     * The supporting materials are applicable for all detail items, product/service categories and specific billing codes.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean
      */
     public $appliesToAll = null;
@@ -133,7 +133,7 @@ class FHIRCoverageEligibilityRequestSupportingInfo extends FHIRBackboneElement i
     }
 
     /**
-     * The supporting materials are applicable for all detail items, product/servce categories and specific billing codes.
+     * The supporting materials are applicable for all detail items, product/service categories and specific billing codes.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean
      */
     public function getAppliesToAll()
@@ -142,7 +142,7 @@ class FHIRCoverageEligibilityRequestSupportingInfo extends FHIRBackboneElement i
     }
 
     /**
-     * The supporting materials are applicable for all detail items, product/servce categories and specific billing codes.
+     * The supporting materials are applicable for all detail items, product/service categories and specific billing codes.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean $appliesToAll
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRDeviceDefinition/FHIRDeviceDefinitionUdiDeviceIdentifier.php
+++ b/src/FHIR/R4/FHIRResource/FHIRDeviceDefinition/FHIRDeviceDefinitionUdiDeviceIdentifier.php
@@ -70,7 +70,7 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRBackboneElement;
 class FHIRDeviceDefinitionUdiDeviceIdentifier extends FHIRBackboneElement implements \JsonSerializable
 {
     /**
-     * The identifier that is to be associated with every Device that references this DeviceDefintiion for the issuer and jurisdication porvided in the DeviceDefinition.udiDeviceIdentifier.
+     * The identifier that is to be associated with every Device that references this DeviceDefinition for the issuer and jurisdiction provided in the DeviceDefinition.udiDeviceIdentifier.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRString
      */
     public $deviceIdentifier = null;
@@ -93,7 +93,7 @@ class FHIRDeviceDefinitionUdiDeviceIdentifier extends FHIRBackboneElement implem
     private $_fhirElementName = 'DeviceDefinition.UdiDeviceIdentifier';
 
     /**
-     * The identifier that is to be associated with every Device that references this DeviceDefintiion for the issuer and jurisdication porvided in the DeviceDefinition.udiDeviceIdentifier.
+     * The identifier that is to be associated with every Device that references this DeviceDefinition for the issuer and jurisdiction provided in the DeviceDefinition.udiDeviceIdentifier.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRString
      */
     public function getDeviceIdentifier()
@@ -102,7 +102,7 @@ class FHIRDeviceDefinitionUdiDeviceIdentifier extends FHIRBackboneElement implem
     }
 
     /**
-     * The identifier that is to be associated with every Device that references this DeviceDefintiion for the issuer and jurisdication porvided in the DeviceDefinition.udiDeviceIdentifier.
+     * The identifier that is to be associated with every Device that references this DeviceDefinition for the issuer and jurisdiction provided in the DeviceDefinition.udiDeviceIdentifier.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRString $deviceIdentifier
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRDocumentReference/FHIRDocumentReferenceContent.php
+++ b/src/FHIR/R4/FHIRResource/FHIRDocumentReference/FHIRDocumentReferenceContent.php
@@ -65,7 +65,7 @@ namespace OpenEMR\FHIR\R4\FHIRResource\FHIRDocumentReference;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRBackboneElement;
 
 /**
- * A reference to a document of any kind for any purpose. Provides metadata about the document so that the document can be discovered and managed. The scope of a document is any seralized object with a mime-type, so includes formal patient centric documents (CDA), cliical notes, scanned paper, and non-patient specific documents like policy text.
+ * A reference to a document of any kind for any purpose. Provides metadata about the document so that the document can be discovered and managed. The scope of a document is any serialized object with a mime-type, so includes formal patient centric documents (CDA), clinical notes, scanned paper, and non-patient specific documents like policy text.
  */
 class FHIRDocumentReferenceContent extends FHIRBackboneElement implements \JsonSerializable
 {

--- a/src/FHIR/R4/FHIRResource/FHIRDocumentReference/FHIRDocumentReferenceContext.php
+++ b/src/FHIR/R4/FHIRResource/FHIRDocumentReference/FHIRDocumentReferenceContext.php
@@ -65,7 +65,7 @@ namespace OpenEMR\FHIR\R4\FHIRResource\FHIRDocumentReference;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRBackboneElement;
 
 /**
- * A reference to a document of any kind for any purpose. Provides metadata about the document so that the document can be discovered and managed. The scope of a document is any seralized object with a mime-type, so includes formal patient centric documents (CDA), cliical notes, scanned paper, and non-patient specific documents like policy text.
+ * A reference to a document of any kind for any purpose. Provides metadata about the document so that the document can be discovered and managed. The scope of a document is any serialized object with a mime-type, so includes formal patient centric documents (CDA), clinical notes, scanned paper, and non-patient specific documents like policy text.
  */
 class FHIRDocumentReferenceContext extends FHIRBackboneElement implements \JsonSerializable
 {

--- a/src/FHIR/R4/FHIRResource/FHIRDocumentReference/FHIRDocumentReferenceRelatesTo.php
+++ b/src/FHIR/R4/FHIRResource/FHIRDocumentReference/FHIRDocumentReferenceRelatesTo.php
@@ -65,7 +65,7 @@ namespace OpenEMR\FHIR\R4\FHIRResource\FHIRDocumentReference;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRBackboneElement;
 
 /**
- * A reference to a document of any kind for any purpose. Provides metadata about the document so that the document can be discovered and managed. The scope of a document is any seralized object with a mime-type, so includes formal patient centric documents (CDA), cliical notes, scanned paper, and non-patient specific documents like policy text.
+ * A reference to a document of any kind for any purpose. Provides metadata about the document so that the document can be discovered and managed. The scope of a document is any serialized object with a mime-type, so includes formal patient centric documents (CDA), clinical notes, scanned paper, and non-patient specific documents like policy text.
  */
 class FHIRDocumentReferenceRelatesTo extends FHIRBackboneElement implements \JsonSerializable
 {

--- a/src/FHIR/R4/FHIRResource/FHIRElementDefinition/FHIRElementDefinitionExample.php
+++ b/src/FHIR/R4/FHIRResource/FHIRElementDefinition/FHIRElementDefinitionExample.php
@@ -71,7 +71,7 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRBackboneElement;
 class FHIRElementDefinitionExample extends FHIRBackboneElement implements \JsonSerializable
 {
     /**
-     * Describes the purpose of this example amoung the set of examples.
+     * Describes the purpose of this example among the set of examples.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRString
      */
     public $label = null;
@@ -327,7 +327,7 @@ class FHIRElementDefinitionExample extends FHIRBackboneElement implements \JsonS
     private $_fhirElementName = 'ElementDefinition.Example';
 
     /**
-     * Describes the purpose of this example amoung the set of examples.
+     * Describes the purpose of this example among the set of examples.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRString
      */
     public function getLabel()
@@ -336,7 +336,7 @@ class FHIRElementDefinitionExample extends FHIRBackboneElement implements \JsonS
     }
 
     /**
-     * Describes the purpose of this example amoung the set of examples.
+     * Describes the purpose of this example among the set of examples.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRString $label
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRExplanationOfBenefit/FHIRExplanationOfBenefitAddItem.php
+++ b/src/FHIR/R4/FHIRResource/FHIRExplanationOfBenefit/FHIRExplanationOfBenefitAddItem.php
@@ -82,7 +82,7 @@ class FHIRExplanationOfBenefitAddItem extends FHIRBackboneElement implements \Js
     public $detailSequence = [];
 
     /**
-     * The sequence number of the sub-details woithin the details within the claim item which this line is intended to replace.
+     * The sequence number of the sub-details within the details within the claim item which this line is intended to replace.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRPositiveInt[]
      */
     public $subDetailSequence = [];
@@ -236,7 +236,7 @@ class FHIRExplanationOfBenefitAddItem extends FHIRBackboneElement implements \Js
     }
 
     /**
-     * The sequence number of the sub-details woithin the details within the claim item which this line is intended to replace.
+     * The sequence number of the sub-details within the details within the claim item which this line is intended to replace.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRPositiveInt[]
      */
     public function getSubDetailSequence()
@@ -245,7 +245,7 @@ class FHIRExplanationOfBenefitAddItem extends FHIRBackboneElement implements \Js
     }
 
     /**
-     * The sequence number of the sub-details woithin the details within the claim item which this line is intended to replace.
+     * The sequence number of the sub-details within the details within the claim item which this line is intended to replace.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRPositiveInt $subDetailSequence
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRInsurancePlan/FHIRInsurancePlanPlan.php
+++ b/src/FHIR/R4/FHIRResource/FHIRInsurancePlan/FHIRInsurancePlanPlan.php
@@ -76,7 +76,7 @@ class FHIRInsurancePlanPlan extends FHIRBackboneElement implements \JsonSerializ
     public $identifier = [];
 
     /**
-     * Type of plan. For example, "Platinum" or "High Deductable".
+     * Type of plan. For example, "Platinum" or "High Deductible".
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
      */
     public $type = null;
@@ -131,7 +131,7 @@ class FHIRInsurancePlanPlan extends FHIRBackboneElement implements \JsonSerializ
     }
 
     /**
-     * Type of plan. For example, "Platinum" or "High Deductable".
+     * Type of plan. For example, "Platinum" or "High Deductible".
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
      */
     public function getType()
@@ -140,7 +140,7 @@ class FHIRInsurancePlanPlan extends FHIRBackboneElement implements \JsonSerializ
     }
 
     /**
-     * Type of plan. For example, "Platinum" or "High Deductable".
+     * Type of plan. For example, "Platinum" or "High Deductible".
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept $type
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRMedicinalProduct/FHIRMedicinalProductManufacturingBusinessOperation.php
+++ b/src/FHIR/R4/FHIRResource/FHIRMedicinalProduct/FHIRMedicinalProductManufacturingBusinessOperation.php
@@ -88,7 +88,7 @@ class FHIRMedicinalProductManufacturingBusinessOperation extends FHIRBackboneEle
     public $effectiveDate = null;
 
     /**
-     * To indicate if this proces is commercially confidential.
+     * To indicate if this process is commercially confidential.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
      */
     public $confidentialityIndicator = null;
@@ -171,7 +171,7 @@ class FHIRMedicinalProductManufacturingBusinessOperation extends FHIRBackboneEle
     }
 
     /**
-     * To indicate if this proces is commercially confidential.
+     * To indicate if this process is commercially confidential.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
      */
     public function getConfidentialityIndicator()
@@ -180,7 +180,7 @@ class FHIRMedicinalProductManufacturingBusinessOperation extends FHIRBackboneEle
     }
 
     /**
-     * To indicate if this proces is commercially confidential.
+     * To indicate if this process is commercially confidential.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept $confidentialityIndicator
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRMedicinalProduct/FHIRMedicinalProductNamePart.php
+++ b/src/FHIR/R4/FHIRResource/FHIRMedicinalProduct/FHIRMedicinalProductNamePart.php
@@ -76,7 +76,7 @@ class FHIRMedicinalProductNamePart extends FHIRBackboneElement implements \JsonS
     public $part = null;
 
     /**
-     * Idenifying type for this part of the name (e.g. strength part).
+     * Identifying type for this part of the name (e.g. strength part).
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCoding
      */
     public $type = null;
@@ -107,7 +107,7 @@ class FHIRMedicinalProductNamePart extends FHIRBackboneElement implements \JsonS
     }
 
     /**
-     * Idenifying type for this part of the name (e.g. strength part).
+     * Identifying type for this part of the name (e.g. strength part).
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCoding
      */
     public function getType()
@@ -116,7 +116,7 @@ class FHIRMedicinalProductNamePart extends FHIRBackboneElement implements \JsonS
     }
 
     /**
-     * Idenifying type for this part of the name (e.g. strength part).
+     * Identifying type for this part of the name (e.g. strength part).
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCoding $type
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRMedicinalProductAuthorization/FHIRMedicinalProductAuthorizationProcedure.php
+++ b/src/FHIR/R4/FHIRResource/FHIRMedicinalProductAuthorization/FHIRMedicinalProductAuthorizationProcedure.php
@@ -92,7 +92,7 @@ class FHIRMedicinalProductAuthorizationProcedure extends FHIRBackboneElement imp
     public $dateDateTime = null;
 
     /**
-     * Applcations submitted to obtain a marketing authorization.
+     * Applications submitted to obtain a marketing authorization.
      * @var \OpenEMR\FHIR\R4\FHIRResource\FHIRMedicinalProductAuthorization\FHIRMedicinalProductAuthorizationProcedure[]
      */
     public $application = [];
@@ -179,7 +179,7 @@ class FHIRMedicinalProductAuthorizationProcedure extends FHIRBackboneElement imp
     }
 
     /**
-     * Applcations submitted to obtain a marketing authorization.
+     * Applications submitted to obtain a marketing authorization.
      * @return \OpenEMR\FHIR\R4\FHIRResource\FHIRMedicinalProductAuthorization\FHIRMedicinalProductAuthorizationProcedure[]
      */
     public function getApplication()
@@ -188,7 +188,7 @@ class FHIRMedicinalProductAuthorizationProcedure extends FHIRBackboneElement imp
     }
 
     /**
-     * Applcations submitted to obtain a marketing authorization.
+     * Applications submitted to obtain a marketing authorization.
      * @param \OpenEMR\FHIR\R4\FHIRResource\FHIRMedicinalProductAuthorization\FHIRMedicinalProductAuthorizationProcedure $application
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRMolecularSequence/FHIRMolecularSequenceRoc.php
+++ b/src/FHIR/R4/FHIRResource/FHIRMolecularSequence/FHIRMolecularSequenceRoc.php
@@ -70,7 +70,7 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRBackboneElement;
 class FHIRMolecularSequenceRoc extends FHIRBackboneElement implements \JsonSerializable
 {
     /**
-     * Invidual data point representing the GQ (genotype quality) score threshold.
+     * Individual data point representing the GQ (genotype quality) score threshold.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger[]
      */
     public $score = [];
@@ -117,7 +117,7 @@ class FHIRMolecularSequenceRoc extends FHIRBackboneElement implements \JsonSeria
     private $_fhirElementName = 'MolecularSequence.Roc';
 
     /**
-     * Invidual data point representing the GQ (genotype quality) score threshold.
+     * Individual data point representing the GQ (genotype quality) score threshold.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger[]
      */
     public function getScore()
@@ -126,7 +126,7 @@ class FHIRMolecularSequenceRoc extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * Invidual data point representing the GQ (genotype quality) score threshold.
+     * Individual data point representing the GQ (genotype quality) score threshold.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger $score
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRResearchStudy/FHIRResearchStudyArm.php
+++ b/src/FHIR/R4/FHIRResource/FHIRResearchStudy/FHIRResearchStudyArm.php
@@ -76,7 +76,7 @@ class FHIRResearchStudyArm extends FHIRBackboneElement implements \JsonSerializa
     public $name = null;
 
     /**
-     * Categorization of study arm, e.g. experimental, active comparator, placebo comparater.
+     * Categorization of study arm, e.g. experimental, active comparator, placebo comparator.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
      */
     public $type = null;
@@ -113,7 +113,7 @@ class FHIRResearchStudyArm extends FHIRBackboneElement implements \JsonSerializa
     }
 
     /**
-     * Categorization of study arm, e.g. experimental, active comparator, placebo comparater.
+     * Categorization of study arm, e.g. experimental, active comparator, placebo comparator.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
      */
     public function getType()
@@ -122,7 +122,7 @@ class FHIRResearchStudyArm extends FHIRBackboneElement implements \JsonSerializa
     }
 
     /**
-     * Categorization of study arm, e.g. experimental, active comparator, placebo comparater.
+     * Categorization of study arm, e.g. experimental, active comparator, placebo comparator.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept $type
      * @return $this
      */

--- a/src/FHIR/R4/FHIRResource/FHIRValueSet/FHIRValueSetExpansion.php
+++ b/src/FHIR/R4/FHIRResource/FHIRValueSet/FHIRValueSetExpansion.php
@@ -70,7 +70,7 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRBackboneElement;
 class FHIRValueSetExpansion extends FHIRBackboneElement implements \JsonSerializable
 {
     /**
-     * An identifier that uniquely identifies this expansion of the valueset, based on a unique combination of the provided parameters, the system default parameters, and the underlying system code system versions etc. Systems may re-use the same identifier as long as those factors remain the same, and the expansion is the same, but are not required to do so. This is a business identifier.
+     * An identifier that uniquely identifies this expansion of the valueset, based on a unique combination of the provided parameters, the system default parameters, and the underlying system code system versions etc. Systems may reuse the same identifier as long as those factors remain the same, and the expansion is the same, but are not required to do so. This is a business identifier.
      * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRUri
      */
     public $identifier = null;
@@ -111,7 +111,7 @@ class FHIRValueSetExpansion extends FHIRBackboneElement implements \JsonSerializ
     private $_fhirElementName = 'ValueSet.Expansion';
 
     /**
-     * An identifier that uniquely identifies this expansion of the valueset, based on a unique combination of the provided parameters, the system default parameters, and the underlying system code system versions etc. Systems may re-use the same identifier as long as those factors remain the same, and the expansion is the same, but are not required to do so. This is a business identifier.
+     * An identifier that uniquely identifies this expansion of the valueset, based on a unique combination of the provided parameters, the system default parameters, and the underlying system code system versions etc. Systems may reuse the same identifier as long as those factors remain the same, and the expansion is the same, but are not required to do so. This is a business identifier.
      * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRUri
      */
     public function getIdentifier()
@@ -120,7 +120,7 @@ class FHIRValueSetExpansion extends FHIRBackboneElement implements \JsonSerializ
     }
 
     /**
-     * An identifier that uniquely identifies this expansion of the valueset, based on a unique combination of the provided parameters, the system default parameters, and the underlying system code system versions etc. Systems may re-use the same identifier as long as those factors remain the same, and the expansion is the same, but are not required to do so. This is a business identifier.
+     * An identifier that uniquely identifies this expansion of the valueset, based on a unique combination of the provided parameters, the system default parameters, and the underlying system code system versions etc. Systems may reuse the same identifier as long as those factors remain the same, and the expansion is the same, but are not required to do so. This is a business identifier.
      * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRUri $identifier
      * @return $this
      */

--- a/src/FHIR/SMART/Capability.php
+++ b/src/FHIR/SMART/Capability.php
@@ -2,7 +2,7 @@
 
 /**
  * Capability holds the enumerated capabilities for SMART
- * The SMART extension capabilites that our system supports
+ * The SMART extension capabilities that our system supports
  * @see http://hl7.org/fhir/smart-app-launch/conformance/index.html
  *
  * @package openemr
@@ -17,7 +17,7 @@ namespace OpenEMR\FHIR\SMART;
 class Capability
 {
     /**
-     * The SMART extension capabilites that our system supports
+     * The SMART extension capabilities that our system supports
      * @see https://hl7.org/fhir/smart-app-launch/STU2/conformance.html for v2
      *
      * All of these capabilities for MU3 are required to be implemented before HIT certification


### PR DESCRIPTION
## Summary
- Fix spelling errors in FHIR R4 resource PHPDoc comments
- 41 files with typo corrections
- Reverted incorrect inforce→enforce change (inforce is valid FHIR term)

**This is PR 4 of 11 PRs** to fix ~460 files with typos across the codebase.

All PRs in this series:
1. #10333 - Core files, CCR templates, SQL (merged)
2. #10336 - Contrib, controllers, misc files (merged)
3. #10337 - Sites, templates
4. #10338 - FHIR (this PR)
5. #10339 - Library
6. #10340 - Portal
7. #10341 - Interface, modules
8. #10342 - Interface misc
9. #10343 - Src misc
10. #10344 - Tests (merged)
11. #10345 - Misc remaining files

Part of #7939

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>