### PR TITLE
fix(ci): add path fixes for Codecov coverage reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,13 @@ ignore:
 - tests/Rector/          # Rector rules — run outside PHPUnit coverage
 - tests/eventdispatcher/ # Example modules for documentation
 
+# Strip environment-specific path prefixes from coverage reports so Codecov
+# can match them to repository files. See https://docs.codecov.com/docs/fixing-paths
+fixes:
+- '/var/www/localhost/htdocs/openemr/::'     # Apache Docker container
+- '/usr/share/nginx/html/openemr/::'         # nginx Docker container
+- '/home/runner/work/openemr/openemr/::'     # GitHub Actions runner (isolated tests)
+
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary

Fixes #10676

PHPUnit's Clover XML writer outputs absolute file paths. When tests run in different environments (Docker containers, GitHub Actions runners), the paths don't match the repository structure, causing Codecov to show 0% coverage for files that were actually executed.

## Changes

Add `fixes` section to `codecov.yml` to strip environment-specific prefixes:
- `/var/www/localhost/htdocs/openemr/` - Apache Docker container
- `/usr/share/nginx/html/openemr/` - nginx Docker container
- `/home/runner/work/openemr/openemr/` - GitHub Actions runner (isolated tests)

## Test plan

- [ ] Verify Codecov reports show correct file paths after this change merges
- [ ] Check that test files (e.g., `tests/Tests/Services/FacilityServiceTest.php`) show non-zero coverage when tests run

## AI Disclosure

Yes