### PR TITLE
fix: correct typos in clinical notes and track_anything forms

### DIFF
--- a/interface/forms/clinical_notes/clinical-notes.js
+++ b/interface/forms/clinical_notes/clinical-notes.js
@@ -217,7 +217,7 @@
                 // they are clearing out the value so we are going to empty everything out.
                 codeEl.value = "";
                 codeTextEl.value = "";
-                codeContext.vlaue = "";
+                codeContext.value = "";
             }
 
         } catch (e) {

--- a/interface/forms/track_anything/create.php
+++ b/interface/forms/track_anything/create.php
@@ -279,9 +279,9 @@ while ($myrow = sqlFetchArray($result)) {
         echo "<td class='parent'>&nbsp;&nbsp;" . text($type_descr) . "</td>\n";
         echo "<td class='parent'>&nbsp;&nbsp;" . text($type_pos) . "</td>\n";
     } elseif ($type_active == '0') {
-        echo "<td class='deactive'>&nbsp;&nbsp;" . text($type_name) . "</td>\n";
-        echo "<td class='deactive'>&nbsp;&nbsp;" . text($type_descr) . "</td>\n";
-        echo "<td class='deactive'>&nbsp;&nbsp;" . text($type_pos) . "</td>\n";
+        echo "<td class='deactivate'>&nbsp;&nbsp;" . text($type_name) . "</td>\n";
+        echo "<td class='deactivate'>&nbsp;&nbsp;" . text($type_descr) . "</td>\n";
+        echo "<td class='deactivate'>&nbsp;&nbsp;" . text($type_pos) . "</td>\n";
     }
 
     echo "<td class='op'>";
@@ -317,9 +317,9 @@ while ($myrow = sqlFetchArray($result)) {
             echo "<td class='child'>&nbsp;&nbsp;&nbsp;&nbsp; | " . text($item_descr) . "</td>\n";
             echo "<td class='child'>&nbsp;&nbsp;&nbsp;&nbsp; | " . text($item_pos) . "</td>\n";
         } elseif ($item_active == '0') {
-            echo "<td class='deactive'>&nbsp;&nbsp;&nbsp;&nbsp; | " . text($item_name) . "</td>\n";
-            echo "<td class='deactive'>&nbsp;&nbsp;&nbsp;&nbsp; | " . text($item_descr) . "</td>\n";
-            echo "<td class='deactive'>&nbsp;&nbsp;&nbsp;&nbsp; | " . text($item_pos) . "</td>\n";
+            echo "<td class='deactivate'>&nbsp;&nbsp;&nbsp;&nbsp; | " . text($item_name) . "</td>\n";
+            echo "<td class='deactivate'>&nbsp;&nbsp;&nbsp;&nbsp; | " . text($item_descr) . "</td>\n";
+            echo "<td class='deactivate'>&nbsp;&nbsp;&nbsp;&nbsp; | " . text($item_pos) . "</td>\n";
         }
 
         echo "<td class='op'>";


### PR DESCRIPTION
Fixes #10372
Fixes #10373

Short description of what this resolves:
Two typos causing functional bugs in clinical notes and track_anything forms.

Changes proposed in this pull request:
- Fix `vlaue` -> `value` property name typo in `clinical-notes.js:220` that prevented the code context field from being cleared when a clinical note code selection was removed
- Fix CSS class mismatch `deactive` -> `deactivate` in `track_anything/create.php` to match the existing `style.css` selectors (`#ta_type th.deactivate`, `#ta_type td.deactivate`), restoring styling for inactive items

Note: #10371 (vitals growth chart `reuslts` typo) was already fixed on master.

AI: Yes