### PR TITLE
fix: correct typos in portal files

### DIFF
--- a/portal/lib/appsql.class.php
+++ b/portal/lib/appsql.class.php
@@ -29,7 +29,7 @@ class ApplicationTable
      * All DB Transactions take place
      *
      * @param String $sql
-     *            SQL Query Statment
+     *            SQL Query Statement
      * @param array $params
      *            SQL Parameters
      * @param boolean $log
@@ -115,7 +115,7 @@ class ApplicationTable
      * Hoping to work both ends, patient and user, from one or most two tables
      *
      * @param String $sql
-     *            SQL Query Statment for actions will execute sql as normal for cases
+     *            SQL Query Statement for actions will execute sql as normal for cases
      *            user auth is not required.
      * @param array $params
      *            Parameters for actions
@@ -237,7 +237,7 @@ class ApplicationTable
      * Function errorHandler
      * All error display and log
      * Display the Error, Line and File
-     * Same behavior of HelpfulDie fuction in OpenEMR
+     * Same behavior of HelpfulDie function in OpenEMR
      * Path /library/sql.inc.php
      *
      * @param type $e

--- a/portal/patient/fwk/libs/savant/Savant3.php
+++ b/portal/patient/fwk/libs/savant/Savant3.php
@@ -757,7 +757,7 @@ class Savant3 implements \Stringable
 
             // the substr() check added by Ian Eure to make sure
             // that the realpath() results in a directory registered
