### PR TITLE
fix(eye-mag): correct Schirmer field name typos in copy_forward ANTSEG zone

### DIFF
--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -7103,22 +7103,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'ODSCHIRMER1\' on array\\|false\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'ODSCHIRMER2\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODSHIRMER1\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODSHIRMER2\' on array\\|false\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -7308,22 +7298,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'OSSCHIRMER1\' on array\\|false\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'OSSCHIRMER2\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSSHIRMER1\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSSHIRMER2\' on array\\|false\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -410,12 +410,12 @@ function display_PRIOR_section($zone, $orig_id, $id_to_show, $pid, $report = '0'
                 <tr>
                     <td class="right" title="<?php echo xla('Schirmers I (w/o anesthesia)'); ?>"><?php echo xlt('Schirmer I'); ?></td>
                     <td><input disabled type="text" name="PRIOR_ODSCHIRMER1" id="PRIOR_ODSCHIRMER1" value="<?php echo attr($ODSCHIRMER1); ?>"></td>
-                    <td><input disabled type="text" name="PRIOR_OSSCHRIMER2" id="PRIOR_OSSCHIRMER1" value="<?php echo attr($OSSCHIRMER1); ?>"></td>
+                    <td><input disabled type="text" name="PRIOR_OSSCHIRMER1" id="PRIOR_OSSCHIRMER1" value="<?php echo attr($OSSCHIRMER1); ?>"></td>
                 </tr>
                 <tr>
                     <td class="right" title="<?php echo xla('Schirmers II (w/ anesthesia)'); ?>"><?php echo xlt('Schirmer II'); ?></td>
                     <td><input disabled type="text" name="PRIOR_ODSCHIRMER2" id="PRIOR_ODSCHIRMER2" value="<?php echo attr($ODSCHIRMER2); ?>"></td>
-                    <td><input disabled type="text" name="PRIOR_OSSCHRIMER2" id="PRIOR_OSSCHIRMER2" value="<?php echo attr($OSSCHIRMER2); ?>"></td>
+                    <td><input disabled type="text" name="PRIOR_OSSCHIRMER2" id="PRIOR_OSSCHIRMER2" value="<?php echo attr($OSSCHIRMER2); ?>"></td>
                 </tr>
                 <tr>
                     <td class="right" title="<?php echo xla('Tear Break Up Time'); ?>"><?php echo xlt('TBUT{{tear breakup time}}'); ?></td>
@@ -3363,10 +3363,10 @@ function copy_forward($zone, $copy_from, $copy_to, $pid): void
         $result['OSKTHICKNESS'] = $objQuery['OSKTHICKNESS'];
         $result['ODGONIO'] = $objQuery['ODGONIO'];
         $result['OSGONIO'] = $objQuery['OSGONIO'];
-        $result['ODSHRIMER1'] = $objQuery['ODSHIRMER1'];
-        $result['OSSHRIMER1'] = $objQuery['OSSHIRMER1'];
-        $result['ODSHRIMER2'] = $objQuery['ODSHIRMER2'];
-        $result['OSSHRIMER2'] = $objQuery['OSSHIRMER2'];
+        $result['ODSCHIRMER1'] = $objQuery['ODSCHIRMER1'];
+        $result['OSSCHIRMER1'] = $objQuery['OSSCHIRMER1'];
+        $result['ODSCHIRMER2'] = $objQuery['ODSCHIRMER2'];
+        $result['OSSCHIRMER2'] = $objQuery['OSSCHIRMER2'];
         $result['ODTBUT'] = $objQuery['ODTBUT'];
         $result['OSTBUT'] = $objQuery['OSTBUT'];
         $result['ANTSEG_COMMENTS'] = $objQuery['ANTSEG_COMMENTS'];


### PR DESCRIPTION
Fixes #10066

#### Short description of what this resolves:

The ANTSEG zone `copy_forward()` function used misspelled Schirmer field names, causing Schirmer test data to silently fail when copying forward between visits. Also fixes typos in the prior visit display input names.

#### Changes proposed in this pull request:

**`interface/forms/eye_mag/php/eye_mag_functions.php`:**

1. **Lines 3366-3369 (copy_forward ANTSEG zone):** Fixed misspelled field names:
   - `ODSHRIMER1`/`ODSHIRMER1` → `ODSCHIRMER1` (missing 'C', swapped letters)
   - `OSSHRIMER1`/`OSSHIRMER1` → `OSSCHIRMER1`
   - `ODSHRIMER2`/`ODSHIRMER2` → `ODSCHIRMER2`
   - `OSSHRIMER2`/`OSSHIRMER2` → `OSSCHIRMER2`

2. **Line 413 (prior visit display):** Fixed `name="PRIOR_OSSCHRIMER2"` → `name="PRIOR_OSSCHIRMER1"` (corrected spelling and number to match Schirmer I row)

3. **Line 418 (prior visit display):** Fixed `name="PRIOR_OSSCHRIMER2"` → `name="PRIOR_OSSCHIRMER2"` (corrected spelling)

**`.phpstan/baseline/offsetAccess.nonOffsetAccessible.php`:**
- Removed baseline entries for misspelled `ODSHIRMER`/`OSSHIRMER` offsets
- Updated `ODSCHIRMER`/`OSSCHIRMER` counts from 1 to 2 (now used in both EXT and ANTSEG zones)

These field names now match the `form_eye_antseg` database column names (`ODSCHIRMER1`, `OSSCHIRMER1`, `ODSCHIRMER2`, `OSSCHIRMER2`).

#### Does your code include anything generated by an AI Engine? Yes

#### This PR was authored with assistance from Claude (Anthropic). All changes are minimal typo corrections to align code with existing database column names.