### PR TITLE
feat(db): Prepare central ADODB setup

### DIFF
--- a/src/BC/DatabaseConnectionFactory.php
+++ b/src/BC/DatabaseConnectionFactory.php
@@ -6,6 +6,10 @@ namespace OpenEMR\BC;
 
 use ADODB_mysqli_log;
 
+/**
+ * @deprecated New code should use existing DB tooling and not directly create
+ * new connections.
+ */
 class DatabaseConnectionFactory
 {
     public static function createAdodb(


### PR DESCRIPTION
Towards #10774

#### Short description of what this resolves:
Once integrated, this will eliminate a bunch of repeated database setup code. That will unlock moving the connection to DBAL in a _far_ more direct way.

#### Changes proposed in this pull request:
Adds a new DB factory method that does all of the ADODB setup that's repeated in several places.

#### Does your code include anything generated by an AI Engine? Yes / No
No