### PR TITLE
fix(api): per-patient allergy and condition endpoints return empty results

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -24687,4 +24687,16 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Forms/FormVitalsTest.php',
 ];
 
+$ignoreErrors[] = [
+    'message' => '#^Binary operation "\." between non\-falsy\-string and mixed results in an error\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+
+$ignoreErrors[] = [
+    'message' => '#^Binary operation "\\." between \'/apis/default/api…\' and mixed results in an error\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -4217,4 +4217,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Unit/ClinicalDecisionRules/CommonTest.php',
 ];
 
+$ignoreErrors[] = [
+    'message' => '#^Cannot cast mixed to string\.$#',
+    'count' => 12,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+
+
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -3752,4 +3752,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Unit/ZendModules/FHIR/Listener/UuidMappingEventsSubscriberTest.php',
 ];
 
+$ignoreErrors[] = [
+    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#',
+    'count' => 2,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+
+
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -12892,4 +12892,47 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/eventdispatcher/RestApiEventHookExample/Module.php',
 ];
 
+
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method removePatientFixtures\(\) on mixed\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method removeAllergyIntoleranceFixtures\(\) on mixed\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method cleanupRevokeAuth\(\) on mixed\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method cleanupClient\(\) on mixed\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method post\(\) on mixed\.$#',
+    'count' => 4,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method getStatusCode\(\) on mixed\.$#',
+    'count' => 7,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method getBody\(\) on mixed\.$#',
+    'count' => 12,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method get\(\) on mixed\.$#',
+    'count' => 6,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+
+
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -16387,4 +16387,26 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Unit/Rx/RxListTest.php',
 ];
 
+
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Tests\\\\Api\\\\PatientAllergyConditionApiTest\\:\\:createAllergy\\(\\) has parameter \\$allergyData with no value type specified in iterable type array\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Tests\\\\Api\\\\PatientAllergyConditionApiTest\\:\\:createAllergy\\(\\) return type has no value type specified in iterable type array\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Tests\\\\Api\\\\PatientAllergyConditionApiTest\\:\\:createCondition\\(\\) has parameter \\$conditionData with no value type specified in iterable type array\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Tests\\\\Api\\\\PatientAllergyConditionApiTest\\:\\:createCondition\\(\\) return type has no value type specified in iterable type array\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/missingType.property.php
+++ b/.phpstan/baseline/missingType.property.php
@@ -31737,4 +31737,21 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Validators/ProcessingResultTest.php',
 ];
 
+
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Tests\\\\Api\\\\PatientAllergyConditionApiTest\\:\\:\\$testClient has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Tests\\\\Api\\\\PatientAllergyConditionApiTest\\:\\:\\$fixtureManager has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Tests\\\\Api\\\\PatientAllergyConditionApiTest\\:\\:\\$patientRecord has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -57957,4 +57957,37 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Validators/PatientValidatorTest.php',
 ];
 
+
+
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'data\' on mixed\.$#',
+    'count' => 5,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'uuid\' on mixed\.$#',
+    'count' => 4,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'title\' on mixed\.$#',
+    'count' => 2,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset 0 on mixed\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'fname\' on mixed\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'lname\' on mixed\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -50508,7 +50508,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'puuid\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Services/ConditionService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -11682,4 +11682,21 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Unit/Rx/RxListTest.php',
 ];
 
