### PR TITLE
fix(ci): use correct matrix variable for isolated-tests composer cache

### DIFF
--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -57,9 +57,9 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ matrix.configurations.php }}-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
-          ${{ runner.os }}-composer-${{ matrix.configurations.php }}-
+          ${{ runner.os }}-composer-${{ matrix.php-version }}-
           ${{ runner.os }}-composer-
 
     - name: Install dependencies


### PR DESCRIPTION
Fixes #10468

The composer cache key in the isolated-tests workflow referenced `matrix.configurations.php`, which doesn't exist in this workflow's matrix. The correct variable is `matrix.php-version`. All PHP versions were sharing a single cache entry as a result.

#### Changes proposed in this pull request:

- Change `matrix.configurations.php` to `matrix.php-version` in cache key and restore-keys

#### Does your code include anything generated by an AI Engine? Yes / No

Yes — Claude Code