### PR TITLE
fix(security): set HTTP 403 in csrfNotVerified()

### DIFF
--- a/library/ajax/messages/validate_messages_document_ajax.php
+++ b/library/ajax/messages/validate_messages_document_ajax.php
@@ -27,10 +27,9 @@ $format = in_array($format, ['json', 'html']) ? $format : "html";
 try {
     $twig = (new TwigContainer(null, $GLOBALS['kernel']))->getTwig();
     if (!CsrfUtils::verifyCsrfToken($_GET["csrf"])) {
-        http_response_code(403);
-        CsrfUtils::csrfNotVerified(true, true, false);
-        echo $twig->render('core/unauthorized.' . $format . '.twig', ['pageTitle' => xl("Validate Message Documents")]);
-        exit;
+        CsrfUtils::csrfNotVerified(toScreen: false, beforeExit: function () use ($twig, $format): void {
+            echo $twig->render('core/unauthorized.' . $format . '.twig', ['pageTitle' => xl("Validate Message Documents")]);
+        });
     }
 
 

--- a/portal/account/account.php
+++ b/portal/account/account.php
@@ -47,9 +47,7 @@ if ($action == 'verify_email') {
         if (!empty($globalsBag->get('portal_onsite_two_register')) && !empty($globalsBag->get('google_recaptcha_site_key')) && !empty($globalsBag->get('google_recaptcha_secret_key'))) {
             // check csrf
             if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"], 'verifyEmailCsrf', $session->getSymfonySession())) {
-                CsrfUtils::csrfNotVerified(true, true, false);
-                cleanupRegistrationSession();
-                exit;
+                CsrfUtils::csrfNotVerified(beforeExit: cleanupRegistrationSession(...));
             }
             // check recaptcha
             $recaptcha = processRecaptcha($_POST['g-recaptcha-response'] ?? '');
@@ -108,9 +106,7 @@ if ($action == 'reset_password') {
         if (!empty($globalsBag->get('portal_two_pass_reset')) && !empty($globalsBag->get('google_recaptcha_site_key')) && !empty($globalsBag->get('google_recaptcha_secret_key'))) {
             // check csrf
             if (!CsrfUtils::verifyCsrfToken($_GET["csrf_token_form"], 'passwordResetCsrf', $session->getSymfonySession())) {
-                CsrfUtils::csrfNotVerified(true, true, false);
-                cleanupRegistrationSession();
-                exit;
+                CsrfUtils::csrfNotVerified(beforeExit: cleanupRegistrationSession(...));
             }
             // check recaptcha
             $recaptcha = processRecaptcha($_GET['g-recaptcha-response'] ?? '');

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -856,7 +856,7 @@ class AuthorizationController
         if ($request->request->has('user_role')) {
             if (!CsrfUtils::verifyCsrfToken($request->request->get("csrf_token_form"), 'oauth2', $session)) {
                 $this->getSystemLogger()->error("AuthorizationController->userLogin() Invalid CSRF token");
-                CsrfUtils::csrfNotVerified(false, true, false);
+                CsrfUtils::csrfViolation(toScreen: false);
                 $request->request->replace(); // clear out username/password
                 $request->overrideGlobals(); // override the globals with the cleared out request so we don't have the username/password in the request sequence
                 $invalid = "Sorry. Invalid CSRF!"; // todo: display error
@@ -1219,7 +1219,7 @@ class AuthorizationController
             // TODO: @adunsulag if the request is missing the key 'proceed' then we should error out here.
             if ($request->request->has('proceed') && !empty($code) && !empty($session_cache)) {
                 if (!CsrfUtils::verifyCsrfToken($request->request->get("csrf_token_form"), 'oauth2', $this->session)) {
-                    CsrfUtils::csrfNotVerified(false, true, false);
+                    CsrfUtils::csrfViolation(toScreen: false);
                     throw OAuthServerException::serverError("Failed authorization due to failed CSRF check.");
                 } else {
                     if (!$this->saveTrustedUser(

--- a/tests/Tests/Isolated/Common/Csrf/CsrfUtilsTest.php
+++ b/tests/Tests/Isolated/Common/Csrf/CsrfUtilsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Isolated tests for CsrfUtils
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Csrf;
+
+use OpenEMR\Common\Csrf\CsrfUtils;
+use PHPUnit\Framework\TestCase;
+
+class CsrfUtilsTest extends TestCase
+{
+    public function testCsrfViolationSetsHttp403(): void
+    {
+        CsrfUtils::csrfViolation(toScreen: false, toLog: false);
+        $this->assertSame(403, http_response_code());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #10566

`CsrfUtils::csrfNotVerified()` handles echoing the error, logging, and dying — but never sets the HTTP response code. Callers must remember to call `http_response_code(403)` separately, and most don't.

### Changes

- Split into `csrfViolation()` (log only, no exit) and `csrfNotVerified()` (log + exit)
- `csrfViolation()` sets `http_response_code(403)`, echoes the error, and logs
- `csrfNotVerified()` calls `csrfViolation()` then exits, with an optional `beforeExit` callback for pre-exit work (e.g. rendering a Twig template)
- `csrfNotVerified()` returns `never` for static analysis
- Switch `AuthorizationController` to `csrfViolation()` (needs log-only, no exit)
- Switch `account.php` and `validate_messages_document_ajax.php` to use `beforeExit` callbacks
- Remove redundant `http_response_code(403)` from callers that had it

## AI Disclosure

Yes

## Test plan

- [x] Isolated PHPUnit test: `CsrfUtilsTest::testCsrfViolationSetsHttp403`
- [ ] Verify CSRF failure responses now include HTTP 403 status code
- [ ] Verify `AuthorizationController` CSRF handling still returns proper responses