### PR TITLE
fix(ci): Remove merge_coverage call from inferno tests

### DIFF
--- a/.github/workflows/inferno-test.yml
+++ b/.github/workflows/inferno-test.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        submodules: 'recursive'
+        submodules: recursive
         token: ${{ secrets.INFERNO_PAT }}
 
     - name: Fix permissions for Docker uid/gid differences
@@ -315,7 +315,7 @@ jobs:
         ENABLE_COVERAGE: 'true'
         INFERNO_TEST: 'true'
         XDEBUG_ON: '1'
-        XDEBUG_MODE: 'coverage'
+        XDEBUG_MODE: coverage
       run: |
         echo 'Starting Inferno certification test suite with coverage…'
         ./run.sh
@@ -358,14 +358,6 @@ jobs:
       if: ${{ !cancelled() && hashFiles('coverage.inferno-http.clover.xml') != '' }}
       run: mv coverage.inferno-http.clover.xml inferno-http.saved-cov-data
 
-    - name: Upload combined coverage to Codecov
-      if: ${{ !cancelled() && needs.check_secret.outputs.has_codecov_token == 'true' && hashFiles('coverage.clover.xml') != '' }}
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: coverage.clover.xml
-        flags: inferno,combined,php${{ matrix.php-version }}
-
     # Unhide files before uploading to GitHub
     - name: Unhide test results and coverage for GitHub upload
       if: ${{ !cancelled() }}
@@ -385,15 +377,13 @@ jobs:
         path: junit-inferno.xml
 
     - name: Upload coverage artifacts to GitHub
-      if: ${{ !cancelled() && hashFiles('coverage.clover.xml') != '' }}
+      if: ${{ !cancelled() && hashFiles('coverage.inferno-phpunit.clover.xml', 'coverage.inferno-http.clover.xml') != '' }}
       uses: actions/upload-artifact@v6
       with:
         name: inferno-coverage-reports
         path: |
-          coverage.clover.xml
           coverage.inferno-phpunit.clover.xml
           coverage.inferno-http.clover.xml
-          htmlcov/
 
     - name: Cleanup Docker resources
       if: always()

--- a/ci/inferno/run.sh
+++ b/ci/inferno/run.sh
@@ -117,7 +117,7 @@ run_testsuite() {
     # Run PHPUnit tests with coverage if enabled
     if [[ ${ENABLE_COVERAGE:-false} = true ]]; then
         phpunit --testsuite certification \
-                --coverage-php coverage/coverage.inferno-phpunit.cov \
+                --coverage-clover coverage.inferno-phpunit.clover.xml \
                 --log-junit junit-inferno.xml \
                 -c "${OPENEMR_DIR}/phpunit.xml"
     else
@@ -159,22 +159,19 @@ collect_inferno_coverage() {
     # Count raw coverage files
     find "${coverage_raw_tmpdir}" -type f -name '*.php' | wc -l | xargs echo 'Found raw Inferno coverage files:'
 
-    # Convert HTTP request coverage to .cov format
+    # Convert HTTP request coverage to clover.xml format
     if [[ -d "${coverage_raw_tmpdir}/inferno" ]]; then
-        mkdir -p coverage
-        sudo chmod -R 777 coverage
         ./ci/convert-coverage "${coverage_raw_tmpdir}/inferno" \
-                              coverage/coverage.inferno-http.cov \
+                              /dev/null \
                               --clover=coverage.inferno-http.clover.xml
-        ls -lah coverage.inferno-http.clover.xml coverage/coverage.inferno-http.cov || true
+        ls -lah coverage.inferno-http.clover.xml || true
     else
         echo "Warning: No Inferno HTTP coverage files found"
     fi
 
-    # Merge all Inferno coverage (PHPUnit + HTTP requests)
-    cd -P "${repo_root}"
-    . ci/ciLibrary.source
-    merge_coverage
+    # Note: Individual coverage files (coverage.inferno-phpunit.clover.xml and
+    # coverage.inferno-http.clover.xml) are uploaded separately to Codecov,
+    # which handles server-side merging. No local merge needed.
 
     echo 'Inferno coverage collection completed'
 }


### PR DESCRIPTION
## Summary

Fixes #10355

The `merge_coverage()` function was removed from `ci/ciLibrary.source` in commit 3cd96f9249 (#10354), but the inferno test script still called it, causing the inferno certification tests to fail.

## Changes proposed in this pull request

- Generate `coverage.inferno-phpunit.clover.xml` directly from PHPUnit instead of `.cov` files
- Remove `merge_coverage()` call from `collect_inferno_coverage()`
- Remove combined coverage upload step (Codecov handles server-side merge)
- Update artifact upload condition to check for individual coverage files

## Test plan

- [ ] Verify inferno certification tests pass
- [ ] Verify coverage files are uploaded to Codecov

## AI Disclosure

Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)