### PR TITLE
fix(docker): add xdebug support to dev-php-fpm images

### DIFF
--- a/docker/library/dockers/dev-php-fpm-8-2-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-2-redis/Dockerfile
@@ -54,3 +54,9 @@ RUN usermod -u 1000 www-data
 
 # Copy over the php.ini conf
 COPY php.ini /usr/local/etc/php/php.ini
+
+# Copy xdebug installation script for CI coverage support
+# Script is placed at /usr/share/nginx/html/xdebug.sh so CI can call ../xdebug.sh
+# from the OpenEMR directory at /usr/share/nginx/html/openemr
+COPY xdebug.sh /usr/share/nginx/html/xdebug.sh
+RUN chmod +x /usr/share/nginx/html/xdebug.sh

--- a/docker/library/dockers/dev-php-fpm-8-2-redis/xdebug.sh
+++ b/docker/library/dockers/dev-php-fpm-8-2-redis/xdebug.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenEMR dev-php-fpm XDebug Configuration Script
+# ============================================================================
+# This script configures XDebug for PHP debugging, profiling, and coverage.
+# Compatible with Debian-based php-fpm images using install-php-extensions.
+#
+# Environment Variables:
+#   XDEBUG_ON           - Set to "1" to enable XDebug (required)
+#   XDEBUG_IDE_KEY      - IDE key for debugging session (required if XDEBUG_ON not set)
+#   XDEBUG_CLIENT_HOST  - Hostname/IP of the debugging client (optional)
+#   XDEBUG_CLIENT_PORT  - Port for debugging connection (default: 9003)
+#   XDEBUG_PROFILER_ON  - Set to "1" to enable profiling in addition to debugging
+#   XDEBUG_MODE         - Override xdebug mode (e.g., "coverage" for CI)
+#
+# Usage:
+#   Called by CI when coverage is enabled, or manually for debugging
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# NORMALIZE FLAGS
+# ============================================================================
+# Normalize boolean flags once at the start for consistent checking.
+
+case ${XDEBUG_ON:-} in
+    1|[Yy]es|[Tt]rue) xdebug_enabled=true ;;
+    *) xdebug_enabled=false ;;
+esac
+
+case ${XDEBUG_PROFILER_ON:-} in
+    1|[Yy]es|[Tt]rue) profiler_enabled=true ;;
+    *) profiler_enabled=false ;;
+esac
+
+# ============================================================================
+# VALIDATION
+# ============================================================================
+# Ensure XDebug is actually requested before proceeding.
+# At least one of XDEBUG_ON or XDEBUG_IDE_KEY must be set.
+
+if [[ -z "${XDEBUG_IDE_KEY:-}" && "${xdebug_enabled}" = false ]]; then
+    echo "Error: XDebug requested but neither XDEBUG_ON nor XDEBUG_IDE_KEY is set" >&2
+    exit 1
+fi
+
+# ============================================================================
+# INSTALL AND CONFIGURE XDEBUG
+# ============================================================================
+# Install the XDebug PHP extension and configure it.
+# This only runs once per container to avoid repeated installations.
+
+XDEBUG_CONF_FILE="/usr/local/etc/php/conf.d/xdebug.ini"
+
+if [[ ! -f /etc/php-xdebug-configured ]]; then
+    echo "Installing XDebug extension..."
+
+    # Install XDebug using install-php-extensions (works on Debian-based images)
+    install-php-extensions xdebug
+
+    # Determine xdebug mode
+    if [[ -n "${XDEBUG_MODE:-}" ]]; then
+        # Use explicitly set mode (e.g., "coverage" from CI)
+        mode="${XDEBUG_MODE}"
+    elif [[ "${profiler_enabled}" = true ]]; then
+        mode="debug,profile"
+    else
+        mode="debug"
+    fi
+
+    # Configure XDebug
+    {
+        echo "; ========================================================================"
+        echo "; XDebug Configuration"
+        echo "; ========================================================================"
+        echo
+        echo "; XDebug mode: debug, profile, coverage, or combinations"
+        echo "xdebug.mode=${mode}"
+        echo
+        echo "; Directory for XDebug output files (trace files, profiler output)"
+        echo "xdebug.output_dir=/tmp"
+        echo
+        echo "; Start debugging session when triggered (via IDE or browser extension)"
+        echo "xdebug.start_with_request=trigger"
+        echo
+        echo "; Log file for XDebug messages and errors"
+        echo "xdebug.log=/tmp/xdebug.log"
+        echo
+        echo "; Automatically discover the client host (useful for Docker)"
+        echo "xdebug.discover_client_host=1"
+        echo
+        echo "; Port for debugging connection (default: 9003)"
+        echo "xdebug.client_port=${XDEBUG_CLIENT_PORT:-9003}"
+
+        # Override client host if explicitly set
+        if [[ -n "${XDEBUG_CLIENT_HOST:-}" ]]; then
+            echo
+            echo "; Manually configured client host (disables auto-discovery)"
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}"
+        fi
+
+        # Set IDE key if provided
+        if [[ -n "${XDEBUG_IDE_KEY:-}" ]]; then
+            echo
+            echo "; IDE key for debugging session"
+            echo "xdebug.idekey=${XDEBUG_IDE_KEY}"
+        fi
+
+        # Profiler settings
+        if [[ "${profiler_enabled}" = true || "${mode}" == *"profile"* ]]; then
+            echo
+            echo "; Profiler output filename pattern"
+            echo "xdebug.profiler_output_name=cachegrind.out.%s"
+        fi
+        echo
+    } > "${XDEBUG_CONF_FILE}"
+
+    # Mark as configured
+    touch /etc/php-xdebug-configured
+    echo "XDebug installed and configured (mode: ${mode})"
+fi
+
+# ============================================================================
+# ENSURE XDEBUG LOG FILE EXISTS
+# ============================================================================
+# Create XDebug log file if it doesn't exist and set appropriate permissions.
+if [[ ! -f /tmp/xdebug.log ]]; then
+    touch /tmp/xdebug.log
+fi
+chmod 666 /tmp/xdebug.log
+
+echo "XDebug configuration completed"

--- a/docker/library/dockers/dev-php-fpm-8-2/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-2/Dockerfile
@@ -53,3 +53,9 @@ RUN usermod -u 1000 www-data
 
 # Copy over the php.ini conf
 COPY php.ini /usr/local/etc/php/php.ini
+
+# Copy xdebug installation script for CI coverage support
+# Script is placed at /usr/share/nginx/html/xdebug.sh so CI can call ../xdebug.sh
+# from the OpenEMR directory at /usr/share/nginx/html/openemr
+COPY xdebug.sh /usr/share/nginx/html/xdebug.sh
+RUN chmod +x /usr/share/nginx/html/xdebug.sh

