### PR TITLE
docs: add contributor guidelines for branches, translations, and PHPStan

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,3 +11,14 @@ Be specific about which parts were AI-generated
 Do not claim AI-generated code as entirely your own work
 
 When making significant edits to AI-generated code, you may indicate the extent of modifications
+
+## Branching and PRs
+
+- Never commit directly to master. All work must be done in feature branches.
+- Branch naming: When addressing a specific issue, use `issuenumber/brief-description` (e.g., `1234/fix-calendar-date-parsing`).
+- When opening PRs, follow the template in `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## Important Guidelines
+
+- **Translation files are append-only.** Never remove entries from translation files.
+- **Do not manually edit the PHPStan baseline file.** Use `composer phpstan-baseline` to regenerate it. Changes should not increase the baseline error count. "Trades" are acceptable during refactors where an error moves from one file to another.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,14 @@ npm run dev          # Development with file watching
 npm run gulp-build   # Build only (no watch)
 ```
 
+## Branching Strategy
+
+- **Never commit directly to master.** All work must be done in feature branches.
+- **Branch naming:** When addressing a specific issue, use `issuenumber/brief-description`
+  - Example: `1234/fix-calendar-date-parsing`
+  - Example: `5678/add-patient-search-api`
+- Create PRs from your feature branch into `master`
+
 ## Coding Standards
 
 - **Indentation:** 4 spaces
@@ -137,6 +145,14 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 - `feat(api): add PATCH support for patient resource`
 - `fix(calendar): correct date parsing for recurring events`
 - `chore(deps): bump monolog/monolog to 3.10.0`
+
+## Pull Requests
+
+When opening PRs, follow the template in `.github/PULL_REQUEST_TEMPLATE.md`:
+- Link to the issue being fixed (e.g., `Fixes #1234`)
+- Provide a short description of what the PR resolves
+- List the changes proposed
+- Disclose any AI-generated code and mark it appropriately in the source
 
 ## Service Layer Pattern
 
@@ -173,6 +189,17 @@ When modifying PHP files, ensure proper docblock:
 ```
 
 Preserve existing authors/copyrights when editing files.
+
+## Translation Files
+
+- **Translation files are append-only.** Never remove entries from translation files.
+
+## PHPStan Baseline
+
+- **Do not manually edit the PHPStan baseline file.**
+- To regenerate the baseline, run: `composer phpstan-baseline`
+- Changes should not increase the baseline error count (except when adding new rules).
+- "Trades" are acceptable during refactors where an error moves from one file to another (e.g., moving a function causes the same error to appear in the new location).
 
 ## Common Gotchas
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,20 @@ npm run stylelint         # CSS/SCSS linting
 
 These provide higher memory limits than Docker devtools and are what CI runs.
 
+### PHPStan Baseline
+
+Do not manually edit the PHPStan baseline file. To regenerate it:
+
+```sh
+composer phpstan-baseline
+```
+
+Changes should not increase the baseline error count (except when adding new rules). "Trades" are acceptable during refactors where an error moves from one file to another.
+
+### Translation Files
+
+Translation files are **append-only**. Never remove entries from translation files.
+
 ## Isolated Tests (no Docker required)
 
 Some tests run on the host without a database or Docker:
@@ -120,6 +134,8 @@ You will need a "local" version of OpenEMR to make changes to the source code. T
     - (Recommend using Ubuntu Desktop 22.04 for above video and other videos in the [OpenEMR Easy Docker Development Environment Video Series](https://www.youtube.com/playlist?list=PLFiWG_dDadgQT7zjqvEqbXm1OiuubOVO8). Easiest way to do this is setting up a [Ubuntu Desktop 22.04 Virtual Machine on VirtualBox](https://ubuntu.com/tutorials/how-to-run-ubuntu-desktop-on-a-virtual-machine-using-virtualbox), which recommend configuring with 40GB hard drive, assigning 25% of computer memory, and assigning 25% of cpu cores to the virtual machine.)
 
 1. [Create your own fork of OpenEMR](https://github.com/openemr/openemr/fork) (you will need a GitHub account) and `git clone` it to your local machine.
+    - **Important:** Always work in feature branches, never directly on `master`.
+    - **Branch naming:** When addressing a specific issue, use `issuenumber/brief-description` (e.g., `1234/fix-calendar-date-parsing`).
 
     - For the Video Tutorial, click below:
 


### PR DESCRIPTION
### Short description of what this resolves:

Adds guidelines to contributor documentation (CLAUDE.md, CONTRIBUTING.md, and copilot-instructions.md) to help both human and AI contributors follow project conventions.

Human: I've run into several snags when using AI tools for contributions; I'm hoping this helps prevent them going forward. This was my prompt:

```
❯ I want to update contributor docs (including those that will be read by AI tools) to include several items:

  - All work should be done in branches, never directly on master. When a branch is directly targeting a specific issue (which should usually be the case), suggest issuenumber/brief-description as the branch name (e.g. 1234/fix-doodad)
  - When opening PRs from AI tools, follow the PR template guideline in the .github directory
  - Never remove entries from translation files; they are append-only
  - Do not manually maintain the PHPStan baseline file. Use `composer phpstan-baseline` to regenerate it. Changes should not increase the baseline (except when adding new rules), but "trades" are ok during refactors.
 ```

#### Changes proposed in this pull request:

- Always work in feature branches, never directly on master
- Use `issuenumber/brief-description` branch naming convention when addressing issues
- Follow PR template when opening pull requests
- Translation files are append-only (never remove entries)
- Use `composer phpstan-baseline` to regenerate the PHPStan baseline (do not edit manually)

#### Does your code include anything generated by an AI Engine? Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.

This PR was created with assistance from Claude (Anthropic). The documentation text was collaboratively written with AI assistance. The commit includes the Co-Authored-By trailer.