### PR TITLE
fix(qrda): use escaped Mustache variables in XML attribute positions

### DIFF
--- a/src/Services/Qrda/qrda-export/catI-r5/_header.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/_header.mustache
@@ -15,7 +15,7 @@
 <code code="55182-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Measure Report"/>
 <title>QRDA Incidence Report</title>
 <!-- This is the document creation time -->
-<effectiveTime value="{{{current_time}}}"/>
+<effectiveTime value="{{current_time}}"/>
 <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
 <languageCode code="en"/>
 <!-- reported patient -->

--- a/src/Services/Qrda/qrda-export/catI-r5/_reporting_period.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/_reporting_period.mustache
@@ -14,8 +14,8 @@
         <id extension="{{random_id}}" root="1.3.6.1.4.1.115"/>
         <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
         <effectiveTime>
-          <low value="{{{performance_period_start}}}"/>
-          <high value="{{{performance_period_end}}}"/>
+          <low value="{{performance_period_start}}"/>
+          <high value="{{performance_period_end}}"/>
         </effectiveTime>
       </act>
     </entry>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_header/_author.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_header/_author.mustache
@@ -1,5 +1,5 @@
 <author>
-  <time value="{{{current_time}}}"/>
+  <time value="{{current_time}}"/>
   <assignedAuthor>
     <!-- NPI -->
     {{#provider}}

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_header/_legal_authenticator.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_header/_legal_authenticator.mustache
@@ -1,5 +1,5 @@
 <legalAuthenticator>
-  <time value="{{{current_time}}}"/>
+  <time value="{{current_time}}"/>
   <signatureCode code="S"/>
   <assignedEntity>
     <id root="bc01a5d1-3a34-4286-82cc-43eb04c972a7"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/related_person.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/related_person.mustache
@@ -10,7 +10,7 @@
     <participant typeCode="PRF">
       <participantRole classCode="PAT">
         <!-- QDM Attribute: LinkedPatientId -->
-        <id root="{{{namingSystem}}}" extension="{{{value}}}"/>
+        <id root="{{namingSystem}}" extension="{{value}}"/>
       </participantRole>
     </participant>
     {{/identifier}}

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity_care_partner.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity_care_partner.mustache
@@ -1,7 +1,7 @@
 <participantRole>
     <templateId root="2.16.840.1.113883.10.20.24.3.160" extension="2019-12-01" />
     {{#identifier}}
-      <id root="{{{namingSystem}}}" extension="{{{value}}}"/>
+      <id root="{{namingSystem}}" extension="{{value}}"/>
     {{/identifier}}
     {{#relationship}}
       <playingEntity>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity_location.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity_location.mustache
@@ -1,7 +1,7 @@
 <participantRole>
     <templateId root="2.16.840.1.113883.10.20.24.3.172" extension="2021-08-01" />
     {{#identifier}}
-      <id root="{{{namingSystem}}}" extension="{{{value}}}"/>
+      <id root="{{namingSystem}}" extension="{{value}}"/>
     {{/identifier}}
     {{#locationType}}
       <playingEntity>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity_organization.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity_organization.mustache
@@ -1,7 +1,7 @@
 <participantRole>
     <templateId root="2.16.840.1.113883.10.20.24.3.163" extension="2019-12-01" />
     {{#identifier}}
-      <id root="{{{namingSystem}}}" extension="{{{value}}}"/>
+      <id root="{{namingSystem}}" extension="{{value}}"/>
     {{/identifier}}
     {{#type}}
       <playingEntity>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity_patient.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity_patient.mustache
@@ -1,6 +1,6 @@
 <participantRole>
     <templateId root="2.16.840.1.113883.10.20.24.3.161" extension="2019-12-01" />
     {{#identifier}}
-      <id root="{{{namingSystem}}}" extension="{{{value}}}"/>
+      <id root="{{namingSystem}}" extension="{{value}}"/>
     {{/identifier}}
 </participantRole>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity_practitioner.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity_practitioner.mustache
@@ -1,7 +1,7 @@
 <participantRole>
     <templateId root="2.16.840.1.113883.10.20.24.3.162" extension="2019-12-01" />
     {{#identifier}}
-      <id root="{{{namingSystem}}}" extension="{{{value}}}"/>
+      <id root="{{namingSystem}}" extension="{{value}}"/>
     {{/identifier}}
     {{#role}}
       <code {{> _code}}/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_immunization_supply_request.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_immunization_supply_request.mustache
@@ -13,7 +13,7 @@
     {{{author_effective_time}}}
     {{/authorDatetime}}
   {{/relevantPeriod}}
-  <quantity value="{{{value_as_float}}}"/>
+  <quantity value="{{value_as_float}}"/>
   <product>
     <manufacturedProduct classCode="MANU">
       <!-- Immunization Medication Information (consolidation) template -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_medication_supply_request.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_medication_supply_request.mustache
@@ -13,7 +13,7 @@
     {{{author_effective_time}}}
     {{/authorDatetime}}
   {{/relevantPeriod}}
-  <quantity value="{{{value_as_float}}}"/>
+  <quantity value="{{value_as_float}}"/>
   <product>
     <manufacturedProduct classCode="MANU">
       <!-- Medication Information (consolidation) template -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_rank.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_rank.mustache
@@ -2,6 +2,6 @@
   <observation classCode="OBS" moodCode="EVN">
     <templateId root="2.16.840.1.113883.10.20.24.3.166" extension="2019-12-01"/>
     <code code="263486008" displayName="Rank" codeSystem="2.16.840.1.113883.6.96"/>
-    <value xsi:type="INT" value="{{{.}}}"/>
+    <value xsi:type="INT" value="{{.}}"/>
   </observation>
 </entryRelationship>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_related_to.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_related_to.mustache
@@ -1,6 +1,6 @@
 <sdtc:inFulfillmentOf1 typeCode="FLFS">
   <sdtc:templateId root="2.16.840.1.113883.10.20.24.3.150" extension="2017-08-01"/>
   <sdtc:actReference classCode="ACT" moodCode="EVN">
-    <sdtc:id root="1.3.6.1.4.1.115" extension="{{{.}}}"/>
+    <sdtc:id root="1.3.6.1.4.1.115" extension="{{.}}"/>
   </sdtc:actReference>
 </sdtc:inFulfillmentOf1>

--- a/src/Services/Qrda/qrda-export/catIII/_measure_section.mustache
+++ b/src/Services/Qrda/qrda-export/catIII/_measure_section.mustache
@@ -68,8 +68,8 @@
         <id extension="{{random_id}}" root="1.3.6.1.4.1.115"/>
         <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
         <effectiveTime>
-          <low value="{{{performance_period_start}}}"/>
-          <high value="{{{performance_period_end}}}"/>
+          <low value="{{performance_period_start}}"/>
+          <high value="{{performance_period_end}}"/>
         </effectiveTime>
       </act>
     </entry>

--- a/src/Services/Qrda/qrda-export/catIII/_reporting_period.mustache
+++ b/src/Services/Qrda/qrda-export/catIII/_reporting_period.mustache
@@ -14,8 +14,8 @@
         <id extension="{{random_id}}" root="1.3.6.1.4.1.115"/>
         <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
         <effectiveTime>
-          <low value="{{{performance_period_start}}}"/>
-          <high value="{{{performance_period_end}}}"/>
+          <low value="{{performance_period_start}}"/>
+          <high value="{{performance_period_end}}"/>
         </effectiveTime>
       </act>
     </entry>

--- a/src/Services/Qrda/qrda-export/catIII/_supplemental_data.mustache
+++ b/src/Services/Qrda/qrda-export/catIII/_supplemental_data.mustache
@@ -15,7 +15,7 @@
     {{^unknown_supplemental_value}}
       {{#payer_code}}
         <value xsi:type="CD" nullFlavor="OTH">
-          <translation code="{{{cms_payer_code}}}" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes"/>
+          <translation code="{{cms_payer_code}}" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes"/>
         </value>
       {{/payer_code}}
       {{^payer_code}}


### PR DESCRIPTION
Fixes #10463

Switch raw `{{{var}}}` to escaped `{{var}}` in XML attribute values across QRDA/CDA Mustache templates.

## Changes proposed in this pull request
- Change 20 instances of raw `{{{var}}}` (unescaped) to `{{var}}` (escaped) in XML attribute positions across 17 Mustache templates in `src/Services/Qrda/`
- Affected values are timestamps, OIDs, and numeric data that don't contain XML-unsafe characters, so output is identical today
- Escaped variables ensure proper XML escaping (`&`, `<`, `>`, `"`, `'`) if unexpected data ever appears
- Raw `{{{var}}}` in text content positions (XML fragment injection) is left unchanged since those contain pre-built XML elements

Once #10462 is merged, the `*.mustache` exclusion in the Semgrep workflow can potentially be removed since these were the source of the `unquoted-attribute-var` alerts.

## AI Disclosure
Yes