### PR TITLE
perf(ci): add pcov support for faster code coverage

### DIFF
--- a/ci/apache_84_114/docker-compose.yml
+++ b/ci/apache_84_114/docker-compose.yml
@@ -1,8 +1,8 @@
 x-includes:
-  selenium-template: "compose-shared-selenium/docker-compose.yml"
-  webserver-template: "compose-shared-apache.yml"
-  database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  selenium-template: compose-shared-selenium/docker-compose.yml
+  webserver-template: compose-shared-apache.yml
+  database-template: compose-shared-mariadb.yml
+  mailpit-template: compose-shared-mailpit.yml
 
 services:
   mysql:

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -53,6 +53,7 @@ dc() {
 
 _exec() {
     if [[ ${ENABLE_COVERAGE:-false} = true ]]; then
+        # Set XDEBUG_MODE for xdebug coverage (ignored if using pcov)
         dc exec --env XDEBUG_MODE=coverage --workdir "${OPENEMR_DIR?}" openemr "$@"
     else
         dc exec --workdir "${OPENEMR_DIR?}" openemr "$@"
@@ -108,7 +109,16 @@ ccda_build() (
 )
 
 configure_coverage() {
-    _exec sh -c 'XDEBUG_IDE_KEY=unimportant XDEBUG_ON=yes ../xdebug.sh'
+    # Check which coverage driver is available (pcov is faster)
+    # shellcheck disable=SC2310  # Intentionally checking exit code in condition
+    if _exec php -r 'exit(function_exists("pcov\\start") ? 0 : 1);'; then
+        echo "Coverage driver: pcov"
+    elif _exec php -r 'exit(function_exists("xdebug_start_code_coverage") ? 0 : 1);'; then
+        echo "Coverage driver: xdebug (already installed)"
+    else
+        echo "Coverage driver: xdebug (installing)"
+        _exec sh -c 'XDEBUG_IDE_KEY=unimportant XDEBUG_ON=yes ../xdebug.sh'
+    fi
 }
 
 install_configure() {

--- a/ci/compose-shared-apache.yml
+++ b/ci/compose-shared-apache.yml
@@ -6,11 +6,12 @@ services:
     volumes:
     - ../:/var/www/localhost/htdocs/openemr
     environment:
-      EMPTY: "yes"
-      FORCE_NO_BUILD_MODE: "yes"
-      OPENEMR_ENABLE_CI_PHP: "1"
-      ENABLE_COVERAGE: "${ENABLE_COVERAGE:-false}"
-      SELENIUM_BASE_URL: "http://openemr"
+      EMPTY: yes
+      FORCE_NO_BUILD_MODE: yes
+      OPENEMR_ENABLE_CI_PHP: '1'
+      ENABLE_COVERAGE: ${ENABLE_COVERAGE:-false}
+      PCOV_ON: ${ENABLE_COVERAGE:-false}
+      SELENIUM_BASE_URL: http://openemr
     healthcheck:
       test:
       - CMD

--- a/ci/inferno/compose.yml
+++ b/ci/inferno/compose.yml
@@ -28,9 +28,9 @@ services:
     volumes:
     - ../../:/var/www/localhost/htdocs/openemr
     environment:
-      EMPTY: "yes"
-      FORCE_NO_BUILD_MODE: "yes"
-      OPENEMR_ENABLE_CI_PHP: "1"
+      EMPTY: yes
+      FORCE_NO_BUILD_MODE: yes
+      OPENEMR_ENABLE_CI_PHP: '1'
       OPENEMR_SETTING_couchdb_dbase: example
       OPENEMR_SETTING_couchdb_host: couchdb
       OPENEMR_SETTING_couchdb_pass: password
@@ -43,10 +43,11 @@ services:
       MYSQL_PASS: openemr
       # Coverage settings - controlled by ENABLE_COVERAGE variable
       # Set ENABLE_COVERAGE=true in run.sh to enable coverage collection
-      ENABLE_COVERAGE: "${ENABLE_COVERAGE:-false}"
-      INFERNO_TEST: "${INFERNO_TEST:-false}"
-      XDEBUG_ON: "${XDEBUG_ON:-0}"
-      XDEBUG_MODE: "${XDEBUG_MODE:-off}"
+      ENABLE_COVERAGE: ${ENABLE_COVERAGE:-false}
+      PCOV_ON: ${ENABLE_COVERAGE:-false}
+      INFERNO_TEST: ${INFERNO_TEST:-false}
+      XDEBUG_ON: ${XDEBUG_ON:-0}
+      XDEBUG_MODE: ${XDEBUG_MODE:-off}
     depends_on:
       couchdb:
         condition: service_started
@@ -61,13 +62,13 @@ services:
       file: onc-certification-g10-test-kit/docker-compose.yml
       service: inferno
     environment:
-      INFERNO_DISABLE_TLS_TEST: "true"
+      INFERNO_DISABLE_TLS_TEST: 'true'
   worker:
     extends:
       file: onc-certification-g10-test-kit/docker-compose.yml
       service: worker
     environment:
-      INFERNO_DISABLE_TLS_TEST: "true"
+      INFERNO_DISABLE_TLS_TEST: 'true'
   nginx:
     extends:
       file: onc-certification-g10-test-kit/docker-compose.yml


### PR DESCRIPTION
## Summary

Adds pcov as an alternative to xdebug for PHP code coverage collection. pcov is significantly faster than xdebug for coverage-only use cases (CI).

Refs #10328

## Changes proposed in this pull request

- **ci/auto_prepend.php**: Detect pcov/xdebug and use appropriate API for coverage collection
- **ci/ciLibrary.source**: Skip xdebug setup if pcov is available  
- **ci/compose-shared-apache.yml**: Pass `PCOV_ON` environment variable when coverage enabled
- **ci/apache_84_114/docker-compose.yml**: TEMP - Use test image with pcov (`kojiromike/openemr:flex-3.22-pcov-test`)
- **.github/workflows/test-all.yml**: TEMP - Run coverage on `apache_84_114` config for testing

## How it works

The code auto-detects which driver is available:
1. If pcov is present → use pcov (faster)
2. Otherwise → fall back to xdebug (existing behavior)

## Dependencies

- openemr/openemr-devops#547 - Adds pcov support to flex Docker images

## Testing notes

This PR uses a temporary test image (`kojiromike/openemr:flex-3.22-pcov-test`) to verify pcov works correctly with the CI coverage collection. Once openemr/openemr-devops#547 is merged and official images are updated:
- Revert `ci/apache_84_114/docker-compose.yml` to use official image
- Revert `.github/workflows/test-all.yml` to original coverage config

## AI Disclosure

Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)