### PR TITLE
fix(crypto): restore @throws tag on KeyVersion::fromPrefix()

### DIFF
--- a/src/Common/Crypto/KeyVersion.php
+++ b/src/Common/Crypto/KeyVersion.php
@@ -109,6 +109,7 @@ enum KeyVersion: int
      *
      * @param string $value The string to check (should be at least 3 bytes)
      * @return KeyVersion the KeyVersion extracted from the first 3 bytes of the string
+     * @throws \ValueError If the prefix cannot be converted to a KeyVersion
      */
     public static function fromPrefix(string $value): self
     {


### PR DESCRIPTION
Fixes #10451

PR #10452 tightened `KeyVersion::fromPrefix()` but accidentally dropped the `@throws \ValueError` docblock tag. The method still throws — this restores the annotation.

#### Does your code include anything generated by an AI Engine? Yes (Claude Code)