### PR TITLE
fix(e2e): handle optional alert in Create Visit test

### DIFF
--- a/tests/Tests/E2e/Base/BaseTrait.php
+++ b/tests/Tests/E2e/Base/BaseTrait.php
@@ -148,16 +148,22 @@ trait BaseTrait
     private function assertActiveTab(string $text, string $loading = "Loading", bool $looseTabTitle = false, bool $clearAlert = false): void
     {
         if ($clearAlert) {
-            // ok the alert (example case of this is when open the Create Visit link since there is already an encounter on same day)
-            $this->client->wait(10)->until(function ($driver) {
-                try {
-                    $alert = $driver->switchTo()->alert();
-                    $alert->accept();
-                    return true; // Alert is present and has been cleared
-                } catch (\Exception) {
-                    return false; // Alert is not present
-                }
-            });
+            // Accept an alert if present (e.g., duplicate encounter warning when
+            // creating a visit on the same day as an existing encounter). The alert
+            // may not appear if no encounter exists, so don't fail if none shows.
+            try {
+                $this->client->wait(2)->until(function ($driver) {
+                    try {
+                        $alert = $driver->switchTo()->alert();
+                        $alert->accept();
+                        return true;
+                    } catch (\Exception) {
+                        return false;
+                    }
+                });
+            } catch (TimeoutException) {
+                // No alert appeared within the window, which is fine
+            }
         }
         // Wait for each loading indicator to disappear from the live DOM
         if (str_contains($loading, '||')) {


### PR DESCRIPTION
## Summary

Fixes #10617

The `assertActiveTab` method's `clearAlert` parameter was waiting 10 seconds for a JavaScript alert that may never appear. The duplicate encounter alert only shows when creating a visit on the same day as an existing encounter. If no prior visit exists, the test times out and fails.

## Changes proposed

- Reduce alert wait from 10 seconds to 2 seconds for faster feedback
- Wrap the wait in a try-catch for `TimeoutException`
- If no alert appears, continue normally instead of failing
- Alert is still accepted if it does appear

## Testing done

- Pre-commit hooks pass (PHPStan, PHPCS, Rector)
- The fix addresses the exact failure pattern seen in 6/17 CI jobs on commit fd4211d5

## AI Disclosure

Yes

🤖 Generated with [Claude Code](https://claude.com/code)