### PR TITLE
perf(phpstan): Adjust phpstan config to improve cache interaction

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -37,8 +37,6 @@ parameters:
   - templates
   - tests
   - version.php
-  scanDirectories:
-  - ./.phpstan
   scanFiles:
   - library/sql.inc.php
   - interface/modules/custom_modules/oe-module-faxsms/.phpstan/SignalWireStubs.php


### PR DESCRIPTION
#### Short description of what this resolves:
VERY frequently (at least in local dev), PHPStan bypasses cache and does the entire codebase analysis from scratch.

#### Changes proposed in this pull request:
Removes `.phpstan` from `scanDirectories`

From what I can tell, this line caused PHPStan to basically evict its entire cache any time a baseline file changed, which at the moment is pretty darn often. Since the custom rules are part of the `autoload-dev` path. this is not needed to run successfully.

Most of the time, at least half of the analysis can be done from cache which significantly speeds up analysis time. At the moment I'm editing some _very_ widely-used functions; I expect in smaller changes the impact will be more pronounced.

#### Does your code include anything generated by an AI Engine? Yes / No
No