### PR TITLE
test(e2e): add PHPUnit coverage for e2e test files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -729,6 +729,21 @@ jobs:
       if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.e2e.clover.xml') != '' }}
       run: mv coverage.e2e.clover.xml e2e.saved-cov-data
 
+    # E2E test file coverage (collected by PHPUnit, not auto_prepend.php).
+    # This verifies the e2e test code itself is executing, separate from
+    # the server-side application coverage collected via auto_prepend.php.
+    - name: Upload e2e test file coverage to Codecov
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.e2e-tests.clover.xml') != '' }}
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: coverage.e2e-tests.clover.xml
+        flags: e2e-tests,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
+
+    - name: Hide e2e test file coverage from subsequent uploads
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.e2e-tests.clover.xml') != '' }}
+      run: mv coverage.e2e-tests.clover.xml e2e-tests.saved-cov-data
+
     - name: Upload E2E test videos to GitHub
       if: ${{ !cancelled() && steps.parse.outputs.e2e_enabled == 'true' && hashFiles('selenium-videos/video.mp4') != '' }}
       uses: actions/upload-artifact@v6

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -252,10 +252,18 @@ build_test_e2e() {
     # Fix permissions for video recording
     actions_chmod 777 selenium-videos
 
-    # Enable E2E coverage collection if coverage is enabled
+    # Build coverage args for e2e test files (not server-side coverage).
+    # Server-side coverage is collected via auto_prepend.php; this captures
+    # the test file execution itself to verify tests actually ran.
+    local -a e2e_coverage_args=()
     if [[ ${ENABLE_COVERAGE:-false} = true ]]; then
         echo 'Enabling E2E coverage collection…'
         enable_e2e_coverage
+        e2e_coverage_args=(
+            --coverage-clover coverage.e2e-tests.clover.xml
+            --coverage-filter tests/Tests/E2e
+            --coverage-text
+        )
     fi
 
     selenium_video_start
@@ -286,7 +294,11 @@ build_test_e2e() {
 
     echo 'Running E2E tests…'
     set +e
-    _exec php -d memory_limit=8G ./vendor/bin/phpunit --log-junit junit-e2e.xml --testsuite e2e --testdox
+    _exec php -d memory_limit=8G ./vendor/bin/phpunit \
+        --log-junit junit-e2e.xml \
+        --testsuite e2e \
+        --testdox \
+        "${e2e_coverage_args[@]}"
     status=$?
     set -e
 


### PR DESCRIPTION
Fixes #10513

#### Short description of what this resolves:

E2E test patch coverage reports 0% even when all tests pass because the test files themselves aren't instrumented for coverage.

#### Changes proposed in this pull request:

- Add `--coverage-clover` and `--coverage-filter` flags to `build_test_e2e()` when coverage is enabled
- Upload `coverage.e2e-tests.clover.xml` to Codecov with the `e2e-tests` flag
- Server-side coverage (via `auto_prepend.php`) remains unchanged as `coverage.e2e.clover.xml`

This gives two complementary coverage reports:
| File | Flag | What it covers |
|------|------|----------------|
| `coverage.e2e.clover.xml` | `e2e` | Server-side application code exercised via HTTP |
| `coverage.e2e-tests.clover.xml` | `e2e-tests` | Test file execution (verifies tests ran) |

#### Does your code include anything generated by an AI Engine? Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.

All changes in this PR were generated with Claude Code (Claude Opus 4.5).