--- a/docker/library/dockers/dev-php-fpm-8-2/xdebug.sh
+++ b/docker/library/dockers/dev-php-fpm-8-2/xdebug.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenEMR dev-php-fpm XDebug Configuration Script
+# ============================================================================
+# This script configures XDebug for PHP debugging, profiling, and coverage.
+# Compatible with Debian-based php-fpm images using install-php-extensions.
+#
+# Environment Variables:
+#   XDEBUG_ON           - Set to "1" to enable XDebug (required)
+#   XDEBUG_IDE_KEY      - IDE key for debugging session (required if XDEBUG_ON not set)
+#   XDEBUG_CLIENT_HOST  - Hostname/IP of the debugging client (optional)
+#   XDEBUG_CLIENT_PORT  - Port for debugging connection (default: 9003)
+#   XDEBUG_PROFILER_ON  - Set to "1" to enable profiling in addition to debugging
+#   XDEBUG_MODE         - Override xdebug mode (e.g., "coverage" for CI)
+#
+# Usage:
+#   Called by CI when coverage is enabled, or manually for debugging
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# NORMALIZE FLAGS
+# ============================================================================
+# Normalize boolean flags once at the start for consistent checking.
+
+case ${XDEBUG_ON:-} in
+    1|[Yy]es|[Tt]rue) xdebug_enabled=true ;;
+    *) xdebug_enabled=false ;;
+esac
+
+case ${XDEBUG_PROFILER_ON:-} in
+    1|[Yy]es|[Tt]rue) profiler_enabled=true ;;
+    *) profiler_enabled=false ;;
+esac
+
+# ============================================================================
+# VALIDATION
+# ============================================================================
+# Ensure XDebug is actually requested before proceeding.
+# At least one of XDEBUG_ON or XDEBUG_IDE_KEY must be set.
+
+if [[ -z "${XDEBUG_IDE_KEY:-}" && "${xdebug_enabled}" = false ]]; then
+    echo "Error: XDebug requested but neither XDEBUG_ON nor XDEBUG_IDE_KEY is set" >&2
+    exit 1
+fi
+
+# ============================================================================
+# INSTALL AND CONFIGURE XDEBUG
+# ============================================================================
+# Install the XDebug PHP extension and configure it.
+# This only runs once per container to avoid repeated installations.
+
+XDEBUG_CONF_FILE="/usr/local/etc/php/conf.d/xdebug.ini"
+
+if [[ ! -f /etc/php-xdebug-configured ]]; then
+    echo "Installing XDebug extension..."
+
+    # Install XDebug using install-php-extensions (works on Debian-based images)
+    install-php-extensions xdebug
+
+    # Determine xdebug mode
+    if [[ -n "${XDEBUG_MODE:-}" ]]; then
+        # Use explicitly set mode (e.g., "coverage" from CI)
+        mode="${XDEBUG_MODE}"
+    elif [[ "${profiler_enabled}" = true ]]; then
+        mode="debug,profile"
+    else
+        mode="debug"
+    fi
+
+    # Configure XDebug
+    {
+        echo "; ========================================================================"
+        echo "; XDebug Configuration"
+        echo "; ========================================================================"
+        echo
+        echo "; XDebug mode: debug, profile, coverage, or combinations"
+        echo "xdebug.mode=${mode}"
+        echo
+        echo "; Directory for XDebug output files (trace files, profiler output)"
+        echo "xdebug.output_dir=/tmp"
+        echo
+        echo "; Start debugging session when triggered (via IDE or browser extension)"
+        echo "xdebug.start_with_request=trigger"
+        echo
+        echo "; Log file for XDebug messages and errors"
+        echo "xdebug.log=/tmp/xdebug.log"
+        echo
+        echo "; Automatically discover the client host (useful for Docker)"
+        echo "xdebug.discover_client_host=1"
+        echo
+        echo "; Port for debugging connection (default: 9003)"
+        echo "xdebug.client_port=${XDEBUG_CLIENT_PORT:-9003}"
+
+        # Override client host if explicitly set
+        if [[ -n "${XDEBUG_CLIENT_HOST:-}" ]]; then
+            echo
+            echo "; Manually configured client host (disables auto-discovery)"
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}"
+        fi
+
+        # Set IDE key if provided
+        if [[ -n "${XDEBUG_IDE_KEY:-}" ]]; then
+            echo
+            echo "; IDE key for debugging session"
+            echo "xdebug.idekey=${XDEBUG_IDE_KEY}"
+        fi
+
+        # Profiler settings
+        if [[ "${profiler_enabled}" = true || "${mode}" == *"profile"* ]]; then
+            echo
+            echo "; Profiler output filename pattern"
+            echo "xdebug.profiler_output_name=cachegrind.out.%s"
+        fi
+        echo
+    } > "${XDEBUG_CONF_FILE}"
+
+    # Mark as configured
+    touch /etc/php-xdebug-configured
+    echo "XDebug installed and configured (mode: ${mode})"
+fi
+
+# ============================================================================
+# ENSURE XDEBUG LOG FILE EXISTS
+# ============================================================================
+# Create XDebug log file if it doesn't exist and set appropriate permissions.
+if [[ ! -f /tmp/xdebug.log ]]; then
+    touch /tmp/xdebug.log
+fi
+chmod 666 /tmp/xdebug.log
+
+echo "XDebug configuration completed"

--- a/docker/library/dockers/dev-php-fpm-8-3-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-3-redis/Dockerfile
@@ -54,3 +54,9 @@ RUN usermod -u 1000 www-data
 
 # Copy over the php.ini conf
 COPY php.ini /usr/local/etc/php/php.ini
+
+# Copy xdebug installation script for CI coverage support
+# Script is placed at /usr/share/nginx/html/xdebug.sh so CI can call ../xdebug.sh
+# from the OpenEMR directory at /usr/share/nginx/html/openemr
+COPY xdebug.sh /usr/share/nginx/html/xdebug.sh
+RUN chmod +x /usr/share/nginx/html/xdebug.sh

