### PR TITLE
feat(about): add event hooks for module content injection

### DIFF
--- a/interface/main/about_page.php
+++ b/interface/main/about_page.php
@@ -10,8 +10,10 @@
  * @link      http://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Robert Down <robertdown@live.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2017 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2021-2023 Robert Down <robertdown@live.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -22,6 +24,8 @@ require_once("../globals.php");
 
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Common\Uuid\UniqueInstallationUuid;
+use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Events\Core\TemplatePageEvent;
 use OpenEMR\Services\ProductRegistrationService;
 use OpenEMR\Services\VersionService;
 
@@ -53,4 +57,7 @@ $viewArgs = [
     'emailRegistered' => $emailRegistered
 ];
 
-echo $t->render('core/about.html.twig', $viewArgs);
+$templatePageEvent = new TemplatePageEvent('about_page', [], 'core/about.html.twig', $viewArgs);
+$event = OEGlobalsBag::getInstance()->get('kernel')->getEventDispatcher()->dispatch($templatePageEvent, TemplatePageEvent::RENDER_EVENT);
+
+echo $t->render($event->getTwigTemplate(), $event->getTwigVariables());

--- a/templates/core/about.html.twig
+++ b/templates/core/about.html.twig
@@ -41,6 +41,12 @@
                 </div>
                 {% endif %}
 
+                {% if additionalInfoContent is defined and additionalInfoContent is not empty %}
+                <div class="additional-info-content mt-3">
+                    {{ additionalInfoContent|raw }}
+                </div>
+                {% endif %}
+
                 {% if userManualHref %}
                 <div class="user-manual mt-3">
                     <a href="{{ userManualHref|javascriptStringRemove|attr }}" target="_blank" rel="opener" class="btn text-left btn-block btn-outline-secondary btn-lg">
@@ -70,6 +76,12 @@
                     <a href="https://www.open-emr.org/donate" target="_blank" rel="opener" class="btn text-left btn-block btn-outline-danger btn-lg">
                         <i class="fa fa-fw fa-heart fa-lg"></i>&nbsp;{{ "Donate"|xlt }}
                     </a>
+                </div>
+                {% endif %}
+
+                {% if additionalButtonsContent is defined and additionalButtonsContent is not empty %}
+                <div class="additional-buttons-content mt-3">
+                    {{ additionalButtonsContent|raw }}
                 </div>
                 {% endif %}
             </div>


### PR DESCRIPTION
## Summary

Fixes #10587

Dispatch `TemplatePageEvent` from the About page to allow modules to inject content via Twig variables.

## Changes proposed in this pull request

- Dispatch `TemplatePageEvent::RENDER_EVENT` with `pageName='about_page'` before rendering
- Add two content injection points in the Twig template:
  - `additionalInfoContent`: after the version/support info section
  - `additionalButtonsContent`: after the buttons section

### Usage example

Modules can listen for the event and inject content:

```php
$eventDispatcher->addListener(TemplatePageEvent::RENDER_EVENT, function (TemplatePageEvent $event) {
    if ($event->getPageName() !== 'about_page') {
        return;
    }
    $event->setTwigVariables([
        'additionalInfoContent' => '<div class="certification-badge">...</div>',
    ]);
});
```

## AI disclosure

- [x] Yes, I have used an AI to help craft this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)