### PR TITLE
fix: correct typos in interface files

### DIFF
--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -622,7 +622,7 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                     <?php
                         // TPS = This Page Search
                         // The following are the search criteria per page.All the following variable which ends with 'Master' need to be filled properly.
-                        // Each item is seperated by a comma(,).
+                        // Each item is separated by a comma(,).
                         // $TPSCriteriaDisplayMaster ==>It is the display on screen for the set of criteria.
                         // $TPSCriteriaKeyMaster ==>Corresponding database fields in the same order.
                         // $TPSCriteriaDataTypeMaster ==>Corresponding data type in the same order.
@@ -720,7 +720,7 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                         $TPSCriteriaQueryDropDownMasterDefaultKey[1] = "all"; // Only one item will be here
                         // The below section is needed if there is any 'include' type in the $TPSCriteriaDataTypeMaster
                         // Function name is added here.Corresponding include files need to be included in the respective pages as done in this page.
-                        // It is labled(Included for Insurance ajax criteria)(Line:-279-299).
+                        // It is labeled(Included for Insurance ajax criteria)(Line:-279-299).
                         $TPSCriteriaIncludeMaster[1] = "OpenEMR\Billing\BillingReport::insuranceCompanyDisplay";
                         if (!isset($_REQUEST['mode'])) {// default case
                             $_REQUEST['final_this_page_criteria'][0] = "form_encounter.date|between|" . date("Y-m-d 00:00:00") . "|" . date("Y-m-d 23:59:59");
@@ -1032,7 +1032,7 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                                 // Add Encounter Date to display with "To Encounter" button 2/17/09 JCH
                                 $lhtml .= "<span class='font-weight-bold' style='color: " . attr($namecolor) . "'>" . text($ptname) . "</span><span class=small>&nbsp;(" . text($iter['enc_pid']) . "-" . text($iter['enc_encounter']) . ")</span>";
 
-                                // Encounter details are stored to javacript as array.
+                                // Encounter details are stored to javascript as array.
                                 $result4 = sqlStatement(
                                     "SELECT fe.encounter,fe.date,fe.billing_note,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
                                     " LEFT JOIN openemr_postcalendar_categories ON fe.pc_catid=openemr_postcalendar_categories.pc_catid  WHERE fe.pid = ? ORDER BY fe.date DESC",

--- a/interface/billing/edi_270.php
+++ b/interface/billing/edi_270.php
@@ -37,11 +37,11 @@ if (!empty($_POST)) {
     }
 }
 
-// Element data seperator
+// Element data separator
 $eleDataSep = "*";
 // Segment Terminator
 $segTer = "~";
-// Component Element seperator
+// Component Element separator
 $compEleSep     = ":";
 
 // filter conditions for the report and batch creation

--- a/interface/billing/edih_main.php
+++ b/interface/billing/edih_main.php
@@ -23,7 +23,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 define('SITE_IN', 1);
 
 // define constants
-// since enounter digits are sequential, digit length should rarely change
+// since encounter digits are sequential, digit length should rarely change
 // however for a startup they may, or a "mask" value of 1000 or 10000
 // would be a good idea if there are problems with deciphering the pid-encounter
 // same idea for pid value, but since encounter is unique and always last, it is essential
@@ -99,7 +99,7 @@ if (!is_dir($edih_tmp_dir)) {
     }
 }
 
