### PR TITLE
feat(security): add AccessDeniedHelper for standardized denial responses

### DIFF
--- a/custom/import_xml.php
+++ b/custom/import_xml.php
@@ -7,14 +7,17 @@
  * @link    http://www.open-emr.org
  * @author  Rod Roark <rod@sunsetsystems.com>
  * @author  Roberto Vasquez <robertogagliotta@gmail.com>
+ * @author  Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2005 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017 Roberto Vasquez <robertogagliotta@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
 */
 
 require_once("../interface/globals.php");
 require_once("$srcdir/patient.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
@@ -129,7 +132,7 @@ if (!empty($_POST['form_import'])) {
     $olddata = getPatientData($pid);
 
     if ($olddata['squad'] && ! AclMain::aclCheckCore('squads', $olddata['squad'])) {
-        die("You are not authorized to access this squad.");
+        AccessDeniedHelper::deny('Unauthorized access to patient squad');
     }
 
     newPatientData(

--- a/interface/billing/edih_main.php
+++ b/interface/billing/edih_main.php
@@ -16,13 +16,13 @@
 
 require_once(__DIR__ . "/../globals.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 
 // Access control - same permission required as edih_view.php
 if (!AclMain::aclCheckCore('acct', 'eob')) {
-    http_response_code(403);
-    die(xlt('Access denied'));
+    AccessDeniedHelper::deny('Unauthorized access to EDI history');
 }
 
 /**

--- a/interface/drugs/add_edit_lot.php
+++ b/interface/drugs/add_edit_lot.php
@@ -19,6 +19,7 @@ require_once("../globals.php");
 require_once("drugs.inc.php");
 require_once("$srcdir/options.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
@@ -373,7 +374,7 @@ if (!$drug_id) {
                 $form_trans_type == 7 && !AclMain::aclCheckCore('inventory', 'consumption')
             )
         ) {
-            die(xlt('Not authorized'));
+            AccessDeniedHelper::deny('Unauthorized inventory transaction');
         }
 
         // Some fixups depending on transaction type.

--- a/interface/forms/LBF/new.php
+++ b/interface/forms/LBF/new.php
@@ -34,6 +34,7 @@ require_once "$srcdir/patient.inc.php";
 require_once $GLOBALS['fileroot'] . '/custom/code_types.inc.php';
 require_once "$srcdir/FeeSheetHtml.class.php";
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
@@ -194,7 +195,7 @@ if (!AclMain::aclCheckCore('admin', 'super') && !empty($LBF_ACO)) {
     $auth_aco_addonly = AclMain::aclCheckCore($LBF_ACO[0], $LBF_ACO[1], '', 'addonly');
     // echo "\n<!-- '$auth_aco_write' '$auth_aco_addonly' -->\n"; // debugging
     if (!$auth_aco_write && !($auth_aco_addonly && !$formid)) {
-        die(xlt('Access denied'));
+        AccessDeniedHelper::deny('Unauthorized access to LBF form');
     }
 }
 

--- a/interface/forms/LBF/printable.php
+++ b/interface/forms/LBF/printable.php
@@ -23,6 +23,7 @@ require_once("$srcdir/encounter.inc.php");
 require_once($GLOBALS['fileroot'] . '/custom/code_types.inc.php');
 
 use Mpdf\Mpdf;
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
@@ -105,7 +106,7 @@ if (!empty($lobj['aco_spec'])) {
 }
 if (!AclMain::aclCheckCore('admin', 'super') && !empty($LBF_ACO)) {
     if (!AclMain::aclCheckCore($LBF_ACO[0], $LBF_ACO[1])) {
-        die(xlt('Access denied'));
+        AccessDeniedHelper::deny('Unauthorized access to LBF printable form');
     }
 }
 

--- a/interface/forms/LBF/report.php
+++ b/interface/forms/LBF/report.php
@@ -15,6 +15,7 @@
 require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 
 // This function is invoked from printPatientForms in report.inc.php
@@ -34,7 +35,7 @@ function lbf_report($pid, $encounter, $cols, $id, $formname, $no_wrap = false): 
     }
     if (!AclMain::aclCheckCore('admin', 'super') && !empty($LBF_ACO)) {
         if (!AclMain::aclCheckCore($LBF_ACO[0], $LBF_ACO[1])) {
-            die(xlt('Access denied'));
+            AccessDeniedHelper::deny('Unauthorized access to LBF report');
         }
     }
 

--- a/interface/forms/eye_mag/a_issue.php
+++ b/interface/forms/eye_mag/a_issue.php
@@ -11,9 +11,11 @@
  * @authorRod Roark <rod@sunsetsystems.com>
  * @authorRay Magauran <magauran@MedFetch.com>
  * @authorBrady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2005-2011 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2015-2016 Ray Magauran <magauran@MedFetch.com>
  * @copyright Copyright (c) 2017 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @licensehttps://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -29,6 +31,7 @@ require_once($GLOBALS['fileroot'] . '/custom/code_types.inc.php');
 require_once($GLOBALS['srcdir'] . '/csv_like_join.php');
 require_once("../../forms/" . $form_folder . "/php/" . $form_folder . "_functions.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\Header;
 
@@ -52,7 +55,7 @@ $form_type = $_REQUEST['form_type'];
 $uniqueID = $_REQUEST['uniqueID'];
 
 if ($issue && !AclMain::aclCheckCore('patients', 'med', '', 'write')) {
-    die(xlt("Edit is not authorized!"));
+    AccessDeniedHelper::deny('Editing eye exam issue is not authorized');
 }
 
 if (
@@ -61,7 +64,7 @@ if (
     'addonly'
     ])
 ) {
-    die(xlt("Add is not authorized!"));
+    AccessDeniedHelper::deny('Adding eye exam issue is not authorized');
 }
 
 $PMSFH = build_PMSFH($pid);

--- a/interface/forms/fee_sheet/contraception_products/ajax/find_contraception_products.php
+++ b/interface/forms/fee_sheet/contraception_products/ajax/find_contraception_products.php
@@ -3,6 +3,7 @@
 require_once("../../../../globals.php");
 require_once("../../../../drugs/drugs.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 
 function find_contraceptive_methods($contraceptive_code)
@@ -45,9 +46,7 @@ function get_method_description($contraceptive_code)
 }
 
 if (!AclMain::aclCheckCore('acct', 'bill')) {
-    header("HTTP/1.0 403 Forbidden");
-    echo "Not authorized for billing";
-    return false;
+    AccessDeniedHelper::deny('Unauthorized access to contraception products');
 }
 
 $retval = [];

--- a/interface/forms/fee_sheet/review/fee_sheet_ajax.php
+++ b/interface/forms/fee_sheet/review/fee_sheet_ajax.php
@@ -15,15 +15,14 @@
 require_once("../../../globals.php");
 require_once("fee_sheet_queries.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Forms\FeeSheet\Review\CodeInfo;
 use OpenEMR\Forms\FeeSheet\Review\Procedure;
 
 if (!AclMain::aclCheckCore('acct', 'bill')) {
-    header("HTTP/1.0 403 Forbidden");
-    echo "Not authorized for billing";
-    return false;
+    AccessDeniedHelper::deny('Unauthorized access to fee sheet');
 }
 
 if (!CsrfUtils::verifyCsrfToken($_REQUEST["csrf_token_form"])) {

--- a/interface/forms/fee_sheet/review/fee_sheet_justify.php
+++ b/interface/forms/fee_sheet/review/fee_sheet_justify.php
@@ -15,13 +15,12 @@
 require_once("../../../globals.php");
 require_once("fee_sheet_queries.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Forms\FeeSheet\Review\CodeInfo;
 
 if (!AclMain::aclCheckCore('acct', 'bill')) {
-    header("HTTP/1.0 403 Forbidden");
-    echo "Not authorized for billing";
-    return false;
+    AccessDeniedHelper::deny('Unauthorized access to fee sheet justification');
 }
 
 

--- a/interface/forms/fee_sheet/review/fee_sheet_options_ajax.php
+++ b/interface/forms/fee_sheet/review/fee_sheet_options_ajax.php
@@ -15,12 +15,11 @@
 require_once("../../../globals.php");
 require_once("fee_sheet_options_queries.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 
 if (!AclMain::aclCheckCore('acct', 'bill')) {
-    header("HTTP/1.0 403 Forbidden");
-    echo "Not authorized for billing";
-    return false;
+    AccessDeniedHelper::deny('Unauthorized access to fee sheet options');
 }
 
 $pricelevel = $_REQUEST['pricelevel'] ?? 'standard';

--- a/interface/forms/fee_sheet/review/fee_sheet_search_ajax.php
+++ b/interface/forms/fee_sheet/review/fee_sheet_search_ajax.php
@@ -15,12 +15,11 @@
 require_once("../../../globals.php");
 require_once("fee_sheet_search_queries.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 
 if (!AclMain::aclCheckCore('acct', 'bill')) {
-    header("HTTP/1.0 403 Forbidden");
-    echo "Not authorized for billing";
-    return false;
+    AccessDeniedHelper::deny('Unauthorized access to fee sheet search');
 }
 
 if (isset($_REQUEST['search_query'])) {

--- a/interface/forms/newGroupEncounter/save.php
+++ b/interface/forms/newGroupEncounter/save.php
@@ -9,10 +9,12 @@
  * @author    Amiel Elboim <amielel@matrix.co.il>
  * @author    Shachar Zilbershlag <shaharzi@matrix.co.il>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2015 Roberto Vasquez <robertogagliotta@gmail.com>
  * @copyright Copyright (c) 2016 Shachar Zilbershlag <shaharzi@matrix.co.il>
  * @copyright Copyright (c) 2016 Amiel Elboim <amielel@matrix.co.il>
  * @copyright Copyright (c) 2019 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -20,6 +22,7 @@ require_once(__DIR__ . "/../../globals.php");
 require_once("$srcdir/forms.inc.php");
 require_once("$srcdir/encounter.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
@@ -98,7 +101,7 @@ if ($mode == 'new') {
     $id = $_POST["id"];
     $result = sqlQuery("SELECT encounter, sensitivity FROM form_groups_encounter WHERE id = ?", [$id]);
     if ($result['sensitivity'] && !AclMain::aclCheckCore('sensitivities', $result['sensitivity'])) {
-        die(xlt("You are not authorized to see this encounter."));
+        AccessDeniedHelper::deny('Unauthorized access to sensitive group encounter');
     }
 
     $encounter = $result['encounter'];

--- a/interface/forms/physical_exam/edit_diagnoses.php
+++ b/interface/forms/physical_exam/edit_diagnoses.php
@@ -7,13 +7,16 @@
  * @link      http://www.open-emr.org
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2006 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2019 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 require_once(__DIR__ . "/../../globals.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
@@ -22,7 +25,7 @@ $line_id = $_REQUEST['lineid'];
 $info_msg = "";
 
 if ($issue && !AclMain::aclCheckCore('patients', 'med', '', 'write')) {
-    die("Edit is not authorized!");
+    AccessDeniedHelper::deny('Editing physical exam diagnoses is not authorized');
 }
 ?>
 <html>

--- a/interface/orders/single_order_results.php
+++ b/interface/orders/single_order_results.php
@@ -16,6 +16,7 @@ require_once(__DIR__ . '/../globals.php');
 require_once($GLOBALS["include_root"] . "/orders/single_order_results.inc.php");
 
 use Mpdf\Mpdf;
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
@@ -34,7 +35,7 @@ $finals_only = empty($_POST['form_showall']);
 
 if (!empty($_POST['form_sign']) && !empty($_POST['form_sign_list'])) {
     if (!AclMain::aclCheckCore('patients', 'sign')) {
-        die(xlt('Not authorized to sign results'));
+        AccessDeniedHelper::deny('Not authorized to sign order results');
     }
 
   // When signing results we are careful to sign only those reports that were

--- a/interface/orders/types_ajax.php
+++ b/interface/orders/types_ajax.php
@@ -16,10 +16,11 @@
 
 require_once("../globals.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 
 if (!AclMain::aclCheckCore('admin', 'super') && !AclMain::aclCheckCore('patients', 'lab')) {
-    die(xlt('Not authorized'));
+    AccessDeniedHelper::deny('Unauthorized access to order types');
 }
 
 $id = ($_GET['id'] ?? '') + 0;

--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -10,15 +10,18 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Roberto Vasquez <robertogagliotta@gmail.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2005-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2015 Roberto Vasquez <robertogagliotta@gmail.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 require_once('../globals.php');
 
 use OpenEMR\Billing\BillingUtilities;
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
@@ -203,7 +206,7 @@ function popup_close() {
 
             if ($patient) {
                 if (!AclMain::aclCheckCore('admin', 'super') || !$GLOBALS['allow_pat_delete']) {
-                    die(xlt("Not authorized!"));
+                    AccessDeniedHelper::deny('Unauthorized patient deletion attempt');
                 }
 
                 row_modify("billing", "activity = 0", "pid = '" . add_escape_custom($patient) . "'");
@@ -239,7 +242,7 @@ function popup_close() {
                 row_delete("patient_data", "pid = '" . add_escape_custom($patient) . "'");
             } elseif ($encounterid) {
                 if (!AclMain::aclCheckCore('admin', 'super')) {
-                    die("Not authorized!");
+                    AccessDeniedHelper::deny('Unauthorized encounter deletion attempt');
                 }
 
                 row_modify("billing", "activity = 0", "encounter = '" . add_escape_custom($encounterid) . "'");
@@ -255,7 +258,7 @@ function popup_close() {
                 row_delete("forms", "encounter = '" . add_escape_custom($encounterid) . "'");
             } elseif ($formid) {
                 if (!AclMain::aclCheckCore('admin', 'super')) {
-                    die("Not authorized!");
+                    AccessDeniedHelper::deny('Unauthorized form deletion attempt');
                 }
 
                 $row = sqlQuery("SELECT * FROM forms WHERE id = ?", [$formid]);
@@ -267,7 +270,7 @@ function popup_close() {
                 row_delete("forms", "id = '" . add_escape_custom($formid) . "'");
             } elseif ($issue) {
                 if (!AclMain::aclCheckCore('admin', 'super')) {
-                    die("Not authorized!");
+                    AccessDeniedHelper::deny('Unauthorized issue deletion attempt');
                 }
 
                 $ids = explode(",", (string) $issue);
@@ -278,7 +281,7 @@ function popup_close() {
                 }
             } elseif ($document) {
                 if (!AclMain::aclCheckCore('patients', 'docs_rm')) {
-                    die("Not authorized!");
+                    AccessDeniedHelper::deny('Unauthorized document deletion attempt');
                 }
 
                 delete_document($document);
@@ -286,7 +289,7 @@ function popup_close() {
                 if (!AclMain::aclCheckCore('admin', 'super')) {
                     // allow biller to delete misapplied payments
                     if (!AclMain::aclCheckCore('acct', 'bill')) {
-                        die("Not authorized!");
+                        AccessDeniedHelper::deny('Unauthorized payment deletion attempt');
                     }
                 }
 
@@ -364,7 +367,7 @@ function popup_close() {
                 }
             } elseif ($billing) {
                 if (!AclMain::aclCheckCore('acct', 'disc')) {
-                    die("Not authorized!");
+                    AccessDeniedHelper::deny('Unauthorized billing deletion attempt');
                 }
 
                 [$patient_id, $encounter_id] = explode(".", (string) $billing);
@@ -399,7 +402,7 @@ function popup_close() {
                 BillingUtilities::updateClaim(true, $patient_id, $encounter_id, -1, -1, 1, 0, ''); // clears for rebilling
             } elseif ($transaction) {
                 if (!AclMain::aclCheckCore('admin', 'super')) {
-                    die("Not authorized!");
+                    AccessDeniedHelper::deny('Unauthorized transaction deletion attempt');
                 }
 
                 row_delete("transactions", "id = '" . add_escape_custom($transaction) . "'");

--- a/interface/patient_file/history/history_full.php
+++ b/interface/patient_file/history/history_full.php
@@ -18,6 +18,7 @@ require_once("$srcdir/options.inc.php");
 require_once("$srcdir/options.js.php");
 require_once("$srcdir/validation/LBF_Validation.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
@@ -29,12 +30,12 @@ $CPR = 4; // cells per row
 if (AclMain::aclCheckCore('patients', 'med')) {
     $tmp = getPatientData($pid, "squad");
     if ($tmp['squad'] && ! AclMain::aclCheckCore('squads', $tmp['squad'])) {
-        die(xlt("Not authorized for this squad."));
+        AccessDeniedHelper::deny('Not authorized for squad: ' . $tmp['squad']);
     }
 }
 
 if (!AclMain::aclCheckCore('patients', 'med', '', ['write','addonly'])) {
-    die(xlt("Not authorized"));
+    AccessDeniedHelper::deny('Unauthorized access to patient history');
 }
 ?>
 <html>

--- a/interface/patient_file/history/history_save.php
+++ b/interface/patient_file/history/history_save.php
@@ -15,6 +15,7 @@ require_once("$srcdir/patient.inc.php");
 require_once("history.inc.php");
 require_once("$srcdir/options.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 
@@ -31,12 +32,12 @@ if (!empty($module_call_pid)) {
 if (AclMain::aclCheckCore('patients', 'med')) {
     $tmp = getPatientData($pid, "squad");
     if ($tmp['squad'] && ! AclMain::aclCheckCore('squads', $tmp['squad'])) {
-        die(xlt("Not authorized for this squad."));
+        AccessDeniedHelper::deny('Not authorized for squad: ' . $tmp['squad']);
     }
 }
 
 if (!AclMain::aclCheckCore('patients', 'med', '', ['write','addonly'])) {
-    die(xlt("Not authorized"));
+    AccessDeniedHelper::deny('Unauthorized access to patient history save');
 }
 
 foreach ($_POST as $key => $val) {

--- a/interface/patient_file/history/history_sdoh.php
+++ b/interface/patient_file/history/history_sdoh.php
@@ -15,6 +15,7 @@ $srcdir = dirname(__FILE__, 4) . "/library";
 require_once("../../globals.php");
 require_once("$srcdir/options.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -29,7 +30,7 @@ $rec_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $is_new = isset($_GET['new']) ? (int)$_GET['new'] : 0;
 
 if (!AclMain::aclCheckCore('patients', 'med', '', ['write', 'addonly'])) {
-    die(xlt("Not authorized"));
+    AccessDeniedHelper::deny('Unauthorized access to SDOH form');
 }
 
 $csrf = CsrfUtils::collectCsrfToken('default', $session->getSymfonySession());

--- a/interface/patient_file/history/history_sdoh_health_concerns.php
+++ b/interface/patient_file/history/history_sdoh_health_concerns.php
@@ -23,6 +23,7 @@ $srcdir = dirname(__FILE__, 4) . "/library";
 require_once("../../globals.php");
 require_once("$srcdir/options.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
@@ -47,8 +48,7 @@ if (!$pid || !$sdoh_id) {
 }
 
 if (!AclMain::aclCheckCore('patients', 'med', '', ['write', 'addonly'])) {
-    $logger->errorLogCaller("Unauthorized access attempt to SDOH health concerns", ['pid' => $pid, "sdoh_id" => $sdoh_id]);
-    die(xlt("Not authorized"));
+    AccessDeniedHelper::deny('Unauthorized access to SDOH health concerns');
 }
 
 $sdohService = new HistorySdohService();

--- a/interface/patient_file/history/history_sdoh_list.php
+++ b/interface/patient_file/history/history_sdoh_list.php
@@ -22,6 +22,7 @@ $srcdir = dirname(__FILE__, 4) . "/library";
 require_once("../../globals.php");
 require_once($srcdir . "/options.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\Header;
 
@@ -30,7 +31,7 @@ if (!$pid) {
     die(xlt("Missing patient id.")); }
 
 if (!AclMain::aclCheckCore('patients', 'med')) {
-    die(xlt("Not authorized"));
+    AccessDeniedHelper::deny('Unauthorized access to SDOH list');
 }
 
 // Pull rows newest first

--- a/interface/patient_file/history/history_sdoh_save.php
+++ b/interface/patient_file/history/history_sdoh_save.php
@@ -12,6 +12,7 @@
 
 require_once("../../globals.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Uuid\UuidRegistry;
@@ -27,7 +28,7 @@ if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"] ?? '', 'default', $ses
     CsrfUtils::csrfNotVerified();
 }
 if (!AclMain::aclCheckCore('patients', 'med', '', ['write', 'addonly'])) {
-    die(xlt("Not authorized"));
+    AccessDeniedHelper::deny('Unauthorized access to SDOH save');
 }
 
 if (empty($pid)) {

--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -21,6 +21,7 @@ require_once $GLOBALS['srcdir'] . '/options.inc.php';
 require_once $GLOBALS['fileroot'] . '/custom/code_types.inc.php';
 require_once $GLOBALS['srcdir'] . '/csv_like_join.php';
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -69,12 +70,12 @@ $info_msg = "";
 $thistype = empty($_REQUEST['thistype']) ? '' : $_REQUEST['thistype'];
 
 if ($thistype && !$issue && !AclMain::aclCheckIssue($thistype, '', ['write', 'addonly'])) {
-    die(xlt("Add is not authorized!"));
+    AccessDeniedHelper::deny('Not authorized to add issue of this type');
 }
 
 $tmp = getPatientData($thispid, "squad");
 if ($tmp['squad'] && !AclMain::aclCheckCore('squads', $tmp['squad'])) {
-    die(xlt("Not authorized for this squad!"));
+    AccessDeniedHelper::deny('Not authorized for squad: ' . $tmp['squad']);
 }
 
 function QuotedOrNull($fld)

--- a/interface/patient_file/summary/demographics_full.php
+++ b/interface/patient_file/summary/demographics_full.php
@@ -8,11 +8,13 @@
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Stephen Nielson <snielson@discoverandchange.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2017 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2021 Rod Roark <rod@sunsetsystems.com>
- * @copyright  Copyright (c) 2024 Care Management Solutions, Inc. <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2024 Care Management Solutions, Inc. <stephen.waite@cmsvt.com>
  * @copyright Copyright (c) 2025 Jerry Padgett <sjpadgett@gmail.com>
- * @license     https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 require_once("../../globals.php");
@@ -22,6 +24,7 @@ require_once("$srcdir/patientvalidation.inc.php");
 require_once("$srcdir/pid.inc.php");
 require_once("$srcdir/patient.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Csrf\CsrfUtils;
@@ -55,15 +58,15 @@ if ($pid) {
         !$updateEvent->authorized() ||
         !AclMain::aclCheckCore('patients', 'demo', '', 'write')
     ) {
-        die(xlt('Updating demographics is not authorized.'));
+        AccessDeniedHelper::deny('Updating demographics is not authorized');
     }
 
     if ($result['squad'] && !AclMain::aclCheckCore('squads', $result['squad'])) {
-        die(xlt('You are not authorized to access this squad.'));
+        AccessDeniedHelper::deny('Unauthorized access to patient squad');
     }
 } else {
     if (!AclMain::aclCheckCore('patients', 'demo', '', ['write', 'addonly'])) {
-        die(xlt('Adding demographics is not authorized.'));
+        AccessDeniedHelper::deny('Adding demographics is not authorized');
     }
 }
 

--- a/interface/patient_file/summary/demographics_print.php
+++ b/interface/patient_file/summary/demographics_print.php
@@ -8,8 +8,10 @@
  * @link      http://www.open-emr.org
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2009-2015 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -29,6 +31,7 @@ require_once("$srcdir/options.inc.php");
 require_once("$srcdir/patient.inc.php");
 
 use Mpdf\Mpdf;
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Pdf\Config_Mpdf;
@@ -66,10 +69,10 @@ if ($patientid) {
   // Check authorization.
     $thisauth = AclMain::aclCheckCore('patients', 'demo');
     if (!$thisauth) {
-        die(xlt('Demographics not authorized'));
+        AccessDeniedHelper::deny('Demographics access not authorized');
     }
     if ($prow['squad'] && ! AclMain::aclCheckCore('squads', $prow['squad'])) {
-        die(xlt('You are not authorized to access this squad'));
+        AccessDeniedHelper::deny('Unauthorized access to patient squad');
     }
   // $irow = getInsuranceProviders(); // needed?
 }

--- a/interface/patient_file/summary/demographics_save.php
+++ b/interface/patient_file/summary/demographics_save.php
@@ -7,8 +7,10 @@
  * @link      http://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2024 Care Management Solutions, Inc. <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -16,6 +18,7 @@ require_once("../../globals.php");
 require_once("$srcdir/patient.inc.php");
 require_once("$srcdir/options.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Services\ContactService;
@@ -37,16 +40,16 @@ global $pid;
 // Check authorization
 if ($pid) {
     if (!AclMain::aclCheckCore('patients', 'demo', '', 'write')) {
-        die(xlt('Updating demographics is not authorized.'));
+        AccessDeniedHelper::deny('Updating demographics is not authorized');
     }
 
     $tmp = getPatientData($pid, "squad");
     if ($tmp['squad'] && ! AclMain::aclCheckCore('squads', $tmp['squad'])) {
-        die(xlt('You are not authorized to access this squad.'));
+        AccessDeniedHelper::deny('Unauthorized access to patient squad');
     }
 } else {
     if (!AclMain::aclCheckCore('patients', 'demo', '', ['write','addonly'])) {
-        die(xlt('Adding demographics is not authorized.'));
+        AccessDeniedHelper::deny('Adding demographics is not authorized');
     }
 }
 

--- a/interface/patient_file/summary/insurance_edit.php
+++ b/interface/patient_file/summary/insurance_edit.php
@@ -8,9 +8,11 @@
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Stephen Waite <stephen.waite@cmsvt.com>
  * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2017 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2021 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2024 Care Management Solutions, Inc. <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -20,6 +22,7 @@ require_once("$srcdir/patientvalidation.inc.php");
 require_once("$srcdir/pid.inc.php");
 require_once("$srcdir/patient.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Events\PatientDemographics\UpdateEvent;
 use OpenEMR\Common\Twig\TwigContainer;
@@ -30,7 +33,7 @@ $session = SessionWrapperFactory::getInstance()->getWrapper();
 
 // make sure permissions are checked before we allow this page to be accessed.
 if (!AclMain::aclCheckCore('patients', 'demo', '', 'write')) {
-    die(xlt('Updating demographics is not authorized.'));
+    AccessDeniedHelper::deny('Updating demographics is not authorized');
 }
 
 // Session pid must be right or bad things can happen when demographics are saved!
@@ -52,15 +55,15 @@ if ($pid) {
         !$updateEvent->authorized() ||
         !AclMain::aclCheckCore('patients', 'demo', '', 'write')
     ) {
-        die(xlt('Updating insurance is not authorized.'));
+        AccessDeniedHelper::deny('Updating insurance is not authorized');
     }
 
     if ($result['squad'] && ! AclMain::aclCheckCore('squads', $result['squad'])) {
-        die(xlt('You are not authorized to access this squad.'));
+        AccessDeniedHelper::deny('Unauthorized access to patient squad');
     }
 } else {
     if (!AclMain::aclCheckCore('patients', 'demo', '', ['write','addonly'])) {
-        die(xlt('Adding insurance is not authorized.'));
+        AccessDeniedHelper::deny('Adding insurance is not authorized');
     }
 }
 // $statii = array('married','single','divorced','widowed','separated','domestic partner');

--- a/interface/patient_file/summary/pnotes_full.php
+++ b/interface/patient_file/summary/pnotes_full.php
@@ -16,6 +16,7 @@ require_once($GLOBALS['srcdir'] . '/patient.inc.php');
 require_once($GLOBALS['srcdir'] . '/options.inc.php');
 require_once($GLOBALS['srcdir'] . '/gprelations.inc.php');
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
@@ -50,12 +51,12 @@ if ($docid) {
 
 // Check authorization.
 if (!AclMain::aclCheckCore('patients', 'notes', '', ['write','addonly'])) {
-    die(xlt('Not authorized'));
+    AccessDeniedHelper::deny('Unauthorized access to patient notes');
 }
 
 $tmp = getPatientData($patient_id, "squad");
 if ($tmp['squad'] && ! AclMain::aclCheckCore('squads', $tmp['squad'])) {
-    die(xlt('Not authorized for this squad.'));
+    AccessDeniedHelper::deny('Not authorized for squad: ' . $tmp['squad']);
 }
 
 //the number of records to display per screen

--- a/interface/patient_file/summary/pnotes_full_add.php
+++ b/interface/patient_file/summary/pnotes_full_add.php
@@ -16,6 +16,7 @@ require_once("$srcdir/patient.inc.php");
 require_once("$srcdir/options.inc.php");
 require_once("$srcdir/gprelations.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
@@ -46,12 +47,12 @@ if ($docid) {
 
 // Check authorization.
 if (!AclMain::aclCheckCore('patients', 'notes', '', ['write','addonly'])) {
-    die(xlt('Not authorized'));
+    AccessDeniedHelper::deny('Unauthorized access to patient notes');
 }
 
 $tmp = getPatientData($patient_id, "squad");
 if ($tmp['squad'] && !AclMain::aclCheckCore('squads', $tmp['squad'])) {
-    die(xlt('Not authorized for this squad.'));
+    AccessDeniedHelper::deny('Not authorized for squad: ' . $tmp['squad']);
 }
 
 //the number of records to display per screen

--- a/interface/patient_file/summary/pnotes_print.php
+++ b/interface/patient_file/summary/pnotes_print.php
@@ -15,6 +15,7 @@ require_once("$srcdir/patient.inc.php");
 require_once("$srcdir/options.inc.php");
 require_once("$srcdir/pnotes.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\Header;
 
@@ -23,11 +24,11 @@ $prow = getPatientData($pid, "squad, title, fname, mname, lname");
 // Check authorization.
 $thisauth = AclMain::aclCheckCore('patients', 'notes');
 if (!$thisauth) {
-    die(xlt('Not authorized'));
+    AccessDeniedHelper::deny('Unauthorized access to patient notes print');
 }
 
 if ($prow['squad'] && ! AclMain::aclCheckCore('squads', $prow['squad'])) {
-    die(xlt('Not authorized for this squad.'));
+    AccessDeniedHelper::deny('Not authorized for squad: ' . $prow['squad']);
 }
 
 $noteid = $_REQUEST['noteid'];

--- a/interface/patient_file/summary/stats_full.php
+++ b/interface/patient_file/summary/stats_full.php
@@ -17,6 +17,7 @@ require_once($GLOBALS['srcdir'] . '/lists.inc.php');
 require_once($GLOBALS['fileroot'] . '/custom/code_types.inc.php');
 require_once($GLOBALS['srcdir'] . '/options.inc.php');
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
@@ -37,7 +38,7 @@ foreach ($ISSUE_TYPES as $type => $dummy) {
 if ($auth) {
     $tmp = getPatientData($pid, "squad");
     if ($tmp['squad'] && ! AclMain::aclCheckCore('squads', $tmp['squad'])) {
-        die(xlt('Not authorized'));
+        AccessDeniedHelper::deny('Not authorized for squad: ' . $tmp['squad']);
     }
 } else {
     echo (new TwigContainer(null, $GLOBALS['kernel']))->getTwig()->render('core/unauthorized.html.twig', ['pageTitle' => xl("Patient Issues")]);

--- a/interface/usergroup/npi_lookup.php
+++ b/interface/usergroup/npi_lookup.php
@@ -14,6 +14,8 @@
 
 require_once("../globals.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
+use OpenEMR\Common\Acl\AccessDeniedResponseFormat;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use GuzzleHttp\Client as Client;
@@ -22,9 +24,7 @@ use GuzzleHttp\Exception\ConnectException;
 
 // Check authorization
 if (!AclMain::aclCheckCore('admin', 'practice')) {
-    http_response_code(403);
-    echo json_encode(['error' => 'Unauthorized']);
-    exit;
+    AccessDeniedHelper::deny('Unauthorized access to NPI lookup', format: AccessDeniedResponseFormat::Json);
 }
 
 // Verify CSRF token for security

--- a/portal/import_template.php
+++ b/portal/import_template.php
@@ -10,6 +10,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
@@ -120,7 +121,7 @@ if (($_POST['mode'] ?? null) === 'save') {
         CsrfUtils::csrfNotVerified();
     }
     if (!$authUploadTemplates) {
-        die(xlt('Not authorized to edit template'));
+        AccessDeniedHelper::deny('Not authorized to edit template');
     }
     if ($_POST['docid']) {
         if (stripos((string)$_POST['content'], "<?php") === false) {
@@ -139,7 +140,7 @@ if (($_POST['mode'] ?? null) === 'save') {
         CsrfUtils::csrfNotVerified();
     }
     if (!$authUploadTemplates) {
-        die(xlt('Not authorized to delete template'));
+        AccessDeniedHelper::deny('Not authorized to delete template');
     }
     if ($_POST['docid']) {
         $template = $templateService->deleteTemplate($_POST['docid'], ($_POST['template'] ?? null));

--- a/portal/lib/doc_lib.php
+++ b/portal/lib/doc_lib.php
@@ -12,6 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
@@ -36,9 +37,10 @@ if ($session->isSymfonySession() && !empty($session->get('pid')) && !empty($sess
     require_once(__DIR__ . "/../../interface/globals.php");
     // only support download handler from patient portal
     if ($_POST['handler'] != 'download' && $_POST['handler'] != 'fetch_pdf') {
-        echo xlt("Not authorized");
-        SessionUtil::portalSessionCookieDestroy();
-        exit;
+        AccessDeniedHelper::deny(
+            'Unauthorized handler in patient portal document library',
+            beforeExit: SessionUtil::portalSessionCookieDestroy(...),
+        );
     }
 } else {
     SessionUtil::portalSessionCookieDestroy();

--- a/portal/patient/templates/OnsiteActivityViewListView.tpl.php
+++ b/portal/patient/templates/OnsiteActivityViewListView.tpl.php
@@ -13,6 +13,7 @@
 $this->assign('title', xlt('Portal') . ' | ' . xlt('Activity'));
 $this->assign('nav', 'onsiteactivityviews');
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -21,7 +22,7 @@ use OpenEMR\Core\OEGlobalsBag;
 $session = SessionWrapperFactory::getInstance()->getWrapper();
 
 if (!AclMain::aclCheckCore('patientportal', 'portal')) {
-    die(xlt("Unauthorized"));
+    AccessDeniedHelper::deny('Unauthorized access to onsite activity view');
 }
 
 $globalsBag = OEGlobalsBag::getInstance();

--- a/portal/patient/templates/ProviderHome.tpl.php
+++ b/portal/patient/templates/ProviderHome.tpl.php
@@ -13,13 +13,13 @@
 $this->assign('title', xlt("Portal Dashboard") . " | " . xlt("Home"));
 $this->assign('nav', 'home');
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 
 if (!AclMain::aclCheckCore('patientportal', 'portal')) {
-    die(xlt("Unauthorized"));
-    exit;
+    AccessDeniedHelper::deny('Unauthorized access to provider home');
 }
 $globalsBag = OEGlobalsBag::getInstance();
 $web_root = $globalsBag->getString('web_root');

--- a/sphere/process_revert_response.php
+++ b/sphere/process_revert_response.php
@@ -15,6 +15,7 @@
 
 require_once(__DIR__ . "/../interface/globals.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
@@ -30,7 +31,7 @@ if ($GLOBALS['payment_gateway'] != 'Sphere') {
 }
 
 if (!AclMain::aclCheckCore('acct', 'rep_a')) {
-    die(xlt("Unauthorized access."));
+    AccessDeniedHelper::deny('Unauthorized access to Sphere revert');
 }
 ?>
 

--- a/sphere/token.php
+++ b/sphere/token.php
@@ -8,12 +8,15 @@
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2021 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 require_once(__DIR__ . "/../interface/globals.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\PaymentProcessing\PaymentProcessing;
@@ -28,7 +31,7 @@ if ($GLOBALS['payment_gateway'] != 'Sphere') {
 }
 
 if (!AclMain::aclCheckCore('acct', 'rep_a')) {
-    die("Unauthorized access.");
+    AccessDeniedHelper::deny('Unauthorized access to Sphere token generation');
 }
 
 $confirmPinPost = $_POST['pin_code'] ?? null;

--- a/src/Common/Acl/AccessDeniedHelper.php
+++ b/src/Common/Acl/AccessDeniedHelper.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Standardize the deny-and-exit sequence for legacy scripts
+ *
+ * Legacy scripts (interface/, library/, portal/) are standalone entry points
+ * with no framework exception handler. When access is denied they must
+ * manually log, audit, set the HTTP response code, and exit. This class
+ * provides a single method that handles all four steps.
+ *
+ * Modern controllers should continue throwing AccessDeniedException instead.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Acl;
+
+use OpenEMR\Common\Logging\EventAuditLogger;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Session\SessionWrapperFactory;
+use Symfony\Component\HttpFoundation\Response;
+
+class AccessDeniedHelper
+{
+    /**
+     * Log an access denial and terminate the request.
+     *
+     * @param string                     $comment     Audit log comment describing what was attempted
+     * @param string                     $auditEvent  Event name for EventAuditLogger
+     * @param Response::HTTP_UNAUTHORIZED|Response::HTTP_FORBIDDEN|Response::HTTP_NOT_FOUND $httpStatus
+     * @param AccessDeniedResponseFormat $format      Response body format
+     * @param ?(callable(): void)         $beforeExit  Optional callback to run before exiting
+     *                                                (e.g. render a template, clean up session)
+     */
+    public static function deny(
+        string $comment,
+        string $auditEvent = 'security-access-denied',
+        int $httpStatus = Response::HTTP_FORBIDDEN,
+        AccessDeniedResponseFormat $format = AccessDeniedResponseFormat::Text,
+        ?callable $beforeExit = null,
+    ): never {
+        $session = SessionWrapperFactory::getInstance()->getWrapper();
+        $user = $session->get('authUser', 'unknown');
+        $group = $session->get('authProvider', '');
+
+        (new SystemLogger())->warning("Access denied: $comment", [
+            'user' => $user,
+        ]);
+
+        EventAuditLogger::getInstance()->newEvent(
+            $auditEvent,
+            $user,
+            $group,
+            0,
+            $comment,
+        );
+
+        http_response_code($httpStatus);
+
+        match ($format) {
+            AccessDeniedResponseFormat::Json => (static function (): void {
+                header('Content-Type: application/json');
+                echo json_encode(['error' => xl('Access denied')]);
+            })(),
+            AccessDeniedResponseFormat::Text => (static function (): void {
+                echo xlt('Access denied');
+            })(),
+        };
+
+        if ($beforeExit !== null) {
+            $beforeExit();
+        }
+
+        exit;
+    }
+}

--- a/src/Common/Acl/AccessDeniedResponseFormat.php
+++ b/src/Common/Acl/AccessDeniedResponseFormat.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Response body format for access denial responses
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Acl;
+
+enum AccessDeniedResponseFormat
+{
+    case Text;
+    case Json;
+}


### PR DESCRIPTION
## Summary

Fixes #10562

Add `AccessDeniedHelper::deny()` — a single method that handles the full deny-and-exit sequence for legacy scripts: SystemLogger warning, EventAuditLogger audit event, HTTP response code, and exit.

Every security fix in legacy code currently assembles this sequence ad-hoc, leading to inconsistency (some log but don't audit, some audit but don't set the response code, etc.). This provides a standard one-liner:

```php
AccessDeniedHelper::deny('Unauthorized access to patient notes');
```

Modern controllers should continue using `throw new AccessDeniedException(...)`.

### Changes

- New `AccessDeniedHelper::deny()` with SystemLogger + EventAuditLogger + HTTP 403 + exit
- New `AccessDeniedResponseFormat` enum (Text, Json)
- Uses Symfony `Response::HTTP_*` constants for HTTP status, constrained by PHPStan type annotation
- Uses `SessionWrapper` instead of `$_SESSION`
- Optional `beforeExit` callback for pre-exit work (e.g. session cleanup)
- Convert 60+ access denial sites across 40 files to use `AccessDeniedHelper::deny()`:
  - Document retrieval (C_Document.class.php: raw file, patient_picture, document access, IDOR check)
  - Patient demographics and insurance (demographics_full, demographics_save, demographics_print, insurance_edit)
  - Patient history (history_full, history_save, history_sdoh, etc.)
  - Deleter (patient, encounter, form, issue, document, payment, billing, transaction)
  - Fee sheet AJAX endpoints
  - Various other forms and scripts

### Skipped

- Custom modules (oe-module-faxsms, oe-module-comlink-telehealth, oe-module-dashboard-context)
- CSRF checks (handled by `csrfNotVerified` in #10567)
- Twig-rendered unauthorized pages
- Feature gates and non-access-denial error conditions

## AI Disclosure

Yes

## Test plan

- [ ] Verify the class autoloads correctly (PSR-4 in `src/Common/Acl/`)
- [ ] Verify `deny()` sets HTTP 403, logs to SystemLogger and EventAuditLogger, and exits
- [ ] Verify `format: AccessDeniedResponseFormat::Json` returns JSON with `Content-Type: application/json`
- [ ] Verify converted callers still deny access correctly