### PR TITLE
fix(ci): prevent PHPStan pre-commit hook baseline mismatch (#10868)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,6 +127,7 @@ repos:
     entry: composer phpstan --
     language: system
     files: \.php$
+    pass_filenames: false
 
   - id: rector
     name: Rector


### PR DESCRIPTION
## Summary
- Add `pass_filenames: false` to the PHPStan pre-commit hook entry to prevent baseline mismatch failures when running on individual staged files

## Problem
The PHPStan pre-commit hook passes individual staged PHP files to `composer phpstan --`. However, the PHPStan baseline (`.phpstan/baseline/`) was generated against the **full codebase**. When PHPStan analyzes only a single file, all baseline entries for other files appear as "unmatched" and trigger `reportUnmatchedIgnoredErrors` failures — even though the baseline is correct.

This makes the PHPStan pre-commit hook unusable for local development.

## Fix
Add `pass_filenames: false` so the hook runs PHPStan against its configured default paths (the full project) rather than individual files. This matches the pattern already used by the `phpcs`, `rector`, and `composer-require-checker` hooks in the same config file.

## Test plan
- [ ] `pre-commit run phpstan --files src/Services/PatientService.php` succeeds
- [ ] `pre-commit run phpstan --all-files` succeeds
- [ ] Full `pre-commit run --all-files` passes

## AI Disclosure
Yes — Claude Code (Anthropic) used for implementation. All AI-touched files reviewed.

Fixes #10868

🤖 Generated with [Claude Code](https://claude.com/claude-code)