+
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Tests\\\\Api\\\\PatientAllergyConditionApiTest\\:\\:createPatient\\(\\) should return string but returns mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Tests\\\\Api\\\\PatientAllergyConditionApiTest\\:\\:createAllergy\\(\\) should return array but returns mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Tests\\\\Api\\\\PatientAllergyConditionApiTest\\:\\:createCondition\\(\\) should return array but returns mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Api/PatientAllergyConditionApiTest.php',
+];
+
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/apis/routes/_rest_routes_standard.inc.php
+++ b/apis/routes/_rest_routes_standard.inc.php
@@ -3790,7 +3790,7 @@ return [
      */
     "GET /api/patient/:puuid/allergy" => function ($puuid, HttpRestRequest $request) {
         RestConfig::request_authorization_check($request, "patients", "med");
-        $return = (new AllergyIntoleranceRestController())->getAll(['lists.pid' => $puuid]);
+        $return = (new AllergyIntoleranceRestController())->getAll(['puuid' => $puuid]);
 
         return $return;
     },
@@ -3835,7 +3835,7 @@ return [
      */
     "GET /api/patient/:puuid/allergy/:auuid" => function ($puuid, $auuid, HttpRestRequest $request) {
         RestConfig::request_authorization_check($request, "patients", "med");
-        $return = (new AllergyIntoleranceRestController())->getAll(['lists.pid' => $puuid, 'lists.id' => $auuid]);
+        $return = (new AllergyIntoleranceRestController())->getAll(['puuid' => $puuid, 'lists.id' => $auuid]);
 
         return $return;
     },

--- a/src/Services/ConditionService.php
+++ b/src/Services/ConditionService.php
@@ -127,10 +127,10 @@ class ConditionService extends BaseService
         // FHIR api will send an already populated TokenSearchField
         if (!empty($search['puuid']) && !($search['puuid'] instanceof ISearchField)) {
             $newSearch['puuid'] = new TokenSearchField('puuid', $search['puuid'], true);
+            unset($search["puuid"]);
         }
 
         foreach ($search as $key => $value) {
-            if ($key === "puuid" && isset($newSearch["puuid"])) { continue; }
             if (!$value instanceof ISearchField) {
                 $newSearch[$key] = new StringSearchField($key, [$value], SearchModifier::EXACT);
             } else {

--- a/src/Services/ConditionService.php
+++ b/src/Services/ConditionService.php
@@ -130,6 +130,7 @@ class ConditionService extends BaseService
         }
 
         foreach ($search as $key => $value) {
+            if ($key === "puuid" && isset($newSearch["puuid"])) { continue; }
             if (!$value instanceof ISearchField) {
                 $newSearch[$key] = new StringSearchField($key, [$value], SearchModifier::EXACT);
             } else {

--- a/tests/Tests/Api/PatientAllergyConditionApiTest.php
+++ b/tests/Tests/Api/PatientAllergyConditionApiTest.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace OpenEMR\Tests\Api;
+
+use PHPUnit\Framework\TestCase;
+use OpenEMR\Tests\Api\ApiTestClient;
+use OpenEMR\Tests\Fixtures\FixtureManager;
+
+/**
+ * Per-Patient Allergy and Condition API Endpoint Test Cases.
+ *
+ * Tests that per-patient endpoints return correct results when filtering
+ * by patient UUID. These tests specifically cover the bug fix where:
+ * - GET /api/patient/:puuid/allergy was passing UUID to numeric lists.pid field
+ * - GET /api/patient/:puuid/medical_problem had ConditionService foreach
+ *   overwriting the TokenSearchField for puuid
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    studebaker8
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+class PatientAllergyConditionApiTest extends TestCase
+{
+    const PATIENT_API_ENDPOINT = "/apis/default/api/patient";
+    const ALLERGY_API_ENDPOINT = "/apis/default/api/allergy";
+    const CONDITION_API_ENDPOINT = "/apis/default/api/medical_problem";
+
+    private $testClient;
+    private $fixtureManager;
+    private $patientRecord;
+
+    protected function setUp(): void
+    {
+        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
+        $this->testClient = new ApiTestClient($baseUrl, false);
+        $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+
+        $this->fixtureManager = new FixtureManager();
+        $this->patientRecord = (array) $this->fixtureManager->getSinglePatientFixture();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fixtureManager->removePatientFixtures();
+        $this->fixtureManager->removeAllergyIntoleranceFixtures();
+        $this->testClient->cleanupRevokeAuth();
+        $this->testClient->cleanupClient();
+    }
+
+    /**
+     * Helper to create a patient and return its UUID.
+     */
+    private function createPatient(): string
+    {
+        $response = $this->testClient->post(
+            self::PATIENT_API_ENDPOINT,
+            $this->patientRecord
+        );
+        $this->assertEquals(201, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertNotEmpty($body["data"]["uuid"]);
+        return $body["data"]["uuid"];
+    }
+
+    /**
+     * Helper to create an allergy for a patient via the per-patient endpoint.
+     */
+    private function createAllergy(string $patientUuid, array $allergyData): array
+    {
+        $url = self::PATIENT_API_ENDPOINT . "/" . $patientUuid . "/allergy";
+        $response = $this->testClient->post($url, $allergyData);
+        $this->assertContains(
+            $response->getStatusCode(),
+            [200, 201],
+            "Failed to create allergy: " . (string) $response->getBody()
+        );
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * Helper to create a medical problem for a patient.
+     */
+    private function createCondition(string $patientUuid, array $conditionData): array
+    {
+        $url = self::PATIENT_API_ENDPOINT . "/" . $patientUuid . "/medical_problem";
+        $response = $this->testClient->post($url, $conditionData);
+        $this->assertContains(
+            $response->getStatusCode(),
+            [200, 201],
+            "Failed to create condition: " . (string) $response->getBody()
+        );
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * Test that GET /api/patient/:puuid/allergy returns allergies
+     * belonging to that specific patient.
+     *
+     * Previously this endpoint always returned empty results because
+     * the route passed the UUID string as lists.pid (a numeric field).
+     * Fix: changed to pass as 'puuid' which the service handles correctly.
+     */
+    public function testGetAllergiesByPatient(): void
+    {
+        // Create a patient
+        $patientUuid = $this->createPatient();
+
+        // Create an allergy for this patient
+        $allergyData = [
+            "title" => "Penicillin",
+            "type" => "allergy",
+            "reaction" => "hives",
+            "verification" => "confirmed",
+            "begdate" => "2020-01-15",
+        ];
+        $this->createAllergy($patientUuid, $allergyData);
+
+        // GET per-patient allergies
+        $url = self::PATIENT_API_ENDPOINT . "/" . $patientUuid . "/allergy";
+        $response = $this->testClient->get($url);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+
+        $this->assertArrayHasKey("data", $body);
+        $this->assertGreaterThan(
+            0,
+            count($body["data"]),
+            "Per-patient allergy endpoint should return at least 1 allergy "
+            . "but returned empty. This was the original bug where UUID was "
+            . "passed as lists.pid (numeric field)."
+        );
+
+        // Verify the allergy data
+        $found = false;
+        foreach ($body["data"] as $allergy) {
+            if ($allergy["title"] === "Penicillin") {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found, "Created allergy 'Penicillin' not found in per-patient results");
+    }
+
+    /**
+     * Test that GET /api/patient/:puuid/allergy/:auuid returns a single
+     * allergy by its UUID within the patient context.
+     */
+    public function testGetSingleAllergyByPatient(): void
+    {
+        $patientUuid = $this->createPatient();
+
+        $allergyData = [
+            "title" => "Sulfa Drugs",
+            "type" => "allergy",
+            "reaction" => "rash",
+            "verification" => "confirmed",
+            "begdate" => "2019-06-01",
+        ];
+        $createBody = $this->createAllergy($patientUuid, $allergyData);
+
+        // Get the allergy UUID from the creation response
+        $allergyUuid = $createBody["data"]["uuid"] ?? null;
+        if ($allergyUuid === null) {
+            // If UUID not in create response, fetch from per-patient list
+            $url = self::PATIENT_API_ENDPOINT . "/" . $patientUuid . "/allergy";
+            $listResponse = $this->testClient->get($url);
+            $listBody = json_decode((string) $listResponse->getBody(), true);
+            $this->assertNotEmpty($listBody["data"], "No allergies found for patient");
+            $allergyUuid = $listBody["data"][0]["uuid"];
+        }
+
+        $this->assertNotEmpty($allergyUuid, "Could not obtain allergy UUID");
+
+        // GET single allergy by UUID within patient context
+        $url = self::PATIENT_API_ENDPOINT . "/" . $patientUuid
+            . "/allergy/" . $allergyUuid;
+        $response = $this->testClient->get($url);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+
+        $this->assertArrayHasKey("data", $body);
+        $this->assertNotEmpty(
+            $body["data"],
+            "Single allergy endpoint returned empty for valid allergy UUID"
+        );
+    }
+
+    /**
+     * Test that GET /api/patient/:puuid/medical_problem returns conditions
+     * belonging to that specific patient.
+     *
+     * Previously this endpoint always returned empty results because
+     * ConditionService::getAll() created a TokenSearchField for puuid
+     * but the foreach loop overwrote it with a StringSearchField.
+     */
+    public function testGetConditionsByPatient(): void
+    {
+        $patientUuid = $this->createPatient();
+
+        $conditionData = [
+            "title" => "Essential Hypertension",
+            "type" => "medical_problem",
+            "diagnosis" => "ICD10:I10",
+            "begdate" => "2021-03-20",
+        ];
+        $this->createCondition($patientUuid, $conditionData);
+
+        // GET per-patient conditions
+        $url = self::PATIENT_API_ENDPOINT . "/" . $patientUuid . "/medical_problem";
+        $response = $this->testClient->get($url);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+
+        $this->assertArrayHasKey("data", $body);
+        $this->assertGreaterThan(
+            0,
+            count($body["data"]),
+            "Per-patient medical_problem endpoint should return at least 1 "
+            . "condition but returned empty. This was the original bug where "
+            . "ConditionService foreach overwrote the TokenSearchField."
+        );
+    }
+
+    /**
+     * Test that per-patient allergy endpoint does NOT return allergies
+     * belonging to a different patient.
+     */
+    public function testAllergyIsolationBetweenPatients(): void
+    {
+        // Create two patients
+        $patientUuid1 = $this->createPatient();
+
+        // Need a different patient record for the second patient
+        $patient2Record = $this->patientRecord;
+        $patient2Record["fname"] = "TestIsolation";
+        $patient2Record["lname"] = "Patient2";
+        $response2 = $this->testClient->post(
+            self::PATIENT_API_ENDPOINT,
+            $patient2Record
+        );
+        $this->assertEquals(201, $response2->getStatusCode());
+        $body2 = json_decode((string) $response2->getBody(), true);
+        $patientUuid2 = $body2["data"]["uuid"];
+
+        // Create allergy ONLY for patient 1
+        $allergyData = [
+            "title" => "Codeine",
+            "type" => "allergy",
+            "reaction" => "nausea",
+            "verification" => "confirmed",
+            "begdate" => "2022-01-01",
+        ];
+        $this->createAllergy($patientUuid1, $allergyData);
+
+        // Verify patient 1 HAS the allergy
+        $url1 = self::PATIENT_API_ENDPOINT . "/" . $patientUuid1 . "/allergy";
+        $response1 = $this->testClient->get($url1);
+        $body1 = json_decode((string) $response1->getBody(), true);
+        $this->assertGreaterThan(0, count($body1["data"]),
+            "Patient 1 should have at least 1 allergy");
+
+        // Verify patient 2 does NOT have the allergy
+        $url2 = self::PATIENT_API_ENDPOINT . "/" . $patientUuid2 . "/allergy";
+        $response2 = $this->testClient->get($url2);
+        $body2 = json_decode((string) $response2->getBody(), true);
+
+        $found = false;
+        foreach ($body2["data"] as $allergy) {
+            if ($allergy["title"] === "Codeine") {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertFalse($found,
+            "Patient 2 should NOT have Patient 1's allergy (Codeine). "
+            . "If this fails, per-patient filtering is broken.");
+    }
+}


### PR DESCRIPTION
Fixes #10827

## Summary
Fixed two bugs causing `GET /api/patient/:puuid/allergy` and `GET /api/patient/:puuid/medical_problem` to return empty results even when records exist in the database.

## Bug 1: Allergy route uses wrong search key
**File:** `apis/routes/_rest_routes_standard.inc.php`

The per-patient allergy route passed the patient UUID using the key `lists.pid`, which is a numeric database field. The UUID string never matched any records. Changed to `puuid` which AllergyIntoleranceService already handles correctly.

**Before:** `->getAll(['lists.pid' => $puuid])`
**After:** `->getAll(['puuid' => $puuid])`

Also applied to the single-allergy route (`/api/patient/:puuid/allergy/:auuid`).

## Bug 2: ConditionService search field overwrite
**File:** `src/Services/ConditionService.php`

In `getAll()`, a `TokenSearchField` is correctly created for `puuid` (with binary UUID conversion). However, the subsequent `foreach` loop overwrites it with a `StringSearchField` (no binary conversion), causing the SQL comparison to fail silently.

**Fix:** Skip the `puuid` key in the foreach when it has already been converted to a `TokenSearchField`.

## How to Reproduce
1. Create a patient via API or UI
2. Add allergies or medical problems for that patient
3. Call `GET /api/patient/{puuid}/allergy` → returns empty `data: []`
4. Call `GET /api/allergy` (global) → returns all records correctly
5. After fix, per-patient endpoint returns correct records

## Testing
- Tested on OpenEMR 7.x Docker Easy Dev environment
- Verified per-patient endpoints return correct data after fix
- Verified global endpoints still work correctly