### PR TITLE
fix(ci): use files pattern for PHP pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,9 +91,7 @@ repos:
     name: PHP Syntax Check
     entry: php -l
     language: system
-    types:
-    - inc
-    - php
+    files: \.(php|inc)$
 
   - id: composer-validate
     name: Validate composer.json
@@ -113,33 +111,25 @@ repos:
     name: PHP Code Beautifier and Fixer
     entry: php -d memory_limit=1g ./vendor/bin/phpcbf --standard=ci/phpcs.xml
     language: system
-    types:
-    - inc
-    - php
+    files: \.(php|inc)$
 
   - id: phpcs
     name: PHP_CodeSniffer
     entry: php -d memory_limit=1g ./vendor/bin/phpcs --standard=ci/phpcs.xml
     language: system
-    types:
-    - inc
-    - php
+    files: \.(php|inc)$
 
   - id: phpstan
     name: PHPStan Static Analysis
     entry: php -d memory_limit=1g ./vendor/bin/phpstan analyze --configuration=phpstan.neon.dist
     language: system
-    types:
-    - inc
-    - php
+    files: \.(php|inc)$
 
   - id: rector
     name: Rector
     entry: php -d memory_limit=1g ./vendor/bin/rector process
     language: system
-    types:
-    - inc
-    - php
+    files: \.(php|inc)$
 
   - id: composer-require-checker
     name: Composer Require Checker


### PR DESCRIPTION
Fixes #10427

## Description
The `types: [inc, php]` filter uses AND logic, requiring files to match both types simultaneously. Since `inc` isn't a recognized pre-commit type identifier, no files ever matched and all PHP hooks (php-syntax-check, phpcbf, phpcs, phpstan, rector) were silently skipped.

## Changes
Replace `types: [inc, php]` with `files: \.(php|inc)$` on all five affected hooks to correctly match both `.php` and `.inc` files.

## AI Disclosure
Yes