--- a/docker/library/dockers/dev-php-fpm-8-3-redis/xdebug.sh
+++ b/docker/library/dockers/dev-php-fpm-8-3-redis/xdebug.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenEMR dev-php-fpm XDebug Configuration Script
+# ============================================================================
+# This script configures XDebug for PHP debugging, profiling, and coverage.
+# Compatible with Debian-based php-fpm images using install-php-extensions.
+#
+# Environment Variables:
+#   XDEBUG_ON           - Set to "1" to enable XDebug (required)
+#   XDEBUG_IDE_KEY      - IDE key for debugging session (required if XDEBUG_ON not set)
+#   XDEBUG_CLIENT_HOST  - Hostname/IP of the debugging client (optional)
+#   XDEBUG_CLIENT_PORT  - Port for debugging connection (default: 9003)
+#   XDEBUG_PROFILER_ON  - Set to "1" to enable profiling in addition to debugging
+#   XDEBUG_MODE         - Override xdebug mode (e.g., "coverage" for CI)
+#
+# Usage:
+#   Called by CI when coverage is enabled, or manually for debugging
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# NORMALIZE FLAGS
+# ============================================================================
+# Normalize boolean flags once at the start for consistent checking.
+
+case ${XDEBUG_ON:-} in
+    1|[Yy]es|[Tt]rue) xdebug_enabled=true ;;
+    *) xdebug_enabled=false ;;
+esac
+
+case ${XDEBUG_PROFILER_ON:-} in
+    1|[Yy]es|[Tt]rue) profiler_enabled=true ;;
+    *) profiler_enabled=false ;;
+esac
+
+# ============================================================================
+# VALIDATION
+# ============================================================================
+# Ensure XDebug is actually requested before proceeding.
+# At least one of XDEBUG_ON or XDEBUG_IDE_KEY must be set.
+
+if [[ -z "${XDEBUG_IDE_KEY:-}" && "${xdebug_enabled}" = false ]]; then
+    echo "Error: XDebug requested but neither XDEBUG_ON nor XDEBUG_IDE_KEY is set" >&2
+    exit 1
+fi
+
+# ============================================================================
+# INSTALL AND CONFIGURE XDEBUG
+# ============================================================================
+# Install the XDebug PHP extension and configure it.
+# This only runs once per container to avoid repeated installations.
+
+XDEBUG_CONF_FILE="/usr/local/etc/php/conf.d/xdebug.ini"
+
+if [[ ! -f /etc/php-xdebug-configured ]]; then
+    echo "Installing XDebug extension..."
+
+    # Install XDebug using install-php-extensions (works on Debian-based images)
+    install-php-extensions xdebug
+
+    # Determine xdebug mode
+    if [[ -n "${XDEBUG_MODE:-}" ]]; then
+        # Use explicitly set mode (e.g., "coverage" from CI)
+        mode="${XDEBUG_MODE}"
+    elif [[ "${profiler_enabled}" = true ]]; then
+        mode="debug,profile"
+    else
+        mode="debug"
+    fi
+
+    # Configure XDebug
+    {
+        echo "; ========================================================================"
+        echo "; XDebug Configuration"
+        echo "; ========================================================================"
+        echo
+        echo "; XDebug mode: debug, profile, coverage, or combinations"
+        echo "xdebug.mode=${mode}"
+        echo
+        echo "; Directory for XDebug output files (trace files, profiler output)"
+        echo "xdebug.output_dir=/tmp"
+        echo
+        echo "; Start debugging session when triggered (via IDE or browser extension)"
+        echo "xdebug.start_with_request=trigger"
+        echo
+        echo "; Log file for XDebug messages and errors"
+        echo "xdebug.log=/tmp/xdebug.log"
+        echo
+        echo "; Automatically discover the client host (useful for Docker)"
+        echo "xdebug.discover_client_host=1"
+        echo
+        echo "; Port for debugging connection (default: 9003)"
+        echo "xdebug.client_port=${XDEBUG_CLIENT_PORT:-9003}"
+
+        # Override client host if explicitly set
+        if [[ -n "${XDEBUG_CLIENT_HOST:-}" ]]; then
+            echo
+            echo "; Manually configured client host (disables auto-discovery)"
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}"
+        fi
+
+        # Set IDE key if provided
+        if [[ -n "${XDEBUG_IDE_KEY:-}" ]]; then
+            echo
+            echo "; IDE key for debugging session"
+            echo "xdebug.idekey=${XDEBUG_IDE_KEY}"
+        fi
+
+        # Profiler settings
+        if [[ "${profiler_enabled}" = true || "${mode}" == *"profile"* ]]; then
+            echo
+            echo "; Profiler output filename pattern"
+            echo "xdebug.profiler_output_name=cachegrind.out.%s"
+        fi
+        echo
+    } > "${XDEBUG_CONF_FILE}"
+
+    # Mark as configured
+    touch /etc/php-xdebug-configured
+    echo "XDebug installed and configured (mode: ${mode})"
+fi
+
+# ============================================================================
+# ENSURE XDEBUG LOG FILE EXISTS
+# ============================================================================
+# Create XDebug log file if it doesn't exist and set appropriate permissions.
+if [[ ! -f /tmp/xdebug.log ]]; then
+    touch /tmp/xdebug.log
+fi
+chmod 666 /tmp/xdebug.log
+
+echo "XDebug configuration completed"

--- a/docker/library/dockers/dev-php-fpm-8-3/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-3/Dockerfile
@@ -53,3 +53,9 @@ RUN usermod -u 1000 www-data
 
 # Copy over the php.ini conf
 COPY php.ini /usr/local/etc/php/php.ini
+
+# Copy xdebug installation script for CI coverage support
+# Script is placed at /usr/share/nginx/html/xdebug.sh so CI can call ../xdebug.sh
+# from the OpenEMR directory at /usr/share/nginx/html/openemr
+COPY xdebug.sh /usr/share/nginx/html/xdebug.sh
+RUN chmod +x /usr/share/nginx/html/xdebug.sh

--- a/docker/library/dockers/dev-php-fpm-8-3/xdebug.sh
+++ b/docker/library/dockers/dev-php-fpm-8-3/xdebug.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenEMR dev-php-fpm XDebug Configuration Script
+# ============================================================================
+# This script configures XDebug for PHP debugging, profiling, and coverage.
+# Compatible with Debian-based php-fpm images using install-php-extensions.
+#
+# Environment Variables:
+#   XDEBUG_ON           - Set to "1" to enable XDebug (required)
+#   XDEBUG_IDE_KEY      - IDE key for debugging session (required if XDEBUG_ON not set)
+#   XDEBUG_CLIENT_HOST  - Hostname/IP of the debugging client (optional)
+#   XDEBUG_CLIENT_PORT  - Port for debugging connection (default: 9003)
+#   XDEBUG_PROFILER_ON  - Set to "1" to enable profiling in addition to debugging
+#   XDEBUG_MODE         - Override xdebug mode (e.g., "coverage" for CI)
+#
+# Usage:
+#   Called by CI when coverage is enabled, or manually for debugging
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# NORMALIZE FLAGS
+# ============================================================================
+# Normalize boolean flags once at the start for consistent checking.
+
+case ${XDEBUG_ON:-} in
+    1|[Yy]es|[Tt]rue) xdebug_enabled=true ;;
+    *) xdebug_enabled=false ;;
+esac
+
+case ${XDEBUG_PROFILER_ON:-} in
+    1|[Yy]es|[Tt]rue) profiler_enabled=true ;;
+    *) profiler_enabled=false ;;
+esac
+
+# ============================================================================
+# VALIDATION
+# ============================================================================
+# Ensure XDebug is actually requested before proceeding.
+# At least one of XDEBUG_ON or XDEBUG_IDE_KEY must be set.
+
+if [[ -z "${XDEBUG_IDE_KEY:-}" && "${xdebug_enabled}" = false ]]; then
+    echo "Error: XDebug requested but neither XDEBUG_ON nor XDEBUG_IDE_KEY is set" >&2
+    exit 1
+fi
+
+# ============================================================================
+# INSTALL AND CONFIGURE XDEBUG
+# ============================================================================
+# Install the XDebug PHP extension and configure it.
+# This only runs once per container to avoid repeated installations.
+
+XDEBUG_CONF_FILE="/usr/local/etc/php/conf.d/xdebug.ini"
+
+if [[ ! -f /etc/php-xdebug-configured ]]; then
+    echo "Installing XDebug extension..."
+
+    # Install XDebug using install-php-extensions (works on Debian-based images)
+    install-php-extensions xdebug
+
+    # Determine xdebug mode
+    if [[ -n "${XDEBUG_MODE:-}" ]]; then
+        # Use explicitly set mode (e.g., "coverage" from CI)
+        mode="${XDEBUG_MODE}"
+    elif [[ "${profiler_enabled}" = true ]]; then
+        mode="debug,profile"
+    else
+        mode="debug"
+    fi
+
+    # Configure XDebug
+    {
+        echo "; ========================================================================"
+        echo "; XDebug Configuration"
+        echo "; ========================================================================"
+        echo
+        echo "; XDebug mode: debug, profile, coverage, or combinations"
+        echo "xdebug.mode=${mode}"
+        echo
+        echo "; Directory for XDebug output files (trace files, profiler output)"
+        echo "xdebug.output_dir=/tmp"
+        echo
+        echo "; Start debugging session when triggered (via IDE or browser extension)"
+        echo "xdebug.start_with_request=trigger"
+        echo
+        echo "; Log file for XDebug messages and errors"
+        echo "xdebug.log=/tmp/xdebug.log"
+        echo
+        echo "; Automatically discover the client host (useful for Docker)"
+        echo "xdebug.discover_client_host=1"
+        echo
+        echo "; Port for debugging connection (default: 9003)"
+        echo "xdebug.client_port=${XDEBUG_CLIENT_PORT:-9003}"
+
+        # Override client host if explicitly set
+        if [[ -n "${XDEBUG_CLIENT_HOST:-}" ]]; then
+            echo
+            echo "; Manually configured client host (disables auto-discovery)"
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}"
+        fi
+
+        # Set IDE key if provided
+        if [[ -n "${XDEBUG_IDE_KEY:-}" ]]; then
+            echo
+            echo "; IDE key for debugging session"
+            echo "xdebug.idekey=${XDEBUG_IDE_KEY}"
+        fi
+
+        # Profiler settings
+        if [[ "${profiler_enabled}" = true || "${mode}" == *"profile"* ]]; then
+            echo
+            echo "; Profiler output filename pattern"
+            echo "xdebug.profiler_output_name=cachegrind.out.%s"
+        fi
+        echo
+    } > "${XDEBUG_CONF_FILE}"
+
+    # Mark as configured
+    touch /etc/php-xdebug-configured
+    echo "XDebug installed and configured (mode: ${mode})"
+fi
+
+# ============================================================================
+# ENSURE XDEBUG LOG FILE EXISTS
+# ============================================================================
+# Create XDebug log file if it doesn't exist and set appropriate permissions.
+if [[ ! -f /tmp/xdebug.log ]]; then
+    touch /tmp/xdebug.log
+fi
+chmod 666 /tmp/xdebug.log
+
+echo "XDebug configuration completed"

