### PR TITLE
fix(claimrev): restrict file permissions for EDI downloads

### DIFF
--- a/interface/modules/custom_modules/oe-module-claimrev-connect/src/EligibilityTransfer.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/src/EligibilityTransfer.php
@@ -116,14 +116,14 @@ class EligibilityTransfer extends BaseService
             $savePath = $siteDir . '/documents/edi/history/' . $reportFolder . '/';
             if (!file_exists($savePath)) {
                 // Create a directory
-                mkdir($savePath, 0777, true);
+                mkdir($savePath, 0750, true);
             }
 
             $fileText = $raw271;
             $fileName = $result->claimRevResultId;
             $filePathName =  $savePath . $fileName . '.txt';
             file_put_contents($filePathName, $fileText);
-            chmod($filePathName, 0777);
+            chmod($filePathName, 0640);
         }
 
         if ($result->retryLater) {

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/src/ReportDownload.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/src/ReportDownload.php
@@ -35,7 +35,7 @@ class ReportDownload extends BaseService
             //$savePath = $siteDir . '/documents/edi/';
             if (!file_exists($savePath)) {
                 // Create a directory
-                mkdir($savePath, 0777, true);
+                mkdir($savePath, 0750, true);
             }
 
             $datas = ClaimRevApi::getReportFiles($reportType, $token);
@@ -46,7 +46,7 @@ class ReportDownload extends BaseService
                         $fileName = $data->fileName ;
                         $filePathName =  $savePath . $fileName . '.txt';
                         file_put_contents($filePathName, $fileText);
-                        chmod($filePathName, 0777);
+                        chmod($filePathName, 0640);
                     } else {
                         error_log("Unable to find property FileText in ClaimRevConnector.ReportDownload.getWaitingFiles");
                     }
@@ -65,7 +65,7 @@ class ReportDownload extends BaseService
         //$savePath = $siteDir . '/documents/edi/';
         if (!file_exists($savePath)) {
             // Create a directory
-            mkdir($savePath, 0777, true);
+            mkdir($savePath, 0750, true);
         }
 
         $data = ClaimRevApi::getFileForDownload($objectId, $token);
@@ -75,7 +75,7 @@ class ReportDownload extends BaseService
             $fileName = $objectId . ".edi";
             $filePathName =  $savePath . $fileName;
             file_put_contents($filePathName, $fileText);
-            chmod($filePathName, 0777);
+            chmod($filePathName, 0640);
         } else {
             error_log("Unable to find property FileText in ClaimRevConnector.ReportDownload.getWaitingFiles");
         }


### PR DESCRIPTION
## Summary

- Change overly permissive `0777` permissions to more restrictive values
- Directories: `0750` (owner rwx, group rx, others none)
- Files: `0640` (owner rw, group r, others none)

Fixes #10741

## Changes

- `ReportDownload.php`: Updated 4 permission calls (2 mkdir, 2 chmod)
- `EligibilityTransfer.php`: Updated 2 permission calls (1 mkdir, 1 chmod)

## Test Plan

- [ ] Verify EDI file downloads still work correctly
- [ ] Verify downloaded files have correct permissions

## AI Disclosure

- [x] Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)