### PR TITLE
chore: add codespell to local development tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,12 @@ repos:
     - --autofix
     - --indent=2
 
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.4.1
+  hooks:
+  - id: codespell
+    # Configuration in .codespellrc
+
 - repo: local
   hooks:
   - id: php-syntax-check

--- a/composer.json
+++ b/composer.json
@@ -260,6 +260,7 @@
             "composer normalize --dry-run"
         ],
         "code-quality": [
+            "@codespell",
             "@conventional-commits:check",
             "@php-syntax-check",
             "@phpcbf",
@@ -268,6 +269,7 @@
             "@rector-check",
             "@require-checker"
         ],
+        "codespell": "command -v codespell >/dev/null 2>&1 && codespell || echo 'codespell not found. Install with: brew install codespell OR pipx install codespell' >&2",
         "conventional-commits:check": "./vendor/bin/conventional-commits validate",
         "php-syntax-check": "git ls-files -z '*.inc' '*.php' | xargs -0 php -l | grep -vF 'No syntax errors detected in'",
         "phpcbf": "php -d memory_limit=4g ./vendor/bin/phpcbf --standard=ci/phpcs.xml .",


### PR DESCRIPTION
Fixes #10388

## Description

Following #10327 which added codespell to CI, this adds local development tooling so developers can run codespell before pushing.

## Changes proposed in this pull request

- Add codespell pre-commit hook (uses existing `.codespellrc` for configuration)
- Add `composer codespell` script that:
  - Runs codespell if installed
  - Shows helpful installation instructions (brew or pipx) if not installed
  - Does not fail if codespell is missing (warning only)
- Add `@codespell` to the `code-quality` composer script

## AI Disclosure

Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)