--- a/docker/library/dockers/dev-php-fpm-8-4-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-4-redis/Dockerfile
@@ -54,3 +54,9 @@ RUN usermod -u 1000 www-data
 
 # Copy over the php.ini conf
 COPY php.ini /usr/local/etc/php/php.ini
+
+# Copy xdebug installation script for CI coverage support
+# Script is placed at /usr/share/nginx/html/xdebug.sh so CI can call ../xdebug.sh
+# from the OpenEMR directory at /usr/share/nginx/html/openemr
+COPY xdebug.sh /usr/share/nginx/html/xdebug.sh
+RUN chmod +x /usr/share/nginx/html/xdebug.sh

--- a/docker/library/dockers/dev-php-fpm-8-4-redis/xdebug.sh
+++ b/docker/library/dockers/dev-php-fpm-8-4-redis/xdebug.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenEMR dev-php-fpm XDebug Configuration Script
+# ============================================================================
+# This script configures XDebug for PHP debugging, profiling, and coverage.
+# Compatible with Debian-based php-fpm images using install-php-extensions.
+#
+# Environment Variables:
+#   XDEBUG_ON           - Set to "1" to enable XDebug (required)
+#   XDEBUG_IDE_KEY      - IDE key for debugging session (required if XDEBUG_ON not set)
+#   XDEBUG_CLIENT_HOST  - Hostname/IP of the debugging client (optional)
+#   XDEBUG_CLIENT_PORT  - Port for debugging connection (default: 9003)
+#   XDEBUG_PROFILER_ON  - Set to "1" to enable profiling in addition to debugging
+#   XDEBUG_MODE         - Override xdebug mode (e.g., "coverage" for CI)
+#
+# Usage:
+#   Called by CI when coverage is enabled, or manually for debugging
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# NORMALIZE FLAGS
+# ============================================================================
+# Normalize boolean flags once at the start for consistent checking.
+
+case ${XDEBUG_ON:-} in
+    1|[Yy]es|[Tt]rue) xdebug_enabled=true ;;
+    *) xdebug_enabled=false ;;
+esac
+
+case ${XDEBUG_PROFILER_ON:-} in
+    1|[Yy]es|[Tt]rue) profiler_enabled=true ;;
+    *) profiler_enabled=false ;;
+esac
+
+# ============================================================================
+# VALIDATION
+# ============================================================================
+# Ensure XDebug is actually requested before proceeding.
+# At least one of XDEBUG_ON or XDEBUG_IDE_KEY must be set.
+
+if [[ -z "${XDEBUG_IDE_KEY:-}" && "${xdebug_enabled}" = false ]]; then
+    echo "Error: XDebug requested but neither XDEBUG_ON nor XDEBUG_IDE_KEY is set" >&2
+    exit 1
+fi
+
+# ============================================================================
+# INSTALL AND CONFIGURE XDEBUG
+# ============================================================================
+# Install the XDebug PHP extension and configure it.
+# This only runs once per container to avoid repeated installations.
+
+XDEBUG_CONF_FILE="/usr/local/etc/php/conf.d/xdebug.ini"
+
+if [[ ! -f /etc/php-xdebug-configured ]]; then
+    echo "Installing XDebug extension..."
+
+    # Install XDebug using install-php-extensions (works on Debian-based images)
+    install-php-extensions xdebug
+
+    # Determine xdebug mode
+    if [[ -n "${XDEBUG_MODE:-}" ]]; then
+        # Use explicitly set mode (e.g., "coverage" from CI)
+        mode="${XDEBUG_MODE}"
+    elif [[ "${profiler_enabled}" = true ]]; then
+        mode="debug,profile"
+    else
+        mode="debug"
+    fi
+
+    # Configure XDebug
+    {
+        echo "; ========================================================================"
+        echo "; XDebug Configuration"
+        echo "; ========================================================================"
+        echo
+        echo "; XDebug mode: debug, profile, coverage, or combinations"
+        echo "xdebug.mode=${mode}"
+        echo
+        echo "; Directory for XDebug output files (trace files, profiler output)"
+        echo "xdebug.output_dir=/tmp"
+        echo
+        echo "; Start debugging session when triggered (via IDE or browser extension)"
+        echo "xdebug.start_with_request=trigger"
+        echo
+        echo "; Log file for XDebug messages and errors"
+        echo "xdebug.log=/tmp/xdebug.log"
+        echo
+        echo "; Automatically discover the client host (useful for Docker)"
+        echo "xdebug.discover_client_host=1"
+        echo
+        echo "; Port for debugging connection (default: 9003)"
+        echo "xdebug.client_port=${XDEBUG_CLIENT_PORT:-9003}"
+
+        # Override client host if explicitly set
+        if [[ -n "${XDEBUG_CLIENT_HOST:-}" ]]; then
+            echo
+            echo "; Manually configured client host (disables auto-discovery)"
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}"
+        fi
+
+        # Set IDE key if provided
+        if [[ -n "${XDEBUG_IDE_KEY:-}" ]]; then
+            echo
+            echo "; IDE key for debugging session"
+            echo "xdebug.idekey=${XDEBUG_IDE_KEY}"
+        fi
+
+        # Profiler settings
+        if [[ "${profiler_enabled}" = true || "${mode}" == *"profile"* ]]; then
+            echo
+            echo "; Profiler output filename pattern"
+            echo "xdebug.profiler_output_name=cachegrind.out.%s"
+        fi
+        echo
+    } > "${XDEBUG_CONF_FILE}"
+
+    # Mark as configured
+    touch /etc/php-xdebug-configured
+    echo "XDebug installed and configured (mode: ${mode})"
+fi
+
+# ============================================================================
+# ENSURE XDEBUG LOG FILE EXISTS
+# ============================================================================
+# Create XDebug log file if it doesn't exist and set appropriate permissions.
+if [[ ! -f /tmp/xdebug.log ]]; then
+    touch /tmp/xdebug.log
+fi
+chmod 666 /tmp/xdebug.log
+
+echo "XDebug configuration completed"

--- a/docker/library/dockers/dev-php-fpm-8-4/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-4/Dockerfile
@@ -53,3 +53,9 @@ RUN usermod -u 1000 www-data
 
 # Copy over the php.ini conf
 COPY php.ini /usr/local/etc/php/php.ini
