### PR TITLE
ci(api-docs): upload regenerated docs as artifact on failure

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -25,7 +25,7 @@ jobs:
         php-version: ['8.2']
     name: API Docs Freshness Check
     steps:
-    - name: "Checkout Code"
+    - name: Checkout Code
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
@@ -35,11 +35,11 @@ jobs:
       with:
         php-version: ${{ matrix.php-version }}
 
-    - name: "Refresh API Documentation"
+    - name: Refresh API Documentation
       run: php bin/console openemr:create-api-documentation --skip-globals
 
     # If after docs regeneration there are any diff - that means docs are not in sync with new API code changes
-    - name: "Check Docs Freshness"
+    - name: Check Docs Freshness
       run: |
         if git diff --quiet; then
           echo "✅ The API documentation is in sync with the code"
@@ -47,12 +47,24 @@ jobs:
           echo "\`openemr-api.yaml\` is in sync with your changes" >> "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
-        echo "⚠️ The API documentation is not in sync with the code — see the Job Summary for next steps."
+        echo '⚠️ The API documentation is not in sync with the code — see the Job Summary for next steps.'
+        # shellcheck disable=SC2016
         {
-          echo "# ⚠️ The API documentation is not in sync with the code"
-          echo "Looks like \`openemr-api.yaml\` is not in sync with your changes."
-          echo "Please, run:"
-          echo "\`php bin/console openemr:create-api-documentation --skip-globals\`"
-          echo "and push updated \`openemr-api.yaml\` file into your PR"
+          echo '# ⚠️ The API documentation is not in sync with the code'
+          echo 'Looks like `openemr-api.yaml` is not in sync with your changes.'
+          echo
+          echo '## Option 1: Download the updated file'
+          echo 'Download `openemr-api.yaml` from the **Artifacts** section of this workflow run and commit it to your PR.'
+          echo
+          echo '## Option 2: Regenerate locally'
+          echo 'Run `php bin/console openemr:create-api-documentation --skip-globals` and push the updated file.'
         } >> "$GITHUB_STEP_SUMMARY"
         exit 1
+
+    - name: Upload updated API docs
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: openemr-api-yaml
+        path: swagger/openemr-api.yaml
+        retention-days: 14


### PR DESCRIPTION
## Summary
- Upload the regenerated `openemr-api.yaml` as a workflow artifact when the freshness check fails
- Update the job summary to explain both download and local regeneration options

Fixes #10629

## Test plan
- [ ] Verify the workflow still passes when docs are in sync
- [ ] Verify the artifact is uploaded when docs are out of sync
- [ ] Verify the job summary shows the updated instructions

## AI disclosure
Yes