### PR TITLE
refactor(auth): consolidate base64url encode/decode to HttpUtils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,7 @@
         "nyholm/psr7-server": "^1.1.0",
         "omnipay/stripe": "^3.2.0",
         "openemr/mustache": "^2.15.2",
+        "paragonie/constant_time_encoding": "^3.1.3",
         "particle/validator": "^2.3.6",
         "pear/archive_tar": "^1.6.0",
         "php-http/discovery": "^1.20.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2ba73ee121826c25e1cd914892b8e3d",
+    "content-hash": "9de3406b42b4ffdaa835529aa9baef34",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -16581,5 +16581,5 @@
         "ext-zlib": "8.2",
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Common/Utils/HttpUtils.php
+++ b/src/Common/Utils/HttpUtils.php
@@ -2,19 +2,29 @@
 
 /**
  * HttpUtils utility class for functions dealing with urls and http.
- * @package openemr
+ *
+ * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2023 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 namespace OpenEMR\Common\Utils;
 
+use ParagonIE\ConstantTime\Base64UrlSafe;
+
 class HttpUtils
 {
-    public static function base64url_encode($data): string
+    public static function base64url_encode(string $data): string
     {
-        return rtrim(strtr(base64_encode((string) $data), '+/', '-_'), '=');
+        return Base64UrlSafe::encodeUnpadded($data);
+    }
+
+    public static function base64url_decode(string $data): string
+    {
+        return Base64UrlSafe::decode($data);
     }
 }

--- a/src/RestControllers/Authorization/OAuth2PublicJsonWebKeyController.php
+++ b/src/RestControllers/Authorization/OAuth2PublicJsonWebKeyController.php
@@ -4,6 +4,7 @@ namespace OpenEMR\RestControllers\Authorization;
 
 use League\OAuth2\Server\Exception\OAuthServerException;
 use OpenEMR\Common\Http\HttpRestRequest;
+use OpenEMR\Common\Utils\HttpUtils;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -31,8 +32,8 @@ class OAuth2PublicJsonWebKeyController
         }
         $key_info = [
             'kty' => 'RSA',
-            'n' => $this->base64url_encode($keyPublic['rsa']['n']),
-            'e' => $this->base64url_encode($keyPublic['rsa']['e']),
+            'n' => HttpUtils::base64url_encode($keyPublic['rsa']['n']),
+            'e' => HttpUtils::base64url_encode($keyPublic['rsa']['e']),
         ];
         $key_info['use'] = 'sig';
 
@@ -40,11 +41,5 @@ class OAuth2PublicJsonWebKeyController
 
         $request->getSession()->invalidate();
         return new JsonResponse($jsonData);
-    }
-
-
-    public function base64url_encode($input): string
-    {
-        return rtrim(strtr(base64_encode((string) $input), '+/', '-_'), '=');
     }
 }

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -473,17 +473,6 @@ class AuthorizationController
         ))->fromGlobals();
     }
 
-    public function base64url_encode($data): string
-    {
-        return HttpUtils::base64url_encode($data);
-    }
-
-    public function base64url_decode($token): string
-    {
-        $b64 = strtr($token, '-_', '+/');
-        return base64_decode($b64);
-    }
-
     public function clientRegisteredDetails(HttpRestRequest $request): ResponseInterface
     {
         $response = $this->createServerResponse();
@@ -1438,7 +1427,7 @@ class AuthorizationController
 
     public function decodeToken($token)
     {
-        return json_decode($this->base64url_decode($token), true);
+        return json_decode(HttpUtils::base64url_decode($token), true);
     }
 
     public function userSessionLogout(HttpRestRequest $request): ResponseInterface


### PR DESCRIPTION
Fixes #10542

#### Short description of what this resolves:

Deduplicates base64url encoding/decoding implementations scattered across four files into `HttpUtils`, backed by `paragonie/constant_time_encoding` for constant-time operations in security-sensitive OAuth2/JWT code.

#### Changes proposed in this pull request:

- Add `paragonie/constant_time_encoding` as a direct dependency (previously transitive via phpseclib)
- Add `base64url_decode()` to `HttpUtils` alongside existing `base64url_encode()`
- Delegate both methods to `ParagonIE\ConstantTime\Base64UrlSafe`
- Update callsites in `AuthorizationController`, `OAuth2PublicJsonWebKeyController`, and `RsaSha384Signer`
- Remove duplicate implementations from those three files

#### Does your code include anything generated by an AI Engine? Yes

Claude Code (claude-opus-4-5-20251101) was used to implement this change. All modified files contain AI-generated code.