### PR TITLE
refactor(js): replace jQuery $.ajax with native fetch() API

### DIFF
--- a/interface/main/messages/templates/linked_documents.php
+++ b/interface/main/messages/templates/linked_documents.php
@@ -230,7 +230,7 @@ try {
     window.addEventListener("DOMContentLoaded", startDocumentValidation);
 
     // this originally came from the messages class... but it makes no sense to have it there when we only use it here.
-    function gotoReport(doc_id, pname, pid, pubpid, str_dob) {
+    async function gotoReport(doc_id, pname, pid, pubpid, str_dob) {
         EncounterDateArray = [];
         CalendarCategoryArray = [];
         EncounterIdArray = [];
@@ -248,15 +248,18 @@ try {
         }
         ?>
         top.restoreSession();
-        $.ajax({
-            type: 'get',
-            url: '<?php echo $GLOBALS['webroot'] . "/library/ajax/set_pt.php";?>',
-            data: {
-                set_pid: pid,
-                csrf_token_form: <?php echo js_escape(CsrfUtils::collectCsrfToken()); ?>
-            },
-            async: false
+        const params = new URLSearchParams({
+            set_pid: pid,
+            csrf_token_form: <?php echo js_escape(CsrfUtils::collectCsrfToken()); ?>
         });
+        try {
+            await fetch('<?php echo $GLOBALS['webroot'] . "/library/ajax/set_pt.php";?>?' + params.toString(), {
+                method: 'GET',
+                credentials: 'same-origin'
+            });
+        } catch (error) {
+            console.error('Error setting patient session:', error);
+        }
         parent.left_nav.setPatient(pname, pid, pubpid, '', str_dob);
         parent.left_nav.setPatientEncounter(EncounterIdArray, EncounterDateArray, CalendarCategoryArray);
         var docurl = '../controller.php?document&view' + "&patient_id=" + encodeURIComponent(pid) + "&document_id=" + encodeURIComponent(doc_id) + "&";

--- a/interface/main/tabs/js/tabs_view_model.js
+++ b/interface/main/tabs/js/tabs_view_model.js
@@ -311,7 +311,7 @@ function popMenuDialog(url, title) {
     });
 }
 
-function menuActionClick(data,evt)
+async function menuActionClick(data,evt)
 {
     // Yet another menu fixup for legacy 'popup'.
     // let's abandon a tab and call a support function from this view.
@@ -327,7 +327,7 @@ function menuActionClick(data,evt)
         if(data.requirement===2)
         {
             var encounterID=app_view_model.application_data[attendant_type]().selectedEncounterID();
-            if(isEncounterLocked(encounterID))
+            if(await isEncounterLocked(encounterID))
             {
                 alert(xl('This encounter is locked. No new forms can be added.'));
                 return;

--- a/interface/usergroup/user_info.php
+++ b/interface/usergroup/user_info.php
@@ -47,20 +47,25 @@ function update_password()
     // Strong if required
     // Matches
 
-    $.post("user_info_ajax.php",
-        {
-            curPass:    $("input[name='curPass']").val(),
-            newPass:    $("input[name='newPass']").val(),
-            newPass2:   $("input[name='newPass2']").val(),
-            csrf_token_form: <?php echo js_escape(CsrfUtils::collectCsrfToken()); ?>
-        },
-        function(data)
-        {
-            $("input[type='password']").val("");
-            $("#display_msg").html(data);
-        }
+    var formData = new FormData();
+    formData.append('curPass', document.querySelector("input[name='curPass']").value);
+    formData.append('newPass', document.querySelector("input[name='newPass']").value);
+    formData.append('newPass2', document.querySelector("input[name='newPass2']").value);
+    formData.append('csrf_token_form', <?php echo js_escape(CsrfUtils::collectCsrfToken()); ?>);
 
-    );
+    fetch("user_info_ajax.php", {
+        method: 'POST',
+        body: formData,
+        credentials: 'same-origin'
+    }).then(function(response) {
+        return response.text();
+    }).then(function(data) {
+        document.querySelectorAll("input[type='password']").forEach(function(el) { el.value = ''; });
+        document.getElementById('display_msg').innerHTML = data;
+    }).catch(function(error) {
+        console.error('Error updating password:', error);
+    });
+
     return false;
 }
 


### PR DESCRIPTION
## Summary

- Replace synchronous `$.ajax({async: false})` calls with `async/await fetch()` to eliminate browser main-thread blocking
- Convert jQuery `$.post()` and `$.ajax()` to the native `fetch()` API with proper error handling
- Start with the files recommended by maintainers and the most harmful `async: false` patterns

## Changes

| File | Change |
|------|--------|
| `interface/usergroup/user_info.php` | `$.post()` → `fetch()` with Promise chaining (maintainer-suggested first target) |
| `interface/main/tabs/main.php` | `isEncounterLocked()`: `$.ajax({async:false})` → `async/await fetch()`; `getSessionValue()`: `$.ajax` → `fetch()` |
| `interface/main/tabs/js/tabs_view_model.js` | `menuActionClick()` made `async`, uses `await isEncounterLocked()` |
| `interface/main/messages/templates/linked_documents.php` | `gotoReport()`: `$.ajax({async:false})` → `async/await fetch()` |

## Notes

- The `isEncounterLocked` conversion in `main.php` fulfils an existing `@TODO` comment in the code that explicitly called for this change
- CSRF tokens and `restoreSession()` calls are preserved in all conversions
- `credentials: 'same-origin'` is set on all fetch calls to maintain session handling
- This is an incremental PR — additional files with `async: false` and standard jQuery AJAX calls will be addressed in follow-up PRs

## Testing

- [ ] Verify password change form works on the user info page
- [ ] Verify encounter lock checking works when opening forms from the menu
- [ ] Verify linked document navigation works from the messages page
- [ ] Confirm no console errors in browser developer tools

Fixes #2072

> Code generated with the assistance of Claude (Anthropic)