### PR TITLE
refactor(auth): remove obsolete constructor argument from AuthHash calls

### DIFF
--- a/.phpstan/baseline/arguments.count.php
+++ b/.phpstan/baseline/arguments.count.php
@@ -32,21 +32,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_sms_notification.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Class OpenEMR\\\\Common\\\\Auth\\\\AuthHash constructor invoked with 1 parameter, 0 required\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/account/account.lib.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Class OpenEMR\\\\Common\\\\Auth\\\\AuthHash constructor invoked with 1 parameter, 0 required\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/account/index_reset.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Class OpenEMR\\\\Common\\\\Auth\\\\AuthHash constructor invoked with 1 parameter, 0 required\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Class GenericRouter constructor invoked with 0 parameters, 3 required\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/patient/fwk/libs/verysimple/Phreeze/Dispatcher.php',
@@ -57,11 +42,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Class OpenEMR\\\\Common\\\\Auth\\\\AuthHash constructor invoked with 1 parameter, 0 required\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/AuthUtils.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Class OpenEMR\\\\Cqm\\\\CqmClient constructor invoked with 0 parameters, 2\\-4 required\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Cqm/test.php',
@@ -70,11 +50,6 @@ $ignoreErrors[] = [
     'message' => '#^Class OpenEMR\\\\Services\\\\FHIR\\\\FhirDocRefService constructor invoked with 1 parameter, 0 required\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/Operations/FhirOperationDocRefRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Class OpenEMR\\\\Common\\\\Auth\\\\AuthHash constructor invoked with 1 parameter, 0 required\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/PatientAccessOnsiteService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Class OpenEMR\\\\Events\\\\Patient\\\\Summary\\\\PortalCredentialsTemplateDataFilterEvent constructor invoked with 2 parameters, 0 required\\.$#',

--- a/portal/account/account.lib.php
+++ b/portal/account/account.lib.php
@@ -420,7 +420,7 @@ function doCredentials($pid, $resetPass = false, $resetPassEmail = ''): bool
     }
 
     if (!$resetPass) {
-        $newHash = (new AuthHash('auth'))->passwordHash($clear_pass);
+        $newHash = (new AuthHash())->passwordHash($clear_pass);
         if (empty($newHash)) {
             // Serious issue if this is case, so exit.
             EventAuditLogger::getInstance()->newEvent('patient-registration', '', '', 0, "Patient credential creation registration failure secondary critical hashing error for email " . $newpd['email'] . " and pid: " . $pid);

--- a/portal/account/index_reset.php
+++ b/portal/account/index_reset.php
@@ -88,7 +88,7 @@ if (isset($_POST['submit'])) {
         $bind = [];
         $updateFields = [];
         if (!empty($password_new)) {
-            $new_hash = (new AuthHash('auth'))->passwordHash($password_new);
+            $new_hash = (new AuthHash())->passwordHash($password_new);
             unset($password_new);
             if (empty($new_hash)) {
                 // Something is seriously wrong

--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -161,7 +161,7 @@ if ($password_update === 2) {
     }
 } else {
     if (AuthHash::passwordVerify($_POST['pass'], $auth[COL_POR_PWD])) {
-        $authHashPortal = new AuthHash('auth');
+        $authHashPortal = new AuthHash();
         if ($authHashPortal->passwordNeedsRehash($auth[COL_POR_PWD])) {
             // If so, create a new hash, and replace the old one (this will ensure always using most modern hashing)
             $reHash = $authHashPortal->passwordHash($_POST['pass']);
@@ -227,7 +227,7 @@ if ($userData = sqlQuery($sql, [$auth['pid']])) { // if query gets executed
         $code_new = $_POST['pass_new'];
         $code_new_confirm = $_POST['pass_new_confirm'];
         if (!(empty($_POST['pass_new'])) && !(empty($_POST['pass_new_confirm'])) && ($code_new == $code_new_confirm)) {
-            $new_hash = (new AuthHash('auth'))->passwordHash($code_new);
+            $new_hash = (new AuthHash())->passwordHash($code_new);
             if (empty($new_hash)) {
                 // Something is seriously wrong
                 error_log('OpenEMR Error : OpenEMR is not working because unable to create a hash.');

--- a/src/Common/Auth/AuthUtils.php
+++ b/src/Common/Auth/AuthUtils.php
@@ -81,8 +81,8 @@ class AuthUtils
             $this->otherAuth = true;
         }
 
-        // Set up AuthHash instance (note it uses auth mode)
-        $this->authHashAuth = new AuthHash('auth');
+        // Set up AuthHash instance for password hashing
+        $this->authHashAuth = new AuthHash();
 
         // Ensure timing attack stuff is in place. This will be to prevent a bad actor from guessing
         //  usernames and knowing they got a hit since the hash verification will then take time

--- a/src/Services/PatientAccessOnsiteService.php
+++ b/src/Services/PatientAccessOnsiteService.php
@@ -102,7 +102,7 @@ class PatientAccessOnsiteService
 
         $updatedEvent = $this->kernel->getEventDispatcher()->dispatch($preUpdateEvent, PortalCredentialsUpdatedEvent::EVENT_UPDATE_PRE) ?? $preUpdateEvent;
         $query_parameters = [$updatedEvent->getUsername(), $updatedEvent->getLoginUsername()];
-        $hash = (new AuthHash('auth'))->passwordHash($clear_pass);
+        $hash = (new AuthHash())->passwordHash($clear_pass);
         if (empty($hash)) {
             // Something is seriously wrong
             error_log('OpenEMR Error : OpenEMR is not working because unable to create a hash.');


### PR DESCRIPTION
## Summary

The `AuthHash` constructor no longer accepts a `$mode` parameter (removed in #4114), but several callers still passed `'auth'` as an argument. This PR removes these obsolete arguments.

Fixes #10409

## Changes

- Remove `'auth'` argument from all `new AuthHash('auth')` calls, changing them to `new AuthHash()`
- Update outdated comment in `AuthUtils.php`

## Test plan

- [ ] Verify portal login still works
- [ ] Verify password reset functionality works
- [ ] PHPStan passes without `AuthHash constructor invoked with 1 parameter, 0 required` errors

## AI Disclosure

Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)