### PR TITLE
fix(sql): qualify column reference in CareTeamService::getCareTeamData()

### DIFF
--- a/src/Services/CareTeamService.php
+++ b/src/Services/CareTeamService.php
@@ -567,7 +567,7 @@ class CareTeamService extends BaseService
             WHERE foreign_table_name = 'person'
          ) person_contact ON ctm.contact_id = person_contact.contact_record_id
          LEFT JOIN person p ON person_contact.person_record_id = p.id
-         LEFT JOIN contact_relation cr ON cr.target_id = p.id AND target_table='person' AND cr.active = 1
+         LEFT JOIN contact_relation cr ON cr.target_id = p.id AND cr.target_table='person' AND cr.active = 1
          LEFT JOIN contact patient_contact ON cr.contact_id = patient_contact.id AND patient_contact.foreign_table_name = 'patient_data' AND patient_contact.foreign_id = ct.pid
          LEFT JOIN facility f ON ctm.facility_id = f.id
          LEFT JOIN list_options lo1 ON lo1.option_id = ctm.role AND lo1.list_id = 'care_team_roles'


### PR DESCRIPTION
## Summary

Adds `cr.` table alias prefix to the unqualified `target_table` column reference in the `getCareTeamData()` LEFT JOIN condition (line 570).

**Before:** `LEFT JOIN contact_relation cr ON cr.target_id = p.id AND target_table='person' AND cr.active = 1`
**After:** `LEFT JOIN contact_relation cr ON cr.target_id = p.id AND cr.target_table='person' AND cr.active = 1`

This matches the qualified form already used in `getCareTeamContacts()` (line 282) in the same file.

Fixes #10886

## Testing

- Care team data should load correctly for any patient
- No behavioral change expected (currently benign since `target_table` is unambiguous)

## AI Disclosure

Yes — Claude Code (Anthropic) used for implementation. Code has been reviewed by the contributor.