### PR TITLE
feat(auth): allow admins to force password reset on next login

### DIFF
--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -439,30 +439,49 @@ if (OEGlobalsBag::getInstance()->getBoolean('login_into_facility')) {
     }
 }
 
-// Fetch the password expiration date (note LDAP skips this)
+// Fetch the password expiration date and the forced-password-change flag (note LDAP skips this)
 $is_expired = false;
-if ((!AuthUtils::useActiveDirectory()) && (OEGlobalsBag::getInstance()->getInt('password_expiration_days') != 0) && (check_integer(OEGlobalsBag::getInstance()->getInt('password_expiration_days')))) {
-    $result = privQuery("select `last_update_password` from `users_secure` where `id` = ?", [$session->get('authUserID')]);
-    $current_date = date('Y-m-d');
-    if (!empty($result['last_update_password'])) {
-        $pwd_last_update = $result['last_update_password'];
-    } else {
-        error_log("OpenEMR ERROR: there is a problem with recording of last_update_password entry in users_secure table");
-        $pwd_last_update = $current_date;
+$force_new_password = false;
+if (!AuthUtils::useActiveDirectory()) {
+    $result = privQuery(
+        'SELECT `last_update_password`, `force_new_password` FROM `users_secure` WHERE `id` = ?',
+        [$session->get('authUserID')]
+    );
+    if (!is_array($result)) {
+        $result = [];
     }
 
-    // Display the password expiration message (will show during the grace time)
-    $pwd_alert_date = date('Y-m-d', strtotime($pwd_last_update . '+' . OEGlobalsBag::getInstance()->getInt('password_expiration_days') . ' days'));
+    // An administrator has required this user to change their password on next login
+    $force_new_password_flag = $result['force_new_password'] ?? 0;
+    $force_new_password = is_numeric($force_new_password_flag) && (int) $force_new_password_flag !== 0;
 
-    if (empty(strtotime($pwd_alert_date))) {
-        error_log("OpenEMR ERROR: there is a problem when trying to check if user's password is expired");
-    } elseif (strtotime($current_date) >= strtotime($pwd_alert_date)) {
-        $is_expired = true;
+    // Check for password expiration
+    $password_expiration_days = OEGlobalsBag::getInstance()->getInt('password_expiration_days');
+    if (($password_expiration_days !== 0) && check_integer($password_expiration_days)) {
+        $current_date = date('Y-m-d');
+        if (!empty($result['last_update_password'])) {
+            $pwd_last_update = $result['last_update_password'];
+        } else {
+            error_log('OpenEMR ERROR: there is a problem with recording of last_update_password entry in users_secure table');
+            $pwd_last_update = $current_date;
+        }
+
+        // Display the password expiration message (will show during the grace time)
+        $pwd_alert_date = date('Y-m-d', strtotime($pwd_last_update . '+' . $password_expiration_days . ' days'));
+
+        if (empty(strtotime($pwd_alert_date))) {
+            error_log("OpenEMR ERROR: there is a problem when trying to check if user's password is expired");
+        } elseif (strtotime($current_date) >= strtotime($pwd_alert_date)) {
+            $is_expired = true;
+        }
     }
 }
 
 $listSvc = new ListService();
 $_tabs = $listSvc->getOptionsByListName('default_open_tabs', ['activity' => 1]);
+if (!is_array($_tabs)) {
+    $_tabs = [];
+}
 
 if ($is_expired) {
     //display the php file containing the password expiration message.
@@ -470,6 +489,13 @@ if ($is_expired) {
         'notes' => "interface/main/pwd_expires_alert.php?csrf_token_form=" . CsrfUtils::collectCsrfToken(session: $session),
         'id' => "adm",
         "label" => xl("Password Reset"),
+    ]);
+} elseif ($force_new_password) {
+    // Admin has required this user to change their password
+    array_unshift($_tabs, [
+        'notes' => 'interface/usergroup/user_info.php',
+        'option_id' => 'adm',
+        'title' => xl('Password Change Required'),
     ]);
 } elseif (!empty($_POST['patientID'])) {
     // Patient is open, so add this to the list of tabs, at the end

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -9,10 +9,12 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Daniel Pflieger <daniel@mi-squared.com> <daniel@growlingflea.com>
  * @author    Ken Chapple <ken@mi-squared.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2021 Daniel Pflieger <daniel@mi-squared.com> <daniel@growlingflea.com>
  * @copyright Copyright (c) 2021 Ken Chapple <ken@mi-squared.com>
  * @copyright Copyright (c) 2021 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -22,7 +24,9 @@ require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/options.
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclExtended;
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Auth\AuthUtils;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -54,6 +58,20 @@ for ($iter = 0; $row = sqlFetchArray($res); $iter++) {
 }
 
 $iter = $result[0];
+
+// Fetch the forced-password-change flag from users_secure (skip for LDAP users,
+// whose passwords are not stored here). Hoisted so the render below reuses the
+// same decision rather than re-evaluating it.
+$isLdapUser = AuthUtils::useActiveDirectory($iter['username']);
+$forceNewPassword = false;
+if (!$isLdapUser) {
+    $secureRow = QueryUtils::querySingleRow(
+        'SELECT `force_new_password` FROM `users_secure` WHERE `id` = ?',
+        [$iter['id']]
+    );
+    $forceNewPasswordFlag = is_array($secureRow) ? ($secureRow['force_new_password'] ?? 0) : 0;
+    $forceNewPassword = is_numeric($forceNewPasswordFlag) && (int) $forceNewPasswordFlag !== 0;
+}
 ?>
 
 <html>
@@ -350,6 +368,10 @@ if ($iter["portal_user"]) {
 } ?> /></span>
 <span class='text'><?php echo xlt('Active'); ?>:
     <input type="checkbox" name="active"<?php echo ($iter["active"]) ? " checked" : ""; ?>/></span>
+<?php if (!$isLdapUser) { ?>
+<span class='text' title="<?php echo xla('Require this user to change their password on next login'); ?>"><?php echo xlt('Force Password Change'); ?>:
+    <input type="checkbox" name="force_new_password"<?php echo $forceNewPassword ? " checked" : ""; ?>/></span>
+<?php } ?>
 </TD>
 </TR>
 

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -11,12 +11,14 @@
  * @author    Ken Chapple <ken@mi-squared.com>
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Robert DOwn <robertdown@live.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2015 Roberto Vasquez <robertogagliotta@gmail.com>
  * @copyright Copyright (c) 2017-2019 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2021 Daniel Pflieger <daniel@mi-squared.com> <daniel@growlingflea.com>
  * @copyright Copyright (c) 2021 Ken Chapple <ken@mi-squared.com>
  * @copyright Copyright (c) 2021 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2022-2023 Robert Down <robertdown@live.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -27,6 +29,8 @@ use OpenEMR\Common\Acl\AclExtended;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Auth\AuthUtils;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\Header;
@@ -246,6 +250,20 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
                 error_log(errorLogEscape($authUtilsUpdatePassword->getErrorMessage()));
                 $alertmsg .= $authUtilsUpdatePassword->getErrorMessage();
             }
+        }
+
+        // Update the forced-password-change flag in users_secure. This runs after
+        // the admin password reset above, because AuthUtils::updatePassword()
+        // clears the flag; doing it in the other order would silently discard a
+        // tick made in the same submission. Skipped for LDAP users, whose
+        // passwords do not live in users_secure.
+        $targetUsername = is_array($user_data) ? ($user_data['username'] ?? null) : null;
+        if (is_string($targetUsername) && $targetUsername !== '' && !AuthUtils::useActiveDirectory($targetUsername)) {
+            $postParams = CurrentRequest::get()->request;
+            QueryUtils::sqlStatementThrowException(
+                'UPDATE `users_secure` SET `force_new_password` = ? WHERE `id` = ?',
+                [$postParams->has('force_new_password') ? 1 : 0, $postParams->getInt('id')]
+            );
         }
 
         $tqvar  = (!empty($_POST["authorized"])) ? 1 : 0;

--- a/sql/8_3_0-to-8_4_0_upgrade.sql
+++ b/sql/8_3_0-to-8_4_0_upgrade.sql
@@ -158,3 +158,7 @@ INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`
 #IfNotRow2D list_options list_id care_plan_engagement_category option_id closed
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`, `subtype`, `edit_options`) VALUES ('care_plan_engagement_category','closed','Closed',60,0,0,'','','',0,0,1,'',1);
 #EndIf
