### PR TITLE
fix(reports): prevent inflated totals in Financial Summary by Service Code

### DIFF
--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -4283,12 +4283,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/svc_code_financial_report.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/svc_code_financial_report.php',
 ];
 $ignoreErrors[] = [
@@ -8000,6 +8000,11 @@ $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
     'count' => 42,
     'path' => __DIR__ . '/../../tests/Tests/E2e/JjEncounterContextMainMenuLinksTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
+    'count' => 6,
+    'path' => __DIR__ . '/../../tests/Tests/E2e/SvcCodeFinancialReportTest.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',

--- a/interface/reports/svc_code_financial_report.php
+++ b/interface/reports/svc_code_financial_report.php
@@ -14,8 +14,10 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Visolve
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (C) 2006-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017-2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -28,6 +30,7 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
+use OpenEMR\Services\Reports\FinancialSummaryReportService;
 
 if (!AclMain::aclCheckCore('acct', 'rep_a')) {
     echo (new TwigContainer(null, $GLOBALS['kernel']))->getTwig()->render('core/unauthorized.html.twig', ['pageTitle' => xl("Financial Summary by Service Code")]);
@@ -48,8 +51,8 @@ $grand_total_amt_balance  = 0;
 
 $form_from_date = (isset($_POST['form_from_date'])) ? DateToYYYYMMDD($_POST['form_from_date']) : date('Y-m-d');
 $form_to_date   = (isset($_POST['form_to_date'])) ? DateToYYYYMMDD($_POST['form_to_date']) : date('Y-m-d');
-$form_facility  = $_POST['form_facility'] ?? null;
-$form_provider  = $_POST['form_provider'] ?? null;
+$form_facility  = isset($_POST['form_facility']) && $_POST['form_facility'] !== '' ? (int) $_POST['form_facility'] : null;
+$form_provider  = isset($_POST['form_provider']) && $_POST['form_provider'] !== '' ? (int) $_POST['form_provider'] : null;
 
 if (!empty($_POST['form_csvexport'])) {
     header("Pragma: public");
@@ -209,61 +212,23 @@ if (!empty($_POST['form_csvexport'])) {
    // end not export
 
 if (!empty($_POST['form_refresh']) || !empty($_POST['form_csvexport'])) {
+    $service = new FinancialSummaryReportService();
+    $summaries = $service->getServiceCodeSummary(
+        new \DateTimeImmutable($form_from_date),
+        new \DateTimeImmutable($form_to_date),
+        $form_facility,
+        $form_provider,
+        !empty($_POST['form_details']),
+    );
     $rows = [];
-    $from_date = $form_from_date;
-    $to_date   = $form_to_date;
-    $sqlBindArray = [];
-    $query = "select b.code,sum(b.units) as units,sum(b.fee) as billed,sum(ar_act.paid) as PaidAmount, " .
-    "sum(ar_act.adjust) as AdjustAmount,(sum(b.fee)-(sum(ar_act.paid)+sum(ar_act.adjust))) as Balance, " .
-    "c.financial_reporting " .
-    "FROM form_encounter as fe " .
-    "JOIN billing as b on b.pid=fe.pid and b.encounter=fe.encounter " .
-    "JOIN (select pid, encounter, code, sum(pay_amount) as paid, sum(adj_amount) as adjust " .
-    "from ar_activity WHERE deleted IS NULL group by pid, encounter, code) as ar_act " .
-    "ON ar_act.pid=b.pid and ar_act.encounter=b.encounter and ar_act.code=b.code " .
-    "LEFT OUTER JOIN codes AS c ON c.code = b.code " .
-    "INNER JOIN code_types AS ct ON ct.ct_key = b.code_type AND ct.ct_fee = '1' " .
-    "WHERE b.code_type != 'COPAY' AND b.activity = 1 /* AND b.fee != 0 */ AND " .
-    "fe.date >=  ? AND fe.date <= ?";
-    array_push($sqlBindArray, "$from_date 00:00:00", "$to_date 23:59:59");
-    // If a facility was specified.
-    if ($form_facility) {
-        $query .= " AND fe.facility_id = ?";
-        array_push($sqlBindArray, $form_facility);
+    foreach ($summaries as $summary) {
+        $rows[$summary->code . '|' . $summary->units] = $summary->toArray();
     }
-
-    // If a provider was specified.
-    if ($form_provider) {
-        $query .= " AND b.provider_id = ?";
-        array_push($sqlBindArray, $form_provider);
-    }
-
-    // If selected important codes
-    if (!empty($_POST['form_details'])) {
-        $query .= " AND c.financial_reporting = '1'";
-    }
-
-    $query .= " GROUP BY b.code ORDER BY b.code, fe.date, fe.id ";
-    $res = sqlStatement($query, $sqlBindArray);
     $grand_total_units  = 0;
     $grand_total_amt_billed  = 0;
     $grand_total_amt_paid  = 0;
     $grand_total_amt_adjustment  = 0;
     $grand_total_amt_balance  = 0;
-
-    while ($erow = sqlFetchArray($res)) {
-        $row = [];
-        $row['pid'] = $erow['pid'] ?? null;
-        $row['provider_id'] = $erow['provider_id'] ?? null;
-        $row['Procedure codes'] = $erow['code'];
-        $row['Units'] = $erow['units'];
-        $row['Amt Billed'] = $erow['billed'];
-        $row['Paid Amt'] = $erow['PaidAmount'];
-        $row['Adjustment Amt'] = $erow['AdjustAmount'];
-        $row['Balance Amt'] = $erow['Balance'];
-        $row['financial_reporting'] = $erow['financial_reporting'];
-        $rows[($erow['pid'] ?? null) . '|' . $erow['code'] . '|' . $erow['units']] = $row;
-    }
 
     if ($_POST['form_csvexport']) {
       // CSV headers:

--- a/src/Services/Reports/FinancialSummaryReportService.php
+++ b/src/Services/Reports/FinancialSummaryReportService.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Query logic for the Financial Summary by Service Code report.
+ *
+ * Fixes a bug where the original LEFT JOIN on the codes table matched only
+ * on `code`, producing a Cartesian product when multiple rows shared the
+ * same code value (different modifiers or code types). The fix uses a
+ * subquery grouped by (code, code_type) and joins on both columns.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services\Reports;
+
+use OpenEMR\Common\Database\QueryUtils;
+
+class FinancialSummaryReportService
+{
+    /**
+     * Get financial summary data grouped by service code.
+     *
+     * @param ?int $facilityId Filter by facility (null = all)
+     * @param ?int $providerId Filter by provider (null = all)
+     * @param bool $financialReportingOnly Limit to codes flagged for financial reporting
+     * @return ServiceCodeSummary[]
+     */
+    public function getServiceCodeSummary(
+        \DateTimeInterface $fromDate,
+        \DateTimeInterface $toDate,
+        ?int $facilityId = null,
+        ?int $providerId = null,
+        bool $financialReportingOnly = false
+    ): array {
+        $query = <<<'SQL'
+            SELECT
+                b.code,
+                SUM(b.units) AS units,
+                SUM(b.fee) AS billed,
+                SUM(ar_act.paid) AS paid,
+                SUM(ar_act.adjusted) AS adjusted,
+                MAX(c.financial_reporting) AS financial_reporting
+            FROM form_encounter AS fe
+            JOIN billing AS b
+                ON b.pid = fe.pid AND b.encounter = fe.encounter
+            JOIN (
+                SELECT pid, encounter, code,
+                    SUM(pay_amount) AS paid, SUM(adj_amount) AS adjusted
+                FROM ar_activity
+                WHERE deleted IS NULL
+                GROUP BY pid, encounter, code
+            ) AS ar_act
+                ON ar_act.pid = b.pid
+                AND ar_act.encounter = b.encounter
+                AND ar_act.code = b.code
+            INNER JOIN code_types AS ct
+                ON ct.ct_key = b.code_type AND ct.ct_fee = '1'
+            LEFT OUTER JOIN (
+                SELECT code, code_type,
+                    MAX(financial_reporting) AS financial_reporting
+                FROM codes
+                GROUP BY code, code_type
+            ) AS c
+                ON c.code = b.code AND c.code_type = ct.ct_id
+            SQL;
+
+        $conditions = [
+            "b.code_type != 'COPAY'",
+            'b.activity = 1',
+            'fe.date BETWEEN ? AND ?',
+        ];
+        $binds = [
+            $fromDate->format('Y-m-d 00:00:00'),
+            $toDate->format('Y-m-d 23:59:59'),
+        ];
+
+        if ($facilityId !== null) {
+            $conditions[] = 'fe.facility_id = ?';
+            $binds[] = $facilityId;
+        }
+
+        if ($providerId !== null) {
+            $conditions[] = 'b.provider_id = ?';
+            $binds[] = $providerId;
+        }
+
+        $query .= ' WHERE ' . implode(' AND ', $conditions);
+        $query .= ' GROUP BY b.code';
+
+        if ($financialReportingOnly) {
+            $query .= " HAVING MAX(c.financial_reporting) = '1'";
+        }
+
+        $query .= ' ORDER BY b.code';
+
+        /** @var array<int, array{code: string, units: string, billed: string, paid: string, adjusted: string, financial_reporting: string|null}> $records */
+        $records = QueryUtils::fetchRecords($query, $binds);
+
+        return array_map(ServiceCodeSummary::fromArray(...), $records);
+    }
+}

--- a/src/Services/Reports/ServiceCodeSummary.php
+++ b/src/Services/Reports/ServiceCodeSummary.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Data object representing one row of the Financial Summary by Service Code report.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services\Reports;
+
+readonly class ServiceCodeSummary
+{
+    public function __construct(
+        public string $code,
+        public int $units,
+        public float $billed,
+        public float $paid,
+        public float $adjusted,
+        public float $balance,
+        public ?bool $financialReporting,
+    ) {
+    }
+
+    /**
+     * Build from a database result row.
+     *
+     * @param array{code: string, units: string, billed: string, paid: string, adjusted: string, financial_reporting: string|null} $row
+     */
+    public static function fromArray(array $row): self
+    {
+        $billed = (float) $row['billed'];
+        $paid = (float) $row['paid'];
+        $adjusted = (float) $row['adjusted'];
+
+        return new self(
+            code: $row['code'],
+            units: (int) $row['units'],
+            billed: $billed,
+            paid: $paid,
+            adjusted: $adjusted,
+            balance: $billed - $paid - $adjusted,
+            financialReporting: $row['financial_reporting'] === null ? null : (bool) $row['financial_reporting'],
+        );
+    }
+
+    /**
+     * Convert to the associative array format the report rendering layer expects.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'Procedure codes' => $this->code,
+            'Units' => $this->units,
+            'Amt Billed' => $this->billed,
+            'Paid Amt' => $this->paid,
+            'Adjustment Amt' => $this->adjusted,
+            'Balance Amt' => $this->balance,
+            'financial_reporting' => $this->financialReporting,
+        ];
+    }
+}

--- a/tests/Tests/E2e/SvcCodeFinancialReportTest.php
+++ b/tests/Tests/E2e/SvcCodeFinancialReportTest.php
@@ -1,0 +1,304 @@
+<?php
+
+/**
+ * E2e tests for the Financial Summary by Service Code report.
+ *
+ * Verifies the report renders correctly, displays expected data from
+ * fixture billing records, and applies the Important Codes filter.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\E2e;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Tests\E2e\Base\BaseTrait;
+use OpenEMR\Tests\E2e\Login\LoginTestData;
+use OpenEMR\Tests\E2e\Login\LoginTrait;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Panther\PantherTestCase;
+
+class SvcCodeFinancialReportTest extends PantherTestCase
+{
+    use BaseTrait;
+    use LoginTrait;
+
+    private $client;
+    private $crawler;
+
+    /**
+     * Encounter number for test fixtures, chosen to avoid collisions.
+     */
+    private const TEST_ENCOUNTER = 888888001;
+    private const TEST_PID = 1;
+    private const TEST_DATE = '2026-01-15';
+    private const TEST_CODE_IMPORTANT = 'E2ETST01';
+    private const TEST_CODE_NORMAL = 'E2ETST02';
+
+    /**
+     * XPath to the report iframe. Reports open in a frame named 'rep'.
+     */
+    private const REPORT_IFRAME = "//*[@id='framesDisplay']//iframe[@name='rep']";
+
+    /**
+     * Report page navigates, loads, and shows the empty state message.
+     */
+    #[Test]
+    #[Depends('testLoginAuthorized')]
+    public function testReportPageLoads(): void
+    {
+        $this->base();
+        try {
+            $this->login(LoginTestData::username, LoginTestData::password);
+            $this->goToMainMenuLink('Reports||Financial||Financial Summary by Service Code');
+            $this->assertActiveTab('Financial Summary by Service Code');
+        } catch (\Throwable $e) {
+            $this->client->quit();
+            throw $e;
+        }
+        $this->client->quit();
+    }
+
+    /**
+     * Submit the report with no data and verify "No matches found" message.
+     */
+    #[Test]
+    #[Depends('testLoginAuthorized')]
+    public function testReportEmptySubmit(): void
+    {
+        $this->base();
+        try {
+            $this->login(LoginTestData::username, LoginTestData::password);
+            $this->goToMainMenuLink('Reports||Financial||Financial Summary by Service Code');
+            $this->assertActiveTab('Financial Summary by Service Code');
+
+            $this->switchToIFrame(self::REPORT_IFRAME);
+            $this->submitReportForm('2020-01-01', '2020-01-02');
+
+            $this->crawler = $this->client->refreshCrawler();
+            $pageText = $this->crawler->filterXPath('//body')->text();
+            $this->assertStringContainsString('No matches found', $pageText);
+        } catch (\Throwable $e) {
+            $this->client->quit();
+            throw $e;
+        }
+        $this->client->quit();
+    }
+
+    /**
+     * Insert fixture data, submit the report, and verify the table shows
+     * correct totals.
+     */
+    #[Test]
+    #[Depends('testLoginAuthorized')]
+    public function testReportShowsCorrectTotals(): void
+    {
+        $this->insertFixtureData();
+
+        $this->base();
+        try {
+            $this->login(LoginTestData::username, LoginTestData::password);
+            $this->goToMainMenuLink('Reports||Financial||Financial Summary by Service Code');
+            $this->assertActiveTab('Financial Summary by Service Code');
+
+            $this->switchToIFrame(self::REPORT_IFRAME);
+            $this->submitReportForm(self::TEST_DATE, self::TEST_DATE);
+
+            $this->crawler = $this->client->refreshCrawler();
+
+            // Verify the report table exists and contains our test code
+            $tableText = $this->crawler->filterXPath('//table[@id="mymaintable"]')->text();
+            $this->assertStringContainsString(self::TEST_CODE_IMPORTANT, $tableText, 'Important code should appear in results');
+            $this->assertStringContainsString(self::TEST_CODE_NORMAL, $tableText, 'Normal code should appear in results');
+
+            // Verify specific values for the important code row
+            $this->assertStringContainsString('250.00', $tableText, 'Billed amount should be 250.00');
+            $this->assertStringContainsString('180.00', $tableText, 'Paid amount should be 180.00');
+            $this->assertStringContainsString('Grand Total', $tableText, 'Grand Total row should exist');
+        } catch (\Throwable $e) {
+            $this->client->quit();
+            $this->cleanUpFixtureData();
+            throw $e;
+        }
+        $this->client->quit();
+        $this->cleanUpFixtureData();
+    }
+
+    /**
+     * Verify that the Important Codes checkbox filters results to only
+     * codes with financial_reporting=1.
+     */
+    #[Test]
+    #[Depends('testLoginAuthorized')]
+    public function testImportantCodesFilter(): void
+    {
+        $this->insertFixtureData();
+
+        $this->base();
+        try {
+            $this->login(LoginTestData::username, LoginTestData::password);
+            $this->goToMainMenuLink('Reports||Financial||Financial Summary by Service Code');
+            $this->assertActiveTab('Financial Summary by Service Code');
+
+            $this->switchToIFrame(self::REPORT_IFRAME);
+
+            // Check the Important Codes checkbox before submitting
+            $checkbox = $this->crawler->filterXPath('//input[@name="form_details"]');
+            if (!$checkbox->getElement(0)->isSelected()) {
+                $checkbox->getElement(0)->click();
+            }
+
+            $this->submitReportForm(self::TEST_DATE, self::TEST_DATE);
+
+            $this->crawler = $this->client->refreshCrawler();
+
+            $tableText = $this->crawler->filterXPath('//table[@id="mymaintable"]')->text();
+            // Important code (financial_reporting=1) should appear
+            $this->assertStringContainsString(self::TEST_CODE_IMPORTANT, $tableText, 'Important code should appear with filter');
+            // Normal code (financial_reporting=0) should NOT appear
+            $this->assertStringNotContainsString(self::TEST_CODE_NORMAL, $tableText, 'Normal code should be filtered out');
+        } catch (\Throwable $e) {
+            $this->client->quit();
+            $this->cleanUpFixtureData();
+            throw $e;
+        }
+        $this->client->quit();
+        $this->cleanUpFixtureData();
+    }
+
+    /**
+     * Verify that duplicate modifier rows in the codes table do NOT
+     * inflate report totals. This is the core bug fix.
+     */
+    #[Test]
+    #[Depends('testLoginAuthorized')]
+    public function testDuplicateModifiersDoNotInflateTotals(): void
+    {
+        $this->insertFixtureData();
+        // Add extra modifier variants that would inflate totals with the old query
+        $this->insertCode(self::TEST_CODE_IMPORTANT, 1, '26', 0);
+        $this->insertCode(self::TEST_CODE_IMPORTANT, 1, 'TC', 0);
+
+        $this->base();
+        try {
+            $this->login(LoginTestData::username, LoginTestData::password);
+            $this->goToMainMenuLink('Reports||Financial||Financial Summary by Service Code');
+            $this->assertActiveTab('Financial Summary by Service Code');
+
+            $this->switchToIFrame(self::REPORT_IFRAME);
+            $this->submitReportForm(self::TEST_DATE, self::TEST_DATE);
+
+            $this->crawler = $this->client->refreshCrawler();
+
+            // Extract rows from the report table
+            $rows = $this->crawler->filterXPath('//table[@id="mymaintable"]//tr[td]');
+            $found = false;
+            for ($i = 0; $i < $rows->count(); $i++) {
+                $cells = $rows->eq($i)->filterXPath('.//td');
+                $code = trim((string) $cells->eq(0)->text());
+                if ($code === self::TEST_CODE_IMPORTANT) {
+                    $found = true;
+                    $billed = trim((string) $cells->eq(2)->text());
+                    $paid = trim((string) $cells->eq(3)->text());
+                    // Without the fix these would be tripled (3 modifier rows x original values)
+                    $this->assertSame('250.00', $billed, 'Billed should be 250.00, not inflated by duplicate modifiers');
+                    $this->assertSame('180.00', $paid, 'Paid should be 180.00, not inflated by duplicate modifiers');
+                    break;
+                }
+            }
+            $this->assertTrue($found, 'Expected to find code ' . self::TEST_CODE_IMPORTANT . ' in results');
+        } catch (\Throwable $e) {
+            $this->client->quit();
+            $this->cleanUpFixtureData();
+            throw $e;
+        }
+        $this->client->quit();
+        $this->cleanUpFixtureData();
+    }
+
+    // -------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------
+
+    private function submitReportForm(string $fromDate, string $toDate): void
+    {
+        // Set date fields via WebDriver (visible text inputs)
+        $fromInput = $this->crawler->filter('#form_from_date')->getElement(0);
+        $fromInput->clear();
+        $fromInput->sendKeys($fromDate);
+        $toInput = $this->crawler->filter('#form_to_date')->getElement(0);
+        $toInput->clear();
+        $toInput->sendKeys($toDate);
+
+        // Set hidden fields and submit via JavaScript since WebDriver
+        // cannot sendKeys to hidden inputs
+        $this->client->executeScript(
+            'document.getElementById("form_refresh").value = "true";'
+            . 'document.getElementById("form_csvexport").value = "";'
+            . 'document.getElementById("theform").submit();'
+        );
+        $this->client->waitFor('body');
+        $this->crawler = $this->client->refreshCrawler();
+    }
+
+    private function insertFixtureData(): void
+    {
+        $this->cleanUpFixtureData();
+
+        QueryUtils::sqlInsert("INSERT INTO facility (name) VALUES (?)", ['e2e-test-svc-report']);
+        /** @var array{id: int}|false $row */
+        $row = QueryUtils::querySingleRow("SELECT id FROM facility WHERE name = ?", ['e2e-test-svc-report']);
+        $facilityId = $row ? (int) $row['id'] : 0;
+
+        QueryUtils::sqlInsert(
+            "INSERT INTO form_encounter (pid, encounter, date, facility_id, reason) VALUES (?, ?, ?, ?, ?)",
+            [self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_DATE . ' 12:00:00', $facilityId, 'e2e-test-svc-code-report']
+        );
+
+        // Important code: financial_reporting=1, units=2, fee=250, paid=180, adj=30
+        QueryUtils::sqlInsert(
+            "INSERT INTO billing (pid, encounter, code, code_type, units, fee, provider_id, activity) VALUES (?, ?, ?, ?, ?, ?, ?, 1)",
+            [self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_IMPORTANT, 'CPT4', 2, 250.00, 1]
+        );
+        QueryUtils::sqlInsert(
+            "INSERT INTO ar_activity (pid, encounter, sequence_no, code_type, code, payer_type, post_time, post_user, session_id, pay_amount, adj_amount, modified_time, follow_up, account_code) VALUES (?, ?, 1, '', ?, 0, NOW(), 1, 0, ?, ?, NOW(), '', '')",
+            [self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_IMPORTANT, 180.00, 30.00]
+        );
+        $this->insertCode(self::TEST_CODE_IMPORTANT, 1, '', 1);
+
+        // Normal code: financial_reporting=0, units=1, fee=75, paid=60, adj=10
+        QueryUtils::sqlInsert(
+            "INSERT INTO billing (pid, encounter, code, code_type, units, fee, provider_id, activity) VALUES (?, ?, ?, ?, ?, ?, ?, 1)",
+            [self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_NORMAL, 'CPT4', 1, 75.00, 1]
+        );
+        QueryUtils::sqlInsert(
+            "INSERT INTO ar_activity (pid, encounter, sequence_no, code_type, code, payer_type, post_time, post_user, session_id, pay_amount, adj_amount, modified_time, follow_up, account_code) VALUES (?, ?, 2, '', ?, 0, NOW(), 1, 0, ?, ?, NOW(), '', '')",
+            [self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_NORMAL, 60.00, 10.00]
+        );
+        $this->insertCode(self::TEST_CODE_NORMAL, 1, '', 0);
+    }
+
+    private function insertCode(string $code, int $codeType, string $modifier, int $financialReporting): void
+    {
+        QueryUtils::sqlInsert(
+            "INSERT INTO codes (code, code_type, modifier, financial_reporting, code_text) VALUES (?, ?, ?, ?, ?)",
+            [$code, $codeType, $modifier, $financialReporting, 'e2e-test-svc-code-report']
+        );
+    }
+
+    private function cleanUpFixtureData(): void
+    {
+        QueryUtils::fetchRecordsNoLog("DELETE FROM ar_activity WHERE pid = ? AND encounter = ?", [self::TEST_PID, self::TEST_ENCOUNTER]);
+        QueryUtils::fetchRecordsNoLog("DELETE FROM billing WHERE pid = ? AND encounter = ?", [self::TEST_PID, self::TEST_ENCOUNTER]);
+        QueryUtils::fetchRecordsNoLog("DELETE FROM form_encounter WHERE reason = 'e2e-test-svc-code-report'", []);
+        QueryUtils::fetchRecordsNoLog("DELETE FROM codes WHERE code_text = 'e2e-test-svc-code-report'", []);
+        QueryUtils::fetchRecordsNoLog("DELETE FROM facility WHERE name = 'e2e-test-svc-report'", []);
+    }
+}

--- a/tests/Tests/Services/Reports/FinancialSummaryReportServiceTest.php
+++ b/tests/Tests/Services/Reports/FinancialSummaryReportServiceTest.php
@@ -1,0 +1,424 @@
+<?php
+
+/**
+ * Integration tests for FinancialSummaryReportService.
+ *
+ * Verifies the service code financial summary query produces correct totals
+ * and does not inflate results when the codes table contains multiple rows
+ * for the same code value (different modifiers or code types).
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services\Reports;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\Reports\FinancialSummaryReportService;
+use OpenEMR\Services\Reports\ServiceCodeSummary;
+use PHPUnit\Framework\TestCase;
+
+class FinancialSummaryReportServiceTest extends TestCase
+{
+    private FinancialSummaryReportService $service;
+
+    /**
+     * Unique encounter number used across all tests, chosen to avoid
+     * collisions with real data.
+     */
+    private const TEST_ENCOUNTER = 999999001;
+
+    /**
+     * Test PID that does not exist in a real install.
+     */
+    private const TEST_PID = 999999001;
+
+    /**
+     * Date range that covers our test fixtures.
+     */
+    private const TEST_DATE = '2025-06-15';
+
+    /**
+     * Identifiable code values for test fixtures.
+     */
+    private const TEST_CODE_A = 'TSTA0001';
+    private const TEST_CODE_B = 'TSTB0002';
+
+    /**
+     * Track IDs for cleanup.
+     *
+     * @var array<string, int[]>
+     */
+    private array $insertedIds = [
+        'form_encounter' => [],
+        'billing' => [],
+        'ar_activity' => [],
+        'codes' => [],
+        'facility' => [],
+    ];
+
+    /**
+     * Auto-incrementing sequence number for ar_activity inserts.
+     */
+    private int $arSequenceNo = 0;
+
+    protected function setUp(): void
+    {
+        $this->service = new FinancialSummaryReportService();
+        $this->cleanUpTestData();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpTestData();
+    }
+
+    /**
+     * One code, one billing row, one ar_activity row.
+     * Assert units, billed, paid, adjusted, balance are correct.
+     */
+    public function testSummaryWithSingleCode(): void
+    {
+        $this->insertFacility(1, 'Test Facility A');
+        $this->insertEncounter(self::TEST_PID, self::TEST_ENCOUNTER, 1);
+        $this->insertBilling(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 'CPT4', 2, 150.00, 1);
+        $this->insertArActivity(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 100.00, 20.00);
+        $this->insertCode(self::TEST_CODE_A, 1, '', 0);
+
+        $results = $this->service->getServiceCodeSummary(new \DateTimeImmutable(self::TEST_DATE), new \DateTimeImmutable(self::TEST_DATE));
+
+        $result = $this->findByCode($results, self::TEST_CODE_A);
+        $this->assertNotNull($result, 'Expected result for code ' . self::TEST_CODE_A);
+        $this->assertSame(2, $result->units);
+        $this->assertEqualsWithDelta(150.00, $result->billed, 0.01);
+        $this->assertEqualsWithDelta(100.00, $result->paid, 0.01);
+        $this->assertEqualsWithDelta(20.00, $result->adjusted, 0.01);
+        $this->assertEqualsWithDelta(30.00, $result->balance, 0.01);
+    }
+
+    /**
+     * Core bug fix test: insert 3 rows into codes for the same (code, code_type)
+     * with different modifiers. Assert sums are NOT inflated.
+     */
+    public function testDuplicateCodesWithDifferentModifiers(): void
+    {
+        $this->insertFacility(1, 'Test Facility A');
+        $this->insertEncounter(self::TEST_PID, self::TEST_ENCOUNTER, 1);
+        $this->insertBilling(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 'CPT4', 1, 200.00, 1);
+        $this->insertArActivity(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 150.00, 30.00);
+
+        // 3 modifier variants of the same code and code_type
+        $this->insertCode(self::TEST_CODE_A, 1, '', 0);
+        $this->insertCode(self::TEST_CODE_A, 1, '26', 0);
+        $this->insertCode(self::TEST_CODE_A, 1, 'TC', 0);
+
+        $results = $this->service->getServiceCodeSummary(new \DateTimeImmutable(self::TEST_DATE), new \DateTimeImmutable(self::TEST_DATE));
+
+        $result = $this->findByCode($results, self::TEST_CODE_A);
+        $this->assertNotNull($result, 'Expected result for code ' . self::TEST_CODE_A);
+
+        // Without the fix, these would be tripled (3x modifier rows)
+        $this->assertSame(1, $result->units);
+        $this->assertEqualsWithDelta(200.00, $result->billed, 0.01);
+        $this->assertEqualsWithDelta(150.00, $result->paid, 0.01);
+        $this->assertEqualsWithDelta(30.00, $result->adjusted, 0.01);
+        $this->assertEqualsWithDelta(20.00, $result->balance, 0.01);
+    }
+
+    /**
+     * With financialReportingOnly=true, only codes flagged financial_reporting=1
+     * should appear.
+     */
+    public function testFinancialReportingFilter(): void
+    {
+        $this->insertFacility(1, 'Test Facility A');
+        $this->insertEncounter(self::TEST_PID, self::TEST_ENCOUNTER, 1);
+
+        // Code A: financial_reporting=1
+        $this->insertBilling(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 'CPT4', 1, 100.00, 1);
+        $this->insertArActivity(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 80.00, 10.00);
+        $this->insertCode(self::TEST_CODE_A, 1, '', 1);
+
+        // Code B: financial_reporting=0
+        $this->insertBilling(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_B, 'CPT4', 1, 50.00, 2);
+        $this->insertArActivity(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_B, 40.00, 5.00);
+        $this->insertCode(self::TEST_CODE_B, 1, '', 0);
+
+        $results = $this->service->getServiceCodeSummary(
+            new \DateTimeImmutable(self::TEST_DATE),
+            new \DateTimeImmutable(self::TEST_DATE),
+            financialReportingOnly: true,
+        );
+
+        $this->assertNotNull($this->findByCode($results, self::TEST_CODE_A));
+        $this->assertNull($this->findByCode($results, self::TEST_CODE_B));
+    }
+
+    /**
+     * When modifiers have mixed financial_reporting values, MAX picks up the 1.
+     */
+    public function testFinancialReportingMaxAcrossModifiers(): void
+    {
+        $this->insertFacility(1, 'Test Facility A');
+        $this->insertEncounter(self::TEST_PID, self::TEST_ENCOUNTER, 1);
+        $this->insertBilling(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 'CPT4', 1, 100.00, 1);
+        $this->insertArActivity(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 80.00, 10.00);
+
+        // One modifier has financial_reporting=1, others have 0
+        $this->insertCode(self::TEST_CODE_A, 1, '', 0);
+        $this->insertCode(self::TEST_CODE_A, 1, '26', 1);
+        $this->insertCode(self::TEST_CODE_A, 1, 'TC', 0);
+
+        $results = $this->service->getServiceCodeSummary(new \DateTimeImmutable(self::TEST_DATE), new \DateTimeImmutable(self::TEST_DATE));
+
+        $result = $this->findByCode($results, self::TEST_CODE_A);
+        $this->assertNotNull($result);
+        $this->assertTrue($result->financialReporting);
+    }
+
+    /**
+     * Filtering by facility returns only matching data.
+     */
+    public function testFacilityFilter(): void
+    {
+        $this->insertFacility(1, 'Test Facility A');
+        $this->insertFacility(2, 'Test Facility B');
+
+        // Encounter in facility 1
+        $this->insertEncounter(self::TEST_PID, self::TEST_ENCOUNTER, 1);
+        $this->insertBilling(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 'CPT4', 1, 100.00, 1);
+        $this->insertArActivity(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 80.00, 10.00);
+        $this->insertCode(self::TEST_CODE_A, 1, '', 0);
+
+        // Encounter in facility 2
+        $enc2 = self::TEST_ENCOUNTER + 1;
+        $this->insertEncounter(self::TEST_PID, $enc2, 2);
+        $this->insertBilling(self::TEST_PID, $enc2, self::TEST_CODE_B, 'CPT4', 1, 50.00, 2);
+        $this->insertArActivity(self::TEST_PID, $enc2, self::TEST_CODE_B, 40.00, 5.00);
+        $this->insertCode(self::TEST_CODE_B, 1, '', 0);
+
+        // Filter to facility 1 only
+        $facilityId = $this->getFacilityId('Test Facility A');
+        $this->assertNotNull($facilityId, 'Test facility A should exist');
+
+        $results = $this->service->getServiceCodeSummary(
+            new \DateTimeImmutable(self::TEST_DATE),
+            new \DateTimeImmutable(self::TEST_DATE),
+            facilityId: $facilityId,
+        );
+
+        $this->assertNotNull($this->findByCode($results, self::TEST_CODE_A));
+        $this->assertNull($this->findByCode($results, self::TEST_CODE_B));
+    }
+
+    /**
+     * Filtering by provider returns only matching data.
+     */
+    public function testProviderFilter(): void
+    {
+        $this->insertFacility(1, 'Test Facility A');
+        $this->insertEncounter(self::TEST_PID, self::TEST_ENCOUNTER, 1);
+
+        // Code A billed by provider 1
+        $this->insertBilling(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 'CPT4', 1, 100.00, 1);
+        $this->insertArActivity(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 80.00, 10.00);
+        $this->insertCode(self::TEST_CODE_A, 1, '', 0);
+
+        // Code B billed by provider 2
+        $this->insertBilling(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_B, 'CPT4', 1, 50.00, 2);
+        $this->insertArActivity(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_B, 40.00, 5.00);
+        $this->insertCode(self::TEST_CODE_B, 1, '', 0);
+
+        // Filter to provider 1 only
+        $results = $this->service->getServiceCodeSummary(
+            new \DateTimeImmutable(self::TEST_DATE),
+            new \DateTimeImmutable(self::TEST_DATE),
+            providerId: 1,
+        );
+
+        $this->assertNotNull($this->findByCode($results, self::TEST_CODE_A));
+        $this->assertNull($this->findByCode($results, self::TEST_CODE_B));
+    }
+
+    /**
+     * Billing code not in codes table. Assert financialReporting is null
+     * (LEFT JOIN behavior preserved).
+     */
+    public function testNoMatchingCodesReturnsNullFinancialReporting(): void
+    {
+        $this->insertFacility(1, 'Test Facility A');
+        $this->insertEncounter(self::TEST_PID, self::TEST_ENCOUNTER, 1);
+        $this->insertBilling(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 'CPT4', 1, 100.00, 1);
+        $this->insertArActivity(self::TEST_PID, self::TEST_ENCOUNTER, self::TEST_CODE_A, 80.00, 10.00);
+        // Deliberately do NOT insert into codes table
+
+        $results = $this->service->getServiceCodeSummary(new \DateTimeImmutable(self::TEST_DATE), new \DateTimeImmutable(self::TEST_DATE));
+
+        $result = $this->findByCode($results, self::TEST_CODE_A);
+        $this->assertNotNull($result, 'Expected result even without codes table match');
+        $this->assertNull($result->financialReporting);
+    }
+
+    // -------------------------------------------------------------------
+    // Fixture helpers
+    // -------------------------------------------------------------------
+
+    private function insertFacility(int $index, string $name): void
+    {
+        // Use a unique name prefix so we can identify and clean up test facilities
+        $testName = 'test-fixture-' . $name;
+
+        // Check if facility already exists from a prior test in this run
+        $existing = QueryUtils::querySingleRow(
+            "SELECT id FROM facility WHERE name = ?",
+            [$testName]
+        );
+        if ($existing) {
+            return;
+        }
+
+        $id = QueryUtils::sqlInsert(
+            "INSERT INTO facility (name) VALUES (?)",
+            [$testName]
+        );
+        $this->insertedIds['facility'][] = $id;
+    }
+
+    private function getFacilityId(string $name): ?int
+    {
+        /** @var array{id: int}|false $row */
+        $row = QueryUtils::querySingleRow(
+            "SELECT id FROM facility WHERE name = ?",
+            ['test-fixture-' . $name]
+        );
+        return $row ? (int) $row['id'] : null;
+    }
+
+    private function insertEncounter(int $pid, int $encounter, int $facilityIndex): void
+    {
+        $facilityId = $this->getFacilityId(
+            $facilityIndex === 1 ? 'Test Facility A' : 'Test Facility B'
+        );
+
+        $id = QueryUtils::sqlInsert(
+            "INSERT INTO form_encounter (pid, encounter, date, facility_id, reason)"
+            . " VALUES (?, ?, ?, ?, ?)",
+            [$pid, $encounter, self::TEST_DATE . ' 12:00:00', $facilityId, 'test-fixture-report-test']
+        );
+        $this->insertedIds['form_encounter'][] = $id;
+    }
+
+    private function insertBilling(
+        int $pid,
+        int $encounter,
+        string $code,
+        string $codeType,
+        int $units,
+        float $fee,
+        int $providerId
+    ): void {
+        $id = QueryUtils::sqlInsert(
+            "INSERT INTO billing (pid, encounter, code, code_type, units, fee, provider_id, activity)"
+            . " VALUES (?, ?, ?, ?, ?, ?, ?, 1)",
+            [$pid, $encounter, $code, $codeType, $units, $fee, $providerId]
+        );
+        $this->insertedIds['billing'][] = $id;
+    }
+
+    private function insertArActivity(
+        int $pid,
+        int $encounter,
+        string $code,
+        float $payAmount,
+        float $adjAmount
+    ): void {
+        $this->arSequenceNo++;
+        $id = QueryUtils::sqlInsert(
+            "INSERT INTO ar_activity (pid, encounter, sequence_no, code_type, code, payer_type,"
+            . " post_time, post_user, session_id, pay_amount, adj_amount, modified_time, follow_up, account_code)"
+            . " VALUES (?, ?, ?, '', ?, 0, NOW(), 1, 0, ?, ?, NOW(), '', '')",
+            [$pid, $encounter, $this->arSequenceNo, $code, $payAmount, $adjAmount]
+        );
+        $this->insertedIds['ar_activity'][] = $id;
+    }
+
+    private function insertCode(string $code, int $codeType, string $modifier, int $financialReporting): void
+    {
+        $id = QueryUtils::sqlInsert(
+            "INSERT INTO codes (code, code_type, modifier, financial_reporting, code_text)"
+            . " VALUES (?, ?, ?, ?, ?)",
+            [$code, $codeType, $modifier, $financialReporting, 'test-fixture-report-test']
+        );
+        $this->insertedIds['codes'][] = $id;
+    }
+
+    /**
+     * @param ServiceCodeSummary[] $results
+     */
+    private function findByCode(array $results, string $code): ?ServiceCodeSummary
+    {
+        foreach ($results as $result) {
+            if ($result->code === $code) {
+                return $result;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Remove all test fixture data by tracked IDs and known identifiers.
+     */
+    private function cleanUpTestData(): void
+    {
+        // Delete by tracked IDs
+        foreach ($this->insertedIds['ar_activity'] as $id) {
+            QueryUtils::fetchRecordsNoLog("DELETE FROM ar_activity WHERE pid = ?", [self::TEST_PID]);
+        }
+        foreach ($this->insertedIds['billing'] as $id) {
+            QueryUtils::fetchRecordsNoLog("DELETE FROM billing WHERE id = ?", [$id]);
+        }
+        foreach ($this->insertedIds['form_encounter'] as $id) {
+            QueryUtils::fetchRecordsNoLog("DELETE FROM form_encounter WHERE id = ?", [$id]);
+        }
+        foreach ($this->insertedIds['codes'] as $id) {
+            QueryUtils::fetchRecordsNoLog("DELETE FROM codes WHERE id = ?", [$id]);
+        }
+        foreach ($this->insertedIds['facility'] as $id) {
+            QueryUtils::fetchRecordsNoLog("DELETE FROM facility WHERE id = ?", [$id]);
+        }
+
+        // Also delete by known identifiers as a safety net
+        QueryUtils::fetchRecordsNoLog(
+            "DELETE FROM ar_activity WHERE pid = ?",
+            [self::TEST_PID]
+        );
+        QueryUtils::fetchRecordsNoLog(
+            "DELETE FROM billing WHERE pid = ?",
+            [self::TEST_PID]
+        );
+        QueryUtils::fetchRecordsNoLog(
+            "DELETE FROM form_encounter WHERE reason = 'test-fixture-report-test'",
+            []
+        );
+        QueryUtils::fetchRecordsNoLog(
+            "DELETE FROM codes WHERE code_text = 'test-fixture-report-test'",
+            []
+        );
+        QueryUtils::fetchRecordsNoLog(
+            "DELETE FROM facility WHERE name LIKE 'test-fixture-%'",
+            []
+        );
+
+        $this->insertedIds = [
+            'form_encounter' => [],
+            'billing' => [],
+            'ar_activity' => [],
+            'codes' => [],
+            'facility' => [],
+        ];
+        $this->arSequenceNo = 0;
+    }
+}


### PR DESCRIPTION
Fixes #8651

#### Short description of what this resolves:

The Financial Summary by Service Code report produces inflated totals (billed, paid, adjusted, balance) when the `codes` table contains multiple rows for the same code value with different modifiers.

#### Changes proposed in this pull request:

**Primary fix — Cartesian product on codes JOIN:**

The `LEFT OUTER JOIN codes AS c ON c.code = b.code` matches every modifier variant, creating a Cartesian product that multiplies all SUM aggregates. For example, if code `99213` has 3 modifier rows in `codes`, every billing row for that code gets tripled.

Replace the direct join with a subquery that collapses modifier variants via `GROUP BY code, code_type`, and join on both `code` and `code_type` (through `code_types.ct_id`):

```sql
-- Before (buggy):
LEFT OUTER JOIN codes AS c ON c.code = b.code

-- After (fixed):
INNER JOIN code_types AS ct ON ct.ct_key = b.code_type AND ct.ct_fee = '1'
LEFT OUTER JOIN (
    SELECT code, code_type, MAX(financial_reporting) AS financial_reporting
    FROM codes
    GROUP BY code, code_type
) AS c ON c.code = b.code AND c.code_type = ct.ct_id
```

**Additional fixes to pre-existing query bugs:**

- `c.financial_reporting` was in SELECT without aggregation or GROUP BY — non-deterministic when a code maps to multiple code types. Wrapped in `MAX()`.
- `ORDER BY fe.date, fe.id` without those columns in GROUP BY — non-deterministic. Simplified to `ORDER BY b.code`.
- "Important Codes" filter used `WHERE c.financial_reporting = '1'` which excludes billing rows before aggregation. Moved to `HAVING MAX(c.financial_reporting) = '1'` so all billing amounts are included for codes that have any financial_reporting flag.
- `Balance` column redundantly recomputed all three SUMs in SQL. Now computed in the DTO from `billed - paid - adjusted`.

**Refactoring:**

- Extract query logic into `FinancialSummaryReportService` with a `ServiceCodeSummary` readonly DTO
- Service accepts `DateTimeInterface` for date params, `?int` for facility/provider (null = all)
- Report file handles only rendering; type conversion from POST strings happens at the boundary

**Tests:**

- 7 integration tests: single code, duplicate modifiers (core bug), financial reporting filter, MAX across modifiers, facility filter, provider filter, LEFT JOIN null behavior
- 4 e2e browser tests: page load, empty submit, correct totals, important codes filter, duplicate modifier non-inflation

**Note:** The `ar_activity` subquery groups by `(pid, encounter, code)` without `modifier`, which can cause a similar inflation when billing has multiple rows for the same `(pid, encounter, code)` with different modifiers. This is a separate pre-existing bug and should be filed as its own issue.

#### Does your code include anything generated by an AI Engine? Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code. Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.

All new files (`ServiceCodeSummary.php`, `FinancialSummaryReportService.php`, `FinancialSummaryReportServiceTest.php`, `SvcCodeFinancialReportTest.php`) and the modifications to `svc_code_financial_report.php` were generated with Claude Code (Claude Opus 4.5).