### PR TITLE
perf(ci): restore file timestamps to enable PHPStan caching

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -48,14 +48,30 @@ jobs:
           | .version
         ' composer.lock)
         printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
-    - name: PHPStan Cache
+    - name: Restore PHPStan Cache
       # https://phpstan.org/user-guide/result-cache
-      uses: actions/cache@v5
+      id: phpstan-cache
+      uses: actions/cache/restore@v5
       with:
         path: tmp-phpstan # same as in phpstan.neon
         key: phpstan-result-cache-${{ steps.phpstan-version.outputs.version }}-${{ hashFiles('phpstan.neon.dist', '.phpstan/**', 'tests/PHPStan/**') }}-${{ github.run_id }}
         restore-keys: |
           phpstan-result-cache-${{ steps.phpstan-version.outputs.version }}-${{ hashFiles('phpstan.neon.dist', '.phpstan/**', 'tests/PHPStan/**') }}-
+    # PHPStan's container cache uses file mtimes for validation. Git doesn't
+    # preserve mtimes, so without restoration every cached file looks stale
+    # and the cache is effectively useless. Only worth doing when we actually
+    # restored a cache - on a cold miss this is pure overhead.
+    - name: Restore file timestamps
+      if: steps.phpstan-cache.outputs.cache-matched-key != ''
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends git-restore-mtime
+        # Guard against running on a non-shallow checkout - --unshallow errors
+        # with "does not make sense" if history is already complete.
+        if [ -f .git/shallow ]; then
+          git fetch --unshallow --quiet
+        fi
+        git restore-mtime --skip-missing --quiet
     - name: PHPStan Diagnose
       run: vendor/bin/phpstan --memory-limit=8G diagnose
     # Use CI config which sets reportUnmatchedIgnoredErrors: false so this step
@@ -86,6 +102,15 @@ jobs:
     - name: Regenerate PHPStan Baseline
       if: always()
       run: composer phpstan-baseline
+    # Save after baseline regeneration so the cache captures the full set of
+    # PHPStan invocations for the run. Even on failure - partial cache still
+    # speeds up the next run.
+    - name: Save PHPStan Cache
+      if: always()
+      uses: actions/cache/save@v5
+      with:
+        path: tmp-phpstan
+        key: ${{ steps.phpstan-cache.outputs.cache-primary-key }}
     # Check for baseline drift. Only meaningful when analysis passed - if analysis
     # failed, the baseline will differ due to the new errors.
     - name: Ensure baseline is stable


### PR DESCRIPTION
## Summary

Fixes #10386

PHPStan's container cache (Nette DI) validates against file modification times. Git doesn't preserve mtimes, so a freshly checked out file always looks newer than its cached metadata, invalidating the entire container and forcing a full re-analysis of all ~4000 files even when the result cache restored cleanly.

## Approach

The expensive parts of fixing this are (1) a full-history clone, which `git-restore-mtime` needs to walk, and (2) installing the tool itself. Both are pure waste on a cold cache miss. So this PR makes them conditional on whether a cache was actually restored:

- Replace `actions/cache@v5` with `actions/cache/restore@v5` + `actions/cache/save@v5` so the restore step exposes a `cache-hit` / `cache-matched-key` output.
- When (and only when) a cache was restored: install `git-restore-mtime` from apt, `git fetch --unshallow`, and walk the history to restore mtimes.
- Save the cache on `always()` so partial results from a failed analyze still seed the next run.

Cold misses pay zero new overhead vs. before this PR. Warm hits pay an unshallow + mtime walk to make the restored cache validate.

## Testing

The first run after merge is still cold-cache (no savings). Compare runtime on the second and third runs of the same branch to confirm the cache is now effective.
