### PR TITLE
docs(docker-compose): correct duplicate MYSQL_PASS in comments

### DIFF
--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -1,6 +1,6 @@
 # Use admin/pass as user/password credentials to login to openemr (from OE_USER and OE_PASS below)
 # MYSQL_HOST and MYSQL_ROOT_PASS are required for openemr
-# MYSQL_USER, MYSQL_PASS, OE_USER, MYSQL_PASS are optional for openemr and
+# MYSQL_USER, MYSQL_PASS, OE_USER, OE_PASS are optional for openemr and
 #   if not provided, then default to openemr, openemr, admin, and pass respectively.
 services:
   mysql:


### PR DESCRIPTION
<!--Thanks for sending a pull request!
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #10418

<!-- PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details -->

#### Short description of what this resolves:
This PR simply fixes a duplication typo in the comments of docker/production/docker-compose.yml. 

Correct MYSQL_PASS to OE_PASS in docker comments

#### Changes proposed in this pull request:
N/A - comments only

#### Does your code include anything generated by an AI Engine? No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
