### PR TITLE
fix(oauth2): create certificates directory before writing key files

### DIFF
--- a/src/Common/Auth/OAuth2KeyConfig.php
+++ b/src/Common/Auth/OAuth2KeyConfig.php
@@ -238,6 +238,10 @@ class OAuth2KeyConfig
         }
 
         // Successfully created encryption/public/private keys and passphrase, so store them and log success
+        $certDir = dirname($this->privateKey);
+        if (!is_dir($certDir)) {
+            mkdir($certDir, 0750, true);
+        }
         file_put_contents($this->privateKey, $privkey);
         chmod($this->privateKey, 0640);
         file_put_contents($this->publicKey, $pubkey);


### PR DESCRIPTION
## Summary

- `OAuth2KeyConfig::createOrRecreateKeys()` writes key files to the certificates directory but doesn't create the directory if it's missing
- `file_put_contents()` silently fails, and `configKeyPairs()` then throws a 500 error because the key files don't exist
- Add `mkdir()` before writing the key files to ensure the directory exists

Fixes #10887

## Test plan

- [ ] Remove `sites/default/documents/certificates/` directory and the `oauth2key`/`oauth2passphrase` rows from the `keys` table
- [ ] Make an API request that triggers OAuth2 key generation
- [ ] Verify the certificates directory is created and key files are written successfully