### PR TITLE
fix(phpstan): remove dead code and fix @param false docblocks

### DIFF
--- a/interface/drugs/dispense_drug.php
+++ b/interface/drugs/dispense_drug.php
@@ -199,28 +199,7 @@ sprintf("\n%s %s %s %s\n%s %s %s", xl('Lot'), $row['lot_number'], xl('Exp'), $ro
 //  $label_text .= ($refills_row['count'] - 1) . ' of ' . $row['refills'] . ' refills';
 // }
 
-// We originally went for PDF output on the theory that output formatting
-// would be more controlled.  However the clumisness of invoking a PDF
-// viewer from the browser becomes intolerable in a POS environment, and
-// printing HTML is much faster and easier if the browser's page setup is
-// configured properly.
-//
-if (false) { // if PDF output is desired
-    $pdf = new Cezpdf($dconfig['paper_size']);
-    $pdf->ezSetMargins($dconfig['top'], $dconfig['bottom'], $dconfig['left'], $dconfig['right']);
-    $pdf->selectFont('Helvetica');
-    $pdf->ezSetDy(20); // dunno why we have to do this...
-    $pdf->ezText($header_text, 7, ['justification' => 'center']);
-    if (!empty($dconfig['logo'])) {
-        $pdf->ezSetDy(-5); // add space (move down) before the image
-        $pdf->ezImage($dconfig['logo'], 0, 180, '', 'left');
-        $pdf->ezSetDy(8);  // reduce space (move up) after the image
-    }
-
-    $pdf->ezText($label_text, 9, ['justification' => 'center']);
-    $pdf->ezStream();
-} else { // HTML output
-    ?>
+?>
 <html>
     <script src="<?php echo $webroot ?>/interface/main/tabs/js/include_opener.js"></script>
 <head>
@@ -267,6 +246,3 @@ body {
 </script>
 </body>
 </html>
-    <?php
-}
-?>

--- a/library/patient.inc.php
+++ b/library/patient.inc.php
@@ -1185,7 +1185,7 @@ function pdValueOrNull($key, $value)
  *
  * @param $pid
  * @param $new
- * @param false $create
+ * @param bool $create
  * @return mixed
  */
 function updatePatientData($pid, $new, $create = false)

--- a/src/Billing/BillingProcessor/Tasks/AbstractGenerator.php
+++ b/src/Billing/BillingProcessor/Tasks/AbstractGenerator.php
@@ -98,7 +98,7 @@ abstract class AbstractGenerator extends AbstractProcessingTask implements Gener
      *
      * @param $filename
      * @param $location
-     * @param false $delete
+     * @param bool $delete
      */
     public function printDownloadClaimFileJS($filename, $location = '', $delete = false)
     {

--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -27,7 +27,7 @@ class X125010837P
      * @param  $encounter
      * @param  $x12_partner
      * @param  $log
-     * @param  false $encounter_claim
+     * @param  bool $encounter_claim
      * @param  $SEFLAG
      * @param  $HLcount
      * @param  $edicount

--- a/src/Services/CodeTypesService.php
+++ b/src/Services/CodeTypesService.php
@@ -185,7 +185,7 @@ class CodeTypesService
 
     /**
      * @param       $code
-     * @param false $useOid
+     * @param bool $useOid
      * @return string|null
      */
     public function getSystemForCode($code, $useOid = false)
@@ -290,7 +290,7 @@ class CodeTypesService
 
     /**
      * @param string $codeType
-     * @param false  $useOid
+     * @param bool  $useOid
      * @return string|null
      */
     public function getSystemForCodeType($codeType, $useOid = false)

--- a/src/Services/DocumentTemplates/DocumentTemplateService.php
+++ b/src/Services/DocumentTemplates/DocumentTemplateService.php
@@ -72,7 +72,7 @@ class DocumentTemplateService extends QuestionnaireService
      *
      * @param int    $pid
      * @param string $category
-     * @param false  $is_portal
+     * @param bool  $is_portal
      * @return array
      */
     public function getPortalAssignedTemplates($pid = 0, $category = '', $is_portal = false): array
@@ -380,7 +380,7 @@ class DocumentTemplateService extends QuestionnaireService
     }
 
     /**
-     * @param false $patients_only
+     * @param bool $patients_only
      * @return array|string[][]
      */
     public function fetchPortalAuthUsers($patients_only = false): array


### PR DESCRIPTION
## Summary

Fixes #10623

- Remove unreachable `if (false)` block in `dispense_drug.php` (dead PDF output code that can never execute)
- Fix `@param false` annotations to `@param bool` in 6 files

## Changes

| File | Change |
|------|--------|
| `interface/drugs/dispense_drug.php` | Remove dead `if (false) { ... } else { ... }` block |
| `library/patient.inc.php` | Fix `@param false $create` → `@param bool $create` |
| `src/Billing/BillingProcessor/Tasks/AbstractGenerator.php` | Fix `@param false $delete` → `@param bool $delete` |
| `src/Billing/X125010837P.php` | Fix `@param false $encounter_claim` → `@param bool $encounter_claim` |
| `src/Services/CodeTypesService.php` | Fix `@param false $useOid` → `@param bool $useOid` (2 occurrences) |
| `src/Services/DocumentTemplates/DocumentTemplateService.php` | Fix `@param false $is_portal` and `@param false $patients_only` → `@param bool` |

## Why

The `@param false` docblock annotations incorrectly tell PHPStan that these parameters can only be `false`, not a general `bool`. This causes PHPStan (at level 9) to flag any conditional checks like `if ($useOid)` as dead code since it believes the condition is always false.

## Test plan

- [x] All pre-commit hooks pass (PHPStan, PHPCS, Rector)
- [ ] Verify dispense_drug.php still renders prescription labels correctly
- [ ] Verify functions with fixed docblocks still work when called with `true`

## AI disclosure
Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)