### PR TITLE
fix(e2e): replace sleep/retry with proper WebDriver wait conditions

### DIFF
--- a/tests/Tests/E2e/GgUserMenuLinksTest.php
+++ b/tests/Tests/E2e/GgUserMenuLinksTest.php
@@ -6,7 +6,9 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2024 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -21,7 +23,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Panther\PantherTestCase;
-use Symfony\Component\Panther\Client;
 
 class GgUserMenuLinksTest extends PantherTestCase
 {
@@ -36,39 +37,24 @@ class GgUserMenuLinksTest extends PantherTestCase
     #[Test]
     public function testUserMenuLink(string $menuTreeIcon, string $menuLinkItem, string $expectedTabTitle): void
     {
-        $counter = 0;
-        $threwSomething = true;
-        // below will basically allow 3 timeouts
-        while ($threwSomething) {
-            $threwSomething = false;
-            $counter++;
-            if ($counter > 1) {
-                echo "\n" . "RE-attempt (" . $menuTreeIcon . ") number " . $counter . " of 3" . "\n";
+        $this->base();
+        try {
+            $this->login(LoginTestData::username, LoginTestData::password);
+            if ($menuLinkItem == 'Logout') {
+                // special case for Logout
+                $this->logOut();
+            } else {
+                $this->goToUserMenuLink($menuTreeIcon);
+                $this->assertActiveTab($expectedTabTitle);
             }
-            $this->base();
-            try {
-                $this->login(LoginTestData::username, LoginTestData::password);
-                if ($menuLinkItem == 'Logout') {
-                    // special case for Logout
-                    $this->logOut();
-                } else {
-                    $this->goToUserMenuLink($menuTreeIcon);
-                    $this->assertActiveTab($expectedTabTitle);
-                }
-            } catch (\Throwable $e) {
-                // Close client
-                $this->client->quit();
-                if ($counter > 2) {
-                    // re-throw since have failed 3 tries
-                    throw $e;
-                } else {
-                    // try again since not yet 3 tries
-                    $threwSomething = true;
-                }
-            }
+        } catch (\Throwable $e) {
             // Close client
             $this->client->quit();
+            // re-throw the exception
+            throw $e;
         }
+        // Close client
+        $this->client->quit();
     }
 
     /** @codeCoverageIgnore Data providers run before coverage instrumentation starts. */

--- a/tests/Tests/E2e/HhMainMenuLinksTest.php
+++ b/tests/Tests/E2e/HhMainMenuLinksTest.php
@@ -6,7 +6,9 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2024 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -21,7 +23,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Panther\PantherTestCase;
-use Symfony\Component\Panther\Client;
 
 class HhMainMenuLinksTest extends PantherTestCase
 {
@@ -46,34 +47,19 @@ class HhMainMenuLinksTest extends PantherTestCase
             $loading = "Loading";
         }
 
-        $counter = 0;
-        $threwSomething = true;
-        // below will basically allow 3 timeouts
-        while ($threwSomething) {
-            $threwSomething = false;
-            $counter++;
-            if ($counter > 1) {
-                echo "\n" . "RE-attempt (" . $menuLink . ") number " . $counter . " of 3" . "\n";
-            }
-            $this->base();
-            try {
-                $this->login(LoginTestData::username, LoginTestData::password);
-                $this->goToMainMenuLink($menuLink);
-                $this->assertActiveTab($expectedTabTitle, $loading);
-            } catch (\Throwable $e) {
-                // Close client
-                $this->client->quit();
-                if ($counter > 2) {
-                    // re-throw since have failed 3 tries
-                    throw $e;
-                } else {
-                    // try again since not yet 3 tries
-                    $threwSomething = true;
-                }
-            }
+        $this->base();
+        try {
+            $this->login(LoginTestData::username, LoginTestData::password);
+            $this->goToMainMenuLink($menuLink);
+            $this->assertActiveTab($expectedTabTitle, $loading);
+        } catch (\Throwable $e) {
             // Close client
             $this->client->quit();
+            // re-throw the exception
+            throw $e;
         }
+        // Close client
+        $this->client->quit();
     }
 
     /** @codeCoverageIgnore Data providers run before coverage instrumentation starts. */

--- a/tests/Tests/E2e/IiPatientContextMainMenuLinksTest.php
+++ b/tests/Tests/E2e/IiPatientContextMainMenuLinksTest.php
@@ -6,7 +6,9 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2024 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -23,7 +25,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Panther\PantherTestCase;
-use Symfony\Component\Panther\Client;
 
 class IiPatientContextMainMenuLinksTest extends PantherTestCase
 {
@@ -54,39 +55,24 @@ class IiPatientContextMainMenuLinksTest extends PantherTestCase
             $clearAlert = false;
         }
 
-        $counter = 0;
-        $threwSomething = true;
-        // below will basically allow 3 timeouts
-        while ($threwSomething) {
-            $threwSomething = false;
-            $counter++;
-            if ($counter > 1) {
-                echo "\n" . "RE-attempt (" . $menuLink . ") number " . $counter . " of 3" . "\n";
+        $this->base();
+        try {
+            $this->login(LoginTestData::username, LoginTestData::password);
+            $this->patientOpenIfExist(PatientTestData::FNAME, PatientTestData::LNAME, PatientTestData::DOB, PatientTestData::SEX, false);
+            $this->goToMainMenuLink($menuLink);
+            if ($popup) {
+                $this->assertActivePopup($expectedTabPopupTitle);
+            } else {
+                $this->assertActiveTab($expectedTabPopupTitle, $loading, false, $clearAlert);
             }
-            $this->base();
-            try {
-                $this->login(LoginTestData::username, LoginTestData::password);
-                $this->patientOpenIfExist(PatientTestData::FNAME, PatientTestData::LNAME, PatientTestData::DOB, PatientTestData::SEX, false);
-                $this->goToMainMenuLink($menuLink);
-                if ($popup) {
-                    $this->assertActivePopup($expectedTabPopupTitle);
-                } else {
-                    $this->assertActiveTab($expectedTabPopupTitle, $loading, false, $clearAlert);
-                }
-            } catch (\Throwable $e) {
-                // Close client
-                $this->client->quit();
-                if ($counter > 2) {
-                    // re-throw since have failed 3 tries
-                    throw $e;
-                } else {
-                    // try again since not yet 3 tries
-                    $threwSomething = true;
-                }
-            }
+        } catch (\Throwable $e) {
             // Close client
             $this->client->quit();
+            // re-throw the exception
+            throw $e;
         }
+        // Close client
+        $this->client->quit();
     }
 
     /** @codeCoverageIgnore Data providers run before coverage instrumentation starts. */

--- a/tests/Tests/E2e/JjEncounterContextMainMenuLinksTest.php
+++ b/tests/Tests/E2e/JjEncounterContextMainMenuLinksTest.php
@@ -6,7 +6,9 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2024 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -23,7 +25,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Panther\PantherTestCase;
-use Symfony\Component\Panther\Client;
 
 class JjEncounterContextMainMenuLinksTest extends PantherTestCase
 {
@@ -55,40 +56,25 @@ class JjEncounterContextMainMenuLinksTest extends PantherTestCase
             $looseTabTitle = false;
         }
 
-        $counter = 0;
-        $threwSomething = true;
-        // below will basically allow 3 timeouts
-        while ($threwSomething) {
-            $threwSomething = false;
-            $counter++;
-            if ($counter > 1) {
-                echo "\n" . "RE-attempt (" . $menuLink . ") number " . $counter . " of 3" . "\n";
+        $this->base();
+        try {
+            $this->login(LoginTestData::username, LoginTestData::password);
+            $this->patientOpenIfExist(PatientTestData::FNAME, PatientTestData::LNAME, PatientTestData::DOB, PatientTestData::SEX, false);
+            $this->encounterOpenIfExist(PatientTestData::FNAME, PatientTestData::LNAME, PatientTestData::DOB, PatientTestData::SEX, false, false);
+            $this->goToMainMenuLink($menuLink);
+            if ($popup) {
+                $this->assertActivePopup($expectedTabPopupTitle);
+            } else {
+                $this->assertActiveTab($expectedTabPopupTitle, $loading, $looseTabTitle);
             }
-            $this->base();
-            try {
-                $this->login(LoginTestData::username, LoginTestData::password);
-                $this->patientOpenIfExist(PatientTestData::FNAME, PatientTestData::LNAME, PatientTestData::DOB, PatientTestData::SEX, false);
-                $this->encounterOpenIfExist(PatientTestData::FNAME, PatientTestData::LNAME, PatientTestData::DOB, PatientTestData::SEX, false, false);
-                $this->goToMainMenuLink($menuLink);
-                if ($popup) {
-                    $this->assertActivePopup($expectedTabPopupTitle);
-                } else {
-                    $this->assertActiveTab($expectedTabPopupTitle, $loading, $looseTabTitle);
-                }
-            } catch (\Throwable $e) {
-                // Close client
-                $this->client->quit();
-                if ($counter > 2) {
-                    // re-throw since have failed 3 tries
-                    throw $e;
-                } else {
-                    // try again since not yet 3 tries
-                    $threwSomething = true;
-                }
-            }
+        } catch (\Throwable $e) {
             // Close client
             $this->client->quit();
+            // re-throw the exception
+            throw $e;
         }
+        // Close client
+        $this->client->quit();
     }
 
     /** @codeCoverageIgnore Data providers run before coverage instrumentation starts. */


### PR DESCRIPTION
Fixes #10499

#### Short description of what this resolves:

E2e tests use `sleep()` calls, stale-crawler polling loops, and 3x retry patterns that cause flaky results and slow execution.

#### Changes proposed in this pull request:

- **BaseTrait:** Replace manual `microtime()`/`usleep()` polling (which reads a stale crawler) with `waitForElementToNotContain()` and `waitForElementToContain()` — these query the live DOM on each poll
- **UserAddTrait:** Replace `sleep(2)` with JS wait for `submitform` function and field-value wait; replace `assertUserInDatabase` sleep loop with `WebDriverWait` polling every 500ms
- **4 menu link tests:** Remove `while ($threwSomething)` 3x retry loops from `GgUserMenuLinksTest`, `HhMainMenuLinksTest`, `IiPatientContextMainMenuLinksTest`, `JjEncounterContextMainMenuLinksTest`

**Not included:** PatientAddTrait is left unchanged. After 5 failed iterations trying to replace its `sleep(5)` and retry mechanism, the dialog callback chain (`dlgclose` → Bootstrap modal hide → `hidden.bs.modal` → `srcConfirmSave` → `form.submit`) proved to have timing dependencies that resist reliable WebDriver wait replacement. See investigation log below for details; this will be addressed in a follow-up.

#### Does your code include anything generated by an AI Engine? Yes

Claude Code (Anthropic) generated the replacement wait conditions and refactored the retry loop removal.

---

### Investigation log (PatientAddTrait — reverted, for reference)

PatientAddTrait was reverted after 5 failed iterations. This log is preserved so we don't repeat steps in a follow-up PR.

#### Background

The original `patientAddIfNotExist()` has `sleep(5)` before clicking the confirm button, then waits for a JS `alert()`. The alert never actually appears (see iteration 3 analysis), so the `alertIsPresent()` always times out. A 3-attempt retry mechanism catches the `TimeoutException` — on retry, `isPatientExist()` returns true and the test is skipped.

#### Iteration 1 — `typeof dlgclose === "function"`

**CI result:** `alertIsPresent()` timed out on both servers.

**Analysis:** `dlgclose` is defined when `dialog.js` loads, before `dlgopen()` completes dialog infrastructure setup. Check passes too early.

#### Iteration 2 — `document.readyState === "complete"`

**CI result:** Same `alertIsPresent()` timeout.

**Analysis:** Checks the iframe's own load state (already complete when button is clickable), not the parent frame's dialog infrastructure.

#### Iteration 3 — `typeof dlgclose === "function" && typeof top.setCallBack === "function"`

**CI result:** Same `alertIsPresent()` timeout. But on apache the patient WAS created (DdOpenPatient passed); on nginx it was NOT.

**Key finding — no alert exists:** Traced `new_comprehensive_save.php` (lines 28-37, 228-230). The `alert()` only fires for duplicate patient external IDs (`pubpid`). The test doesn't set `form_pubpid`, so no alert ever appears. The `alertIsPresent()` ALWAYS times out. The original retry masks this.

#### Iteration 4 — removed alertIsPresent, added `.modal.show` check, wait for dashboard UI

**CI result:** Both servers failed — "Medical Record Dashboard" not found (30s timeout). Patient not in DB on either server.

**Analysis:** (a) The `.modal.show` check may have caused a regression — previously apache created the patient without it. (b) The dashboard UI never loads in `PATIENT_IFRAME` through this flow — the original test never verified it (dead code after the always-failing alert wait). (c) Immediate WebDriver page interaction after the click may interfere with the async Bootstrap modal hide transition.

#### Iteration 5 — reverted `.modal.show`, replaced UI check with DB polling

**CI result:** Both servers failed — `assertPatientInDatabase()` timed out after 30s. Patient not in DB.

**Analysis:** Even with no WebDriver commands after the click (DB polling uses direct SQL), the form submission chain still doesn't complete reliably. The original `sleep(5)` provides 5 seconds of complete browser idle time that appears necessary for the Bootstrap modal/dialog callback chain to function. The mechanism involves: `dlgclose()` → iframe removal from DOM → `modal("hide")` → CSS transition (~300ms) → `hidden.bs.modal` event → callback resolution via `window[functionName]` across frame boundaries → `form.submit()`. This chain has too many async browser-internal dependencies to replace with a deterministic WebDriver wait condition.

#### Conclusion

Reverted to original code. The `sleep(5)` + retry is the pragmatic solution until the underlying dialog architecture can be investigated more deeply (potentially requires changes to `dialog.js` itself, not just the test).