+
+# Copy xdebug installation script for CI coverage support
+# Script is placed at /usr/share/nginx/html/xdebug.sh so CI can call ../xdebug.sh
+# from the OpenEMR directory at /usr/share/nginx/html/openemr
+COPY xdebug.sh /usr/share/nginx/html/xdebug.sh
+RUN chmod +x /usr/share/nginx/html/xdebug.sh

--- a/docker/library/dockers/dev-php-fpm-8-4/xdebug.sh
+++ b/docker/library/dockers/dev-php-fpm-8-4/xdebug.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenEMR dev-php-fpm XDebug Configuration Script
+# ============================================================================
+# This script configures XDebug for PHP debugging, profiling, and coverage.
+# Compatible with Debian-based php-fpm images using install-php-extensions.
+#
+# Environment Variables:
+#   XDEBUG_ON           - Set to "1" to enable XDebug (required)
+#   XDEBUG_IDE_KEY      - IDE key for debugging session (required if XDEBUG_ON not set)
+#   XDEBUG_CLIENT_HOST  - Hostname/IP of the debugging client (optional)
+#   XDEBUG_CLIENT_PORT  - Port for debugging connection (default: 9003)
+#   XDEBUG_PROFILER_ON  - Set to "1" to enable profiling in addition to debugging
+#   XDEBUG_MODE         - Override xdebug mode (e.g., "coverage" for CI)
+#
+# Usage:
+#   Called by CI when coverage is enabled, or manually for debugging
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# NORMALIZE FLAGS
+# ============================================================================
+# Normalize boolean flags once at the start for consistent checking.
+
+case ${XDEBUG_ON:-} in
+    1|[Yy]es|[Tt]rue) xdebug_enabled=true ;;
+    *) xdebug_enabled=false ;;
+esac
+
+case ${XDEBUG_PROFILER_ON:-} in
+    1|[Yy]es|[Tt]rue) profiler_enabled=true ;;
+    *) profiler_enabled=false ;;
+esac
+
+# ============================================================================
+# VALIDATION
+# ============================================================================
+# Ensure XDebug is actually requested before proceeding.
+# At least one of XDEBUG_ON or XDEBUG_IDE_KEY must be set.
+
+if [[ -z "${XDEBUG_IDE_KEY:-}" && "${xdebug_enabled}" = false ]]; then
+    echo "Error: XDebug requested but neither XDEBUG_ON nor XDEBUG_IDE_KEY is set" >&2
+    exit 1
+fi
+
+# ============================================================================
+# INSTALL AND CONFIGURE XDEBUG
+# ============================================================================
+# Install the XDebug PHP extension and configure it.
+# This only runs once per container to avoid repeated installations.
+
+XDEBUG_CONF_FILE="/usr/local/etc/php/conf.d/xdebug.ini"
+
+if [[ ! -f /etc/php-xdebug-configured ]]; then
+    echo "Installing XDebug extension..."
+
+    # Install XDebug using install-php-extensions (works on Debian-based images)
+    install-php-extensions xdebug
+
+    # Determine xdebug mode
+    if [[ -n "${XDEBUG_MODE:-}" ]]; then
+        # Use explicitly set mode (e.g., "coverage" from CI)
+        mode="${XDEBUG_MODE}"
+    elif [[ "${profiler_enabled}" = true ]]; then
+        mode="debug,profile"
+    else
+        mode="debug"
+    fi
+
+    # Configure XDebug
+    {
+        echo "; ========================================================================"
+        echo "; XDebug Configuration"
+        echo "; ========================================================================"
+        echo
+        echo "; XDebug mode: debug, profile, coverage, or combinations"
+        echo "xdebug.mode=${mode}"
+        echo
+        echo "; Directory for XDebug output files (trace files, profiler output)"
+        echo "xdebug.output_dir=/tmp"
+        echo
+        echo "; Start debugging session when triggered (via IDE or browser extension)"
+        echo "xdebug.start_with_request=trigger"
+        echo
+        echo "; Log file for XDebug messages and errors"
+        echo "xdebug.log=/tmp/xdebug.log"
+        echo
+        echo "; Automatically discover the client host (useful for Docker)"
+        echo "xdebug.discover_client_host=1"
+        echo
+        echo "; Port for debugging connection (default: 9003)"
+        echo "xdebug.client_port=${XDEBUG_CLIENT_PORT:-9003}"
+
+        # Override client host if explicitly set
+        if [[ -n "${XDEBUG_CLIENT_HOST:-}" ]]; then
+            echo
+            echo "; Manually configured client host (disables auto-discovery)"
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}"
+        fi
+
+        # Set IDE key if provided
+        if [[ -n "${XDEBUG_IDE_KEY:-}" ]]; then
+            echo
+            echo "; IDE key for debugging session"
+            echo "xdebug.idekey=${XDEBUG_IDE_KEY}"
+        fi
+
+        # Profiler settings
+        if [[ "${profiler_enabled}" = true || "${mode}" == *"profile"* ]]; then
+            echo
+            echo "; Profiler output filename pattern"
+            echo "xdebug.profiler_output_name=cachegrind.out.%s"
+        fi
+        echo
+    } > "${XDEBUG_CONF_FILE}"
+
+    # Mark as configured
+    touch /etc/php-xdebug-configured
+    echo "XDebug installed and configured (mode: ${mode})"
+fi
+
+# ============================================================================
+# ENSURE XDEBUG LOG FILE EXISTS
+# ============================================================================
+# Create XDebug log file if it doesn't exist and set appropriate permissions.
+if [[ ! -f /tmp/xdebug.log ]]; then
+    touch /tmp/xdebug.log
+fi
+chmod 666 /tmp/xdebug.log
+
+echo "XDebug configuration completed"

--- a/docker/library/dockers/dev-php-fpm-8-5-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-5-redis/Dockerfile
@@ -88,3 +88,9 @@ RUN usermod -u 1000 www-data
 
 # Copy over the php.ini conf
 COPY php.ini /usr/local/etc/php/php.ini
+
+# Copy xdebug installation script for CI coverage support
+# Script is placed at /usr/share/nginx/html/xdebug.sh so CI can call ../xdebug.sh
+# from the OpenEMR directory at /usr/share/nginx/html/openemr
+COPY xdebug.sh /usr/share/nginx/html/xdebug.sh
+RUN chmod +x /usr/share/nginx/html/xdebug.sh

