### PR TITLE
test: add isolated tests for search query subsystem

### DIFF
--- a/tests/Tests/Isolated/Services/Search/ReferenceSearchValueTest.php
+++ b/tests/Tests/Isolated/Services/Search/ReferenceSearchValueTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * ReferenceSearchValue Isolated Test
+ *
+ * Tests non-UUID reference parsing and formatting. UUID-specific behavior
+ * requires UuidRegistry and is tested in integration tests.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Search;
+
+use OpenEMR\Services\Search\ReferenceSearchValue;
+use PHPUnit\Framework\TestCase;
+
+class ReferenceSearchValueTest extends TestCase
+{
+    // =========================================================================
+    // Constructor
+    // =========================================================================
+
+    public function testConstructorWithIdOnly(): void
+    {
+        $ref = new ReferenceSearchValue('23');
+        $this->assertSame('23', $ref->getId());
+        $this->assertNull($ref->getResource());
+    }
+
+    public function testConstructorWithIdAndResource(): void
+    {
+        $ref = new ReferenceSearchValue('23', 'Patient');
+        $this->assertSame('23', $ref->getId());
+        $this->assertSame('Patient', $ref->getResource());
+    }
+
+    // =========================================================================
+    // createFromRelativeUri
+    // =========================================================================
+
+    public function testCreateFromRelativeUriWithResourceAndId(): void
+    {
+        $ref = ReferenceSearchValue::createFromRelativeUri('Patient/23');
+        $this->assertSame('Patient', $ref->getResource());
+        $this->assertSame('23', $ref->getId());
+    }
+
+    public function testCreateFromRelativeUriWithIdOnly(): void
+    {
+        $ref = ReferenceSearchValue::createFromRelativeUri('23');
+        $this->assertNull($ref->getResource());
+        $this->assertSame('23', $ref->getId());
+    }
+
+    public function testCreateFromRelativeUriWithDeepPath(): void
+    {
+        // For paths with multiple slashes, resource is first segment, id is last
+        $ref = ReferenceSearchValue::createFromRelativeUri('Organization/dept/42');
+        $this->assertSame('Organization', $ref->getResource());
+        $this->assertSame('42', $ref->getId());
+    }
+
+    public function testCreateFromRelativeUriWithCommonFhirResources(): void
+    {
+        $resources = [
+            'Patient/100' => ['Patient', '100'],
+            'Encounter/200' => ['Encounter', '200'],
+            'Practitioner/300' => ['Practitioner', '300'],
+            'Organization/400' => ['Organization', '400'],
+            'Location/500' => ['Location', '500'],
+        ];
+
+        foreach ($resources as $uri => [$expectedResource, $expectedId]) {
+            $ref = ReferenceSearchValue::createFromRelativeUri($uri);
+            $this->assertSame($expectedResource, $ref->getResource(), "Resource mismatch for URI: {$uri}");
+            $this->assertSame($expectedId, $ref->getId(), "ID mismatch for URI: {$uri}");
+        }
+    }
+
+    // =========================================================================
+    // __toString
+    // =========================================================================
+
+    public function testToStringWithResourceAndId(): void
+    {
+        $ref = new ReferenceSearchValue('23', 'Patient');
+        $this->assertSame('Patient/23', (string) $ref);
+    }
+
+    public function testToStringWithIdOnly(): void
+    {
+        $ref = new ReferenceSearchValue('23');
+        $this->assertSame('23', (string) $ref);
+    }
+
+    // =========================================================================
+    // getHumanReadableId (non-UUID)
+    // =========================================================================
+
+    public function testGetHumanReadableIdReturnsIdDirectlyForNonUuid(): void
+    {
+        $ref = new ReferenceSearchValue('42', 'Patient');
+        $this->assertSame('42', $ref->getHumanReadableId());
+    }
+
+    // =========================================================================
+    // Round-trip: createFromRelativeUri -> __toString
+    // =========================================================================
+
+    public function testRoundTripFromRelativeUri(): void
+    {
+        $uri = 'Patient/23';
+        $ref = ReferenceSearchValue::createFromRelativeUri($uri);
+        $this->assertSame($uri, (string) $ref);
+    }
+}

