### PR TITLE
fix(ci): Adjust PHPStan to only scan the critical vendor paths

### DIFF
--- a/.phpstan/phpstan.github.neon
+++ b/.phpstan/phpstan.github.neon
@@ -3,6 +3,8 @@ includes:
   - baseline/loader.php
 parameters:
   reportUnmatchedIgnoredErrors: true
+  scanDirectories:
+    - ../vendor/adodb/adodb-php
   scanFiles:
     - ../vendor/phpunit/phpunit/src/Framework/TestCase.php
   excludePaths:

--- a/composer.json
+++ b/composer.json
@@ -278,7 +278,7 @@
         "phpstan": "phpstan analyze --memory-limit=4G --configuration=phpstan.neon.dist",
         "phpstan-baseline": [
             "phpstan analyze --memory-limit=8G --configuration=phpstan.neon.dist --generate-baseline=.phpstan/baseline/loader.php",
-            "split-phpstan-baseline .phpstan/baseline/loader.php --no-error-count"
+            "php -d memory_limit=1g vendor/bin/split-phpstan-baseline .phpstan/baseline/loader.php --no-error-count"
         ],
         "phpunit-isolated": "phpunit -c phpunit-isolated.xml",
         "rector-check": "php -d memory_limit=4g ./vendor/bin/rector process --dry-run",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -38,7 +38,6 @@ parameters:
   - tests
   - version.php
   scanDirectories:
-  - ./vendor
   - ./.phpstan
   scanFiles:
   - library/sql.inc.php


### PR DESCRIPTION
Towards #10236.

#### Short description of what this resolves:
PHPStan is pre-scanning the _entire_ vendor directory. Doing so is, under normal circumstances, unnecessary (it knows how to read symbols from there). It can also result in conflicts - in particular, if it scans polyfills for native functions, it can throw off the signatures used during static analysis.

Since ADODB is not a good citizen regarding autoloading, we still need to do a limited amount of this, but not the whole shebang.

#### Changes proposed in this pull request:
- Change PHPStan to only scan the necessary vendor paths to function as intended
- Bump the memory limit on the baseline splitter

#### Does your code include anything generated by an AI Engine? Yes / No
No