--- a/docker/library/dockers/dev-php-fpm-8-5-redis/xdebug.sh
+++ b/docker/library/dockers/dev-php-fpm-8-5-redis/xdebug.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenEMR dev-php-fpm XDebug Configuration Script
+# ============================================================================
+# This script configures XDebug for PHP debugging, profiling, and coverage.
+# Compatible with Debian-based php-fpm images using install-php-extensions.
+#
+# Environment Variables:
+#   XDEBUG_ON           - Set to "1" to enable XDebug (required)
+#   XDEBUG_IDE_KEY      - IDE key for debugging session (required if XDEBUG_ON not set)
+#   XDEBUG_CLIENT_HOST  - Hostname/IP of the debugging client (optional)
+#   XDEBUG_CLIENT_PORT  - Port for debugging connection (default: 9003)
+#   XDEBUG_PROFILER_ON  - Set to "1" to enable profiling in addition to debugging
+#   XDEBUG_MODE         - Override xdebug mode (e.g., "coverage" for CI)
+#
+# Usage:
+#   Called by CI when coverage is enabled, or manually for debugging
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# NORMALIZE FLAGS
+# ============================================================================
+# Normalize boolean flags once at the start for consistent checking.
+
+case ${XDEBUG_ON:-} in
+    1|[Yy]es|[Tt]rue) xdebug_enabled=true ;;
+    *) xdebug_enabled=false ;;
+esac
+
+case ${XDEBUG_PROFILER_ON:-} in
+    1|[Yy]es|[Tt]rue) profiler_enabled=true ;;
+    *) profiler_enabled=false ;;
+esac
+
+# ============================================================================
+# VALIDATION
+# ============================================================================
+# Ensure XDebug is actually requested before proceeding.
+# At least one of XDEBUG_ON or XDEBUG_IDE_KEY must be set.
+
+if [[ -z "${XDEBUG_IDE_KEY:-}" && "${xdebug_enabled}" = false ]]; then
+    echo "Error: XDebug requested but neither XDEBUG_ON nor XDEBUG_IDE_KEY is set" >&2
+    exit 1
+fi
+
+# ============================================================================
+# INSTALL AND CONFIGURE XDEBUG
+# ============================================================================
+# Install the XDebug PHP extension and configure it.
+# This only runs once per container to avoid repeated installations.
+
+XDEBUG_CONF_FILE="/usr/local/etc/php/conf.d/xdebug.ini"
+
+if [[ ! -f /etc/php-xdebug-configured ]]; then
+    echo "Installing XDebug extension..."
+
+    # Install XDebug using install-php-extensions (works on Debian-based images)
+    install-php-extensions xdebug
+
+    # Determine xdebug mode
+    if [[ -n "${XDEBUG_MODE:-}" ]]; then
+        # Use explicitly set mode (e.g., "coverage" from CI)
+        mode="${XDEBUG_MODE}"
+    elif [[ "${profiler_enabled}" = true ]]; then
+        mode="debug,profile"
+    else
+        mode="debug"
+    fi
+
+    # Configure XDebug
+    {
+        echo "; ========================================================================"
+        echo "; XDebug Configuration"
+        echo "; ========================================================================"
+        echo
+        echo "; XDebug mode: debug, profile, coverage, or combinations"
+        echo "xdebug.mode=${mode}"
+        echo
+        echo "; Directory for XDebug output files (trace files, profiler output)"
+        echo "xdebug.output_dir=/tmp"
+        echo
+        echo "; Start debugging session when triggered (via IDE or browser extension)"
+        echo "xdebug.start_with_request=trigger"
+        echo
+        echo "; Log file for XDebug messages and errors"
+        echo "xdebug.log=/tmp/xdebug.log"
+        echo
+        echo "; Automatically discover the client host (useful for Docker)"
+        echo "xdebug.discover_client_host=1"
+        echo
+        echo "; Port for debugging connection (default: 9003)"
+        echo "xdebug.client_port=${XDEBUG_CLIENT_PORT:-9003}"
+
+        # Override client host if explicitly set
+        if [[ -n "${XDEBUG_CLIENT_HOST:-}" ]]; then
+            echo
+            echo "; Manually configured client host (disables auto-discovery)"
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}"
+        fi
+
+        # Set IDE key if provided
+        if [[ -n "${XDEBUG_IDE_KEY:-}" ]]; then
+            echo
+            echo "; IDE key for debugging session"
+            echo "xdebug.idekey=${XDEBUG_IDE_KEY}"
+        fi
+
+        # Profiler settings
+        if [[ "${profiler_enabled}" = true || "${mode}" == *"profile"* ]]; then
+            echo
+            echo "; Profiler output filename pattern"
+            echo "xdebug.profiler_output_name=cachegrind.out.%s"
+        fi
+        echo
+    } > "${XDEBUG_CONF_FILE}"
+
+    # Mark as configured
+    touch /etc/php-xdebug-configured
+    echo "XDebug installed and configured (mode: ${mode})"
+fi
+
+# ============================================================================
+# ENSURE XDEBUG LOG FILE EXISTS
+# ============================================================================
+# Create XDebug log file if it doesn't exist and set appropriate permissions.
+if [[ ! -f /tmp/xdebug.log ]]; then
+    touch /tmp/xdebug.log
+fi
+chmod 666 /tmp/xdebug.log
+
+echo "XDebug configuration completed"

--- a/docker/library/dockers/dev-php-fpm-8-5/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-5/Dockerfile
@@ -71,3 +71,9 @@ RUN usermod -u 1000 www-data
 
 # Copy over the php.ini conf
 COPY php.ini /usr/local/etc/php/php.ini
+
+# Copy xdebug installation script for CI coverage support
+# Script is placed at /usr/share/nginx/html/xdebug.sh so CI can call ../xdebug.sh
+# from the OpenEMR directory at /usr/share/nginx/html/openemr
+COPY xdebug.sh /usr/share/nginx/html/xdebug.sh
+RUN chmod +x /usr/share/nginx/html/xdebug.sh

--- a/docker/library/dockers/dev-php-fpm-8-5/xdebug.sh
+++ b/docker/library/dockers/dev-php-fpm-8-5/xdebug.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenEMR dev-php-fpm XDebug Configuration Script
+# ============================================================================
+# This script configures XDebug for PHP debugging, profiling, and coverage.
+# Compatible with Debian-based php-fpm images using install-php-extensions.
+#
+# Environment Variables:
+#   XDEBUG_ON           - Set to "1" to enable XDebug (required)
+#   XDEBUG_IDE_KEY      - IDE key for debugging session (required if XDEBUG_ON not set)
+#   XDEBUG_CLIENT_HOST  - Hostname/IP of the debugging client (optional)
+#   XDEBUG_CLIENT_PORT  - Port for debugging connection (default: 9003)
+#   XDEBUG_PROFILER_ON  - Set to "1" to enable profiling in addition to debugging
+#   XDEBUG_MODE         - Override xdebug mode (e.g., "coverage" for CI)
+#
+# Usage:
+#   Called by CI when coverage is enabled, or manually for debugging
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# NORMALIZE FLAGS
+# ============================================================================
+# Normalize boolean flags once at the start for consistent checking.
+
+case ${XDEBUG_ON:-} in
+    1|[Yy]es|[Tt]rue) xdebug_enabled=true ;;
+    *) xdebug_enabled=false ;;
+esac
+
+case ${XDEBUG_PROFILER_ON:-} in
+    1|[Yy]es|[Tt]rue) profiler_enabled=true ;;
+    *) profiler_enabled=false ;;
+esac
+
+# ============================================================================
+# VALIDATION
+# ============================================================================
+# Ensure XDebug is actually requested before proceeding.
+# At least one of XDEBUG_ON or XDEBUG_IDE_KEY must be set.
+
+if [[ -z "${XDEBUG_IDE_KEY:-}" && "${xdebug_enabled}" = false ]]; then
+    echo "Error: XDebug requested but neither XDEBUG_ON nor XDEBUG_IDE_KEY is set" >&2
+    exit 1
+fi
+
+# ============================================================================
+# INSTALL AND CONFIGURE XDEBUG
+# ============================================================================
+# Install the XDebug PHP extension and configure it.
+# This only runs once per container to avoid repeated installations.
+
+XDEBUG_CONF_FILE="/usr/local/etc/php/conf.d/xdebug.ini"
+
+if [[ ! -f /etc/php-xdebug-configured ]]; then
+    echo "Installing XDebug extension..."
+
+    # Install XDebug using install-php-extensions (works on Debian-based images)
+    install-php-extensions xdebug
+
+    # Determine xdebug mode
+    if [[ -n "${XDEBUG_MODE:-}" ]]; then
+        # Use explicitly set mode (e.g., "coverage" from CI)
+        mode="${XDEBUG_MODE}"
+    elif [[ "${profiler_enabled}" = true ]]; then
+        mode="debug,profile"
+    else
+        mode="debug"
+    fi
+
+    # Configure XDebug
+    {
+        echo "; ========================================================================"
+        echo "; XDebug Configuration"
+        echo "; ========================================================================"
+        echo
+        echo "; XDebug mode: debug, profile, coverage, or combinations"
+        echo "xdebug.mode=${mode}"
+        echo
+        echo "; Directory for XDebug output files (trace files, profiler output)"
+        echo "xdebug.output_dir=/tmp"
+        echo
+        echo "; Start debugging session when triggered (via IDE or browser extension)"
+        echo "xdebug.start_with_request=trigger"
+        echo
+        echo "; Log file for XDebug messages and errors"
+        echo "xdebug.log=/tmp/xdebug.log"
+        echo
+        echo "; Automatically discover the client host (useful for Docker)"
+        echo "xdebug.discover_client_host=1"
+        echo
+        echo "; Port for debugging connection (default: 9003)"
+        echo "xdebug.client_port=${XDEBUG_CLIENT_PORT:-9003}"
+
+        # Override client host if explicitly set
+        if [[ -n "${XDEBUG_CLIENT_HOST:-}" ]]; then
+            echo
+            echo "; Manually configured client host (disables auto-discovery)"
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}"
+        fi
+
+        # Set IDE key if provided
+        if [[ -n "${XDEBUG_IDE_KEY:-}" ]]; then
+            echo
+            echo "; IDE key for debugging session"
+            echo "xdebug.idekey=${XDEBUG_IDE_KEY}"
+        fi
+
+        # Profiler settings
+        if [[ "${profiler_enabled}" = true || "${mode}" == *"profile"* ]]; then
+            echo
+            echo "; Profiler output filename pattern"
+            echo "xdebug.profiler_output_name=cachegrind.out.%s"
+        fi
+        echo
+    } > "${XDEBUG_CONF_FILE}"
+
+    # Mark as configured
+    touch /etc/php-xdebug-configured
+    echo "XDebug installed and configured (mode: ${mode})"
+fi
+
+# ============================================================================
+# ENSURE XDEBUG LOG FILE EXISTS
+# ============================================================================
+# Create XDebug log file if it doesn't exist and set appropriate permissions.
+if [[ ! -f /tmp/xdebug.log ]]; then
+    touch /tmp/xdebug.log
+fi
+chmod 666 /tmp/xdebug.log
+
+echo "XDebug configuration completed"