--- a/tests/Tests/Isolated/Services/Search/SearchComparatorTest.php
+++ b/tests/Tests/Isolated/Services/Search/SearchComparatorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * SearchComparator Isolated Test
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Search;
+
+use OpenEMR\Services\Search\SearchComparator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class SearchComparatorTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     * @codeCoverageIgnore
+     */
+    public static function validComparatorProvider(): iterable
+    {
+        yield 'equals' => [SearchComparator::EQUALS];
+        yield 'not equals' => [SearchComparator::NOT_EQUALS];
+        yield 'greater than' => [SearchComparator::GREATER_THAN];
+        yield 'less than' => [SearchComparator::LESS_THAN];
+        yield 'greater than or equal' => [SearchComparator::GREATER_THAN_OR_EQUAL_TO];
+        yield 'less than or equal' => [SearchComparator::LESS_THAN_OR_EQUAL_TO];
+        yield 'starts after' => [SearchComparator::STARTS_AFTER];
+        yield 'ends before' => [SearchComparator::ENDS_BEFORE];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     * @codeCoverageIgnore
+     */
+    public static function invalidComparatorProvider(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'random string' => ['foo'];
+        yield 'uppercase EQ' => ['EQ'];
+        yield 'approximately' => [SearchComparator::APROXIMATELY_SAME];
+    }
+
+    #[DataProvider('validComparatorProvider')]
+    public function testIsValidComparatorWithValidValues(string $comparator): void
+    {
+        $this->assertTrue(SearchComparator::isValidComparator($comparator));
+    }
+
+    #[DataProvider('invalidComparatorProvider')]
+    public function testIsValidComparatorWithInvalidValues(string $comparator): void
+    {
+        $this->assertFalse(SearchComparator::isValidComparator($comparator));
+    }
+
+    public function testAllComparatorsConstantMatchesValidComparators(): void
+    {
+        foreach (SearchComparator::ALL_COMPARATORS as $comparator) {
+            $this->assertTrue(
+                SearchComparator::isValidComparator($comparator),
+                "ALL_COMPARATORS entry '{$comparator}' should be valid"
+            );
+        }
+    }
+
+    public function testApproximatelyIsNotInAllComparators(): void
+    {
+        // "ap" (approximately) is intentionally excluded from ALL_COMPARATORS
+        $this->assertFalse(SearchComparator::isValidComparator(SearchComparator::APROXIMATELY_SAME));
+    }
+}