-// avoid unitialized variable error
+// avoid uninitialized variable error
 $html_str = '';
 // debug
 if (count($_GET)) {

--- a/interface/billing/edit_payment.php
+++ b/interface/billing/edit_payment.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Payments can be edited here whch includes deletion of an allocation, modifying the
+ * Payments can be edited here, which includes deletion of an allocation, modifying the
  * same or adding a new allocation. Log is kept for the deleted ones.
  * The functions of this class support the billing process like the script billing_process.php.
  *
@@ -367,7 +367,7 @@ $ResultSearchSub = sqlStatement(
             }
             if (CompletlyBlankAbove())//The distribution rows already in the database are checked.
             {
-                alert(<?php echo xlj('None of the Top Distribution Row Can be Completly Blank.'); ?> +"\n" + <?php echo xlj('Use Delete Option to Remove.'); ?>);
+                alert(<?php echo xlj('None of the Top Distribution Row Can be Completely Blank.'); ?> +"\n" + <?php echo xlj('Use Delete Option to Remove.'); ?>);
                 return false;
             }
     if (!CheckPayingEntityAndDistributionPostFor()) {
@@ -403,7 +403,7 @@ $ResultSearchSub = sqlStatement(
             }
             if (CompletlyBlankAbove())//The distribution rows already in the database are checked.
             {
-                alert(<?php echo xlj('None of the Top Distribution Row Can be Completly Blank.'); ?> +"\n" + <?php echo xlj('Use Delete Option to Remove.'); ?>);
+                alert(<?php echo xlj('None of the Top Distribution Row Can be Completely Blank.'); ?> +"\n" + <?php echo xlj('Use Delete Option to Remove.'); ?>);
                 return false;
             }
             if (!CheckPayingEntityAndDistributionPostFor())//Ensures that Insurance payment is distributed under Ins1,Ins2,Ins3 and Patient paymentat under Pat.
@@ -447,7 +447,7 @@ $ResultSearchSub = sqlStatement(
         }
 
         function CompletlyBlankAbove() {//The distribution rows already in the database are checked.
-            //It is not allowed to be made completly empty.If needed delete option need to be used.
+            //It is not allowed to be made completely empty.If needed delete option need to be used.
     let CountIndexAbove = document.getElementById('CountIndexAbove').value * 1;
             for (RowCount = 1; RowCount <= CountIndexAbove; RowCount++) {
                 if (document.getElementById('Allowed' + RowCount).value == '' && document.getElementById('Payment' + RowCount).value == '' && document.getElementById('AdjAmount' + RowCount).value == '' && document.getElementById('Deductible' + RowCount).value == '' && document.getElementById('Takeback' + RowCount).value == '' && document.getElementById('FollowUp' + RowCount).checked == false) {
@@ -458,7 +458,7 @@ $ResultSearchSub = sqlStatement(
         }
 
         function CompletlyBlankBelow() {//The newly added distribution rows are checked.
-            //It is not allowed to be made completly empty.
+            //It is not allowed to be made completely empty.
     let CountIndexAbove = document.getElementById('CountIndexAbove').value * 1;
     let CountIndexBelow = document.getElementById('CountIndexBelow').value * 1;
             if (CountIndexBelow == 0)
@@ -767,9 +767,8 @@ $ResultSearchSub = sqlStatement(
                                         $rowMoneyAdjusted = sqlFetchArray($resMoneyAdjusted);
                                         $MoneyAdjusted = $rowMoneyAdjusted['MoneyAdjusted'];
                                     } else {
-                                        //Fetch till that much got
-                                        //Fetch the HIGHEST sequence_no till this session.
-                                        //Used maily in  the case if primary/others pays once more.
+                                        // Get the highest sequence_no for this session to calculate running totals.
+                                        // Handles cases where primary or other payers submit additional payments.
                                         $resSequence = sqlStatement("SELECT sequence_no from ar_activity where session_id=? and
                                     pid=? and encounter=? order by sequence_no desc ", [$payment_id, $PId, $Encounter]);
                                         $rowSequence = sqlFetchArray($resSequence);
@@ -816,9 +815,8 @@ $ResultSearchSub = sqlStatement(
                                         $rowMoneyAdjusted = sqlFetchArray($resMoneyAdjusted);
                                         $MoneyAdjusted = $rowMoneyAdjusted['MoneyAdjusted'];
                                     } else {
-                                        //Got just before the previous
-                                        //Fetch the LOWEST sequence_no till this session.
-                                        //Used maily in  the case if primary/others pays once more.
+                                        // Get the lowest sequence_no for this session to calculate totals from the start.
+                                        // Handles cases where primary or other payers submit additional payments.
                                         $resSequence = sqlStatement(
                                             "SELECT sequence_no FROM ar_activity WHERE " .
                                             "session_id = ? AND deleted IS NULL AND pid = ? AND encounter = ? " .

--- a/interface/billing/print_daysheet_report_num1.php
+++ b/interface/billing/print_daysheet_report_num1.php
@@ -109,7 +109,7 @@ if (!isset($_GET["mode"])) {
             $itero = [];
 
             if ($ret = getBillsBetweendayReport($code_type)) {
-            // checking to see if there is any information in the array if not display a message (located after this if statment)
+            // checking to see if there is any information in the array if not display a message (located after this if statement)
                 $anypats = count($ret);
                 $run_provider = 0;
                 $old_pid = -1;
@@ -124,7 +124,7 @@ if (!isset($_GET["mode"])) {
                     $catch_provider[] = $iter['provider_id'];
                 }
 
-            //This statment uniques the arrays removing duplicates
+            //This statement uniques the arrays removing duplicates
 
                 $user_list = array_unique($catch_user);
                 $provider_list = array_unique($catch_provider);
@@ -132,7 +132,7 @@ if (!isset($_GET["mode"])) {
             // reorder the list starting with array element zero
                 $user_final_list = array_values($user_list);
                 $provider_final_list = array_values($provider_list);
-            // sort array in assending order
+            // sort array in ascending order
                 sort($user_final_list);
                 sort($provider_final_list);
                 $all4 = array_natsort($ret, 'pid', 'fulname', 'asc');
@@ -146,7 +146,7 @@ if (!isset($_GET["mode"])) {
                 }
 
                 foreach ($all4 as $iter) {
-                    // Case statment to tally information by user
+                    // Case statement to tally information by user
                     switch ($iter['user']) {
                         case $user_final_list[0]:
                             $us0_user = $iter['user'];
@@ -570,7 +570,7 @@ if (!isset($_GET["mode"])) {
                             break;
                     }
 
-                    // Case statment to tally information by Provider
+                    // Case statement to tally information by Provider
                     switch ($iter['provider_id']) {
                         case $provider_final_list[0]:
                             $pro0_user = $iter['provider_id'];
@@ -1217,7 +1217,7 @@ if (!isset($_GET["mode"])) {
                 ?><p><?php echo xlt('No Data to Process')?></p><?php
             }
 
-            // TEST TO SEE IF THERE IS INFORMATION IN THE VARAIBLES THEN ADD TO AN ARRAY FOR PRINTING
+            // TEST TO SEE IF THERE IS INFORMATION IN THE VARIABLES THEN ADD TO AN ARRAY FOR PRINTING
             if ($run_provider != 1) {
                 if ($us0_fee != 0 || $us0_inspay != 0 || $us0_insadj != 0 || $us0_patadj != 0 || $us0_patpay != 0 || $us0_insref != 0 || $us0_patref != 0) {
                     $user_info['user'][$k] = $us0_user;

--- a/interface/billing/print_daysheet_report_num2.php
+++ b/interface/billing/print_daysheet_report_num2.php
@@ -110,7 +110,7 @@ $the_first_time = 1;
 $itero = [];
 
 if ($ret = getBillsBetweendayReport($code_type)) {
-// checking to see if there is any information in the array if not display a message (located after this if statment)
+// checking to see if there is any information in the array if not display a message (located after this if statement)
     $anypats = count($ret);
 
 
@@ -125,11 +125,11 @@ if ($ret = getBillsBetweendayReport($code_type)) {
           $catch_user[] = $iter['user'];
     }
 
-//This statment uniques the array removing duplicates
+//This statement uniques the array removing duplicates
     $user_list = array_unique($catch_user);
 // reorder the list starting with array element zero
     $final_list = array_values($user_list);
-// sort array in assending order
+// sort array in ascending order
     sort($final_list);
 
     $all4 = array_natsort($ret, 'pid', 'fulname', 'asc');
@@ -139,7 +139,7 @@ if ($ret = getBillsBetweendayReport($code_type)) {
     }
 
     foreach ($all4 as $iter) {
-        // Case statment to tally information by user
+        // Case statement to tally information by user
         switch ($iter['user']) {
             case $final_list[0]:
                 $us0_user = $iter['user'];
@@ -478,7 +478,7 @@ if ($anypats == 0) {
     ?><font size = 5 ><?php echo xlt('No Data to Process')?></font><?php
 }
 
-// TEST TO SEE IF THERE IS INFORMATION IN THE VARAIBLES THEN ADD TO AN ARRAY FOR PRINTING
+// TEST TO SEE IF THERE IS INFORMATION IN THE VARIABLES THEN ADD TO AN ARRAY FOR PRINTING
 
 if ($us0_fee != 0 || $us0_inspay != 0 || $us0_insadj != 0 || $us0_patadj != 0 || $us0_patpay != 0) {
     $user_info['user'][$k] = $us0_user;

--- a/interface/billing/print_daysheet_report_num3.php
+++ b/interface/billing/print_daysheet_report_num3.php
@@ -111,7 +111,7 @@ $the_first_time = 1;
 $itero = [];
 
 if ($ret = getBillsBetweendayReport($code_type)) {
-// checking to see if there is any information in the array if not display a message (located after this if statment)
+// checking to see if there is any information in the array if not display a message (located after this if statement)
     $anypats = count($ret);
 
 
@@ -126,12 +126,12 @@ if ($ret = getBillsBetweendayReport($code_type)) {
           $catch_user[] = $iter['user'];
     }
 
-//This statment uniques the array removing duplicates
+//This statement uniques the array removing duplicates
     $user_list = array_unique($catch_user);
 // reorder the list starting with array element zero
     $final_list = array_values($user_list);
 
-// sort array in assending order
+// sort array in ascending order
     sort($final_list);
 
     $all4 = array_natsort($ret, 'pid', 'fulname', 'asc');
@@ -140,7 +140,7 @@ if ($ret = getBillsBetweendayReport($code_type)) {
     }
 
     foreach ($all4 as $iter) {
-        // Case statment to tally information by user
+        // Case statement to tally information by user
         switch ($iter['user']) {
             case $final_list[0]:
                 $us0_user = $iter['user'];
@@ -503,7 +503,7 @@ if ($anypats == 0) {
     ?><span><?php echo xlt('No Data to Process')?></span><?php
 }
 
-// TEST TO SEE IF THERE IS INFORMATION IN THE VARAIBLES THEN ADD TO AN ARRAY FOR PRINTING
+// TEST TO SEE IF THERE IS INFORMATION IN THE VARIABLES THEN ADD TO AN ARRAY FOR PRINTING
 
 if ($us0_fee != 0 || $us0_inspay != 0 || $us0_insadj != 0 || $us0_patadj != 0 || $us0_patpay != 0) {
     $user_info['user'][$k] = $us0_user;

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -67,7 +67,7 @@ $form_cb = false;
 
 /* Load dependencies only if we need them */
 if (!empty($GLOBALS['portal_onsite_two_enable'])) {
-    /* Addition of onsite portal patient notify of invoice and reformated invoice - sjpadgett 01/2017 */
+    /* Addition of onsite portal patient notify of invoice and reformatted invoice - sjpadgett 01/2017 */
     require_once("../../portal/lib/portal_mail.inc.php");
     require_once("../../portal/lib/appsql.class.php");
 

--- a/interface/billing/ub04_dispose.php
+++ b/interface/billing/ub04_dispose.php
@@ -42,7 +42,7 @@ function ub04_dispose(): void
         } elseif ($dispose == "reset_claim") {
             $pid = $_POST['pid'] ?? $_GET['pid'];
             $encounter = $_POST['encounter'] ?? $_GET['encounter'];
-            // clear claim first otherwise get ub04 returns cuurent version.
+            // clear claim first otherwise get ub04 returns current version.
             //
             $flg = exist_ub04_claim($pid, $encounter, true);
             if ($flg === true) {

--- a/interface/clickmap/AbstractClickmapModel.php
+++ b/interface/clickmap/AbstractClickmapModel.php
@@ -124,7 +124,7 @@ abstract class AbstractClickmapModel extends ORDataObject
     /**
      * @brief Override this abstract function with your implementation of getCode.
      *
-     * @return A string thats a 'code' for this form.
+     * @return A string that's a 'code' for this form.
      */
     abstract function getCode();
 

--- a/interface/clickmap/C_AbstractClickmap.php
+++ b/interface/clickmap/C_AbstractClickmap.php
@@ -65,7 +65,7 @@ abstract class C_AbstractClickmap extends Controller
     abstract public function createModel($form_id = "");
 
     /**
-     * @brief Override this abstract function with your implememtation of getImage
+     * @brief Override this abstract function with your implementation of getImage
      *
      * @return The path to the image backing this form relative to the webroot.
      */
@@ -79,7 +79,7 @@ abstract class C_AbstractClickmap extends Controller
     abstract function getOptionsLabel();
 
     /**
-     * @brief Override this abstract functon to return a hash of the optionlist (key=>value pairs).
+     * @brief Override this abstract function to return a hash of the optionlist (key=>value pairs).
      *
      * @return A hash of key=>value pairs, representing all the possible options in the dropdown boxes on this form.
      */

--- a/interface/code_systems/list_staged.php
+++ b/interface/code_systems/list_staged.php
@@ -48,7 +48,7 @@ $file_checksum = "";
 //
 // Get current revision (if installed)
 //
-// this retreives the most recent revision_date for a table "name"
+// this retrieves the most recent revision_date for a table "name"
 //
 // for SNOMED and RXNORM you get the date from the filename as those naming
 // conventions allow for that derivation
@@ -102,7 +102,7 @@ if (is_dir($mainPATH)) {
             if ($db == 'RXNORM') {
                 if (preg_match("/RxNorm_full_([0-9]{8}).zip/", $file, $matches)) {
             // Hard code the version RxNorm feed to be Standard
-                    //  (if add different RxNorm types/versions/lanuages, then can use this)
+                    //  (if add different RxNorm types/versions/languages, then can use this)
             //
                     $version = "Standard";
                     $date_release = substr($matches[1], 4) . "-" . substr($matches[1], 0, 2) . "-" . substr($matches[1], 2, -4);
@@ -143,7 +143,7 @@ if (is_dir($mainPATH)) {
                     // of a International SNOMED version.
                     // Hard code this version SNOMED feed to be US Extension
                     // Note the US extension package has been deprecated for some time and was replaced by the Complete US extension package, which is
-                    // a complete SNOMED pacakge.
+                    // a complete SNOMED package.
                     //
                     $version = "US Extension";
                     $date_release = substr($matches[1], 0, 4) . "-" . substr($matches[1], 4, -2) . "-" . substr($matches[1], 6);
@@ -206,7 +206,7 @@ if (is_dir($mainPATH)) {
                     $supported_file = 1;
                 } elseif (preg_match("/SnomedCT_ManagedServiceUS_PRODUCTION_US[0-9]{7}_([0-9a-zA-Z]{8})T[0-9Z]{7}.zip/", $file, $matches)) {
                     // Hard code the version SNOMED feed to be Complete US Extension
-                    // file format changed in 2024 so need to handle previous versions for backwards compatability and new ones.
+                    // file format changed in 2024 so need to handle previous versions for backwards compatibility and new ones.
                     //
                     $version = "Complete US Extension";
                     $rf2 = true;
@@ -232,7 +232,7 @@ if (is_dir($mainPATH)) {
                 // this query determines whether you can load the data into openEMR. you must have the correct
                 // filename and checksum for each file that are part of the same release.
                 //
-                // IMPORTANT: Releases that contain mutliple zip file (e.g. ICD10) are grouped together based
+                // IMPORTANT: Releases that contain multiple zip file (e.g. ICD10) are grouped together based
                 // on the load_release_date attribute value specified in the supported_external_dataloads table
                 //
                 // Just in case same filename is released on different release dates, best to actually include the md5sum in the query itself.
@@ -363,7 +363,7 @@ if ($supported_file === 1) {
             if ($current_name == "SNOMED" && $current_version != $file_revision && $file_revision != "US Extension" && $current_version == "US Extension") {
                 // The US extension for snomed has been previously installed, so will allow to Replace with installation of any international set.
                 // Note the US extension package has been deprecated for some time and was replaced by the Complete US extension package, which is
-                // a complete SNOMED pacakge.
+                // a complete SNOMED package.
                 ?>
                 <div class="stg"><?php echo text(basename($file_revision_path)); ?> <?php echo xlt("is a different version of the following database") . ": " . text($db); ?></div>
                 <?php
@@ -377,7 +377,7 @@ if ($supported_file === 1) {
             } elseif ($current_name == "SNOMED" && $current_version == "US Extension" && $file_revision == "US Extension") {
                 // The Staged US Extension SNOMED package has already been installed
                 // Note the US extension package has been deprecated for some time and was replaced by the Complete US extension package, which is
-                // a complete SNOMED pacakge.
+                // a complete SNOMED package.
                 ?>
                 <div class="error_msg"><?php echo xlt("The compatible staged US Extension SNOMED package has already been installed."); ?></div>
             <div class="stg msg"><?php echo xlt("Follow these instructions for installing or upgrading the following database") . ": " . text($db); ?><span class="msg" id="<?php echo attr($db); ?>_instrmsg">?</span></div>
@@ -385,7 +385,7 @@ if ($supported_file === 1) {
             } elseif ($current_name == "SNOMED" && $current_version != "International:English" && $file_revision == "US Extension") {
                 // The Staged US Extension SNOMED file is not compatible with non-english snomed sets
                 // Note the US extension package has been deprecated for some time and was replaced by the Complete US extension package, which is
-                // a complete SNOMED pacakge.
+                // a complete SNOMED package.
                 ?>
                 <div class="error_msg"><?php echo xlt("The installed International SNOMED version is not compatible with the staged US Extension SNOMED package."); ?></div>
             <div class="stg msg"><?php echo xlt("Follow these instructions for installing or upgrading the following database") . ": " . text($db); ?><span class="msg" id="<?php echo attr($db); ?>_instrmsg">?</span></div>
@@ -393,14 +393,14 @@ if ($supported_file === 1) {
             } elseif (($current_name == "SNOMED" && $current_version == "International:English" && $file_revision == "US Extension") && ((strtotime($current_revision . " +6 month") < strtotime((string) $file_revision_date)) || (strtotime($current_revision . " -6 month") > strtotime((string) $file_revision_date)))) {
                 // The Staged US Extension SNOMED file is not compatible with the current SNOMED International Package (ie. the International package is outdated)
                 // Note the US extension package has been deprecated for some time and was replaced by the Complete US extension package, which is
-                // a complete SNOMED pacakge.
+                // a complete SNOMED package.
                 ?>
                 <div class="error_msg"><?php echo xlt("The installed International SNOMED version is out of date and not compatible with the staged US Extension SNOMED file."); ?></div>
             <div class="stg msg"><?php echo xlt("Follow these instructions for installing or upgrading the following database") . ": " . text($db); ?><span class="msg" id="<?php echo attr($db); ?>_instrmsg">?</span></div>
                 <?php
             } elseif ($current_name == "SNOMED" && $current_version == "International:English" && $file_revision == "US Extension") {
                 // Note the US extension package has been deprecated for some time and was replaced by the Complete US extension package, which is
-                // a complete SNOMED pacakge.
+                // a complete SNOMED package.
                 // Offer to upgrade to the US Extension.
                 ?>
                 <div class="stg"><?php echo text(basename($file_revision_path)); ?> <?php echo xlt("is an extension of the following database") . ": " . text($db); ?></div>
@@ -409,7 +409,7 @@ if ($supported_file === 1) {
             } elseif ((strtotime((string) $current_revision) == strtotime((string) $file_revision_date))) {
                 // Note the exception here when installing US Extension
                 // Note the US extension package has been deprecated for some time and was replaced by the Complete US extension package, which is
-                // a complete SNOMED pacakge.
+                // a complete SNOMED package.
                 ?>
             <div class="error_msg"><?php echo xlt("The installed version and the staged files are the same."); ?></div>
             <div class="stg msg"><?php echo xlt("Follow these instructions for installing or upgrading the following database") . ": " . text($db); ?><span class="msg" id="<?php echo attr($db); ?>_instrmsg">?</span></div>
@@ -417,7 +417,7 @@ if ($supported_file === 1) {
             } elseif (strtotime((string) $current_revision) > strtotime((string) $file_revision_date)) {
                 // Note the exception here when installing US Extension
                 // Note the US extension package has been deprecated for some time and was replaced by the Complete US extension package, which is
-                // a complete SNOMED pacakge.
+                // a complete SNOMED package.
                 ?>
                 <div class="error_msg"><?php echo xlt("The installed version is a more recent version than the staged files."); ?></div>
                 <div class="stg msg"><?php echo xlt("Follow these instructions for installing or upgrading the following database") . ": " . text($db); ?><span class="msg" id="<?php echo attr($db); ?>_instrmsg">?</span></div>
@@ -432,7 +432,7 @@ if ($supported_file === 1) {
             if ($db == "SNOMED" && $file_revision == "US Extension") {
                 // The old Staged US Extension SNOMED package could not be installed by itself (it was done after the international package is installed).
                 // Note the US extension package has been deprecated for some time and was replaced by the Complete US extension package, which is
-                // a complete SNOMED pacakge.
+                // a complete SNOMED package.
                 ?>
                 <div class="error_msg"><?php echo xlt("The staged US Extension SNOMED package can not be installed until after the International SNOMED package has been installed."); ?></div>
             <div class="stg msg"><?php echo xlt("Follow these instructions for installing or upgrading the following database") . ": " . text($db); ?><span class="msg" id="<?php echo attr($db); ?>_instrmsg">?</span></div>

--- a/interface/de_identification_forms/de_identification_screen1.php
+++ b/interface/de_identification_forms/de_identification_screen1.php
@@ -337,7 +337,7 @@ if (empty($row)) {
         }
 
         if ($no_of_items <= 1) {
-       //start new search - no patient record fount
+       //start new search - no patient record found
             $query = "update de_identification_status set status = 0";
             $res = sqlStatement($query);
             ?>
@@ -406,7 +406,7 @@ if (empty($row)) {
         <td>&nbsp;</td>
         <td rowspan="3">
         <br />
-        <?php echo xlt('Some error has occured during De Identification Process');
+        <?php echo xlt('Some error has occurred during De Identification Process');
           echo "<br /><br />";
           echo xlt('De Identified data may not be complete');
           echo "<br /><br />";

--- a/interface/de_identification_forms/re_identification_input_screen.php
+++ b/interface/de_identification_forms/re_identification_input_screen.php
@@ -162,7 +162,7 @@ function download_file()
             }
 
             if ($no_of_items <= 1) {
-                //start new search - no patient record fount
+                //start new search - no patient record found
                 $query = "update re_identification_status set status = 0";
                 $res = sqlStatement($query);
                 ?>

--- a/interface/de_identification_forms/re_identification_op_single_patient.php
+++ b/interface/de_identification_forms/re_identification_op_single_patient.php
@@ -150,9 +150,9 @@ system($sh_cmd);
     <tr valign="top">
         <td>&nbsp;</td>
         <td rowspan="3"><br />
-        <?php echo xlt('No match Patient record found for the given Re Idenitification code');
+        <?php echo xlt('No matching patient record found for the given re-identification code');
         echo "<br /><br />";
-        echo xlt('Please enter correct Re Identification code');
+        echo xlt('Please enter correct re-identification code');
         echo "<br />";   ?> <br />
         </td>
         <td>&nbsp;</td>

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -591,7 +591,7 @@ if (!empty($glrow)) {
         // the $css_header_value is set above
         $new_theme = 'rtl_' . $temp_css_theme_name;
 
-        // Check file existance
+        // Check file existence
         if (file_exists($webserver_root . '/public/themes/' . $new_theme)) {
             //Escape css file name using 'attr' for security (prevent XSS).
             $GLOBALS['css_header'] = $web_root . '/public/themes/' . attr($new_theme) . '?v=' . $v_js_includes;
@@ -609,7 +609,7 @@ if (!empty($glrow)) {
         // the $css_header_value is set above
         $new_theme = 'rtl_' . $portal_temp_css_theme_name;
 
-        // Check file existance
+        // Check file existence
         if (file_exists($webserver_root . '/public/themes/' . $new_theme)) {
             //Escape css file name using 'attr' for security (prevent XSS).
             $GLOBALS['portal_css_header'] = $web_root . '/public/themes/' . attr($new_theme) . '?v=' . $v_js_includes;

--- a/interface/language/lang_constant.php
+++ b/interface/language/lang_constant.php
@@ -54,7 +54,7 @@ if (!empty($_POST['add'])) {
         $sql = "INSERT INTO lang_constants SET constant_name=?";
         sqlStatement($sql, [$_POST['constant_name']]);
 
-                //insert into the log table - to allow persistant customizations
+                //insert into the log table - to allow persistent customizations
             insert_language_log('', '', $_POST['constant_name'], '');
 
         echo xlt('Constant') . ' ' . text($_POST['constant_name']) . ' ' . xlt('added') . '<br />';

--- a/interface/language/lang_definition.php
+++ b/interface/language/lang_definition.php
@@ -117,7 +117,7 @@ if (!empty($_POST['load'])) {
         CsrfUtils::csrfNotVerified();
     }
 
-  // query for entering new definitions it picks the cons_id because is existant.
+  // query for entering new definitions; uses cons_id because the constant already exists.
     if (!empty($_POST['cons_id'])) {
         foreach ($_POST['cons_id'] as $key => $value) {
             $value = trim((string) $value);
@@ -131,7 +131,7 @@ if (!empty($_POST['load'])) {
             $sql = "INSERT INTO lang_definitions (`cons_id`,`lang_id`,`definition`) VALUES (?,?,?)";
             sqlStatement($sql, [$key, $_POST['lang_id'], $value]);
 
-            // insert each entry into the log table - to allow persistant customizations
+            // insert each entry into the log table - to allow persistent customizations
             $sql = "SELECT lang_description, lang_code FROM lang_languages WHERE lang_id=? LIMIT 1";
             $res = sqlStatement($sql, [$_POST['lang_id']]);
             $row_l = sqlFetchArray($res);
@@ -158,7 +158,7 @@ if (!empty($_POST['load'])) {
                 $sql = "UPDATE `lang_definitions` SET `definition`=? WHERE `def_id`=? LIMIT 1";
                 sqlStatement($sql, [$value, $key]);
 
-                // insert each entry into the log table - to allow persistant customizations
+                // insert each entry into the log table - to allow persistent customizations
                 $sql = "SELECT ll.lang_description, ll.lang_code, lc.constant_name ";
                 $sql .= "FROM lang_definitions AS ld, lang_languages AS ll, lang_constants AS lc ";
                 $sql .= "WHERE ld.def_id=? ";

--- a/interface/language/lang_language.php
+++ b/interface/language/lang_language.php
@@ -54,7 +54,7 @@ if (!empty($_POST['add'])) {
         $sql = "INSERT INTO lang_languages SET lang_code=?, lang_description=?";
         sqlStatement($sql, [$_POST['lang_code'],$_POST['lang_name']]);
 
-        //insert into the log table - to allow persistant customizations
+        //insert into the log table - to allow persistent customizations
         insert_language_log($_POST['lang_name'], $_POST['lang_code'], '', '');
 
             echo xlt('Language definition added') . '<br />';

--- a/interface/main/backup.php
+++ b/interface/main/backup.php
@@ -771,7 +771,7 @@ if ($form_step == 102) {
         }
         if (!empty($form_sel_lists)) {
             foreach ($form_sel_lists as $listid) {
-                // skip if have backtic(s)
+                // skip if have backtick(s)
                 if (str_contains((string) $listid, '`')) {
                     echo xlt("Skipping illegal list name") . ": " . text($listid) . "<br>";
                     continue;
@@ -810,7 +810,7 @@ if ($form_step == 102) {
             $do_history_repair = false;
             $do_demographics_repair = false;
             foreach ($_POST['form_sel_layouts'] as $layoutid) {
-                // skip if have backtic(s)
+                // skip if have backtick(s)
                 if (str_contains((string) $layoutid, '`')) {
                     echo xlt("Skipping illegal layout name") . ": " . text($layoutid) . "<br>";
                     continue;

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -237,7 +237,7 @@ function DOBandEncounter($pc_eid): void
             # Capture the appt status and room number for patient tracker. This will map the encounter to it also.
             if (isset($GLOBALS['temporary-eid-for-manage-tracker']) || !empty($_GET['eid'])) {
                 // Note that the temporary-eid-for-manage-tracker is used to capture the eid for new appointments and when separate a recurring
-                // appointment. It is set in the InsertEvent() function. Note that in the case of spearating a recurrent appointment, the get eid
+                // appointment. It is set in the InsertEvent() function. Note that in the case of separating a recurrent appointment, the get eid
                 // parameter is actually erroneous(is eid of the recurrent appt and not the new separated appt), so need to use the
                 // temporary-eid-for-manage-tracker global instead.
                 $temp_eid = $GLOBALS['temporary-eid-for-manage-tracker'] ?? $_GET['eid'];
@@ -387,7 +387,7 @@ if (!empty($_POST['form_action']) && ($_POST['form_action'] == "duplicate" || $_
             if (in_array($my_repeat_type, [5, 7, 8, 9])) { //Added conditions for 7th, 8th, 9th.
                 $my_repeat_on_num = intval((date('j', $time) - 1) / 7) + 1;
             } else {
-                // Last occurence of this weekday on the month
+                // Last occurrence of this weekday on the month
                 $my_repeat_on_num = 5; // Might need adjustment for new options.
             }
             // Maybe not needed, but for consistency with postcalendar:
@@ -470,7 +470,7 @@ if (!empty($_POST['form_action']) && ($_POST['form_action'] == "save")) {
 
             // ===== Only current event of repeating series =====
             if ($_POST['recurr_affect'] == 'current') {
-                // update all existing event records to exlude the current date
+                // update all existing event records to exclude the current date
                 foreach ($providers_current as $provider) {
                     // update the provider's original event
                     // get the original event's repeat specs
@@ -1497,7 +1497,7 @@ if ($_GET['group'] === true && $have_group_global_enabled) { ?>
     // multi providers
     // =======================================
     if ($GLOBALS['select_multi_providers']) {
-        //  there are two posible situations: edit and new record
+        //  there are two possible situations: edit and new record
         $providers_array = [];
         // this is executed only on edit ($eid)
         if ($eid) {
@@ -1865,7 +1865,7 @@ function are_days_checked(){
 * this enable to add new rules for this form in the pageValidation list.
 * */
 var collectvalidation = <?php echo $collectthis; ?>;
-function validateform(event,valu){
+function validateform(event,value){
     let allDay = document.getElementById('rballday1').checked;
     collectvalidation.form_hour = {
         numericality: {
@@ -1965,7 +1965,7 @@ function validateform(event,valu){
     var submit = submitme(1, event, <?php echo js_escape($form_id); ?>, collectvalidation);
     if(!submit)return $('#form_save').attr('disabled', false);
 
-    $('#form_action').val(valu);
+    $('#form_action').val(value);
 
     <?php if ($repeats) : ?>
     // existing repeating events need additional prompt

--- a/interface/main/calendar/includes/pnAPI.php
+++ b/interface/main/calendar/includes/pnAPI.php
@@ -529,7 +529,7 @@ function pnVarPrepHTMLDisplay()
 }
 
 /**
- * ready databse output
+ * ready database output
  * <br />
  * Gets a variable, cleaning it up such that the text is
  * stored in a database exactly as expected

--- a/interface/main/calendar/includes/pnMod.php
+++ b/interface/main/calendar/includes/pnMod.php
@@ -272,14 +272,14 @@ function pnModAPILoad($modname, $type = 'user')
         require "modules/$osdirectory/pnlang/eng/{$ostype}api.php";
     }
 
-    // Load datbase info
+    // Load database info
     pnModDBInfoLoad($modname, $directory);
 
     return true;
 }
 
 /**
- * load datbase definition for a module
+ * load database definition for a module
  * @param name - name of module to load database definition for
  * @param directory - directory that module is in (if known)
  * @returns bool
@@ -391,7 +391,7 @@ function pnModLoad($modname, $type = 'user')
         require "modules/$osdirectory/pnlang/eng/$ostype.php";
     }
 
-    // Load datbase info
+    // Load database info
     pnModDBInfoLoad($modname, $directory);
 
     // Return the module name

--- a/interface/main/calendar/modules/PostCalendar/pnincludes/AnchorPosition.js
+++ b/interface/main/calendar/modules/PostCalendar/pnincludes/AnchorPosition.js
@@ -25,7 +25,7 @@ Last modified: 2/18/02
 DESCRIPTION: These functions find the position of an <A> tag in a document,
 so other elements can be positioned relative to it.
 
-COMPATABILITY: Works with Netscape 4.x, 6.x, IE 5.x on Windows. Some small
+COMPATIBILITY: Works with Netscape 4.x, 6.x, IE 5.x on Windows. Some small
 positioning errors - usually with Window positioning - occur on the
 Macintosh platform.
 

--- a/interface/main/calendar/modules/PostCalendar/pnincludes/ColorPicker2.js
+++ b/interface/main/calendar/modules/PostCalendar/pnincludes/ColorPicker2.js
@@ -26,7 +26,7 @@ DESCRIPTION: This widget is used to select a color, in hexadecimal #RRGGBB
 form. It uses a color "swatch" to display the standard 216-color web-safe
 palette. The user can then click on a color to select it.
 
-COMPATABILITY: See notes in AnchorPosition.js and PopupWindow.js.
+COMPATIBILITY: See notes in AnchorPosition.js and PopupWindow.js.
 Only the latest DHTML-capable browsers will show the color and hex values
 at the bottom as your mouse goes over them.
 

--- a/interface/main/calendar/modules/PostCalendar/pnincludes/Date/Calc.php
+++ b/interface/main/calendar/modules/PostCalendar/pnincludes/Date/Calc.php
@@ -1331,7 +1331,7 @@ class Date_Calc
      * Calculates the date of the Nth weekday of the month,
      * such as the second Saturday of January 2000.
      *
-     * @param string occurance: 1=first, 2=second, 3=third, etc.
+     * @param string occurrence: 1=first, 2=second, 3=third, etc.
      * @param string dayOfWeek: 0=Sunday, 1=Monday, etc.
      * @param string year in format CCYY
      * @param string month in format MM
@@ -1342,16 +1342,16 @@ class Date_Calc
      * @return string date in given format
      */
 
-    static function NWeekdayOfMonth($occurance, $dayOfWeek, $month, $year, $format = "%Y%m%d")
+    static function NWeekdayOfMonth($occurrence, $dayOfWeek, $month, $year, $format = "%Y%m%d")
     {
 
         $year = sprintf("%04d", $year);
         $month = sprintf("%02d", $month);
 
-        $DOW1day = sprintf("%02d", (($occurance - 1) * 7 + 1));
+        $DOW1day = sprintf("%02d", (($occurrence - 1) * 7 + 1));
         $DOW1 = Date_Calc::dayOfWeek($DOW1day, $month, $year);
 
-        $wdate = ($occurance - 1) * 7 + 1 +
+        $wdate = ($occurrence - 1) * 7 + 1 +
                 (7 + $dayOfWeek - $DOW1) % 7;
 
         if ($wdate > Date_Calc::daysInMonth($month, $year)) {
@@ -1593,7 +1593,7 @@ class Date_Calc
     } // end func getWeekdayFullname
 
     /**
-    * Returns the numeric month from the month name or an abreviation
+    * Returns the numeric month from the month name or an abbreviation
     *
     * Both August and Aug would return 8.
     * Month name is case insensitive.
@@ -1615,7 +1615,7 @@ class Date_Calc
     }
 
     /**
-    * Retunrs an array of month names
+    * Returns an array of month names
     *
     * Used to take advantage of the setlocale function to return
     * language specific month names.

--- a/interface/main/calendar/modules/PostCalendar/pnincludes/PopupWindow.js
+++ b/interface/main/calendar/modules/PostCalendar/pnincludes/PopupWindow.js
@@ -26,7 +26,7 @@ DESCRIPTION: This object allows you to easily and quickly popup a window
 in a certain place. The window can either be a DIV or a separate browser
 window.
 
-COMPATABILITY: Works with Netscape 4.x, 6.x, IE 5.x on Windows. Some small
+COMPATIBILITY: Works with Netscape 4.x, 6.x, IE 5.x on Windows. Some small
 positioning errors - usually with Window positioning - occur on the
 Macintosh platform. Due to bugs in Netscape 4.x, populating the popup
 window with <STYLE> tags may cause errors.

--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -174,7 +174,7 @@ function postcalendar_userapi_buildView($args)
     $tpl = new pcSmarty();
 
     //if(!$tpl->is_cached("$template_name/views/$viewtype/$template_view_load.html",$cacheid)) {
-    //diable caching completely
+    //disable caching completely
     if (true) {
         //=================================================================
         //  Let's just finish setting things up
@@ -1205,8 +1205,8 @@ function getBlockTime($time)
 }
 
 /*==========================
- * Gather up all the Events matching the arguements
- * Arguements can be:
+ * Gather up all the Events matching the arguments
+ * Arguments can be:
  *  start = starting date in m/d/Y format
  *  end = ending date in m/d/Y format
  *  viewtype = day|week|month|year
@@ -1407,7 +1407,7 @@ function calculateEvents($days, $events, $viewtype)
                         $excluded = false;
                         if (isset($exdate)) {
                             foreach (explode(",", (string) $exdate) as $exception) {
-                                // occurrance format == yyyy-mm-dd
+                                // occurrence format == yyyy-mm-dd
                                 // exception format == yyyymmdd
                                 if (preg_replace("/-/", "", (string) $occurance) == $exception) {
                                     $excluded = true;
@@ -1470,7 +1470,7 @@ function calculateEvents($days, $events, $viewtype)
                 }
 
                 // $nd will sometimes be 29, 30 or 31 and if used in the mktime functions
-                // below a problem with overfow will occur so it is set to 1 to prevent this.
+                // below a problem with overflow will occur so it is set to 1 to prevent this.
                 // (for rt2 appointments set prior to fix it remains unchanged). This can be done
                 // since $nd has no influence past the mktime functions - epsdky 2016.
 
@@ -1492,7 +1492,7 @@ function calculateEvents($days, $events, $viewtype)
                         $excluded = false;
                         if (isset($exdate)) {
                             foreach (explode(",", (string) $exdate) as $exception) {
-                                // occurrance format == yyyy-mm-dd
+                                // occurrence format == yyyy-mm-dd
                                 // exception format == yyyymmdd
                                 if (preg_replace("/-/", "", $occurance) == $exception) {
                                     $excluded = true;

--- a/interface/main/dated_reminders/dated_reminders.php
+++ b/interface/main/dated_reminders/dated_reminders.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-// removed as jquery is already called in messages page (if you need to use jQuery, uncomment it futher down)
+// removed as jquery is already called in messages page (if you need to use jQuery, uncomment it further down)
 require_once(__DIR__ . '/../../globals.php');
 require_once("$srcdir/dated_reminder_functions.php");
 
@@ -29,7 +29,7 @@ $today = strtotime(date('Y/m/d'));
 // ----- set $hasAlerts to false, this is used for auto-hiding reminders if there are no due or overdue reminders
 $hasAlerts = false;
 
-// mulitply $updateDelay by 1000 to get miliseconds
+// multiply $updateDelay by 1000 to get milliseconds
 $updateDelay *= 1000;
 
 //-----------------------------------------------------------------------------

--- a/interface/main/dated_reminders/dated_reminders_add.php
+++ b/interface/main/dated_reminders/dated_reminders_add.php
@@ -79,14 +79,14 @@ if ($_POST) {
  // ------ fills an array with all recipients
     $sendTo = $_POST['sendTo'];
 
-  // for incase of data error, this allows the previously entered data to re-populate the boxes
+  // in case of a data error, this allows the previously entered data to re-populate the boxes
     $this_message['message'] = ($_POST['message'] ?? '');
     $this_message['priority'] = ($_POST['priority'] ?? '');
     $this_message['dueDate'] = ($_POST['dueDate'] ?? '');
 
 
 // --------------------------------------------------------------------------------------------------------------------------
-// --- check for the post, if it is valid, commit to the database, close this window and run opener.Handeler
+// --- check for the post, if it is valid, commit to the database, close this window and run opener.Handler
     if (
 // ------- check sendTo is not empty
         !empty($sendTo) and

--- a/interface/main/holidays/Holidays_Storage.php
+++ b/interface/main/holidays/Holidays_Storage.php
@@ -78,7 +78,7 @@ class Holidays_Storage
             }
 
             $row = [
-                self::CALENDAR_CATEGORY_HOLIDAY,//catgory
+                self::CALENDAR_CATEGORY_HOLIDAY,//category
                 0,//authid
                 0,//pid
                 $holiday['description'],//title

--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -400,7 +400,7 @@ if ($GLOBALS['login_into_facility']) {
     }
     $_SESSION['facilityId'] = $facility_id;
     if ($GLOBALS['set_facility_cookie']) {
-        // set cookie with facility for the calender screens
+        // set cookie with facility for the calendar screens
         setcookie("pc_facility", (string) $_SESSION['facilityId'], ['expires' => time() + (3600 * 365), 'path' => $GLOBALS['webroot']]);
     }
 }

--- a/interface/main/messages/save.php
+++ b/interface/main/messages/save.php
@@ -150,7 +150,7 @@ if ($_REQUEST['MedEx'] == "start") {
         }
         //then redirect user to preferences with a success message!
     } else {
-        echo xlt("Sorry you are not privileged enough. Enrollment is limited to Adminstrator accounts.");
+        echo xlt("Sorry you are not privileged enough. Enrollment is limited to Administrator accounts.");
     }
     exit;
 }

--- a/interface/orders/orders_results.php
+++ b/interface/orders/orders_results.php
@@ -349,7 +349,7 @@ if (!empty($_POST['form_submit']) && !empty($_POST['form_line'])) {
                             <?php
                         } // end header for batch option
                         ?>
-                        <!-- removed by jcw -- check/submit sequece too tedious.  This is a quick fix -->
+                        <!-- removed by jcw -- check/submit sequence too tedious.  This is a quick fix -->
                         <!--   <input type='checkbox' name='form_all' value='1' <?php if (!empty($_POST['form_all'])) {
                             echo " checked";
                                                                                 } ?>><?php echo xlt('Include Completed') ?>&nbsp;-->
@@ -410,7 +410,7 @@ if (!empty($_POST['form_submit']) && !empty($_POST['form_line'])) {
                     "po.date_ordered, po.procedure_order_id, " .
                     "pc.procedure_order_seq, pr.procedure_report_id";
 
-                // removed by jcw -- check/submit sequece too tedious.  This is a quick fix
+                // removed by jcw -- check/submit sequence too tedious.  This is a quick fix
                 //$where = empty($_POST['form_all']) ?
                 //  "( pr.report_status IS NULL OR pr.report_status = '' OR pr.report_status = 'prelim' )" :
                 //  "1 = 1";

--- a/interface/orders/receive_hl7_results.inc.php
+++ b/interface/orders/receive_hl7_results.inc.php
@@ -1364,7 +1364,7 @@ function receive_hl7_results(&$hl7, &$matchreq, $lab_id = 0, $direction = 'B', $
             $ares['result_text'] = $result_text;
             $ares['date'] = rhl7DateTime($a[14] ?? '');
             //$ares['facility'] = rhl7Text($a[15]);
-            // Ensoftek: Units may have mutiple segments(as seen in MU2 samples), parse and take just first segment.
+            // Ensoftek: Units may have multiple segments(as seen in MU2 samples), parse and take just first segment.
             $tmp = explode($d2, ($a[6] ?? ''));
             $ares['units'] = rhl7Text($tmp[0]);
             $ares['range'] = rhl7Text($a[7] ?? '');

--- a/interface/orders/types_edit.php
+++ b/interface/orders/types_edit.php
@@ -756,7 +756,7 @@ function recursiveDelete($typeid): void
                 </form>
             </div>
         </div>
-    </div><!--end of conatainer div-->
+    </div><!--end of container div-->
     <script>
         //jqury-ui tooltip
         $(function () {

--- a/interface/patient_file/barcode_label.php
+++ b/interface/patient_file/barcode_label.php
@@ -102,7 +102,7 @@ if ($GLOBALS['barcode_label_type'] == '12') {   // datamatrix
 }
 
 // -------------------------------------------------- //
-//            ALLOCATE FPDF RESSOURCE
+//            ALLOCATE FPDF RESOURCE
 // -------------------------------------------------- //
 
 $pdf = new eFPDF('P', 'mm', [102,252]); // set the orentation, unit of measure and size of the page

--- a/interface/patient_file/download_template.php
+++ b/interface/patient_file/download_template.php
@@ -216,7 +216,7 @@ function doSubs($s)
            /* defaults to ISO standard date format yyyy-mm-dd
             * modified by string following ':' as follows
             * 'global' will use the global date format setting
-            * 'YYYY-MM-DD', 'MM/DD/YYYY', 'DD/MM/YYYY' overide the global setting
+            * 'YYYY-MM-DD', 'MM/DD/YYYY', 'DD/MM/YYYY' override the global setting
             * anything else is ignored
             *
             * oeFormatShortDate($date = 'today', $showYear = true) - OpenEMR function to format
@@ -230,7 +230,7 @@ function doSubs($s)
                 /* use global setting */
                 $currentdate = oeFormatShortDate(date('Y-m-d'), true);
             } elseif (
-                /* there's an overiding format */
+                /* there's an overriding format */
                     preg_match('/YYYY-MM-DD/i', $matched, $matches)
             ) {
                    /* nothing to do here as this is the default format */

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -62,7 +62,7 @@ if ($is_group && !AclMain::aclCheckCore("groups", "glog", false, ['view', 'write
 }
 
 $eventDispatcher = $GLOBALS['kernel']->getEventDispatcher();
-// instantiate the locator at the beginning so our file caching can be re-used.
+// instantiate the locator at the beginning so our file caching can be reused.
 $formLocator = new FormLocator();
 ?>
 <!DOCTYPE html>
@@ -525,7 +525,7 @@ if (!empty($GLOBALS['google_signin_enabled']) && !empty($GLOBALS['google_signin_
 </head>
 <body>
 <nav>
-    <?php //DYNAMIC FORM RETREIVAL
+    <?php //DYNAMIC FORM RETRIEVAL
     require_once("$srcdir/registry.inc.php");
 
     $reg = getFormsByCategory();

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -942,7 +942,7 @@ $(function () {
     // Report tooltip where popover will stay open for 30 seconds
     // or mouse leaves popover or user clicks anywhere in popover.
     // this will allow user to enter popover report view and scroll if report
-    // height is overflowed. Poporver will eiter close when mouse leaves view
+    // height is overflowed. Popover will either close when mouse leaves view
     // or user clicks anywhere in view.
     $('[data-toggle="PopOverReport"]').on('show.bs.popover', function () {
         let elements = $('[aria-describedby^="popover"]');

--- a/interface/patient_file/pos_checkout_normal.php
+++ b/interface/patient_file/pos_checkout_normal.php
@@ -552,7 +552,7 @@ function generate_receipt($patient_id, $encounter = 0): void
         "<br />";
     }
 
-    // Pring receipt header for Provider
+    // Print receipt header for Provider
     function printProviderHeader($pvdrow): void
     {
         echo text($pvdrow['title']) . " " . text($pvdrow['fname']) . " " . text($pvdrow['mname']) . " " . text($pvdrow['lname']) . " " .

--- a/interface/patient_file/report/custom_report.php
+++ b/interface/patient_file/report/custom_report.php
@@ -184,7 +184,7 @@ function zip_content($source, $destination, $content = '', $create = true)
     <?php Header::setupHeader(['esign-theme-only', 'search-highlight']); ?>
     <?php } ?>
 
-    <?php // do not show stuff from report.php in forms that is encaspulated
+    <?php // do not show stuff from report.php in forms that is encapsulated
     // by div of navigateLink class. Specifically used for CAMOS, but
     // can also be used by other forms that require output in the
     // encounter listings output, but not in the custom report. ?>

--- a/interface/patient_file/report/patient_report.php
+++ b/interface/patient_file/report/patient_report.php
@@ -2,8 +2,8 @@
 
 /**
  * Patient report
- * TODO: Note that this file can be refactored to re-use shared code with the portal_patient_report.php file
- * that file has been refactored to use twig templates and this file could be reworked to re-use much of that code
+ * TODO: Note that this file can be refactored to reuse shared code with the portal_patient_report.php file
+ * that file has been refactored to use twig templates and this file could be reworked to reuse much of that code
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org

--- a/interface/patient_file/rules/patient_data.php
+++ b/interface/patient_file/rules/patient_data.php
@@ -92,7 +92,7 @@ if ($_POST['form_complete'] ?? null) {
     }
 
     // Save that form as a row in rule_patient_data table
-    //  and then close the window/modul.
+    //  and then close the window/module.
 
     // Collect and trim variables
     if (isset($_POST['form_entryID'])) {

--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -540,7 +540,7 @@ function getCodeText($code)
 
     // Called when the Active checkbox is clicked.  For consistency we
     // use the existence of an end date to indicate inactivity, even
-    // though the simple verion of the form does not show an end date.
+    // though the simple version of the form does not show an end date.
     function activeClicked(cb) {
         var f = document.forms[0];
         if (cb.checked) {

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -934,7 +934,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
             var EncounterIdArray = [];
             var Count = 0;
                 <?php
-            //Encounter details are stored to javacript as array.
+            //Encounter details are stored to javascript as array.
                 $result4 = sqlStatement("SELECT fe.encounter,fe.date,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
                 " left join openemr_postcalendar_categories on fe.pc_catid=openemr_postcalendar_categories.pc_catid  WHERE fe.pid = ? order by fe.date desc", [$pid]);
                 if (sqlNumRows($result4) > 0) {
@@ -978,7 +978,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
         border-radius: 0;
       }
 
-      /* Short term fix. This ensures the problem list, allergies, medications, and immunization cards handle long lists without interuppting
+      /* Short term fix. This ensures the problem list, allergies, medications, and immunization cards handle long lists without interrupting
          the UI. This should be configurable and should go in a more appropriate place
       .pami-list {
           max-height: 200px;
@@ -1852,7 +1852,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 }
                             }
 
-                            // Note the translaution occurs here instead of in teh Twig file for some specific concatenation needs
+                            // Note the translaution occurs here instead of in the Twig file for some specific concatenation needs
                             $etitle = xl('(Click to edit)');
                             if ($row['pc_hometext'] != "") {
                                 $etitle = xl('Comments') . ": " . ($row['pc_hometext']) . "\r\n" . $etitle;

--- a/interface/patient_file/summary/disc_fragment.php
+++ b/interface/patient_file/summary/disc_fragment.php
@@ -24,7 +24,7 @@ if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
 /**
  * Retrieve the recent 'N' disclosures.
  * @param $pid   -  patient id.
- * @param $limit -  certain limit up to which the disclosures are to be displyed.
+ * @param $limit -  certain limit up to which the disclosures are to be displayed.
  */
 function getDisclosureByDate($pid, $limit)
 {

--- a/interface/patient_tracker/patient_tracker.php
+++ b/interface/patient_tracker/patient_tracker.php
@@ -77,7 +77,7 @@ if (!$GLOBALS['ptkr_date_range']) {
         $from_date = date('Y-m-d', strtotime('previous saturday'));
     }
 } else {
-    //shouldnt be able to get here...
+    //shouldn't be able to get here...
     $from_date = date('Y-m-d');
 }
 

--- a/interface/reports/ippf_statistics.php
+++ b/interface/reports/ippf_statistics.php
@@ -888,8 +888,8 @@ function process_visit($row): void
       $dres = LBFgcac_query($row['pid'], $row['encounter'], 'contrameth');
       while ($drow = sqlFetchArray($dres)) {
         $a = explode('|', $drow['field_value']);
-        foreach ($a as $methid) {
-        if (empty($methid)) continue;
+        foreach ($a as $method) {
+        if (empty($method)) continue;
         $crow = sqlQuery("SELECT title FROM list_options WHERE " .
           "list_id = 'contrameth' AND option_id = '$methid'");
         $key = $crow['title'];

--- a/interface/reports/non_reported.php
+++ b/interface/reports/non_reported.php
@@ -168,7 +168,7 @@ if (!empty($_POST['form_get_hl7']) && ($_POST['form_get_hl7'] === 'true')) {
         "|" . $facility_info['name'] . "^" . $facility_info['facility_npi'] . "^NPI" .
         "|||$now||" .
         "ADT^A01^ADT_A01" . // Hard-code to A01: Patient visits provider/facility
-        "|$nowdate|P^T|2.5.1|||||||||PH_SS-NoAck^SS Sender^2.16.840.1.114222.4.10.3^ISO" . // No acknowlegement
+        "|$nowdate|P^T|2.5.1|||||||||PH_SS-NoAck^SS Sender^2.16.840.1.114222.4.10.3^ISO" . // No acknowledgement
         "$D";
 
         // EVN

--- a/interface/reports/report.script.php
+++ b/interface/reports/report.script.php
@@ -148,13 +148,13 @@
         document.getElementById('table_' + choose_this_page_criteria_value).style.display = '';
     }
 
-    function checkOptionExist(value0, seperator)//It returns the position of the option, if the value is found, in the final criteria select box submitted.
+    function checkOptionExist(value0, separator)//It returns the position of the option, if the value is found, in the final criteria select box submitted.
     {//If doesn't exist new insertion is done.If exist it is updated.
         var elSel = document.getElementById('final_this_page_criteria');
         var i;
         for (i = elSel.length - 1; i >= 0; i--) {
             OptionValue = elSel.options[i].value;
-            OptionValue = OptionValue.split('|' + seperator.trim());
+            OptionValue = OptionValue.split('|' + separator.trim());
             if (OptionValue[0] == value0) {
                 return i;
             }
@@ -176,17 +176,17 @@
         return -1;
     }
 
-    function appendOptionRadioCriteria(text0, value0, text1, value1, seperator, Type) {//If option doesn't exist new insertion is done.If exist it is updated in the select drop down.//Remove the item if the option is All.
+    function appendOptionRadioCriteria(text0, value0, text1, value1, separator, Type) {//If option doesn't exist new insertion is done.If exist it is updated in the select drop down.//Remove the item if the option is All.
         var elOptNew = document.createElement('option');
         if (Type == 'radio' || Type == 'query_drop_down') {
-            elOptNew.text = text0 + seperator + text1;
-            elOptNew.value = value0 + "|" + seperator.trim() + "|" + value1;
+            elOptNew.text = text0 + separator + text1;
+            elOptNew.value = value0 + "|" + separator.trim() + "|" + value1;
         } else if (Type == 'radio_like') {
             elOptNew.text = text0 + ' = ' + text1;
-            elOptNew.value = value0 + "|" + seperator.trim() + "|" + value1;
+            elOptNew.value = value0 + "|" + separator.trim() + "|" + value1;
         }
         var elSel = document.getElementById('final_this_page_criteria');
-        TheOptionIndex = checkOptionExist(value0, seperator);
+        TheOptionIndex = checkOptionExist(value0, separator);
         if (TheOptionIndex == -1) {
             if (value1 != 'all') {
                 try {
@@ -203,16 +203,16 @@
         }
     }
 
-    function appendOptionTextCriteria(text0, value0, text1, value1, seperator, Type) {//If option doesn't exist new insertion is done.If exist it is updated in the select drop down.//Remove the item if the value is blank.
+    function appendOptionTextCriteria(text0, value0, text1, value1, separator, Type) {//If option doesn't exist new insertion is done.If exist it is updated in the select drop down.//Remove the item if the value is blank.
         var elOptNew = document.createElement('option');
-        elOptNew.text = text0 + seperator + text1;
+        elOptNew.text = text0 + separator + text1;
         if (Type == 'text') {
-            elOptNew.value = value0 + "|" + seperator.trim() + "|" + value1;
+            elOptNew.value = value0 + "|" + separator.trim() + "|" + value1;
         } else if (Type == 'text_like') {
-            elOptNew.value = value0 + "|" + seperator.trim() + "|" + value1 + "%";
+            elOptNew.value = value0 + "|" + separator.trim() + "|" + value1 + "%";
         }
         var elSel = document.getElementById('final_this_page_criteria');
-        TheOptionIndex = checkOptionExist(value0, seperator);
+        TheOptionIndex = checkOptionExist(value0, separator);
         if (TheOptionIndex == -1) {
             if (!(value1 == '' || value1 == '&nbsp;'))//'&nbsp;' is for ajax case
             {
@@ -230,10 +230,10 @@
         }
     }
 
-    function appendOptionDateCriteria(text0, value0, text1, value1, seperator, FromDate, ToDate, Type)//For Date drop down
+    function appendOptionDateCriteria(text0, value0, text1, value1, separator, FromDate, ToDate, Type)//For Date drop down
     {//If option doesn't exist new insertion is done.If exist it is updated in the select drop down.//Remove the item if the drop down is All.
         var elOptNew = document.createElement('option');
-        elOptNew.text = text0 + seperator + text1;
+        elOptNew.text = text0 + separator + text1;
         FromDateValue = document.getElementById(FromDate).value;
         ToDateValue = document.getElementById(ToDate).value;
         // only require biller to enter from date
@@ -262,13 +262,13 @@
         }
     }
 
-    function CleanUpAjax(text0, value0, seperator) {//Cleans the values in the ajax (Insurance Company criteria)
+    function CleanUpAjax(text0, value0, separator) {//Cleans the values in the ajax (Insurance Company criteria)
         document.getElementById('type_code').value = '';
         document.getElementById('hidden_ajax_close_value').value = '';
         document.getElementById('hidden_type_code').value = '';
         document.getElementById('div_insurance_or_patient').innerHTML = '';
         var elSel = document.getElementById('final_this_page_criteria');
-        TheOptionIndex = checkOptionExist(value0, seperator);
+        TheOptionIndex = checkOptionExist(value0, separator);
         if (TheOptionIndex == -1) {
         } else {
             elSel.remove(TheOptionIndex);
@@ -376,8 +376,8 @@
     }
 
     //-------------------------------------------------------------------------------------------------------------------------
-    //In Internet Explorer the ajax drop down of insurance was gettign hidden under the select drop down towards the right side.
-    //So an iframe is added to solve this issue.
+    //In Internet Explorer the ajax drop down of insurance was getting hidden under the select drop down towards the right side.
+    //So an iframe was added to solve this issue.
     //-------------------------------------------------------------------------------------------------------------------------
     function show_frame_to_hide() {//Show the iframe
         if (document.getElementById("AjaxContainerInsurance")) {

--- a/interface/smart/register-app.php
+++ b/interface/smart/register-app.php
@@ -2,7 +2,7 @@
 
 /**
  * register-app.php Handles the registration of a new OpenEMR OAuth2 application.  This is just a front-end GUI for the
- * /oauth2/<site>/registeration endpoint.
+ * /oauth2/<site>/registration endpoint.
  * TODO: @adunsulag we should twigify this file.
  *
  * @package OpenEMR

--- a/interface/super/rules/www/js/jQuery.autocomplete.js
+++ b/interface/super/rules/www/js/jQuery.autocomplete.js
@@ -318,7 +318,7 @@ jQuery.autocomplete = function(input, options) {
 	function requestData(q) {
 		if (!options.matchCase) q = q.toLowerCase();
 		var data = options.cacheLength ? loadFromCache(q) : null;
-		// recieve the cached data
+		// receive the cached data
 		if (data) {
 			receiveData(q, data);
 		// if an AJAX url has been supplied, try loading the data now

--- a/interface/themes/jquery.autocomplete.css
+++ b/interface/themes/jquery.autocomplete.css
@@ -18,15 +18,15 @@
   cursor: default;
   display: block;
   /*
-	if width will be 100% horizontal scrollbar will apear
+	if the width is 100% a horizontal scrollbar will appear
 	when scroll mode will be used
 	*/
   /*width: 100%;*/
   font: menu;
   font-size: 12px;
   /*
-	it is very important, if line-height not setted or setted
-	in relative units scroll will be broken in firefox
+	Use an absolute line-height value here;
+	relative units or omitting it breaks scrolling in Firefox.
 	*/
   line-height: 16px;
   margin: 0;

--- a/interface/themes/rtl.scss
+++ b/interface/themes/rtl.scss
@@ -24,7 +24,7 @@
     padding: 5px 2px 5px 10px;
   }
 
-  /* Calander */
+  /* Calendar */
   #bottomLeft {
     float: right !important;
   }

--- a/interface/themes/rtl_style_pdf.css
+++ b/interface/themes/rtl_style_pdf.css
@@ -1282,7 +1282,7 @@ div.notab-right {
     Author     : Amiel Elboim, Matrix
 */
 
-/* General RTL calsses */
+/* General RTL classes */
 
 tr,
 td,
@@ -1655,7 +1655,7 @@ div.tab table td {
   margin: 0 0 10px;
 }
 
-/* Calander */
+/* Calendar */
 #bottomLeft {
 
   float: right !important;

--- a/interface/usergroup/checkpwd_validation.js
+++ b/interface/usergroup/checkpwd_validation.js
@@ -9,7 +9,7 @@
 
 
 /*
- *  Fuction to check that the password contains at least 3 of the following:
+ *  Function to check that the password contains at least 3 of the following:
  *  - an integer one integer
  *  - a lower case letter
  *  - an upper case letter

--- a/interface/usergroup/ssl_certificates_admin.php
+++ b/interface/usergroup/ssl_certificates_admin.php
@@ -208,7 +208,7 @@ function create_and_download_certificates(): void
         $clientPassPhrase = trim((string) $_POST['clientPassPhrase']);
     }
 
-    /* Create the Certficate Authority (CA) */
+    /* Create the Certificate Authority (CA) */
     $arr = create_csr(
         "OpenEMR CA for " . $commonName,
         $emailAddress,

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -126,7 +126,7 @@ function submitform() {
 
     }//If pwd null ends here
 
-    // Valiate Google email address (if provided)
+    // Validate Google email address (if provided)
     if(document.forms[0].google_signin_email.value != "" && !isValidEmail(document.forms[0].google_signin_email.value)) {
         flag=1;
         alert(<?php echo xlj('Google email provided is invalid/not properly formatted (e.g. first.last@gmail.com)') ?>);

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -113,7 +113,7 @@ function submitform() {
         }
     } //secure_pwd if ends here
 
-    // Valiate Google email (if provided)
+    // Validate Google email (if provided)
     if(document.new_user.google_signin_email.value != "" && !isValidEmail(document.new_user.google_signin_email.value)) {
         alert(<?php echo xlj('Google email provided is invalid/not properly formatted (e.g. first.last@gmail.com)') ?>);
         return false;


### PR DESCRIPTION
## Summary
- Fix spelling errors in interface PHP, JavaScript, and template files
- 60 files with typo corrections
- Covers: billing, clickmap, code_systems, de_identification, globals, language, main, orders, patient_file, reports, themes, usergroup

**This is PR 8b of 12 PRs** to fix ~460 files with typos across the codebase.

All PRs in this series:
1. #10333 - Core files, CCR templates, SQL (merged)
2. #10336 - Contrib, controllers, misc files (merged)
3. #10337 - Sites, templates (merged)
4. #10338 - FHIR (merged)
5. #10339 - Library (merged)
6. #10340 - Portal (merged)
7. #10341 - Interface, modules (merged)
8a. #10342 - Interface/forms (merged)
8b. This PR - Interface misc
9. #10343 - Src misc
10. #10344 - Tests (merged)
11. #10345 - Misc remaining files

Part of #7939

## Test plan
- [ ] Verify typo fixes don't change code behavior
- [ ] Check that no variable/function names were altered

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>