### PR TITLE
fix(security): escape unescaped URL attributes in Twig templates

### DIFF
--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/portal/thirdparty.html.twig
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/portal/thirdparty.html.twig
@@ -67,7 +67,7 @@
 {% endblock %}
 {% block header %}
 <nav id="topNav" class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
-	<a class="navbar-brand" href="{{ portalUrl }}">
+	<a class="navbar-brand" href="{{ portalUrl|attr }}">
 		<img class="img-fluid" width="140" src="{{ images_static_relative | attr }}/logo-full-con.png"/>
 	</a>
 </nav>
@@ -79,14 +79,14 @@
             {{ "We're sorry but this Telehealth Session either does not exist or has ended."|xlt }}
             {{ "Please contact your provider if you have questions."|xlt }}
         </p>
-        <a href="{{ portalUrl }}" class="btn btn-lg btn-link">{{ "Back to Portal Dashboard"|xlt  }}</a>
+        <a href="{{ portalUrl|attr }}" class="btn btn-lg btn-link">{{ "Back to Portal Dashboard"|xlt  }}</a>
     </div>
     <div class="card overflow-auto text-center {% if not activeSession %}d-none{% endif %}">
         <header class="card-header bg-primary text-light">{{ 'Starting Telehealth Session' | xlt }}</header>
         <h5 class="m-5">{{ "If your session does not start in a few seconds, use the Launch Session button below"|xlt }}</h5>
         <input class="btn btn-success btn-lg" type="button" value="{{ "Launch Session"|xlt  }}" />
 
-        <a href="{{ portalUrl }}" class="btn btn-lg btn-link mt-5">{{ "Back to Portal Dashboard"|xlt  }}</a>
+        <a href="{{ portalUrl|attr }}" class="btn btn-lg btn-link mt-5">{{ "Back to Portal Dashboard"|xlt  }}</a>
     </div>
     {% if activeSession %}
         <script>

--- a/templates/document_categories/general_list.html.twig
+++ b/templates/document_categories/general_list.html.twig
@@ -47,7 +47,7 @@
             {% if add_node %}
             {{ "This new category will be a sub-category of "|xlt }} {{ parent_name|xlt }}
             {% endif %}
-            <form method="post" action="{{ FORM_ACTION }}" onsubmit="return top.restoreSession()">
+            <form method="post" action="{{ FORM_ACTION|attr }}" onsubmit="return top.restoreSession()">
 
                 <table>
                     <tr>

--- a/templates/interface/smart/admin-client/token-parse.html.twig
+++ b/templates/interface/smart/admin-client/token-parse.html.twig
@@ -1,7 +1,7 @@
 
 {% extends "interface/smart/admin-client/token-tools.html.twig" %}
 {% block toolContents %}
-<form method="POST" action="{{ actionUrl}}">
+<form method="POST" action="{{ actionUrl|attr }}">
     {% include "interface/smart/admin-client/partials/textarea.html.twig" with {key: 'token', 'setting': tokenSettings} %}
     <input type="submit" class="btn btn-sm btn-primary" value="{{ "Parse Token"|xla }}" />
 

--- a/templates/interface/smart/admin-client/token-tools.html.twig
+++ b/templates/interface/smart/admin-client/token-tools.html.twig
@@ -15,7 +15,7 @@
             </div>
             {% endif %}
             {% block toolContents %}
-            <form method="POST" action="{{ actionUrl }}">
+            <form method="POST" action="{{ actionUrl|attr }}">
                 {% include "interface/smart/admin-client/partials/textarea.html.twig" with {key: 'token', 'setting': tokenSettings} %}
                 <input type="submit" class="btn btn-sm btn-primary" value="{{ "Parse Token"|xla }}" />
             </form>

--- a/templates/oauth2/ehr-launch-autosubmit.html.twig
+++ b/templates/oauth2/ehr-launch-autosubmit.html.twig
@@ -3,7 +3,7 @@
     <title>{{ "Launching Application"|xlt }}</title>
 </head>
 <body>
-<form method="POST" action="{{ endpoint }}">
+<form method="POST" action="{{ endpoint|attr }}">
     {# Do we want to show any kind of message...? For satellite or slow latency connections... we'd want to show something here. #}
 </form>
 <script>

--- a/templates/portal/login/autologin.html.twig
+++ b/templates/portal/login/autologin.html.twig
@@ -34,7 +34,7 @@
         {% else %}
         <h5 class="m-5">{{ "Please wait while we authenticate your session"|xlt }}</h5>
         {% endif %}
-        <form method="POST" id="autologinform" action="{{ action }}">
+        <form method="POST" id="autologinform" action="{{ action|attr }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token|attr }}" />
             <input type="hidden" name="service_auth" value="{{ service_auth|attr }}" />
             <input type="hidden" name="target" value="{{ target|attr_url }}" />

--- a/templates/portal/partial/_nav_icon.html.twig
+++ b/templates/portal/partial/_nav_icon.html.twig
@@ -6,8 +6,7 @@
     data-toggle="collapse" data-parent="#{{ cardGroup|attr }}" aria-expanded="false"
     href="#{{ url|attr_url }}"
    {% else %}
-       {# Note url for urls that are not localLink must be escaped by the caller of this template to avoid double-escaping #}
-    href="{{ url }}"
+    href="{{ url|attr }}"
    {% endif %}
    {# windowTitle is used to update the current webpage's title property whenever a card is toggled to be displayed.
         Note the window title is sanitized to be text only in javascript.  #}

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/nav-icon-external-link.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/nav-icon-external-link.html
@@ -1,6 +1,6 @@
 
 <a id="test-nav" class="col-lg-2 col-md-4 col-sm-6 col-6 card bg-light pl-sm-2 pr-sm-2 pl-0 pr-0 pt-2 pb-2 text-center text-decoration-none"
-              href="https://example.com"
+       href="https://example.com"
              data-window-title="External"
    >
     <h1 class="card-image">


### PR DESCRIPTION
## Summary
- Add `|attr` filter to 9 unescaped `action` and `href` attributes across 7 Twig templates
- Autoescape is globally disabled in OpenEMR, so these require explicit escape filters
- Use `|attr` (`htmlspecialchars`) rather than `|attr_url` (`urlencode`) because these attributes contain complete URLs/paths, not URL components — `urlencode` mangles path separators and scheme prefixes, breaking navigation and form submission
- Resolves all open `openemr-twig-unescaped-output-in-action` and `openemr-twig-unescaped-output-in-href` Semgrep findings

Fixes #10473

## Test plan
- [x] Twig render tests pass (`composer phpunit-isolated --group=twig`)
- [ ] Verify document category add/edit form still submits correctly
- [ ] Verify SMART token parse/tools pages still function
- [ ] Verify EHR launch auto-submit still redirects correctly
- [ ] Verify portal autologin flow still works
- [ ] Verify portal navigation icons still link correctly (both local and external links)
- [ ] Verify Comlink telehealth third-party portal page still navigates correctly

**AI Disclosure:** Yes