-            // with Savant so that non-registered directores are not
+            // with Savant so that non-registered directories are not
             // accessible via directory traversal attempts.
             if (file_exists($fullname) && is_readable($fullname) && str_starts_with($fullname, (string) $path)) {
                 return $fullname;

--- a/portal/patient/fwk/libs/savant/Savant3/resources/Savant3_Filter_trimwhitespace.php
+++ b/portal/patient/fwk/libs/savant/Savant3/resources/Savant3_Filter_trimwhitespace.php
@@ -69,7 +69,7 @@ class Savant3_Filter_trimwhitespace extends Savant3_Filter
         $buffer = preg_replace("!<textarea[^>]+>.*?</textarea>!is", '@@@SAVANT:TRIM:TEXTAREA@@@', (string) $buffer);
 
         // remove all leading spaces, tabs and carriage returns NOT
-        // preceeded by a php close tag.
+        // preceded by a php close tag.
         $buffer = trim((string) preg_replace('/((?<!\?>)\n)[\s]+/m', '\1', (string) $buffer));
 
         // replace script blocks

--- a/portal/patient/fwk/libs/util/Mime_Types.php
+++ b/portal/patient/fwk/libs/util/Mime_Types.php
@@ -124,7 +124,7 @@ class Mime_Types
     /**
      * Scan - goes through all MIME types passing the extension and type to the callback function.
      * The types will be sent in alphabetical order.
-     * If a type has multiple extensions, each extension will be passed seperately (not as an array).
+     * If a type has multiple extensions, each extension will be passed separately (not as an array).
      *
      * The callback function can be a method from another object (eg. array(&$my_obj, 'my_method')).
      * The callback function should accept 3 arguments:
@@ -283,7 +283,7 @@ class Mime_Types
      *          either array containing type and extensions, or the type as string
      * @param mixed $exts
      *          either array holding extensions, or string holding extensions
-     *          seperated by space.
+     *          separated by space.
      * @return void
      */
     function set($type, $exts = null)
@@ -401,7 +401,7 @@ class Mime_Types
      * $mime->remove_extension(array('txt', 'exe', 'html'));
      *
      * @param mixed $exts
-     *          string holding extension(s) seperated by space, or array
+     *          string holding extension(s) separated by space, or array
      * @return void
      */
     function remove_extension($exts)

--- a/portal/patient/fwk/libs/util/parsecsv.lib.php
+++ b/portal/patient/fwk/libs/util/parsecsv.lib.php
@@ -65,7 +65,7 @@ class parseCSV
      * $csv->save();
      * ----------------
      * # add row/entry to end of CSV file
-     * # - only recommended when you know the extact sctructure of the file
+     * # - only recommended when you know the exact structure of the file
      * $csv = new parseCSV();
      * $csv->save('data.csv', array('1986', 'Home', 'Nowhere', ''), true);
      * ----------------
@@ -163,7 +163,7 @@ class parseCSV
     // array of field values in data parsed
     public $titles =  [];
 
-    // two dimentional array of CSV data
+    // two dimensional array of CSV data
     public $data =  [];
 
     /**
@@ -365,7 +365,7 @@ class parseCSV
         $n = 1;
         $to_end = true;
 
-        // walk specific depth finding posssible delimiter characters
+        // walk specific depth finding possible delimiter characters
         for ($i = 0; $i < $strlen; $i++) {
             $ch = $data [$i];
             $nch = $data [$i + 1] ?? false;

--- a/portal/patient/fwk/libs/util/thumbnail.php
+++ b/portal/patient/fwk/libs/util/thumbnail.php
@@ -47,9 +47,9 @@ class thumbnail
      * @param string $sourceFilename
      *          Filename for the image to have thumbnail made from
      * @param integer $maxWidth
-     *          The maxium width for the resulting thumbnail
+     *          The maximum width for the resulting thumbnail
      * @param integer $maxHeight
-     *          The maxium height for the resulting thumbnail
+     *          The maximum height for the resulting thumbnail
      * @param string $targetFormatOrFilename
      *          Either a filename extension (gif|jpg|png) or the
      * @param

--- a/portal/patient/fwk/libs/verysimple/DB/DataDriver/IDataDriver.php
+++ b/portal/patient/fwk/libs/verysimple/DB/DataDriver/IDataDriver.php
@@ -19,7 +19,7 @@ interface IDataDriver
 {
     /**
      * returns a string to identify the type of server
-     * supported in the implemenation
+     * supported in the implementation
      *
      * @return string
      */
@@ -82,7 +82,7 @@ interface IDataDriver
     function Execute($connection, $sql);
 
     /**
-     * Moves the database curser forward and returns the current row as an associative array
+     * Moves the database cursor forward and returns the current row as an associative array
      * When no more data is available, null is returned
      *
      * @param
@@ -122,7 +122,7 @@ interface IDataDriver
     function Release($connection, $rs);
 
     /**
-     * Remove or escape any characters that will cause a SQL statment
+     * Remove or escape any characters that will cause a SQL statement
      * to crash or cause an injection exploit
      *
      * @param
@@ -149,7 +149,7 @@ interface IDataDriver
      * @param
      *          string name of the database
      * @param $ommitEmptyTables (default
-     *          false) set to true and tables with no data will be ommitted
+     *          false) set to true and tables with no data will be omitted
      */
     function GetTableNames($connection, $dbname, $ommitEmptyTables = false);
 

--- a/portal/patient/fwk/libs/verysimple/HTTP/BrowserDevice.php
+++ b/portal/patient/fwk/libs/verysimple/HTTP/BrowserDevice.php
@@ -25,7 +25,7 @@
 class BrowserDevice
 {
     /**
-     * patters to search for devices
+     * patterns to search for devices
      *
      * @var Array
      */
@@ -38,7 +38,7 @@ class BrowserDevice
     ];
 
     /**
-     * patters to search for devices
+     * patterns to search for devices
      *
      * @var Array
      */

--- a/portal/patient/fwk/libs/verysimple/HTTP/RequestUtil.php
+++ b/portal/patient/fwk/libs/verysimple/HTTP/RequestUtil.php
@@ -336,7 +336,7 @@ class RequestUtil
 
     /**
      * Returns a form upload as a FileUpload object.
-     * This function throws an exeption on fail
+     * This function throws an exception on fail
      * with details, so it is recommended to use try/catch when calling this function
      *
      * @param string $fieldname

--- a/portal/patient/fwk/libs/verysimple/IO/IncludeException.php
+++ b/portal/patient/fwk/libs/verysimple/IO/IncludeException.php
@@ -3,7 +3,7 @@
 /** @package    verysimple::Phreeze */
 
 /**
- * NotFoundExeption is thrown when a persisted object is requsted by primary key
+ * NotFoundExeption is thrown when a persisted object is requested by primary key
  * but does not exist in the data store
  *
  * @package verysimple::Phreeze

--- a/portal/patient/fwk/libs/verysimple/IO/Includer.php
+++ b/portal/patient/fwk/libs/verysimple/IO/Includer.php
@@ -75,7 +75,7 @@ class Includer
             }
 
             try {
-                // append a directory separater if necessary
+                // append a directory separator if necessary
                 if ($path && !str_ends_with((string) $path, "/")) {
                     $path .= "/";
                 }

--- a/portal/patient/fwk/libs/verysimple/Phreeze/Criteria.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/Criteria.php
@@ -10,7 +10,7 @@ require_once("CriteriaFilter.php");
 require_once("verysimple/IO/Includer.php");
 
 /**
- * Criteria is a base object that is passed into Phreeze->Query for retreiving
+ * Criteria is a base object that is passed into Phreeze->Query for retrieving
  * records based on specific criteria
  *
  * @package verysimple::Phreeze
@@ -168,7 +168,7 @@ class Criteria
     }
 
     /**
-     * Reset the Criteria for re-use.
+     * Reset the Criteria for reuse.
      * This is called by querybuilder after the criteria has been used
      * to generate SQL. It can be called manually as well.
      */

--- a/portal/patient/fwk/libs/verysimple/Phreeze/DataAdapter.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/DataAdapter.php
@@ -45,7 +45,7 @@ class DataAdapter implements IObservable
     static $RETRY_ON_COMMUNICATION_ERROR = false;
 
     /**
-     * Contructor initializes the object
+     * Constructor initializes the object
      *
      * @access public
      * @param ConnectionSetting $csetting
@@ -316,7 +316,7 @@ class DataAdapter implements IObservable
     }
 
     /**
-     * Start a DB transaction, disabling auto-commit if necessar)
+     * Start a DB transaction, disabling auto-commit if necessary)
      *
      * @access public
      */
@@ -387,7 +387,7 @@ class DataAdapter implements IObservable
      * Returns an array of all table names in the current database
      *
      * @param
-     *          bool true to ommit tables that are empty (default = false)
+     *          bool true to omit tables that are empty (default = false)
      * @return array
      */
     public function GetTableNames($ommitEmptyTables = false)
@@ -439,7 +439,7 @@ class DataAdapter implements IObservable
     }
 
     /**
-     * Moves the database curser forward and returns the current row as an associative array
+     * Moves the database cursor forward and returns the current row as an associative array
      * the resultset passed in must have been created by the same database driver that
      * was connected when Select was called
      *

--- a/portal/patient/fwk/libs/verysimple/Phreeze/DataPage.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/DataPage.php
@@ -17,7 +17,7 @@
 class DataPage implements Iterator
 {
     /**
-     * The Rows property is an array of objects retreived from the data store
+     * The Rows property is an array of objects retrieved from the data store
      */
     public $Rows = null;
 

