### PR TITLE
refactor(pre-commit): delegate to composer scripts instead of hard-coding commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,31 +109,31 @@ repos:
 
   - id: phpcbf
     name: PHP Code Beautifier and Fixer
-    entry: php -d memory_limit=1g ./vendor/bin/phpcbf --standard=ci/phpcs.xml
+    entry: composer phpcbf --
     language: system
     files: \.php$
 
   - id: phpcs
     name: PHP_CodeSniffer
-    entry: php -d memory_limit=1g ./vendor/bin/phpcs --standard=ci/phpcs.xml
+    entry: composer phpcs --
     language: system
     files: \.php$
 
   - id: phpstan
     name: PHPStan Static Analysis
-    entry: php -d memory_limit=1g ./vendor/bin/phpstan analyze --configuration=phpstan.neon.dist
+    entry: composer phpstan --
     language: system
     files: \.php$
 
   - id: rector
     name: Rector
-    entry: php -d memory_limit=1g ./vendor/bin/rector process
+    entry: composer rector-fix --
     language: system
     files: \.php$
 
   - id: composer-require-checker
     name: Composer Require Checker
-    entry: composer run-script require-checker
+    entry: composer require-checker
     language: system
     files: ^(composer\.json|.*\.php)$
     pass_filenames: false

--- a/composer.json
+++ b/composer.json
@@ -266,8 +266,8 @@
             "@codespell",
             "@conventional-commits:check",
             "@php-syntax-check",
-            "@phpcbf",
-            "@phpcs",
+            "@phpcbf .",
+            "@phpcs .",
             "@phpstan",
             "@rector-check",
             "@require-checker"
@@ -275,9 +275,9 @@
         "codespell": "command -v codespell >/dev/null 2>&1 && codespell || echo 'codespell not found. Install with: brew install codespell OR pipx install codespell' >&2",
         "conventional-commits:check": "./vendor/bin/conventional-commits validate",
         "php-syntax-check": "git ls-files -z '*.php' | xargs -0 php -l | grep -vF 'No syntax errors detected in'",
-        "phpcbf": "php -d memory_limit=4g ./vendor/bin/phpcbf --standard=ci/phpcs.xml .",
-        "phpcs": "php -d memory_limit=4g ./vendor/bin/phpcs --standard=ci/phpcs.xml .",
-        "phpstan": "phpstan analyze --memory-limit=4G --configuration=phpstan.neon.dist",
+        "phpcbf": "php -d memory_limit=4g ./vendor/bin/phpcbf --standard=ci/phpcs.xml",
+        "phpcs": "php -d memory_limit=4g ./vendor/bin/phpcs --standard=ci/phpcs.xml",
+        "phpstan": "phpstan analyze --memory-limit=4G",
         "phpstan-baseline": [
             "phpstan analyze --memory-limit=8G --configuration=phpstan.neon.dist --generate-baseline=.phpstan/baseline/loader.php",
             "php -d memory_limit=1g vendor/bin/split-phpstan-baseline .phpstan/baseline/loader.php --no-error-count"


### PR DESCRIPTION
Fixes #10532

Pre-commit hooks for phpcbf, phpcs, phpstan, and rector hard-coded the full command instead of delegating to the corresponding composer scripts — causing configurations to diverge (most notably memory limits: 1g in pre-commit vs 4g in composer).

## Changes proposed in this pull request

- Pre-commit hooks now call `composer <script> --` (pre-commit appends staged files after the `--`), matching the pattern already used by `composer-require-checker` and `conventional-commits`
- Remove hardcoded `.` target from phpcbf/phpcs composer scripts so callers pass it explicitly; `code-quality` meta-script uses `@phpcbf .` / `@phpcs .`
- Remove redundant `--configuration=phpstan.neon.dist` from phpstan script (`phpstan.neon.dist` is the default config location)
- Normalize `composer-require-checker` hook entry to shorthand form

## AI disclosure

Yes