--- a/docker/library/dockers/dev-php-fpm-8-6-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-6-redis/Dockerfile
@@ -88,3 +88,9 @@ RUN usermod -u 1000 www-data
 
 # Copy over the php.ini conf
 COPY php.ini /usr/local/etc/php/php.ini
+
+# Copy xdebug installation script for CI coverage support
+# Script is placed at /usr/share/nginx/html/xdebug.sh so CI can call ../xdebug.sh
+# from the OpenEMR directory at /usr/share/nginx/html/openemr
+COPY xdebug.sh /usr/share/nginx/html/xdebug.sh
+RUN chmod +x /usr/share/nginx/html/xdebug.sh

--- a/docker/library/dockers/dev-php-fpm-8-6-redis/xdebug.sh
+++ b/docker/library/dockers/dev-php-fpm-8-6-redis/xdebug.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenEMR dev-php-fpm XDebug Configuration Script
+# ============================================================================
+# This script configures XDebug for PHP debugging, profiling, and coverage.
+# Compatible with Debian-based php-fpm images using install-php-extensions.
+#
+# Environment Variables:
+#   XDEBUG_ON           - Set to "1" to enable XDebug (required)
+#   XDEBUG_IDE_KEY      - IDE key for debugging session (required if XDEBUG_ON not set)
+#   XDEBUG_CLIENT_HOST  - Hostname/IP of the debugging client (optional)
+#   XDEBUG_CLIENT_PORT  - Port for debugging connection (default: 9003)
+#   XDEBUG_PROFILER_ON  - Set to "1" to enable profiling in addition to debugging
+#   XDEBUG_MODE         - Override xdebug mode (e.g., "coverage" for CI)
+#
+# Usage:
+#   Called by CI when coverage is enabled, or manually for debugging
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# NORMALIZE FLAGS
+# ============================================================================
+# Normalize boolean flags once at the start for consistent checking.
+
+case ${XDEBUG_ON:-} in
+    1|[Yy]es|[Tt]rue) xdebug_enabled=true ;;
+    *) xdebug_enabled=false ;;
+esac
+
+case ${XDEBUG_PROFILER_ON:-} in
+    1|[Yy]es|[Tt]rue) profiler_enabled=true ;;
+    *) profiler_enabled=false ;;
+esac
+
+# ============================================================================
+# VALIDATION
+# ============================================================================
+# Ensure XDebug is actually requested before proceeding.
+# At least one of XDEBUG_ON or XDEBUG_IDE_KEY must be set.
+
+if [[ -z "${XDEBUG_IDE_KEY:-}" && "${xdebug_enabled}" = false ]]; then
+    echo "Error: XDebug requested but neither XDEBUG_ON nor XDEBUG_IDE_KEY is set" >&2
+    exit 1
+fi
+
+# ============================================================================
+# INSTALL AND CONFIGURE XDEBUG
+# ============================================================================
+# Install the XDebug PHP extension and configure it.
+# This only runs once per container to avoid repeated installations.
+
+XDEBUG_CONF_FILE="/usr/local/etc/php/conf.d/xdebug.ini"
+
+if [[ ! -f /etc/php-xdebug-configured ]]; then
+    echo "Installing XDebug extension..."
+
+    # Install XDebug using install-php-extensions (works on Debian-based images)
+    install-php-extensions xdebug
+
+    # Determine xdebug mode
+    if [[ -n "${XDEBUG_MODE:-}" ]]; then
+        # Use explicitly set mode (e.g., "coverage" from CI)
+        mode="${XDEBUG_MODE}"
+    elif [[ "${profiler_enabled}" = true ]]; then
+        mode="debug,profile"
+    else
+        mode="debug"
+    fi
+
+    # Configure XDebug
+    {
+        echo "; ========================================================================"
+        echo "; XDebug Configuration"
+        echo "; ========================================================================"
+        echo
+        echo "; XDebug mode: debug, profile, coverage, or combinations"
+        echo "xdebug.mode=${mode}"
+        echo
+        echo "; Directory for XDebug output files (trace files, profiler output)"
+        echo "xdebug.output_dir=/tmp"
+        echo
+        echo "; Start debugging session when triggered (via IDE or browser extension)"
+        echo "xdebug.start_with_request=trigger"
+        echo
+        echo "; Log file for XDebug messages and errors"
+        echo "xdebug.log=/tmp/xdebug.log"
+        echo
+        echo "; Automatically discover the client host (useful for Docker)"
+        echo "xdebug.discover_client_host=1"
+        echo
+        echo "; Port for debugging connection (default: 9003)"
+        echo "xdebug.client_port=${XDEBUG_CLIENT_PORT:-9003}"
+
+        # Override client host if explicitly set
+        if [[ -n "${XDEBUG_CLIENT_HOST:-}" ]]; then
+            echo
+            echo "; Manually configured client host (disables auto-discovery)"
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}"
+        fi
+
+        # Set IDE key if provided
+        if [[ -n "${XDEBUG_IDE_KEY:-}" ]]; then
+            echo
+            echo "; IDE key for debugging session"
+            echo "xdebug.idekey=${XDEBUG_IDE_KEY}"
+        fi
+
+        # Profiler settings
+        if [[ "${profiler_enabled}" = true || "${mode}" == *"profile"* ]]; then
+            echo
+            echo "; Profiler output filename pattern"
+            echo "xdebug.profiler_output_name=cachegrind.out.%s"
+        fi
+        echo
+    } > "${XDEBUG_CONF_FILE}"
+
+    # Mark as configured
+    touch /etc/php-xdebug-configured
+    echo "XDebug installed and configured (mode: ${mode})"
+fi
+
+# ============================================================================
+# ENSURE XDEBUG LOG FILE EXISTS
+# ============================================================================
+# Create XDebug log file if it doesn't exist and set appropriate permissions.
+if [[ ! -f /tmp/xdebug.log ]]; then
+    touch /tmp/xdebug.log
+fi
+chmod 666 /tmp/xdebug.log
+
+echo "XDebug configuration completed"

