### PR TITLE
fix: #10454 webroot session fix

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -225,6 +225,8 @@ if (empty($globalsBag)) {
 }
 $globalsBag->set('webserver_root', $webserver_root);
 $globalsBag->set('web_root', $web_root);
+// Absolute path to the location of documentroot directory for use with include statements:
+$globalsBag->set('webroot', $web_root);
 $globalsBag->set('vendor_dir', $GLOBALS['vendor_dir'] ?? "$webserver_root/vendor");
 $globalsBag->set('restRequest', $restRequest);
 $globalsBag->set('OE_SITES_BASE', $GLOBALS['OE_SITES_BASE'] ?? "$webserver_root/sites");
@@ -310,8 +312,6 @@ $globalsBag->set('fileroot', $webserver_root);
 // Absolute path to the location of interface directory for use with include statements:
 $include_root = "$webserver_root/interface";
 $globalsBag->set('include_root', $include_root);
-// Absolute path to the location of documentroot directory for use with include statements:
-$globalsBag->set('webroot', $web_root);
 
 // Static assets directory, relative to the webserver root.
 // (it is very likely that this path will be changed in the future))


### PR DESCRIPTION
Moved the order of the webroot variable to be higher up in the globals.php file so that it is available in the session instantiation logic.

Originally the session used the variable $web_root but the SymfonySessionWrapper relies on the global value of 'webroot' which didn't happen until further down the instantiation chain.

Fixes #10454

Didn't discover this until working through all of the redis session logic.