### PR TITLE
fix(portal): one-time token for portal document notification broken

### DIFF
--- a/src/Common/Auth/OneTimeAuth.php
+++ b/src/Common/Auth/OneTimeAuth.php
@@ -232,28 +232,31 @@ class OneTimeAuth
         if (stripos((string) $site_addr, "?") === false) {
             $format = "%s?%s";
         }
+        // Use RFC3986 so + and / in base64-like tokens are encoded as %2B and %2F,
+        // preventing query string parsing from turning + into space (issue #10517).
+        $enc_type = defined('PHP_QUERY_RFC3986') ? PHP_QUERY_RFC3986 : 2;
         if ($this->scope == 'register') {
             $encoded_link = sprintf($format, attr($site_addr), http_build_query([
                 'forward_email_verify' => $token_encrypt,
                 'site' => $site_id
-            ]));
+            ], '', '&', $enc_type));
         } elseif ($this->scope == 'reset_password') {
             $encoded_link = sprintf($format, attr($site_addr), http_build_query([
                 'forward' => $token_encrypt,
                 'site' => $site_id
-            ]));
+            ], '', '&', $enc_type));
         } else {
             if (!empty($encrypted_redirect)) {
                 $encoded_link = sprintf($format, attr($site_addr), http_build_query([
                     'service_auth' => $token_encrypt,
                     'target' => $encrypted_redirect,
                     'site' => $site_id
-                ]));
+                ], '', '&', $enc_type));
             } else {
                 $encoded_link = sprintf($format, attr($site_addr), http_build_query([
                     'service_auth' => $token_encrypt,
                     'site' => $site_id
-                ]));
+                ], '', '&', $enc_type));
             }
         }
         $this->systemLogger->debug("Onetime link " . text($encoded_link) . " encoded");


### PR DESCRIPTION
Encode one-time links with RFC3986 so + and / in tokens are sent as %2B and %2F. Query string parsing otherwise turns + into space and corrupts the token, causing decode failure and redirect to login.

- OneTimeAuth::encodeLink(): use PHP_QUERY_RFC3986 for all onetime query strings (register, reset_password, service_auth).
- portal/index.php: normalize service_auth and target by replacing space with + when reading from GET/POST so existing links still work.

Fixes #10517

<!--Thanks for sending a pull request!
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->

<!-- PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details -->

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
