### PR TITLE
refactor(dates): migrate oeFormatDateTime to DateFormatterUtils and add tests

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -16742,11 +16742,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/js/xl/jquery-datetimepicker-2-5-4.js.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../library/js/xl/jquery-datetimepicker-2-5-4.js.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \', \' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/js/xl/select2.js.php',
@@ -21057,17 +21052,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/System/System.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Twig/TwigContainer.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'/templates\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Twig/TwigContainer.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Twig/TwigContainer.php',
 ];
@@ -23970,11 +23955,6 @@ $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \\= \\?\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/UserService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \' \' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -3968,7 +3968,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 13,
+    'count' => 8,
     'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/echo.nonString.php
+++ b/.phpstan/baseline/echo.nonString.php
@@ -1548,7 +1548,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../library/js/xl/jquery-datetimepicker-2-5-4.js.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -5308,11 +5308,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 33,
     'path' => __DIR__ . '/../../src/Services/Utils/SQLUpgradeService.php',
 ];

--- a/.phpstan/baseline/function.deprecated.php
+++ b/.phpstan/baseline/function.deprecated.php
@@ -8,12 +8,6 @@ Use FormService\\:\\:addForm\\(\\) instead$#',
     'path' => __DIR__ . '/../../controllers/C_Document.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../custom/chart_tracker.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to deprecated function collect_codetypes\\(\\)\\:
 use CodeTypesService\\:\\:collectCodeTypes\\(\\)$#',
     'count' => 2,
