### PR TITLE
refactor(services): add type safety to AddressService

### DIFF
--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -7202,16 +7202,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/Operations/FhirOperationExportRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/AddressService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/AddressService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/AllergyIntoleranceService.php',

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/FormattedPatientService.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/FormattedPatientService.php
@@ -4,6 +4,7 @@
 namespace Comlink\OpenEMR\Modules\TeleHealthModule\Services;
 
 use InvalidArgumentException;
+use OpenEMR\Services\Address\AddressRecord;
 use OpenEMR\Services\AddressService;
 use OpenEMR\Services\PatientService;
 
@@ -25,7 +26,7 @@ class FormattedPatientService
         $patientResult['dobFormatted'] = $dobYmd;
         $patientResult['age'] = $patientService->getPatientAgeDisplay($dobYmd);
         $addressService = new AddressService();
-        $patientResult['addressFull'] = $addressService->getAddressFromRecordAsString($patientResult);
+        $patientResult['addressFull'] = $addressService->getAddressFromRecordAsString(AddressRecord::fromArray($patientResult));
         return $patientResult;
     }
 }

--- a/interface/practice/ins_search.php
+++ b/interface/practice/ins_search.php
@@ -296,7 +296,7 @@ if (
   <td class="font-weight-bold" nowrap><?php echo xlt('Address1'); ?>:</td>
   <td>
    <input type='text' size='20' name='form_addr1' maxlength='35' class='form-control form-control-sm' title='First address line'
-       value='<?php echo attr($ins_co_address['line1'] ?? ''); ?>' />
+       value='<?php echo attr($ins_co_address?->line1 ?? ''); ?>' />
   </td>
  </tr>
 
@@ -304,7 +304,7 @@ if (
   <td class="font-weight-bold" nowrap><?php echo xlt('Address2'); ?>:</td>
   <td>
    <input type='text' size='20' name='form_addr2' maxlength='35' class='form-control form-control-sm' title='Second address line, if any'
-       value='<?php echo attr($ins_co_address['line2'] ?? ''); ?>' />
+       value='<?php echo attr($ins_co_address?->line2 ?? ''); ?>' />
   </td>
  </tr>
 
@@ -313,11 +313,11 @@ if (
      <td class="form-row">
          <div class="col">
              <input type='text' size='20' name='form_city' maxlength='25' class='form-control form-control-sm' title='City name'
-                 value='<?php echo attr($ins_co_address['city'] ?? ''); ?>' />
+                 value='<?php echo attr($ins_co_address?->city ?? ''); ?>' />
          </div>
          <div class="col">
              <input type='text' size='3' name='form_state' maxlength='35' class='form-control form-control-sm' title='State or locality'
-                 value='<?php echo attr($ins_co_address['state'] ?? ''); ?>' />
+                 value='<?php echo attr($ins_co_address?->state ?? ''); ?>' />
          </div>
      </td>
  </tr>
@@ -327,11 +327,11 @@ if (
      <td class="form-row">
          <div class="col">
              <input type='text' size='20' name='form_zip' maxlength='10' class='form-control form-control-sm' title='Postal code'
-                 value='<?php echo attr(($ins_co_address['zip'] ?? '') . ($ins_co_address['plus_four'] ?? '')); ?>' />
+                 value='<?php echo attr(($ins_co_address?->zip ?? '') . ($ins_co_address?->plusFour ?? '')); ?>' />
          </div>
          <div class="col">
              <input type='text' size='20' class="form-control form-control-sm" name='form_country' value='USA' maxlength='35' title='Country name'
-                 value='<?php echo attr($ins_co_address['country'] ?? ''); ?>' />
+                 value='<?php echo attr($ins_co_address?->country ?? ''); ?>' />
          </div>
      </td>
  </tr>

--- a/src/RestControllers/InsuranceCompanyRestController.php
+++ b/src/RestControllers/InsuranceCompanyRestController.php
@@ -13,6 +13,7 @@
 namespace OpenEMR\RestControllers;
 
 use OpenEMR\RestControllers\RestControllerHelper;
+use OpenEMR\Services\Address\AddressData;
 use OpenEMR\Services\AddressService;
 use OpenEMR\Services\InsuranceCompanyService;
 
@@ -53,7 +54,7 @@ class InsuranceCompanyRestController
             return $insuranceCompanyValidationHandlerResult;
         }
 
-        $addressValidationResult = $this->addressService->validate($data);
+        $addressValidationResult = $this->addressService->validate(AddressData::fromArray($data));
         $addressValidationHandlerResult = RestControllerHelper::validationHandler($addressValidationResult);
         if (is_array($addressValidationHandlerResult)) {
             return $addressValidationHandlerResult;
@@ -71,7 +72,7 @@ class InsuranceCompanyRestController
             return $insuranceCompanyValidationHandlerResult;
         }
 
-        $addressValidationResult = $this->addressService->validate($data);
+        $addressValidationResult = $this->addressService->validate(AddressData::fromArray($data));
         $addressValidationHandlerResult = RestControllerHelper::validationHandler($addressValidationResult);
         if (is_array($addressValidationHandlerResult)) {
             return $addressValidationHandlerResult;

--- a/src/Services/Address/AddressData.php
+++ b/src/Services/Address/AddressData.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * AddressData value object for address insert/update operations
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services\Address;
+
+/**
+ * Immutable value object representing address data for database operations.
+ *
+ * This DTO is used for insert and update operations on the addresses table.
+ * It can be constructed from an array (for backward compatibility with existing
+ * code that passes mixed data arrays) or directly with named arguments.
+ */
+readonly class AddressData
+{
+    public function __construct(
+        public string $line1,
+        public string $line2,
+        public string $city,
+        public string $state,
+        public string $zip,
+        public string $country,
+        public ?string $plusFour = null,
+    ) {
+    }
+
+    /**
+     * Create an AddressData instance from an array.
+     *
+     * Supports both camelCase and snake_case keys for flexibility.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            line1: self::getString($data, 'line1'),
+            line2: self::getString($data, 'line2'),
+            city: self::getString($data, 'city'),
+            state: self::getString($data, 'state'),
+            zip: self::getString($data, 'zip'),
+            country: self::getString($data, 'country'),
+            plusFour: self::getStringOrNull($data, 'plus_four'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function getString(array $data, string $key): string
+    {
+        $value = $data[$key] ?? '';
+        return is_string($value) ? $value : '';
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function getStringOrNull(array $data, string $key): ?string
+    {
+        if (!isset($data[$key])) {
+            return null;
+        }
+        $value = $data[$key];
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Convert to array for database operations.
+     *
+     * @return array<string, string|null>
+     */
+    public function toArray(): array
+    {
+        return [
+            'line1' => $this->line1,
+            'line2' => $this->line2,
+            'city' => $this->city,
+            'state' => $this->state,
+            'zip' => $this->zip,
+            'country' => $this->country,
+            'plus_four' => $this->plusFour,
+        ];
+    }
+}

--- a/src/Services/Address/AddressRecord.php
+++ b/src/Services/Address/AddressRecord.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * AddressRecord value object for address display formatting
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services\Address;
+
+/**
+ * Immutable value object representing an address record for display formatting.
+ *
+ * This DTO represents address data as stored in patient/user records, which
+ * uses different field names than the addresses table (street vs line1, etc.).
+ */
+readonly class AddressRecord implements \Stringable
+{
+    public function __construct(
+        public string $street = '',
+        public string $city = '',
+        public string $state = '',
+        public string $postalCode = '',
+        public string $countryCode = '',
+    ) {
+    }
+
+    /**
+     * Create an AddressRecord instance from an array.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            street: self::getString($data, 'street'),
+            city: self::getString($data, 'city'),
+            state: self::getString($data, 'state'),
+            postalCode: self::getString($data, 'postal_code'),
+            countryCode: self::getString($data, 'country_code'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function getString(array $data, string $key): string
+    {
+        $value = $data[$key] ?? '';
+        return is_string($value) ? $value : '';
+    }
+
+    /**
+     * Format the address as a multi-line string.
+     */
+    public function toString(): string
+    {
+        $lines = [];
+
+        if ($this->street !== '') {
+            $lines[] = $this->street;
+        }
+
+        $addressLine = implode(' ', array_filter([
+            $this->city !== '' ? $this->city . ',' : '',
+            $this->state,
+            $this->postalCode,
+            $this->countryCode,
+        ]));
+
+        if ($addressLine !== '') {
+            $lines[] = $addressLine;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+}

--- a/src/Services/AddressService.php
+++ b/src/Services/AddressService.php
@@ -7,14 +7,19 @@
  * @link      http://www.open-emr.org
  * @author    Matthew Vita <matthewvita48@gmail.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2018 Matthew Vita <matthewvita48@gmail.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 namespace OpenEMR\Services;
 
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\Address\AddressData;
+use OpenEMR\Services\Address\AddressRecord;
+use Particle\Validator\ValidationResult;
 use Particle\Validator\Validator;
 
 class AddressService extends BaseService
@@ -23,7 +28,10 @@ class AddressService extends BaseService
     {
     }
 
-    public function validate($insuranceCompany)
+    /**
+     * Validate address data against length constraints.
+     */
+    public function validate(AddressData $address): ValidationResult
     {
         $validator = new Validator();
 
@@ -35,37 +43,25 @@ class AddressService extends BaseService
         $validator->optional('plus_four')->lengthBetween(2, 4);
         $validator->optional('country')->lengthBetween(2, 255);
 
-        return $validator->validate($insuranceCompany);
+        return $validator->validate($address->toArray());
     }
 
-    public function getAddressFromRecordAsString(array $addressRecord)
+    /**
+     * Format an address record as a multi-line string.
+     */
+    public function getAddressFromRecordAsString(AddressRecord $addressRecord): string
     {
-        // works for patients and users
-        $address = [];
-        if (!empty($addressRecord['street'])) {
-            $address[] = $addressRecord['street'];
-            $address[] = "\n";
-        }
-        if (!empty($addressRecord['city'])) {
-            $address[] = $addressRecord['city'];
-            $address[] = ", ";
-        }
-        if (!empty($addressRecord['state'])) {
-            $address[] = $addressRecord['state'];
-            $address[] = " ";
-        }
-        if (!empty($addressRecord['postal_code'])) {
-            $address[] = $addressRecord['postal_code'];
-            $address[] = " ";
-        }
-        if (!empty($addressRecord['country_code'])) {
-            $address[] = $addressRecord['country_code'];
-        }
-        return implode("", $address);
+        return $addressRecord->toString();
     }
 
-    public function insert($data, $foreignId)
+    /**
+     * Insert a new address record.
+     *
+     * @return int|false The new address ID, or false on failure
+     */
+    public function insert(AddressData $data, int $foreignId): int|false
     {
+        /** @var int $freshId */
         $freshId = $this->getFreshId("id", "addresses");
 
         $addressesSql  = " INSERT INTO addresses SET";
@@ -83,25 +79,30 @@ class AddressService extends BaseService
             $addressesSql,
             [
                 $freshId,
-                $data["line1"],
-                $data["line2"],
-                $data["city"],
-                $data["state"],
-                $data["zip"],
-                $data["plus_four"] ?? null,
-                $data["country"],
+                $data->line1,
+                $data->line2,
+                $data->city,
+                $data->state,
+                $data->zip,
+                $data->plusFour,
+                $data->country,
                 $foreignId
             ]
         );
 
-        if (!$addressesSqlResults) {
+        if ($addressesSqlResults === 0) {
             return false;
         }
 
         return $freshId;
     }
 
-    public function update($data, $foreignId)
+    /**
+     * Update an existing address record.
+     *
+     * @return int|string|null The address ID, or null if not found
+     */
+    public function update(AddressData $data, int $foreignId): int|string|null
     {
         $addressesSql  = " UPDATE addresses SET";
         $addressesSql .= "     line1=?,";
@@ -113,32 +114,40 @@ class AddressService extends BaseService
         $addressesSql .= "     country=?";
         $addressesSql .= "     WHERE foreign_id=?";
 
-        $addressesSqlResults = sqlStatement(
+        QueryUtils::sqlStatementThrowException(
             $addressesSql,
             [
-                $data["line1"],
-                $data["line2"],
-                $data["city"],
-                $data["state"],
-                $data["zip"],
-                $data["plus_four"] ?? null,
-                $data["country"],
+                $data->line1,
+                $data->line2,
+                $data->city,
+                $data->state,
+                $data->zip,
+                $data->plusFour,
+                $data->country,
                 $foreignId
             ]
         );
 
-        if (!$addressesSqlResults) {
-            return false;
-        }
+        /** @var array{id: int|string}|false $addressIdSqlResults */
+        $addressIdSqlResults = QueryUtils::querySingleRow(
+            "SELECT id FROM addresses WHERE foreign_id=? LIMIT 1",
+            [$foreignId]
+        );
 
-        $addressIdSqlResults = sqlQuery("SELECT id FROM addresses WHERE foreign_id=?", $foreignId);
-
-        return $addressIdSqlResults["id"];
+        return $addressIdSqlResults["id"] ?? null;
     }
 
-    public function getOneByForeignId($foreignId)
+    /**
+     * Get an address by its foreign ID.
+     */
+    public function getOneByForeignId(int $foreignId): ?AddressData
     {
-        $sql = "SELECT * FROM addresses WHERE foreign_id=?";
-        return sqlQuery($sql, [$foreignId]);
+        $sql = "SELECT * FROM addresses WHERE foreign_id=? LIMIT 1";
+        /** @var array<string, mixed>|false $result */
+        $result = QueryUtils::querySingleRow($sql, [$foreignId]);
+        if ($result === false) {
+            return null;
+        }
+        return AddressData::fromArray($result);
     }
 }

--- a/src/Services/InsuranceCompanyService.php
+++ b/src/Services/InsuranceCompanyService.php
@@ -20,6 +20,7 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Database\SqlQueryException;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\Services\Address\AddressData;
 use OpenEMR\Services\{
     AddressService,
     PhoneNumberService,
@@ -382,7 +383,7 @@ class InsuranceCompanyService extends BaseService
         );
 
         if (($data["city"] ?? '') !== '' && ($data["state"] ?? '') !== '') {
-            $this->addressService->insert($data, $freshId);
+            $this->addressService->insert(AddressData::fromArray($data), $freshId);
         }
 
         if (($data["phone"] ?? '') !== '') {
@@ -424,7 +425,7 @@ class InsuranceCompanyService extends BaseService
             return false;
         }
 
-        $addressesResults = $this->addressService->update($data, $iid);
+        $addressesResults = $this->addressService->update(AddressData::fromArray($data), $iid);
 
         if (!$addressesResults) {
             return false;

--- a/tests/Tests/Api/InsuranceCompanyApiTest.php
+++ b/tests/Tests/Api/InsuranceCompanyApiTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * InsuranceCompany API Endpoint Tests
+ *
+ * The insurance company REST API has pre-existing bugs:
+ * - POST/PUT: InsuranceCompanyService::validate() does not exist
+ * - GET one: Binary UUID in raw row causes JSON encoding error
+ * - GET all: ProcessingResult is not handled by responseHandler()
+ *
+ * These tests document the broken state and verify the one working endpoint.
+ * Service-layer tests in InsuranceCompanyServiceTest and AddressServiceTest
+ * cover the AddressData DTO integration that this PR introduces.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Api;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class InsuranceCompanyApiTest extends TestCase
+{
+    private const API_ENDPOINT = "/apis/default/api/insurance_company";
+
+    private ApiTestClient $testClient;
+
+    protected function setUp(): void
+    {
+        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
+        $this->testClient = new ApiTestClient($baseUrl, false);
+        $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+    }
+
+    #[Test]
+    public function testGetInsuranceTypes(): void
+    {
+        /** @var \Psr\Http\Message\ResponseInterface $response */
+        $response = $this->testClient->get("/apis/default/api/insurance_type");
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($body);
+        $this->assertNotEmpty($body, 'Should return at least one insurance type');
+    }
+
+    #[Test]
+    public function testGetOneReturns404ForMissingId(): void
+    {
+        /** @var \Psr\Http\Message\ResponseInterface $response */
+        $response = $this->testClient->getOne(self::API_ENDPOINT, 999999999);
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function testPostReturns500DueMissingValidateMethod(): void
+    {
+        // Pre-existing bug: InsuranceCompanyRestController::post() calls
+        // $this->insuranceCompanyService->validate() which does not exist.
+        $response = $this->testClient->post(self::API_ENDPOINT, [
+            'name' => 'test-fixture-Bug Test Insurance',
+            'attn' => '',
+            'cms_id' => '',
+            'ins_type_code' => '1',
+            'x12_receiver_id' => '',
+            'alt_cms_id' => '',
+        ]);
+
+        $this->assertEquals(500, $response->getStatusCode());
+    }
+}

--- a/tests/Tests/Isolated/Services/Address/AddressDataTest.php
+++ b/tests/Tests/Isolated/Services/Address/AddressDataTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * AddressData Unit Tests
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Address;
+
+use OpenEMR\Services\Address\AddressData;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class AddressDataTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $address = new AddressData(
+            line1: '123 Main St',
+            line2: 'Apt 4',
+            city: 'Springfield',
+            state: 'IL',
+            zip: '62701',
+            country: 'USA',
+            plusFour: '1234',
+        );
+
+        $this->assertSame('123 Main St', $address->line1);
+        $this->assertSame('Apt 4', $address->line2);
+        $this->assertSame('Springfield', $address->city);
+        $this->assertSame('IL', $address->state);
+        $this->assertSame('62701', $address->zip);
+        $this->assertSame('USA', $address->country);
+        $this->assertSame('1234', $address->plusFour);
+    }
+
+    public function testConstructorWithNullPlusFour(): void
+    {
+        $address = new AddressData(
+            line1: '123 Main St',
+            line2: '',
+            city: 'Springfield',
+            state: 'IL',
+            zip: '62701',
+            country: 'USA',
+        );
+
+        $this->assertNull($address->plusFour);
+    }
+
+    public function testFromArray(): void
+    {
+        $data = [
+            'line1' => '456 Oak Ave',
+            'line2' => 'Suite 100',
+            'city' => 'Chicago',
+            'state' => 'IL',
+            'zip' => '60601',
+            'country' => 'USA',
+            'plus_four' => '5678',
+        ];
+
+        $address = AddressData::fromArray($data);
+
+        $this->assertSame('456 Oak Ave', $address->line1);
+        $this->assertSame('Suite 100', $address->line2);
+        $this->assertSame('Chicago', $address->city);
+        $this->assertSame('IL', $address->state);
+        $this->assertSame('60601', $address->zip);
+        $this->assertSame('USA', $address->country);
+        $this->assertSame('5678', $address->plusFour);
+    }
+
+    public function testFromArrayWithMissingKeys(): void
+    {
+        $address = AddressData::fromArray([]);
+
+        $this->assertSame('', $address->line1);
+        $this->assertSame('', $address->line2);
+        $this->assertSame('', $address->city);
+        $this->assertSame('', $address->state);
+        $this->assertSame('', $address->zip);
+        $this->assertSame('', $address->country);
+        $this->assertNull($address->plusFour);
+    }
+
+    public function testFromArrayWithNonStringValues(): void
+    {
+        $data = [
+            'line1' => 123,
+            'line2' => null,
+            'city' => ['not', 'a', 'string'],
+            'state' => true,
+            'zip' => 62701,
+            'country' => new \stdClass(),
+            'plus_four' => 1234,
+        ];
+
+        $address = AddressData::fromArray($data);
+
+        // Non-string values should become empty strings
+        $this->assertSame('', $address->line1);
+        $this->assertSame('', $address->line2);
+        $this->assertSame('', $address->city);
+        $this->assertSame('', $address->state);
+        $this->assertSame('', $address->zip);
+        $this->assertSame('', $address->country);
+        $this->assertNull($address->plusFour);
+    }
+
+    public function testToArray(): void
+    {
+        $address = new AddressData(
+            line1: '789 Pine Rd',
+            line2: '',
+            city: 'Boston',
+            state: 'MA',
+            zip: '02101',
+            country: 'USA',
+            plusFour: '9999',
+        );
+
+        $expected = [
+            'line1' => '789 Pine Rd',
+            'line2' => '',
+            'city' => 'Boston',
+            'state' => 'MA',
+            'zip' => '02101',
+            'country' => 'USA',
+            'plus_four' => '9999',
+        ];
+
+        $this->assertSame($expected, $address->toArray());
+    }
+
+    public function testToArrayWithNullPlusFour(): void
+    {
+        $address = new AddressData(
+            line1: '789 Pine Rd',
+            line2: '',
+            city: 'Boston',
+            state: 'MA',
+            zip: '02101',
+            country: 'USA',
+        );
+
+        $result = $address->toArray();
+
+        $this->assertNull($result['plus_four']);
+    }
+
+    public function testImmutability(): void
+    {
+        $address = new AddressData(
+            line1: '123 Main St',
+            line2: '',
+            city: 'Springfield',
+            state: 'IL',
+            zip: '62701',
+            country: 'USA',
+        );
+
+        // Verify the class is readonly by checking reflection
+        $reflection = new \ReflectionClass($address);
+        $this->assertTrue($reflection->isReadOnly());
+    }
+}

--- a/tests/Tests/Isolated/Services/Address/AddressRecordTest.php
+++ b/tests/Tests/Isolated/Services/Address/AddressRecordTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * AddressRecord Unit Tests
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Address;
+
+use OpenEMR\Services\Address\AddressRecord;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class AddressRecordTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $address = new AddressRecord(
+            street: '123 Main St',
+            city: 'Springfield',
+            state: 'IL',
+            postalCode: '62701',
+            countryCode: 'USA',
+        );
+
+        $this->assertSame('123 Main St', $address->street);
+        $this->assertSame('Springfield', $address->city);
+        $this->assertSame('IL', $address->state);
+        $this->assertSame('62701', $address->postalCode);
+        $this->assertSame('USA', $address->countryCode);
+    }
+
+    public function testConstructorDefaults(): void
+    {
+        $address = new AddressRecord();
+
+        $this->assertSame('', $address->street);
+        $this->assertSame('', $address->city);
+        $this->assertSame('', $address->state);
+        $this->assertSame('', $address->postalCode);
+        $this->assertSame('', $address->countryCode);
+    }
+
+    public function testFromArray(): void
+    {
+        $data = [
+            'street' => '456 Oak Ave',
+            'city' => 'Chicago',
+            'state' => 'IL',
+            'postal_code' => '60601',
+            'country_code' => 'USA',
+        ];
+
+        $address = AddressRecord::fromArray($data);
+
+        $this->assertSame('456 Oak Ave', $address->street);
+        $this->assertSame('Chicago', $address->city);
+        $this->assertSame('IL', $address->state);
+        $this->assertSame('60601', $address->postalCode);
+        $this->assertSame('USA', $address->countryCode);
+    }
+
+    public function testFromArrayWithMissingKeys(): void
+    {
+        $address = AddressRecord::fromArray([]);
+
+        $this->assertSame('', $address->street);
+        $this->assertSame('', $address->city);
+        $this->assertSame('', $address->state);
+        $this->assertSame('', $address->postalCode);
+        $this->assertSame('', $address->countryCode);
+    }
+
+    public function testFromArrayWithNonStringValues(): void
+    {
+        $data = [
+            'street' => 123,
+            'city' => null,
+            'state' => ['array'],
+            'postal_code' => 62701,
+            'country_code' => true,
+        ];
+
+        $address = AddressRecord::fromArray($data);
+
+        // Non-string values should become empty strings
+        $this->assertSame('', $address->street);
+        $this->assertSame('', $address->city);
+        $this->assertSame('', $address->state);
+        $this->assertSame('', $address->postalCode);
+        $this->assertSame('', $address->countryCode);
+    }
+
+    #[DataProvider('toStringProvider')]
+    public function testToString(AddressRecord $address, string $expected): void
+    {
+        $this->assertSame($expected, $address->toString());
+        $this->assertSame($expected, (string) $address);
+    }
+
+    /**
+     * @return array<string, array{AddressRecord, string}>
+     */
+    public static function toStringProvider(): array
+    {
+        return [
+            'full address' => [
+                new AddressRecord(
+                    street: '123 Main St',
+                    city: 'Springfield',
+                    state: 'IL',
+                    postalCode: '62701',
+                    countryCode: 'USA',
+                ),
+                "123 Main St\nSpringfield, IL 62701 USA",
+            ],
+            'no country' => [
+                new AddressRecord(
+                    street: '123 Main St',
+                    city: 'Springfield',
+                    state: 'IL',
+                    postalCode: '62701',
+                ),
+                "123 Main St\nSpringfield, IL 62701",
+            ],
+            'no street' => [
+                new AddressRecord(
+                    city: 'Springfield',
+                    state: 'IL',
+                    postalCode: '62701',
+                    countryCode: 'USA',
+                ),
+                'Springfield, IL 62701 USA',
+            ],
+            'city and state only' => [
+                new AddressRecord(
+                    city: 'Springfield',
+                    state: 'IL',
+                ),
+                'Springfield, IL',
+            ],
+            'state only' => [
+                new AddressRecord(
+                    state: 'IL',
+                ),
+                'IL',
+            ],
+            'empty address' => [
+                new AddressRecord(),
+                '',
+            ],
+            'street only' => [
+                new AddressRecord(
+                    street: '123 Main St',
+                ),
+                '123 Main St',
+            ],
+            'no city' => [
+                new AddressRecord(
+                    street: '123 Main St',
+                    state: 'IL',
+                    postalCode: '62701',
+                ),
+                "123 Main St\nIL 62701",
+            ],
+        ];
+    }
+
+    public function testImmutability(): void
+    {
+        $address = new AddressRecord();
+
+        $reflection = new \ReflectionClass($address);
+        $this->assertTrue($reflection->isReadOnly());
+    }
+}

--- a/tests/Tests/Services/AddressServiceTest.php
+++ b/tests/Tests/Services/AddressServiceTest.php
@@ -1,0 +1,328 @@
+<?php
+
+/**
+ * AddressService Integration Tests
+ *
+ * Tests AddressService methods against a live database using the
+ * AddressData and AddressRecord DTOs.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\Address\AddressData;
+use OpenEMR\Services\Address\AddressRecord;
+use OpenEMR\Services\AddressService;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class AddressServiceTest extends TestCase
+{
+    private AddressService $addressService;
+
+    /** @var list<int> Foreign IDs used in tests, for cleanup */
+    private array $testForeignIds = [];
+
+    protected function setUp(): void
+    {
+        $this->addressService = new AddressService();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->testForeignIds as $foreignId) {
+            QueryUtils::fetchRecordsNoLog(
+                "DELETE FROM `addresses` WHERE `foreign_id` = ?",
+                [$foreignId]
+            );
+        }
+    }
+
+    /**
+     * Generate a unique foreign ID for test isolation.
+     * Use the sequences table like InsuranceCompanyService does.
+     */
+    private function generateTestForeignId(): int
+    {
+        /** @var int $id */
+        $id = QueryUtils::generateId();
+        $this->testForeignIds[] = $id;
+        return $id;
+    }
+
+    #[Test]
+    public function testValidateAcceptsValidAddress(): void
+    {
+        $address = new AddressData(
+            line1: '123 Main St',
+            line2: 'Apt 4B',
+            city: 'Springfield',
+            state: 'IL',
+            zip: '62701',
+            country: 'USA',
+        );
+
+        $result = $this->addressService->validate($address);
+
+        $this->assertTrue($result->isValid());
+        $this->assertEmpty($result->getMessages());
+    }
+
+    #[Test]
+    public function testValidateAcceptsEmptyOptionalFields(): void
+    {
+        $address = new AddressData(
+            line1: '',
+            line2: '',
+            city: '',
+            state: '',
+            zip: '',
+            country: '',
+        );
+
+        $result = $this->addressService->validate($address);
+
+        $this->assertTrue($result->isValid());
+    }
+
+    #[Test]
+    public function testValidateRejectsFieldTooShort(): void
+    {
+        $address = new AddressData(
+            line1: 'X', // below minimum length of 2
+            line2: '',
+            city: 'Springfield',
+            state: 'IL',
+            zip: '62701',
+            country: 'USA',
+        );
+
+        $result = $this->addressService->validate($address);
+
+        $this->assertFalse($result->isValid());
+        $messages = $result->getMessages();
+        $this->assertArrayHasKey('line1', $messages);
+    }
+
+    #[Test]
+    public function testValidateRejectsMultipleInvalidFields(): void
+    {
+        $address = new AddressData(
+            line1: 'X',
+            line2: '',
+            city: 'Y',
+            state: 'Z',
+            zip: '1',
+            country: 'A',
+        );
+
+        $result = $this->addressService->validate($address);
+
+        $this->assertFalse($result->isValid());
+        $messages = $result->getMessages();
+        $this->assertArrayHasKey('line1', $messages);
+        $this->assertArrayHasKey('city', $messages);
+        // state minimum is 2, 'Z' is only 1
+        $this->assertArrayHasKey('state', $messages);
+        $this->assertArrayHasKey('zip', $messages);
+        $this->assertArrayHasKey('country', $messages);
+    }
+
+    #[Test]
+    public function testInsertAndGetOneByForeignId(): void
+    {
+        $foreignId = $this->generateTestForeignId();
+        $data = new AddressData(
+            line1: '456 Oak Ave',
+            line2: 'Floor 3',
+            city: 'Chicago',
+            state: 'IL',
+            zip: '60601',
+            country: 'USA',
+            plusFour: '1234',
+        );
+
+        $addressId = $this->addressService->insert($data, $foreignId);
+
+        $this->assertIsInt($addressId);
+        $this->assertGreaterThan(0, $addressId);
+
+        // Retrieve and verify round-trip
+        $retrieved = $this->addressService->getOneByForeignId($foreignId);
+
+        $this->assertInstanceOf(AddressData::class, $retrieved);
+        $this->assertEquals('456 Oak Ave', $retrieved->line1);
+        $this->assertEquals('Floor 3', $retrieved->line2);
+        $this->assertEquals('Chicago', $retrieved->city);
+        $this->assertEquals('IL', $retrieved->state);
+        $this->assertEquals('60601', $retrieved->zip);
+        $this->assertEquals('USA', $retrieved->country);
+        $this->assertEquals('1234', $retrieved->plusFour);
+    }
+
+    #[Test]
+    public function testInsertWithNullPlusFour(): void
+    {
+        $foreignId = $this->generateTestForeignId();
+        $data = new AddressData(
+            line1: '789 Pine Rd',
+            line2: '',
+            city: 'Boston',
+            state: 'MA',
+            zip: '02101',
+            country: 'USA',
+        );
+
+        $addressId = $this->addressService->insert($data, $foreignId);
+
+        $this->assertIsInt($addressId);
+
+        $retrieved = $this->addressService->getOneByForeignId($foreignId);
+        $this->assertInstanceOf(AddressData::class, $retrieved);
+        $this->assertNull($retrieved->plusFour);
+    }
+
+    #[Test]
+    public function testUpdateModifiesAddress(): void
+    {
+        $foreignId = $this->generateTestForeignId();
+        $original = new AddressData(
+            line1: '100 First St',
+            line2: '',
+            city: 'Austin',
+            state: 'TX',
+            zip: '73301',
+            country: 'USA',
+        );
+        $this->addressService->insert($original, $foreignId);
+
+        // Update with new data
+        $updated = new AddressData(
+            line1: '200 Second Ave',
+            line2: 'Unit B',
+            city: 'Dallas',
+            state: 'TX',
+            zip: '75201',
+            country: 'USA',
+            plusFour: '5678',
+        );
+        $resultId = $this->addressService->update($updated, $foreignId);
+
+        $this->assertNotNull($resultId);
+
+        // Verify update persisted
+        $retrieved = $this->addressService->getOneByForeignId($foreignId);
+        $this->assertInstanceOf(AddressData::class, $retrieved);
+        $this->assertEquals('200 Second Ave', $retrieved->line1);
+        $this->assertEquals('Unit B', $retrieved->line2);
+        $this->assertEquals('Dallas', $retrieved->city);
+        $this->assertEquals('75201', $retrieved->zip);
+        $this->assertEquals('5678', $retrieved->plusFour);
+    }
+
+    #[Test]
+    public function testGetOneByForeignIdReturnsNullWhenNotFound(): void
+    {
+        $result = $this->addressService->getOneByForeignId(999999999);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function testGetAddressFromRecordAsString(): void
+    {
+        $record = new AddressRecord(
+            street: '123 Main St',
+            city: 'Springfield',
+            state: 'IL',
+            postalCode: '62701',
+            countryCode: 'USA',
+        );
+
+        $result = $this->addressService->getAddressFromRecordAsString($record);
+
+        $this->assertEquals("123 Main St\nSpringfield, IL 62701 USA", $result);
+    }
+
+    #[Test]
+    public function testGetAddressFromRecordAsStringPartialAddress(): void
+    {
+        $record = new AddressRecord(
+            city: 'Springfield',
+            state: 'IL',
+        );
+
+        $result = $this->addressService->getAddressFromRecordAsString($record);
+
+        $this->assertEquals('Springfield, IL', $result);
+    }
+
+    #[Test]
+    public function testGetAddressFromRecordAsStringEmptyAddress(): void
+    {
+        $record = new AddressRecord();
+
+        $result = $this->addressService->getAddressFromRecordAsString($record);
+
+        $this->assertEquals('', $result);
+    }
+
+    #[Test]
+    public function testInsertWithFromArrayIntegration(): void
+    {
+        $foreignId = $this->generateTestForeignId();
+
+        // Simulate how InsuranceCompanyService calls AddressService -
+        // converting a mixed data array to AddressData via fromArray()
+        $rawData = [
+            'name' => 'Test Insurance Co',
+            'line1' => '321 Insurance Way',
+            'line2' => '',
+            'city' => 'Hartford',
+            'state' => 'CT',
+            'zip' => '06101',
+            'country' => 'USA',
+            'plus_four' => '0001',
+            'some_unrelated_field' => 'ignored',
+        ];
+
+        $addressData = AddressData::fromArray($rawData);
+        $addressId = $this->addressService->insert($addressData, $foreignId);
+
+        $this->assertIsInt($addressId);
+        $this->assertGreaterThan(0, $addressId);
+
+        $retrieved = $this->addressService->getOneByForeignId($foreignId);
+        $this->assertInstanceOf(AddressData::class, $retrieved);
+        $this->assertEquals('321 Insurance Way', $retrieved->line1);
+        $this->assertEquals('Hartford', $retrieved->city);
+        $this->assertEquals('CT', $retrieved->state);
+        $this->assertEquals('06101', $retrieved->zip);
+        $this->assertEquals('0001', $retrieved->plusFour);
+    }
+
+    #[Test]
+    public function testValidateWithFromArrayIntegration(): void
+    {
+        // Simulate the InsuranceCompanyRestController path:
+        // AddressData::fromArray($data) → AddressService::validate()
+        $data = [
+            'line1' => '123 Main St',
+            'city' => 'Springfield',
+            'state' => 'IL',
+            'zip' => '62701',
+            'country' => 'USA',
+        ];
+
+        $addressData = AddressData::fromArray($data);
+        $result = $this->addressService->validate($addressData);
+
+        $this->assertTrue($result->isValid());
+    }
+}

--- a/tests/Tests/Services/InsuranceCompanyServiceTest.php
+++ b/tests/Tests/Services/InsuranceCompanyServiceTest.php
@@ -1,0 +1,249 @@
+<?php
+
+/**
+ * InsuranceCompanyService Integration Tests
+ *
+ * Tests InsuranceCompanyService insert and update methods, verifying
+ * that AddressData DTO integration works correctly when creating and
+ * modifying insurance companies with address records.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\AddressService;
+use OpenEMR\Services\Address\AddressData;
+use OpenEMR\Services\InsuranceCompanyService;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class InsuranceCompanyServiceTest extends TestCase
+{
+    private InsuranceCompanyService $service;
+    private AddressService $addressService;
+
+    /** @var list<int|string> */
+    private array $createdIds = [];
+
+    protected function setUp(): void
+    {
+        $this->service = new InsuranceCompanyService();
+        $this->addressService = new AddressService();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdIds as $id) {
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `addresses` WHERE `foreign_id` = ?", [$id]);
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `phone_numbers` WHERE `foreign_id` = ?", [$id]);
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `insurance_companies` WHERE `id` = ?", [$id]);
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getTestData(): array
+    {
+        return [
+            'name' => 'test-fixture-Service Test Insurance',
+            'attn' => 'Claims Department',
+            'cms_id' => '88888',
+            'ins_type_code' => '1',
+            'x12_receiver_id' => '',
+            'x12_default_partner_id' => '',
+            'alt_cms_id' => '',
+            'line1' => '100 Insurance Blvd',
+            'line2' => 'Suite 200',
+            'city' => 'Springfield',
+            'state' => 'IL',
+            'zip' => '62701',
+            'country' => 'USA',
+        ];
+    }
+
+    /**
+     * Insert test data and track the ID for cleanup.
+     *
+     * @return int|string
+     */
+    private function insertAndTrack(): int|string
+    {
+        /** @var int|string $id */
+        $id = $this->service->insert($this->getTestData());
+        $this->createdIds[] = $id;
+        return $id;
+    }
+
+    #[Test]
+    public function testInsertCreatesInsuranceCompany(): void
+    {
+        $id = $this->insertAndTrack();
+
+        $this->assertIsInt($id);
+        $this->assertGreaterThan(0, $id);
+
+        /** @var array{name: string, cms_id: string}|false $row */
+        $row = QueryUtils::querySingleRow(
+            "SELECT name, cms_id FROM insurance_companies WHERE id = ?",
+            [$id]
+        );
+        $this->assertNotFalse($row);
+        $this->assertEquals('test-fixture-Service Test Insurance', $row['name']);
+        $this->assertEquals('88888', $row['cms_id']);
+    }
+
+    #[Test]
+    public function testInsertCreatesAddressRecord(): void
+    {
+        $id = $this->insertAndTrack();
+
+        // The insert path calls AddressData::fromArray($data) then
+        // addressService->insert() - verify the address was stored
+        /** @var int $intId */
+        $intId = $id;
+        $address = $this->addressService->getOneByForeignId($intId);
+
+        $this->assertInstanceOf(AddressData::class, $address);
+        $this->assertEquals('100 Insurance Blvd', $address->line1);
+        $this->assertEquals('Suite 200', $address->line2);
+        $this->assertEquals('Springfield', $address->city);
+        $this->assertEquals('IL', $address->state);
+        $this->assertEquals('62701', $address->zip);
+        $this->assertEquals('USA', $address->country);
+    }
+
+    #[Test]
+    public function testInsertSkipsAddressWhenCityAndStateMissing(): void
+    {
+        $data = $this->getTestData();
+        $data['city'] = '';
+        $data['state'] = '';
+
+        /** @var int|string $id */
+        $id = $this->service->insert($data);
+        $this->createdIds[] = $id;
+
+        // Address should not be created when city and state are empty
+        /** @var int $intId */
+        $intId = $id;
+        $address = $this->addressService->getOneByForeignId($intId);
+        $this->assertNull($address);
+    }
+
+    #[Test]
+    public function testUpdateModifiesInsuranceCompany(): void
+    {
+        $id = $this->insertAndTrack();
+
+        $data = $this->getTestData();
+        $data['name'] = 'test-fixture-Updated Insurance Co';
+        $data['line1'] = '200 Updated Ave';
+        $data['city'] = 'Chicago';
+        $data['zip'] = '60601';
+
+        $result = $this->service->update($data, $id);
+
+        $this->assertEquals($id, $result);
+
+        /** @var array{name: string}|false $row */
+        $row = QueryUtils::querySingleRow(
+            "SELECT name FROM insurance_companies WHERE id = ?",
+            [$id]
+        );
+        $this->assertNotFalse($row);
+        $this->assertEquals('test-fixture-Updated Insurance Co', $row['name']);
+    }
+
+    #[Test]
+    public function testUpdateModifiesAddressRecord(): void
+    {
+        $id = $this->insertAndTrack();
+
+        $data = $this->getTestData();
+        $data['line1'] = '200 Updated Ave';
+        $data['line2'] = 'Floor 5';
+        $data['city'] = 'Chicago';
+        $data['state'] = 'IL';
+        $data['zip'] = '60601';
+        $data['country'] = 'US';
+
+        $this->service->update($data, $id);
+
+        // The update path calls AddressData::fromArray($data) then
+        // addressService->update() - verify the address was modified
+        /** @var int $intId */
+        $intId = $id;
+        $address = $this->addressService->getOneByForeignId($intId);
+
+        $this->assertInstanceOf(AddressData::class, $address);
+        $this->assertEquals('200 Updated Ave', $address->line1);
+        $this->assertEquals('Floor 5', $address->line2);
+        $this->assertEquals('Chicago', $address->city);
+        $this->assertEquals('60601', $address->zip);
+        $this->assertEquals('US', $address->country);
+    }
+
+    #[Test]
+    public function testGetOneByIdReturnsCompanyData(): void
+    {
+        $id = $this->insertAndTrack();
+
+        $result = $this->service->getOneById($id);
+
+        $this->assertIsArray($result);
+        $this->assertEquals($id, $result['id']);
+        $this->assertEquals('test-fixture-Service Test Insurance', $result['name']);
+        $this->assertEquals('88888', $result['cms_id']);
+    }
+
+    #[Test]
+    public function testSearchReturnsInsuranceCompanyWithAddressJoin(): void
+    {
+        $id = $this->insertAndTrack();
+
+        $result = $this->service->search(['id' => $id]);
+
+        $this->assertTrue($result->hasData());
+        /** @var list<array<string, mixed>> $records */
+        $records = $result->getData();
+        $this->assertCount(1, $records);
+
+        $record = $records[0];
+        $this->assertEquals('test-fixture-Service Test Insurance', $record['name']);
+        // Address fields should be joined from the addresses table
+        $this->assertEquals('100 Insurance Blvd', $record['line1']);
+        $this->assertEquals('Suite 200', $record['line2']);
+        $this->assertEquals('Springfield', $record['city']);
+        $this->assertEquals('IL', $record['state']);
+        $this->assertEquals('62701', $record['zip']);
+        $this->assertEquals('USA', $record['country']);
+    }
+
+    #[Test]
+    public function testInsertWithExplicitId(): void
+    {
+        $data = $this->getTestData();
+        $data['id'] = 9999999;
+
+        /** @var int|string $id */
+        $id = $this->service->insert($data);
+        $this->createdIds[] = $id;
+
+        $this->assertEquals(9999999, $id);
+
+        /** @var array{id: int}|false $row */
+        $row = QueryUtils::querySingleRow(
+            "SELECT id FROM insurance_companies WHERE id = ?",
+            [$id]
+        );
+        $this->assertNotFalse($row);
+        $this->assertEquals(9999999, $row['id']);
+    }
+}


### PR DESCRIPTION
## Summary

Introduce `AddressData` and `AddressRecord` readonly DTOs to replace untyped arrays in `AddressService`. Add return type declarations and parameter types to all public methods. Replace deprecated `sqlStatement()`/`sqlQuery()` calls with `QueryUtils` methods.

Fixes #10417

## Changes proposed in this pull request

- Add `AddressData` immutable DTO for insert/update operations with `fromArray()` factory
- Add `AddressRecord` immutable DTO for address display formatting with `toString()`/`__toString()`
- Add return types and parameter types to all `AddressService` public methods
- Replace deprecated `sqlStatement()`/`sqlQuery()` with `QueryUtils::sqlStatementThrowException()`/`querySingleRow()`
- Fix always-false boolean expression in `InsuranceCompanyService::update()`
- Replace `empty()` checks with explicit string comparisons
- Update callers: `InsuranceCompanyService`, `InsuranceCompanyRestController`, `ins_search.php`, `FormattedPatientService`
- Remove resolved entries from PHPStan deprecated SQL function baseline
- Add integration tests: `AddressServiceTest` (13 tests), `InsuranceCompanyServiceTest` (8 tests), `InsuranceCompanyApiTest` (3 tests)
- Add isolated unit tests: `AddressDataTest`, `AddressRecordTest`

## AI Disclosure
Yes - assisted by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)