### PR TITLE
docs(api): add CLI testing tip for special characters in passwords

### DIFF
--- a/Documentation/api/AUTHENTICATION.md
+++ b/Documentation/api/AUTHENTICATION.md
@@ -644,9 +644,11 @@ curl -X POST -k \
 > **Solutions for modified commands:**
 > - Disable bash history expansion (`!`): `set +H` before running curl
 > - Use single quotes around arguments containing special characters
-> - For passwords containing both `!` and `'`, use `printf -v`:
+> - For passwords containing both `!` and `'`, use a heredoc:
 >   ```bash
->   printf -v password "%s" 'my!complex'\''password'
+>   read -r password <<'EOF'
+>   my!complex'password
+>   EOF
 >   curl ... --data-urlencode "password=$password"
 >   ```
 >


### PR DESCRIPTION
Closes #10488

## Summary
- Adds a tip to the Password Grant section in `Documentation/api/AUTHENTICATION.md`
- Warns developers about bash shell interpretation causing authentication failures when passwords contain special characters (`!`, `$`, `\`)
- Provides practical solutions (disable history expansion, use single quotes, URL-encode, or use scripting languages)

## Context
While implementing OAuth2 password grant for a mobile healthcare app, I discovered that bash history expansion silently escapes the `!` character. This causes the API to receive an incorrect password (e.g., `Test123\!` instead of `Test123!`), resulting in a "Failed Authentication" error without any indication of the root cause.

This is a shell behavior issue, not an OpenEMR bug. Production apps using HTTP libraries will not experience this problem.

## Test plan
- [ ] Verify the markdown renders correctly in the documentation
- [ ] Confirm the tip appears after the Password Grant parameters section

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)