### PR TITLE
fix(api): use isPortalRequest() for portal route detection in RoutesExtensionListener

### DIFF
--- a/src/RestControllers/Subscriber/RoutesExtensionListener.php
+++ b/src/RestControllers/Subscriber/RoutesExtensionListener.php
@@ -56,7 +56,7 @@ class RoutesExtensionListener implements EventSubscriberInterface
                 (new SearchRequestNormalizer($this->getSystemLogger()))->normalizeSearchRequest($request);
             }
             $response = $this->processFhirRequest($request, $kernel);
-        } else if ($request->isPatientRequest()) {
+        } else if ($request->isPortalRequest()) {
             $response = $this->processPatientPortalRequest($request, $kernel);
         } else {
             $response = $this->processStandardRequest($request, $kernel);


### PR DESCRIPTION
Fixes #10829

## Summary

`RoutesExtensionListener::onKernelRequest()` uses `$request->isPatientRequest()` (line 59) to determine if a request should be handled as a patient portal request. However, `isPatientRequest()` checks the `patientRequest` boolean flag which is:

1. Initialized to `false` in `HttpRestRequest::createFromGlobals()` (line 151)
2. Only set to `true` later in the lifecycle by `HttpRestRouteHandler` (line 67) during scope context resolution

Since `RoutesExtensionListener` runs **before** `HttpRestRouteHandler`, `isPatientRequest()` always returns `false` at this point, so portal routes (`/portal/*`) are never matched by the listener.

## Fix

Replace `isPatientRequest()` with `isPortalRequest()`, which checks the URL path for `/portal/` and is available immediately.

## Test plan

- [ ] Verify portal API routes (`GET /portal/patient`, `GET /portal/patient/encounter`, etc.) are correctly routed
- [ ] Verify standard API routes (`/api/*`) still work
- [ ] Verify FHIR routes (`/fhir/*`) still work