### PR TITLE
refactor(billing): return booleans instead of string values in connectivity checks

### DIFF
--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -4822,11 +4822,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-dorn/src/ConnectorApi.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\Dorn\\\\ConnectorApi\\:\\:canConnectToClaimRev\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-dorn/src/ConnectorApi.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\Dorn\\\\ConnectorApi\\:\\:createRoute\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-dorn/src/ConnectorApi.php',

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/public/debug-info.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/public/debug-info.php
@@ -46,7 +46,7 @@ if (!AclMain::aclCheckCore('acct', 'bill')) {
                     <li><?php echo xlt("Client Scope");?>: <?php echo text($connectivityInfo->client_scope); ?></li>
                     <li><?php echo xlt("API Server");?>: <?php echo text($connectivityInfo->api_server); ?></li>
                     <li><?php echo xlt("Default Account");?>: <?php echo text($connectivityInfo->defaultAccount); ?>  </li>
-                    <li><?php echo xlt("Token");?>:  <?php echo text($connectivityInfo->hasToken); ?>  </li>
+                    <li><?php echo xlt("Token");?>:  <?php echo $connectivityInfo->hasToken ? xlt("Yes") : xlt("No"); ?>  </li>
                 </ul>
             </div>
         </div>

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/src/ConnectivityInfo.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/src/ConnectivityInfo.php
@@ -23,7 +23,7 @@ class ConnectivityInfo
     public string $client_scope;
     public string $client_secret;
     public string $api_server;
-    public string $hasToken;
+    public bool $hasToken;
     public string $defaultAccount;
 
     public function __construct()
@@ -42,13 +42,13 @@ class ConnectivityInfo
 
         try {
             $api = ClaimRevApi::makeFromGlobals();
-            $this->hasToken = $api->canConnect() ? 'Yes' : 'No';
+            $this->hasToken = $api->canConnect();
             $this->defaultAccount = json_encode($api->getDefaultAccount(), JSON_THROW_ON_ERROR);
         } catch (ClaimRevAuthenticationException) {
-            $this->hasToken = 'No';
+            $this->hasToken = false;
             $this->defaultAccount = '';
         } catch (ClaimRevApiException) {
-            $this->hasToken = 'Yes';
+            $this->hasToken = true;
             $this->defaultAccount = '';
         }
     }

--- a/interface/modules/custom_modules/oe-module-dorn/src/ConnectorApi.php
+++ b/interface/modules/custom_modules/oe-module-dorn/src/ConnectorApi.php
@@ -336,13 +336,13 @@ class ConnectorApi
     }
 
 
-    public static function canConnectToClaimRev()
+    public static function canConnectToClaimRev(): bool
     {
         try {
             ClaimRevApi::makeFromGlobals();
-            return "Yes";
+            return true;
         } catch (ClaimRevAuthenticationException) {
-            return "No";
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace `"Yes"`/`"No"` string literals with native PHP `bool` in `ConnectorApi::canConnectToClaimRev()` and `ConnectivityInfo::$hasToken`
- Move Yes/No string rendering to the presentation layer in `debug-info.php` using `xlt()` on a boolean ternary
- Add explicit `: bool` return type annotation to `canConnectToClaimRev()`
- Remove now-resolved PHPStan baseline suppression for missing return type

## Changes

- `interface/modules/custom_modules/oe-module-dorn/src/ConnectorApi.php`: Changed return type from `string` (`"Yes"`/`"No"`) to `bool` (`true`/`false`); added `: bool` return type declaration
- `interface/modules/custom_modules/oe-module-claimrev-connect/src/ConnectivityInfo.php`: Changed `$hasToken` property type from `string` to `bool`; updated all assignments to boolean values
- `interface/modules/custom_modules/oe-module-claimrev-connect/public/debug-info.php`: Updated token display to use `$connectivityInfo->hasToken ? xlt("Yes") : xlt("No")` — localized string conversion now happens at the view layer
- `.phpstan/baseline/missingType.return.php`: Removed suppression for `canConnectToClaimRev()` return type (now explicitly typed)

## Testing

- Verify the ClaimRev Connect debug page still displays "Yes" or "No" for the Token field
- `composer phpstan` passes with no errors
- `composer phpcs` passes with no violations
- `codespell` passes on all changed files

Fixes #10819

> Code generated with the assistance of Claude (Anthropic)