### PR TITLE
fix(session): breakage when add new patient via new patient UI

### DIFF
--- a/src/Common/Session/SessionUtil.php
+++ b/src/Common/Session/SessionUtil.php
@@ -166,6 +166,12 @@ class SessionUtil
 
     public static function unsetSession($session_key_or_array): void
     {
+        // Since our default is read_and_close the session shouldn't be active here.
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            // ensure the session file is written from a previous
+            // session open for write.
+            session_write_close();
+        }
         self::coreSessionStart($GLOBALS['webroot'], false);
         if (is_array($session_key_or_array)) {
             foreach ($session_key_or_array as $value) {
@@ -188,6 +194,12 @@ class SessionUtil
 
     public static function setUnsetSession($setArray, $unsetArray): void
     {
+        // Since our default is read_and_close the session shouldn't be active here.
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            // ensure the session file is written from a previous
+            // session open for write.
+            session_write_close();
+        }
         self::coreSessionStart($GLOBALS['webroot'], false);
         foreach ($setArray as $key => $value) {
             $_SESSION[$key] = $value;


### PR DESCRIPTION
fixes #10529

To be honest, this fixes but not totally sure what I am doing here (seems to make sense to save the session before do start wrapper since that seems to fail if there is an active session). To repeat though, not sure my brain understands  how the session code is working.

Need more eyes on this.