--- a/portal/patient/fwk/libs/verysimple/Phreeze/DataSet.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/DataSet.php
@@ -14,7 +14,7 @@ require_once("DataPage.php");
  * results all at once.
  *
  * The DataSet executes queries lazily, only when the first result is retrieved.
- * Using GetDataPage will allow retreival of sub-sets of large amounts of data without
+ * Using GetDataPage will allow retrieval of sub-sets of large amounts of data without
  * querying the entire database
  *
  * @package verysimple::Phreeze
@@ -47,7 +47,7 @@ class DataSet implements Iterator // @TODO implement Countable, ArrayAccess
     public $CountSQL = "";
 
     /**
-     * Contructor initializes the object
+     * Constructor initializes the object
      *
      * @access public
      * @param Phreezer $preezer
@@ -364,7 +364,7 @@ class DataSet implements Iterator // @TODO implement Countable, ArrayAccess
      * If $countrecords is true then the total number of records will be eagerly fetched
      * using a count query. This is necessary in order to calculate the total number of
      * results and total number of pages. If you do not care about pagination and simply
-     * want to limit the results, then this can be set to false to supress the count
+     * want to limit the results, then this can be set to false to suppress the count
      * query. However, the pagination settings will not be correct and the total number
      * of rows will be -1
      *

--- a/portal/patient/fwk/libs/verysimple/Phreeze/Dispatcher.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/Dispatcher.php
@@ -28,7 +28,7 @@ class Dispatcher
 
     /**
      * FAST_LOOKUP mode instructs the dispatcher to assume that the controller and method
-     * supplied by the router are valid and not do any checking for the existance of
+     * supplied by the router are valid and not do any checking for the existence of
      * the controller file or the method before trying to call it
      *
      * @var boolean use fast lookup mode if true
@@ -181,7 +181,7 @@ class Dispatcher
      * Fired by the PHP error handler function.
      * Calling this function will
      * always throw an exception unless error_reporting == 0. If the
-     * PHP command is called with @ preceeding it, then it will be ignored
+     * PHP command is called with @ preceding it, then it will be ignored
      * here as well.
      *
      * @deprecated use ExceptionThrower::HandleError instead

--- a/portal/patient/fwk/libs/verysimple/Phreeze/ExportUtility.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/ExportUtility.php
@@ -145,7 +145,7 @@ class ExportUtility
     }
 
     /**
-     * Given a zero-based column number, the approriate Excel column letter is
+     * Given a zero-based column number, the appropriate Excel column letter is
      * returned, ie A, B, AB, CJ, etc.
      * max supported is ZZ, higher than that will
      * throw an exception.

--- a/portal/patient/fwk/libs/verysimple/Phreeze/ICache.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/ICache.php
@@ -14,7 +14,7 @@
 interface ICache
 {
     /**
-     * Retreives a value from the cache
+     * Retrieves a value from the cache
      *
      * @access public
      * @param string $key

--- a/portal/patient/fwk/libs/verysimple/Phreeze/NotFoundException.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/NotFoundException.php
@@ -3,7 +3,7 @@
 /** @package    verysimple::Phreeze */
 
 /**
- * NotFoundExeption is thrown when a persisted object is requsted by primary key
+ * NotFoundExeption is thrown when a persisted object is requested by primary key
  * but does not exist in the data store
  *
  * @package verysimple::Phreeze

--- a/portal/patient/fwk/libs/verysimple/Phreeze/Phreezable.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/Phreezable.php
@@ -208,7 +208,7 @@ abstract class Phreezable
     }
 
     /**
-     * Init is called after contruction.
+     * Init is called after construction.
      * When loading, Init is called prior to Load().
      * When creating a blank object, Init is called immediately after LoadDefaults()
      *

--- a/portal/patient/fwk/libs/verysimple/Phreeze/Phreezer.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/Phreezer.php
@@ -68,7 +68,7 @@ class Phreezer extends Observable
 /**
 *
 * @var set to true to save each individual query object in the level-2 cache
-*      this can lead to a lot of save operations on the level-2 cahce that don't
+*      this can lead to a lot of save operations on the level-2 cache that don't
 *      ever get read, so enable only if you know it will improve performance
 */
     public $CacheQueryObjectLevel2 = false;
