### PR TITLE
fix(migrations): set deprecated care_team layout fields to uor=0 (#10848)

### DIFF
--- a/sql/8_0_0-to-8_0_1_upgrade.sql
+++ b/sql/8_0_0-to-8_0_1_upgrade.sql
@@ -173,3 +173,16 @@ ALTER TABLE `patient_data` CHANGE `interpretter` `interpreter` varchar(255) NOT 
 #IfRow2D layout_options form_id DEM field_id interpretter
 UPDATE `layout_options` SET `field_id` = 'interpreter' WHERE `form_id` = 'DEM' AND `field_id` = 'interpretter';
 #EndIf
+
+--
+-- Hide deprecated care_team_* layout fields on fresh installs.
+-- The 7.0.3-to-7.0.4 upgrade already handles this for upgraded systems via
+-- #IfCareTeamsV1MigrationNeeded, but database.sql still had uor=1.
+-- This catches any systems that were fresh-installed after the migration
+-- was introduced but before database.sql was corrected.
+-- See: https://github.com/openemr/openemr/issues/10848
+--
+
+#IfRow3D layout_options form_id DEM field_id care_team_provider uor 1
+UPDATE `layout_options` SET `uor` = 0 WHERE `form_id` = 'DEM' AND `field_id` IN ('care_team_provider', 'care_team_status', 'care_team_facility') AND `uor` = 1;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3,7 +3,7 @@
 --
 -- Keep v_database in sync with $v_database in version.php.
 -- CI will fail if they don't match.
--- v_database: 534
+-- v_database: 535
 --
 
 --
@@ -3748,9 +3748,9 @@ INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`dat
 INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`data_type`,`uor`,`fld_length`,`max_length`,`list_id`,`titlecols`,`datacols`,`default_value`,`edit_options`,`description`,`fld_rows`) VALUES ('DEM', 'publ_code_eff_date'  , '3', 'Publicity Code Effective Date'  ,180, 4, 1,10,10, '', 1, 1, '', '', 'Publicity Code Effective Date', 0);
 INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`data_type`,`uor`,`fld_length`,`max_length`,`list_id`,`titlecols`,`datacols`,`default_value`,`edit_options`,`description`,`fld_rows`) VALUES ('DEM', 'protect_indicator'  , '3', 'Protection Indicator'  ,190, 1, 1,1,0, 'yesno', 1, 1, '', '', 'Protection Indicator', 0);
 INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`data_type`,`uor`,`fld_length`,`max_length`,`list_id`,`titlecols`,`datacols`,`default_value`,`edit_options`,`description`,`fld_rows`) VALUES ('DEM', 'prot_indi_effdate'  , '3', 'Protection Indicator Effective Date'  ,200, 4, 1,10,10, '', 1, 1, '', '', 'Protection Indicator Effective Date', 0);
-INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`data_type`,`uor`,`fld_length`,`max_length`,`list_id`,`titlecols`,`datacols`,`default_value`,`edit_options`,`description`,`fld_rows`) VALUES ('DEM', 'care_team_provider', '3', 'Care Team (Provider)', 210, 45, 1, 0, 0, '', 1, 1, '', '[\"EP\"]', '', 0);
-INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`data_type`,`uor`,`fld_length`,`max_length`,`list_id`,`titlecols`,`datacols`,`default_value`,`edit_options`,`description`,`fld_rows`) VALUES ('DEM', 'care_team_status', '3', 'Care Team Status', 220, 1, 1, 0, 0, 'Care_Team_Status', 1, 1, '', '[\"EP\"]', 'Indicates whether the care team is current , represents future intentions or is now a historical record.', 0);
-INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`data_type`,`uor`,`fld_length`,`max_length`,`list_id`,`titlecols`,`datacols`,`default_value`,`edit_options`,`description`,`fld_rows`) VALUES ('DEM', 'care_team_facility', '3', 'Care Team (Facility)', 230, 44, 1, 0, 0, '', 1, 1, '', '[\"EP\"]', '', 0);
+INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`data_type`,`uor`,`fld_length`,`max_length`,`list_id`,`titlecols`,`datacols`,`default_value`,`edit_options`,`description`,`fld_rows`) VALUES ('DEM', 'care_team_provider', '3', 'Care Team (Provider)', 210, 45, 0, 0, 0, '', 1, 1, '', '[\"EP\"]', '', 0);
+INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`data_type`,`uor`,`fld_length`,`max_length`,`list_id`,`titlecols`,`datacols`,`default_value`,`edit_options`,`description`,`fld_rows`) VALUES ('DEM', 'care_team_status', '3', 'Care Team Status', 220, 1, 0, 0, 0, 'Care_Team_Status', 1, 1, '', '[\"EP\"]', 'Indicates whether the care team is current , represents future intentions or is now a historical record.', 0);
+INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`data_type`,`uor`,`fld_length`,`max_length`,`list_id`,`titlecols`,`datacols`,`default_value`,`edit_options`,`description`,`fld_rows`) VALUES ('DEM', 'care_team_facility', '3', 'Care Team (Facility)', 230, 44, 0, 0, 0, '', 1, 1, '', '[\"EP\"]', '', 0);
 INSERT INTO `layout_options` (`form_id`, `field_id`, `group_id`, `title`, `seq`, `data_type`, `uor`, `fld_length`, `max_length`, `list_id`, `titlecols`, `datacols`, `default_value`, `edit_options`, `description`, `fld_rows`, `list_backup_id`, `source`, `conditions`, `validation`, `codes`) VALUES ('DEM','patient_groups','3','Patient Categories',240,36,1,0,0,'Patient_Groupings',1,1,'','[\"EP\",\"DAP\"]','Add patient to one or more category.',0,'','F','','','');
 --
 INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`data_type`,`uor`,`fld_length`,`max_length`,`list_id`,`titlecols`,`datacols`,`default_value`,`edit_options`,`description`,`fld_rows`, `list_backup_id`) VALUES ('DEM', 'occupation', '4', 'Occupation', 1, 26, 1, 20, 63, 'OccupationODH', 1, 1, '', 'C', 'Occupation', 0, 'Occupation');

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@ $v_realpatch = '0';
 //
 // Keep in sync with the v_database comment in sql/database.sql.
 // CI will fail if they don't match.
-$v_database = 534;
+$v_database = 535;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
## Summary
- Set `uor=0` (hidden) for deprecated `care_team_provider`, `care_team_status`, and `care_team_facility` fields in `database.sql` so fresh installs no longer show deprecated fields on the demographics form
- Add upgrade SQL to catch systems that were fresh-installed between the original 7.0.3→7.0.4 migration and this fix
- Bump `v_database` from 534 to 535

## Problem
The 7.0.3→7.0.4 upgrade correctly hid deprecated care_team layout fields via `#IfCareTeamsV1MigrationNeeded`, replacing them with the new `care_teams`/`care_team_member` table structure. However, `database.sql` was never updated to match — it still creates these fields with `uor=1` (visible). This means:
- **Upgraded systems**: Fields correctly hidden ✅
- **Fresh installs**: Deprecated fields visible on demographics form ❌

## Changes
- `sql/database.sql` — change `uor` from 1→0 for three care_team INSERT statements; bump v_database header
- `version.php` — bump `$v_database` 534→535
- `sql/8_0_0-to-8_0_1_upgrade.sql` — add `#IfRow3D` conditional UPDATE for systems needing the fix

## Test plan
- [ ] Fresh install shows no care_team fields on Demographics form
- [ ] Upgrade from previous version hides care_team fields
- [ ] Database version CI check passes (v_database matches)
- [ ] `composer phpunit-isolated` passes

## AI Disclosure
Yes — Claude Code (Anthropic) used for implementation. All AI-touched files reviewed.

Fixes #10848

🤖 Generated with [Claude Code](https://claude.com/claude-code)