### PR TITLE
test(twig): add render tests for Twig templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,35 @@ docker compose exec openemr /root/devtools php-log
 **Tip:** Install [openemr-cmd](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-cmd)
 for shorter commands (e.g., `openemr-cmd ut` for unit tests) from any directory.
 
+### Isolated tests (no Docker required)
+
+Isolated tests run on the host without a database or Docker:
+
+```bash
+composer phpunit-isolated        # Run all isolated tests
+```
+
+### Twig template tests
+
+Twig templates have two layers of testing (both isolated):
+
+- **Compilation tests** verify every `.twig` file parses and references valid
+  filters/functions/tests. These run automatically over all templates.
+- **Render tests** render specific templates with known parameters and compare
+  the full HTML output to expected fixture files in
+  `tests/Tests/Isolated/Common/Twig/fixtures/render/`.
+
+When modifying a Twig template that has render test coverage, update the
+fixture files:
+
+```bash
+composer update-twig-fixtures    # Regenerate fixture files
+```
+
+Review the diff before committing. See the
+[fixtures README](tests/Tests/Isolated/Common/Twig/fixtures/render/README.md)
+for details on adding new test cases.
+
 ## Code Quality
 
 These run on the host (requires local PHP/Node):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,25 @@ npm run stylelint         # CSS/SCSS linting
 
 These provide higher memory limits than Docker devtools and are what CI runs.
 
