### PR TITLE
fix(vitals): add translation support for BMI status display

### DIFF
--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -4,9 +4,11 @@
  * vitals C_FormVitals.php
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -14,14 +16,15 @@ require_once($GLOBALS['fileroot'] . "/library/forms.inc.php");
 require_once($GLOBALS['fileroot'] . "/library/patient.inc.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
-use OpenEMR\Common\Forms\FormVitals;
+use OpenEMR\Common\Forms\BmiCategory;
 use OpenEMR\Common\Forms\FormVitalDetails;
+use OpenEMR\Common\Forms\FormVitals;
 use OpenEMR\Common\Forms\ReasonStatusCodes;
 use OpenEMR\Common\Logging\SystemLogger;
-use OpenEMR\Common\Uuid\UuidRegistry;
-use OpenEMR\Services\VitalsService;
-use OpenEMR\Services\ListService;
 use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\Services\ListService;
+use OpenEMR\Services\VitalsService;
 
 class C_FormVitals
 {
@@ -398,21 +401,12 @@ class C_FormVitals
             $_POST["BMI"] = ($weight / $height / $height) * 703;
         }
 
-        // TODO: this should go into the vitals form...
-        if ($_POST["BMI"] > 42) {
-            $_POST["BMI_status"] = 'Obesity III';
-        } elseif ($_POST["BMI"] > 34) {
-            $_POST["BMI_status"] = 'Obesity II';
-        } elseif ($_POST["BMI"] > 30) {
-            $_POST["BMI_status"] = 'Obesity I';
-        } elseif ($_POST["BMI"] > 27) {
-            $_POST["BMI_status"] = 'Overweight';
-        } elseif ($_POST["BMI"] > 25) {
-            $_POST["BMI_status"] = 'Normal BL';
-        } elseif ($_POST["BMI"] > 18.5) {
-            $_POST["BMI_status"] = 'Normal';
-        } elseif ($_POST["BMI"] > 10) {
-            $_POST["BMI_status"] = 'Underweight';
+        $bmi = $_POST["BMI"] ?? null;
+        if (is_numeric($bmi)) {
+            $bmiCategory = BmiCategory::fromBmi((float)$bmi);
+            if ($bmiCategory !== null) {
+                $_POST["BMI_status"] = $bmiCategory->value;
+            }
         }
 
         $temperature = $_POST["temperature"];

--- a/interface/forms/vitals/templates/vitals/vitals_bmi_status.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals_bmi_status.html.twig
@@ -4,13 +4,13 @@
     {% if is_edit %}
     <td class='currentvalues p-2'>
         <input type="text" class="form-control skip-template-editor" size='20'
-            name="BMI_status" id="BMI_status" value="{{ vitals.get_BMI_status()|attr }}"/></td>
+            name="BMI_status" id="BMI_status" value="{{ vitals.get_BMI_status(true)|attr }}"/></td>
     <td class="editonly"></td>
     <td class="editonly actions">
         {% include 'vitals_actions.html.twig' with { input:'BMI_Status' } %}
     </td>
     {% endif %}
-    {% include 'vitals_historical_values.html.twig' with { useMetric:false, vitalsValue:'get_BMI_status', vitals:vitals, results:results, is_edit:is_edit } %}
+    {% include 'vitals_historical_values.html.twig' with { useMetric:false, vitalsValue:'get_BMI_status', translate:true, vitals:vitals, results:results, is_edit:is_edit } %}
 </tr>
 {% if is_edit %}
 {% include 'vitals_reason_row.html.twig' with { input:'BMI_Status', title:'BMI Status'|xl, vitalDetails:vitals.get_details_for_column('BMI_Status') } %}

--- a/interface/forms/vitals/templates/vitals/vitals_historical_values.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals_historical_values.html.twig
@@ -13,6 +13,8 @@
             {% if attribute(result, vitalsValue) != 0 %}
                 {% if precision is defined %}
                     {{ attribute(result, vitalsValue)|number_format(precision)|text }}
+                {% elseif translate|default(false) %}
+                    {{ attribute(result, vitalsValue, [true])|text }}
                 {% else %}
                     {{ attribute(result, vitalsValue)|text }}
                 {% endif %}

--- a/src/Common/Forms/BmiCategory.php
+++ b/src/Common/Forms/BmiCategory.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * BMI Category enum for classifying Body Mass Index values
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Forms;
+
+enum BmiCategory: string
+{
+    // BMI lower bounds for category classification
+    public const OBESITY_III_LOWER_BOUND = 42;
+    public const OBESITY_II_LOWER_BOUND = 34;
+    public const OBESITY_I_LOWER_BOUND = 30;
+    public const OVERWEIGHT_LOWER_BOUND = 27;
+    public const NORMAL_BORDERLINE_LOWER_BOUND = 25;
+    public const NORMAL_LOWER_BOUND = 18.5;
+    public const UNDERWEIGHT_LOWER_BOUND = 10;
+
+    case ObesityIII = 'Obesity III';
+    case ObesityII = 'Obesity II';
+    case ObesityI = 'Obesity I';
+    case Overweight = 'Overweight';
+    case NormalBorderline = 'Normal BL';
+    case Normal = 'Normal';
+    case Underweight = 'Underweight';
+
+    /**
+     * Determine BMI category from a BMI value
+     */
+    public static function fromBmi(float $bmi): ?self
+    {
+        return match (true) {
+            $bmi > self::OBESITY_III_LOWER_BOUND => self::ObesityIII,
+            $bmi > self::OBESITY_II_LOWER_BOUND => self::ObesityII,
+            $bmi > self::OBESITY_I_LOWER_BOUND => self::ObesityI,
+            $bmi > self::OVERWEIGHT_LOWER_BOUND => self::Overweight,
+            $bmi > self::NORMAL_BORDERLINE_LOWER_BOUND => self::NormalBorderline,
+            $bmi > self::NORMAL_LOWER_BOUND => self::Normal,
+            $bmi > self::UNDERWEIGHT_LOWER_BOUND => self::Underweight,
+            default => null,
+        };
+    }
+
+    /**
+     * Create a BmiCategory from a stored string value
+     */
+    public static function tryFromValue(string $value): ?self
+    {
+        return self::tryFrom($value);
+    }
+
+    /**
+     * Get the translated display label
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::ObesityIII => xl('Obesity III'),
+            self::ObesityII => xl('Obesity II'),
+            self::ObesityI => xl('Obesity I'),
+            self::Overweight => xl('Overweight'),
+            self::NormalBorderline => xl('Normal BL'),
+            self::Normal => xl('Normal'),
+            self::Underweight => xl('Underweight'),
+        };
+    }
+}

--- a/src/Common/Forms/FormVitals.php
+++ b/src/Common/Forms/FormVitals.php
@@ -5,10 +5,12 @@
  * For backwards compatibility it extends ORDataObject (which implements the a form of the Active record data pattern),
  * but the preferred mechanism is to use this as a POPO (Plain old PHP object) and save / retrieve data using
  * the VitalsService class.
- * @package openemr
- * @link      http://www.open-emr.org
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
  * @author    Stephen Nielson <stephen@nielson.org>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -20,10 +22,11 @@ namespace OpenEMR\Common\Forms;
  */
 
 use OpenEMR\Common\Database\QueryUtils;
-use OpenEMR\Services\FHIR\Observation\FhirObservationVitalsService;
+use OpenEMR\Common\Forms\BmiCategory;
 use OpenEMR\Common\ORDataObject\ORDataObject;
-use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Common\Utils\MeasurementUtils;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\Services\FHIR\Observation\FhirObservationVitalsService;
 
 class FormVitals extends ORDataObject
 {
@@ -61,7 +64,7 @@ class FormVitals extends ORDataObject
     public $respiration;
     public $note;
     public $BMI;
-    public $BMI_status;
+    public ?string $BMI_status = null;
     public $waist_circ;
     public $head_circ;
     public $oxygen_saturation;
@@ -319,11 +322,17 @@ class FormVitals extends ORDataObject
             $this->BMI = $bmi;
         }
     }
-    public function get_BMI_status()
+    public function get_BMI_status(bool $translate = false): ?string
     {
+        if ($this->BMI_status === null || $this->BMI_status === '') {
+            return null;
+        }
+        if ($translate) {
+            return BmiCategory::tryFrom($this->BMI_status)?->label() ?? $this->BMI_status;
+        }
         return $this->BMI_status;
     }
-    public function set_BMI_status($status)
+    public function set_BMI_status(?string $status): void
     {
         $this->BMI_status = $status;
     }


### PR DESCRIPTION
Fixes #8343

#### Short description of what this resolves:
BMI status values (Obesity III, Overweight, Normal, etc.) were not being translated when displayed in non-English locales.

#### Changes proposed in this pull request:
- Add `BmiCategory` enum to centralize BMI classification logic with translatable labels
- Add optional `$translate` parameter to `FormVitals::get_BMI_status()` 
- Refactor `C_FormVitals` to use `BmiCategory::fromBmi()` instead of if/elseif chain
- Update vitals templates to request translated BMI status values

The enum approach ensures translation strings are literal (collectable by translation tools) while keeping the English values in the database for CCDA/FHIR compatibility.

#### Does your code include anything generated by an AI Engine? Yes / No
Yes

#### If you answered yes:
Claude Code was used to implement this feature. The `BmiCategory` enum and related changes were developed with AI assistance.

---
Supersedes #9679 with a cleaner implementation.