### PR TITLE
fix(e2e): handle duplicate visit alert immediately after menu click

### DIFF
--- a/tests/Tests/E2e/IiPatientContextMainMenuLinksTest.php
+++ b/tests/Tests/E2e/IiPatientContextMainMenuLinksTest.php
@@ -59,11 +59,11 @@ class IiPatientContextMainMenuLinksTest extends PantherTestCase
         try {
             $this->login(LoginTestData::username, LoginTestData::password);
             $this->patientOpenIfExist(PatientTestData::FNAME, PatientTestData::LNAME, PatientTestData::DOB, PatientTestData::SEX, false);
-            $this->goToMainMenuLink($menuLink);
+            $this->goToMainMenuLink($menuLink, $clearAlert);
             if ($popup) {
                 $this->assertActivePopup($expectedTabPopupTitle);
             } else {
-                $this->assertActiveTab($expectedTabPopupTitle, $loading, false, $clearAlert);
+                $this->assertActiveTab($expectedTabPopupTitle, $loading);
             }
         } catch (\Throwable $e) {
             // Close client


### PR DESCRIPTION
## Summary

- Move alert handling from `assertActiveTab()` to `goToMainMenuLink()` so it runs immediately after the click that triggers it
- The previous approach was too late - the alert blocked WebDriver operations before `assertActiveTab()` had a chance to dismiss it
- Removes unused `$clearAlert` parameter from `assertActiveTab()`

Fixes #10684

## Test plan

- [ ] E2E tests pass on PHP 8.3 + MariaDB 11.8 (the previously failing configuration)
- [ ] "Create Visit" test no longer fails with `UnexpectedAlertOpenException`

## AI disclosure

Yes

🤖 Generated with [Claude Code](https://claude.ai/code)