### PR TITLE
fix(e2e): wait for Knockout.js menu render before navigating

### DIFF
--- a/tests/Tests/E2e/Base/BaseTrait.php
+++ b/tests/Tests/E2e/Base/BaseTrait.php
@@ -120,6 +120,8 @@ trait BaseTrait
         // wait for the main menu to be visible
         // ensure on main page (ie. not in an iframe)
         $this->client->switchTo()->defaultContent();
+        // Wait for the main menu to be populated by Knockout.js
+        $this->client->waitForVisibility('//div[@id="mainMenu"]/div', 30);
         // got to and click the menu link
         $menuLinkSequenceArray = explode('||', $menuLink);
         $counter = 0;


### PR DESCRIPTION
Fixes #10531

## Description
`goToMainMenuLink()` can fail when Knockout.js hasn't finished rendering the `#mainMenu` template after login. The `login()` method only checks the page title is "OpenEMR" — it doesn't verify the JavaScript framework has populated `#mainMenu`.

## Changes proposed
Add `waitForVisibility('//div[@id="mainMenu"]/div', 30)` in `goToMainMenuLink()` before the menu item loop. This waits for at least one child `div` inside `#mainMenu` to be visible, confirming Knockout.js has processed the menu template binding. Once the container has children, the subsequent `waitFor` calls for specific items find them immediately (Knockout renders all items synchronously from the template).

All 4 menu link test classes (Gg, Hh, Ii, Jj) benefit since they all call `goToMainMenuLink()`.

## AI disclosure
Yes — authored with Claude Code.