### PR TITLE
fix(lbf): respect default value for checkboxes

### DIFF
--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -1064,7 +1064,7 @@ function generate_form_field($frow, $currvalue): void
                 echo "<td width='" . attr($tdpct) . "%' nowrap>";
                 echo "<input type='checkbox' name='form_{$field_id_esc}[$option_id_esc]'" .
                 "id='form_{$field_id_esc}[$option_id_esc]' class='form-check-inline' value='1' $lbfonchange";
-                if (in_array($option_id, $avalue)) {
+                if (in_array($option_id, $avalue) || ($avalue === [''] && $lrow['is_default'])) {
                     echo " checked";
                 }
                 // Added 5-09 by BM - Translate label if applicable


### PR DESCRIPTION
Fixes #10716

## Summary

Checkbox fields (data_type 21) in Layout Based Forms now correctly respect the `is_default` flag when no value is saved, matching the existing behavior of radio buttons (data_type 27).

## Changes

- Add default value check to checkbox rendering in `library/options.inc.php`

## Root Cause

The checkbox rendering code only checked if an option was in the saved value array:
```php
if (in_array($option_id, $avalue)) {
    echo " checked";
}
```

Radio buttons (data_type 27) already handled defaults correctly:
```php
if (
    (strlen((string) $currvalue) == 0 && $lrow['is_default']) ||
    (strlen((string) $currvalue)  > 0 && $option_id == $currvalue)
) {
    echo " checked";
}
```

The fix applies the same logic to checkboxes.

## Test Plan

1. Create a list with a default option (Admin > Forms > Lists)
2. Create an LBF with a checkbox field pointing to that list
3. Open a new form entry
4. Verify the default checkbox is pre-selected
5. Save a different selection
6. Reopen and verify the saved selection persists (not the default)

## AI Disclosure

Yes