### PR TITLE
fix(e2e): add CI full test mode and fix stale element in assertActiveTab

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -6,7 +6,13 @@
 #
 # Matrix strategy:
 # - Pull requests: Only PHP 8.2 configurations (oldest supported) for faster feedback
+# - Pull requests with "Test-Mode: full" trailer: All configurations (like nightly)
 # - Push to master/rel-*: All configurations
+#
+# To run all configurations on a PR (useful for debugging flaky tests that only
+# appear in specific configurations), add this trailer to any commit message:
+#
+#   Test-Mode: full
 #
 # Coverage is collected for one configuration (apache_82_118 on PRs, apache_84_114 on push).
 # Full coverage across ALL configurations runs in the scheduled nightly workflow.
@@ -36,16 +42,43 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6
+      with:
+        # For PRs, checkout the PR head ref to access commit trailers
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        # Fetch enough history to find the merge base with the target branch
+        fetch-depth: 0
+
+    - name: Check for full test mode
+      id: test-mode
+      if: github.event_name == 'pull_request'
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: |
+        # Find merge base with the target branch and check commits for trailer
+        # The checkout with fetch-depth=0 already has full history
+        merge_base=$(git merge-base "origin/${BASE_REF}" HEAD) || {
+          echo "::warning::Could not find merge base, skipping trailer check"
+          echo 'full=false' >> "$GITHUB_OUTPUT"
+          exit 0
+        }
+        echo "::debug::Checking commits ${merge_base}..HEAD for Test-Mode trailer"
+        if git log --format='%(trailers:key=Test-Mode,valueonly)' "${merge_base}..HEAD" | grep -qi '^full$'; then
+          echo 'full=true' >> "$GITHUB_OUTPUT"
+          echo "::notice::Full test mode enabled via commit trailer"
+        else
+          echo 'full=false' >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Collect Docker Dirs
       id: docker-dirs
       env:
         IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
+        FULL_TEST_MODE: ${{ steps.test-mode.outputs.full }}
       ##
       # Collect the docker directory names from ci subdirectories
       # and compute display names for each configuration.
-      # For PRs, only include PHP 8.2 configs (oldest supported version).
-      # For pushes to master/rel-*, include all configs.
+      # For PRs (without full mode): only PHP 8.2 configs (oldest supported).
+      # For PRs with full mode or pushes to master/rel-*: all configs.
       run: |
         shopt -s nullglob
         shopt -s extglob
@@ -54,8 +87,8 @@ jobs:
         dirs=( "${dirs[@]%/docker-compose.yml}" )
         dirs=( "${dirs[@]#ci/}" )
 
-        if [[ "${IS_PULL_REQUEST}" = "true" ]]; then
-          # For PRs: filter to only PHP 8.2 configurations
+        if [[ "${IS_PULL_REQUEST}" = 'true' && "${FULL_TEST_MODE}" != 'true' ]]; then
+          # For PRs without full mode: filter to only PHP 8.2 configurations
           ci/parse_docker_dir.sh "${dirs[@]}" |
             jq -rc --arg is_pr "${IS_PULL_REQUEST}" 'map({
               docker_dir: .output.docker_dir,
@@ -65,7 +98,7 @@ jobs:
               save_node_cache: .output.save_node_cache
             }) | map(select(.php == "8.2")) | "configs=\(.)"' >> "$GITHUB_OUTPUT"
         else
-          # For pushes: include all configurations
+          # For PRs with full mode or pushes: include all configurations
           ci/parse_docker_dir.sh "${dirs[@]}" |
             jq -rc 'map({
               docker_dir: .output.docker_dir,


### PR DESCRIPTION
## Summary

Fixes #10764

This PR addresses two related problems:

1. **CI Enhancement**: Add `Test-Mode: full` commit trailer support to run all CI configurations on PRs (not just PHP 8.2). This helps catch flaky tests that only occur in specific configurations (like nginx) before they reach nightly runs.

2. **E2E Fix**: Fix stale element reference in `assertActiveTab()` that caused E2E test failures on nginx configurations.

## Changes

- **`.github/workflows/test-all.yml`**: Check for `Test-Mode: full` trailer in PR commits and run all configurations when present
- **`tests/Tests/E2e/Base/BaseTrait.php`**: Add retry logic in `assertActiveTab()` to handle stale element exceptions during page transitions

## Test Plan

- [x] This PR includes the `Test-Mode: full` trailer to trigger all configurations
- [ ] Verify nginx configurations (nginx_82, nginx_83, nginx_85) pass E2E tests
- [ ] Verify the "Create Visit menu link" test case passes

## AI Disclosure

Yes