### PR TITLE
fix: #10481 EHR launch skip login screen

### DIFF
--- a/src/Common/Http/HttpSessionFactory.php
+++ b/src/Common/Http/HttpSessionFactory.php
@@ -108,7 +108,7 @@ class HttpSessionFactory implements SessionFactoryInterface
         // while we migrate the sessions to testable objects.
         if (!empty($_SESSION)) {
             foreach ($_SESSION as $key => $value) {
-                if ($key !== $session->getName()) { // Avoid overwriting session name
+                if (!in_array($key, [SessionUtil::OAUTH_SESSION_ID, SessionUtil::API_SESSION_ID, SessionUtil::CORE_SESSION_ID])) { // Avoid overwriting session name
                     $session->set($key, $value);
                 }
             }


### PR DESCRIPTION
Fixes the issues with the session switching from oauth2 to core as the logic was broken as part of the api refactor.  This fix resolves those issues.  I had to handle the session_id uniquely as I couldn't just instantiate new session objects with symfony which was the error in the prior logic. 

Fixes #10481 