@@ -75,12 +69,6 @@ $ignoreErrors[] = [
 Use DrugSalesService\\:\\:sellDrug instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/drugs/dispense_drug.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/easipro/pro.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to deprecated function addForm\\(\\)\\:
@@ -335,46 +323,16 @@ Use FormService\\:\\:addForm\\(\\) instead$#',
     'path' => __DIR__ . '/../../interface/forms/treatment_plan/save.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/logview/logview.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/main/dated_reminders/dated_reminders_log.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to deprecated function prevSetting\\(\\)\\:
 7\\.0\\.3 see UserSettingsService\\:\\:prevSetting$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/finder/dynamic_finder.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/messages/messages.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to deprecated function prevSetting\\(\\)\\:
 7\\.0\\.3 see UserSettingsService\\:\\:prevSetting$#',
     'count' => 4,
     'path' => __DIR__ . '/../../interface/main/messages/messages.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/main/onotes/office_comments.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/onotes/office_comments_full.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to deprecated function addForm\\(\\)\\:
@@ -485,34 +443,10 @@ Use EmployerService\\-\\>updateEmployerData\\(\\) instead\\.$#',
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics_save.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/summary/pnotes_fragment.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/summary/pnotes_full.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to deprecated function getUserSetting\\(\\)\\:
 7\\.0\\.3 see UserSettingsService\\:\\:getUserSetting$#',
     'count' => 5,
     'path' => __DIR__ . '/../../interface/patient_file/summary/stats.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/patient_file/summary/stats_full.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/transaction/transactions.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to deprecated function oeFormatTime\\(\\)\\:
@@ -527,64 +461,16 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_tracker/patient_tracker.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/reports/amc_tracking.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to deprecated function oeFormatTime\\(\\)\\:
 use DateFormatterUtils\\:\\:oeFormatTime\\(\\)$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/appointments_report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/reports/audit_log_tamper_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/reports/background_services.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/chart_location_activity.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/charts_checked_out.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to deprecated function collect_codetypes\\(\\)\\:
 use CodeTypesService\\:\\:collectCodeTypes\\(\\)$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/reports/clinical_reports.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 6,
-    'path' => __DIR__ . '/../../interface/reports/clinical_reports.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/reports/cqm.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/direct_message_log.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to deprecated function getFormByEncounter\\(\\)\\:
@@ -593,40 +479,16 @@ Use FormService\\:\\:getFormByEncounter\\(\\) instead$#',
     'path' => __DIR__ . '/../../interface/reports/encounters_report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/reports/ip_tracker.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to deprecated function oeFormatTime\\(\\)\\:
 use DateFormatterUtils\\:\\:oeFormatTime\\(\\)$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/reports/patient_flow_board_report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 5,
-    'path' => __DIR__ . '/../../interface/reports/patient_list_creation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 5,
-    'path' => __DIR__ . '/../../interface/reports/payment_processing_report.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to deprecated function collect_codetypes\\(\\)\\:
 use CodeTypesService\\:\\:collectCodeTypes\\(\\)$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/receipts_by_method_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/reports/report_results.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to deprecated function removeUserSetting\\(\\)\\:
@@ -663,12 +525,6 @@ $ignoreErrors[] = [
 7\\.0\\.3 see UserSettingsService\\:\\:getUserIDInfo$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/usergroup/user_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/usergroup/usergroup_admin.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to deprecated function addForm\\(\\)\\:
@@ -742,18 +598,6 @@ use LayoutsUtils\\:\\:isOption$#',
     'path' => __DIR__ . '/../../library/options.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../library/options.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/patient.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to deprecated function addForm\\(\\)\\:
 Use FormService\\:\\:addForm\\(\\) instead$#',
     'count' => 1,
@@ -793,12 +637,6 @@ use EmployerService\\-\\>getMostRecentEmployerData\\(\\)$#',
     'path' => __DIR__ . '/../../portal/report/portal_custom_report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/Controller/ControllerLog.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to deprecated function checkUserSetting\\(\\)\\:
 7\\.0\\.3 see UserSettingsService\\:\\:checkUserSetting$#',
     'count' => 1,
@@ -808,18 +646,6 @@ $ignoreErrors[] = [
     'message' => '#^Call to deprecated function get_db\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Twig/TwigExtension.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Easipro/Easipro.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to deprecated function getUserSetting\\(\\)\\:
@@ -898,12 +724,6 @@ $ignoreErrors[] = [
 Use FormService\\:\\:addForm\\(\\) instead$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/VitalsService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function oeFormatDateTime\\(\\)\\:
-use DateFormatterUtils\\:\\:oeFormatDateTime\\(\\)$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../templates/super/rules/controllers/log/view.php',
 ];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -25237,21 +25237,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/formatting.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function oeFormatDateTime\\(\\) has parameter \\$datetime with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/formatting.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function oeFormatDateTime\\(\\) has parameter \\$formatTime with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/formatting.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function oeFormatDateTime\\(\\) has parameter \\$seconds with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/formatting.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function oeFormatMoney\\(\\) has parameter \\$amount with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/formatting.inc.php',
@@ -25277,17 +25262,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/formatting.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function oeFormatShortDate\\(\\) has parameter \\$showYear with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/formatting.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function oeFormatTime\\(\\) has parameter \\$format with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/formatting.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function oeFormatTime\\(\\) has parameter \\$seconds with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/formatting.inc.php',
 ];
@@ -48610,61 +48585,6 @@ $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\UserService\\:\\:toggleSensitiveFields\\(\\) has parameter \\$fields with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/UserService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:DateToYYYYMMDD\\(\\) has parameter \\$DateValue with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:getShortDateFormat\\(\\) has parameter \\$showYear with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:getTimeFormat\\(\\) has parameter \\$seconds with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:oeFormatDateTime\\(\\) has parameter \\$datetime with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:oeFormatDateTime\\(\\) has parameter \\$formatTime with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:oeFormatDateTime\\(\\) has parameter \\$seconds with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:oeFormatShortDate\\(\\) has parameter \\$date with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:oeFormatShortDate\\(\\) has parameter \\$showYear with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:oeFormatTime\\(\\) has parameter \\$format with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:oeFormatTime\\(\\) has parameter \\$seconds with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:oeFormatTime\\(\\) has parameter \\$time with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\SQLUpgradeService\\:\\:echo\\(\\) has parameter \\$msg with no type specified\\.$#',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -30927,21 +30927,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:getShortDateFormat\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:getTimeFormat\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:isNotEmptyDateTimeString\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\Utils\\\\DateFormatterUtils\\:\\:oeFormatShortDate\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',

--- a/.phpstan/baseline/nullCoalesce.variable.php
+++ b/.phpstan/baseline/nullCoalesce.variable.php
@@ -761,10 +761,5 @@ $ignoreErrors[] = [
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/UserService.php',
 ];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$DateValue on left side of \\?\\? always exists and is not nullable\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/openemr.forbiddenGlobalsAccess.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalsAccess.php
@@ -3363,11 +3363,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$GLOBALS is forbidden\\. Use OEGlobalsBag\\:\\:getInstance\\(\\)\\-\\>get\\(\\) instead\\.$#',
-    'count' => 19,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$GLOBALS is forbidden\\. Use OEGlobalsBag\\:\\:getInstance\\(\\)\\-\\>get\\(\\) instead\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../src/Services/Utils/SQLUpgradeService.php',
 ];

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -17612,11 +17612,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/QuestionnaireService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$newDate might not be defined\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/Utils/DateFormatterUtils.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$records might not be defined\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/Utils/SQLUpgradeService.php',

--- a/custom/chart_tracker.php
+++ b/custom/chart_tracker.php
@@ -23,6 +23,7 @@ require_once("$srcdir/options.inc.php");
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 use OpenEMR\Services\UserService;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 $form_newid   = isset($_POST['form_newid'  ]) ? trim((string) $_POST['form_newid'  ]) : '';
 $form_curpid  = isset($_POST['form_curpid' ]) ? trim((string) $_POST['form_curpid' ]) : '';
@@ -119,7 +120,7 @@ if (!empty($row)) {
         if ($user === false) {
             throw new \RuntimeException("User not found for ct_userid: " . json_encode($ct_userid));
         }
-        $current_location = text($user['lname'] . ", " . $user['fname'] . " " . $user['mname'] . " " . oeFormatDateTime($row['ct_when'], "global", true));
+        $current_location = text($user['lname'] . ", " . $user['fname'] . " " . $user['mname'] . " " . DateFormatterUtils::oeFormatDateTime($row['ct_when'], "global", true));
     } elseif ($ct_location) {
         $current_location = generate_display_field(['data_type' => '1','list_id' => 'chartloc'], $ct_location);
     }

--- a/interface/easipro/pro.php
+++ b/interface/easipro/pro.php
@@ -21,6 +21,7 @@ use OpenEMR\Core\Header;
 use OpenEMR\Easipro\Easipro;
 use OpenEMR\Menu\PatientMenuRole;
 use OpenEMR\OeUI\OemrUI;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 ?>
 <!DOCTYPE html>
@@ -310,7 +311,7 @@ use OpenEMR\OeUI\OemrUI;
                     <?php foreach ($records1 as $value1) { ?>
                         <tr>
                             <td><?php echo text($value1['form_name']); ?></td>
-                            <td><?php echo text(oeFormatDateTime($value1['deadline'])); ?></td>
+                            <td><?php echo text(DateFormatterUtils::oeFormatDateTime($value1['deadline'])); ?></td>
                             <td><?php echo text($value1['status']); ?></td>
                             <td><?php echo text(substr((string) $value1['score'], 0, 4)); ?></td>
                         </tr>

--- a/interface/logview/logview.php
+++ b/interface/logview/logview.php
@@ -20,6 +20,7 @@ use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Core\Header;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (!AclMain::aclCheckCore('admin', 'users')) {
     AccessDeniedHelper::denyWithTemplate("ACL check failed for admin/users: Logs Viewer", xl("Logs Viewer"));
@@ -136,11 +137,11 @@ if (!empty($_GET)) {
                                 <div class="form-row">
                                     <label class="col-sm-1 col-form-label" for="start_date"><?php echo xlt('Start Date'); ?>:</label>
                                     <div class="col-sm-3">
-                                        <input class="datetimepicker form-control" type="text" size="18" name="start_date" id="start_date" value="<?php echo attr(oeFormatDateTime($start_date, 0)); ?>" title="<?php echo xla('Start Date'); ?>" />
+                                        <input class="datetimepicker form-control" type="text" size="18" name="start_date" id="start_date" value="<?php echo attr(DateFormatterUtils::oeFormatDateTime($start_date, 0)); ?>" title="<?php echo xla('Start Date'); ?>" />
                                     </div>
                                     <label class="col-sm-1 col-form-label" for="end_date"><?php echo xlt('End Date'); ?>:</label>
                                     <div class="col-sm-3">
-                                        <input class="datetimepicker form-control" type="text" size="18" name="end_date" id="end_date" value="<?php echo attr(oeFormatDateTime($end_date, 0)); ?>" title="<?php echo xla('End Date'); ?>" />
+                                        <input class="datetimepicker form-control" type="text" size="18" name="end_date" id="end_date" value="<?php echo attr(DateFormatterUtils::oeFormatDateTime($end_date, 0)); ?>" title="<?php echo xla('End Date'); ?>" />
                                     </div>
                                     <label class="col-sm-1 col-form-label" for="end_date"><?php echo xlt('Patient'); ?>:</label>
                                     <div class="col-sm-3">
@@ -367,7 +368,7 @@ if (!empty($_GET)) {
                                                 }
                                                 ?>
                                                 <tr>
-                                                    <td><?php echo text(oeFormatDateTime($iter["date"], 'global', true)); ?></td>
+                                                    <td><?php echo text(DateFormatterUtils::oeFormatDateTime($iter["date"], 'global', true)); ?></td>
                                                     <td><?php echo text(preg_replace('/select$/', 'Query', (string) $iter["event"])); //Convert select term to Query for MU2 requirements ?></td>
                                                     <td><?php echo text($iter["category"]); ?></td>
                                                     <td><?php echo text($iter["user"]); ?></td>
@@ -399,7 +400,7 @@ if (!empty($_GET)) {
                                                     $comments = xl('Recipient Name') . ":" . $iter["recipient"] . ";" . xl('Disclosure Info') . ":" . $iter["description"];
                                                     ?>
                                                     <tr>
-                                                        <td><?php echo text(oeFormatDateTime($iter["date"], 'global', true)); ?></td>
+                                                        <td><?php echo text(DateFormatterUtils::oeFormatDateTime($iter["date"], 'global', true)); ?></td>
                                                         <td><?php echo xlt($iter["event"]); ?></td>
                                                         <td><?php echo xlt($iter["category"] ?? ''); ?></td>
                                                         <td><?php echo text($iter["user"]); ?></td>

--- a/interface/main/dated_reminders/dated_reminders_log.php
+++ b/interface/main/dated_reminders/dated_reminders_log.php
@@ -17,6 +17,7 @@
     use OpenEMR\Common\Acl\AclMain;
     use OpenEMR\Common\Csrf\CsrfUtils;
     use OpenEMR\Core\Header;
+    use OpenEMR\Services\Utils\DateFormatterUtils;
 
     $isAdmin = AclMain::aclCheckCore('admin', 'users');
 ?>
@@ -80,13 +81,13 @@ if ($_GET) {
         foreach ($remindersArray as $RA) {
             echo '<tr>
                     <td>' . text($RA['messageID']) . '</td>
-                    <td>' . text(oeFormatDateTime($RA['sDate'])) . '</td>
+                    <td>' . text(DateFormatterUtils::oeFormatDateTime($RA['sDate'])) . '</td>
                     <td>' . text($RA['fromName']) . '</td>
                     <td>' . text($RA['ToName']) . '</td>
                     <td>' . text($RA['PatientName']) . '</td>
                     <td>' . text($RA['message']) . '</td>
                     <td>' . text(oeFormatShortDate($RA['dDate'])) . '</td>
-                    <td>' . text(oeFormatDateTime($RA['pDate'])) . '</td>
+                    <td>' . text(DateFormatterUtils::oeFormatDateTime($RA['pDate'])) . '</td>
                     <td>' . text($RA['processedByName']) . '</td>
                 </tr>';
         }

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -31,6 +31,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Core\Header;
 use OpenEMR\OeUI\OemrUI;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 //Gets validation rules from Page Validation list.
 $collectthis = collectValidationPageRules("/interface/main/messages/messages.php");
@@ -666,7 +667,7 @@ if (!empty($_REQUEST['go'])) { ?>
                                         <div>" .
                                             xlt($myrow['title']) . "</div>
                                     <td>
-                                        <div>" . text(oeFormatDateTime($myrow['date'])) . "</div>
+                                        <div>" . text(DateFormatterUtils::oeFormatDateTime($myrow['date'])) . "</div>
                                     </td>
                                     <td>
                                         <div>" . text(getListItemTitle('message_status', $myrow['message_status'])) . "</div>

--- a/interface/main/onotes/office_comments.php
+++ b/interface/main/onotes/office_comments.php
@@ -16,6 +16,7 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\Header;
 use OpenEMR\Services\ONoteService;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 // Control access
 if (!AclMain::aclCheckCore('encounters', 'notes')) {
@@ -62,9 +63,9 @@ $oNoteService = new ONoteService();
                     $date = (new DateTime($note['date']))->format('Y-m-d H:i:s');
                     $todaysDate = new DateTime();
                     if ($todaysDate->format('Y-m-d') == $date) {
-                        $date_string = xl("Today") . ", " . oeFormatDateTime($date);
+                        $date_string = xl("Today") . ", " . DateFormatterUtils::oeFormatDateTime($date);
                     } else {
-                        $date_string = oeFormatDateTime($date);
+                        $date_string = DateFormatterUtils::oeFormatDateTime($date);
                     }
                     $card = '';
                     $card .= '<div class="card panel-default">';

--- a/interface/main/onotes/office_comments_full.php
+++ b/interface/main/onotes/office_comments_full.php
@@ -19,6 +19,7 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 use OpenEMR\Services\ONoteService;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 // Control access
 if (!AclMain::aclCheckCore('encounters', 'notes')) {
@@ -160,7 +161,7 @@ function renderPaginationControls($currentPage, $totalPages, $active): string
                         </form>
                     </td>
                     <td class="text-left">
-                        <?php echo oeFormatDateTime((new DateTime($note['date']))->format('Y-m-d H:i:s')) . " (" . text($note['user']) . ")"; ?>
+                        <?php echo text(DateFormatterUtils::oeFormatDateTime((new DateTime($note['date']))->format('Y-m-d H:i:s'))) . " (" . text($note['user']) . ")"; ?>
                     </td>
                     <td class="text-left"><?php echo nl2br(text($note['body'])); ?></td>
                     <td class="text-center">

--- a/interface/patient_file/summary/pnotes_fragment.php
+++ b/interface/patient_file/summary/pnotes_fragment.php
@@ -19,6 +19,7 @@ require_once("$srcdir/options.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
     CsrfUtils::csrfNotVerified();
@@ -91,7 +92,7 @@ if (isset($_GET['docUpdateId'])) {
                 // Modified 6/2009 by BM to incorporate the patient notes into the list_options listings
                 echo "<td class='text'>" . text($iter['user']) . "</td>\n";
                 echo "<td class='text'>" . text($iter['assigned_to']) . "</td>\n";
-                echo "<td class='text'>" . text(oeFormatDateTime(date('Y-m-d H:i', strtotime((string) $iter['date'])))) . "</td>\n";
+                echo "<td class='text'>" . text(DateFormatterUtils::oeFormatDateTime(date('Y-m-d H:i', strtotime((string) $iter['date'])))) . "</td>\n";
                 echo "  <td class='text'><b>";
                 echo generate_display_field(['data_type' => '1','list_id' => 'note_type'], $iter['title']);
                 echo "</b></td>\n";

--- a/interface/patient_file/summary/pnotes_full.php
+++ b/interface/patient_file/summary/pnotes_full.php
@@ -23,6 +23,7 @@ use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Services\UserService;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 $session = SessionWrapperFactory::getInstance()->getWrapper();
 
@@ -519,7 +520,7 @@ function restoreSession() {
                                 echo getListItemTitle("message_status", $iter['message_status']);
                                 echo "  </td>\n";
                                 echo "  <td class='notecell'>";
-                                echo text(oeFormatDateTime($iter['update_date']));
+                                echo text(DateFormatterUtils::oeFormatDateTime($iter['update_date']));
                                 echo "  </td>\n";
                                 echo "  <td class='notecell'>";
                                 $updateBy = $userService->getUser($iter['update_by']);

--- a/interface/patient_file/summary/stats_full.php
+++ b/interface/patient_file/summary/stats_full.php
@@ -27,6 +27,7 @@ use OpenEMR\Core\Header;
 use OpenEMR\Menu\PatientMenuRole;
 use OpenEMR\OeUI\OemrUI;
 use OpenEMR\Services\ListService;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 // Check if user has permission for any issue type.
 $auth = false;
@@ -351,10 +352,10 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
 
                             $shortBegDate = trim(oeFormatShortDate($row['begdate']) ?? '');
                             $shortEndDate = trim(oeFormatShortDate($row['enddate']) ?? '');
-                            $fullBegDate = trim(oeFormatDateTime($row['begdate']) ?? '');
-                            $fullEndDate = trim(oeFormatDateTime($row['enddate']) ?? '');
+                            $fullBegDate = trim(DateFormatterUtils::oeFormatDateTime($row['begdate']) ?? '');
+                            $fullEndDate = trim(DateFormatterUtils::oeFormatDateTime($row['enddate']) ?? '');
                             $shortModDate = trim(oeFormatShortDate($row['modifydate']) ?? '');
-                            $fullModDate = trim(oeFormatDateTime($row['modifydate']) ?? '');
+                            $fullModDate = trim(DateFormatterUtils::oeFormatDateTime($row['modifydate']) ?? '');
 
                             $outcome = ($row['outcome']) ?  generate_display_field(['data_type' => 1, 'list_id' => 'outcome'], $row['outcome']) : false;
                             ?>

--- a/interface/patient_file/transaction/transactions.php
+++ b/interface/patient_file/transaction/transactions.php
@@ -19,6 +19,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 use OpenEMR\Menu\PatientMenuRole;
 use OpenEMR\OeUI\OemrUI;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 ?>
 <html>
@@ -110,7 +111,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                         //  (note this only contains a date without a time)
                                         $date = oeFormatShortDate($item['refer_date']);
                                     } else {
-                                        $date = oeFormatDateTime($item['date']);
+                                        $date = DateFormatterUtils::oeFormatDateTime($item['date']);
                                     }
 
                                     $id = $item['id'];

--- a/interface/reports/amc_tracking.php
+++ b/interface/reports/amc_tracking.php
@@ -19,6 +19,7 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (!AclMain::aclCheckCore('patients', 'med')) {
     AccessDeniedHelper::denyWithTemplate("ACL check failed for patients/med: AMC Tracking", xl("Automated Measure Calculations (AMC) Tracking"));
@@ -201,7 +202,7 @@ $provider  = trim($_POST['form_provider'] ?? '');
                         <?php echo xlt('Begin Date'); ?>:
                       </td>
                       <td>
-                         <input type='text' name='form_begin_date' id="form_begin_date" size='20' value='<?php echo attr(oeFormatDateTime($begin_date, "global", true)); ?>' class='datepicker form-control' />
+                         <input type='text' name='form_begin_date' id="form_begin_date" size='20' value='<?php echo attr(DateFormatterUtils::oeFormatDateTime($begin_date, "global", true)); ?>' class='datepicker form-control' />
                       </td>
                  </tr>
 
@@ -210,7 +211,7 @@ $provider  = trim($_POST['form_provider'] ?? '');
                             <?php echo xlt('End Date'); ?>:
                         </td>
                         <td>
-                           <input type='text' name='form_end_date' id="form_end_date" size='20' value='<?php echo attr(oeFormatDateTime($end_date, "global", true)); ?>' class='datepicker form-control' />
+                           <input type='text' name='form_end_date' id="form_end_date" size='20' value='<?php echo attr(DateFormatterUtils::oeFormatDateTime($end_date, "global", true)); ?>' class='datepicker form-control' />
                         </td>
                 </tr>
 
@@ -366,7 +367,7 @@ if (!empty($_POST['form_refresh'])) {
         echo "<tr bgcolor='" . attr($bgcolor ?? '') . "'>";
         echo "<td>" . text($result['lname'] . "," . $result['fname']) . "</td>";
         echo "<td>" . text($result['pid']) . "</td>";
-        echo "<td>" . text(oeFormatDateTime($result['date'], "global", true)) . "</td>";
+        echo "<td>" . text(DateFormatterUtils::oeFormatDateTime($result['date'], "global", true)) . "</td>";
         if ($rule == "send_sum_amc" || $rule == "provide_sum_pat_amc") {
             echo "<td>" . text($result['id']) . "</td>";
         } else { //$rule == "provide_rec_pat_amc"

--- a/interface/reports/audit_log_tamper_report.php
+++ b/interface/reports/audit_log_tamper_report.php
@@ -20,6 +20,7 @@ use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Core\Header;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 // Control access
 if (!AclMain::aclCheckCore('admin', 'super')) {
@@ -141,12 +142,12 @@ $sortby = $_GET['sortby'] ?? null;
 <tr><td>
 <span class="text"><?php echo xlt('Start Date'); ?>: </span>
 </td><td>
-<input type="text" size="18" class="datetimepicker" name="start_date" id="start_date" value="<?php echo attr(oeFormatDateTime($start_date, 'global', true)); ?>" title="<?php echo xla('Start date'); ?>" />
+<input type="text" size="18" class="datetimepicker" name="start_date" id="start_date" value="<?php echo attr(DateFormatterUtils::oeFormatDateTime($start_date, 'global', true)); ?>" title="<?php echo xla('Start date'); ?>" />
 </td>
 <td>
 <span class="text"><?php echo xlt('End Date'); ?>: </span>
 </td><td>
-<input type="text" size="18" class="datetimepicker" name="end_date" id="end_date" value="<?php echo attr(oeFormatDateTime($end_date, 'global', true)); ?>" title="<?php echo xla('End date'); ?>" />
+<input type="text" size="18" class="datetimepicker" name="end_date" id="end_date" value="<?php echo attr(DateFormatterUtils::oeFormatDateTime($end_date, 'global', true)); ?>" title="<?php echo xla('End date'); ?>" />
 </td>
 
 <td>
@@ -328,7 +329,7 @@ $check_sum = isset($_GET['check_sum']);
      <TR class="oneresult">
           <TD class="text tamperColor"><?php echo text($logType); ?></TD>
           <TD class="text tamperColor"><?php echo text($iter["id"]); ?></TD>
-          <TD class="text tamperColor"><?php echo text(oeFormatDateTime($iter["date"], "global", true)); ?></TD>
+          <TD class="text tamperColor"><?php echo text(DateFormatterUtils::oeFormatDateTime($iter["date"], "global", true)); ?></TD>
           <TD class="text tamperColor"><?php echo text($iter["user"]); ?></TD>
           <TD class="text tamperColor"><?php echo text($iter["patient_id"]);?></TD>
                 <?php // Using mb_convert_encoding to change binary stuff (uuid) to just be '?' characters ?>

--- a/interface/reports/background_services.php
+++ b/interface/reports/background_services.php
@@ -15,6 +15,7 @@ require_once("../globals.php");
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\Header;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (!AclMain::aclCheckCore('admin', 'super')) {
     AccessDeniedHelper::denyWithTemplate("ACL check failed for admin/super: Background Services", xl("Background Services"));
@@ -145,13 +146,13 @@ while ($row = sqlFetchArray($res)) {
           <td align='center'><?php echo ($row['running'] > 0) ? xlt("Yes") : xlt("No"); ?></td>
 
         <?php if ($row['running'] > -1) { ?>
-          <td align='center'><?php echo text(oeFormatDateTime($row['last_run_start'], "global", true)); ?></td>
+          <td align='center'><?php echo text(DateFormatterUtils::oeFormatDateTime($row['last_run_start'], "global", true)); ?></td>
         <?php } else { ?>
           <td align='center'><?php echo xlt('Never'); ?></td>
         <?php } ?>
 
         <?php if ($row['active'] && ($row['execute_interval'] > 0)) { ?>
-          <td align='center'><?php echo text(oeFormatDateTime($row['next_run'], "global", true)); ?></td>
+          <td align='center'><?php echo text(DateFormatterUtils::oeFormatDateTime($row['next_run'], "global", true)); ?></td>
         <?php } else { ?>
           <td align='center'><?php echo xlt('Not Applicable'); ?></td>
         <?php } ?>

--- a/interface/reports/chart_location_activity.php
+++ b/interface/reports/chart_location_activity.php
@@ -19,6 +19,7 @@ require_once("$srcdir/options.inc.php");
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 use OpenEMR\Services\PatientService;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (!empty($_POST)) {
     if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
@@ -171,7 +172,7 @@ if (!empty($_POST['form_refresh']) || !empty($ptrow)) {
             ?>
    <tr>
     <td>
-            <?php echo text(oeFormatDateTime($row['ct_when'], "global", true)); ?>
+            <?php echo text(DateFormatterUtils::oeFormatDateTime($row['ct_when'], "global", true)); ?>
   </td>
   <td>
             <?php

--- a/interface/reports/charts_checked_out.php
+++ b/interface/reports/charts_checked_out.php
@@ -17,6 +17,7 @@ require_once("$srcdir/patient.inc.php");
 
 use OpenEMR\Core\Header;
 use OpenEMR\Services\PatientService;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 ?>
 <html>
@@ -105,7 +106,7 @@ while ($row = sqlFetchArray($res)) {
     <?php echo text($row['ulname'] . ', ' . $row['ufname'] . ' ' . $row['umname']); ?>
   </td>
   <td>
-    <?php echo text(oeFormatDateTime($row['ct_when'], "global", true)); ?>
+    <?php echo text(DateFormatterUtils::oeFormatDateTime($row['ct_when'], "global", true)); ?>
   </td>
  </tr>
     <?php

--- a/interface/reports/clinical_reports.php
+++ b/interface/reports/clinical_reports.php
@@ -21,6 +21,7 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (!AclMain::aclCheckCore('patients', 'med')) {
     AccessDeniedHelper::denyWithTemplate("ACL check failed for patients/med: Clinical Reports", xl("Clinical Reports"));
@@ -223,8 +224,8 @@ $communication = trim($_POST["communication"] ?? '');
 <!-- Search can be done using age range, gender, and ethnicity filters.
 Search options include diagnosis, procedure, prescription, medical history, and lab results.
 -->
-<div id="report_parameters_daterange"> <?php echo text(oeFormatDateTime($sql_date_from, "global", true)) .
-      " &nbsp; " . xlt("to{{Range}}") . " &nbsp; " . text(oeFormatDateTime($sql_date_to, "global", true)); ?> </div>
+<div id="report_parameters_daterange"> <?php echo text(DateFormatterUtils::oeFormatDateTime($sql_date_from, "global", true)) .
+      " &nbsp; " . xlt("to{{Range}}") . " &nbsp; " . text(DateFormatterUtils::oeFormatDateTime($sql_date_to, "global", true)); ?> </div>
 <form name='theform' id='theform' method='post' action='clinical_reports.php' onsubmit='return top.restoreSession()'>
     <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
     <div id="report_parameters">
@@ -237,13 +238,13 @@ Search options include diagnosis, procedure, prescription, medical history, and 
                         <td class='col-form-label' width="100"><?php echo xlt('Facility'); ?>: </td>
                         <td width="250"> <?php dropdown_facility($facility, 'facility', false); ?> </td>
                         <td class='col-form-label' width="100"><?php echo xlt('From'); ?>: </td>
-                        <td><input type='text' class='datetimepicker form-control' name='date_from' id="date_from" size='18' value='<?php echo attr(oeFormatDateTime($sql_date_from, "global", true)); ?>'></td>
+                        <td><input type='text' class='datetimepicker form-control' name='date_from' id="date_from" size='18' value='<?php echo attr(DateFormatterUtils::oeFormatDateTime($sql_date_from, "global", true)); ?>'></td>
                     </tr>
                     <tr>
                         <td class='col-form-label'><?php echo xlt('Patient ID'); ?>:</td>
                         <td><input name='patient_id' class="numeric_only form-control" type='text' id="patient_id" title='<?php echo xla('Optional numeric patient ID'); ?>' value='<?php echo attr($patient_id); ?>' size='10' maxlength='20' /></td>
                         <td class='col-form-label'><?php echo xlt('To{{Range}}'); ?>: </td>
-                        <td><input type='text' class='datetimepicker form-control' name='date_to' id="date_to" size='18' value='<?php echo attr(oeFormatDateTime($sql_date_to, "global", true)); ?>'></td>
+                        <td><input type='text' class='datetimepicker form-control' name='date_to' id="date_to" size='18' value='<?php echo attr(DateFormatterUtils::oeFormatDateTime($sql_date_to, "global", true)); ?>'></td>
                     </tr>
                     <tr>
                         <td class='col-form-label'><?php echo xlt('Age Range'); ?>:</td>
@@ -782,7 +783,7 @@ if (!empty($_POST['form_refresh'])) {
                 <td colspan='10'><strong><?php echo xlt('Diagnosis Name');?></strong></td>
                 </tr>
                 <tr class='bg-white'>
-                <td><?php echo text(oeFormatDateTime($row['lists_date'], "global", true)); ?>&nbsp;</td>
+                <td><?php echo text(DateFormatterUtils::oeFormatDateTime($row['lists_date'], "global", true)); ?>&nbsp;</td>
                 <td><?php echo text($row['lists_diagnosis']); ?>&nbsp;</td>
                                 <td colspan='10'><?php echo text($row['lists_title']); ?>&nbsp;</td>
                 </tr>
@@ -1013,7 +1014,7 @@ if (!empty($_POST['form_refresh'])) {
                         <td colspan="7"><strong><?php echo xlt('Notes');?></strong></td>
                     </tr>
                     <tr class='bg-white'>
-                        <td><?php echo text(oeFormatDateTime($row['imm_date'])); ?>&nbsp;</td>
+                        <td><?php echo text(DateFormatterUtils::oeFormatDateTime($row['imm_date'])); ?>&nbsp;</td>
                         <td><?php echo text($row['cvx_code']); ?>&nbsp;</td>
                         <td><?php echo text($row['imm_code_short']) . " (" . text($row['imm_code']) . ")"; ?>&nbsp;</td>
                         <td>

--- a/interface/reports/cqm.php
+++ b/interface/reports/cqm.php
@@ -28,6 +28,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\PractitionerService;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (!AclMain::aclCheckCore('patients', 'med')) {
     AccessDeniedHelper::denyWithTemplate("ACL check failed for patients/med: Report", xl("Report"));
@@ -123,7 +124,7 @@ $twig = $twigContainer->getTwig();
 $formData = [
     'type_report' => $type_report
     ,'heading_title' => $heading_title
-    ,'date_report' => isset($date_report) ? oeFormatDateTime($date_report, "global", true) : ''
+    ,'date_report' => isset($date_report) ? DateFormatterUtils::oeFormatDateTime($date_report, "global", true) : ''
     ,'report_id' => $report_id ?? null
     ,'show_help' => $show_help
     ,'oemrUiSettings' =>  [
@@ -141,8 +142,8 @@ $formData = [
     ,'widthDyn' => '610px'
     ,'is_amc_report' => $is_amc_report
     ,'dis_text' => (!empty($report_id) ? "disabled='disabled'" : "")
-    ,'begin_date' => isset($begin_date) ? oeFormatDateTime($begin_date, 0, true) : ""
-    ,'target_date' => oeFormatDateTime($target_date, 0, true)
+    ,'begin_date' => isset($begin_date) ? DateFormatterUtils::oeFormatDateTime($begin_date, 0, true) : ""
+    ,'target_date' => DateFormatterUtils::oeFormatDateTime($target_date, 0, true)
     ,'target_date_label' => ($is_amc_report ? xl('End Date') : xl('Target Date'))
     ,'rule_filters' => []
     ,'show_plans' => !$is_amc_report

--- a/interface/reports/direct_message_log.php
+++ b/interface/reports/direct_message_log.php
@@ -16,6 +16,7 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (!AclMain::aclCheckCore('admin', 'super')) {
     AccessDeniedHelper::denyWithTemplate("ACL check failed for admin/super: Direct Message Log", xl("Direct Message Log"));
@@ -163,7 +164,7 @@ while ($row = sqlFetchArray($res)) {
           <td align='center'>&nbsp;</td>
     <?php } ?>
 
-    <td align='center'><?php echo text(oeFormatDateTime($row['create_ts'], "global", true)); ?></td>
+    <td align='center'><?php echo text(DateFormatterUtils::oeFormatDateTime($row['create_ts'], "global", true)); ?></td>
     <td align='center'><?php echo text($row['sender']); ?></td>
     <td align='center'><?php echo text($row['recipient']); ?></td>
 

--- a/interface/reports/ip_tracker.php
+++ b/interface/reports/ip_tracker.php
@@ -17,6 +17,7 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Auth\AuthUtils;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 
 if (!empty($_POST)) {
@@ -228,7 +229,7 @@ $showOnlyAutoBlocked = !empty($_POST['showOnlyAutoBlocked']) ? true : false;
                             }
                             ?>
                         </td>
-                        <td class="detail" id="last-fail-<?php echo attr($row['id']) ?>"><?php echo (!empty($row['ip_last_login_fail'])) ? text(oeFormatDateTime($row['ip_last_login_fail'])) : xlt("Not Applicable"); ?></td>
+                        <td class="detail" id="last-fail-<?php echo attr($row['id']) ?>"><?php echo (!empty($row['ip_last_login_fail'])) ? text(DateFormatterUtils::oeFormatDateTime($row['ip_last_login_fail'])) : xlt("Not Applicable"); ?></td>
                         <td class="detail" id="autoblock-<?php echo attr($row['id']) ?>">
                             <?php
                             $autoBlocked = false;
@@ -246,7 +247,7 @@ $showOnlyAutoBlocked = !empty($_POST['showOnlyAutoBlocked']) ? true : false;
                             if ($autoBlocked) {
                                 echo xlt("Yes");
                                 if (!empty($autoBlockEnd)) {
-                                    echo ' (' . xlt("Autoblock ends on") . ' ' . text(oeFormatDateTime($autoBlockEnd)) . ')';
+                                    echo ' (' . xlt("Autoblock ends on") . ' ' . text(DateFormatterUtils::oeFormatDateTime($autoBlockEnd)) . ')';
                                 }
                             } else {
                                 echo xlt("No");

--- a/interface/reports/patient_list_creation.php
+++ b/interface/reports/patient_list_creation.php
@@ -28,6 +28,7 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (!AclMain::aclCheckCore('patients', 'med')) {
     AccessDeniedHelper::denyWithTemplate("ACL check failed for patients/med: Patient List Creation", xl("Patient List Creation"));
@@ -440,8 +441,8 @@ if ($csv) {
 
         <div id="report_parameters_daterange">
             <p>
-            <?php echo "<span style='margin-left:5px;'><strong>" . xlt('Date Range') . ":</strong>&nbsp;" . text(oeFormatDateTime($sql_date_from, "global", true))
-                . " &nbsp; " . xlt('to{{Range}}') . " &nbsp; " . text(oeFormatDateTime($sql_date_to, "global", true)) . "</span>"; ?>
+            <?php echo "<span style='margin-left:5px;'><strong>" . xlt('Date Range') . ":</strong>&nbsp;" . text(DateFormatterUtils::oeFormatDateTime($sql_date_from, "global", true))
+                . " &nbsp; " . xlt('to{{Range}}') . " &nbsp; " . text(DateFormatterUtils::oeFormatDateTime($sql_date_to, "global", true)) . "</span>"; ?>
             <span style="margin-left:5px;"><strong><?php echo xlt('Option'); ?>:</strong>&nbsp;<?php echo text($_POST['srch_option'] ?? '');
             if (!empty($_POST['srch_option']) && ($_POST['srch_option'] == "comms") && ($_POST['communication'] != "")) {
                 if (isset($comarr[$_POST['communication']])) {
@@ -472,9 +473,9 @@ if ($csv) {
                                 <table class='text'>
                                     <tr>
                                         <td class='col-form-label'><?php echo xlt('From'); ?>: </td>
-                                        <td><input type='text' class='datetimepicker form-control' name='date_from' id="date_from" size='18' value='<?php echo attr(oeFormatDateTime($sql_date_from, 0, true)); ?>'></td>
+                                        <td><input type='text' class='datetimepicker form-control' name='date_from' id="date_from" size='18' value='<?php echo attr(DateFormatterUtils::oeFormatDateTime($sql_date_from, 0, true)); ?>'></td>
                                         <td class='col-form-label'><?php echo xlt('To{{range}}'); ?>: </td>
-                                        <td><input type='text' class='datetimepicker form-control' name='date_to' id="date_to" size='18' value='<?php echo attr(oeFormatDateTime($sql_date_to, 0, true)); ?>'></td>
+                                        <td><input type='text' class='datetimepicker form-control' name='date_to' id="date_to" size='18' value='<?php echo attr(DateFormatterUtils::oeFormatDateTime($sql_date_to, 0, true)); ?>'></td>
                                         <td class='col-form-label'><?php echo xlt('Option'); ?>: </td>
                                         <td>
                                             <select class="form-control" name="srch_option" id="srch_option"
@@ -988,7 +989,7 @@ if (!empty($_POST['form_refresh'])) {
                 switch ($report_col) { // Convert column data into readable format if necessary
                     case "patient_date":
                     case "other_date":
-                        $report_value_print = ($report_value != '') ? text(oeFormatDateTime($report_value, "global", true)) : '';
+                        $report_value_print = ($report_value != '') ? text(DateFormatterUtils::oeFormatDateTime($report_value, "global", true)) : '';
                         break;
                     case "patient_race":
                         $report_value_print = generate_display_field(['data_type' => '36', 'list_id' => 'race'], $report_value);

--- a/interface/reports/payment_processing_report.php
+++ b/interface/reports/payment_processing_report.php
@@ -19,6 +19,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 use OpenEMR\PaymentProcessing\PaymentProcessing;
 use OpenEMR\PaymentProcessing\Sphere\SphereRevert;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (!empty($_POST)) {
     if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
@@ -144,9 +145,9 @@ $actionName = $_POST['form_action_name'] ?? null;
             </tr>
             <tr>
                 <td class='col-form-label'><?php echo xlt('From'); ?>:</td>
-                <td><input type='text' name='form_from_date' id="form_from_date" class='datepicker form-control' size='10' value='<?php echo attr(oeFormatDateTime($from_date)); ?>' /></td>
+                <td><input type='text' name='form_from_date' id="form_from_date" class='datepicker form-control' size='10' value='<?php echo attr(DateFormatterUtils::oeFormatDateTime($from_date)); ?>' /></td>
                 <td class='col-form-label'><?php echo xlt('To{{Range}}'); ?>:</td>
-                <td><input type='text' name='form_to_date' id="form_to_date" class='datepicker form-control' size='10' value='<?php echo attr(oeFormatDateTime($to_date)); ?>'></td>
+                <td><input type='text' name='form_to_date' id="form_to_date" class='datepicker form-control' size='10' value='<?php echo attr(DateFormatterUtils::oeFormatDateTime($to_date)); ?>'></td>
             </tr>
 
             <tr>
@@ -228,7 +229,7 @@ if (!empty($_POST['form_refresh'])) {
         ?>
 
         <tr valign='top' bgcolor='<?php echo attr($bgcolor ?? ''); ?>'>
-            <td class="detail">&nbsp;<?php echo text(oeFormatDateTime($auditEntry['date'])); ?></td>
+            <td class="detail">&nbsp;<?php echo text(DateFormatterUtils::oeFormatDateTime($auditEntry['date'])); ?></td>
             <td class="detail">&nbsp;<?php echo text($auditEntry['service']); ?></td>
             <td class="detail">&nbsp;<?php echo text($auditEntry['front_label']); ?></td>
             <td class="detail">&nbsp;<?php echo text($auditEntry['ticket']); ?></td>
@@ -244,10 +245,10 @@ if (!empty($_POST['form_refresh'])) {
                     if (!empty($auditEntry['reverted'])) {
                         // Charge has already been reverted
                         if ($auditEntry['revert_action_name'] == 'void') {
-                            echo xlt("This charge was reversed via void on following date") . ": " . text(oeFormatDateTime($auditEntry['revert_date'])) . "<br>" .
+                            echo xlt("This charge was reversed via void on following date") . ": " . text(DateFormatterUtils::oeFormatDateTime($auditEntry['revert_date'])) . "<br>" .
                                 xlt("The transaction_id for the void was") . ": " . text($auditEntry['revert_transaction_id']);
                         } else { // $auditEntry['revert_action_name'] == 'credit'
-                            echo xlt("This charge was reversed via credit on following date") . ": " . text(oeFormatDateTime($auditEntry['revert_date'])) . "<br>" .
+                            echo xlt("This charge was reversed via credit on following date") . ": " . text(DateFormatterUtils::oeFormatDateTime($auditEntry['revert_date'])) . "<br>" .
                                 xlt("The Transaction ID for the credit was") . ": " . text($auditEntry['revert_transaction_id']);
                         }
                     }

--- a/interface/reports/report_results.php
+++ b/interface/reports/report_results.php
@@ -22,6 +22,7 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (!AclMain::aclCheckCore('patients', 'med')) {
     AccessDeniedHelper::denyWithTemplate("ACL check failed for patients/med: Report Results/History", xl("Report Results/History"));
@@ -107,7 +108,7 @@ $form_end_date = DateTimeToYYYYMMDDHHMMSS($_POST['form_end_date'] ?? '');
                             <?php echo xlt('Begin Date'); ?>:
                       </td>
                       <td>
-                         <input type='text' name='form_begin_date' id='form_begin_date' size='20' value='<?php echo attr(oeFormatDateTime($form_begin_date, "global", true)); ?>'
+                         <input type='text' name='form_begin_date' id='form_begin_date' size='20' value='<?php echo attr(DateFormatterUtils::oeFormatDateTime($form_begin_date, "global", true)); ?>'
                             class='datepicker form-control' />
                       </td>
                    </tr>
@@ -117,7 +118,7 @@ $form_end_date = DateTimeToYYYYMMDDHHMMSS($_POST['form_end_date'] ?? '');
                                 <?php echo xlt('End Date'); ?>:
                         </td>
                         <td>
-                           <input type='text' name='form_end_date' id='form_end_date' size='20' value='<?php echo attr(oeFormatDateTime($form_end_date, "global", true)); ?>'
+                           <input type='text' name='form_end_date' id='form_end_date' size='20' value='<?php echo attr(DateFormatterUtils::oeFormatDateTime($form_end_date, "global", true)); ?>'
                                 class='datepicker form-control' />
                         </td>
                 </tr>
@@ -252,7 +253,7 @@ while ($row = sqlFetchArray($res)) {
     <?php } else { ?>
       <td class='text-center'><?php echo text($type_title); ?></td>
     <?php } ?>
-  <td class='text-center'><?php echo text(oeFormatDateTime($row["date_report"], "global", true)); ?></td>
+  <td class='text-center'><?php echo text(DateFormatterUtils::oeFormatDateTime($row["date_report"], "global", true)); ?></td>
     <?php if ($row["progress"] == "complete") { ?>
       <td class='text-center'><?php echo xlt("Complete") . " (" . xlt("Processing Time") . ": " . text($row['report_time_processing']) . " " . xlt("Minutes") . ")"; ?></td>
     <?php } else { ?>

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -34,6 +34,7 @@ use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\User\UserCreatedEvent;
 use OpenEMR\Events\User\UserUpdatedEvent;
 use OpenEMR\Services\UserService;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (!empty($_REQUEST)) {
     if (!CsrfUtils::verifyCsrfToken($_REQUEST["csrf_token_form"])) {
@@ -714,7 +715,7 @@ function resetCounter(username) {
                                 if (!empty($queryCounter['login_fail_counter'])) {
                                     echo text($queryCounter['login_fail_counter']);
                                     if (!empty($queryCounter['last_login_fail'])) {
-                                        echo ' (' . xlt('last on') . ' ' . text(oeFormatDateTime($queryCounter['last_login_fail'])) . ')';
+                                        echo ' (' . xlt('last on') . ' ' . text(DateFormatterUtils::oeFormatDateTime($queryCounter['last_login_fail'])) . ')';
                                     }
                                     echo ' ' . '<button type="button" class="btn btn-sm btn-danger ml-1" onclick="resetCounter(' . attr_js($iter["username"]) . ')">' . xlt("Reset Counter") . '</button>';
                                     $autoBlocked = false;
@@ -732,7 +733,7 @@ function resetCounter(username) {
                                     if ($autoBlocked) {
                                         echo '<br>' . xlt("Currently Autoblocked");
                                         if (!empty($autoBlockEnd)) {
-                                            echo ' (' . xlt("Autoblock ends on") . ' ' . text(oeFormatDateTime($autoBlockEnd)) . ')';
+                                            echo ' (' . xlt("Autoblock ends on") . ' ' . text(DateFormatterUtils::oeFormatDateTime($autoBlockEnd)) . ')';
                                         }
                                     }
                                 } else {

--- a/library/formatting.inc.php
+++ b/library/formatting.inc.php
@@ -22,7 +22,7 @@ function oeFormatMoney($amount, $symbol = false)
     return FormatMoney::getFormattedMoney($amount, $symbol);
 }
 
-function oeFormatShortDate($date = 'today', $showYear = true)
+function oeFormatShortDate($date = 'today', bool $showYear = true)
 {
     return DateFormatterUtils::oeFormatShortDate($date, $showYear);
 }
@@ -38,20 +38,9 @@ function oeFormatShortDate($date = 'today', $showYear = true)
  * @return string
  *@deprecated use DateFormatterUtils::oeFormatTime()
  */
-function oeFormatTime($time, $format = "global", $seconds = false)
+function oeFormatTime($time, $format = "global", bool $seconds = false)
 {
     return DateFormatterUtils::oeFormatTime($time, $format, $seconds);
-}
-
-/**
- * Returns the complete formatted datetime string according the global date and time format
- * @deprecated use DateFormatterUtils::oeFormatDateTime()
- * @param $datetime
- * @return string
- */
-function oeFormatDateTime($datetime, $formatTime = "global", $seconds = false)
-{
-    return DateFormatterUtils::oeFormatDateTime($datetime, $formatTime, $seconds);
 }
 
 /**

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -75,6 +75,7 @@ use OpenEMR\Services\FacilityService;
 use OpenEMR\Services\PatientService;
 use OpenEMR\Services\PatientNameHistoryService;
 use OpenEMR\Events\PatientDemographics\RenderPharmacySectionEvent;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 $facilityService = new FacilityService();
 
@@ -784,7 +785,7 @@ function generate_form_field($frow, $currvalue): void
                 $dateValue  = oeFormatShortDate(substr($currescaped, 0, 10));
                 echo "<input type='text' size='10' class='datepicker$datetimepickerclass form-control$smallform' name='form_$field_id_esc' id='form_$field_id_esc'" . " value='" .  attr($dateValue)  . "'";
             } else {
-                $dateValue  = oeFormatDateTime(substr($currescaped, 0, 20), 0);
+                $dateValue  = DateFormatterUtils::oeFormatDateTime(substr($currescaped, 0, 20), 0);
                 echo "<input type='text' size='20' class='datetimepicker$datetimepickerclass form-control$smallform' name='form_$field_id_esc' id='form_$field_id_esc'" . " value='" . attr($dateValue) . "'";
             }
         }
@@ -1792,7 +1793,7 @@ function generate_print_field($frow, $currvalue, $value_allowed = true): void
             if (!$modtmp) {
                 echo text(oeFormatShortDate($currvalue));
             } else {
-                echo text(oeFormatDateTime($currvalue));
+                echo text(DateFormatterUtils::oeFormatDateTime($currvalue));
             }
             if ($agestr) {
                 echo "&nbsp;(" . text($agestr) . ")";
@@ -2411,7 +2412,7 @@ function generate_display_field($frow, $currvalue)
             if (!$modtmp) {
                 $s .= text(oeFormatShortDate($currvalue));
             } else {
-                $s .= text(oeFormatDateTime($currvalue));
+                $s .= text(DateFormatterUtils::oeFormatDateTime($currvalue));
             }
             if ($agestr) {
                 $s .= "&nbsp;(" . text($agestr) . ")";
@@ -2899,7 +2900,7 @@ function generate_plaintext_field($frow, $currvalue)
         $s = $billingCodeType->buildPlaintextView($frow, $currvalue);
     } elseif ($data_type == 4) { // date
         $modtmp = isOption($edit_options, 'F') === false ? 0 : 1;
-        $s = !$modtmp ? text(oeFormatShortDate($currvalue)) : text(oeFormatDateTime($currvalue));
+        $s = !$modtmp ? text(oeFormatShortDate($currvalue)) : text(DateFormatterUtils::oeFormatDateTime($currvalue));
         $description = (isset($frow['description']) ? htmlspecialchars(xl_layout_label($frow['description']), ENT_QUOTES) : '');
         $age_asof_date = '';
         // Optional display of age or gestational age.

--- a/library/patient.inc.php
+++ b/library/patient.inc.php
@@ -26,6 +26,7 @@ use OpenEMR\Billing\InsurancePolicyTypes;
 use OpenEMR\Services\InsuranceCompanyService;
 use OpenEMR\Services\EmployerService;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 require_once(__DIR__ . "/dupscore.inc.php");
 
@@ -461,7 +462,7 @@ function genPatientHeaderFooter($pid, $DOS = null)
 
     // Footer
     $s .= '<htmlpagefooter name="PageFooter1"><div style="text-align: right; font-weight: bold;">';
-    $s .= '<div style="float: right; width:33%; text-align: left;">' . oeFormatDateTime(date("Y-m-d H:i:s")) . '</div>';
+    $s .= '<div style="float: right; width:33%; text-align: left;">' . DateFormatterUtils::oeFormatDateTime(date("Y-m-d H:i:s")) . '</div>';
     $s .= '<div style="float: right; width:33%; text-align: center;">{PAGENO}/{nbpg}</div>';
     $s .= '<div style="float: right; width:33%; text-align: right;">' . text($patient_name) . '</div>';
     $s .= '</div></htmlpagefooter>';

--- a/src/ClinicalDecisionRules/Interface/Controller/ControllerLog.php
+++ b/src/ClinicalDecisionRules/Interface/Controller/ControllerLog.php
@@ -10,6 +10,7 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfInvalidException;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -100,7 +101,7 @@ class ControllerLog extends BaseController
             $row['category_title'] = $category_title;
             $row['all_alerts'] = $all_alerts;
             $row['new_alerts'] = $new_alerts;
-            $row['date_formatted'] = oeFormatDateTime($row['date'], "global", true);
+            $row['date_formatted'] = DateFormatterUtils::oeFormatDateTime($row['date'], "global", true);
             $row['formatted_all_alerts'] = $this->getFormattedAlerts($all_alerts, $row);
             $row['formatted_new_alerts'] = $this->getFormattedAlerts($new_alerts, $row);
             $records[] = $row;

--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -29,6 +29,7 @@ use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\OeUI\OemrUI;
 use OpenEMR\Services\EncounterService;
 use OpenEMR\Services\LogoService;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
@@ -282,7 +283,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('shortDate', oeFormatShortDate(...)),
             new TwigFilter(
                 'oeFormatDateTime',
-                fn($string, $formatTime = "global", $seconds = false) => oeFormatDateTime($string, $formatTime, $seconds)
+                fn($string, $formatTime = "global", bool $seconds = false) => DateFormatterUtils::oeFormatDateTime($string, $formatTime, $seconds)
             ),
             new TwigFilter('xlLayoutLabel', xl_layout_label(...)),
             new TwigFilter('xlListLabel', xl_list_label(...)),

--- a/src/Easipro/Easipro.php
+++ b/src/Easipro/Easipro.php
@@ -22,6 +22,7 @@ namespace OpenEMR\Easipro;
 use MyMailer;
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Http\oeHttp;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 class Easipro
 {
@@ -107,7 +108,7 @@ class Easipro
         $message .= 'Dear ' . text($pt_name) . ', <br><br>Your provider has ordered a assessment for you: <b>';
         $message .= text($form_name);
         $message .= '</b><br><b>Your assessment will close after ';
-        $message .= text(oeFormatDateTime($expiration));
+        $message .= text(DateFormatterUtils::oeFormatDateTime($expiration));
         $message .= ' ,</b> so please log in and complete it before then.';
         $message .= '<center>Go to: ' . text($GLOBALS['portal_onsite_two_address']) . '</center><br>Thanks.';
         $message .= '</td></tr></tbody></table>';

--- a/src/Services/Utils/DateFormatterUtils.php
+++ b/src/Services/Utils/DateFormatterUtils.php
@@ -8,177 +8,238 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2010-2014 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017-2018 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2022 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 namespace OpenEMR\Services\Utils;
 
 use DateTime;
+use OpenEMR\Core\OEGlobalsBag;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 class DateFormatterUtils
 {
-    public static function isNotEmptyDateTimeString(?string $dateString)
+    /**
+     * Date display format constants
+     */
+    public const DATE_FORMAT_ISO = 0;      // Y-m-d (ISO 8601)
+    public const DATE_FORMAT_US = 1;       // m/d/Y (US format)
+    public const DATE_FORMAT_INTL = 2;     // d/m/Y (International format)
+
+    /**
+     * Time display format constants
+     */
+    public const TIME_FORMAT_24HR = 0;
+    public const TIME_FORMAT_12HR = 1;
+
+    public static function isNotEmptyDateTimeString(?string $dateString): bool
     {
-        return !empty($dateString) && $dateString !== '0000-00-00 00:00:00' && $dateString !== '1970-01-01 00:00:00';
+        return $dateString !== null
+            && $dateString !== ''
+            && $dateString !== '0000-00-00 00:00:00'
+            && $dateString !== '1970-01-01 00:00:00';
     }
-    public static function DateToYYYYMMDD($DateValue)
+
+    /**
+     * Convert a date from the configured display format to YYYY-MM-DD (ISO 8601).
+     *
+     * @param mixed $DateValue The date string in the configured format
+     * @param ?ParameterBag $globals Optional globals bag for testing
+     */
+    public static function DateToYYYYMMDD($DateValue, ?ParameterBag $globals = null)
     {
-        //With the help of function DateFormatRead() now the user can enter date is any of the 3 formats depending upon the global setting.
-        //But in database the date can be stored only in the yyyy-mm-dd format.
-        //This function accepts a date in any of the 3 formats, and as per the global setting, converts it to the yyyy-mm-dd format.
-        if (trim($DateValue ?? '') == '') {
+        if (trim($DateValue ?? '') === '') {
             return '';
         }
 
-        if ($GLOBALS['date_display_format'] == 0) {
+        $globals ??= OEGlobalsBag::getInstance();
+        $dateFormat = $globals->getInt('date_display_format', 0);
+
+        if ($dateFormat === self::DATE_FORMAT_ISO) {
             return $DateValue;
-        } elseif ($GLOBALS['date_display_format'] == 1 || $GLOBALS['date_display_format'] == 2) {
+        }
+
+        if ($dateFormat === self::DATE_FORMAT_US || $dateFormat === self::DATE_FORMAT_INTL) {
             $DateValueArray = explode('/', (string) $DateValue);
-            if ($GLOBALS['date_display_format'] == 1) {
+            if ($dateFormat === self::DATE_FORMAT_US) {
                 return $DateValueArray[2] . '-' . $DateValueArray[0] . '-' . $DateValueArray[1];
             }
 
-            if ($GLOBALS['date_display_format'] == 2) {
-                return $DateValueArray[2] . '-' . $DateValueArray[1] . '-' . $DateValueArray[0];
-            }
+            return $DateValueArray[2] . '-' . $DateValueArray[1] . '-' . $DateValueArray[0];
         }
+
+        return '';
     }
 
     /**
-     * Given a date string it will return a DateTime object using the global date format.  If the date could not be parsed
-     * then it returns false.  The DateTime must be in the format of Y-m-d, d/m/Y, or m/d/Y depending on the global settings
-     * to be parsed correct.  If an empty string is passed in then the current date is returned as a DateTime object.
+     * Given a date string it will return a DateTime object using the global date format.
+     *
+     * If the date could not be parsed then it returns false. The DateTime must be in the
+     * format of Y-m-d, d/m/Y, or m/d/Y depending on the global settings to be parsed correctly.
+     * If an empty string is passed in then the current date is returned as a DateTime object.
+     *
      * @param string $DateValue
-     * @param bool $includeSeconds Whether seconds are included in the time portion of the string and should be parsed
+     * @param bool $includeSeconds Whether seconds are included in the time portion
+     * @param ?ParameterBag $globals Optional globals bag for testing
      * @return bool|DateTime false if the date could not be parsed
      */
-    public static function dateStringToDateTime(string $DateValue, bool $includeSeconds = false)
+    public static function dateStringToDateTime(string $DateValue, bool $includeSeconds = false, ?ParameterBag $globals = null)
     {
-        $dateTime = new DateTime();
-        //With the help of function DateFormatRead() now the user can enter date is any of the 3 formats depending upon the global setting.
-        //But in database the date can be stored only in the yyyy-mm-dd format.
-        //This function accepts a date in any of the 3 formats, and as per the global setting, converts it to the yyyy-mm-dd format.
+        $globals ??= OEGlobalsBag::getInstance();
+        $dateFormat = $globals->getInt('date_display_format', 0);
+
         $timeFormat = '';
         if (str_contains($DateValue, ":")) {
-            $timeFormat = " " . self::getTimeFormat($includeSeconds);
+            $timeFormat = " " . self::getTimeFormat($includeSeconds, $globals);
         }
-        if (trim($DateValue ?? '') == '') {
-            $dateTime = new DateTime();
-        } else if ($GLOBALS['date_display_format'] == 0) {
-            $dateTime = \DateTime::createFromFormat("Y-m-d$timeFormat", $DateValue);
-        } elseif ($GLOBALS['date_display_format'] == 1 || $GLOBALS['date_display_format'] == 2) {
-            if ($GLOBALS['date_display_format'] == 1) {
-                $dateTime = \DateTime::createFromFormat("m/d/Y$timeFormat", $DateValue);
-            }
 
-            if ($GLOBALS['date_display_format'] == 2) {
-                $dateTime = \DateTime::createFromFormat("d/m/Y$timeFormat", $DateValue);
-            }
+        if (trim($DateValue) === '') {
+            return new DateTime();
         }
-        return $dateTime;
+
+        if ($dateFormat === self::DATE_FORMAT_ISO) {
+            return DateTime::createFromFormat("Y-m-d$timeFormat", $DateValue);
+        }
+
+        if ($dateFormat === self::DATE_FORMAT_US) {
+            return DateTime::createFromFormat("m/d/Y$timeFormat", $DateValue);
+        }
+
+        if ($dateFormat === self::DATE_FORMAT_INTL) {
+            return DateTime::createFromFormat("d/m/Y$timeFormat", $DateValue);
+        }
+
+        return new DateTime();
     }
 
-    public static function getShortDateFormat($showYear = true)
+    /**
+     * Get the PHP date format string for the configured date display format.
+     *
+     * @param bool $showYear Whether to include the year (currently unused but kept for compatibility)
+     * @param ?ParameterBag $globals Optional globals bag for testing
+     */
+    public static function getShortDateFormat($showYear = true, ?ParameterBag $globals = null): string
     {
-        if ($GLOBALS['date_display_format'] == 0) { // $GLOBALS['date_display_format'] == 0
-            return 'Y-m-d';
-        } elseif ($GLOBALS['date_display_format'] == 1) {
-            return 'm/d/Y';
-        } elseif ($GLOBALS['date_display_format'] == 2) { // dd/mm/yyyy, note year is added below
-            return 'd/m/Y';
-        }
+        $globals ??= OEGlobalsBag::getInstance();
+        $dateFormat = $globals->getInt('date_display_format', 0);
+
+        return match ($dateFormat) {
+            self::DATE_FORMAT_US => 'm/d/Y',
+            self::DATE_FORMAT_INTL => 'd/m/Y',
+            default => 'Y-m-d',
+        };
     }
 
-
-    // 0 - Time format 24 hr
-    // 1 - Time format 12 hr
-    public static function oeFormatTime($time, $format = "global", $seconds = false): string
+    /**
+     * Format a time string according to the configured time format.
+     *
+     * @param mixed $time The time to format
+     * @param mixed $format "global" to use configured format, or 0 (24hr) / 1 (12hr)
+     * @param bool $seconds Whether to include seconds
+     * @param ?ParameterBag $globals Optional globals bag for testing
+     */
+    public static function oeFormatTime($time, $format = "global", $seconds = false, ?ParameterBag $globals = null): string
     {
-        if (empty($time)) {
+        if ($time === null || $time === '') {
             return "";
         }
 
-        $formatted = $time;
+        $globals ??= OEGlobalsBag::getInstance();
 
         if ($format === "global") {
-            $format = $GLOBALS['time_display_format'];
+            $format = $globals->getInt('time_display_format', 0);
         }
 
-
-        if ($format == 1) {
-            $formatted = $seconds ? date("g:i:s a", strtotime((string) $time)) : date("g:i a", strtotime((string) $time));
-        } else { // ($format == 0)
-            $formatted = $seconds ? date("H:i:s", strtotime((string) $time)) : date("H:i", strtotime((string) $time));
+        if ($format == self::TIME_FORMAT_12HR) {
+            return $seconds ? date("g:i:s a", strtotime((string) $time)) : date("g:i a", strtotime((string) $time));
         }
 
-        return $formatted;
+        // Default: 24hr format
+        return $seconds ? date("H:i:s", strtotime((string) $time)) : date("H:i", strtotime((string) $time));
     }
 
     /**
-     * Returns the complete formatted datetime string according the global date and time format
-     * @param $datetime
-     * @return string
+     * Returns the complete formatted datetime string according the global date and time format.
+     *
+     * @param mixed $datetime The datetime string in Y-m-d H:i:s format
+     * @param mixed $formatTime "global" to use configured format, or 0 (24hr) / 1 (12hr)
+     * @param bool $seconds Whether to include seconds
+     * @param ?ParameterBag $globals Optional globals bag for testing
      */
-    public static function oeFormatDateTime($datetime, $formatTime = "global", $seconds = false): string
+    public static function oeFormatDateTime($datetime, $formatTime = "global", $seconds = false, ?ParameterBag $globals = null): string
     {
-        return self::oeFormatShortDate(substr($datetime ?? '', 0, 10)) . " " . self::oeFormatTime(substr($datetime ?? '', 11), $formatTime, $seconds);
+        return self::oeFormatShortDate(substr($datetime ?? '', 0, 10), true, $globals)
+            . " "
+            . self::oeFormatTime(substr($datetime ?? '', 11), $formatTime, $seconds, $globals);
     }
 
-    public static function oeFormatShortDate($date = 'today', $showYear = true)
+    /**
+     * Format a date string for display according to the configured date format.
+     *
+     * @param mixed $date The date in Y-m-d format, or 'today' for current date
+     * @param bool $showYear Whether to include the year in the output
+     * @param ?ParameterBag $globals Optional globals bag for testing
+     */
+    public static function oeFormatShortDate($date = 'today', $showYear = true, ?ParameterBag $globals = null)
     {
         if ($date === 'today') {
             $date = date('Y-m-d');
         }
 
-        if (strlen($date ?? '') >= 10) {
-            // assume input is yyyy-mm-dd
-            if ($GLOBALS['date_display_format'] == 1) {      // mm/dd/yyyy, note year is added below
-                $newDate = substr((string) $date, 5, 2) . '/' . substr((string) $date, 8, 2);
-            } elseif ($GLOBALS['date_display_format'] == 2) { // dd/mm/yyyy, note year is added below
-                $newDate = substr((string) $date, 8, 2) . '/' . substr((string) $date, 5, 2);
-            }
-
-            // process the year (add for formats 1 and 2; remove for format 0)
-            if ($GLOBALS['date_display_format'] == 1 || $GLOBALS['date_display_format'] == 2) {
-                if ($showYear) {
-                    $newDate .= '/' . substr((string) $date, 0, 4);
-                }
-            } elseif (!$showYear) { // $GLOBALS['date_display_format'] == 0
-                // need to remove the year
-                $newDate = substr((string) $date, 5, 2) . '-' . substr((string) $date, 8, 2);
-            } else { // $GLOBALS['date_display_format'] == 0
-                // keep the year (so will simply be the original $date)
-                $newDate = substr((string) $date, 0, 10);
-            }
-
-            return $newDate;
+        if (strlen($date ?? '') < 10) {
+            return $date;
         }
 
-        // this is case if the $date does not have 10 characters
-        return $date;
+        $globals ??= OEGlobalsBag::getInstance();
+        $dateFormat = $globals->getInt('date_display_format', 0);
+
+        // Input is assumed to be yyyy-mm-dd
+        $year = substr((string) $date, 0, 4);
+        $month = substr((string) $date, 5, 2);
+        $day = substr((string) $date, 8, 2);
+
+        if ($dateFormat === self::DATE_FORMAT_US) {
+            return $showYear ? "$month/$day/$year" : "$month/$day";
+        }
+
+        if ($dateFormat === self::DATE_FORMAT_INTL) {
+            return $showYear ? "$day/$month/$year" : "$day/$month";
+        }
+
+        // Default: ISO format (Y-m-d)
+        return $showYear ? "$year-$month-$day" : "$month-$day";
     }
 
-    public static function getTimeFormat($seconds = false)
+    /**
+     * Get the PHP time format string for the configured time display format.
+     *
+     * @param bool $seconds Whether to include seconds in the format
+     * @param ?ParameterBag $globals Optional globals bag for testing
+     */
+    public static function getTimeFormat($seconds = false, ?ParameterBag $globals = null): string
     {
-        $format = $GLOBALS['time_display_format'] ?? 0;
+        $globals ??= OEGlobalsBag::getInstance();
+        $format = $globals->getInt('time_display_format', 0);
 
-        if ($format == 1) {
-            $formatted = $seconds ? "g:i:s a" : "g:i a";
-        } else { // ($format == 0)
-            $formatted = $seconds ? "H:i:s" : "H:i";
+        if ($format == self::TIME_FORMAT_12HR) {
+            return $seconds ? "g:i:s a" : "g:i a";
         }
-        return $formatted;
+
+        // Default: 24hr format
+        return $seconds ? "H:i:s" : "H:i";
     }
 
+    /**
+     * Format a DateTime object as ISO 8601 with milliseconds.
+     */
     public static function getFormattedISO8601DateFromDateTime(\DateTime $dateTime): string
     {
         // ISO8601 doesn't support fractional dates so we need to change from microseconds to milliseconds
-        // TODO: @adunsulag this is a hack to get around the fact that PHP does microseconds and ISO8601 uses milliseconds
-        //      , look at refactoring all of this so we don't have to do multiple date conversions up and down the stack.
-        $dateStr = substr($dateTime->format('Y-m-d\TH:i:s.u'), 0, -3) . $dateTime->format('P');
-        return $dateStr;
+        return substr($dateTime->format('Y-m-d\TH:i:s.u'), 0, -3) . $dateTime->format('P');
     }
 }

--- a/templates/super/rules/controllers/log/view.php
+++ b/templates/super/rules/controllers/log/view.php
@@ -17,6 +17,7 @@
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 if (empty($viewBean)) {
     // should never get here...
@@ -115,7 +116,7 @@ $records = $viewBean->records ?>
                                     <?php echo xlt('Begin Date'); ?>:
                                 </td>
                                 <td>
-                                    <input type='text' name='form_begin_date' id='form_begin_date' size='20' value='<?php echo attr(oeFormatDateTime($form_begin_date, "global", true)); ?>'
+                                    <input type='text' name='form_begin_date' id='form_begin_date' size='20' value='<?php echo attr(DateFormatterUtils::oeFormatDateTime($form_begin_date, "global", true)); ?>'
                                            class='datepicker form-control'>
                                 </td>
                             </tr>
@@ -125,7 +126,7 @@ $records = $viewBean->records ?>
                                     <?php echo xlt('End Date'); ?>:
                                 </td>
                                 <td>
-                                    <input type='text' name='form_end_date' id='form_end_date' size='20' value='<?php echo attr(oeFormatDateTime($form_end_date, "global", true)); ?>'
+                                    <input type='text' name='form_end_date' id='form_end_date' size='20' value='<?php echo attr(DateFormatterUtils::oeFormatDateTime($form_end_date, "global", true)); ?>'
                                            class='datepicker form-control'>
                                 </td>
                             </tr>
@@ -196,7 +197,7 @@ $records = $viewBean->records ?>
                 <tbody>  <!-- added for better print-ability -->
                 <?php foreach ($records as $row) : ?>
                     <tr>
-                        <td><?php echo text(oeFormatDateTime($row['date'], "global", true)); ?></td>
+                        <td><?php echo text(DateFormatterUtils::oeFormatDateTime($row['date'], "global", true)); ?></td>
                         <td><?php echo text($row['pid']); ?></td>
                         <td><?php echo text($row['uid']); ?></td>
                         <td><?php echo text($row['facility_id']); ?></td>

--- a/tests/Tests/Isolated/Services/Utils/DateFormatterUtilsTest.php
+++ b/tests/Tests/Isolated/Services/Utils/DateFormatterUtilsTest.php
@@ -1,0 +1,461 @@
+<?php
+
+/**
+ * Isolated DateFormatterUtils Test
+ *
+ * Tests date and time formatting with injectable globals.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Services\Utils;
+
+use OpenEMR\Services\Utils\DateFormatterUtils;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+class DateFormatterUtilsTest extends TestCase
+{
+    private function createGlobals(int $dateFormat = 0, int $timeFormat = 0): ParameterBag
+    {
+        return new ParameterBag([
+            'date_display_format' => $dateFormat,
+            'time_display_format' => $timeFormat,
+        ]);
+    }
+
+    // ==========================================================================
+    // isNotEmptyDateTimeString tests
+    // ==========================================================================
+
+    public function testIsNotEmptyDateTimeStringWithValidDate(): void
+    {
+        $this->assertTrue(DateFormatterUtils::isNotEmptyDateTimeString('2024-06-15 14:30:00'));
+    }
+
+    public function testIsNotEmptyDateTimeStringWithNull(): void
+    {
+        $this->assertFalse(DateFormatterUtils::isNotEmptyDateTimeString(null));
+    }
+
+    public function testIsNotEmptyDateTimeStringWithEmptyString(): void
+    {
+        $this->assertFalse(DateFormatterUtils::isNotEmptyDateTimeString(''));
+    }
+
+    public function testIsNotEmptyDateTimeStringWithZeroDate(): void
+    {
+        $this->assertFalse(DateFormatterUtils::isNotEmptyDateTimeString('0000-00-00 00:00:00'));
+    }
+
+    public function testIsNotEmptyDateTimeStringWithEpochDate(): void
+    {
+        $this->assertFalse(DateFormatterUtils::isNotEmptyDateTimeString('1970-01-01 00:00:00'));
+    }
+
+    // ==========================================================================
+    // DateToYYYYMMDD tests
+    // ==========================================================================
+
+    public function testDateToYYYYMMDDWithIsoFormat(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_ISO);
+
+        $result = DateFormatterUtils::DateToYYYYMMDD('2024-06-15', $globals);
+
+        $this->assertSame('2024-06-15', $result);
+    }
+
+    public function testDateToYYYYMMDDWithUsFormat(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_US);
+
+        $result = DateFormatterUtils::DateToYYYYMMDD('06/15/2024', $globals);
+
+        $this->assertSame('2024-06-15', $result);
+    }
+
+    public function testDateToYYYYMMDDWithIntlFormat(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_INTL);
+
+        $result = DateFormatterUtils::DateToYYYYMMDD('15/06/2024', $globals);
+
+        $this->assertSame('2024-06-15', $result);
+    }
+
+    public function testDateToYYYYMMDDWithEmptyString(): void
+    {
+        $globals = $this->createGlobals();
+
+        $result = DateFormatterUtils::DateToYYYYMMDD('', $globals);
+
+        $this->assertSame('', $result);
+    }
+
+    public function testDateToYYYYMMDDWithNull(): void
+    {
+        $globals = $this->createGlobals();
+
+        $result = DateFormatterUtils::DateToYYYYMMDD(null, $globals);
+
+        $this->assertSame('', $result);
+    }
+
+    public function testDateToYYYYMMDDWithWhitespace(): void
+    {
+        $globals = $this->createGlobals();
+
+        $result = DateFormatterUtils::DateToYYYYMMDD('   ', $globals);
+
+        $this->assertSame('', $result);
+    }
+
+    // ==========================================================================
+    // dateStringToDateTime tests
+    // ==========================================================================
+
+    public function testDateStringToDateTimeWithIsoFormat(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_ISO);
+
+        $result = DateFormatterUtils::dateStringToDateTime('2024-06-15', false, $globals);
+
+        $this->assertInstanceOf(\DateTime::class, $result);
+        $this->assertSame('2024-06-15', $result->format('Y-m-d'));
+    }
+
+    public function testDateStringToDateTimeWithUsFormat(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_US);
+
+        $result = DateFormatterUtils::dateStringToDateTime('06/15/2024', false, $globals);
+
+        $this->assertInstanceOf(\DateTime::class, $result);
+        $this->assertSame('2024-06-15', $result->format('Y-m-d'));
+    }
+
+    public function testDateStringToDateTimeWithIntlFormat(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_INTL);
+
+        $result = DateFormatterUtils::dateStringToDateTime('15/06/2024', false, $globals);
+
+        $this->assertInstanceOf(\DateTime::class, $result);
+        $this->assertSame('2024-06-15', $result->format('Y-m-d'));
+    }
+
+    public function testDateStringToDateTimeWithEmptyStringReturnsCurrentDate(): void
+    {
+        $globals = $this->createGlobals();
+
+        $result = DateFormatterUtils::dateStringToDateTime('', false, $globals);
+
+        $this->assertInstanceOf(\DateTime::class, $result);
+        $this->assertSame(date('Y-m-d'), $result->format('Y-m-d'));
+    }
+
+    public function testDateStringToDateTimeWithTimeComponent(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_ISO, DateFormatterUtils::TIME_FORMAT_24HR);
+
+        $result = DateFormatterUtils::dateStringToDateTime('2024-06-15 14:30', false, $globals);
+
+        $this->assertInstanceOf(\DateTime::class, $result);
+        $this->assertSame('2024-06-15 14:30', $result->format('Y-m-d H:i'));
+    }
+
+    // ==========================================================================
+    // getShortDateFormat tests
+    // ==========================================================================
+
+    public function testGetShortDateFormatWithIso(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_ISO);
+
+        $result = DateFormatterUtils::getShortDateFormat(true, $globals);
+
+        $this->assertSame('Y-m-d', $result);
+    }
+
+    public function testGetShortDateFormatWithUs(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_US);
+
+        $result = DateFormatterUtils::getShortDateFormat(true, $globals);
+
+        $this->assertSame('m/d/Y', $result);
+    }
+
+    public function testGetShortDateFormatWithIntl(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_INTL);
+
+        $result = DateFormatterUtils::getShortDateFormat(true, $globals);
+
+        $this->assertSame('d/m/Y', $result);
+    }
+
+    // ==========================================================================
+    // oeFormatTime tests
+    // ==========================================================================
+
+    public function testOeFormatTimeWith24HourFormat(): void
+    {
+        $globals = $this->createGlobals(0, DateFormatterUtils::TIME_FORMAT_24HR);
+
+        $result = DateFormatterUtils::oeFormatTime('14:30:00', 'global', false, $globals);
+
+        $this->assertSame('14:30', $result);
+    }
+
+    public function testOeFormatTimeWith12HourFormat(): void
+    {
+        $globals = $this->createGlobals(0, DateFormatterUtils::TIME_FORMAT_12HR);
+
+        $result = DateFormatterUtils::oeFormatTime('14:30:00', 'global', false, $globals);
+
+        $this->assertSame('2:30 pm', $result);
+    }
+
+    public function testOeFormatTimeWith24HourFormatAndSeconds(): void
+    {
+        $globals = $this->createGlobals(0, DateFormatterUtils::TIME_FORMAT_24HR);
+
+        $result = DateFormatterUtils::oeFormatTime('14:30:45', 'global', true, $globals);
+
+        $this->assertSame('14:30:45', $result);
+    }
+
+    public function testOeFormatTimeWith12HourFormatAndSeconds(): void
+    {
+        $globals = $this->createGlobals(0, DateFormatterUtils::TIME_FORMAT_12HR);
+
+        $result = DateFormatterUtils::oeFormatTime('14:30:45', 'global', true, $globals);
+
+        $this->assertSame('2:30:45 pm', $result);
+    }
+
+    public function testOeFormatTimeWithEmptyTime(): void
+    {
+        $globals = $this->createGlobals();
+
+        $result = DateFormatterUtils::oeFormatTime('', 'global', false, $globals);
+
+        $this->assertSame('', $result);
+    }
+
+    public function testOeFormatTimeWithNullTime(): void
+    {
+        $globals = $this->createGlobals();
+
+        $result = DateFormatterUtils::oeFormatTime(null, 'global', false, $globals);
+
+        $this->assertSame('', $result);
+    }
+
+    public function testOeFormatTimeWithExplicitFormat(): void
+    {
+        $globals = $this->createGlobals(0, DateFormatterUtils::TIME_FORMAT_24HR);
+
+        // Use explicit 12hr format even though global is 24hr
+        $result = DateFormatterUtils::oeFormatTime('14:30:00', 1, false, $globals);
+
+        $this->assertSame('2:30 pm', $result);
+    }
+
+    public function testOeFormatTimeMorningAm(): void
+    {
+        $globals = $this->createGlobals(0, DateFormatterUtils::TIME_FORMAT_12HR);
+
+        $result = DateFormatterUtils::oeFormatTime('09:15:00', 'global', false, $globals);
+
+        $this->assertSame('9:15 am', $result);
+    }
+
+    public function testOeFormatTimeMidnight(): void
+    {
+        $globals = $this->createGlobals(0, DateFormatterUtils::TIME_FORMAT_12HR);
+
+        $result = DateFormatterUtils::oeFormatTime('00:00:00', 'global', false, $globals);
+
+        $this->assertSame('12:00 am', $result);
+    }
+
+    public function testOeFormatTimeNoon(): void
+    {
+        $globals = $this->createGlobals(0, DateFormatterUtils::TIME_FORMAT_12HR);
+
+        $result = DateFormatterUtils::oeFormatTime('12:00:00', 'global', false, $globals);
+
+        $this->assertSame('12:00 pm', $result);
+    }
+
+    // ==========================================================================
+    // oeFormatShortDate tests
+    // ==========================================================================
+
+    public function testOeFormatShortDateWithIsoFormat(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_ISO);
+
+        $result = DateFormatterUtils::oeFormatShortDate('2024-06-15', true, $globals);
+
+        $this->assertSame('2024-06-15', $result);
+    }
+
+    public function testOeFormatShortDateWithUsFormat(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_US);
+
+        $result = DateFormatterUtils::oeFormatShortDate('2024-06-15', true, $globals);
+
+        $this->assertSame('06/15/2024', $result);
+    }
+
+    public function testOeFormatShortDateWithIntlFormat(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_INTL);
+
+        $result = DateFormatterUtils::oeFormatShortDate('2024-06-15', true, $globals);
+
+        $this->assertSame('15/06/2024', $result);
+    }
+
+    public function testOeFormatShortDateWithoutYear(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_US);
+
+        $result = DateFormatterUtils::oeFormatShortDate('2024-06-15', false, $globals);
+
+        $this->assertSame('06/15', $result);
+    }
+
+    public function testOeFormatShortDateWithIsoFormatWithoutYear(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_ISO);
+
+        $result = DateFormatterUtils::oeFormatShortDate('2024-06-15', false, $globals);
+
+        $this->assertSame('06-15', $result);
+    }
+
+    public function testOeFormatShortDateWithIntlFormatWithoutYear(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_INTL);
+
+        $result = DateFormatterUtils::oeFormatShortDate('2024-06-15', false, $globals);
+
+        $this->assertSame('15/06', $result);
+    }
+
+    public function testOeFormatShortDateWithShortInput(): void
+    {
+        $globals = $this->createGlobals();
+
+        $result = DateFormatterUtils::oeFormatShortDate('2024-06', true, $globals);
+
+        $this->assertSame('2024-06', $result);
+    }
+
+    // ==========================================================================
+    // oeFormatDateTime tests
+    // ==========================================================================
+
+    public function testOeFormatDateTimeWithIsoAnd24Hr(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_ISO, DateFormatterUtils::TIME_FORMAT_24HR);
+
+        $result = DateFormatterUtils::oeFormatDateTime('2024-06-15 14:30:00', 'global', false, $globals);
+
+        $this->assertSame('2024-06-15 14:30', $result);
+    }
+
+    public function testOeFormatDateTimeWithUsAnd12Hr(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_US, DateFormatterUtils::TIME_FORMAT_12HR);
+
+        $result = DateFormatterUtils::oeFormatDateTime('2024-06-15 14:30:00', 'global', false, $globals);
+
+        $this->assertSame('06/15/2024 2:30 pm', $result);
+    }
+
+    public function testOeFormatDateTimeWithSeconds(): void
+    {
+        $globals = $this->createGlobals(DateFormatterUtils::DATE_FORMAT_ISO, DateFormatterUtils::TIME_FORMAT_24HR);
+
+        $result = DateFormatterUtils::oeFormatDateTime('2024-06-15 14:30:45', 'global', true, $globals);
+
+        $this->assertSame('2024-06-15 14:30:45', $result);
+    }
+
+    // ==========================================================================
+    // getTimeFormat tests
+    // ==========================================================================
+
+    public function testGetTimeFormatWith24Hr(): void
+    {
+        $globals = $this->createGlobals(0, DateFormatterUtils::TIME_FORMAT_24HR);
+
+        $result = DateFormatterUtils::getTimeFormat(false, $globals);
+
+        $this->assertSame('H:i', $result);
+    }
+
+    public function testGetTimeFormatWith12Hr(): void
+    {
+        $globals = $this->createGlobals(0, DateFormatterUtils::TIME_FORMAT_12HR);
+
+        $result = DateFormatterUtils::getTimeFormat(false, $globals);
+
+        $this->assertSame('g:i a', $result);
+    }
+
+    public function testGetTimeFormatWith24HrAndSeconds(): void
+    {
+        $globals = $this->createGlobals(0, DateFormatterUtils::TIME_FORMAT_24HR);
+
+        $result = DateFormatterUtils::getTimeFormat(true, $globals);
+
+        $this->assertSame('H:i:s', $result);
+    }
+
+    public function testGetTimeFormatWith12HrAndSeconds(): void
+    {
+        $globals = $this->createGlobals(0, DateFormatterUtils::TIME_FORMAT_12HR);
+
+        $result = DateFormatterUtils::getTimeFormat(true, $globals);
+
+        $this->assertSame('g:i:s a', $result);
+    }
+
+    // ==========================================================================
+    // getFormattedISO8601DateFromDateTime tests
+    // ==========================================================================
+
+    public function testGetFormattedISO8601DateFromDateTime(): void
+    {
+        $dateTime = new \DateTime('2024-06-15 14:30:45.123456', new \DateTimeZone('UTC'));
+
+        $result = DateFormatterUtils::getFormattedISO8601DateFromDateTime($dateTime);
+
+        $this->assertStringStartsWith('2024-06-15T14:30:45.123', $result);
+        $this->assertStringEndsWith('+00:00', $result);
+    }
+
+    public function testGetFormattedISO8601DateFromDateTimeWithTimezone(): void
+    {
+        $dateTime = new \DateTime('2024-06-15 14:30:45', new \DateTimeZone('America/New_York'));
+
+        $result = DateFormatterUtils::getFormattedISO8601DateFromDateTime($dateTime);
+
+        $this->assertStringContainsString('2024-06-15T14:30:45', $result);
+        // EDT is -04:00, EST is -05:00
+        $this->assertMatchesRegularExpression('/-0[45]:00$/', $result);
+    }
+
+}


### PR DESCRIPTION
## Summary
- Replace all 30 callers of the removed global `oeFormatDateTime()` with `DateFormatterUtils::oeFormatDateTime()` across `interface/`, `library/`, `src/`, `templates/`, and `custom/`
- Refactor `DateFormatterUtils` to accept an injectable `ParameterBag` for globals instead of accessing `$GLOBALS` directly, enabling isolated testing
- Add comprehensive isolated tests (461 lines) covering all date/time format combinations, edge cases, and error handling
- Remove the global `oeFormatDateTime()` wrapper from `formatting.inc.php`
- Fix always-true conditional in `DateFormatterUtils::DateToYYYYMMDD()`
- Add `bool` type hints to `oeFormatShortDate()` and `oeFormatTime()` wrapper functions
- Update PHPStan baselines (remove 180 deprecated-function entries, update counts)

## Test plan
- [x] `composer phpunit-isolated` — all 1408 tests pass
- [x] `composer phpstan` — no errors
- [x] All pre-commit hooks pass (phpcs, phpstan, rector, require-checker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)