@@ -105,7 +105,7 @@ class Phreezer extends Observable
     }
 
 /**
-* Contructor initializes the object.
+* Constructor initializes the object.
 * The database connection is opened only when
 * a DB call is made.
 *
@@ -201,13 +201,10 @@ class Phreezer extends Observable
 /**
 * ValueCache is a utility method allowing any object or value to
 * be stored in the cache.
-* The timout is specified by
-* ValueCacheTimeout. This
 *
-* @param string $sql
-* @param variant $val
-* @param
-*          int cache timeout (in seconds) default = Phreezer->ValueCacheTimeout. set to zero for no cache
+* @param string $key cache key
+* @param variant $val value to cache
+* @param ?int $timeout cache timeout in seconds (default: Phreezer->ValueCacheTimeout, 0 to disable)
 * @return bool true if cache was set, false if not
 */
     public function SetValueCache($key, $val, $timeout = null)
@@ -229,7 +226,7 @@ class Phreezer extends Observable
     }
 
 /**
-* Retreives an object or value that was persisted using SetValueCache
+* Retrieves an object or value that was persisted using SetValueCache
 *
 * @param string $key
 * @return variant
@@ -283,10 +280,10 @@ class Phreezer extends Observable
             return false;
         }
 
-    // if the object hasn't changed at level 1, then supress the cache update
+    // if the object hasn't changed at level 1, then suppress the cache update
         $obj = $this->_level1Cache->Get($objectclass . "_" . $id);
         if ($obj && serialize($obj) == serialize($val)) {
-            $this->Observe("TYPE='$objectclass' ID='$id' level 1 cache has not changed.  SetCache was supressed", OBSERVE_DEBUG);
+            $this->Observe("TYPE='$objectclass' ID='$id' level 1 cache has not changed.  SetCache was suppressed", OBSERVE_DEBUG);
             return false;
         }
 
@@ -325,7 +322,7 @@ class Phreezer extends Observable
             return $obj;
         }
 
-    // try the level 2 cahce
+    // try the level 2 cache
         $obj = $this->_level2Cache->Get($cachekey);
         if ($obj) {
             $this->Observe("Retrieved TYPE='$objectclass' ID='$id' from 2nd Level Cache", OBSERVE_DEBUG);
@@ -820,7 +817,7 @@ class Phreezer extends Observable
     }
 
 /**
-* Returns the name of the DB column associted with the given property
+* Returns the name of the DB column associated with the given property
 *
 * @access public
 * @param string $objectclass
@@ -836,7 +833,7 @@ class Phreezer extends Observable
     }
 
 /**
-* Returns the name of the DB Table associted with the given property
+* Returns the name of the DB Table associated with the given property
 *
 * @access public
 * @param string $objectclass

--- a/portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
@@ -16,7 +16,7 @@ require_once("verysimple/Authentication/IAuthenticatable.php");
 /**
  * Controller is a base controller object used for an MVC pattern
  * This controller uses Phreeze ORM and RenderEngine Template Engine
- * This controller could be extended to use a differente ORM and
+ * This controller could be extended to use a different ORM and
  * Rendering engine as long as they implement compatible functions.
  *
  * @package verysimple::Phreeze
@@ -34,7 +34,7 @@ abstract class PortalController
      *
      * @var string ModelName is used by the base Controller class for certain functions in which
      *      require knowledge of what Model is being used. For example, when validating user input.
-     *      This may be defined in Init() if any of thes base Controller features will be used.
+     *      This may be defined in Init() if any of these base Controller features will be used.
      */
     protected $ModelName;
     protected $Context;
