### PR TITLE
ci: add check for v_database alignment between version.php and database.sql

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,22 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels: []
+
+# Configuration variables in array of strings defined in your repository or
+# organization. `null` means disabling configuration variables check.
+# Empty array means no configuration variable is allowed.
+config-variables:
+
+# Configuration for file paths. The keys are glob patterns to match to file
+# paths relative to the repository root. The values are the configurations for
+# the file paths. Note that the path separator is always '/'.
+# The following configurations are available.
+#
+# "ignore" is an array of regular expression patterns. Matched error messages
+# are ignored. This is similar to the "-ignore" command line option.
+paths:
+  .github/workflows/database-version.yml:
+    # SC2016 warns about $ and backticks in single quotes not expanding.
+    # We intentionally use single quotes for literal markdown output.
+    ignore:
+    - SC2016

--- a/.github/workflows/database-version.yml
+++ b/.github/workflows/database-version.yml
@@ -1,0 +1,102 @@
+# Ensures v_database is aligned between version.php and sql/database.sql
+#
+# The v_database value must be:
+# 1. Declared in version.php as: $v_database = NNN;
+# 2. Declared in sql/database.sql header as: -- v_database: NNN
+# 3. Both values must match
+#
+# This prevents database migrations from being silently skipped on upgrades.
+name: Database Version Check
+
+on:
+  pull_request:
+    branches:
+    - master
+    - rel-*
+    paths:
+    - version.php
+    - sql/database.sql
+    - sql/patch.sql
+    - sql/*-to-*_upgrade.sql
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  check-v-database:
+    name: Check v_database alignment
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v6
+
+    - name: Setup PHP
+      uses: ./.github/actions/setup-php-composer
+      with:
+        php-version: '8.2'
+
+    - name: Check v_database alignment
+      run: |
+        # Extract v_database from version.php using AST parser
+        php_version=$(php bin/get-v-database.php version.php)
+
+        # Extract v_database from database.sql header comment
+        sql_version=$(awk '/^-- v_database:/ { print $3; exit }' sql/database.sql)
+
+        # Check if database.sql has the v_database comment
+        if [[ -z "$sql_version" ]]; then
+          {
+            echo '## ❌ Missing v_database in database.sql'
+            echo
+            echo 'The `sql/database.sql` file must declare the database version in its header:'
+            echo
+            echo '```sql'
+            echo '--'
+            echo '-- Database: `openemr`'
+            printf '%s\n' "-- v_database: $php_version"
+            echo '--'
+            echo '```'
+            echo
+            printf 'This should match the %s value in %s (currently %s).\n' '`$v_database`' '`version.php`' "$php_version"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        fi
+
+        # Check if versions match
+        if [[ "$php_version" != "$sql_version" ]]; then
+          {
+            echo '## ❌ v_database mismatch'
+            echo
+            echo 'The database version numbers do not match:'
+            echo
+            echo '| File | Value |'
+            echo '|------|-------|'
+            printf '| `version.php` | %s |\n' "$php_version"
+            printf '| `sql/database.sql` | %s |\n' "$sql_version"
+            echo
+            echo '### How to fix'
+            echo
+            echo 'Both files must have the same v_database value. Update whichever is incorrect:'
+            echo
+            echo '**version.php:**'
+            echo '```php'
+            printf '$v_database = %s;\n' "$php_version"
+            echo '```'
+            echo
+            echo '**sql/database.sql** (in header):'
+            echo '```sql'
+            printf '%s\n' "-- v_database: $php_version"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        fi
+
+        {
+          echo '## ✅ v_database is aligned'
+          echo
+          printf 'Both `version.php` and `sql/database.sql` declare v_database = %s\n' "$php_version"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/bin/get-v-database.php
+++ b/bin/get-v-database.php
@@ -1,0 +1,81 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Extract v_database value from version.php using AST parsing
+ *
+ * Outputs the integer value to stdout. Exits non-zero if not found.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\Node;
+use PhpParser\ParserFactory;
+
+$file = $argv[1] ?? __DIR__ . '/../version.php';
+
+if (!file_exists($file)) {
+    fwrite(STDERR, "File not found: $file\n");
+    exit(1);
+}
+
+$code = file_get_contents($file);
+if ($code === false) {
+    fwrite(STDERR, "Could not read file: $file\n");
+    exit(1);
+}
+
+$parser = (new ParserFactory())->createForNewestSupportedVersion();
+
+try {
+    $ast = $parser->parse($code);
+} catch (PhpParser\Error $e) {
+    fwrite(STDERR, "Parse error: {$e->getMessage()}\n");
+    exit(1);
+}
+
+if ($ast === null) {
+    fwrite(STDERR, "Parse returned null for: $file\n");
+    exit(1);
+}
+
+$visitor = new class extends NodeVisitorAbstract {
+    public ?int $vDatabase = null;
+
+    public function enterNode(Node $node): ?int
+    {
+        // Look for: $v_database = <number>;
+        if (
+            $node instanceof Node\Expr\Assign
+            && $node->var instanceof Node\Expr\Variable
+            && $node->var->name === 'v_database'
+            && $node->expr instanceof Node\Scalar\Int_
+        ) {
+            $this->vDatabase = $node->expr->value;
+            return NodeVisitor::STOP_TRAVERSAL;
+        }
+        return null;
+    }
+};
+
+$traverser = new NodeTraverser();
+$traverser->addVisitor($visitor);
+$traverser->traverse($ast);
+
+if ($visitor->vDatabase === null) {
+    fwrite(STDERR, "Could not find \$v_database assignment in $file\n");
+    exit(1);
+}
+
+echo $visitor->vDatabase . "\n";

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -1,6 +1,10 @@
 --
 -- Database: `openemr`
 --
+-- Keep v_database in sync with $v_database in version.php.
+-- CI will fail if they don't match.
+-- v_database: 533
+--
 
 --
 -- Table structure for table `addresses`

--- a/version.php
+++ b/version.php
@@ -28,6 +28,8 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
+// Keep in sync with the v_database comment in sql/database.sql.
+// CI will fail if they don't match.
 $v_database = 533;
 
 // Access control version identifier, this is to be incremented whenever there


### PR DESCRIPTION
## Summary

- Adds `bin/get-v-database.php` using nikic/php-parser for safe AST-based extraction
- Adds `-- v_database: NNN` comment to sql/database.sql header
- CI workflow verifies both files declare the same v_database value

## Test plan

- [ ] Verify workflow triggers on PRs modifying `version.php`, `sql/database.sql`, `sql/patch.sql`, or upgrade SQL files
- [ ] Verify it passes when v_database is aligned in both files
- [ ] Verify it fails with helpful message when values don't match

Fixes #10767

---

🤖 Generated with [Claude Code](https://claude.ai/code)