### PR TITLE
refactor(db): change $_db property from public to protected

### DIFF
--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -63,7 +63,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method Execute\\(\\) on mixed\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../controllers/C_Document.class.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/property.nonObject.php
+++ b/.phpstan/baseline/property.nonObject.php
@@ -12,11 +12,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../ccr/createCCR.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access property \\$EOF on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_Document.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access property \\$_db on mixed\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../controllers/C_Document.class.php',

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -997,9 +997,9 @@ class C_Document extends Controller
         if (is_numeric($new_patient_id) && is_numeric($document_id)) {
             $d = new Document($document_id);
             $sql = "SELECT pid from patient_data where pid = ?";
-            $result = $d->_db->Execute($sql, [$new_patient_id]);
+            $result = QueryUtils::querySingleRow($sql, [$new_patient_id]);
 
-            if (!$result || $result->EOF) {
+            if ($result === false) {
                 //patient id does not exist
                 $messages .= sprintf("%s '%s' %s\n", xl('Document could not be moved to patient id'), $new_patient_id, xl('because that id does not exist.'));
             } else {

--- a/src/Common/ORDataObject/ORDataObject.php
+++ b/src/Common/ORDataObject/ORDataObject.php
@@ -17,7 +17,7 @@ class ORDataObject
     private $_throwExceptionOnError = false;
     protected $_prefix;
     protected $_table;
-    public $_db; // Need to be public so can access from C_Document class
+    protected $_db;
 
     public function __construct($table = null, $prefix = null)
     {


### PR DESCRIPTION
Towards #10149

#### Short description of what this resolves:

Changes the `$_db` property in `ORDataObject` from public to protected, improving encapsulation. Knowing it's self-contained will make reworking that entire system much more straightforward.

#### Changes proposed in this pull request:

- Changed `ORDataObject::$_db` from `public` to `protected`
- Updated `C_Document` to use `QueryUtils::querySingleRow()` instead of directly accessing `$_db->Execute()`
- Removed outdated comment about the property needing to be public
- Updated PHPStan baseline to reflect reduced error counts

#### Does your code include anything generated by an AI Engine? Yes / No

Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.

The changes in this PR were generated with assistance from Claude (Anthropic). The modifications are minimal refactoring changes (visibility change and replacing one method call pattern with another).

🤖 Generated with [Claude Code](https://claude.ai/code)