### PR TITLE
fix(billing): prevent sending blank statement emails

### DIFF
--- a/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
@@ -158,7 +158,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use of the "global" keyword is forbidden \\(\\$STMT_TEMP_FILE_PDF\\)\\. Use dependency injection instead\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.noGlobalNsFunctions.php
+++ b/.phpstan/baseline/openemr.noGlobalNsFunctions.php
@@ -602,11 +602,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function upload_file_to_client_email may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function upload_file_to_client_pdf may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -4167,11 +4167,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/sl_eob_invoice.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$countline might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$srcdir might not be defined\\.$#',
     'count' => 8,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',

--- a/.phpstan/phpstan-remaining-baseline.neon
+++ b/.phpstan/phpstan-remaining-baseline.neon
@@ -3384,10 +3384,6 @@ parameters:
       identifier: nullCoalesce.variable
       count: 1
       path: ../interface/billing/sl_eob_invoice.php
-    - message: '#^Variable \$countline might not be defined\.$#'
-      identifier: variable.undefined
-      count: 1
-      path: ../interface/billing/sl_eob_search.php
     - message: '#^Variable \$srcdir might not be defined\.$#'
       identifier: variable.undefined
       count: 8

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -180,19 +180,30 @@ function era_callback(&$out): void
     }
 }
 
-function emailLogin($patient_id, $message)
+/**
+ * Email a patient statement bill.
+ *
+ * @param non-empty-string $message
+ * @throws \InvalidArgumentException if message has no text content
+ * @throws \RuntimeException if the email cannot be sent
+ */
+function emailLogin(int $patient_id, string $message): void
 {
+    if (trim(strip_tags($message)) === '') {
+        throw new InvalidArgumentException('Statement message has no text content');
+    }
+
     $patientData = sqlQuery("SELECT * FROM `patient_data` WHERE `pid`=?", [$patient_id]);
-    if ($patientData['hipaa_allowemail'] != "YES" || empty($patientData['email']) || empty($GLOBALS['patient_reminder_sender_email'])) {
-        return false;
+    if ($patientData['hipaa_allowemail'] != "YES" || ($patientData['email'] ?? '') === '' || ($GLOBALS['patient_reminder_sender_email'] ?? '') === '') {
+        throw new RuntimeException(xl('Email is not allowed or not configured for this patient'));
     }
 
     if (!(ValidationUtils::isValidEmail($patientData['email']))) {
-        return false;
+        throw new RuntimeException(xl('Patient email address is invalid'));
     }
 
     if (!(ValidationUtils::isValidEmail($GLOBALS['patient_reminder_sender_email']))) {
-        return false;
+        throw new RuntimeException(xl('Sender email address is not configured or invalid'));
     }
 
     if ($_SESSION['pc_facility']) {
@@ -217,12 +228,12 @@ function emailLogin($patient_id, $message)
     $mail->AltBody = $message;
 
     if ($mail->Send()) {
-        return true;
-    } else {
-        $email_status = $mail->ErrorInfo;
-        error_log("EMAIL ERROR: " . errorLogEscape($email_status), 0);
-        return false;
+        return;
     }
+
+    $email_status = $mail->ErrorInfo;
+    error_log("EMAIL ERROR: " . errorLogEscape($email_status), 0);
+    throw new RuntimeException(xl('Failed to send statement email'));
 }
 
 // Upload a file to the client's browser
@@ -243,22 +254,6 @@ function upload_file_to_client($file_to_send): void
     exit(); //added to exit from process properly in order to stop bad html code -ehrlive
     // sleep one second to ensure there's no follow-on.
     sleep(1);
-}
-
-function upload_file_to_client_email($ppid, $file_to_send): void
-{
-    $message = "";
-    global $STMT_TEMP_FILE_PDF;
-    $file = fopen($file_to_send, "r");//this file contains the text to be converted to pdf.
-    while (!feof($file)) {
-        $OneLine = fgets($file);//one line is read
-
-        $message = $message . $OneLine . '<br />';
-
-        $countline++;
-    }
-
-    emailLogin($ppid, $message);
 }
 
 function upload_file_to_client_pdf($file_to_send, $aPatFirstName = '', $aPatID = null, $flagCFN = false): void
@@ -557,7 +552,11 @@ if (
                 } else {
                     $tmp = make_statement($stmt);
                     if (!empty($_REQUEST['form_email']) && $tmp !== '') {
-                        emailLogin($inv_pid[$inv_count], $tmp);
+                        try {
+                            emailLogin($inv_pid[$inv_count], $tmp);
+                        } catch (RuntimeException $e) {
+                            $alertmsg = $e->getMessage();
+                        }
                     }
                     if (empty($tmp)) {
                         $tmp = xlt("This EOB item does not meet minimum print requirements setup in Globals or there is an unknown error.") . " " . xlt("EOB Id") . ":" . text($inv_pid[$inv_count]) . " " . xlt("Encounter") . ":" . text($stmt['encounter']) . "\n";


### PR DESCRIPTION
Fixes #10485

#### Short description of what this resolves:

`emailLogin()` silently sent blank emails when called with an empty or markup-only message, and all failure paths returned `false` which callers ignored.

#### Changes proposed in this pull request:

- `emailLogin()` throws instead of returning `false`: `InvalidArgumentException` for empty message (contract violation), `RuntimeException` for email validation, config, and send failures
- Call site (moved into the per-patient loop by #8327) catches `RuntimeException` and sets `$alertmsg`, so one patient's failure doesn't abort the batch
- Remove dead `upload_file_to_client_email()` function (sole call site removed by #8327)
- Add type annotations: native param/return types and PHPDoc `non-empty-string` constraint
- Replace `empty()` checks with explicit null/empty-string checks

#### Does your code include anything generated by an AI Engine? Yes

Claude Code (Claude Opus 4.5) was used to implement this fix.