### PR TITLE
fix(ci): reduce ~111 false positive Semgrep code scanning alerts

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,10 +38,12 @@ jobs:
 
     - name: Run Semgrep (full scan)
       if: github.event_name != 'pull_request'
-      # Exclude the default echoed-request rule from p/php and use our custom
-      # version in semgrep.yaml instead. Our custom rule adds OpenEMR's
-      # sanitization functions (attr, text, xlt, etc.) to prevent false positives
-      # while still detecting real XSS vulnerabilities.
+      # Exclude the default echoed-request and printed-request rules from p/php
+      # and use our custom versions in semgrep.yaml instead. Our custom rules add
+      # OpenEMR's sanitization functions (attr, text, xlt, etc.) to prevent false
+      # positives while still detecting real XSS vulnerabilities.
+      # Exclude Documentation/ (generated SchemaSpy HTML, not application code)
+      # and *.mustache (QRDA/CDA XML templates, not browser-rendered HTML).
       run: |
         semgrep \
           --config p/php \
@@ -51,7 +53,10 @@ jobs:
           --exclude node_modules \
           --exclude tests \
           --exclude ccdaservice/node_modules \
+          --exclude Documentation \
+          --exclude '*.mustache' \
           --exclude-rule php.lang.security.injection.echoed-request.echoed-request \
+          --exclude-rule php.lang.security.injection.printed-request.printed-request \
           --sarif \
           --output=semgrep-results.sarif \
           .
@@ -60,10 +65,12 @@ jobs:
       if: github.event_name == 'pull_request'
       env:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
-      # Exclude the default echoed-request rule from p/php and use our custom
-      # version in semgrep.yaml instead. Our custom rule adds OpenEMR's
-      # sanitization functions (attr, text, xlt, etc.) to prevent false positives
-      # while still detecting real XSS vulnerabilities.
+      # Exclude the default echoed-request and printed-request rules from p/php
+      # and use our custom versions in semgrep.yaml instead. Our custom rules add
+      # OpenEMR's sanitization functions (attr, text, xlt, etc.) to prevent false
+      # positives while still detecting real XSS vulnerabilities.
+      # Exclude Documentation/ (generated SchemaSpy HTML, not application code)
+      # and *.mustache (QRDA/CDA XML templates, not browser-rendered HTML).
       run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
         semgrep \
@@ -74,7 +81,10 @@ jobs:
           --exclude node_modules \
           --exclude tests \
           --exclude ccdaservice/node_modules \
+          --exclude Documentation \
+          --exclude '*.mustache' \
           --exclude-rule php.lang.security.injection.echoed-request.echoed-request \
+          --exclude-rule php.lang.security.injection.printed-request.printed-request \
           --baseline-commit="$BASE_SHA" \
           --sarif \
           --output=semgrep-results.sarif \

--- a/run-semgrep.sh
+++ b/run-semgrep.sh
@@ -66,6 +66,14 @@ declare -a EXCLUDES=(
     "--exclude=node_modules"
     "--exclude=tests"
     "--exclude=ccdaservice/node_modules"
+    "--exclude=Documentation"
+    "--exclude=*.mustache"
+)
+
+# Exclude default p/php rules that we override in semgrep.yaml with OpenEMR sanitizers
+declare -a EXCLUDE_RULES=(
+    "--exclude-rule=php.lang.security.injection.echoed-request.echoed-request"
+    "--exclude-rule=php.lang.security.injection.printed-request.printed-request"
 )
 
 # Build output arguments
@@ -130,6 +138,7 @@ docker run --rm \
     "${FORMAT_ARG[@]}" \
     --no-git-ignore \
     "${EXCLUDES[@]}" \
+    "${EXCLUDE_RULES[@]}" \
     "${EXTRA_EXCLUDES[@]}" \
     "${OUTPUT_ARGS[@]}" \
     .

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -79,6 +79,85 @@ rules:
     impact: MEDIUM
     confidence: MEDIUM
 
+  # Override printed-request rule from p/php to add OpenEMR sanitizers
+  # Same as echoed-request above, but for print statements instead of echo
+- id: printed-request
+  mode: taint
+  message: >-
+    `Print`ing user input risks cross-site scripting vulnerability.
+    Use `attr()` for attribute values or `text()` for text content.
+    See library/htmlspecialchars.inc.php for available sanitizers.
+  languages: [php]
+  severity: ERROR
+  pattern-sources:
+  - pattern: $_REQUEST
+  - pattern: $_GET
+  - pattern: $_POST
+  pattern-sinks:
+  - pattern: print $...VARS;
+  pattern-sanitizers:
+      # Standard PHP sanitizers
+  - pattern: htmlentities(...)
+  - pattern: htmlspecialchars(...)
+  - pattern: strip_tags(...)
+  - pattern: isset(...)
+  - pattern: empty(...)
+      # WordPress sanitizers
+  - pattern: esc_html(...)
+  - pattern: esc_attr(...)
+  - pattern: wp_kses(...)
+      # Laravel/Symfony/Twig sanitizers
+  - pattern: e(...)
+  - pattern: twig_escape_filter(...)
+      # CodeIgniter sanitizers
+  - pattern: xss_clean(...)
+  - pattern: html_escape(...)
+      # Drupal sanitizers
+  - pattern: Html::escape(...)
+  - pattern: Xss::filter(...)
+      # Laminas sanitizers
+  - pattern: escapeHtml(...)
+  - pattern: escapeHtmlAttr(...)
+      # OpenEMR sanitizers (library/htmlspecialchars.inc.php)
+  - pattern: text(...)
+  - pattern: attr(...)
+  - pattern: attr_url(...)
+  - pattern: attr_js(...)
+  - pattern: js_escape(...)
+  - pattern: js_url(...)
+  - pattern: xlt(...)
+  - pattern: xla(...)
+  - pattern: xlj(...)
+  - pattern: xlx(...)
+  - pattern: xmlEscape(...)
+  - pattern: csvEscape(...)
+  - pattern: errorLogEscape(...)
+      # OpenEMR display function (library/options.inc.php) - uses htmlspecialchars internally
+  - pattern: generate_display_field(...)
+  fix: print attr($...VARS);
+  metadata:
+    technology:
+    - php
+    cwe:
+    - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    category: security
+    references:
+    - https://www.php.net/manual/en/function.htmlentities.php
+    - https://www.php.net/manual/en/reserved.variables.request.php
+    - https://www.php.net/manual/en/reserved.variables.post.php
+    - https://www.php.net/manual/en/reserved.variables.get.php
+    - https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+
   # OpenEMR-specific SQL functions with string concatenation
   # These functions are unique to OpenEMR and not covered by p/php or p/security-audit
 - id: openemr-sql-injection-sqlstatement


### PR DESCRIPTION
Fixes #10461

Reduce ~111 false positive Semgrep code scanning alerts across three categories.

## Changes proposed in this pull request
- Add custom `printed-request` taint rule to `semgrep.yaml` mirroring the existing `echoed-request` override but with `print` as the sink (69 alerts)
- Exclude `Documentation/` directory — generated SchemaSpy HTML, not application code (6 `var-in-script-tag` alerts)
- Exclude `*.mustache` files — QRDA/CDA XML templates for clinical data interchange, not browser-rendered HTML (36 `unquoted-attribute-var` alerts)
- Fix `run-semgrep.sh` missing the `--exclude-rule` for `echoed-request` that the CI workflow already had

The mustache templates also have raw `{{{var}}}` in some XML attribute positions that should use escaped `{{var}}` instead — that will be addressed in a follow-up PR.

## AI Disclosure
Yes