### PR TITLE
fix(erx): allow allergy entry without eRx role

### DIFF
--- a/interface/patient_file/summary/stats_full.php
+++ b/interface/patient_file/summary/stats_full.php
@@ -7,8 +7,10 @@
  * @link      http://www.open-emr.org
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2005-2017 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -20,6 +22,7 @@ require_once($GLOBALS['srcdir'] . '/options.inc.php');
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\Menu\PatientMenuRole;
@@ -220,7 +223,20 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                     $canSelect = $btnDelete;
                     $btnAdd = false;
                     if (AclMain::aclCheckIssue($t, '', ['write', 'addonly'])) {
+                        // Check if we should use eRx interface for allergies/medications.
+                        // Only redirect to eRx.php if the user has an eRx role configured,
+                        // otherwise allow them to add allergies via the normal interface.
+                        $userHasErxRole = false;
                         if (in_array($t, ['allergy', 'medications']) && $GLOBALS['erx_enable']) {
+                            $erxRoleRow = QueryUtils::fetchSingleValue(
+                                "SELECT newcrop_user_role FROM users WHERE id = ?",
+                                'newcrop_user_role',
+                                [$_SESSION['authUserID']]
+                            );
+                            $userHasErxRole = $erxRoleRow !== null && $erxRoleRow !== '';
+                        }
+
+                        if ($userHasErxRole) {
                             $btnAdd = [
                                 'href' => '../../eRx.php?page=medentry',
                                 'onclick' => 'top.restoreSession()',


### PR DESCRIPTION
Fixes #10675

#### Short description of what this resolves:

When Ensora/NewCrop e-prescribe is enabled, users without an eRx role configured were unable to add allergies, receiving "Unauthorized access to ePrescription" error. This happened because the add button for allergies unconditionally redirected to `eRx.php` when `erx_enable` was true.

#### Changes proposed in this pull request:

- Check if the current user has a `newcrop_user_role` configured before redirecting to the eRx interface
- Users without an eRx role can now add allergies via the normal `add_edit_issue.php` dialog
- Same logic applies to medications

#### Does your code include anything generated by an AI Engine? Yes