+## Isolated Tests (no Docker required)
+
+Some tests run on the host without a database or Docker:
+
+```sh
+composer phpunit-isolated        # Run all isolated tests
+```
+
+This includes Twig template tests that verify compilation and rendering. If you
+modify a Twig template that has render test coverage, update the expected output
+fixtures:
+
+```sh
+composer update-twig-fixtures    # Regenerate fixture files
+```
+
+Review the diff before committing. See
+`tests/Tests/Isolated/Common/Twig/fixtures/render/README.md` for details.
+
 ## Code Contributions (local development)
 
 You will need a "local" version of OpenEMR to make changes to the source code. The easiest way to do this is with [Docker](https://hub.docker.com/r/openemr/openemr/):

--- a/composer.json
+++ b/composer.json
@@ -283,6 +283,7 @@
         "phpunit-isolated": "phpunit -c phpunit-isolated.xml",
         "rector-check": "php -d memory_limit=4g ./vendor/bin/rector process --dry-run",
         "rector-fix": "php -d memory_limit=4g ./vendor/bin/rector process",
-        "require-checker": "php -d memory_limit=4g ./vendor/bin/composer-require-checker check --config-file=.composer-require-checker.json"
+        "require-checker": "php -d memory_limit=4g ./vendor/bin/composer-require-checker check --config-file=.composer-require-checker.json",
+        "update-twig-fixtures": "UPDATE_FIXTURES=1 phpunit -c phpunit-isolated.xml --filter TwigTemplateRenderTest"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -16577,5 +16577,5 @@
         "ext-zlib": "8.2",
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
+++ b/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/**
+ * Render Twig templates with known parameters and compare output to fixtures.
+ *
+ * The compilation test (TwigTemplateCompilationTest) verifies that every
+ * template parses and references valid filters/functions, but never renders
+ * templates with actual data. This test fills that gap: it renders real
+ * templates with fixture data and asserts the full HTML output matches
+ * an expected file, catching structural bugs like wrong attributes, missing
+ * prefixes, or broken escaping.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Common\Twig;
+
+use OpenEMR\Common\Twig\TwigContainer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\TwigFunction;
+
+#[Group('isolated')]
+#[Group('twig')]
+class TwigTemplateRenderTest extends TestCase
+{
+    private static ?Environment $twig = null;
+
+    protected function setUp(): void
+    {
+        $GLOBALS['fileroot'] ??= self::fileroot();
+        $GLOBALS['date_display_format'] ??= 0;
+        // Bypass database-dependent translation lookups so xl() returns the
+        // original string and xlt()/xla() apply only escaping.
+        $GLOBALS['disable_translation'] = true;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    #[Test]
+    #[DataProvider('renderCaseProvider')]
+    public function templateRendersExpectedOutput(string $templateName, array $parameters, string $fixturePath): void
+    {
+        $twig = self::twigEnvironment();
+        // Normalize immediately so fixtures and comparisons use the same form.
+        // Twig's block processing leaves trailing whitespace on empty lines;
+        // stripping it here keeps fixture files clean for pre-commit hooks.
+        $rendered = self::normalizeTrailingWhitespace(
+            $twig->render($templateName, $parameters)
+        );
+
+        // @codeCoverageIgnoreStart
+        if (getenv('UPDATE_FIXTURES') === '1') {
+            file_put_contents($fixturePath, $rendered);
+            self::markTestSkipped("Fixture updated: $fixturePath");
+        }
+        // @codeCoverageIgnoreEnd
+
+        $expected = file_get_contents($fixturePath);
+        self::assertIsString($expected, "Failed to read fixture: $fixturePath");
+        self::assertSame(
+            $expected,
+            $rendered,
+            "Rendered output does not match fixture: $fixturePath\n"
+            . "If you modified this template, update fixtures with: composer update-twig-fixtures\n"
+            . "Review the changes with `git diff` before committing."
+        );
+    }
+
+    /**
+     * Provide [templateName, parameters, fixturePath] for each render test case.
+     *
+     * To add a new test case:
+     * 1. Add a yield below with the template name, parameters, and fixture path.
+     * 2. Generate the expected output file:
+     *    composer update-twig-fixtures
+     * 3. Review the generated fixture with `git diff` and commit it.
+     *
+     * @return iterable<string, array{string, array<string, mixed>, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function renderCaseProvider(): iterable
+    {
+        $fixtureDir = __DIR__ . '/fixtures/render';
+
+        yield 'portal/partial/_nav_icon local link (defaults)' => [
+            'portal/partial/_nav_icon.html.twig',
+            [
+                'id'      => 'test-nav',
+                'url'     => 'testSection',
+                'navText' => 'Test Nav',
+                'icon'    => 'home',
+            ],
+            $fixtureDir . '/nav-icon-local-link.html',
+        ];
+
+        yield 'portal/partial/_nav_icon external link' => [
+            'portal/partial/_nav_icon.html.twig',
+            [
+                'id'        => 'test-nav',
+                'url'       => 'https://example.com',
+                'navText'   => 'External',
+                'icon'      => 'globe',
+                'localLink' => false,
+            ],
+            $fixtureDir . '/nav-icon-external-link.html',
+        ];
+
+        yield 'oauth2/ehr-launch-autosubmit' => [
+            'oauth2/ehr-launch-autosubmit.html.twig',
+            [
+                'endpoint' => '/oauth2/launch',
+            ],
+            $fixtureDir . '/ehr-launch-autosubmit.html',
+        ];
+
+        yield 'portal/login/autologin pin required' => [
+            'portal/login/autologin.html.twig',
+            [
+                'pagetitle'              => 'Telehealth Login',
+                'images_static_relative' => '/public/images',
+                'pin_required'           => 1,
+                'action'                 => '/portal/autologin',
+                'csrf_token'             => 'test-csrf-token',
+                'service_auth'           => 'test-auth-value',
+                'target'                 => 'https://example.com/telehealth',
+            ],
+            $fixtureDir . '/autologin-pin-required.html',
+        ];
+
+        yield 'portal/login/autologin no pin' => [
+            'portal/login/autologin.html.twig',
+            [
+                'pagetitle'              => 'Telehealth Login',
+                'images_static_relative' => '/public/images',
+                'pin_required'           => false,
+                'action'                 => '/portal/autologin',
+                'csrf_token'             => 'test-csrf-token',
+                'service_auth'           => 'test-auth-value',
+                'target'                 => 'https://example.com/telehealth',
+            ],
+            $fixtureDir . '/autologin-no-pin.html',
+        ];
+    }
+
+    /**
+     * Build and cache the Twig environment with stubs for isolated render testing.
+     *
+     * Stubs setupHeader() because the real implementation needs the kernel and
+     * event dispatcher, which aren't available in isolated tests. Render tests
+     * verify template structure, not header generation.
+     *
+     */
+    private static function twigEnvironment(): Environment
+    {
+        if (self::$twig !== null) {
+            return self::$twig;
+        }
+
+        $GLOBALS['fileroot'] ??= self::fileroot();
+        $GLOBALS['date_display_format'] ??= 0;
+        $GLOBALS['disable_translation'] = true;
+
+        $twigContainer = new TwigContainer();
+        $twig = $twigContainer->getTwig();
+
+        // Override setupHeader() before the first render initializes extensions.
+        // The real function requires $kernel for event dispatching; the stub
+        // returns an HTML comment so templates that extend base.html.twig
+        // render without the full application bootstrap, and the fixture files
+        // show exactly where the real function's output would appear.
+        $twig->addFunction(new TwigFunction(
+            'setupHeader',
+            fn () => '<!-- setupHeader stub -->',
+            ['is_safe' => ['html']]
+        ));
+
+        self::$twig = $twig;
+        return $twig;
+    }
+
+    /**
+     * Strip trailing whitespace from each line.
+     *
+     */
+    private static function normalizeTrailingWhitespace(string $text): string
+    {
+        return implode("\n", array_map(rtrim(...), explode("\n", $text)));
+    }
+
+    /** @codeCoverageIgnore */
+    private static function fileroot(): string
+    {
+        return dirname(__DIR__, 5);
+    }
+}

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/README.md
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/README.md
@@ -1,0 +1,42 @@
+# Twig Render Test Fixtures
+
+Expected HTML output for `TwigTemplateRenderTest`. Each `.html` file is the
+full rendered output of a Twig template with known parameters. The test renders
+the template and asserts the output matches the fixture.
+
+## Adding a fixture
+
+1. Add a new test case to `renderCaseProvider()` in `TwigTemplateRenderTest.php`
+   with the template name, parameters, and fixture path.
+2. Generate the fixture file:
+   ```bash
+   composer update-twig-fixtures
+   ```
+3. Review the generated file with `git diff`, then commit it.
+
+## Updating fixtures
+
+When a template changes intentionally, regenerate and review:
+
+```bash
+composer update-twig-fixtures
+git diff tests/Tests/Isolated/Common/Twig/fixtures/render/
+```
+
+## Test environment
+
+These tests run without a database or application kernel. Two things to know:
+
+- **Translation is disabled.** `xlt()`, `xla()`, etc. return the original
+  English string with escaping applied. Fixtures show untranslated text.
+- **`setupHeader()` is stubbed.** The real function requires the kernel and
+  event dispatcher. The stub returns `<!-- setupHeader stub -->`, which appears
+  in autologin fixtures wherever the real output would be.
+
+## Trailing whitespace
+
+Twig's block processing can leave trailing whitespace on otherwise-empty lines
+(e.g., indentation before `{{ parent() }}` followed by the parent block's
+leading newline). The test normalizes trailing whitespace before writing
+fixtures and before comparing, so the `.html` files stay clean for pre-commit
+hooks and the assertions still match.

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/autologin-no-pin.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/autologin-no-pin.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+                <!-- setupHeader stub -->
+
+
+
+    <title>    Telehealth Login
+</title>
+</head>
+<body>
+        <nav id="topNav" class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
+        <div class="navbar-brand">
+            <img class="img-fluid" width="140" src="/public/images/logo-full-con.png"/>
+        </div>
+    </nav>
+    <div class="container-fluid">
+            <div class="card overflow-auto text-center">
+        <header class="card-header bg-primary text-light">
+            <h1>Authenticating Login Session</h1>
+        </header>
+                <h5 class="m-5">Please wait while we authenticate your session</h5>
+                <form method="POST" id="autologinform" action="/portal/autologin">
+            <input type="hidden" name="csrf_token" value="test-csrf-token" />
+            <input type="hidden" name="service_auth" value="test-auth-value" />
+            <input type="hidden" name="target" value="https%3A%2F%2Fexample.com%2Ftelehealth" />
+                        <input class="btn btn-lg btn-primary" type="submit" name="autoLoginSubmit" value="Go To Destination" />
+                    </form>
+                <p>If you have not been redirected in a few seconds click the button above</p>
+        <p>You will be sent to the following web page https://example.com/telehealth</p>
+            </div>
+    <script>
+        const pinRequired = false;
+        (function() {
+            window.addEventListener("DOMContentLoaded", function() {
+                let form = window.document.getElementById("autologinform");
+                if (!form) {
+                    console.error("Failed to find autologinform");
+                    return;
+                }
+                // if pin is not required, submit the form immediately
+                // otherwise, wait for the user to enter the pin and submit the form.
+                // The pin will be validated on the server side before redirect.
+                // he action must be set in the onetime create actions.
+                if (!pinRequired) {
+                    form.submit(); // submit the form as soon as we load to start the session}
+                }
+            });
+        })(window);
+    </script>
+                    </div>
+</body>
+</html>

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/autologin-pin-required.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/autologin-pin-required.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+                <!-- setupHeader stub -->
+
+
+
+    <title>    Telehealth Login
+</title>
+</head>
+<body>
+        <nav id="topNav" class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
+        <div class="navbar-brand">
+            <img class="img-fluid" width="140" src="/public/images/logo-full-con.png"/>
+        </div>
+    </nav>
+    <div class="container-fluid">
+            <div class="card overflow-auto text-center">
+        <header class="card-header bg-primary text-light">
+            <h1>Authenticating Login Session</h1>
+        </header>
+                <h5 class="m-5">Enter PIN to authenticate your session</h5>
+                <form method="POST" id="autologinform" action="/portal/autologin">
+            <input type="hidden" name="csrf_token" value="test-csrf-token" />
+            <input type="hidden" name="service_auth" value="test-auth-value" />
+            <input type="hidden" name="target" value="https%3A%2F%2Fexample.com%2Ftelehealth" />
+                        <label for="login_pin">PIN Required value</label>
+            <input type="text" class="text-center m-1" maxlength="6" id="login_pin" name="login_pin" value="" />
+            <input class="btn btn-sm btn-primary" type="submit" name="autoLoginSubmit" value="Authorize and Go To Destination" />
+                    </form>
+                <p>You are Required to confirm access by entering the companion PIN. https://example.com/telehealth</p>
+            </div>
+    <script>
+        const pinRequired = 1;
+        (function() {
+            window.addEventListener("DOMContentLoaded", function() {
+                let form = window.document.getElementById("autologinform");
+                if (!form) {
+                    console.error("Failed to find autologinform");
+                    return;
+                }
+                // if pin is not required, submit the form immediately
+                // otherwise, wait for the user to enter the pin and submit the form.
+                // The pin will be validated on the server side before redirect.
+                // he action must be set in the onetime create actions.
+                if (!pinRequired) {
+                    form.submit(); // submit the form as soon as we load to start the session}
+                }
+            });
+        })(window);
+    </script>
+                    </div>
+</body>
+</html>

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/ehr-launch-autosubmit.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/ehr-launch-autosubmit.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+    <title>Launching Application</title>
+</head>
+<body>
+<form method="POST" action="/oauth2/launch">
+    </form>
+<script>
+    // grab the launch token and autosubmit it to the launch endpoint
+    (function() {
+        document.addEventListener("DOMContentLoaded", function(event) {
+            var form = document.getElementsByTagName('form')[0];
+            form.submit();
+        });
+    })();
+</script>
+</body>
+</html>

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/nav-icon-external-link.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/nav-icon-external-link.html
@@ -1,0 +1,14 @@
+
+<a id="test-nav" class="col-lg-2 col-md-4 col-sm-6 col-6 card bg-light pl-sm-2 pr-sm-2 pl-0 pr-0 pt-2 pb-2 text-center text-decoration-none"
+              href="https://example.com"
+             data-window-title="External"
+   >
+    <h1 class="card-image">
+        <i class="fa fa-2x fa-globe text-dark"></i>
+    </h1>
+    <div class="card-body pl-1 pr-1 pl-sm-3 pr-sm-3">
+        <button class="btn btn-success d-block w-100 text-light">
+                        External
+                    </button>
+    </div>
+</a>

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/nav-icon-local-link.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/nav-icon-local-link.html
@@ -1,0 +1,15 @@
+
+<a id="test-nav" class="col-lg-2 col-md-4 col-sm-6 col-6 card bg-light pl-sm-2 pr-sm-2 pl-0 pr-0 pt-2 pb-2 text-center text-decoration-none"
+       data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false"
+    href="#testSection"
+             data-window-title="Test Nav"
+   >
+    <h1 class="card-image">
+        <i class="fa fa-2x fa-home text-dark"></i>
+    </h1>
+    <div class="card-body pl-1 pr-1 pl-sm-3 pr-sm-3">
+        <button class="btn btn-success d-block w-100 text-light">
+                        Test Nav
+                    </button>
+    </div>
+</a>

