### PR TITLE
fix(claimrev): validate required settings in isConfigured()

### DIFF
--- a/interface/modules/custom_modules/oe-module-claimrev-connect/src/GlobalConfig.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/src/GlobalConfig.php
@@ -10,7 +10,9 @@
  * @link    http://www.open-emr.org
  *
  * @author    Brad Sharp <brad.sharp@claimrev.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2022 Brad Sharp <brad.sharp@claimrev.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -49,18 +51,20 @@ class GlobalConfig
 
     /**
      * Returns true if all of the settings have been configured.  Otherwise it returns false.
-     *
-     * @return bool
      */
-    public function isConfigured()
+    public function isConfigured(): bool
     {
-        // $keys = [self::CONFIG_OPTION_TEXT, self::CONFIG_OPTION_ENCRYPTED];
-        // foreach ($keys as $key) {
-        //     $value = $this->getGlobalSetting($key);
-        //     if (empty($value)) {
-        //         return false;
-        //     }
-        // }
+        $requiredKeys = [
+            self::CONFIG_OPTION_ENVIRONMENT,
+            self::CONFIG_OPTION_CLIENTID,
+            self::CONFIG_OPTION_CLIENTSECRET,
+        ];
+        foreach ($requiredKeys as $key) {
+            $value = $this->getGlobalSetting($key);
+            if ($value === null || $value === '') {
+                return false;
+            }
+        }
         return true;
     }
 


### PR DESCRIPTION
Fixes #10739

## Description
The `isConfigured()` method in ClaimRev's GlobalConfig always returned `true` because the validation logic was commented out and referenced non-existent constants (`CONFIG_OPTION_TEXT`, `CONFIG_OPTION_ENCRYPTED`).

## Changes
- Validate the three required settings: environment, client ID, and client secret
- Add `: bool` return type declaration
- Use explicit null/empty string check instead of `empty()`

## AI Disclosure
Yes