+
+#IfMissingColumn users_secure force_new_password
+ALTER TABLE `users_secure` ADD COLUMN `force_new_password` tinyint(1) NOT NULL DEFAULT 0 COMMENT 'When 1, the user must change their password at next login' AFTER `auto_block_emailed`;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3,7 +3,7 @@
 --
 -- Keep v_database in sync with $v_database in version.php.
 -- CI will fail if they don't match.
--- v_database: 543
+-- v_database: 544
 --
 
 --
@@ -9894,6 +9894,7 @@ CREATE TABLE `users_secure` (
   `login_fail_counter` INT(11) DEFAULT '0',
   `last_login_fail` datetime DEFAULT NULL,
   `auto_block_emailed` tinyint DEFAULT 0,
+  `force_new_password` tinyint(1) NOT NULL DEFAULT 0 COMMENT 'When 1, the user must change their password at next login',
   PRIMARY KEY (`id`),
   UNIQUE KEY `USERNAME_ID` (`id`,`username`)
 ) ENGINE=InnoDb;

--- a/src/Common/Auth/AuthUtils.php
+++ b/src/Common/Auth/AuthUtils.php
@@ -31,10 +31,12 @@
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Ken Chapple <ken@mi-squared.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2013 Kevin Yeh <kevin.y@integralemr.com>
  * @copyright Copyright (c) 2013 OEMR
  * @copyright Copyright (c) 2018-2021 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2021 Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -765,6 +767,7 @@ class AuthUtils
             $updateSQL .= ", `login_fail_counter` = 0";
             $updateSQL .= ", `last_login_fail` = null";
             $updateSQL .= ", `auto_block_emailed` = 0";