--- a/tests/Tests/README.md
+++ b/tests/Tests/README.md
@@ -7,13 +7,14 @@ OpenEMR integration and unit tests are implemented using [phpunit](https://phpun
 ### Test Case Directory Structure
 
 | Directory | Test Case Type |
-| --------- | --------------
-| Api       |  API Controller Tests |
-| Common    |  Tests OpenEMR "common"/reusable components |
-| E2e       |  Browser Based Tests (End to End) |
-| Fixture   |  Manages test case fixtures |
-| Service   |  Service/Data Access Tests |
-| Unit      |  Tests components which don't require database integration |
+| --------- | -------------- |
+| Api       | API Controller Tests |
+| Common    | Tests OpenEMR "common"/reusable components |
+| E2e       | Browser Based Tests (End to End) |
+| Fixture   | Manages test case fixtures |
+| Isolated  | Tests that run without a database or Docker (Twig templates, etc.) |
+| Service   | Service/Data Access Tests |
+| Unit      | Tests components which don't require database integration |
 
 ### Test Case Fixtures
 
@@ -26,3 +27,20 @@ The FixtureManager currently supports the following record types:
 To support additional record types within FixtureManager:
 - Add a supporting json file to the Fixture Namespace which maps to an OpenEMR database table.
 - Add public methods to the class to get, install, and remove fixture records.
+
+### Isolated Tests
+
+Isolated tests live in `Isolated/` and run without a database or Docker using a
+separate PHPUnit config:
+
+```sh
+composer phpunit-isolated
+```
+
+Currently includes:
+- **Twig compilation tests** — verify all `.twig` templates parse and reference
+  valid filters/functions/tests.
+- **Twig render tests** — render specific templates with known parameters and
+  compare full HTML output to expected fixture files. Update fixtures with
+  `composer update-twig-fixtures`. See
+  `Isolated/Common/Twig/fixtures/render/README.md` for details.


### PR DESCRIPTION
Fixes #10490

#### Short description of what this resolves:

The compilation test (`TwigTemplateCompilationTest`) verifies every template parses and references valid filters/functions, but never renders templates with actual data. Structural bugs — wrong attributes, missing prefixes, broken escaping — go undetected until manual testing.

#### Changes proposed in this pull request:

- Add `TwigTemplateRenderTest` that renders templates with known parameters and compares full HTML output to expected fixture files
- Cover three priority templates with five test cases:
  - `_nav_icon.html.twig` — local link (default cardGroup) and external link variants
  - `ehr-launch-autosubmit.html.twig` — basic render
  - `autologin.html.twig` — pin-required and no-pin variants
- Stub `setupHeader()` for templates that extend `base.html.twig` (requires kernel/event dispatcher unavailable in isolated tests)
- Normalize trailing whitespace in comparisons so fixtures survive pre-commit hooks
- Add `composer update-twig-fixtures` command to regenerate fixtures, with clear instructions in assertion failure messages
- Update CLAUDE.md, CONTRIBUTING.md, and tests/Tests/README.md with isolated test and fixture documentation

#### Does your code include anything generated by an AI Engine? Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.

The test class and fixture files were generated with Claude Code (Claude Opus 4.5).