### PR TITLE
refactor(ci): simplify phpstan workflow using failure() condition

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -67,6 +67,8 @@ jobs:
     - name: PHPStan Baseline
       if: failure()
       run: composer run phpstan-baseline
+    # Upload the resulting baseline as an artifact. This is intended mostly for
+    # debugging and isn't actively used by GH workflows.
     - name: Upload PHPStan Baseline
       if: failure()
       uses: actions/upload-artifact@v6


### PR DESCRIPTION
#### Short description of what this resolves:

Simplifies the PHPStan CI workflow by replacing the workaround pattern of `continue-on-error` + manual failure check with the cleaner `if: failure()` condition.

#### Changes proposed in this pull request:

- Remove `continue-on-error: true` from the PHPStan analyze step - let it fail the job naturally
- Use `if: failure()` on baseline generation and upload steps instead of checking step outcome
- Remove the `Check PHPStan Results` step that ran `false` to fail the job
- **Test commit included**: Adds a deliberate PHPStan error to verify the workflow works correctly (will be removed before merge)

#### Does your code include anything generated by an AI Engine? Yes / No

Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.

Co-authored with Claude Opus 4.5. The changes are straightforward workflow simplifications.