--- a/tests/Tests/Isolated/Services/Search/SearchConfigClauseBuilderTest.php
+++ b/tests/Tests/Isolated/Services/Search/SearchConfigClauseBuilderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * SearchConfigClauseBuilder Isolated Test
+ *
+ * Tests the buildSortOrderClauseFromConfig method which generates SQL ORDER BY
+ * clauses with column whitelist enforcement.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Search;
+
+use OpenEMR\Services\Search\SearchConfigClauseBuilder;
+use OpenEMR\Services\Search\SearchFieldOrder;
+use OpenEMR\Services\Search\SearchQueryConfig;
+use PHPUnit\Framework\TestCase;
+
+class SearchConfigClauseBuilderTest extends TestCase
+{
+    private const ALLOWED_COLUMNS = ['name', 'date', 'status', 'id'];
+
+    public function testEmptyConfigReturnsEmptyString(): void
+    {
+        $config = new SearchQueryConfig();
+        $result = SearchConfigClauseBuilder::buildSortOrderClauseFromConfig($config, self::ALLOWED_COLUMNS);
+        $this->assertSame('', $result);
+    }
+
+    public function testSingleAscendingField(): void
+    {
+        $config = new SearchQueryConfig();
+        $config->addSearchFieldOrder(new SearchFieldOrder('name', true));
+
+        $result = SearchConfigClauseBuilder::buildSortOrderClauseFromConfig($config, self::ALLOWED_COLUMNS);
+        $this->assertSame('ORDER BY name ASC', $result);
+    }
+
+    public function testSingleDescendingField(): void
+    {
+        $config = new SearchQueryConfig();
+        $config->addSearchFieldOrder(new SearchFieldOrder('date', false));
+
+        $result = SearchConfigClauseBuilder::buildSortOrderClauseFromConfig($config, self::ALLOWED_COLUMNS);
+        $this->assertSame('ORDER BY date DESC', $result);
+    }
+
+    public function testMultipleFields(): void
+    {
+        $config = new SearchQueryConfig();
+        $config->addSearchFieldOrder(new SearchFieldOrder('name', true));
+        $config->addSearchFieldOrder(new SearchFieldOrder('date', false));
+        $config->addSearchFieldOrder(new SearchFieldOrder('id', true));
+
+        $result = SearchConfigClauseBuilder::buildSortOrderClauseFromConfig($config, self::ALLOWED_COLUMNS);
+        $this->assertSame('ORDER BY name ASC, date DESC, id ASC', $result);
+    }
+
+    public function testDisallowedColumnIsFiltered(): void
+    {
+        $config = new SearchQueryConfig();
+        $config->addSearchFieldOrder(new SearchFieldOrder('malicious_column', true));
+
+        $result = SearchConfigClauseBuilder::buildSortOrderClauseFromConfig($config, self::ALLOWED_COLUMNS);
+        $this->assertSame('', $result);
+    }
+
+    public function testMixOfAllowedAndDisallowedColumns(): void
+    {
+        $config = new SearchQueryConfig();
+        $config->addSearchFieldOrder(new SearchFieldOrder('name', true));
+        $config->addSearchFieldOrder(new SearchFieldOrder('DROP TABLE users', true));
+        $config->addSearchFieldOrder(new SearchFieldOrder('date', false));
+
+        $result = SearchConfigClauseBuilder::buildSortOrderClauseFromConfig($config, self::ALLOWED_COLUMNS);
+        $this->assertSame('ORDER BY name ASC, date DESC', $result);
+    }
+
+    public function testEmptyAllowedColumnsFiltersEverything(): void
+    {
+        $config = new SearchQueryConfig();
+        $config->addSearchFieldOrder(new SearchFieldOrder('name', true));
+
+        $result = SearchConfigClauseBuilder::buildSortOrderClauseFromConfig($config, []);
+        $this->assertSame('', $result);
+    }
+}

