### PR TITLE
fix(docker): Don't special-case vendor when mounting local filesystem

### DIFF
--- a/docker/development-easy/docker-compose.yml
+++ b/docker/development-easy/docker-compose.yml
@@ -37,7 +37,6 @@ services:
     - themevolume:/var/www/localhost/htdocs/openemr/public/themes:rw
     - sitesvolume:/var/www/localhost/htdocs/openemr/sites:rw
     - nodemodules:/var/www/localhost/htdocs/openemr/node_modules:rw
-    - vendordir:/var/www/localhost/htdocs/openemr/vendor:rw
     - ccdanodemodules:/var/www/localhost/htdocs/openemr/ccdaservice/node_modules:rw
     - logvolume:/var/log
     - couchdbvolume:/couchdb/data
@@ -187,7 +186,6 @@ volumes:
   themevolume: {}
   sitesvolume: {}
   nodemodules: {}
-  vendordir: {}
   ccdanodemodules: {}
   logvolume: {}
   couchdbvolume: {}


### PR DESCRIPTION
#### Short description of what this resolves:
When using the `development-easy` Docker Compose setup, the host's version of `vendor` isn't mounted; instead, it's pinned to what's in the image. This can disrupt development and testing of package changes, including working on modules.

AFAICT the Compose file was always set up this way, it's unclear to me from the PRs in the git history why this is. I've never seen it done before - every containerized PHP app I've _ever_ worked on simply mounts the repo root straight-through (in fact, every interpreted language I've seen does that, full stop). I'd go so far as to say that _most_ of the surrounding volume mounts are likely to cause similar problems (the db ones are fine in the other services), but I haven't dug in there yet.

#### Changes proposed in this pull request:
Removes the special-casing of `vendor` from the compose file, causing the host's `vendor/` directory to stay synced inside of the docker container at runtime.

#### Does your code include anything generated by an AI Engine? Yes / No
No