### PR TITLE
fix(claimrev): use $postData parameter instead of $_POST

### DIFF
--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -6777,11 +6777,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimSearch.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\ClaimRevConnector\\\\ClaimsPage\\:\\:searchClaims\\(\\) has parameter \\$postData with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimsPage.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\ClaimRevConnector\\\\EligibilityData\\:\\:getEligibilityCheckByStatus\\(\\) has parameter \\$status with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/EligibilityData.php',
@@ -7115,11 +7110,6 @@ $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\ClaimRevConnector\\\\ValueMapping\\:\\:mapPayerResponsibility\\(\\) has parameter \\$payerResponsibility with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/ValueMapping.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\ClaimRevConnector\\\\X12TrackerPage\\:\\:searchX12Tracker\\(\\) has parameter \\$postData with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/X12TrackerPage.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method Comlink\\\\OpenEMR\\\\Modules\\\\TeleHealthModule\\\\Bootstrap\\:\\:getService\\(\\) has parameter \\$className with no type specified\\.$#',

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/public/claims.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/public/claims.php
@@ -95,6 +95,7 @@ if (!AclMain::aclCheckCore('acct', 'bill')) {
         <?php
             $datas = [];
         if (isset($_POST['SubmitButton'])) { //check if form was submitted
+            /** @var array<string, mixed> $_POST */
             $datas = ClaimsPage::searchClaims($_POST);
             if ($datas == null) {
                 $datas = [];

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/public/x12Tracker.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/public/x12Tracker.php
@@ -26,6 +26,7 @@ if (!AclMain::aclCheckCore('acct', 'bill')) {
     $datas = [];
     //check if form was submitted
 if (isset($_POST['SubmitButton'])) {
+    /** @var array<string, mixed> $_POST */
     $datas = X12TrackerPage::searchX12Tracker($_POST);
 }
 ?>

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimsPage.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimsPage.php
@@ -1,12 +1,14 @@
 <?php
 
 /**
+ * Claims search page for ClaimRev integration
  *
- * @package OpenEMR
- * @link    http://www.open-emr.org
- *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
  * @author    Brad Sharp <brad.sharp@claimrev.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2022 Brad Sharp <brad.sharp@claimrev.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -17,12 +19,15 @@ use OpenEMR\Modules\ClaimRevConnector\ClaimSearchModel;
 
 class ClaimsPage
 {
-    public static function searchClaims($postData)
+    /**
+     * @param array<string, mixed> $postData
+     */
+    public static function searchClaims(array $postData)
     {
-        $firstName = $_POST['patFirstName'];
-        $lastName = $_POST['patLastName'];
-        $startDate = $_POST['startDate'];
-        $endDate = $_POST['endDate'];
+        $firstName = $postData['patFirstName'] ?? '';
+        $lastName = $postData['patLastName'] ?? '';
+        $startDate = $postData['startDate'] ?? '';
+        $endDate = $postData['endDate'] ?? '';
 
         $model = new ClaimSearchModel();
         $model->patientFirstName = $firstName;

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/src/X12TrackerPage.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/src/X12TrackerPage.php
@@ -1,12 +1,14 @@
 <?php
 
 /**
+ * X12 tracker search page for ClaimRev integration
  *
- * @package OpenEMR
- * @link    http://www.open-emr.org
- *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
  * @author    Brad Sharp <brad.sharp@claimrev.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2022 Brad Sharp <brad.sharp@claimrev.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -14,10 +16,13 @@ namespace OpenEMR\Modules\ClaimRevConnector;
 
 class X12TrackerPage
 {
-    public static function searchX12Tracker($postData)
+    /**
+     * @param array<string, mixed> $postData
+     */
+    public static function searchX12Tracker(array $postData)
     {
-        $startDate = $_POST['startDate'];
-        $endDate = $_POST['endDate'];
+        $startDate = $postData['startDate'] ?? '';
+        $endDate = $postData['endDate'] ?? '';
 
         $sql = "SELECT * FROM x12_remote_tracker where created_at BETWEEN ? AND ?";
         $files = sqlStatementNoLog($sql, [$startDate,$endDate]);


### PR DESCRIPTION
## Summary

`ClaimsPage::searchClaims()` and `X12TrackerPage::searchX12Tracker()` accept a `$postData` parameter but were ignoring it and accessing `$_POST` directly. This made the methods untestable and inconsistent with `EraPage::searchEras()` which correctly uses its parameter.

## Changes

- Add `array` type hint to both methods
- Change `$_POST` access to `$postData` with null coalescing defaults

Fixes #10744

## Testing

Manual testing in Docker environment:
- Navigate to ClaimRev module claims search
- Perform a search with patient name and date range
- Verify results return correctly

**AI Disclosure:** Yes