--- a/tests/Tests/Isolated/Services/Search/SearchQueryConfigTest.php
+++ b/tests/Tests/Isolated/Services/Search/SearchQueryConfigTest.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * SearchQueryConfig Isolated Test
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Search;
+
+use OpenEMR\Services\Search\SearchFieldOrder;
+use OpenEMR\Services\Search\SearchQueryConfig;
+use PHPUnit\Framework\TestCase;
+
+class SearchQueryConfigTest extends TestCase
+{
+    /**
+     * Assert and return typed search field orders from a config.
+     *
+     * @return list<SearchFieldOrder>
+     */
+    private function getTypedOrders(SearchQueryConfig $config): array
+    {
+        $orders = $config->getSearchFieldOrders();
+        $this->assertContainsOnlyInstancesOf(SearchFieldOrder::class, $orders);
+        /** @var list<SearchFieldOrder> $orders */
+        return $orders;
+    }
+
+    /**
+     * Call createConfigFromQueryParams and assert the return type.
+     *
+     * @param array<string, mixed> $params
+     */
+    private function createConfig(array $params): SearchQueryConfig
+    {
+        $config = SearchQueryConfig::createConfigFromQueryParams($params);
+        $this->assertInstanceOf(SearchQueryConfig::class, $config);
+        return $config;
+    }
+
+    /**
+     * Call createFhirConfigFromSearchParams and assert the return type.
+     *
+     * @param array<string, mixed> $params
+     */
+    private function createFhirConfig(array $params): SearchQueryConfig
+    {
+        $config = SearchQueryConfig::createFhirConfigFromSearchParams($params);
+        $this->assertInstanceOf(SearchQueryConfig::class, $config);
+        return $config;
+    }
+
+    // =========================================================================
+    // Constructor defaults
+    // =========================================================================
+
+    public function testDefaultPaginationIsZero(): void
+    {
+        $config = new SearchQueryConfig();
+        $this->assertSame(0, $config->getPagination()->getLimit());
+    }
+
+    public function testDefaultSearchFieldOrdersIsEmpty(): void
+    {
+        $config = new SearchQueryConfig();
+        $this->assertSame([], $config->getSearchFieldOrders());
+    }
+
+    // =========================================================================
+    // addSearchFieldOrder
+    // =========================================================================
+
+    public function testAddSearchFieldOrderAccumulatesOrders(): void
+    {
+        $config = new SearchQueryConfig();
+        $config->addSearchFieldOrder(new SearchFieldOrder('name', true));
+        $config->addSearchFieldOrder(new SearchFieldOrder('date', false));
+
+        $orders = $this->getTypedOrders($config);
+        $this->assertCount(2, $orders);
+        $this->assertSame('name', $orders[0]->getField());
+        $this->assertTrue($orders[0]->isAscending());
+        $this->assertSame('date', $orders[1]->getField());
+        $this->assertFalse($orders[1]->isAscending());
+    }
+
+    // =========================================================================
+    // createConfigFromQueryParams — pagination
+    // =========================================================================
+
+    public function testCreateConfigFromQueryParamsWithMaxresults(): void
+    {
+        $config = $this->createConfig([
+            '_maxresults' => '50',
+            '_offset' => '10',
+        ]);
+
+        $this->assertSame(50, $config->getPagination()->getLimit());
+        $this->assertSame(10, $config->getPagination()->getCurrentOffsetId());
+    }
+
+    public function testCreateConfigFromQueryParamsWithLimit(): void
+    {
+        $config = $this->createConfig(['_limit' => '25']);
+        $this->assertSame(25, $config->getPagination()->getLimit());
+    }
+
+    public function testCreateConfigFromQueryParamsMaxresultsTakesPrecedenceOverLimit(): void
+    {
+        $config = $this->createConfig([
+            '_maxresults' => '100',
+            '_limit' => '25',
+        ]);
+
+        $this->assertSame(100, $config->getPagination()->getLimit());
+    }
+
+    public function testCreateConfigFromQueryParamsDefaultsToZeroPagination(): void
+    {
+        $config = $this->createConfig([]);
+
+        $this->assertSame(0, $config->getPagination()->getLimit());
+        $this->assertSame(0, $config->getPagination()->getCurrentOffsetId());
+    }
+
+    // =========================================================================
+    // createConfigFromQueryParams — sort
+    // =========================================================================
+
+    public function testCreateConfigFromQueryParamsWithAscendingSort(): void
+    {
+        $config = $this->createConfig(['_sort' => 'name']);
+
+        $orders = $this->getTypedOrders($config);
+        $this->assertCount(1, $orders);
+        $this->assertSame('name', $orders[0]->getField());
+        $this->assertTrue($orders[0]->isAscending());
+    }
+
+    public function testCreateConfigFromQueryParamsWithDescendingSort(): void
+    {
+        $config = $this->createConfig(['_sort' => '-date']);
+
+        $orders = $this->getTypedOrders($config);
+        $this->assertCount(1, $orders);
+        $this->assertSame('date', $orders[0]->getField());
+        $this->assertFalse($orders[0]->isAscending());
+    }
+
+    public function testCreateConfigFromQueryParamsWithMultipleSortFields(): void
+    {
+        $config = $this->createConfig(['_sort' => 'name,-date,status']);
+
+        $orders = $this->getTypedOrders($config);
+        $this->assertCount(3, $orders);
+
+        $this->assertSame('name', $orders[0]->getField());
+        $this->assertTrue($orders[0]->isAscending());
+
+        $this->assertSame('date', $orders[1]->getField());
+        $this->assertFalse($orders[1]->isAscending());
+
+        $this->assertSame('status', $orders[2]->getField());
+        $this->assertTrue($orders[2]->isAscending());
+    }
+
+    public function testCreateConfigFromQueryParamsWithNoSort(): void
+    {
+        $config = $this->createConfig(['_maxresults' => '10']);
+        $this->assertSame([], $config->getSearchFieldOrders());
+    }
+
+    // =========================================================================
+    // createFhirConfigFromSearchParams
+    // =========================================================================
+
+    public function testCreateFhirConfigFromSearchParamsWithCountAndOffset(): void
+    {
+        $config = $this->createFhirConfig([
+            '_count' => '20',
+            '_offset' => '5',
+        ]);
+
+        $this->assertSame(20, $config->getPagination()->getLimit());
+        $this->assertSame(5, $config->getPagination()->getCurrentOffsetId());
+    }
+
+    public function testCreateFhirConfigFromSearchParamsDefaultsToZero(): void
+    {
+        $config = $this->createFhirConfig([]);
+
+        $this->assertSame(0, $config->getPagination()->getLimit());
+        $this->assertSame(0, $config->getPagination()->getCurrentOffsetId());
+    }
+
+    public function testCreateFhirConfigFromSearchParamsWithSortOrders(): void
+    {
+        $order1 = new SearchFieldOrder('family', true);
+        $order2 = new SearchFieldOrder('birthdate', false);
+
+        $config = $this->createFhirConfig(['_sort' => [$order1, $order2]]);
+
+        $orders = $this->getTypedOrders($config);
+        $this->assertCount(2, $orders);
+        $this->assertSame('family', $orders[0]->getField());
+        $this->assertSame('birthdate', $orders[1]->getField());
+    }
+
+    public function testCreateFhirConfigFromSearchParamsIgnoresNonSearchFieldOrderItems(): void
+    {
+        $order = new SearchFieldOrder('name', true);
+
+        $config = $this->createFhirConfig([
+            '_sort' => [$order, 'not-a-search-field-order', 42],
+        ]);
+
+        $orders = $this->getTypedOrders($config);
+        $this->assertCount(1, $orders);
+        $this->assertSame('name', $orders[0]->getField());
+    }
+}

