### PR TITLE
test(coverage): exclude uncoverable test infrastructure from coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,7 @@ codecov:
 ignore:
 - tests/PHPStan/         # Static analysis rules — not exercised by PHPUnit
 - tests/Rector/          # Rector rules — run outside PHPUnit coverage
+- tests/eventdispatcher/ # Example modules for documentation
 
 coverage:
   status:

--- a/tests/bootstrap-integration.php
+++ b/tests/bootstrap-integration.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * PHPUnit bootstrap file for isolated tests.
+ *
+ * @codeCoverageIgnore Bootstrap files run before coverage instrumentation starts.
+ */
+
 declare(strict_types=1);
 
 // make sure this can only be run on the command line.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * PHPUnit bootstrap file for integration tests.
+ *
+ * @codeCoverageIgnore Bootstrap files run before coverage instrumentation starts.
+ */
+
 declare(strict_types=1);
 
 // make sure this can only be run on the command line.


### PR DESCRIPTION
## Summary

Fixes #10640

- Add `tests/eventdispatcher/` to codecov.yml ignore list (example modules, not test code)
- Add `@codeCoverageIgnore` to bootstrap files (run before coverage instrumentation)

This is the first step toward 100% coverage of the `tests/` directory. Data providers already have `@codeCoverageIgnore` annotations.

## Test plan

- [ ] Verify codecov no longer reports `tests/eventdispatcher/` in coverage
- [ ] Verify bootstrap files no longer contribute to coverage gaps

🤖 Generated with [Claude Code](https://claude.ai/code)

---

- [ ] My code follows the style guidelines of this project
- [ ] New and existing unit tests pass locally with my changes

**AI Disclosure:** Yes