--- a/docker/library/dockers/dev-php-fpm-8-6/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-6/Dockerfile
@@ -71,3 +71,9 @@ RUN usermod -u 1000 www-data
 
 # Copy over the php.ini conf
 COPY php.ini /usr/local/etc/php/php.ini
+
+# Copy xdebug installation script for CI coverage support
+# Script is placed at /usr/share/nginx/html/xdebug.sh so CI can call ../xdebug.sh
+# from the OpenEMR directory at /usr/share/nginx/html/openemr
+COPY xdebug.sh /usr/share/nginx/html/xdebug.sh
+RUN chmod +x /usr/share/nginx/html/xdebug.sh

--- a/docker/library/dockers/dev-php-fpm-8-6/xdebug.sh
+++ b/docker/library/dockers/dev-php-fpm-8-6/xdebug.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenEMR dev-php-fpm XDebug Configuration Script
+# ============================================================================
+# This script configures XDebug for PHP debugging, profiling, and coverage.
+# Compatible with Debian-based php-fpm images using install-php-extensions.
+#
+# Environment Variables:
+#   XDEBUG_ON           - Set to "1" to enable XDebug (required)
+#   XDEBUG_IDE_KEY      - IDE key for debugging session (required if XDEBUG_ON not set)
+#   XDEBUG_CLIENT_HOST  - Hostname/IP of the debugging client (optional)
+#   XDEBUG_CLIENT_PORT  - Port for debugging connection (default: 9003)
+#   XDEBUG_PROFILER_ON  - Set to "1" to enable profiling in addition to debugging
+#   XDEBUG_MODE         - Override xdebug mode (e.g., "coverage" for CI)
+#
+# Usage:
+#   Called by CI when coverage is enabled, or manually for debugging
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# NORMALIZE FLAGS
+# ============================================================================
+# Normalize boolean flags once at the start for consistent checking.
+
+case ${XDEBUG_ON:-} in
+    1|[Yy]es|[Tt]rue) xdebug_enabled=true ;;
+    *) xdebug_enabled=false ;;
+esac
+
+case ${XDEBUG_PROFILER_ON:-} in
+    1|[Yy]es|[Tt]rue) profiler_enabled=true ;;
+    *) profiler_enabled=false ;;
+esac
+
+# ============================================================================
+# VALIDATION
+# ============================================================================
+# Ensure XDebug is actually requested before proceeding.
+# At least one of XDEBUG_ON or XDEBUG_IDE_KEY must be set.
+
+if [[ -z "${XDEBUG_IDE_KEY:-}" && "${xdebug_enabled}" = false ]]; then
+    echo "Error: XDebug requested but neither XDEBUG_ON nor XDEBUG_IDE_KEY is set" >&2
+    exit 1
+fi
+
+# ============================================================================
+# INSTALL AND CONFIGURE XDEBUG
+# ============================================================================
+# Install the XDebug PHP extension and configure it.
+# This only runs once per container to avoid repeated installations.
+
+XDEBUG_CONF_FILE="/usr/local/etc/php/conf.d/xdebug.ini"
+
+if [[ ! -f /etc/php-xdebug-configured ]]; then
+    echo "Installing XDebug extension..."
+
+    # Install XDebug using install-php-extensions (works on Debian-based images)
+    install-php-extensions xdebug
+
+    # Determine xdebug mode
+    if [[ -n "${XDEBUG_MODE:-}" ]]; then
+        # Use explicitly set mode (e.g., "coverage" from CI)
+        mode="${XDEBUG_MODE}"
+    elif [[ "${profiler_enabled}" = true ]]; then
+        mode="debug,profile"
+    else
+        mode="debug"
+    fi
+
+    # Configure XDebug
+    {
+        echo "; ========================================================================"
+        echo "; XDebug Configuration"
+        echo "; ========================================================================"
+        echo
+        echo "; XDebug mode: debug, profile, coverage, or combinations"
+        echo "xdebug.mode=${mode}"
+        echo
+        echo "; Directory for XDebug output files (trace files, profiler output)"
+        echo "xdebug.output_dir=/tmp"
+        echo
+        echo "; Start debugging session when triggered (via IDE or browser extension)"
+        echo "xdebug.start_with_request=trigger"
+        echo
+        echo "; Log file for XDebug messages and errors"
+        echo "xdebug.log=/tmp/xdebug.log"
+        echo
+        echo "; Automatically discover the client host (useful for Docker)"
+        echo "xdebug.discover_client_host=1"
+        echo
+        echo "; Port for debugging connection (default: 9003)"
+        echo "xdebug.client_port=${XDEBUG_CLIENT_PORT:-9003}"
+
+        # Override client host if explicitly set
+        if [[ -n "${XDEBUG_CLIENT_HOST:-}" ]]; then
+            echo
+            echo "; Manually configured client host (disables auto-discovery)"
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}"
+        fi
+
+        # Set IDE key if provided
+        if [[ -n "${XDEBUG_IDE_KEY:-}" ]]; then
+            echo
+            echo "; IDE key for debugging session"
+            echo "xdebug.idekey=${XDEBUG_IDE_KEY}"
+        fi
+
+        # Profiler settings
+        if [[ "${profiler_enabled}" = true || "${mode}" == *"profile"* ]]; then
+            echo
+            echo "; Profiler output filename pattern"
+            echo "xdebug.profiler_output_name=cachegrind.out.%s"
+        fi
+        echo
+    } > "${XDEBUG_CONF_FILE}"
+
+    # Mark as configured
+    touch /etc/php-xdebug-configured
+    echo "XDebug installed and configured (mode: ${mode})"
+fi
+
+# ============================================================================
+# ENSURE XDEBUG LOG FILE EXISTS
+# ============================================================================
+# Create XDebug log file if it doesn't exist and set appropriate permissions.
+if [[ ! -f /tmp/xdebug.log ]]; then
+    touch /tmp/xdebug.log
+fi
+chmod 666 /tmp/xdebug.log
+
+echo "XDebug configuration completed"


### PR DESCRIPTION
## Summary

Fixes #10368

Add xdebug.sh installation script to all dev-php-fpm images to enable code coverage collection in scheduled CI runs.

## Changes

- Add `xdebug.sh` script to all dev-php-fpm images (PHP 8.2-8.6, including redis variants)
- Update Dockerfiles to copy the script to `/usr/share/nginx/html/xdebug.sh`

The script uses `install-php-extensions xdebug` (compatible with Debian-based images) and supports the same environment variables as the flex images (`XDEBUG_ON`, `XDEBUG_IDE_KEY`, `XDEBUG_MODE`, etc.).

## Test plan

- [x] Rebuild one of the dev-php-fpm images locally
- [x] Verify `../xdebug.sh` can be called from the OpenEMR directory
- [ ] Run the scheduled test workflow to confirm coverage works

## AI Disclosure

Yes