--- a/tests/Tests/Isolated/Services/Search/TokenSearchValueTest.php
+++ b/tests/Tests/Isolated/Services/Search/TokenSearchValueTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * TokenSearchValue Isolated Test
+ *
+ * Tests non-UUID token parsing and formatting. UUID-specific behavior
+ * requires UuidRegistry and is tested in integration tests.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Search;
+
+use OpenEMR\Services\Search\TokenSearchValue;
+use PHPUnit\Framework\TestCase;
+
+class TokenSearchValueTest extends TestCase
+{
+    // =========================================================================
+    // Constructor
+    // =========================================================================
+
+    public function testConstructorWithCodeOnly(): void
+    {
+        $token = new TokenSearchValue('active');
+        $this->assertSame('active', $token->getCode());
+        $this->assertNull($token->getSystem());
+    }
+
+    public function testConstructorWithCodeAndSystem(): void
+    {
+        $token = new TokenSearchValue('M', 'http://hl7.org/fhir/administrative-gender');
+        $this->assertSame('M', $token->getCode());
+        $this->assertSame('http://hl7.org/fhir/administrative-gender', $token->getSystem());
+    }
+
+    public function testConstructorWithNumericCode(): void
+    {
+        $token = new TokenSearchValue(42);
+        $this->assertSame(42, $token->getCode());
+    }
+
+    // =========================================================================
+    // buildFromFHIRString
+    // =========================================================================
+
+    public function testBuildFromFHIRStringWithCodeOnly(): void
+    {
+        $token = TokenSearchValue::buildFromFHIRString('active');
+        $this->assertSame('active', $token->getCode());
+        $this->assertNull($token->getSystem());
+    }
+
+    public function testBuildFromFHIRStringWithSystemAndCode(): void
+    {
+        $token = TokenSearchValue::buildFromFHIRString('http://hl7.org/fhir/administrative-gender|M');
+        $this->assertSame('M', $token->getCode());
+        $this->assertSame('http://hl7.org/fhir/administrative-gender', $token->getSystem());
+    }
+
+    public function testBuildFromFHIRStringWithEmptySystem(): void
+    {
+        $token = TokenSearchValue::buildFromFHIRString('|active');
+        $this->assertSame('active', $token->getCode());
+        $this->assertSame('', $token->getSystem());
+    }
+
+    public function testBuildFromFHIRStringWithMultiplePipes(): void
+    {
+        // When there are multiple pipes, system is first part, code is last part
+        $token = TokenSearchValue::buildFromFHIRString('system|subsystem|code');
+        $this->assertSame('code', $token->getCode());
+        $this->assertSame('system', $token->getSystem());
+    }
+
+    // =========================================================================
+    // setCode / setSystem
+    // =========================================================================
+
+    public function testSetCodeUpdatesCode(): void
+    {
+        $token = new TokenSearchValue('old');
+        $token->setCode('new');
+        $this->assertSame('new', $token->getCode());
+    }
+
+    public function testSetSystemUpdatesSystem(): void
+    {
+        $token = new TokenSearchValue('code');
+        $token->setSystem('http://example.org');
+        $this->assertSame('http://example.org', $token->getSystem());
+    }
+
+    // =========================================================================
+    // __toString
+    // =========================================================================
+
+    public function testToStringWithCodeAndSystem(): void
+    {
+        $token = new TokenSearchValue('M', 'http://hl7.org/fhir/gender');
+        $this->assertSame('M|http://hl7.org/fhir/gender', (string) $token);
+    }
+
+    public function testToStringWithCodeOnly(): void
+    {
+        $token = new TokenSearchValue('active');
+        $this->assertSame('active|', (string) $token);
+    }
+
+    // =========================================================================
+    // getHumanReadableCode (non-UUID)
+    // =========================================================================
+
+    public function testGetHumanReadableCodeReturnsCodeDirectlyForNonUuid(): void
+    {
+        $token = new TokenSearchValue('active');
+        $this->assertSame('active', $token->getHumanReadableCode());
+    }
+}


### PR DESCRIPTION
## Summary

- **SearchQueryConfigTest** (14 tests): query parameter parsing for `_sort`, `_maxresults`/`_limit`, `_offset`/`_count`; FHIR vs generic config creation; ascending/descending sort parsing with `-` prefix
- **SearchConfigClauseBuilderTest** (7 tests): ORDER BY clause generation with column whitelist enforcement; filters disallowed columns (SQL injection prevention)
- **TokenSearchValueTest** (12 tests): FHIR token parsing (`system|code` format), `buildFromFHIRString()`, code/system accessors, `__toString` formatting
- **ReferenceSearchValueTest** (11 tests): relative URI parsing (`Resource/id` format), common FHIR resources, deep paths, round-trip conversion
- **SearchComparatorTest** (14 tests): FHIR search comparator validation (eq, ne, gt, lt, ge, le, sa, eb); verifies `ap` is excluded from valid comparators

## Test plan

- [x] All 58 tests pass locally via `phpunit-isolated.xml`
- [x] PHPStan level 10 clean
- [x] Pre-commit hooks pass (phpcs, rector, codespell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)