### PR TITLE
fix(search): wrap DATETIME empty-string comparisons with CAST

### DIFF
--- a/interface/eRx_xml.php
+++ b/interface/eRx_xml.php
@@ -788,7 +788,7 @@ function PatientMedication($doc, $r, $pid, $med_limit)
     global $msg;
     $active = '';
     if ($GLOBALS['erx_upload_active'] == 1) {
-        $active = " and (enddate is null or enddate = '' or enddate = '0000-00-00' )";
+        $active = " and (enddate is null or enddate = '0000-00-00' )";
     }
 
     $res_med = sqlStatement("select * from lists where type='medication' and pid=? and title<>''
@@ -848,7 +848,7 @@ function PatientFreeformAllergy($doc, $r, $pid)
 {
     $res = sqlStatement("SELECT id,l.title as title1,lo.title as title2,comments FROM lists AS l
     LEFT JOIN list_options AS lo ON l.outcome = lo.option_id AND lo.list_id = 'outcome' AND lo.activity = 1
-	WHERE `type`='allergy' AND pid=? AND erx_source='0' and erx_uploaded='0' AND (enddate is null or enddate = '' or enddate = '0000-00-00')", [$pid]);
+	WHERE `type`='allergy' AND pid=? AND erx_source='0' and erx_uploaded='0' AND (enddate is null or enddate = '0000-00-00')", [$pid]);
     $allergyId = [];
     while ($row = sqlFetchArray($res)) {
         $val = [];

--- a/src/Services/Search/SearchFieldStatementResolver.php
+++ b/src/Services/Search/SearchFieldStatementResolver.php
@@ -224,12 +224,12 @@ class SearchFieldStatementResolver
             if ($modifier === SearchModifier::MISSING) {
                 if ($value->getCode() === false) {
                     // often our tokens get treated as string values so we will do this here also
-                    $clauses[] = "(" . $searchField->getField() . " IS NOT NULL AND " . $searchField->getField() . " != '') ";
+                    $clauses[] = "(" . $searchField->getField() . " IS NOT NULL AND CAST(" . $searchField->getField() . " AS CHAR) != '') ";
                 } else {
                     // TODO: @adunsulag do we want to compare token values to empty strings... it seems like that would be a missing value but
                     // could we get an inaccurate result here? or will we end up with a case with a number to string conversion on a field
                     // if the value is not a string?
-                    $clauses[] = "(" . $searchField->getField() . " IS NULL OR " . $searchField->getField() . " = '') ";
+                    $clauses[] = "(" . $searchField->getField() . " IS NULL OR CAST(" . $searchField->getField() . " AS CHAR) = '') ";
                 }
             // if we have other modifiers we would handle them here
             } else {

--- a/tests/Tests/Isolated/Services/Search/SearchFieldStatementResolverTokenTest.php
+++ b/tests/Tests/Isolated/Services/Search/SearchFieldStatementResolverTokenTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * SearchFieldStatementResolver Token Resolution Test
+ *
+ * Verify that resolveTokenField() generates CAST-wrapped SQL for the
+ * MISSING modifier so DATETIME columns are never compared directly to
+ * empty strings (which MySQL strict mode rejects).
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Search;
+
+use OpenEMR\Services\Search\SearchFieldStatementResolver;
+use OpenEMR\Services\Search\SearchModifier;
+use OpenEMR\Services\Search\TokenSearchField;
+use OpenEMR\Services\Search\TokenSearchValue;
+use PHPUnit\Framework\TestCase;
+
+class SearchFieldStatementResolverTokenTest extends TestCase
+{
+    /**
+     * When missing=true (code === true), the generated SQL must use
+     * CAST(field AS CHAR) = '' instead of field = ''.
+     */
+    public function testMissingTrueUsesCastForEmptyStringComparison(): void
+    {
+        $field = new TokenSearchField('enddate', [new TokenSearchValue(true)]);
+        $field->setModifier(SearchModifier::MISSING);
+
+        $fragment = SearchFieldStatementResolver::resolveTokenField($field);
+        $sql = $fragment->getFragment();
+
+        $this->assertStringContainsString('IS NULL', $sql);
+        $this->assertStringContainsString("CAST(enddate AS CHAR) = ''", $sql);
+        $this->assertStringNotContainsString("enddate = ''", $sql);
+    }
+
+    /**
+     * When missing=false (code === false), the generated SQL must use
+     * CAST(field AS CHAR) != '' instead of field != ''.
+     */
+    public function testMissingFalseUsesCastForEmptyStringComparison(): void
+    {
+        $field = new TokenSearchField('enddate', [new TokenSearchValue(false)]);
+        $field->setModifier(SearchModifier::MISSING);
+
+        $fragment = SearchFieldStatementResolver::resolveTokenField($field);
+        $sql = $fragment->getFragment();
+
+        $this->assertStringContainsString('IS NOT NULL', $sql);
+        $this->assertStringContainsString("CAST(enddate AS CHAR) != ''", $sql);
+        $this->assertStringNotContainsString("enddate != ''", $sql);
+    }
+}


### PR DESCRIPTION
## Summary
- MySQL 8.4 rejects `DATETIME = ''` during `PREPARE` statement validation, regardless of `sql_mode` settings
- The FHIR search layer generates `enddate = ''` for the `MISSING` modifier in `SearchFieldStatementResolver::resolveTokenField()`, which fails on MySQL 8.4
- Wrap empty-string comparisons with `CAST(field AS CHAR)` so `PREPARE` validation succeeds on all MySQL versions
- Remove dead `enddate = ''` checks from `eRx_xml.php` — DATETIME columns cannot store empty strings, so these conditions never match

## Detail

The call chain is: `C_Prescription::getDiagnosisCodesList()` → `PatientIssuesService::getActiveIssues()` → `search()` → `FhirSearchWhereClauseBuilder` → `SearchFieldStatementResolver::resolveTokenField()`, which generates `(enddate IS NULL OR enddate = '')`.

MySQL 8.4 validates column types during `PREPARE` and rejects comparing a DATETIME column to an empty string, even with `sql_mode = ''`. The `CAST(field AS CHAR)` wrapper is safe for all column types: for DATETIME it yields a date string (never `''`), and for VARCHAR it's a no-op.

Closes #10834

## Test plan
- [ ] New isolated unit tests pass: `composer phpunit-isolated`
- [ ] PHPStan passes
- [ ] Test prescription add/edit on MySQL 8.4 to confirm no error
- [ ] Test prescription add/edit on MariaDB to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)