### PR TITLE
feat(ci): extend Semgrep SAST coverage to JavaScript, Twig, and XSL

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   semgrep:
-    name: Semgrep PHP Security Scan
+    name: Semgrep Security Scan
     runs-on: ubuntu-latest
     container:
       image: semgrep/semgrep:latest
@@ -44,10 +44,13 @@ jobs:
       # positives while still detecting real XSS vulnerabilities.
       # Exclude Documentation/ (generated SchemaSpy HTML, not application code)
       # and *.mustache (QRDA/CDA XML templates, not browser-rendered HTML).
+      # JS/Node rulesets scan frontend scripts and ccdaservice.
       run: |
         semgrep \
           --config p/php \
           --config p/security-audit \
+          --config p/javascript \
+          --config p/nodejs \
           --config ./semgrep.yaml \
           --exclude vendor \
           --exclude node_modules \
@@ -71,11 +74,14 @@ jobs:
       # positives while still detecting real XSS vulnerabilities.
       # Exclude Documentation/ (generated SchemaSpy HTML, not application code)
       # and *.mustache (QRDA/CDA XML templates, not browser-rendered HTML).
+      # JS/Node rulesets scan frontend scripts and ccdaservice.
       run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
         semgrep \
           --config p/php \
           --config p/security-audit \
+          --config p/javascript \
+          --config p/nodejs \
           --config ./semgrep.yaml \
           --exclude vendor \
           --exclude node_modules \

--- a/run-semgrep.sh
+++ b/run-semgrep.sh
@@ -114,12 +114,14 @@ else
     CONFIG_ARGS+=(
         "--config=p/php"
         "--config=p/security-audit"
+        "--config=p/javascript"
+        "--config=p/nodejs"
         "--config=/src/semgrep.yaml"
     )
-    echo "Config: p/php p/security-audit semgrep.yaml"
+    echo "Config: p/php p/security-audit p/javascript p/nodejs semgrep.yaml"
 fi
 
-echo "Running Semgrep on OpenEMR PHP code..."
+echo "Running Semgrep on OpenEMR code..."
 if [[ -n "${SEVERITY}" ]]; then
     echo "Severity filter: ${SEVERITY}"
 fi

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -184,3 +184,140 @@ rules:
   message: Potential SQL injection in sqlQuery() - use parameterized queries
   languages: [php]
   severity: ERROR
+
+  # --- JavaScript rules ---
+
+  # Detect eval() on dynamic data (e.g. AJAX responses, variables).
+  # Excludes eval of literal strings which are safe.
+- id: openemr-js-eval-ajax-response
+  patterns:
+  - pattern: eval($DATA)
+  - pattern-not: eval("...")
+  message: >-
+    eval() on dynamic data risks code injection. Use JSON.parse() for data
+    or a safer alternative to eval().
+  languages: [javascript]
+  severity: ERROR
+  metadata:
+    technology:
+    - javascript
+    cwe:
+    - "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
+    owasp:
+    - A03:2021 - Injection
+    category: security
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+
+  # Detect dynamic innerHTML assignments (DOM-based XSS).
+  # Excludes assignments of literal strings which are safe.
+- id: openemr-js-innerhtml-dynamic
+  patterns:
+  - pattern: $EL.innerHTML = $DATA;
+  - pattern-not: $EL.innerHTML = "...";
+  - pattern-not: $EL.innerHTML = '';
+  message: >-
+    Assigning dynamic data to innerHTML risks DOM-based XSS.
+    Use textContent for text or sanitize HTML before insertion.
+  languages: [javascript]
+  severity: WARNING
+  metadata:
+    technology:
+    - javascript
+    cwe:
+    - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp:
+    - A03:2021 - Injection
+    category: security
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+
+  # --- Twig template rules (generic mode) ---
+  # Autoescape is globally disabled in OpenEMR (TwigContainer.php:66),
+  # so all escaping is manual. These rules target high-risk attribute contexts
+  # where unescaped output leads to XSS.
+
+  # Detect unescaped Twig output in href attributes.
+  # Safe patterns use |e or |attr_url filters.
+- id: openemr-twig-unescaped-output-in-href
+  pattern: href="{{ $VAR }}"
+  message: >-
+    Unescaped Twig variable in href attribute. Autoescape is disabled in OpenEMR.
+    Use |e('html_attr') or |attr_url to prevent XSS.
+  languages: [generic]
+  severity: ERROR
+  paths:
+    include:
+    - '*.twig'
+  metadata:
+    technology:
+    - twig
+    cwe:
+    - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp:
+    - A03:2021 - Injection
+    category: security
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: HIGH
+    confidence: MEDIUM
+
+  # Detect unescaped Twig output in form action attributes.
+- id: openemr-twig-unescaped-output-in-action
+  pattern: action="{{ $VAR }}"
+  message: >-
+    Unescaped Twig variable in action attribute. Autoescape is disabled in OpenEMR.
+    Use |e('html_attr') or |attr_url to prevent XSS.
+  languages: [generic]
+  severity: ERROR
+  paths:
+    include:
+    - '*.twig'
+  metadata:
+    technology:
+    - twig
+    cwe:
+    - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp:
+    - A03:2021 - Injection
+    category: security
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: HIGH
+    confidence: MEDIUM
+
+  # --- XSL template rules (generic mode) ---
+
+  # Detect disable-output-escaping in XSL transforms.
+  # Bypasses XML output encoding, risky when transforming untrusted CCR/CCD data.
+- id: openemr-xsl-disable-output-escaping
+  pattern: disable-output-escaping="yes"
+  message: >-
+    disable-output-escaping bypasses XML output encoding. When transforming
+    untrusted CCR/CCD data, this can lead to XSS in the rendered output.
+  languages: [generic]
+  severity: WARNING
+  paths:
+    include:
+    - '*.xsl'
+  metadata:
+    technology:
+    - xsl
+    cwe:
+    - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp:
+    - A03:2021 - Injection
+    category: security
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM


### PR DESCRIPTION
Fixes #10465

#### Short description of what this resolves:

Extends Semgrep code scanning beyond PHP to cover JavaScript, Twig templates, and XSL transforms.

#### Changes proposed in this pull request:

- Add `p/javascript` and `p/nodejs` registry rulesets to CI workflow and local run script
- Add 5 custom Semgrep rules for patterns not covered by registry rulesets:
  - `openemr-js-eval-ajax-response`: `eval()` on dynamic data (code injection)
  - `openemr-js-innerhtml-dynamic`: dynamic `.innerHTML` assignments (DOM XSS)
  - `openemr-twig-unescaped-output-in-href`: unescaped `{{ var }}` in `href` attributes
  - `openemr-twig-unescaped-output-in-action`: unescaped `{{ var }}` in `action` attributes
  - `openemr-xsl-disable-output-escaping`: `disable-output-escaping="yes"` in XSL transforms
- Twig rules target high-risk attribute contexts because autoescape is globally disabled (`TwigContainer.php:66`)
- XSL rule catches known instances in `ccr/` that bypass output encoding on untrusted CCR/CCD data
- Rename CI job from "Semgrep PHP Security Scan" to "Semgrep Security Scan"

#### Does your code include anything generated by an AI Engine? Yes

Claude Code (Claude Opus 4.5) was used to implement the changes across all three files. The semgrep rules, workflow updates, and shell script changes were AI-generated based on a human-authored implementation plan.