### PR TITLE
test(api): add PHPUnit coverage for api test files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -471,6 +471,21 @@ jobs:
       if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.api.clover.xml') != '' }}
       run: mv coverage.api.clover.xml api.saved-cov-data
 
+    # API test file coverage (collected by PHPUnit, not auto_prepend.php).
+    # This verifies the API test code itself is executing, separate from
+    # the server-side application coverage collected via auto_prepend.php.
+    - name: Upload api test file coverage to Codecov
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.api-tests.clover.xml') != '' }}
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: coverage.api-tests.clover.xml
+        flags: api-tests,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
+
+    - name: Hide api test file coverage from subsequent uploads
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.api-tests.clover.xml') != '' }}
+      run: mv coverage.api-tests.clover.xml api-tests.saved-cov-data
+
     - name: Fixtures testing
       if: ${{ success() || failure() }}
       run: |

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -378,7 +378,15 @@ build_test() {
     local -a args=( --testsuite "${testsuite}" )
     shift
     case "${testsuite}" in
-        api) # API tests collect coverage via auto_prepend.php
+        api) # API tests collect server-side coverage via auto_prepend.php.
+             # Also collect test file coverage to verify tests actually ran.
+             if [[ ${ENABLE_COVERAGE:-false} = true ]]; then
+                 args+=(
+                     --coverage-clover coverage.api-tests.clover.xml
+                     --coverage-filter tests/Tests/Api
+                     --coverage-text
+                 )
+             fi
              phpunit "${args[@]}" "$@"
              return
              ;;


### PR DESCRIPTION
## Summary

Fixes #10633

Like E2E tests, API tests use HTTP requests to exercise the server, so the test code runs in a different process from the application code. Server-side coverage is already collected via `auto_prepend.php`, but the test files themselves were not being instrumented.

## Changes proposed in this pull request

- Add `--coverage-filter tests/Tests/Api` to the API test run when coverage is enabled
- Produce `coverage.api-tests.clover.xml` and upload to Codecov with the `api-tests` flag
- Follows the same pattern as #10628 which added this for E2E tests

## AI Disclosure

Yes - Claude Code assisted with this implementation

🤖 Generated with [Claude Code](https://claude.ai/code)