@@ -157,7 +157,7 @@ abstract class PortalController
 
     /**
      * Init is called by the base constructor immediately after construction.
-     * This method must be implemented and provided an oportunity to
+     * This method must be implemented and provided an opportunity to
      * set any class-wide variables such as ModelName, implement
      * authentication for this Controller or any other class-wide initialization
      */
@@ -359,7 +359,7 @@ abstract class PortalController
     }
 
     /**
-     * Use as an alterative to print in order to capture debug output
+     * Use as an alternative to print in order to capture debug output
      *
      * @param
      *          string text to print
@@ -481,7 +481,7 @@ abstract class PortalController
             try {
                 $fms = $this->Phreezer->GetFieldMaps($page->ObjectName);
             } catch (exception $ex) {
-                throw new Exception("The objects contained in this DataPage do not have a FieldMap.  Set noMap argument to true to supress this error: " . $ex->getMessage());
+                throw new Exception("The objects contained in this DataPage do not have a FieldMap.  Set noMap argument to true to suppress this error: " . $ex->getMessage());
             }
         }
 
@@ -571,7 +571,7 @@ abstract class PortalController
                     ) // guid
                     ;
                 } else {
-                    $rssWriter->addItem("Item $count doesn't implment IRSSFeedItem", "about:blank", '', 'Error', date(DATE_RSS));
+                    $rssWriter->addItem("Item $count doesn't implement IRSSFeedItem", "about:blank", '', 'Error', date(DATE_RSS));
                 }
             }
         } else {
@@ -627,7 +627,7 @@ abstract class PortalController
         } else {
             $vr->Success = false;
             $vr->Errors = $obj->GetValidationErrors();
-            $vr->Message = "Validation Errors Occured";
+            $vr->Message = "Validation Errors Occurred";
         }
 
         // if the user requested to save inline, their Save method will take over from here
@@ -862,7 +862,7 @@ abstract class PortalController
      * @param
      *          bool if true then objects will be returned ->GetObject() (only supports ObjectArray or individual Phreezable or Reporter object)
      * @param
-     *          array (only relvant if useSimpleObject is true) options array passed through to Phreezable->ToString()
+     *          array (only relevant if useSimpleObject is true) options array passed through to Phreezable->ToString()
      * @param
      *          bool set to 0 to leave data untouched. set to 1 to always force value to UTF8. set to 2 to only force UTF8 if an encoding error occurs (WARNING: options 1 or 2 will likely result in unreadable characters. The recommended fix is to set your database charset to utf8)
      */
