### PR TITLE
ci(phpstan): experiment with multi-PHP version matrix

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -21,9 +21,9 @@ jobs:
   phpstan:
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
-        # Single-element matrix provides named variable and job title
-        php-version: ['8.4']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6
@@ -37,23 +37,23 @@ jobs:
       run: composer remove --dev --optimize-autoloader rector/rector
     - name: PHPStan Cache
       # https://phpstan.org/user-guide/result-cache
+      # Use PHP-version-specific cache since results can differ across versions
       uses: actions/cache@v5
       with:
         path: tmp-phpstan # same as in phpstan.neon
-        key: "phpstan-result-cache-${{ github.run_id }}"
+        key: phpstan-result-cache-php${{ matrix.php-version }}-${{ github.run_id }}
         restore-keys: |
-          phpstan-result-cache-
+          phpstan-result-cache-php${{ matrix.php-version }}-
     - name: PHPStan Diagnose
       run: vendor/bin/phpstan --memory-limit=8G diagnose
     - name: PHPStan Analyze
+      # Allow analysis to fail - we want to compare baselines across versions
+      continue-on-error: true
       run: vendor/bin/phpstan --memory-limit=8G analyze --error-format=github
     - name: PHPStan Baseline
-      if: failure()
+      # Always generate baseline to compare across PHP versions
       run: composer run phpstan-baseline
-    # Upload the resulting baseline as an artifact. This is intended mostly for
-    # debugging and isn't actively used by GH workflows.
     - name: Upload PHPStan Baseline
-      if: failure()
       uses: actions/upload-artifact@v6
       with:
         name: phpstan-baseline-php${{ matrix.php-version }}


### PR DESCRIPTION
## Summary
- Test running PHPStan across PHP 8.2, 8.3, 8.4, and 8.5 to see if different versions produce different errors
- If baselines differ across versions, we may need version-specific baselines

## Changes
- Expand matrix to test PHP 8.2-8.5
- Use `fail-fast: false` so all versions run even if some fail
- Use PHP-version-specific cache keys since analysis results may differ
- Always generate and upload baseline artifacts (not just on failure) for comparison
- Use `continue-on-error` on analysis step to ensure baselines are generated for all versions

## Test plan
- [ ] Review the CI artifacts after all jobs complete
- [ ] Compare baselines across PHP versions to identify any differences
- [ ] Determine if version-specific baselines are needed

## AI disclosure
Yes