### PR TITLE
perf(ci): Add scheduled nightly tests with full coverage

### DIFF
--- a/.github/workflows/test-scheduled.yml
+++ b/.github/workflows/test-scheduled.yml
@@ -1,0 +1,69 @@
+##
+# Scheduled nightly test run with full coverage
+#
+# Runs all test configurations daily with coverage enabled for all.
+# This moves coverage collection off PRs to reduce CI time on pull requests.
+#
+# Schedule: 9:00 UTC (4am EST / 5am EDT)
+
+name: Test (Scheduled)
+
+on:
+  schedule:
+    # 9:00 UTC = 4:00 AM EST / 5:00 AM EDT
+  - cron: 0 9 * * *
+  workflow_dispatch:
+    inputs:
+      enable_coverage:
+        description: Enable coverage collection for all configurations
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  collect:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v6
+
+    - name: Collect Docker Dirs
+      id: docker-dirs
+      ##
+      # Collect the docker directory names from ci subdirectories
+      # and compute display names for each configuration.
+      run: |
+        shopt -s nullglob
+        shopt -s extglob
+        # Remove compose-shared-* from the list
+        dirs=( ci/!(compose-shared-*)/docker-compose.yml )
+        dirs=( "${dirs[@]%/docker-compose.yml}" )
+        dirs=( "${dirs[@]#ci/}" )
+        ci/parse_docker_dir.sh "${dirs[@]}" |
+          jq -rc 'map({
+            docker_dir: .output.docker_dir,
+            display_name: "PHP \(.output.php) - \(.output.webserver) - \(.output.database) \(.output.db)",
+            save_composer_cache: .output.save_composer_cache,
+            save_node_cache: .output.save_node_cache
+          }) | "configs=\(.)"' >> "$GITHUB_OUTPUT"
+    outputs:
+      configs: ${{ steps.docker-dirs.outputs.configs }}
+  build:
+    name: ${{ matrix.config.display_name }}
+    needs: collect
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.collect.outputs.configs) }}
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
+    with:
+      docker_dir: ${{ matrix.config.docker_dir }}
+      display_name: ${{ matrix.config.display_name }}
+      # Enable coverage for ALL configurations in scheduled runs
+      enable_coverage: ${{ inputs.enable_coverage == '' && true || inputs.enable_coverage }}
+      save_composer_cache: ${{ matrix.config.save_composer_cache == 'true' }}
+      save_node_cache: ${{ matrix.config.save_node_cache == 'true' }}


### PR DESCRIPTION
## Summary

Add scheduled nightly CI workflow that runs all test configurations with full coverage.

Refs #10328

## Changes proposed in this pull request

New `test-scheduled.yml` workflow:
- Runs daily at 4am ET (9am UTC) 
- Runs all 16 test configurations
- Coverage enabled for ALL configurations (not just one)
- Can be triggered manually via workflow_dispatch for testing

## Expected Impact

- Comprehensive coverage data available nightly
- No change to PR or push CI behavior (that's a separate PR)

## AI Disclosure

Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)