### PR TITLE
fix(e2e): add fresh session retry when JS fails to initialize after login

### DIFF
--- a/tests/Tests/E2e/Login/LoginTrait.php
+++ b/tests/Tests/E2e/Login/LoginTrait.php
@@ -40,7 +40,41 @@ trait LoginTrait
 
     private function login(string $name, string $password, bool $goalPass = true): void
     {
-        // login
+        $this->performLogin($name, $password, $goalPass);
+
+        if ($goalPass) {
+            // Wait for the JavaScript application to fully initialize
+            // (Knockout.js bindings applied, menu rendered). Without
+            // this, tests that immediately navigate menus or click UI
+            // elements can fail because the page HTML loaded but the
+            // JS framework hasn't finished rendering.
+            //
+            // Use a short initial timeout to detect failure quickly.
+            // If JS doesn't initialize within 5s, it's likely a CI
+            // environment issue where scripts failed to load. In that
+            // case, retry with a fresh session rather than waiting the
+            // full 30s timeout.
+            if (!$this->waitForAppReady(5)) {
+                // JS failed to initialize - retry with fresh session
+                fwrite(STDERR, "[E2E] JS failed to initialize after login, retrying with fresh session...\n");
+                $this->client->quit();
+                $this->base();
+                $this->performLogin($name, $password, $goalPass);
+
+                // Use longer timeout on retry - if this fails too,
+                // it's probably a real issue, not a transient failure
+                if (!$this->waitForAppReady(30)) {
+                    throw $this->createAppReadyTimeoutException();
+                }
+            }
+        }
+    }
+
+    /**
+     * Submit the login form.
+     */
+    private function performLogin(string $name, string $password, bool $goalPass): void
+    {
         $this->crawler = $this->client->request('GET', '/interface/login/login.php?site=default&testing_mode=1');
         $form = $this->crawler->filter('#login_form')->form();
         $form['authUser'] = $name;
@@ -49,12 +83,6 @@ trait LoginTrait
         $title = $this->client->getTitle();
         if ($goalPass) {
             $this->assertSame('OpenEMR', $title, 'Login FAILED');
-            // Wait for the JavaScript application to fully initialize
-            // (Knockout.js bindings applied, menu rendered). Without
-            // this, tests that immediately navigate menus or click UI
-            // elements can fail because the page HTML loaded but the
-            // JS framework hasn't finished rendering.
-            $this->waitForAppReady();
         } else {
             $this->assertSame('OpenEMR Login', $title, 'Login was successful, but should have FAILED');
         }


### PR DESCRIPTION
Fixes #10594

## Short description of what this resolves

E2E tests have a 58% retry rate on master. Every sampled failure (9/9) shows identical symptoms: `koAvailable: false`, `mainMenuChildren: 0`. This indicates Knockout.js never loads in these cases, likely due to CI environment resource pressure.

## Changes proposed in this pull request

Add a fresh session retry mechanism to `login()`:

1. **Fast detection (5s)** - Short initial timeout detects failure quickly instead of waiting 30s
2. **Fresh session** - If JS doesn't initialize, quit browser entirely and create new session with fresh login
3. **Single retry only** - Prevents masking persistent bugs while handling transient CI issues
4. **Diagnostic logging** - Log `koAvailable` state on success to verify hypothesis; log when retry triggers

### Why this works

A page refresh won't work because `prevent_browser_refresh` consumes the session token after first validation. But quitting the browser entirely and creating a fresh session with `base()` + `performLogin()` gets a new token, sidestepping the issue.

### Why this is different from removed retry patterns

PR #10500 removed 3x retry loops from test methods because they masked issues. This approach is different:

| Removed pattern | This approach |
|----------------|---------------|
| Retry in test methods | Retry at login() - earliest possible point |
| Catch any exception | Only when JS fails to initialize |
| 3x retry loop | Single retry |
| Page refresh (doesn't work) | Fresh browser session with new token |

### Evidence and limitations

**What we know:**
- 100% of sampled failures show `koAvailable: false` (knockout never loaded)
- We never see `koAvailable: true` with `mainMenuChildren: 0` (would indicate ko loaded but binding failed)
- Failures are randomly distributed across all PHP/DB configurations

**What we will verify via diagnostic logging:**
- Every successful `waitForAppReady()` logs: `[E2E] waitForAppReady succeeded: {"koAvailable":...,"mainMenuChildren":...}`
- Every retry logs: `[E2E] JS failed to initialize after login, retrying with fresh session...`

## AI Disclosure

Yes