### PR TITLE
fix(payments): Widen param types for payment sequence number generation

### DIFF
--- a/src/PaymentProcessing/Recorder.php
+++ b/src/PaymentProcessing/Recorder.php
@@ -204,7 +204,7 @@ class Recorder
     // Note: even in a default-configured DB transaction, this still has
     // a potential race condition. It should either be done as a subquery in
     // the insert, or using a locking read (SELECT...FOR UPDATE may work?)
-    private function getNextSequenceNumber(string $patientId, string $encounterId): string
+    private function getNextSequenceNumber(int|string $patientId, int|string $encounterId): string
     {
         $result = QueryUtils::querySingleRow(<<<'SQL'
             SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment


### PR DESCRIPTION
Fixes #10544

#### Short description of what this resolves:
Prevents crash when `patientId` or `encounterId` have been fetched as or cast to `int`s.

#### Changes proposed in this pull request:
Allows `int` in sequence number generation helper. String remains supported.

#### Does your code include anything generated by an AI Engine? Yes / No
No