### PR TITLE
fix(immunizations): update broken CDC VIS link

### DIFF
--- a/interface/patient_file/summary/immunizations.php
+++ b/interface/patient_file/summary/immunizations.php
@@ -475,7 +475,7 @@ tr.selected {
                     <div class="form-group mt-3">
                         <label>
                             <?php echo xlt('Date of VIS Statement'); ?>
-                            (<a href="https://www.cdc.gov/vaccines/hcp/vis/current-vis.html" title="<?php echo xla('Help'); ?>" rel="noopener" target="_blank">?</a>)
+                            (<a href="https://www.cdc.gov/vaccines/hcp/current-vis/index.html" title="<?php echo xla('Help'); ?>" rel="noopener" target="_blank">?</a>)
                         </label>
                         <input type='text' size='10' class='datepicker  form-control' name="vis_date" id="vis_date"
                             value='<?php echo (!empty($vis_date)) ? attr($vis_date) : date('Y-m-d'); ?>'


### PR DESCRIPTION
## Summary

- Fix broken CDC Vaccine Information Statement (VIS) help link on immunizations page

Fixes #10631

## Changes proposed in this pull request

The CDC reorganized their website and the old VIS URL was returning 404:
- **Old URL:** `https://www.cdc.gov/vaccines/hcp/vis/current-vis.html` (404)
- **New URL:** `https://www.cdc.gov/vaccines/hcp/current-vis/index.html` (working)

## Does your code include anything generated by an AI Engine? Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)