@@ -947,7 +947,7 @@ abstract class PortalController
      * @param string $action
      *          in the format Controller.Method
      * @param mixed $feedback
-     *          string which will be assigne to the template as "feedback" or an array of values to assign
+     *          string which will be assigned to the template as "feedback" or an array of values to assign
      * @param array $params
      * @param string $mode
      *          (client | header) default = Controller::$DefaultRedirectMode

--- a/portal/patient/fwk/libs/verysimple/Phreeze/QueryBuilder.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/QueryBuilder.php
@@ -167,7 +167,7 @@ class QueryBuilder
      * Removes the "where" from the beginning of a statement
      *
      * @param string $sql partial query to parse
-     * @return string query without the preceeding "where"
+     * @return string query without the preceding "where"
      */
     private function RemoveWherePrefix(string $sql): string
     {

--- a/portal/patient/fwk/libs/verysimple/String/VerySimpleStringUtil.php
+++ b/portal/patient/fwk/libs/verysimple/String/VerySimpleStringUtil.php
@@ -20,7 +20,7 @@ class VerySimpleStringUtil
     /** @var list of xml reserved characters */
     static $XML_SPECIAL_CHARS;
 
-    /** @var associative array containing the html translation for special characters with their numeric equivilant */
+    /** @var associative array containing the html translation for special characters with their numeric equivalent */
     static $HTML_ENTITIES_TABLE;
 
     /** @var common characters, especially on windows systems, that are technical not valid */
@@ -309,7 +309,7 @@ class VerySimpleStringUtil
     }
 
     /**
-     * This replaces all non-numeric html entities with the numeric equivilant
+     * This replaces all non-numeric html entities with the numeric equivalent
      *
      * @param string $string
      * @return string
@@ -333,7 +333,7 @@ class VerySimpleStringUtil
     /**
      * This is The same as UTFToHTML except it utilizes htmlentities, which will return the Named
      * HTML code when possible (ie &pound; &sect;, etc).
-     * It is preferrable in all cases to use
+     * It is preferable in all cases to use
      * UTFToHTML instead unless you absolutely have to have named entities
      *
      * @param string $string

--- a/portal/patient/fwk/libs/verysimple/Util/ExceptionFormatter.php
+++ b/portal/patient/fwk/libs/verysimple/Util/ExceptionFormatter.php
@@ -16,7 +16,7 @@ class ExceptionFormatter
     /**
      * This is a utility function for tracing errors.
      * It will return a string that
-     * displys the current execution stack
+     * displays the current execution stack
      *
      * @param string $msg
      *          a debugging message to include

--- a/portal/patient/fwk/libs/verysimple/Util/ExceptionThrower.php
+++ b/portal/patient/fwk/libs/verysimple/Util/ExceptionThrower.php
@@ -64,7 +64,7 @@ class ExceptionThrower
      * Fired by the PHP error handler function.
      * Calling this function will
      * always throw an exception unless error_reporting == 0. If the
-     * PHP command is called with @ preceeding it, then it will be ignored
+     * PHP command is called with @ preceding it, then it will be ignored
      * here as well.
      *
      * @param string $code
@@ -75,7 +75,7 @@ class ExceptionThrower
      */
     static function HandleError($code, $string, $file, $line, $context = '')
     {
-        // ignore supressed errors
+        // ignore suppressed errors
         if (error_reporting() == 0) {
             return;
         }

--- a/portal/patient/fwk/libs/verysimple/Util/MemCacheProxy.php
+++ b/portal/patient/fwk/libs/verysimple/Util/MemCacheProxy.php
@@ -23,7 +23,7 @@ class MemCacheProxy extends CacheMemCache
     public $LastServerError = '';
 
     /**
-     * Acts as a proxy for a MemCache server and fails gracefull if the pool cannot be contacted
+     * Acts as a proxy for a MemCache server and fails gracefully if it cannot contact the pool
      *
      * @param
      *          array in host/port format: array('host1'=>'11211','host2'=>'11211')

--- a/portal/patient/libs/Controller/AppBasePortalController.php
+++ b/portal/patient/libs/Controller/AppBasePortalController.php
@@ -24,7 +24,7 @@ class AppBasePortalController extends PortalController
 
     /**
      * Init is called by the base controller before the action method
-     * is called.  This provided an oportunity to hook into the system
+     * is called.  This provided an opportunity to hook into the system
      * for all application actions.  This is a good place for authentication
      * code.
      */

--- a/portal/patient/libs/Controller/OnsiteDocumentController.php
+++ b/portal/patient/libs/Controller/OnsiteDocumentController.php
@@ -437,7 +437,7 @@ class OnsiteDocumentController extends AppBasePortalController
     public function Delete()
     {
         try {
-            // TODO: if a soft delete is prefered, change this to update the deleted flag instead of hard-deleting
+            // TODO: if a soft delete is preferred, change this to update the deleted flag instead of hard-deleting
             $pk = $this->GetRouter()->GetUrlParam('id');
             $onsitedocument = $this->Phreezer->Get('OnsiteDocument', $pk);
 

--- a/portal/patient/libs/Controller/OnsitePortalActivityController.php
+++ b/portal/patient/libs/Controller/OnsitePortalActivityController.php
@@ -235,7 +235,7 @@ class OnsitePortalActivityController extends AppBasePortalController
     public function Delete()
     {
         try {
-            // TODO: if a soft delete is prefered, change this to update the deleted flag instead of hard-deleting
+            // TODO: if a soft delete is preferred, change this to update the deleted flag instead of hard-deleting
 
             $pk = $this->GetRouter()->GetUrlParam('id');
             $onsiteportalactivity = $this->Phreezer->Get('OnsitePortalActivity', $pk);

--- a/portal/patient/libs/Reporter/OnsiteActivityViewReporter-query.php
+++ b/portal/patient/libs/Reporter/OnsiteActivityViewReporter-query.php
@@ -18,7 +18,7 @@ require_once("verysimple/Phreeze/Reporter.php");
 /**
  * This is an example Reporter based on the OnsiteActivityView object.
  * The reporter object
- * allows you to run arbitrary queries that return data which may or may not fith within
+ * allows you to run arbitrary queries that return data which may or may not fit within
  * the data access API. This can include aggregate data or subsets of data.
  *
  * Note that Reporters are read-only and cannot be used for saving data.

--- a/portal/patient/libs/Reporter/OnsiteDocumentReporter.php
+++ b/portal/patient/libs/Reporter/OnsiteDocumentReporter.php
@@ -15,7 +15,7 @@ require_once("verysimple/Phreeze/Reporter.php");
 
 /**
  * This is an example Reporter based on the OnsiteDocument object.  The reporter object
- * allows you to run arbitrary queries that return data which may or may not fith within
+ * allows you to run arbitrary queries that return data which may or may not fit within
  * the data access API.  This can include aggregate data or subsets of data.
  *
  * Note that Reporters are read-only and cannot be used for saving data.

--- a/portal/patient/libs/Reporter/OnsitePortalActivityReporter.php
+++ b/portal/patient/libs/Reporter/OnsitePortalActivityReporter.php
@@ -15,7 +15,7 @@ require_once("verysimple/Phreeze/Reporter.php");
 
 /**
  * This is an example Reporter based on the OnsitePortalActivity object.  The reporter object
- * allows you to run arbitrary queries that return data which may or may not fith within
+ * allows you to run arbitrary queries that return data which may or may not fit within
  * the data access API.  This can include aggregate data or subsets of data.
  *
  * Note that Reporters are read-only and cannot be used for saving data.

--- a/portal/patient/scripts/app/onsiteportalactivities.js
+++ b/portal/patient/scripts/app/onsiteportalactivities.js
@@ -52,7 +52,7 @@ var pageAudit = {
 		pageAudit.fetchParams = params;
 
 		if (pageAudit.fetchInProgress) {
-			if (console) console.log('pageAudit supressing fetch because it is already in progress');
+			if (console) console.log('pageAudit suppressing fetch because it is already in progress');
 		}
 
 		pageAudit.fetchInProgress = true;

--- a/portal/patient/scripts/model.js
+++ b/portal/patient/scripts/model.js
@@ -15,7 +15,7 @@ Backbone.emulateJSON = false;
 var model = {};
 
 /**
- * long polling duration in miliseconds.  (5000 = recommended, 0 = disabled)
+ * long polling duration in milliseconds.  (5000 = recommended, 0 = disabled)
  * warning: setting this to a low number will increase server load
  */
 model.longPollDuration = 0;
@@ -78,7 +78,7 @@ model.AbstractCollection = Backbone.Collection.extend({
 				aVal = aVal ? aVal.toLowerCase() : '';
 				bVal = bVal ? bVal.toLowerCase() : '';
 			} else {
-				// treat comparision as a number
+				// treat comparison as a number
 				aVal = Number(aVal);
 				bVal = Number(bVal);
 			}

--- a/portal/patient/scripts/view.js
+++ b/portal/patient/scripts/view.js
@@ -194,7 +194,7 @@ var view = {
 		 *
 		 * <input id="[prop]_[id]"  ... />
 		 *
-		 * where [prop] is the name of the model propery and [id] is the
+		 * where [prop] is the name of the model property and [id] is the
 		 * id (unique id) of the model
 		 */
 		handleViewChange: function(ev) {

--- a/portal/portal_payment.php
+++ b/portal/portal_payment.php
@@ -644,7 +644,7 @@ if (($_POST['form_save'] ?? null) || ($_REQUEST['receipt'] ?? null)) {
                     let msg = <?php $amsg = xl('Payment successfully sent for review and posting to your account.') . "\n" .
                         xl("You will be notified when the payment transaction is confirmed.") . "\n" .
                         xl('Until then you will continue to see payment details here.') . "\n" . xl('Thank You.');
-                        echo json_encode($amsg); // backward compatable 5.0.1
+                        echo json_encode($amsg); // backward compatible 5.0.1
                     ?>;
                     alert(msg);
                     window.location.reload(false);
@@ -700,7 +700,7 @@ if (($_POST['form_save'] ?? null) || ($_REQUEST['receipt'] ?? null)) {
 
         function getAuth() {
             let authnum = document.getElementById("check_number").value;
-            authnum = prompt(<?php echo xlj('Please enter card comfirmation authorization'); ?>, authnum);
+            authnum = prompt(<?php echo xlj('Please enter card confirmation authorization'); ?>, authnum);
             if (authnum != null) {
                 document.getElementById("check_number").value = authnum;
             }

--- a/portal/report/portal_custom_report.php
+++ b/portal/report/portal_custom_report.php
@@ -178,7 +178,7 @@ function zip_content($source, $destination, $content = '', $create = true)
 
 <?php } ?>
 
-<?php // do not show stuff from report.php in forms that is encaspulated
+<?php // do not show stuff from report.php in forms that is encapsulated
       // by div of navigateLink class. Specifically used for CAMOS, but
       // can also be used by other forms that require output in the
       // encounter listings output, but not in the custom report. ?>


### PR DESCRIPTION
## Summary
- Fix spelling errors in portal PHP files and supporting libraries
- 38 files with typo corrections

**Note:** `Interpretter` property names excluded from this PR - tracked separately in #10351.

**This is PR 6 of 11 PRs** to fix ~460 files with typos across the codebase.

All PRs in this series:
1. #10333 - Core files, CCR templates, SQL (merged)
2. #10336 - Contrib, controllers, misc files (merged)
3. #10337 - Sites, templates (merged)
4. #10338 - FHIR (merged)
5. #10339 - Library (merged)
6. #10340 - Portal (this PR)
7. #10341 - Interface, modules
8. #10342 - Interface misc
9. #10343 - Src misc
10. #10344 - Tests (merged)
11. #10345 - Misc remaining files

Part of #7939

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>