+            $updateSQL .= ", `force_new_password` = 0";
             $updateSQL .= ", `password` = ?";
             array_push($updateParams, $newHash);
             if (OEGlobalsBag::getInstance()->get('password_history') != 0) {

--- a/tests/Tests/E2e/KkForcePasswordResetTest.php
+++ b/tests/Tests/E2e/KkForcePasswordResetTest.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * KkForcePasswordResetTest class
+ *
+ * Tests the force password reset feature: when an admin sets
+ * force_new_password on a user, that user sees a password change
+ * form on next login, and after changing their password the flag
+ * is cleared and subsequent logins are normal.
+ *
+ * Self-contained: creates its own test user via direct DB insertion.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\E2e;
+
+use Facebook\WebDriver\WebDriver;
+use Facebook\WebDriver\WebDriverBy;
+use Facebook\WebDriver\WebDriverExpectedCondition;
+use OpenEMR\Common\Acl\AclExtended;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Tests\E2e\Base\BaseTrait;
+use OpenEMR\Tests\E2e\Login\LoginTrait;
+use OpenEMR\Tests\E2e\Xpaths\XpathsConstants;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\Panther\PantherTestCase;
+
+class KkForcePasswordResetTest extends PantherTestCase
+{
+    use BaseTrait;
+    use LoginTrait;
+
+    private Crawler $crawler;
+
+    private const USERNAME = 'forcepwtest';
+    private const PASSWORD = 'Test12te$t';
+    private const NEW_PASSWORD = 'N3wTest12te$t';
+    private const FIRSTNAME = 'Force';
+    private const LASTNAME = 'Reset';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cleanDatabase();
+        $this->createTestUser();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->cleanDatabase();
+    }
+
+    private function cleanDatabase(): void
+    {
+        QueryUtils::sqlStatementThrowException('DELETE FROM `users_secure` WHERE `username` = ?', [self::USERNAME]);
+        QueryUtils::sqlStatementThrowException('DELETE FROM `groups` WHERE `user` = ?', [self::USERNAME]);
+        QueryUtils::sqlStatementThrowException('DELETE FROM `users` WHERE `username` = ?', [self::USERNAME]);
+    }
+
+    /**
+     * Create a minimal test user with force_new_password enabled.
+     *
+     * Populates users, users_secure, groups, and phpGACL tables —
+     * all required for a successful login.
+     */
+    private function createTestUser(): void
+    {
+        $userId = QueryUtils::sqlInsert(
+            'INSERT INTO `users` (`username`, `fname`, `lname`, `active`, `authorized`) VALUES (?, ?, ?, 1, 1)',
+            [self::USERNAME, self::FIRSTNAME, self::LASTNAME]
+        );
+
+        $hash = password_hash(self::PASSWORD, PASSWORD_DEFAULT);
+        QueryUtils::sqlStatementThrowException(
+            <<<'SQL'
+            INSERT INTO `users_secure` (`id`, `username`, `password`, `force_new_password`, `last_update_password`)
+            VALUES (?, ?, ?, 1, NOW())
+            SQL,
+            [$userId, self::USERNAME, $hash]
+        );
+
+        // User must belong to a group for login to succeed
+        QueryUtils::sqlStatementThrowException(
+            <<<'SQL'
+            INSERT INTO `groups` (`name`, `user`) VALUES ('Default', ?)
+            SQL,
+            [self::USERNAME]
+        );
+
+        // User must have a phpGACL ARO entry for login to succeed
+        AclExtended::setUserAro(
+            ['Administrators'],
+            self::USERNAME,
+            self::FIRSTNAME,
+            '',
+            self::LASTNAME
+        );
+    }
+
+    #[Depends('testLoginAuthorized')]
+    #[Test]
+    public function testForcePasswordReset(): void
+    {
+        $this->base();
+        try {
+            // Log in as the test user — should see forced password change tab
+            $this->login(self::USERNAME, self::PASSWORD);
+            // Tab title comes from user_info.php's <title> tag
+            $this->assertActiveTab('Change Password');
+
+            // Switch to the admin iframe containing the password change form
+            $this->switchToIFrame(XpathsConstants::ADMIN_IFRAME);
+            $this->client->waitFor('//input[@name="curPass"]');
+
+            // Fill in the password change form
+            $this->clearAndType('curPass', self::PASSWORD);
+            $this->clearAndType('newPass', self::NEW_PASSWORD);
+            $this->clearAndType('newPass2', self::NEW_PASSWORD);
+
+            // Submit the form (AJAX via update_password())
+            $this->client->wait(10)->until(
+                WebDriverExpectedCondition::elementToBeClickable(
+                    WebDriverBy::xpath('//button[contains(@class, "btn-save")]')
+                )
+            )->click();
+
+            // Wait for the AJAX success response
+            $this->client->wait(15)->until(static function (WebDriver $driver): bool {
+                $msg = $driver->findElement(WebDriverBy::id('display_msg'));
+                return str_contains($msg->getText(), 'Password change successful');
+            });
+
+            // Verify the force flag is cleared in the database. Both checks are
+            // phrased as row-existence questions so the driver's column type
+            // (int vs numeric string) never enters the assertion.
+            $secureRow = QueryUtils::querySingleRow(
+                'SELECT `id` FROM `users_secure` WHERE `username` = ?',
+                [self::USERNAME]
+            );
+            $this->assertIsArray($secureRow, 'the users_secure row for the test user disappeared');
+
+            $stillForced = QueryUtils::querySingleRow(
+                'SELECT `id` FROM `users_secure` WHERE `username` = ? AND `force_new_password` <> 0',
+                [self::USERNAME]
+            );
+            $this->assertFalse($stillForced, 'force_new_password was not cleared by the password change');
+
+            // Log out and log back in with the new password
+            $this->logOut();
+            $this->login(self::USERNAME, self::NEW_PASSWORD);
+
+            // Verify normal login — the forced password change tab is gone.
+            // Read the tab URLs from the view model rather than the rendered
+            // tab text: the text is asynchronously replaced by the iframe's
+            // own title, so asserting on it right after login races the load
+            // and would pass even if the tab were still there.
+            $this->client->switchTo()->defaultContent();
+            $tabUrls = $this->client->executeScript(
+                'return app_view_model.application_data.tabs.tabsList().map(function (t) { return t.url(); });'
+            );
+            $this->assertIsArray($tabUrls, 'unable to read the tab list from the view model');
+            $this->assertNotSame([], $tabUrls, 'the tab list is empty, so the check below would be vacuous');
+            $forcedTabs = array_filter(
+                $tabUrls,
+                static fn(mixed $url): bool => is_string($url) && str_contains($url, 'user_info.php')
+            );
+            $this->assertSame(
+                [],
+                array_values($forcedTabs),
+                'the forced password change tab is still present after the password was changed'
+            );
+
+            $this->logOut();
+        } finally {
+            // finally rather than the catch/rethrow/quit shape used elsewhere
+            // in this suite: the browser is a resource acquired by base(), and
+            // catching \Throwable purely to re-raise it trips the project's
+            // ForbiddenCatchType rule for no benefit.
+            $this->client->quit();
+        }
+    }
+
+    /**
+     * Set a form field value atomically via JavaScript.
+     *
+     * WebDriver sendKeys() dispatches key events one-by-one and Chrome
+     * can drop keystrokes under CI resource pressure. JavaScript value
+     * assignment is atomic and reliable.
+     */
+    private function clearAndType(string $fieldName, string $value): void
+    {
+        $this->client->executeScript(
+            <<<'JS'
+            var f = document.getElementsByName(arguments[0])[0];
+            f.value = "";
+            f.value = arguments[1];
+            f.dispatchEvent(new Event("input", {bubbles: true}));
+            f.dispatchEvent(new Event("change", {bubbles: true}));
+            JS,
+            [$fieldName, $value]
+        );
+    }
+}

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@ $v_realpatch = '0';
 //
 // Keep in sync with the v_database comment in sql/database.sql.
 // CI will fail if they don't match.
-$v_database = 543;
+$v_database = 544;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Fixes #6774

#### Short description of what this resolves:

Adds an administrator-settable flag that prompts a user to change their password at their next login.

#### Changes proposed in this pull request:

- Add a `force_new_password` column to `users_secure`, with a matching upgrade step in `sql/8_3_0-to-8_4_0_upgrade.sql` and a `$v_database` bump so existing installs pick it up
- Add a "Force Password Change" checkbox to the user edit form (Administration > Users), hidden for LDAP users
- Open the Change Password tab first at login when the flag is set for that user
- Clear the flag automatically when the user's password is successfully changed
- Add an end-to-end test covering the login-side flow

#### Scope note

The Change Password tab is opened first, but it does not block navigation — a user can switch to another tab and continue working without changing their password, and will be prompted again at their next login. This is the same behavior as the existing `password_expiration_days` prompt. Hard enforcement would require gating the main screen itself, which is a larger change and not part of this PR.

LDAP users are excluded, matching the password expiration feature.

This takes over from #6775 (WIP by @robertdown).

#### Does your code include anything generated by an AI Engine? Yes
