### PR TITLE
fix(claimrev): add input validation for ERA ID parameter

### DIFF
--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -7027,11 +7027,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/EligibilityTransfer.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\ClaimRevConnector\\\\EraPage\\:\\:downloadEra\\(\\) has parameter \\$id with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/EraPage.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\ClaimRevConnector\\\\EraPage\\:\\:searchEras\\(\\) has parameter \\$postData with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/EraPage.php',

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/public/EraDownload.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/public/EraDownload.php
@@ -4,7 +4,7 @@
  * ERA file download handler
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://www.open-emr.org
  *
  * @author    Brad Sharp <brad.sharp@claimrev.com>
  * @author    Michael A. Smith <michael@opencoreemr.com>
@@ -13,27 +13,36 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-    require_once "../../../../globals.php";
+require_once "../../../../globals.php";
 
-    use OpenEMR\Common\Acl\AccessDeniedHelper;
-    use OpenEMR\Common\Acl\AclMain;
-    use OpenEMR\Modules\ClaimRevConnector\EraPage;
+use OpenEMR\Common\Acl\AccessDeniedHelper;
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Modules\ClaimRevConnector\EraPage;
 
-    //ensure user has proper access
 if (!AclMain::aclCheckCore('acct', 'bill')) {
-    AccessDeniedHelper::denyWithTemplate("ACL check failed for acct/bill: ClaimRev Connect - ERA Download", xl("ClaimRev Connect - ERA Download"));
+    AccessDeniedHelper::denyWithTemplate(
+        "ACL check failed for acct/bill: ClaimRev Connect - ERA Download",
+        xl("ClaimRev Connect - ERA Download")
+    );
 }
 
+$rawEraId = $_GET['eraId'] ?? null;
+$eraId = is_string($rawEraId) ? $rawEraId : '';
 
-    $eraId = $_GET['eraId'];
+try {
     $fileViewModel = EraPage::downloadEra($eraId);
+} catch (\InvalidArgumentException) {
+    http_response_code(400);
+    echo xlt('Invalid ERA ID format');
+    exit;
+}
 
-    header("Pragma: public");
-    header("Expires: 0");
-    header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
-    header("Content-Type: application/edi-x12");
-    header("Content-Length: " . strlen((string) $fileViewModel->fileText));
-    header('Content-Disposition: attachment; filename="' . $fileViewModel->fileName . '"');
-    header("Content-Description: File Transfer");
-    echo (string) $fileViewModel->fileText; // nosemgrep: echoed-request
-    exit(0);
+header("Pragma: public");
+header("Expires: 0");
+header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
+header("Content-Type: application/edi-x12");
+header("Content-Length: " . strlen((string) $fileViewModel->fileText));
+header('Content-Disposition: attachment; filename="' . $fileViewModel->fileName . '"');
+header("Content-Description: File Transfer");
+echo (string) $fileViewModel->fileText; // nosemgrep: echoed-request
+exit;

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/src/EraPage.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/src/EraPage.php
@@ -1,12 +1,15 @@
 <?php
 
 /**
+ * ERA page controller
  *
- * @package OpenEMR
- * @link    http://www.open-emr.org
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
  *
  * @author    Brad Sharp <brad.sharp@claimrev.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2022 Brad Sharp <brad.sharp@claimrev.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -37,8 +40,18 @@ class EraPage
         $data = EraSearch::search($model);
         return $data;
     }
-    public static function downloadEra($id)
+    /**
+     * Download an ERA file by ID.
+     *
+     * @param string $id ERA identifier (alphanumeric and hyphens only)
+     * @throws \InvalidArgumentException If the ID format is invalid
+     */
+    public static function downloadEra(string $id)
     {
+        if ($id === '' || !preg_match('/^[a-zA-Z0-9\-]+$/', $id)) {
+            throw new \InvalidArgumentException('Invalid ERA ID format');
+        }
+
         $data = EraSearch::downloadEra($id);
         $data->fileName = $data->ediType . "-" . $data->payerNumber . "-" .  convert_safe_file_dir_name($id) . ".txt";
 


### PR DESCRIPTION
Fixes #10742

## Summary
Add defense-in-depth input validation for ERA ID parameter in `EraDownload.php`.

**Note:** File permission hardening was addressed separately in #10757.

## Changes proposed in this pull request
- Move ERA ID validation into `EraPage::downloadEra()` which throws `\InvalidArgumentException` for invalid format
- `EraDownload.php` catches the exception and returns HTTP 400 with translated error message
- Validate format: alphanumeric characters and hyphens only (typical API ID format)
- Clean up indentation inconsistencies in `EraDownload.php`

## AI Disclosure
Yes

🤖 Generated with [Claude Code](https://claude.ai/code)