### PR TITLE
fix(claimrev): save all subscribers in eligibility request

### DIFF
--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -12057,11 +12057,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/openemr.bootstrap.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$revenueTools might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/EligibilityObjectCreator.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$benefit might not be defined\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/templates/additional_info.php',

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/src/EligibilityObjectCreator.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/src/EligibilityObjectCreator.php
@@ -6,7 +6,9 @@
  * @link    http://www.open-emr.org
  *
  * @author    Brad Sharp <brad.sharp@claimrev.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2022 Brad Sharp <brad.sharp@claimrev.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -120,8 +122,8 @@ class EligibilityObjectCreator
 
             array_push($payers, $payer);
             $revenueTools->payers = $payers;
+            array_push($results, $revenueTools);
         }
-        array_push($results, $revenueTools);
 
         return $results;
     }


### PR DESCRIPTION
## Summary

Fixes #10736

The `buildObject()` method in `EligibilityObjectCreator.php` had a logic error where `array_push($results, $revenueTools)` was outside the foreach loop, causing only the last subscriber's eligibility request to be saved.

## Changes proposed in this pull request

- Move `array_push($results, $revenueTools)` inside the foreach loop so all subscribers are processed

## AI Disclosure

Yes - Claude Code