### PR TITLE
test: add isolated tests for EDI270, event DTOs, Metadata, and oeHttpResponse

### DIFF
--- a/tests/Tests/Isolated/Billing/EDI270Test.php
+++ b/tests/Tests/Isolated/Billing/EDI270Test.php
@@ -1,0 +1,274 @@
+<?php
+
+/**
+ * Isolated tests for EDI270 X12 segment-creation static methods
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Billing;
+
+use OpenEMR\Billing\EDI270;
+use PHPUnit\Framework\TestCase;
+
+class EDI270Test extends TestCase
+{
+    private string $segTer = '~';
+    private string $compEleSep = ':';
+    /** @var array<string, string> */
+    private array $row;
+    /** @var array<string, string> */
+    private array $X12info;
+
+    protected function setUp(): void
+    {
+        $this->row = [
+            'lname' => 'Doe',
+            'fname' => 'John',
+            'mname' => 'Q',
+            'dob' => '19800115',
+            'sex' => 'Male',
+            'pid' => '42',
+            'pubpid' => '42',
+            'policy_number' => 'POL123456',
+            'provider_npi' => '1234567890',
+            'provider_pin' => 'PIN999',
+            'facility_name' => 'Test Clinic',
+            'facility_npi' => '0987654321',
+            'payer_name' => 'Test Insurance',
+            'cms_id' => 'CMS001',
+            'eligibility_id' => 'ELIG001',
+            'date' => '20260101',
+            'pc_eventDate' => '20260215',
+            'subscriber_relationship' => 'self',
+        ];
+
+        $this->X12info = [
+            'x12_sender_id' => 'SENDER01',
+            'x12_receiver_id' => 'RECEIVER01',
+            'x12_isa05' => 'ZZ',
+            'x12_isa07' => 'ZZ',
+            'x12_isa14' => '0',
+            'x12_isa15' => 'T',
+            'x12_dtp03' => 'A',
+        ];
+    }
+
+    /**
+     * Assert result is a string and parse an EDI segment into fields
+     * @return list<string>
+     */
+    private function assertAndParseSegment(mixed $result): array
+    {
+        $this->assertIsString($result);
+        return explode('*', rtrim($result, '~'));
+    }
+
+    public function testCreateSTReturnsCorrectSegment(): void
+    {
+        $result = EDI270::createST($this->row, $this->X12info, $this->segTer, $this->compEleSep);
+        $this->assertIsString($result);
+
+        $this->assertStringStartsWith('ST*270*', $result);
+        $this->assertStringEndsWith('~', $result);
+        $this->assertStringContainsString('005010X279A1', $result);
+        $fields = $this->assertAndParseSegment($result);
+        $this->assertCount(4, $fields);
+        $this->assertSame('ST', $fields[0]);
+        $this->assertSame('270', $fields[1]);
+        $this->assertSame('000000003', $fields[2]);
+        $this->assertSame('005010X279A1', $fields[3]);
+    }
+
+    public function testCreateBHTReturnsCorrectStructure(): void
+    {
+        $result = EDI270::createBHT($this->row, $this->X12info, $this->segTer, $this->compEleSep);
+        $this->assertIsString($result);
+
+        $this->assertStringStartsWith('BHT*0022*13*PROVTest600*', $result);
+        $this->assertStringEndsWith('~', $result);
+        $fields = $this->assertAndParseSegment($result);
+        $this->assertCount(6, $fields);
+        $this->assertSame('BHT', $fields[0]);
+        $this->assertSame('0022', $fields[1]);
+        $this->assertSame('13', $fields[2]);
+        // BHT[4] is date in CCYYMMDD format — assert 8 chars
+        $this->assertMatchesRegularExpression('/^\d{8}$/', trim($fields[4]));
+        // BHT[5] is time in HHMM format — assert 4 chars
+        $this->assertMatchesRegularExpression('/^\d{4}$/', trim($fields[5]));
+    }
+
+    public function testCreateHLCounter1IsInformationSource(): void
+    {
+        $fields = $this->assertAndParseSegment(
+            EDI270::createHL($this->row, 1, $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        $this->assertSame('HL', $fields[0]);
+        $this->assertSame('1', $fields[1]);
+        $this->assertSame('', $fields[2]); // no parent
+        $this->assertSame('20', $fields[3]); // information source
+        $this->assertSame('1', $fields[4]); // has subordinate
+    }
+
+    public function testCreateHLCounter2IsInformationReceiver(): void
+    {
+        $fields = $this->assertAndParseSegment(
+            EDI270::createHL($this->row, 2, $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        $this->assertSame('HL', $fields[0]);
+        $this->assertSame('2', $fields[1]);
+        $this->assertSame('1', $fields[2]); // parent is HL 1
+        $this->assertSame('21', $fields[3]); // information receiver
+        $this->assertSame('1', $fields[4]); // has subordinate
+    }
+
+    public function testCreateHLCounter3PlusIsSubscriber(): void
+    {
+        $fields = $this->assertAndParseSegment(
+            EDI270::createHL($this->row, 3, $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        $this->assertSame('HL', $fields[0]);
+        $this->assertSame('3', $fields[1]);
+        $this->assertSame('2', $fields[2]); // parent is HL 2
+        $this->assertSame('22', $fields[3]); // subscriber
+        $this->assertSame('0', $fields[4]); // no subordinate
+
+        // Also test counter=5 to confirm >2 branch
+        $fields5 = $this->assertAndParseSegment(
+            EDI270::createHL($this->row, 5, $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        $this->assertSame('5', $fields5[1]);
+        $this->assertSame('22', $fields5[3]);
+    }
+
+    public function testCreateREFWithProviderPin(): void
+    {
+        $fields = $this->assertAndParseSegment(
+            EDI270::createREF($this->row, '1P', $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        $this->assertSame('REF', $fields[0]);
+        $this->assertSame('4A', $fields[1]);
+        $this->assertSame('PIN999', $fields[2]);
+    }
+
+    public function testCreateREFWithPatientAccount(): void
+    {
+        $fields = $this->assertAndParseSegment(
+            EDI270::createREF($this->row, 'EJ', $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        $this->assertSame('REF', $fields[0]);
+        $this->assertSame('EJ', $fields[1]);
+        $this->assertSame('42', $fields[2]);
+    }
+
+    public function testCreateDMGFormatsCorrectly(): void
+    {
+        $fields = $this->assertAndParseSegment(
+            EDI270::createDMG($this->row, $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        $this->assertSame('DMG', $fields[0]);
+        $this->assertSame('D8', $fields[1]);
+        $this->assertSame('19800115', $fields[2]);
+        $this->assertSame('M', $fields[3]); // first char of "Male", uppercased
+    }
+
+    public function testCreateDMGWithFemaleSex(): void
+    {
+        $this->row['sex'] = 'female';
+        $fields = $this->assertAndParseSegment(
+            EDI270::createDMG($this->row, $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        $this->assertSame('F', $fields[3]);
+    }
+
+    public function testCreateDTPWithQual102UsesInsEffectiveDate(): void
+    {
+        $fields = $this->assertAndParseSegment(
+            EDI270::createDTP($this->row, '102', $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        $this->assertSame('DTP', $fields[0]);
+        $this->assertSame('102', $fields[1]);
+        $this->assertSame('D8', $fields[2]);
+        $this->assertSame('20260101', $fields[3]); // row['date']
+    }
+
+    public function testCreateDTPWithNonQual102AndDtp03A(): void
+    {
+        $this->X12info['x12_dtp03'] = 'A';
+        $this->row['pc_eventDate'] = '20260301';
+        $fields = $this->assertAndParseSegment(
+            EDI270::createDTP($this->row, '291', $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        $this->assertSame('291', $fields[1]);
+        $this->assertSame('20260301', $fields[3]); // uses pc_eventDate
+    }
+
+    public function testCreateDTPWithDtp03EUsesDate(): void
+    {
+        $this->X12info['x12_dtp03'] = 'E';
+        $this->row['date'] = '20260501';
+        $fields = $this->assertAndParseSegment(
+            EDI270::createDTP($this->row, '291', $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        $this->assertSame('20260501', $fields[3]);
+    }
+
+    public function testCreateDTPWithDtp03DefaultUsesToday(): void
+    {
+        $this->X12info['x12_dtp03'] = 'Z'; // unknown value triggers default
+        $fields = $this->assertAndParseSegment(
+            EDI270::createDTP($this->row, '291', $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        // Default branch uses date("Ymd")
+        $this->assertSame(date('Ymd'), $fields[3]);
+    }
+
+    public function testCreateEQReturnsFixedOutput(): void
+    {
+        $result = EDI270::createEQ($this->row, $this->X12info, $this->segTer, $this->compEleSep);
+        $this->assertSame('EQ*30~', $result);
+    }
+
+    public function testCreateSEIncludesSegmentCount(): void
+    {
+        $fields = $this->assertAndParseSegment(
+            EDI270::createSE($this->row, 13, $this->X12info, $this->segTer, $this->compEleSep)
+        );
+        $this->assertSame('SE', $fields[0]);
+        $this->assertSame('13', $fields[1]);
+        $this->assertSame('000000003', $fields[2]);
+    }
+
+    public function testCreateGEReturnsFixedOutput(): void
+    {
+        $result = EDI270::createGE($this->row, $this->X12info, $this->segTer, $this->compEleSep);
+        $this->assertSame('GE*1*2~', $result);
+    }
+
+    public function testCreateIEAReturnsFixedOutput(): void
+    {
+        $result = EDI270::createIEA($this->row, $this->X12info, $this->segTer, $this->compEleSep);
+        $this->assertSame('IEA*1*000000001~', $result);
+    }
+
+    public function testTranslateRelationshipSpouse(): void
+    {
+        $this->assertSame('01', EDI270::translateRelationship('spouse'));
+    }
+
+    public function testTranslateRelationshipChild(): void
+    {
+        $this->assertSame('19', EDI270::translateRelationship('child'));
+    }
+
+    public function testTranslateRelationshipDefault(): void
+    {
+        $this->assertSame('S', EDI270::translateRelationship('self'));
+        $this->assertSame('S', EDI270::translateRelationship('other'));
+        $this->assertSame('S', EDI270::translateRelationship(''));
+    }
+}

--- a/tests/Tests/Isolated/Common/Http/oeHttpResponseTest.php
+++ b/tests/Tests/Isolated/Common/Http/oeHttpResponseTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * Isolated tests for oeHttpResponse wrapper
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Common\Http;
+
+use OpenEMR\Common\Http\oeHttpResponse;
+use PHPUnit\Framework\TestCase;
+
+class oeHttpResponseTest extends TestCase
+{
+    /**
+     * Build a mock PSR-7-like response object for testing
+     * @param array<string, list<string>> $headers
+     */
+    private function makeMockResponse(
+        string $body = '',
+        int $statusCode = 200,
+        array $headers = [],
+    ): MockResponse {
+        return new MockResponse($body, $statusCode, $headers);
+    }
+
+    public function testBodyReturnsStringBody(): void
+    {
+        $response = new oeHttpResponse($this->makeMockResponse('Hello World'));
+
+        $this->assertSame('Hello World', $response->body());
+    }
+
+    public function testJsonDecodesAsArrayByDefault(): void
+    {
+        $json = (string) json_encode(['key' => 'value', 'num' => 42]);
+        $response = new oeHttpResponse($this->makeMockResponse($json));
+
+        $result = $response->json();
+        $this->assertIsArray($result);
+        $this->assertSame('value', $result['key']);
+        $this->assertSame(42, $result['num']);
+    }
+
+    public function testJsonDecodesAsObjectWhenFalse(): void
+    {
+        $json = (string) json_encode(['key' => 'value']);
+        $response = new oeHttpResponse($this->makeMockResponse($json));
+
+        $result = $response->json(false);
+        $this->assertInstanceOf(\stdClass::class, $result);
+        $this->assertSame('value', $result->key);
+    }
+
+    public function testHeaderDelegatesToUnderlyingResponse(): void
+    {
+        $mock = $this->makeMockResponse('', 200, [
+            'Content-Type' => ['application/json'],
+        ]);
+        $response = new oeHttpResponse($mock);
+
+        $this->assertSame(['application/json'], $response->header('Content-Type'));
+        $this->assertSame([], $response->header('X-Missing'));
+    }
+
+    public function testHeadersDelegatesToUnderlyingResponse(): void
+    {
+        $allHeaders = [
+            'Content-Type' => ['text/html'],
+            'X-Custom' => ['foo'],
+        ];
+        $response = new oeHttpResponse($this->makeMockResponse('', 200, $allHeaders));
+
+        $this->assertSame($allHeaders, $response->headers());
+    }
+
+    public function testStatusReturnsStatusCode(): void
+    {
+        $response = new oeHttpResponse($this->makeMockResponse('', 404));
+
+        $this->assertSame(404, $response->status());
+    }
+
+    public function testCallProxiesUnknownMethods(): void
+    {
+        $mock = $this->makeMockResponse();
+        $response = new oeHttpResponse($mock);
+
+        // Test __call directly since PHPStan can't resolve dynamic method dispatch
+        $this->assertSame('custom:test', $response->__call('customMethod', ['test']));
+    }
+}
+
+/**
+ * Simple mock for PSR-7-like response used by oeHttpResponse tests
+ */
+class MockResponse
+{
+    /** @param array<string, list<string>> $headers */
+    public function __construct(
+        private readonly string $body = '',
+        private readonly int $statusCode = 200,
+        private readonly array $headers = [],
+    ) {
+    }
+
+    public function getBody(): MockBody
+    {
+        return new MockBody($this->body);
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    /** @return list<string> */
+    public function getHeader(string $name): array
+    {
+        return $this->headers[$name] ?? [];
+    }
+
+    /** @return array<string, list<string>> */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    public function customMethod(string $arg): string
+    {
+        return "custom:$arg";
+    }
+}
+
+/**
+ * Simple mock for PSR-7-like response body
+ */
+class MockBody implements \Stringable
+{
+    public function __construct(private readonly string $body)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return $this->body;
+    }
+}

--- a/tests/Tests/Isolated/Events/AppointmentFilterEventTest.php
+++ b/tests/Tests/Isolated/Events/AppointmentFilterEventTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Isolated tests for AppointmentFilterEvent DTO
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Events;
+
+use OpenEMR\Events\PatientPortal\AppointmentFilterEvent;
+use PHPUnit\Framework\TestCase;
+
+class AppointmentFilterEventTest extends TestCase
+{
+    public function testConstructorSetsPropertiesViaSetters(): void
+    {
+        $dbRecord = ['pc_eid' => '1', 'pc_catid' => '5'];
+        $appointment = ['date' => '2026-01-15', 'provider' => 'Dr. Smith'];
+        $event = new AppointmentFilterEvent($dbRecord, $appointment);
+
+        $this->assertSame($dbRecord, $event->getDbRecord());
+        $this->assertSame($appointment, $event->getAppointment());
+    }
+
+    public function testGetSetDbRecordRoundTrip(): void
+    {
+        $event = new AppointmentFilterEvent(['a' => 1], ['b' => 2]);
+        $newRecord = ['pc_eid' => '99'];
+        $event->setDbRecord($newRecord);
+
+        $this->assertSame($newRecord, $event->getDbRecord());
+    }
+
+    public function testGetSetAppointmentRoundTrip(): void
+    {
+        $event = new AppointmentFilterEvent(['a' => 1], ['b' => 2]);
+        $newAppointment = ['date' => '2026-06-01', 'status' => 'confirmed'];
+        $event->setAppointment($newAppointment);
+
+        $this->assertSame($newAppointment, $event->getAppointment());
+    }
+
+    public function testSetDbRecordReturnsFluent(): void
+    {
+        $event = new AppointmentFilterEvent([], []);
+        $result = $event->setDbRecord(['x' => 1]);
+
+        $this->assertSame($event, $result);
+    }
+
+    public function testSetAppointmentReturnsFluent(): void
+    {
+        $event = new AppointmentFilterEvent([], []);
+        $result = $event->setAppointment(['y' => 2]);
+
+        $this->assertSame($event, $result);
+    }
+}

--- a/tests/Tests/Isolated/Events/CodeTypeInstalledEventTest.php
+++ b/tests/Tests/Isolated/Events/CodeTypeInstalledEventTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Isolated tests for CodeTypeInstalledEvent DTO
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Events;
+
+use OpenEMR\Events\Codes\CodeTypeInstalledEvent;
+use PHPUnit\Framework\TestCase;
+
+class CodeTypeInstalledEventTest extends TestCase
+{
+    public function testConstructorSetsProperties(): void
+    {
+        $details = ['version' => '2024', 'count' => 100];
+        $event = new CodeTypeInstalledEvent('ICD10', $details);
+
+        $this->assertSame('ICD10', $event->getCodeType());
+        $this->assertSame($details, $event->getDetails());
+    }
+
+    public function testGetSetCodeTypeRoundTrip(): void
+    {
+        $event = new CodeTypeInstalledEvent('ICD10', []);
+        $event->setCodeType('CPT4');
+
+        $this->assertSame('CPT4', $event->getCodeType());
+    }
+
+    public function testGetSetDetailsRoundTrip(): void
+    {
+        $event = new CodeTypeInstalledEvent('ICD10', ['a' => 1]);
+        $newDetails = ['b' => 2, 'c' => 3];
+        $event->setDetails($newDetails);
+
+        $this->assertSame($newDetails, $event->getDetails());
+    }
+
+    public function testSetCodeTypeReturnsFluent(): void
+    {
+        $event = new CodeTypeInstalledEvent('ICD10', []);
+        $result = $event->setCodeType('CPT4');
+
+        $this->assertSame($event, $result);
+    }
+
+    public function testSetDetailsReturnsFluent(): void
+    {
+        $event = new CodeTypeInstalledEvent('ICD10', []);
+        $result = $event->setDetails(['x' => 1]);
+
+        $this->assertSame($event, $result);
+    }
+}

--- a/tests/Tests/Isolated/Events/UserUpdatedEventTest.php
+++ b/tests/Tests/Isolated/Events/UserUpdatedEventTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Isolated tests for UserUpdatedEvent DTO
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Events;
+
+use OpenEMR\Events\User\UserUpdatedEvent;
+use PHPUnit\Framework\TestCase;
+
+class UserUpdatedEventTest extends TestCase
+{
+    public function testConstructorSetsProperties(): void
+    {
+        $before = ['id' => 1, 'username' => 'old'];
+        $after = ['id' => 1, 'username' => 'new'];
+        $event = new UserUpdatedEvent($before, $after);
+
+        $this->assertSame($before, $event->getDataBeforeUpdate());
+        $this->assertSame($after, $event->getNewUserData());
+    }
+
+    public function testGetSetDataBeforeUpdateRoundTrip(): void
+    {
+        $event = new UserUpdatedEvent(['a' => 1], ['b' => 2]);
+        $newData = ['c' => 3];
+        $event->setDataBeforeUpdate($newData);
+
+        $this->assertSame($newData, $event->getDataBeforeUpdate());
+    }
+
+    public function testGetSetNewUserDataRoundTrip(): void
+    {
+        $event = new UserUpdatedEvent(['a' => 1], ['b' => 2]);
+        $newData = ['id' => 5, 'username' => 'updated'];
+        $event->setNewUserData($newData);
+
+        $this->assertSame($newData, $event->getNewUserData());
+    }
+
+    public function testGetUserIdReturnsIdWhenPresent(): void
+    {
+        $event = new UserUpdatedEvent([], ['id' => 42, 'username' => 'test']);
+
+        $this->assertSame(42, $event->getUserId());
+    }
+
+    public function testGetUserIdReturnsNullWhenMissing(): void
+    {
+        $event = new UserUpdatedEvent([], ['username' => 'test']);
+
+        $this->assertNull($event->getUserId());
+    }
+}

--- a/tests/Tests/Isolated/PaymentProcessing/Rainforest/MetadataTest.php
+++ b/tests/Tests/Isolated/PaymentProcessing/Rainforest/MetadataTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * Isolated tests for Rainforest Metadata and EncounterData DTOs
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\PaymentProcessing\Rainforest;
+
+use Money\Currency;
+use Money\Money;
+use OpenEMR\PaymentProcessing\Rainforest\EncounterData;
+use OpenEMR\PaymentProcessing\Rainforest\Metadata;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+class MetadataTest extends TestCase
+{
+    private function makeEncounterData(): EncounterData
+    {
+        return new EncounterData(
+            id: '101',
+            code: '99213',
+            codeType: 'CPT4',
+            amount: new Money('5000', new Currency('USD')),
+        );
+    }
+
+    public function testConstructorSetsPublicProperties(): void
+    {
+        $encounter = $this->makeEncounterData();
+        $metadata = new Metadata(patientId: '42', encounters: [$encounter]);
+
+        $this->assertSame('42', $metadata->patientId);
+        $this->assertCount(1, $metadata->encounters);
+        $this->assertSame($encounter, $metadata->encounters[0]);
+    }
+
+    public function testJsonSerializeIncludesFormatVersion(): void
+    {
+        $encounter = $this->makeEncounterData();
+        $metadata = new Metadata(patientId: '42', encounters: [$encounter]);
+        $serialized = $metadata->jsonSerialize();
+
+        $this->assertSame('42', $serialized['patientId']);
+        $this->assertSame(1, $serialized['formatVersion']);
+        $this->assertCount(1, $serialized['encounters']);
+    }
+
+    public function testFromParsedJsonRoundTrips(): void
+    {
+        $encounter = $this->makeEncounterData();
+        $original = new Metadata(patientId: '42', encounters: [$encounter]);
+
+        // Simulate JSON round-trip
+        $json = json_encode($original);
+        $this->assertIsString($json);
+        /** @var array{formatVersion: int, patientId: string, encounters: array<array<string, mixed>>} $parsed */
+        $parsed = json_decode($json, true);
+        $restored = Metadata::fromParsedJson($parsed);
+
+        $this->assertSame('42', $restored->patientId);
+        $this->assertCount(1, $restored->encounters);
+        $this->assertSame('101', $restored->encounters[0]->id);
+        $this->assertSame('99213', $restored->encounters[0]->code);
+        $this->assertSame('CPT4', $restored->encounters[0]->codeType);
+        $this->assertTrue($restored->encounters[0]->amount->equals(new Money('5000', new Currency('USD'))));
+    }
+
+    public function testFromParsedJsonThrowsOnUnknownFormatVersion(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Unknown format version');
+
+        Metadata::fromParsedJson([
+            'formatVersion' => 2,
+            'patientId' => '42',
+            'encounters' => [],
+        ]);
+    }
+
+    public function testEncounterDataConstructorSetsProperties(): void
+    {
+        $amount = new Money('1500', new Currency('USD'));
+        $encounter = new EncounterData(
+            id: '200',
+            code: '99214',
+            codeType: 'CPT4',
+            amount: $amount,
+        );
+
+        $this->assertSame('200', $encounter->id);
+        $this->assertSame('99214', $encounter->code);
+        $this->assertSame('CPT4', $encounter->codeType);
+        $this->assertSame($amount, $encounter->amount);
+    }
+
+    public function testEncounterDataJsonSerialize(): void
+    {
+        $amount = new Money('1500', new Currency('USD'));
+        $encounter = new EncounterData(
+            id: '200',
+            code: '99214',
+            codeType: 'CPT4',
+            amount: $amount,
+        );
+        $serialized = $encounter->jsonSerialize();
+
+        $this->assertSame('200', $serialized['id']);
+        $this->assertSame('99214', $serialized['code']);
+        $this->assertSame('CPT4', $serialized['codeType']);
+        $this->assertSame($amount, $serialized['amount']);
+    }
+
+    public function testEncounterDataFromParsedJson(): void
+    {
+        $data = [
+            'id' => '300',
+            'code' => '99215',
+            'codeType' => 'CPT4',
+            'amount' => ['amount' => '7500', 'currency' => 'USD'],
+        ];
+        $encounter = EncounterData::fromParsedJson($data);
+
+        $this->assertSame('300', $encounter->id);
+        $this->assertSame('99215', $encounter->code);
+        $this->assertSame('CPT4', $encounter->codeType);
+        $this->assertTrue($encounter->amount->equals(new Money('7500', new Currency('USD'))));
+    }
+
+    public function testMultipleEncountersRoundTrip(): void
+    {
+        $enc1 = new EncounterData('1', '99213', 'CPT4', new Money('5000', new Currency('USD')));
+        $enc2 = new EncounterData('2', '99214', 'CPT4', new Money('7500', new Currency('USD')));
+        $original = new Metadata(patientId: '99', encounters: [$enc1, $enc2]);
+
+        $json = json_encode($original);
+        $this->assertIsString($json);
+        /** @var array{formatVersion: int, patientId: string, encounters: array<array<string, mixed>>} $parsed */
+        $parsed = json_decode($json, true);
+        $restored = Metadata::fromParsedJson($parsed);
+
+        $this->assertSame('99', $restored->patientId);
+        $this->assertCount(2, $restored->encounters);
+        $this->assertSame('1', $restored->encounters[0]->id);
+        $this->assertSame('2', $restored->encounters[1]->id);
+    }
+}


### PR DESCRIPTION
## Summary
- Add isolated PHPUnit tests for 6 pure-logic classes that need no Docker or database
- **EDI270**: 18 tests covering X12 segment-creation static methods (`createST`, `createBHT`, `createHL` with all 3 branches, `createREF`, `createDMG`, `createDTP` with all match arms, `createEQ`, `createSE`, `createGE`, `createIEA`) and `translateRelationship`
- **CodeTypeInstalledEvent**: constructor, getter/setter round-trips, fluent API
- **UserUpdatedEvent**: constructor, getter/setter round-trips, `getUserId()` with/without id key
- **AppointmentFilterEvent**: constructor, getter/setter round-trips, fluent API
- **Rainforest Metadata + EncounterData**: JSON serialization round-trips, unknown format version exception
- **oeHttpResponse**: `body()`, `json()` (array and object modes), `header()`, `headers()`, `status()`, `__call()` proxy

## Test plan
- [x] All new tests pass with `composer phpunit-isolated` (1607 tests, 0 failures)
- [x] `php -l` passes on all new files
- [x] PHPStan passes at project level
- [x] Rector passes
- [x] No existing tests break