### PR TITLE
feat(templates): add age, vitals, and provider placeholders

### DIFF
--- a/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
@@ -947,7 +947,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_file/download_template.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use of the "global" keyword is forbidden \\(\\$ptrow, \\$hisrow, \\$enrow, \\$nextLocation, \\$keyLocation, \\$keyLength\\)\\. Use dependency injection instead\\.$#',
+    'message' => '#^Use of the "global" keyword is forbidden \\(\\$ptrow, \\$hisrow, \\$enrow, \\$vitalsrow, \\$nextLocation, \\$keyLocation, \\$keyLength\\)\\. Use dependency injection instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/download_template.php',
 ];

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -12988,7 +12988,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Variable \\$pid might not be defined\\.$#',
-    'count' => 4,
+    'count' => 5,
     'path' => __DIR__ . '/../../interface/patient_file/download_template.php',
 ];
 $ignoreErrors[] = [

--- a/interface/patient_file/download_template.php
+++ b/interface/patient_file/download_template.php
@@ -25,6 +25,7 @@ require_once($GLOBALS['srcdir'] . '/options.inc.php');
 
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Services\PatientService;
 
 if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
@@ -384,7 +385,7 @@ if ($encounter) {
 }
 
 // Get most recent vitals.
-$vitalsrow = sqlQuery(
+$vitalsrow = QueryUtils::querySingleRow(
     "SELECT weight, height, BMI FROM form_vitals WHERE pid = ? ORDER BY id DESC LIMIT 1",
     [$pid]
 );

--- a/src/Services/DocumentTemplates/DocumentTemplateRender.php
+++ b/src/Services/DocumentTemplates/DocumentTemplateRender.php
@@ -24,6 +24,7 @@ namespace OpenEMR\Services\DocumentTemplates;
 use HTMLPurifier;
 use HTMLPurifier_Config;
 use RuntimeException;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Services\PatientService;
 use OpenEMR\Services\PhoneNumberService;
@@ -94,7 +95,7 @@ class DocumentTemplateRender
         }
 
         // Get most recent vitals.
-        $this->vitalsrow = sqlQuery(
+        $this->vitalsrow = QueryUtils::querySingleRow(
             "SELECT weight, height, BMI FROM form_vitals WHERE pid = ? ORDER BY id DESC LIMIT 1",
             [$this->pid]
         ) ?: [];


### PR DESCRIPTION
Fixes #7078

#### Short description of what this resolves:

Adds six new document template placeholders for patient vitals, age, and provider information, requested in #7078.

#### Changes proposed in this pull request:

- Add `{PatientAge}`, `{PatientWeight}`, `{PatientHeight}`, `{PatientBMI}`, `{ProviderName}`, and `{ProviderSpecialty}` placeholders
- Both template processors updated (legacy `download_template.php` and modern `DocumentTemplateRender.php`)
- Vitals pulled from most recent `form_vitals` record
- Patient age computed via `PatientService::getPatientAgeDisplay()`
- Provider name constructed from title + first/middle/last name; specialty from `users.specialty`
- Legacy processor's SQL JOIN updated to also fetch `ur.title` and `ur.specialty` (modern processor already had these)

| Placeholder | Source |
|---|---|
| `{PatientAge}` | Computed from `patient_data.DOB` via `PatientService` |
| `{PatientWeight}` | `form_vitals.weight` (most recent) |
| `{PatientHeight}` | `form_vitals.height` (most recent) |
| `{PatientBMI}` | `form_vitals.BMI` (most recent) |
| `{ProviderName}` | `users.title` + `fname` + `mname` + `lname` |
| `{ProviderSpecialty}` | `users.specialty` |

#### Does your code include anything generated by an AI Engine? Yes

Claude Code (Anthropic Claude Opus 4.5) was used to implement the placeholder handlers in both template processors. Both modified files include the `@author` header identifying the AI-assisted contribution.