### PR TITLE
fix(phpstan): assert $pid is defined in portal_payment.php

### DIFF
--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -17272,11 +17272,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/portal_payment.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$pid might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/portal_payment.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$session_id might not be defined\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/portal_payment.php',

--- a/.phpstan/phpstan-remaining-baseline.neon
+++ b/.phpstan/phpstan-remaining-baseline.neon
@@ -15896,10 +15896,6 @@ parameters:
       identifier: variable.undefined
       count: 1
       path: ../portal/portal_payment.php
-    - message: '#^Variable \$pid might not be defined\.$#'
-      identifier: variable.undefined
-      count: 1
-      path: ../portal/portal_payment.php
     - message: '#^Variable \$session_id might not be defined\.$#'
       identifier: variable.undefined
       count: 1

--- a/portal/portal_payment.php
+++ b/portal/portal_payment.php
@@ -43,6 +43,7 @@ if ($session->isSymfonySession() && !empty($session->get('pid')) && !empty($sess
         exit();
     }
 }
+assert(isset($pid)); // Set by globals.php via session; PHPStan can't see through require_once
 $srcdir = $globalsBag->getString('srcdir');
 require_once(__DIR__ . "/lib/appsql.class.php");
 require_once("$srcdir/patient.inc.php");


### PR DESCRIPTION
Fixes #10446

## Short description of what this resolves:

PHPStan baseline mismatch in `portal/portal_payment.php` — the `$pid` variable was reported as potentially undefined in 23 code paths but the baseline only expected 1.

## Changes proposed in this pull request:

- Add `assert(isset($pid))` after the conditional `globals.php` include to make `$pid` definedness visible to PHPStan
- Remove the now-unnecessary `$pid might not be defined` baseline entries from both `.phpstan/baseline/variable.undefined.php` and `.phpstan/phpstan-remaining-baseline.neon`

## AI disclosure

Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)