### PR TITLE
feat(internals): add ServiceContainer for centralized service access

### DIFF
--- a/src/BC/ServiceContainer.php
+++ b/src/BC/ServiceContainer.php
@@ -18,7 +18,6 @@ use OpenEMR\Common\Crypto;
 use OpenEMR\Common\Logging;
 use Lcobucci\Clock\SystemClock;
 use OpenEMR\Common\Http\Psr17Factory;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use Psr\Clock\ClockInterface;
 use Psr\Http\Message\{
@@ -29,7 +28,6 @@ use Psr\Http\Message\{
     UploadedFileFactoryInterface,
     UriFactoryInterface,
 };
-use Twig\Environment;
 
 /**
  * Utility class for accessing common system services.
@@ -125,21 +123,6 @@ class ServiceContainer
     public static function getStreamFactory(): StreamFactoryInterface
     {
         return self::resolve(StreamFactoryInterface::class) ?? new Psr17Factory();
-    }
-
-    /**
-     * Get a configured Twig environment.
-     *
-     * @param string|null $path Additional template path to include alongside
-     *                          the default /templates directory
-     */
-    public static function getTwig(?string $path = null): Environment
-    {
-        if (($env = self::resolve(Environment::class)) !== null) {
-            return $env;
-        }
-        $kernel = OEGlobalsBag::getInstance()->getKernel();
-        return (new TwigContainer($path, $kernel))->getTwig();
     }
 
     public static function getUploadedFileFactory(): UploadedFileFactoryInterface

--- a/tests/Tests/Isolated/BC/ServiceContainerTest.php
+++ b/tests/Tests/Isolated/BC/ServiceContainerTest.php
@@ -4,7 +4,6 @@
  * ServiceContainer Smoke Tests
  *
  * Tests that ServiceContainer methods return the expected interface types.
- * getTwig() is excluded as it requires global state.
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org


### PR DESCRIPTION
Fixes #8929, alternative to #8944 (well, some of it)

#### Short description of what this resolves:

Introduces a ServiceContainer class that provides centralized access to a selection of common services via static methods returning interfaces. This is a stepping stone toward full dependency injection, allowing code to more easily reference interfaces rather than concrete implementations. I consider it two steps forward, one step back.

Modules can override default implementations during bootstrap using `ServiceContainer::override()`, addressing the core use case from #8929 without the complexity of dealing with the event system. Due to order of operations this may not be perfect, but should handle several common cases from that issue.

Notably, this doesn't really aim to lay _any_ groundwork for next-gen modules; it's intended strictly to ease the transition on existing code (hence being in the BC namespace). It's similar in nature to OEGlobalsBag vs direct Globals. Next-gen modules should a) use a proper PSR-11 container and b) get hooked _so early_ in the request lifecycle that most of the overrides aren't even needed.

Logical next-steps for this, if we want to go with it, would be to add PHPStan rules that disallow direct instantiation of (some of) the classes this provides (systemlogger and cryptogen, for two) and guides towards referencing this. And do the migrations. Once we have a true DI container (with autowiring) set up, we can both migrate the internals of this to use it and deprecate it in favor of the container.

There's probably other classes/interfaces that this should provide!

#### Changes proposed in this pull request:

- Add `ServiceContainer` class in `src/BC/` with static accessors for:
  - PSR-3: `getLogger()` → `LoggerInterface`
  - PSR-17: `getRequestFactory()`, `getResponseFactory()`, `getServerRequestFactory()`, `getStreamFactory()`, `getUploadedFileFactory()`, `getUriFactory()`
  - PSR-20: `getClock()` → `ClockInterface`
  - `getCrypto()` → `CryptoInterface`
  - `getTwig()` → Twig `Environment`
- Add `override(string $interface, object $instance)` method for module overrides
  - Uses PHPStan generics for type safety
  - Validates instance implements the interface
  - Last override wins
  - Lazy instantiation: defaults only created when no override exists
- Add isolated unit tests for almost all methods

#### Does your code include anything generated by an AI Engine? Yes

#### If you answered yes:

Most code in this PR was generated with assistance from Claude (Anthropic). The code was reviewed and approved by a human before inclusion. Files affected:
- `src/BC/ServiceContainer.php` - AI-assisted
- `tests/Tests/Isolated/BC/ServiceContainerTest.php` - AI-assisted

---

🤖 Generated with [Claude Code](https://claude.ai/code)