### PR TITLE
fix(ci): ensure xdebug.mode=coverage for PHPUnit test file coverage (#10687)

### DIFF
--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -55,7 +55,9 @@ dc() {
 
 _exec() {
     if [[ ${ENABLE_COVERAGE:-false} = true ]]; then
-        # Set XDEBUG_MODE for xdebug coverage (ignored if using pcov)
+        # Set XDEBUG_MODE env var for xdebug coverage (ignored if using pcov).
+        # NOTE: This env var is ignored when xdebug.mode is set in php.ini.
+        # PHPUnit invocations also pass -d xdebug.mode=coverage for reliability.
         dc exec --env XDEBUG_MODE=coverage --workdir "${OPENEMR_DIR?}" openemr "$@"
     else
         dc exec --workdir "${OPENEMR_DIR?}" openemr "$@"
@@ -293,8 +295,15 @@ build_test_e2e() {
     dc exec selenium chromedriver --version
 
     echo 'Running E2E tests…'
+    # When coverage is enabled, ensure xdebug.mode=coverage via -d flag.
+    # The XDEBUG_MODE env var (set by _exec) is ignored when xdebug.mode
+    # is already configured in php.ini, so -d is needed as an override.
+    local -a php_args=( -d memory_limit=8G )
+    if [[ ${ENABLE_COVERAGE:-false} = true ]]; then
+        php_args+=( -d xdebug.mode=coverage )
+    fi
     set +e
-    _exec php -d memory_limit=8G ./vendor/bin/phpunit \
+    _exec php "${php_args[@]}" ./vendor/bin/phpunit \
         --log-junit junit-e2e.xml \
         --testsuite e2e \
         --testdox \
@@ -366,7 +375,14 @@ phpunit() {
         shift
     done
     [[ -n "${testsuite_arg}" ]] && args+=( --log-junit "junit-${testsuite_arg}.xml" )
-    _exec php -d memory_limit=8G ./vendor/bin/phpunit --testdox "${args[@]}"
+    # When coverage is enabled, ensure xdebug.mode=coverage via -d flag.
+    # The XDEBUG_MODE env var (set by _exec) is ignored when xdebug.mode
+    # is already configured in php.ini, so -d is needed as an override.
+    local -a php_args=( -d memory_limit=8G )
+    if [[ ${ENABLE_COVERAGE:-false} = true ]]; then
+        php_args+=( -d xdebug.mode=coverage )
+    fi
+    _exec php "${php_args[@]}" ./vendor/bin/phpunit --testdox "${args[@]}"
 }
 
 ##


### PR DESCRIPTION
## Summary

Fixes e2e-tests and api-tests codecov flags reporting 0% coverage by ensuring `xdebug.mode=coverage` is passed via PHP's `-d` CLI flag when running PHPUnit with coverage enabled.

**Root cause:** The `_exec()` wrapper sets `XDEBUG_MODE=coverage` as an environment variable via `docker exec --env`. However, when `xdebug.mode` is already configured in `php.ini` (e.g., `xdebug.mode=debug,profile`), the environment variable is silently ignored — Xdebug's ini setting takes precedence over the env var.

This means PHPUnit's `SebastianBergmann\CodeCoverage` cannot use Xdebug as a coverage driver, resulting in empty coverage reports.

**Fix:** Pass `-d xdebug.mode=coverage` directly to the PHP CLI when `ENABLE_COVERAGE=true`. The `-d` flag overrides ini settings, ensuring coverage mode is always active for PHPUnit runs regardless of the Docker image's php.ini configuration.

Applied to both:
- `phpunit()` wrapper function (used by API and standard test suites)
- `build_test_e2e()` direct invocation (used by E2E tests)

The existing `XDEBUG_MODE` env var in `_exec()` is preserved for backward compatibility with images that don't set `xdebug.mode` in ini.

Fixes #10687

## Testing

- [x] Bash syntax validation passes (`bash -n ci/ciLibrary.source`)
- [x] Verified locally that `-d xdebug.mode=coverage` overrides ini settings
- [x] No behavioral change when coverage is disabled (`ENABLE_COVERAGE=false`)

## AI Disclosure

Yes — Claude Code (Anthropic) used for implementation. All code reviewed and tested.