### PR TITLE
fix(prescriptions): remove empty string DATETIME comparison for MySQL strict mode (#10834)

### DIFF
--- a/interface/eRx_xml.php
+++ b/interface/eRx_xml.php
@@ -788,7 +788,7 @@ function PatientMedication($doc, $r, $pid, $med_limit)
     global $msg;
     $active = '';
     if ($GLOBALS['erx_upload_active'] == 1) {
-        $active = " and (enddate is null or enddate = '' or enddate = '0000-00-00' )";
+        $active = " and (enddate is null or enddate = '0000-00-00' )";
     }
 
     $res_med = sqlStatement("select * from lists where type='medication' and pid=? and title<>''
@@ -848,7 +848,7 @@ function PatientFreeformAllergy($doc, $r, $pid)
 {
     $res = sqlStatement("SELECT id,l.title as title1,lo.title as title2,comments FROM lists AS l
     LEFT JOIN list_options AS lo ON l.outcome = lo.option_id AND lo.list_id = 'outcome' AND lo.activity = 1
-	WHERE `type`='allergy' AND pid=? AND erx_source='0' and erx_uploaded='0' AND (enddate is null or enddate = '' or enddate = '0000-00-00')", [$pid]);
+	WHERE `type`='allergy' AND pid=? AND erx_source='0' and erx_uploaded='0' AND (enddate is null or enddate = '0000-00-00')", [$pid]);
     $allergyId = [];
     while ($row = sqlFetchArray($res)) {
         $val = [];

--- a/tests/Tests/Isolated/eRx/ErxSqlStrictModeTest.php
+++ b/tests/Tests/Isolated/eRx/ErxSqlStrictModeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Isolated eRx SQL Strict Mode Test
+ *
+ * Verifies that eRx_xml.php SQL queries do not compare DATETIME columns
+ * against empty strings, which fails under MySQL strict mode.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\eRx;
+
+use PHPUnit\Framework\TestCase;
+
+class ErxSqlStrictModeTest extends TestCase
+{
+    private string $sourceCode;
+
+    protected function setUp(): void
+    {
+        $filePath = dirname(__DIR__, 3) . '/../interface/eRx_xml.php';
+        $this->assertTrue(file_exists($filePath), 'eRx_xml.php must exist');
+        $this->sourceCode = file_get_contents($filePath);
+    }
+
+    /**
+     * Verify no SQL compares enddate to empty string.
+     *
+     * Comparing a DATETIME column to '' fails under MySQL 5.7+ strict mode.
+     * Only NULL and '0000-00-00' checks should be used for "empty" dates.
+     *
+     * @see https://github.com/openemr/openemr/issues/10834
+     */
+    public function testNoEmptyStringDatetimeComparison(): void
+    {
+        // Match patterns like: enddate = '' or enddate = "" (in SQL context)
+        $pattern = '/enddate\s*=\s*[\'"][\'"]/' ;
+
+        $this->assertDoesNotMatchRegularExpression(
+            $pattern,
+            $this->sourceCode,
+            'eRx_xml.php must not compare DATETIME enddate column to empty string — '
+            . 'use IS NULL or = \'0000-00-00\' instead (MySQL strict mode compatibility)'
+        );
+    }
+
+    /**
+     * Verify enddate NULL checks are present for active medication filtering.
+     */
+    public function testEnddateNullCheckPresent(): void
+    {
+        $this->assertStringContainsString(
+            'enddate is null',
+            $this->sourceCode,
+            'eRx_xml.php should check for NULL enddate values'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Remove `enddate = ''` from two SQL WHERE clauses in `eRx_xml.php` that compare a DATETIME column to an empty string, which is invalid under MySQL 5.7+ strict mode
- Preserve `IS NULL` and `= '0000-00-00'` checks for legacy date handling

## Problem
The `PatientMedication()` and `PatientFreeformAllergy()` functions in `eRx_xml.php` construct SQL queries with `enddate = ''` to catch legacy empty-string dates stored in the `lists.enddate` DATETIME column. Under MySQL 5.7+ strict mode, the empty string is rejected as an invalid DATETIME value before the comparison can evaluate, causing the query to error.

MariaDB diverges on this behavior and tolerates the comparison, which is why the bug wasn't caught in the standard dev environment or online demos.

## Changes
- `interface/eRx_xml.php` line 791: Remove `or enddate = ''` from `$active` filter
- `interface/eRx_xml.php` line 851: Remove `or enddate = ''` from allergy WHERE clause
- Add `tests/Tests/Isolated/eRx/ErxSqlStrictModeTest.php` — regression test

## Test plan
- [ ] Verify prescription add/edit works on MySQL 5.7+ with strict mode enabled
- [ ] Verify allergy queries still return correct results
- [ ] Run isolated tests: `composer phpunit-isolated`

## AI Disclosure
Yes — Claude Code (Anthropic) used for implementation. All AI-touched files reviewed.

Fixes #10834

🤖 Generated with [Claude Code](https://claude.com/claude-code)