### PR TITLE
test(care-team): add CareTeamService unit tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,8 @@ ignore:
 - tests/PHPStan/                       # Static analysis rules — not exercised by PHPUnit
 - tests/Rector/                        # Rector rules — run outside PHPUnit coverage
 - tests/eventdispatcher/               # Example modules for documentation
+- tests/Tests/Services/CareTeamServiceTest.php       # Test harness runs in the non-coverage services suite
+- tests/Tests/Fixtures/CareTeamFixtureManager.php    # Test-only fixture infrastructure
 - portal/messaging/messages.php        # Entry-point script (bootstrap + render) — exercised by manual QA, not unit tests
 - portal/messaging/handle_note.php     # Entry-point script (CSRF, ACL, sendMail) — testable logic extracted to OpenEMR\Services\PortalMessagingSender
 

--- a/tests/Tests/Fixtures/CareTeamFixtureManager.php
+++ b/tests/Tests/Fixtures/CareTeamFixtureManager.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * CareTeamFixtureManager - Provides test fixture data for CareTeamService tests.
+ *
+ * AI-Generated Code Notice: This file contains code generated with
+ * assistance from Claude Code (Anthropic). The code has been reviewed
+ * and tested by the contributor.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Craig Allen <craigrallen@gmail.com>
+ * @copyright Copyright (c) 2026 Craig Allen <craigrallen@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Fixtures;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Database\SqlQueryException;
+use OpenEMR\Common\Logging\SystemLogger;
+
+class CareTeamFixtureManager
+{
+    const FIXTURE_TEAM_NAME_PREFIX = "test-fixture";
+
+    /**
+     * @var FixtureManager
+     */
+    private $patientFixtureManager;
+
+    /**
+     * @var FacilityFixtureManager
+     */
+    private $facilityFixtureManager;
+
+    /**
+     * @var PractitionerFixtureManager
+     */
+    private $practitionerFixtureManager;
+
+    /**
+     * @var bool
+     */
+    private $hasInstalledDependencies = false;
+
+    public function __construct(
+        ?FixtureManager $patientFixtureManager = null,
+        ?FacilityFixtureManager $facilityFixtureManager = null,
+        ?PractitionerFixtureManager $practitionerFixtureManager = null
+    ) {
+        $this->patientFixtureManager = $patientFixtureManager ?? new FixtureManager();
+        $this->facilityFixtureManager = $facilityFixtureManager ?? new FacilityFixtureManager();
+        $this->practitionerFixtureManager = $practitionerFixtureManager ?? new PractitionerFixtureManager();
+    }
+
+    /**
+     * Installs patient, facility, and practitioner fixtures that care teams depend on.
+     *
+     * @return array{pid: int, facility_id: int, provider_id: int}
+     */
+    public function installDependencies(): array
+    {
+        $this->patientFixtureManager->installPatientFixtures();
+        $this->facilityFixtureManager->installFacilityFixtures();
+        $this->practitionerFixtureManager->installPractitionerFixtures();
+        $this->hasInstalledDependencies = true;
+
+        // Get the first test patient's pid
+        $patientRow = sqlQuery(
+            "SELECT pid FROM patient_data WHERE pubpid LIKE ? LIMIT 1",
+            [self::FIXTURE_TEAM_NAME_PREFIX . "%"]
+        );
+        $pid = intval($patientRow['pid']);
+
+        // Get the first test facility's id
+        $facilityRow = sqlQuery(
+            "SELECT id FROM facility WHERE name LIKE ? LIMIT 1",
+            [self::FIXTURE_TEAM_NAME_PREFIX . "%"]
+        );
+        $facilityId = intval($facilityRow['id']);
+
+        // Get the first test practitioner's id
+        $providerRow = sqlQuery(
+            "SELECT id FROM users WHERE fname LIKE ? LIMIT 1",
+            [self::FIXTURE_TEAM_NAME_PREFIX . "%"]
+        );
+        $providerId = intval($providerRow['id']);
+
+        return ['pid' => $pid, 'facility_id' => $facilityId, 'provider_id' => $providerId];
+    }
+
+    /**
+     * Removes all test care team fixtures and their dependencies.
+     */
+    public function removeFixtures(): void
+    {
+        $bindVariable = self::FIXTURE_TEAM_NAME_PREFIX . "%";
+
+        try {
+            // Get care team IDs for our test teams
+            $teamIds = [];
+            $select = sqlStatement(
+                "SELECT id, uuid FROM care_teams WHERE team_name LIKE ?",
+                [$bindVariable]
+            );
+            while ($row = sqlFetchArray($select)) {
+                $teamIds[] = $row['id'];
+                if (!empty($row['uuid'])) {
+                    sqlQuery(
+                        "DELETE FROM uuid_registry WHERE table_name = 'care_teams' AND uuid = ?",
+                        [$row['uuid']]
+                    );
+                }
+            }
+
+            // Remove care team members for our test teams
+            if (!empty($teamIds)) {
+                $placeholders = implode(',', array_fill(0, count($teamIds), '?'));
+                QueryUtils::sqlStatementThrowException(
+                    "DELETE FROM care_team_member WHERE care_team_id IN ($placeholders)",
+                    $teamIds
+                );
+            }
+
+            // Remove the care teams themselves
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM care_teams WHERE team_name LIKE ?",
+                [$bindVariable]
+            );
+        } catch (SqlQueryException $exception) {
+            (new SystemLogger())->error(
+                "Failed to delete care team fixture data",
+                ['message' => $exception->getMessage(), 'trace' => $exception->getTraceAsString()]
+            );
+        }
+
+        // Remove dependency fixtures
+        if ($this->hasInstalledDependencies) {
+            $this->practitionerFixtureManager->removePractitionerFixtures();
+            $this->facilityFixtureManager->removeFixtures();
+            $this->patientFixtureManager->removePatientFixtures();
+            $this->hasInstalledDependencies = false;
+        }
+    }
+}

--- a/tests/Tests/Fixtures/CareTeamFixtureManager.php
+++ b/tests/Tests/Fixtures/CareTeamFixtureManager.php
@@ -16,9 +16,9 @@
 
 namespace OpenEMR\Tests\Fixtures;
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Database\SqlQueryException;
-use OpenEMR\Common\Logging\SystemLogger;
 
 class CareTeamFixtureManager
 {
@@ -58,6 +58,7 @@ class CareTeamFixtureManager
         if ($patientRow === false || !isset($patientRow['pid'])) {
             throw new \RuntimeException('Failed to find test patient fixture — did installPatientFixtures() succeed?');
         }
+        /** @var array{pid: string|int} $patientRow */
         $pid = (int) $patientRow['pid'];
 
         // Get the first test facility's id
@@ -68,6 +69,7 @@ class CareTeamFixtureManager
         if ($facilityRow === false || !isset($facilityRow['id'])) {
             throw new \RuntimeException('Failed to find test facility fixture — did installFacilityFixtures() succeed?');
         }
+        /** @var array{id: string|int} $facilityRow */
         $facilityId = (int) $facilityRow['id'];
 
         // Get the first test practitioner's id
@@ -78,6 +80,7 @@ class CareTeamFixtureManager
         if ($providerRow === false || !isset($providerRow['id'])) {
             throw new \RuntimeException('Failed to find test practitioner fixture — did installPractitionerFixtures() succeed?');
         }
+        /** @var array{id: string|int} $providerRow */
         $providerId = (int) $providerRow['id'];
 
         return ['pid' => $pid, 'facility_id' => $facilityId, 'provider_id' => $providerId];
@@ -122,7 +125,7 @@ class CareTeamFixtureManager
                 [$bindVariable]
             );
         } catch (SqlQueryException $exception) {
-            (new SystemLogger())->error(
+            ServiceContainer::getLogger()->error(
                 "Failed to delete care team fixture data",
                 ['message' => $exception->getMessage(), 'trace' => $exception->getTraceAsString()]
             );

--- a/tests/Tests/Fixtures/CareTeamFixtureManager.php
+++ b/tests/Tests/Fixtures/CareTeamFixtureManager.php
@@ -24,10 +24,8 @@ class CareTeamFixtureManager
 {
     const FIXTURE_PREFIX = "test-fixture";
 
-    /**
-     * @var bool
-     */
-    private $hasInstalledDependencies = false;
+    private bool $hasInstalledDependencies = false;
+    private array $cachedDependencies = [];
 
     public function __construct(
         private readonly FixtureManager $patientFixtureManager = new FixtureManager(),
@@ -43,12 +41,14 @@ class CareTeamFixtureManager
      */
     public function installDependencies(): array
     {
-        if (!$this->hasInstalledDependencies) {
-            $this->patientFixtureManager->installPatientFixtures();
-            $this->facilityFixtureManager->installFacilityFixtures();
-            $this->practitionerFixtureManager->installPractitionerFixtures();
-            $this->hasInstalledDependencies = true;
+        if ($this->hasInstalledDependencies) {
+            return $this->cachedDependencies;
         }
+
+        $this->patientFixtureManager->installPatientFixtures();
+        $this->facilityFixtureManager->installFacilityFixtures();
+        $this->practitionerFixtureManager->installPractitionerFixtures();
+        $this->hasInstalledDependencies = true;
 
         // Get the first test patient's pid
         $patientRow = QueryUtils::querySingleRow(
@@ -83,7 +83,8 @@ class CareTeamFixtureManager
         /** @var array{id: string|int} $providerRow */
         $providerId = (int) $providerRow['id'];
 
-        return ['pid' => $pid, 'facility_id' => $facilityId, 'provider_id' => $providerId];
+        $this->cachedDependencies = ['pid' => $pid, 'facility_id' => $facilityId, 'provider_id' => $providerId];
+        return $this->cachedDependencies;
     }
 
     /**

--- a/tests/Tests/Fixtures/CareTeamFixtureManager.php
+++ b/tests/Tests/Fixtures/CareTeamFixtureManager.php
@@ -25,6 +25,8 @@ class CareTeamFixtureManager
     const FIXTURE_PREFIX = "test-fixture";
 
     private bool $hasInstalledDependencies = false;
+
+    /** @var array{pid: int, facility_id: int, provider_id: int}|array{} */
     private array $cachedDependencies = [];
 
     public function __construct(
@@ -41,7 +43,7 @@ class CareTeamFixtureManager
      */
     public function installDependencies(): array
     {
-        if ($this->hasInstalledDependencies) {
+        if ($this->hasInstalledDependencies && $this->cachedDependencies !== []) {
             return $this->cachedDependencies;
         }
 

--- a/tests/Tests/Fixtures/CareTeamFixtureManager.php
+++ b/tests/Tests/Fixtures/CareTeamFixtureManager.php
@@ -20,6 +20,9 @@ use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Database\SqlQueryException;
 
+// Test fixture infrastructure is not application code and should not affect
+// patch-coverage thresholds.
+// @codeCoverageIgnoreStart
 class CareTeamFixtureManager
 {
     const FIXTURE_PREFIX = "test-fixture";
@@ -143,3 +146,4 @@ class CareTeamFixtureManager
         }
     }
 }
+// @codeCoverageIgnoreEnd

--- a/tests/Tests/Fixtures/CareTeamFixtureManager.php
+++ b/tests/Tests/Fixtures/CareTeamFixtureManager.php
@@ -14,6 +14,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Tests\Fixtures;
 
 use OpenEMR\BC\ServiceContainer;

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -1,0 +1,801 @@
+<?php
+
+/**
+ * CareTeamServiceTest - Tests for CareTeamService CRUD, member management, and queries.
+ *
+ * AI-Generated Code Notice: This file contains code generated with
+ * assistance from Claude Code (Anthropic). The code has been reviewed
+ * and tested by the contributor.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Craig Allen <craigrallen@gmail.com>
+ * @copyright Copyright (c) 2026 Craig Allen <craigrallen@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\Services\CareTeamService;
+use OpenEMR\Services\Search\TokenSearchField;
+use OpenEMR\Tests\Fixtures\CareTeamFixtureManager;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class CareTeamServiceTest extends TestCase
+{
+    /**
+     * @var CareTeamService
+     */
+    private $service;
+
+    /**
+     * @var CareTeamFixtureManager
+     */
+    private $fixtureManager;
+
+    /**
+     * @var int
+     */
+    private int $testPid;
+
+    /**
+     * @var int
+     */
+    private int $testFacilityId;
+
+    /**
+     * @var int
+     */
+    private int $testProviderId;
+
+    private const TEST_TEAM_NAME = "test-fixture-Primary Care Team";
+    private const TEST_TEAM_NAME_ALT = "test-fixture-Secondary Care Team";
+
+    protected function setUp(): void
+    {
+        $this->service = new CareTeamService();
+        $this->fixtureManager = new CareTeamFixtureManager();
+        $deps = $this->fixtureManager->installDependencies();
+        $this->testPid = $deps['pid'];
+        $this->testFacilityId = $deps['facility_id'];
+        $this->testProviderId = $deps['provider_id'];
+
+        // saveCareTeam reads $_SESSION['authUserID']
+        if (!isset($_SESSION['authUserID'])) {
+            $_SESSION['authUserID'] = 1;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fixtureManager->removeFixtures();
+    }
+
+    // =========================================================================
+    // getUuidFields
+    // =========================================================================
+
+    #[Test]
+    public function testGetUuidFieldsReturnsExpectedFields(): void
+    {
+        $fields = $this->service->getUuidFields();
+        $this->assertIsArray($fields);
+        $this->assertContains('uuid', $fields);
+        $this->assertContains('puuid', $fields);
+    }
+
+    // =========================================================================
+    // hasActiveCareTeam
+    // =========================================================================
+
+    #[Test]
+    public function testHasActiveCareTeamReturnsFalseWhenNoTeam(): void
+    {
+        $result = $this->service->hasActiveCareTeam($this->testPid);
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function testHasActiveCareTeamReturnsTrueAfterSave(): void
+    {
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            [],
+            'active'
+        );
+
+        $result = $this->service->hasActiveCareTeam($this->testPid);
+        $this->assertTrue($result);
+    }
+
+    #[Test]
+    public function testHasActiveCareTeamReturnsFalseForInactiveTeam(): void
+    {
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            [],
+            'inactive'
+        );
+
+        $result = $this->service->hasActiveCareTeam($this->testPid);
+        $this->assertFalse($result);
+    }
+
+    // =========================================================================
+    // saveCareTeam — create
+    // =========================================================================
+
+    #[Test]
+    public function testSaveCareTeamCreatesNewTeam(): void
+    {
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            [],
+            'active'
+        );
+
+        $row = sqlQuery(
+            "SELECT id, team_name, status, pid FROM care_teams WHERE team_name = ?",
+            [self::TEST_TEAM_NAME]
+        );
+
+        $this->assertNotEmpty($row);
+        $this->assertEquals(self::TEST_TEAM_NAME, $row['team_name']);
+        $this->assertEquals('active', $row['status']);
+        $this->assertEquals($this->testPid, intval($row['pid']));
+    }
+
+    #[Test]
+    public function testSaveCareTeamAssignsUuid(): void
+    {
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            [],
+            'active'
+        );
+
+        $row = sqlQuery(
+            "SELECT uuid FROM care_teams WHERE team_name = ?",
+            [self::TEST_TEAM_NAME]
+        );
+
+        $this->assertNotEmpty($row['uuid']);
+        $uuidString = UuidRegistry::uuidToString($row['uuid']);
+        $this->assertNotEmpty($uuidString);
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/',
+            $uuidString
+        );
+    }
+
+    #[Test]
+    public function testSaveCareTeamWithProviderMember(): void
+    {
+        $team = [
+            [
+                'user_id' => $this->testProviderId,
+                'role' => 'family_medicine_specialist',
+                'facility_id' => $this->testFacilityId,
+                'provider_since' => date('Y-m-d'),
+                'status' => 'active',
+                'note' => 'Primary physician',
+            ]
+        ];
+
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            $team,
+            'active'
+        );
+
+        // Verify the team was created
+        $teamRow = sqlQuery(
+            "SELECT id FROM care_teams WHERE team_name = ?",
+            [self::TEST_TEAM_NAME]
+        );
+        $this->assertNotEmpty($teamRow);
+
+        // Verify the member was inserted
+        $memberRow = sqlQuery(
+            "SELECT * FROM care_team_member WHERE care_team_id = ? AND user_id = ?",
+            [$teamRow['id'], $this->testProviderId]
+        );
+        $this->assertNotEmpty($memberRow);
+        $this->assertEquals('family_medicine_specialist', $memberRow['role']);
+        $this->assertEquals($this->testFacilityId, intval($memberRow['facility_id']));
+        $this->assertEquals('active', $memberRow['status']);
+        $this->assertEquals('Primary physician', $memberRow['note']);
+    }
+
+    // =========================================================================
+    // saveCareTeam — update
+    // =========================================================================
+
+    #[Test]
+    public function testSaveCareTeamUpdatesExistingTeam(): void
+    {
+        // Create initial team
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            [],
+            'active'
+        );
+
+        $teamRow = sqlQuery(
+            "SELECT id FROM care_teams WHERE team_name = ?",
+            [self::TEST_TEAM_NAME]
+        );
+        $teamId = intval($teamRow['id']);
+
+        // Update the team name and status
+        $this->service->saveCareTeam(
+            $this->testPid,
+            $teamId,
+            self::TEST_TEAM_NAME_ALT,
+            [],
+            'suspended'
+        );
+
+        // Verify the update
+        $updatedRow = sqlQuery(
+            "SELECT team_name, status FROM care_teams WHERE id = ?",
+            [$teamId]
+        );
+        $this->assertEquals(self::TEST_TEAM_NAME_ALT, $updatedRow['team_name']);
+        $this->assertEquals('suspended', $updatedRow['status']);
+
+        // Verify no duplicate was created
+        $count = sqlQuery(
+            "SELECT COUNT(*) as cnt FROM care_teams WHERE pid = ? AND (team_name LIKE 'test-fixture%')",
+            [$this->testPid]
+        );
+        $this->assertEquals(1, intval($count['cnt']));
+    }
+
+    #[Test]
+    public function testSaveCareTeamAddsNewMemberToExistingTeam(): void
+    {
+        // Create team with one member
+        $team = [
+            [
+                'user_id' => $this->testProviderId,
+                'role' => 'family_medicine_specialist',
+                'facility_id' => $this->testFacilityId,
+                'status' => 'active',
+                'note' => '',
+            ]
+        ];
+
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            $team,
+            'active'
+        );
+
+        $teamRow = sqlQuery(
+            "SELECT id FROM care_teams WHERE team_name = ?",
+            [self::TEST_TEAM_NAME]
+        );
+        $teamId = intval($teamRow['id']);
+
+        // Verify initial state: one active member
+        $initialCount = sqlQuery(
+            "SELECT COUNT(*) as cnt FROM care_team_member WHERE care_team_id = ? AND status = 'active'",
+            [$teamId]
+        );
+        $this->assertEquals(1, intval($initialCount['cnt']));
+
+        // Get a second provider id — the admin user (id=1) should always exist
+        $secondProvider = sqlQuery(
+            "SELECT id FROM users WHERE id != ? AND id > 0 AND username IS NOT NULL AND username != '' LIMIT 1",
+            [$this->testProviderId]
+        );
+        $secondProviderId = intval($secondProvider['id'] ?? 0);
+        $this->assertGreaterThan(0, $secondProviderId, "A second user with positive id must exist for this test");
+
+        // Update team with both members
+        $teamUpdated = [
+            [
+                'user_id' => $this->testProviderId,
+                'role' => 'family_medicine_specialist',
+                'facility_id' => $this->testFacilityId,
+                'status' => 'active',
+                'note' => '',
+            ],
+            [
+                'user_id' => $secondProviderId,
+                'role' => 'nurse',
+                'facility_id' => $this->testFacilityId,
+                'status' => 'active',
+                'note' => 'Added nurse',
+            ]
+        ];
+
+        $this->service->saveCareTeam(
+            $this->testPid,
+            $teamId,
+            self::TEST_TEAM_NAME,
+            $teamUpdated,
+            'active'
+        );
+
+        // Verify two active members exist
+        $memberCount = sqlQuery(
+            "SELECT COUNT(*) as cnt FROM care_team_member WHERE care_team_id = ? AND status = 'active'",
+            [$teamId]
+        );
+        $this->assertEquals(2, intval($memberCount['cnt']));
+    }
+
+    #[Test]
+    public function testSaveCareTeamMarksMemberInactiveWhenRemoved(): void
+    {
+        // Create team with one member
+        $team = [
+            [
+                'user_id' => $this->testProviderId,
+                'role' => 'family_medicine_specialist',
+                'facility_id' => $this->testFacilityId,
+                'status' => 'active',
+                'note' => '',
+            ]
+        ];
+
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            $team,
+            'active'
+        );
+
+        $teamRow = sqlQuery(
+            "SELECT id FROM care_teams WHERE team_name = ?",
+            [self::TEST_TEAM_NAME]
+        );
+        $teamId = intval($teamRow['id']);
+
+        // Update team with NO members (removing the provider)
+        $this->service->saveCareTeam(
+            $this->testPid,
+            $teamId,
+            self::TEST_TEAM_NAME,
+            [],
+            'active'
+        );
+
+        // Verify the member was marked inactive (not deleted)
+        $memberRow = sqlQuery(
+            "SELECT status FROM care_team_member WHERE care_team_id = ? AND user_id = ?",
+            [$teamId, $this->testProviderId]
+        );
+        $this->assertNotEmpty($memberRow);
+        $this->assertEquals('inactive', $memberRow['status']);
+    }
+
+    // =========================================================================
+    // getCareTeamData
+    // =========================================================================
+
+    #[Test]
+    public function testGetCareTeamDataReturnsEmptyStructureWhenNoTeam(): void
+    {
+        $result = $this->service->getCareTeamData($this->testPid);
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result['team_name']);
+        $this->assertEquals('active', $result['team_status']);
+        $this->assertIsArray($result['members']);
+        $this->assertEmpty($result['members']);
+        $this->assertEquals(0, $result['member_count']);
+    }
+
+    #[Test]
+    public function testGetCareTeamDataReturnsTeamWithMembers(): void
+    {
+        $team = [
+            [
+                'user_id' => $this->testProviderId,
+                'role' => 'family_medicine_specialist',
+                'facility_id' => $this->testFacilityId,
+                'provider_since' => date('Y-m-d'),
+                'status' => 'active',
+                'note' => 'Test provider note',
+            ]
+        ];
+
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            $team,
+            'active'
+        );
+
+        $result = $this->service->getCareTeamData($this->testPid);
+
+        $this->assertIsArray($result);
+        $this->assertEquals(self::TEST_TEAM_NAME, $result['team_name']);
+        $this->assertEquals('active', $result['team_status']);
+        $this->assertGreaterThanOrEqual(1, $result['member_count']);
+        $this->assertNotEmpty($result['members']);
+
+        // Verify first member structure
+        $member = $result['members'][0];
+        $this->assertEquals('user', $member['member_type']);
+        $this->assertEquals($this->testProviderId, intval($member['user_id']));
+        $this->assertEquals('family_medicine_specialist', $member['role']);
+        $this->assertEquals($this->testFacilityId, intval($member['facility_id']));
+        $this->assertEquals('active', $member['status']);
+        $this->assertEquals('Test provider note', $member['note']);
+    }
+
+    #[Test]
+    public function testGetCareTeamDataPrefersActiveTeam(): void
+    {
+        // Create an inactive team first
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME_ALT,
+            [],
+            'inactive'
+        );
+
+        // Create an active team second
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            [],
+            'active'
+        );
+
+        $result = $this->service->getCareTeamData($this->testPid);
+
+        $this->assertEquals('active', $result['team_status']);
+        $this->assertEquals(self::TEST_TEAM_NAME, $result['team_name']);
+    }
+
+    #[Test]
+    public function testGetCareTeamDataExcludesInactiveMembers(): void
+    {
+        // Create team with a member
+        $team = [
+            [
+                'user_id' => $this->testProviderId,
+                'role' => 'family_medicine_specialist',
+                'facility_id' => $this->testFacilityId,
+                'status' => 'active',
+                'note' => '',
+            ]
+        ];
+
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            $team,
+            'active'
+        );
+
+        $teamRow = sqlQuery(
+            "SELECT id FROM care_teams WHERE team_name = ?",
+            [self::TEST_TEAM_NAME]
+        );
+        $teamId = intval($teamRow['id']);
+
+        // Remove the member (marks inactive)
+        $this->service->saveCareTeam(
+            $this->testPid,
+            $teamId,
+            self::TEST_TEAM_NAME,
+            [],
+            'active'
+        );
+
+        $result = $this->service->getCareTeamData($this->testPid);
+
+        // getCareTeamData filters out inactive/entered-in-error members
+        $this->assertEquals(0, $result['member_count']);
+    }
+
+    // =========================================================================
+    // getOne
+    // =========================================================================
+
+    #[Test]
+    public function testGetOneWithValidUuidReturnsData(): void
+    {
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            [],
+            'active'
+        );
+
+        // Get the UUID from the database
+        $row = sqlQuery(
+            "SELECT uuid FROM care_teams WHERE team_name = ?",
+            [self::TEST_TEAM_NAME]
+        );
+        $uuidString = UuidRegistry::uuidToString($row['uuid']);
+
+        $result = $this->service->getOne($uuidString);
+
+        $this->assertNotNull($result);
+        $this->assertCount(0, $result->getValidationMessages());
+        $this->assertNotEmpty($result->getData());
+
+        $data = $result->getData()[0];
+        $this->assertEquals($uuidString, $data['uuid']);
+        $this->assertEquals(self::TEST_TEAM_NAME, $data['team_name']);
+    }
+
+    #[Test]
+    public function testGetOneWithInvalidUuidReturnsValidationMessages(): void
+    {
+        $result = $this->service->getOne("not-a-valid-uuid");
+
+        $this->assertNotNull($result);
+        $this->assertNotEmpty($result->getValidationMessages());
+        $this->assertArrayHasKey('uuid', $result->getValidationMessages());
+        $this->assertEmpty($result->getData());
+    }
+
+    #[Test]
+    public function testGetOneWithPatientUuidBinding(): void
+    {
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            [],
+            'active'
+        );
+
+        // Get the care team UUID
+        $teamRow = sqlQuery(
+            "SELECT uuid FROM care_teams WHERE team_name = ?",
+            [self::TEST_TEAM_NAME]
+        );
+        $teamUuid = UuidRegistry::uuidToString($teamRow['uuid']);
+
+        // Get the patient UUID
+        $patientRow = sqlQuery(
+            "SELECT uuid FROM patient_data WHERE pid = ?",
+            [$this->testPid]
+        );
+        $patientUuid = UuidRegistry::uuidToString($patientRow['uuid']);
+
+        $result = $this->service->getOne($teamUuid, $patientUuid);
+
+        $this->assertNotNull($result);
+        $this->assertNotEmpty($result->getData());
+        $this->assertEquals($teamUuid, $result->getData()[0]['uuid']);
+    }
+
+    // =========================================================================
+    // getAll
+    // =========================================================================
+
+    #[Test]
+    public function testGetAllReturnsResults(): void
+    {
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            [],
+            'active'
+        );
+
+        $result = $this->service->getAll();
+
+        $this->assertNotNull($result);
+        $this->assertNotEmpty($result->getData());
+
+        // Verify at least one of the results is our test team
+        $found = false;
+        foreach ($result->getData() as $record) {
+            if ($record['team_name'] === self::TEST_TEAM_NAME) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found, "Test care team should be found in getAll results");
+    }
+
+    #[Test]
+    public function testGetAllWithPatientUuidBinding(): void
+    {
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            [],
+            'active'
+        );
+
+        // Get the patient UUID
+        $patientRow = sqlQuery(
+            "SELECT uuid FROM patient_data WHERE pid = ?",
+            [$this->testPid]
+        );
+        $patientUuid = UuidRegistry::uuidToString($patientRow['uuid']);
+
+        $result = $this->service->getAll([], true, $patientUuid);
+
+        $this->assertNotNull($result);
+        $this->assertNotEmpty($result->getData());
+
+        // All returned records should belong to our test patient
+        foreach ($result->getData() as $record) {
+            $this->assertEquals($patientUuid, $record['puuid']);
+        }
+    }
+
+    #[Test]
+    public function testGetAllWithInvalidPatientUuidReturnsValidation(): void
+    {
+        $result = $this->service->getAll([], true, "not-a-valid-uuid");
+
+        // Should return a ProcessingResult with validation errors
+        $this->assertNotNull($result);
+        // BaseValidator returns ProcessingResult with validation messages for invalid UUID
+        $this->assertNotEmpty($result->getValidationMessages());
+    }
+
+    // =========================================================================
+    // search — result structure
+    // =========================================================================
+
+    #[Test]
+    public function testSearchReturnsResultsWithProviders(): void
+    {
+        $team = [
+            [
+                'user_id' => $this->testProviderId,
+                'role' => 'family_medicine_specialist',
+                'facility_id' => $this->testFacilityId,
+                'status' => 'active',
+                'note' => '',
+            ]
+        ];
+
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            $team,
+            'active'
+        );
+
+        // Get the care team UUID for searching
+        $teamRow = sqlQuery(
+            "SELECT uuid FROM care_teams WHERE team_name = ?",
+            [self::TEST_TEAM_NAME]
+        );
+        $teamUuid = UuidRegistry::uuidToString($teamRow['uuid']);
+
+        $search = ['uuid' => new TokenSearchField('uuid', $teamUuid, true)];
+        $result = $this->service->search($search);
+
+        $this->assertNotNull($result);
+        $this->assertNotEmpty($result->getData());
+
+        $record = $result->getData()[0];
+
+        // Verify providers are populated
+        $this->assertArrayHasKey('providers', $record);
+        $this->assertNotEmpty($record['providers']);
+
+        $provider = $record['providers'][0];
+        $this->assertArrayHasKey('provider_uuid', $provider);
+        $this->assertArrayHasKey('provider_name', $provider);
+        $this->assertArrayHasKey('role', $provider);
+        $this->assertArrayHasKey('role_title', $provider);
+    }
+
+    #[Test]
+    public function testSearchReturnsResultsWithFacilities(): void
+    {
+        $team = [
+            [
+                'user_id' => $this->testProviderId,
+                'role' => 'family_medicine_specialist',
+                'facility_id' => $this->testFacilityId,
+                'status' => 'active',
+                'note' => '',
+            ]
+        ];
+
+        $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            $team,
+            'active'
+        );
+
+        $teamRow = sqlQuery(
+            "SELECT uuid FROM care_teams WHERE team_name = ?",
+            [self::TEST_TEAM_NAME]
+        );
+        $teamUuid = UuidRegistry::uuidToString($teamRow['uuid']);
+
+        $search = ['uuid' => new TokenSearchField('uuid', $teamUuid, true)];
+        $result = $this->service->search($search);
+
+        $this->assertNotNull($result);
+        $this->assertNotEmpty($result->getData());
+
+        $record = $result->getData()[0];
+
+        // Verify facilities are populated
+        $this->assertArrayHasKey('facilities', $record);
+        $this->assertNotEmpty($record['facilities']);
+
+        $facility = $record['facilities'][0];
+        $this->assertArrayHasKey('uuid', $facility);
+        $this->assertArrayHasKey('name', $facility);
+    }
+
+    #[Test]
+    public function testSearchReturnsEmptyForNonMatchingCriteria(): void
+    {
+        // Search with a UUID that doesn't exist
+        $fakeUuid = "00000000-0000-0000-0000-000000000000";
+        $search = ['uuid' => new TokenSearchField('uuid', $fakeUuid, true)];
+        $result = $this->service->search($search);
+
+        $this->assertNotNull($result);
+        $this->assertEmpty($result->getData());
+    }
+
+    // =========================================================================
+    // createResultRecordFromDatabaseResult — default values
+    // =========================================================================
+
+    #[Test]
+    public function testCreateResultRecordSetsDefaults(): void
+    {
+        // Provide a minimal row to verify defaults
+        $minimalRow = [
+            'id' => 999,
+            'uuid' => null,
+            'pid' => $this->testPid,
+            'puuid' => null,
+        ];
+
+        $result = $this->service->createResultRecordFromDatabaseResult($minimalRow);
+
+        $this->assertEquals('', $result['team_name']);
+        $this->assertEquals('active', $result['care_team_status']);
+        $this->assertNull($result['date']);
+        $this->assertIsArray($result['providers']);
+        $this->assertEmpty($result['providers']);
+        $this->assertIsArray($result['facilities']);
+        $this->assertEmpty($result['facilities']);
+        $this->assertIsArray($result['contacts']);
+        $this->assertEmpty($result['contacts']);
+    }
+}

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -143,7 +143,7 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
-        $row = sqlQuery(
+        $row = QueryUtils::querySingleRow(
             "SELECT id, team_name, status, pid FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
@@ -151,7 +151,7 @@ class CareTeamServiceTest extends TestCase
         $this->assertNotEmpty($row);
         $this->assertEquals(self::TEST_TEAM_NAME, $row['team_name']);
         $this->assertEquals('active', $row['status']);
-        $this->assertEquals($this->testPid, intval($row['pid']));
+        $this->assertEquals($this->testPid, (int) $row['pid']);
     }
 
     #[Test]
@@ -165,7 +165,7 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
-        $row = sqlQuery(
+        $row = QueryUtils::querySingleRow(
             "SELECT uuid FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
@@ -202,20 +202,20 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Verify the team was created
-        $teamRow = sqlQuery(
+        $teamRow = QueryUtils::querySingleRow(
             "SELECT id FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
         $this->assertNotEmpty($teamRow);
 
         // Verify the member was inserted
-        $memberRow = sqlQuery(
+        $memberRow = QueryUtils::querySingleRow(
             "SELECT * FROM care_team_member WHERE care_team_id = ? AND user_id = ?",
             [$teamRow['id'], $this->testProviderId]
         );
         $this->assertNotEmpty($memberRow);
         $this->assertEquals('family_medicine_specialist', $memberRow['role']);
-        $this->assertEquals($this->testFacilityId, intval($memberRow['facility_id']));
+        $this->assertEquals($this->testFacilityId, (int) $memberRow['facility_id']);
         $this->assertEquals('active', $memberRow['status']);
         $this->assertEquals('Primary physician', $memberRow['note']);
     }
@@ -236,11 +236,11 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
-        $teamRow = sqlQuery(
+        $teamRow = QueryUtils::querySingleRow(
             "SELECT id FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
-        $teamId = intval($teamRow['id']);
+        $teamId = (int) $teamRow['id'];
 
         // Update the team name and status
         $this->service->saveCareTeam(
@@ -252,7 +252,7 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Verify the update
-        $updatedRow = sqlQuery(
+        $updatedRow = QueryUtils::querySingleRow(
             "SELECT team_name, status FROM care_teams WHERE id = ?",
             [$teamId]
         );
@@ -260,11 +260,11 @@ class CareTeamServiceTest extends TestCase
         $this->assertEquals('suspended', $updatedRow['status']);
 
         // Verify no duplicate was created
-        $count = sqlQuery(
+        $count = QueryUtils::querySingleRow(
             "SELECT COUNT(*) as cnt FROM care_teams WHERE pid = ? AND (team_name LIKE 'test-fixture%')",
             [$this->testPid]
         );
-        $this->assertEquals(1, intval($count['cnt']));
+        $this->assertEquals(1, (int) $count['cnt']);
     }
 
     #[Test]
@@ -289,25 +289,25 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
-        $teamRow = sqlQuery(
+        $teamRow = QueryUtils::querySingleRow(
             "SELECT id FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
-        $teamId = intval($teamRow['id']);
+        $teamId = (int) $teamRow['id'];
 
         // Verify initial state: one active member
-        $initialCount = sqlQuery(
+        $initialCount = QueryUtils::querySingleRow(
             "SELECT COUNT(*) as cnt FROM care_team_member WHERE care_team_id = ? AND status = 'active'",
             [$teamId]
         );
-        $this->assertEquals(1, intval($initialCount['cnt']));
+        $this->assertEquals(1, (int) $initialCount['cnt']);
 
         // Get a second provider id — the admin user (id=1) should always exist
-        $secondProvider = sqlQuery(
+        $secondProvider = QueryUtils::querySingleRow(
             "SELECT id FROM users WHERE id != ? AND id > 0 AND username IS NOT NULL AND username != '' LIMIT 1",
             [$this->testProviderId]
         );
-        $secondProviderId = intval($secondProvider['id'] ?? 0);
+        $secondProviderId = (int) ($secondProvider['id'] ?? 0);
         $this->assertGreaterThan(0, $secondProviderId, "A second user with positive id must exist for this test");
 
         // Update team with both members
@@ -337,11 +337,11 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Verify two active members exist
-        $memberCount = sqlQuery(
+        $memberCount = QueryUtils::querySingleRow(
             "SELECT COUNT(*) as cnt FROM care_team_member WHERE care_team_id = ? AND status = 'active'",
             [$teamId]
         );
-        $this->assertEquals(2, intval($memberCount['cnt']));
+        $this->assertEquals(2, (int) $memberCount['cnt']);
     }
 
     #[Test]
@@ -366,11 +366,11 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
-        $teamRow = sqlQuery(
+        $teamRow = QueryUtils::querySingleRow(
             "SELECT id FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
-        $teamId = intval($teamRow['id']);
+        $teamId = (int) $teamRow['id'];
 
         // Update team with NO members (removing the provider)
         $this->service->saveCareTeam(
@@ -382,7 +382,7 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Verify the member was marked inactive (not deleted)
-        $memberRow = sqlQuery(
+        $memberRow = QueryUtils::querySingleRow(
             "SELECT status FROM care_team_member WHERE care_team_id = ? AND user_id = ?",
             [$teamId, $this->testProviderId]
         );
@@ -440,9 +440,9 @@ class CareTeamServiceTest extends TestCase
         // Verify first member structure
         $member = $result['members'][0];
         $this->assertEquals('user', $member['member_type']);
-        $this->assertEquals($this->testProviderId, intval($member['user_id']));
+        $this->assertEquals($this->testProviderId, (int) $member['user_id']);
         $this->assertEquals('family_medicine_specialist', $member['role']);
-        $this->assertEquals($this->testFacilityId, intval($member['facility_id']));
+        $this->assertEquals($this->testFacilityId, (int) $member['facility_id']);
         $this->assertEquals('active', $member['status']);
         $this->assertEquals('Test provider note', $member['note']);
     }
@@ -496,11 +496,11 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
-        $teamRow = sqlQuery(
+        $teamRow = QueryUtils::querySingleRow(
             "SELECT id FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
-        $teamId = intval($teamRow['id']);
+        $teamId = (int) $teamRow['id'];
 
         // Remove the member (marks inactive)
         $this->service->saveCareTeam(
@@ -533,7 +533,7 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Get the UUID from the database
-        $row = sqlQuery(
+        $row = QueryUtils::querySingleRow(
             "SELECT uuid FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
@@ -573,14 +573,14 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Get the care team UUID
-        $teamRow = sqlQuery(
+        $teamRow = QueryUtils::querySingleRow(
             "SELECT uuid FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
         $teamUuid = UuidRegistry::uuidToString($teamRow['uuid']);
 
         // Get the patient UUID
-        $patientRow = sqlQuery(
+        $patientRow = QueryUtils::querySingleRow(
             "SELECT uuid FROM patient_data WHERE pid = ?",
             [$this->testPid]
         );
@@ -636,7 +636,7 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Get the patient UUID
-        $patientRow = sqlQuery(
+        $patientRow = QueryUtils::querySingleRow(
             "SELECT uuid FROM patient_data WHERE pid = ?",
             [$this->testPid]
         );
@@ -690,7 +690,7 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Get the care team UUID for searching
-        $teamRow = sqlQuery(
+        $teamRow = QueryUtils::querySingleRow(
             "SELECT uuid FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
@@ -736,7 +736,7 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
-        $teamRow = sqlQuery(
+        $teamRow = QueryUtils::querySingleRow(
             "SELECT uuid FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -463,14 +463,17 @@ class CareTeamServiceTest extends TestCase
         );
 
         $result = $this->service->getCareTeamData($this->testPid);
+        $this->assertIsArray($result);
 
         $this->assertEquals(self::TEST_TEAM_NAME, $result['team_name']);
         $this->assertEquals('active', $result['team_status']);
         $this->assertGreaterThanOrEqual(1, $result['member_count']);
+        $this->assertIsArray($result['members']);
         $this->assertNotEmpty($result['members']);
 
         // Verify first member structure
         $member = $result['members'][0];
+        $this->assertIsArray($member);
         $this->assertEquals('user', $member['member_type']);
         // @phpstan-ignore cast.int
         $this->assertEquals($this->testProviderId, (int) $member['user_id']);
@@ -583,9 +586,10 @@ class CareTeamServiceTest extends TestCase
 
         $this->assertCount(0, $result->getValidationMessages());
 
-        /** @var array<int, array<string, mixed>> $data */
         $data = $result->getData();
+        $this->assertIsArray($data);
         $this->assertNotEmpty($data);
+        $this->assertIsArray($data[0]);
 
         $this->assertEquals($uuidString, $data[0]['uuid']);
         $this->assertEquals(self::TEST_TEAM_NAME, $data[0]['team_name']);
@@ -636,7 +640,9 @@ class CareTeamServiceTest extends TestCase
 
         /** @var array<int, array<string, mixed>> $data */
         $data = $result->getData();
+        $this->assertIsArray($data);
         $this->assertNotEmpty($data);
+        $this->assertIsArray($data[0]);
         $this->assertEquals($teamUuid, $data[0]['uuid']);
     }
 
@@ -659,6 +665,7 @@ class CareTeamServiceTest extends TestCase
 
         /** @var array<int, array<string, mixed>> $data */
         $data = $result->getData();
+        $this->assertIsArray($data);
         $this->assertNotEmpty($data);
 
         // Verify at least one of the results is our test team
@@ -697,6 +704,7 @@ class CareTeamServiceTest extends TestCase
 
         /** @var array<int, array<string, mixed>> $data */
         $data = $result->getData();
+        $this->assertIsArray($data);
         $this->assertNotEmpty($data);
 
         // All returned records should belong to our test patient
@@ -754,9 +762,11 @@ class CareTeamServiceTest extends TestCase
 
         /** @var array<int, array<string, mixed>> $data */
         $data = $result->getData();
+        $this->assertIsArray($data);
         $this->assertNotEmpty($data);
 
         $record = $data[0];
+        $this->assertIsArray($record);
 
         // Verify providers are populated
         $this->assertArrayHasKey('providers', $record);
@@ -806,9 +816,11 @@ class CareTeamServiceTest extends TestCase
 
         /** @var array<int, array<string, mixed>> $data */
         $data = $result->getData();
+        $this->assertIsArray($data);
         $this->assertNotEmpty($data);
 
         $record = $data[0];
+        $this->assertIsArray($record);
 
         // Verify facilities are populated
         $this->assertArrayHasKey('facilities', $record);

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -638,7 +638,6 @@ class CareTeamServiceTest extends TestCase
 
         $result = $this->service->getOne($teamUuid, $patientUuid);
 
-        /** @var array<int, array<string, mixed>> $data */
         $data = $result->getData();
         $this->assertIsArray($data);
         $this->assertNotEmpty($data);
@@ -663,7 +662,6 @@ class CareTeamServiceTest extends TestCase
 
         $result = $this->service->getAll();
 
-        /** @var array<int, array<string, mixed>> $data */
         $data = $result->getData();
         $this->assertIsArray($data);
         $this->assertNotEmpty($data);
@@ -702,7 +700,6 @@ class CareTeamServiceTest extends TestCase
 
         $result = $this->service->getAll([], true, $patientUuid);
 
-        /** @var array<int, array<string, mixed>> $data */
         $data = $result->getData();
         $this->assertIsArray($data);
         $this->assertNotEmpty($data);
@@ -760,7 +757,6 @@ class CareTeamServiceTest extends TestCase
         $search = ['uuid' => new TokenSearchField('uuid', $teamUuid, true)];
         $result = $this->service->search($search);
 
-        /** @var array<int, array<string, mixed>> $data */
         $data = $result->getData();
         $this->assertIsArray($data);
         $this->assertNotEmpty($data);
@@ -814,7 +810,6 @@ class CareTeamServiceTest extends TestCase
         $search = ['uuid' => new TokenSearchField('uuid', $teamUuid, true)];
         $result = $this->service->search($search);
 
-        /** @var array<int, array<string, mixed>> $data */
         $data = $result->getData();
         $this->assertIsArray($data);
         $this->assertNotEmpty($data);

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -82,7 +82,6 @@ class CareTeamServiceTest extends TestCase
     public function testGetUuidFieldsReturnsExpectedFields(): void
     {
         $fields = $this->service->getUuidFields();
-        $this->assertIsArray($fields);
         $this->assertContains('uuid', $fields);
         $this->assertContains('puuid', $fields);
     }
@@ -143,14 +142,17 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
+        /** @var array<string, mixed>|false $row */
         $row = QueryUtils::querySingleRow(
             "SELECT id, team_name, status, pid FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
 
         $this->assertNotEmpty($row);
+        $this->assertIsArray($row);
         $this->assertEquals(self::TEST_TEAM_NAME, $row['team_name']);
         $this->assertEquals('active', $row['status']);
+        // @phpstan-ignore cast.int
         $this->assertEquals($this->testPid, (int) $row['pid']);
     }
 
@@ -165,12 +167,15 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
+        /** @var array<string, mixed>|false $row */
         $row = QueryUtils::querySingleRow(
             "SELECT uuid FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
 
+        $this->assertIsArray($row);
         $this->assertNotEmpty($row['uuid']);
+        // @phpstan-ignore argument.type
         $uuidString = UuidRegistry::uuidToString($row['uuid']);
         $this->assertNotEmpty($uuidString);
         $this->assertMatchesRegularExpression(
@@ -202,19 +207,24 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Verify the team was created
+        /** @var array<string, mixed>|false $teamRow */
         $teamRow = QueryUtils::querySingleRow(
             "SELECT id FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
+        $this->assertIsArray($teamRow);
         $this->assertNotEmpty($teamRow);
 
         // Verify the member was inserted
+        /** @var array<string, mixed>|false $memberRow */
         $memberRow = QueryUtils::querySingleRow(
             "SELECT * FROM care_team_member WHERE care_team_id = ? AND user_id = ?",
             [$teamRow['id'], $this->testProviderId]
         );
+        $this->assertIsArray($memberRow);
         $this->assertNotEmpty($memberRow);
         $this->assertEquals('family_medicine_specialist', $memberRow['role']);
+        // @phpstan-ignore cast.int
         $this->assertEquals($this->testFacilityId, (int) $memberRow['facility_id']);
         $this->assertEquals('active', $memberRow['status']);
         $this->assertEquals('Primary physician', $memberRow['note']);
@@ -236,10 +246,13 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
+        /** @var array<string, mixed>|false $teamRow */
         $teamRow = QueryUtils::querySingleRow(
             "SELECT id FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
+        $this->assertIsArray($teamRow);
+        // @phpstan-ignore cast.int
         $teamId = (int) $teamRow['id'];
 
         // Update the team name and status
@@ -252,18 +265,23 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Verify the update
+        /** @var array<string, mixed>|false $updatedRow */
         $updatedRow = QueryUtils::querySingleRow(
             "SELECT team_name, status FROM care_teams WHERE id = ?",
             [$teamId]
         );
+        $this->assertIsArray($updatedRow);
         $this->assertEquals(self::TEST_TEAM_NAME_ALT, $updatedRow['team_name']);
         $this->assertEquals('suspended', $updatedRow['status']);
 
         // Verify no duplicate was created
+        /** @var array<string, mixed>|false $count */
         $count = QueryUtils::querySingleRow(
             "SELECT COUNT(*) as cnt FROM care_teams WHERE pid = ? AND (team_name LIKE 'test-fixture%')",
             [$this->testPid]
         );
+        $this->assertIsArray($count);
+        // @phpstan-ignore cast.int
         $this->assertEquals(1, (int) $count['cnt']);
     }
 
@@ -289,24 +307,33 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
+        /** @var array<string, mixed>|false $teamRow */
         $teamRow = QueryUtils::querySingleRow(
             "SELECT id FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
+        $this->assertIsArray($teamRow);
+        // @phpstan-ignore cast.int
         $teamId = (int) $teamRow['id'];
 
         // Verify initial state: one active member
+        /** @var array<string, mixed>|false $initialCount */
         $initialCount = QueryUtils::querySingleRow(
             "SELECT COUNT(*) as cnt FROM care_team_member WHERE care_team_id = ? AND status = 'active'",
             [$teamId]
         );
+        $this->assertIsArray($initialCount);
+        // @phpstan-ignore cast.int
         $this->assertEquals(1, (int) $initialCount['cnt']);
 
         // Get a second provider id — the admin user (id=1) should always exist
+        /** @var array<string, mixed>|false $secondProvider */
         $secondProvider = QueryUtils::querySingleRow(
             "SELECT id FROM users WHERE id != ? AND id > 0 AND username IS NOT NULL AND username != '' LIMIT 1",
             [$this->testProviderId]
         );
+        $this->assertIsArray($secondProvider);
+        // @phpstan-ignore cast.int
         $secondProviderId = (int) ($secondProvider['id'] ?? 0);
         $this->assertGreaterThan(0, $secondProviderId, "A second user with positive id must exist for this test");
 
@@ -337,10 +364,13 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Verify two active members exist
+        /** @var array<string, mixed>|false $memberCount */
         $memberCount = QueryUtils::querySingleRow(
             "SELECT COUNT(*) as cnt FROM care_team_member WHERE care_team_id = ? AND status = 'active'",
             [$teamId]
         );
+        $this->assertIsArray($memberCount);
+        // @phpstan-ignore cast.int
         $this->assertEquals(2, (int) $memberCount['cnt']);
     }
 
@@ -366,10 +396,13 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
+        /** @var array<string, mixed>|false $teamRow */
         $teamRow = QueryUtils::querySingleRow(
             "SELECT id FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
+        $this->assertIsArray($teamRow);
+        // @phpstan-ignore cast.int
         $teamId = (int) $teamRow['id'];
 
         // Update team with NO members (removing the provider)
@@ -382,10 +415,12 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Verify the member was marked inactive (not deleted)
+        /** @var array<string, mixed>|false $memberRow */
         $memberRow = QueryUtils::querySingleRow(
             "SELECT status FROM care_team_member WHERE care_team_id = ? AND user_id = ?",
             [$teamId, $this->testProviderId]
         );
+        $this->assertIsArray($memberRow);
         $this->assertNotEmpty($memberRow);
         $this->assertEquals('inactive', $memberRow['status']);
     }
@@ -399,10 +434,8 @@ class CareTeamServiceTest extends TestCase
     {
         $result = $this->service->getCareTeamData($this->testPid);
 
-        $this->assertIsArray($result);
         $this->assertEmpty($result['team_name']);
         $this->assertEquals('active', $result['team_status']);
-        $this->assertIsArray($result['members']);
         $this->assertEmpty($result['members']);
         $this->assertEquals(0, $result['member_count']);
     }
@@ -431,7 +464,6 @@ class CareTeamServiceTest extends TestCase
 
         $result = $this->service->getCareTeamData($this->testPid);
 
-        $this->assertIsArray($result);
         $this->assertEquals(self::TEST_TEAM_NAME, $result['team_name']);
         $this->assertEquals('active', $result['team_status']);
         $this->assertGreaterThanOrEqual(1, $result['member_count']);
@@ -440,8 +472,10 @@ class CareTeamServiceTest extends TestCase
         // Verify first member structure
         $member = $result['members'][0];
         $this->assertEquals('user', $member['member_type']);
+        // @phpstan-ignore cast.int
         $this->assertEquals($this->testProviderId, (int) $member['user_id']);
         $this->assertEquals('family_medicine_specialist', $member['role']);
+        // @phpstan-ignore cast.int
         $this->assertEquals($this->testFacilityId, (int) $member['facility_id']);
         $this->assertEquals('active', $member['status']);
         $this->assertEquals('Test provider note', $member['note']);
@@ -496,10 +530,13 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
+        /** @var array<string, mixed>|false $teamRow */
         $teamRow = QueryUtils::querySingleRow(
             "SELECT id FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
+        $this->assertIsArray($teamRow);
+        // @phpstan-ignore cast.int
         $teamId = (int) $teamRow['id'];
 
         // Remove the member (marks inactive)
@@ -533,21 +570,25 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Get the UUID from the database
+        /** @var array<string, mixed>|false $row */
         $row = QueryUtils::querySingleRow(
             "SELECT uuid FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
+        $this->assertIsArray($row);
+        // @phpstan-ignore argument.type
         $uuidString = UuidRegistry::uuidToString($row['uuid']);
 
         $result = $this->service->getOne($uuidString);
 
-        $this->assertNotNull($result);
         $this->assertCount(0, $result->getValidationMessages());
-        $this->assertNotEmpty($result->getData());
 
-        $data = $result->getData()[0];
-        $this->assertEquals($uuidString, $data['uuid']);
-        $this->assertEquals(self::TEST_TEAM_NAME, $data['team_name']);
+        /** @var array<int, array<string, mixed>> $data */
+        $data = $result->getData();
+        $this->assertNotEmpty($data);
+
+        $this->assertEquals($uuidString, $data[0]['uuid']);
+        $this->assertEquals(self::TEST_TEAM_NAME, $data[0]['team_name']);
     }
 
     #[Test]
@@ -555,7 +596,6 @@ class CareTeamServiceTest extends TestCase
     {
         $result = $this->service->getOne("not-a-valid-uuid");
 
-        $this->assertNotNull($result);
         $this->assertNotEmpty($result->getValidationMessages());
         $this->assertArrayHasKey('uuid', $result->getValidationMessages());
         $this->assertEmpty($result->getData());
@@ -573,24 +613,31 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Get the care team UUID
+        /** @var array<string, mixed>|false $teamRow */
         $teamRow = QueryUtils::querySingleRow(
             "SELECT uuid FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
+        $this->assertIsArray($teamRow);
+        // @phpstan-ignore argument.type
         $teamUuid = UuidRegistry::uuidToString($teamRow['uuid']);
 
         // Get the patient UUID
+        /** @var array<string, mixed>|false $patientRow */
         $patientRow = QueryUtils::querySingleRow(
             "SELECT uuid FROM patient_data WHERE pid = ?",
             [$this->testPid]
         );
+        $this->assertIsArray($patientRow);
+        // @phpstan-ignore argument.type
         $patientUuid = UuidRegistry::uuidToString($patientRow['uuid']);
 
         $result = $this->service->getOne($teamUuid, $patientUuid);
 
-        $this->assertNotNull($result);
-        $this->assertNotEmpty($result->getData());
-        $this->assertEquals($teamUuid, $result->getData()[0]['uuid']);
+        /** @var array<int, array<string, mixed>> $data */
+        $data = $result->getData();
+        $this->assertNotEmpty($data);
+        $this->assertEquals($teamUuid, $data[0]['uuid']);
     }
 
     // =========================================================================
@@ -610,12 +657,13 @@ class CareTeamServiceTest extends TestCase
 
         $result = $this->service->getAll();
 
-        $this->assertNotNull($result);
-        $this->assertNotEmpty($result->getData());
+        /** @var array<int, array<string, mixed>> $data */
+        $data = $result->getData();
+        $this->assertNotEmpty($data);
 
         // Verify at least one of the results is our test team
         $found = false;
-        foreach ($result->getData() as $record) {
+        foreach ($data as $record) {
             if ($record['team_name'] === self::TEST_TEAM_NAME) {
                 $found = true;
                 break;
@@ -636,19 +684,23 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Get the patient UUID
+        /** @var array<string, mixed>|false $patientRow */
         $patientRow = QueryUtils::querySingleRow(
             "SELECT uuid FROM patient_data WHERE pid = ?",
             [$this->testPid]
         );
+        $this->assertIsArray($patientRow);
+        // @phpstan-ignore argument.type
         $patientUuid = UuidRegistry::uuidToString($patientRow['uuid']);
 
         $result = $this->service->getAll([], true, $patientUuid);
 
-        $this->assertNotNull($result);
-        $this->assertNotEmpty($result->getData());
+        /** @var array<int, array<string, mixed>> $data */
+        $data = $result->getData();
+        $this->assertNotEmpty($data);
 
         // All returned records should belong to our test patient
-        foreach ($result->getData() as $record) {
+        foreach ($data as $record) {
             $this->assertEquals($patientUuid, $record['puuid']);
         }
     }
@@ -658,8 +710,6 @@ class CareTeamServiceTest extends TestCase
     {
         $result = $this->service->getAll([], true, "not-a-valid-uuid");
 
-        // Should return a ProcessingResult with validation errors
-        $this->assertNotNull($result);
         // BaseValidator returns ProcessingResult with validation messages for invalid UUID
         $this->assertNotEmpty($result->getValidationMessages());
     }
@@ -690,25 +740,31 @@ class CareTeamServiceTest extends TestCase
         );
 
         // Get the care team UUID for searching
+        /** @var array<string, mixed>|false $teamRow */
         $teamRow = QueryUtils::querySingleRow(
             "SELECT uuid FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
+        $this->assertIsArray($teamRow);
+        // @phpstan-ignore argument.type
         $teamUuid = UuidRegistry::uuidToString($teamRow['uuid']);
 
         $search = ['uuid' => new TokenSearchField('uuid', $teamUuid, true)];
         $result = $this->service->search($search);
 
-        $this->assertNotNull($result);
-        $this->assertNotEmpty($result->getData());
+        /** @var array<int, array<string, mixed>> $data */
+        $data = $result->getData();
+        $this->assertNotEmpty($data);
 
-        $record = $result->getData()[0];
+        $record = $data[0];
 
         // Verify providers are populated
         $this->assertArrayHasKey('providers', $record);
+        $this->assertIsArray($record['providers']);
         $this->assertNotEmpty($record['providers']);
 
         $provider = $record['providers'][0];
+        $this->assertIsArray($provider);
         $this->assertArrayHasKey('provider_uuid', $provider);
         $this->assertArrayHasKey('provider_name', $provider);
         $this->assertArrayHasKey('role', $provider);
@@ -736,25 +792,31 @@ class CareTeamServiceTest extends TestCase
             'active'
         );
 
+        /** @var array<string, mixed>|false $teamRow */
         $teamRow = QueryUtils::querySingleRow(
             "SELECT uuid FROM care_teams WHERE team_name = ?",
             [self::TEST_TEAM_NAME]
         );
+        $this->assertIsArray($teamRow);
+        // @phpstan-ignore argument.type
         $teamUuid = UuidRegistry::uuidToString($teamRow['uuid']);
 
         $search = ['uuid' => new TokenSearchField('uuid', $teamUuid, true)];
         $result = $this->service->search($search);
 
-        $this->assertNotNull($result);
-        $this->assertNotEmpty($result->getData());
+        /** @var array<int, array<string, mixed>> $data */
+        $data = $result->getData();
+        $this->assertNotEmpty($data);
 
-        $record = $result->getData()[0];
+        $record = $data[0];
 
         // Verify facilities are populated
         $this->assertArrayHasKey('facilities', $record);
+        $this->assertIsArray($record['facilities']);
         $this->assertNotEmpty($record['facilities']);
 
         $facility = $record['facilities'][0];
+        $this->assertIsArray($facility);
         $this->assertArrayHasKey('uuid', $facility);
         $this->assertArrayHasKey('name', $facility);
     }
@@ -767,7 +829,6 @@ class CareTeamServiceTest extends TestCase
         $search = ['uuid' => new TokenSearchField('uuid', $fakeUuid, true)];
         $result = $this->service->search($search);
 
-        $this->assertNotNull($result);
         $this->assertEmpty($result->getData());
     }
 
@@ -791,11 +852,8 @@ class CareTeamServiceTest extends TestCase
         $this->assertEquals('', $result['team_name']);
         $this->assertEquals('active', $result['care_team_status']);
         $this->assertNull($result['date']);
-        $this->assertIsArray($result['providers']);
         $this->assertEmpty($result['providers']);
-        $this->assertIsArray($result['facilities']);
         $this->assertEmpty($result['facilities']);
-        $this->assertIsArray($result['contacts']);
         $this->assertEmpty($result['contacts']);
     }
 }

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -865,4 +865,57 @@ class CareTeamServiceTest extends TestCase
         $this->assertEmpty($result['facilities']);
         $this->assertEmpty($result['contacts']);
     }
+
+    // =========================================================================
+    // Contact-type members
+    // =========================================================================
+
+    #[Test]
+    public function testSaveCareTeamWithContactMember(): void
+    {
+        // Create a test contact
+        $contactRow = QueryUtils::sqlInsert(
+            "INSERT INTO contact (contact_id, patient_id, type, first_name, last_name, created) VALUES (?, ?, ?, ?, ?, NOW())",
+            [null, $this->testPid, 'emergency', 'Emergency', 'Contact']
+        );
+        $contactId = intval($contactRow);
+        $this->assertGreaterThan(0, $contactId);
+
+        // Save a team with a contact member
+        $team = [
+            [
+                'contact_id' => $contactId,
+                'role' => 'emergency_contact',
+                'facility_id' => $this->testFacilityId,
+                'status' => 'active',
+                'note' => 'Emergency contact member',
+            ]
+        ];
+
+        $teamId = $this->service->saveCareTeam(
+            $this->testPid,
+            null,
+            self::TEST_TEAM_NAME,
+            $team
+        );
+
+        $this->assertIsInt($teamId);
+        $this->assertGreaterThan(0, $teamId);
+
+        // Verify contact member was saved
+        /** @var array<string, mixed>|false $contactMember */
+        $contactMember = QueryUtils::querySingleRow(
+            "SELECT * FROM care_team_member WHERE care_team_id = ? AND contact_id = ? AND status = 'active'",
+            [$teamId, $contactId]
+        );
+        $this->assertIsArray($contactMember);
+        $this->assertEquals('emergency_contact', $contactMember['role']);
+        $this->assertEquals('Emergency contact member', $contactMember['note']);
+
+        // Clean up test contact
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM contact WHERE id = ?",
+            [$contactId]
+        );
+    }
 }

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -26,15 +26,9 @@ use PHPUnit\Framework\Attributes\Test;
 
 class CareTeamServiceTest extends TestCase
 {
-    /**
-     * @var CareTeamService
-     */
-    private $service;
-
-    /**
-     * @var CareTeamFixtureManager
-     */
-    private $fixtureManager;
+    private CareTeamService $service;
+    private CareTeamFixtureManager $fixtureManager;
+    private array $backupSession = [];
 
     /**
      * @var int
@@ -51,11 +45,17 @@ class CareTeamServiceTest extends TestCase
      */
     private int $testProviderId;
 
+    /**
+     * @var int Second test practitioner for multi-member tests
+     */
+    private int $testSecondProviderId;
+
     private const TEST_TEAM_NAME = "test-fixture-Primary Care Team";
     private const TEST_TEAM_NAME_ALT = "test-fixture-Secondary Care Team";
 
     protected function setUp(): void
     {
+        $this->backupSession = $_SESSION ?? [];
         $this->service = new CareTeamService();
         $this->fixtureManager = new CareTeamFixtureManager();
         $deps = $this->fixtureManager->installDependencies();
@@ -63,15 +63,26 @@ class CareTeamServiceTest extends TestCase
         $this->testFacilityId = $deps['facility_id'];
         $this->testProviderId = $deps['provider_id'];
 
-        // saveCareTeam reads $_SESSION['authUserID']
-        if (!isset($_SESSION['authUserID'])) {
-            $_SESSION['authUserID'] = 1;
+        // Get a second test practitioner for multi-member tests
+        /** @var array<string, mixed>|false $secondProvider */
+        $secondProvider = QueryUtils::querySingleRow(
+            "SELECT id FROM users WHERE fname LIKE ? AND id != ? LIMIT 1",
+            [CareTeamFixtureManager::FIXTURE_PREFIX . "%", $this->testProviderId]
+        );
+        if ($secondProvider === false || !isset($secondProvider['id'])) {
+            throw new \RuntimeException('Failed to find second test practitioner fixture');
         }
+        // @phpstan-ignore cast.int
+        $this->testSecondProviderId = (int) $secondProvider['id'];
+
+        // saveCareTeam reads $_SESSION['authUserID'] via SessionWrapperFactory
+        $_SESSION['authUserID'] = 1;
     }
 
     protected function tearDown(): void
     {
         $this->fixtureManager->removeFixtures();
+        $_SESSION = $this->backupSession;
     }
 
     // =========================================================================
@@ -326,16 +337,7 @@ class CareTeamServiceTest extends TestCase
         // @phpstan-ignore cast.int
         $this->assertEquals(1, (int) $initialCount['cnt']);
 
-        // Get a second provider id — the admin user (id=1) should always exist
-        /** @var array<string, mixed>|false $secondProvider */
-        $secondProvider = QueryUtils::querySingleRow(
-            "SELECT id FROM users WHERE id != ? AND id > 0 AND username IS NOT NULL AND username != '' LIMIT 1",
-            [$this->testProviderId]
-        );
-        $this->assertIsArray($secondProvider);
-        // @phpstan-ignore cast.int
-        $secondProviderId = (int) ($secondProvider['id'] ?? 0);
-        $this->assertGreaterThan(0, $secondProviderId, "A second user with positive id must exist for this test");
+        // Use the second test provider from setUp
 
         // Update team with both members
         $teamUpdated = [
@@ -347,7 +349,7 @@ class CareTeamServiceTest extends TestCase
                 'note' => '',
             ],
             [
-                'user_id' => $secondProviderId,
+                'user_id' => $this->testSecondProviderId,
                 'role' => 'nurse',
                 'facility_id' => $this->testFacilityId,
                 'status' => 'active',

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -894,14 +894,22 @@ class CareTeamServiceTest extends TestCase
                 ]
             ];
 
-            $teamId = $this->service->saveCareTeam(
+            $this->service->saveCareTeam(
                 $this->testPid,
                 null,
                 self::TEST_TEAM_NAME,
                 $team
             );
 
-            $this->assertIsInt($teamId);
+            // Look up the team by name since saveCareTeam() returns void
+            /** @var array<string, mixed>|false $teamRow */
+            $teamRow = QueryUtils::querySingleRow(
+                "SELECT id FROM care_team WHERE pid = ? AND team_name = ? LIMIT 1",
+                [$this->testPid, self::TEST_TEAM_NAME]
+            );
+            $this->assertIsArray($teamRow);
+            // @phpstan-ignore cast.int
+            $teamId = (int) $teamRow['id'];
             $this->assertGreaterThan(0, $teamId);
 
             // Verify the contact member row was inserted into care_team_member

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -873,49 +873,52 @@ class CareTeamServiceTest extends TestCase
     #[Test]
     public function testSaveCareTeamWithContactMember(): void
     {
-        // Create a test contact
-        $contactRow = QueryUtils::sqlInsert(
-            "INSERT INTO contact (contact_id, patient_id, type, first_name, last_name, created) VALUES (?, ?, ?, ?, ?, NOW())",
-            [null, $this->testPid, 'emergency', 'Emergency', 'Contact']
+        // The `contact` table records an entity from another table via (foreign_table_name, foreign_id).
+        // We use 'patient_data' as the foreign table and the test patient as the foreign_id
+        // so the row is self-contained and can be deleted after the test.
+        $contactId = (int) QueryUtils::sqlInsert(
+            "INSERT INTO contact (foreign_table_name, foreign_id) VALUES (?, ?)",
+            ['patient_data', $this->testPid]
         );
-        $contactId = intval($contactRow);
         $this->assertGreaterThan(0, $contactId);
 
-        // Save a team with a contact member
-        $team = [
-            [
-                'contact_id' => $contactId,
-                'role' => 'emergency_contact',
-                'facility_id' => $this->testFacilityId,
-                'status' => 'active',
-                'note' => 'Emergency contact member',
-            ]
-        ];
+        try {
+            // Save a team with a contact_id member (instead of user_id)
+            $team = [
+                [
+                    'contact_id' => $contactId,
+                    'role' => 'emergency_contact',
+                    'facility_id' => $this->testFacilityId,
+                    'status' => 'active',
+                    'note' => 'Emergency contact member',
+                ]
+            ];
 
-        $teamId = $this->service->saveCareTeam(
-            $this->testPid,
-            null,
-            self::TEST_TEAM_NAME,
-            $team
-        );
+            $teamId = $this->service->saveCareTeam(
+                $this->testPid,
+                null,
+                self::TEST_TEAM_NAME,
+                $team
+            );
 
-        $this->assertIsInt($teamId);
-        $this->assertGreaterThan(0, $teamId);
+            $this->assertIsInt($teamId);
+            $this->assertGreaterThan(0, $teamId);
 
-        // Verify contact member was saved
-        /** @var array<string, mixed>|false $contactMember */
-        $contactMember = QueryUtils::querySingleRow(
-            "SELECT * FROM care_team_member WHERE care_team_id = ? AND contact_id = ? AND status = 'active'",
-            [$teamId, $contactId]
-        );
-        $this->assertIsArray($contactMember);
-        $this->assertEquals('emergency_contact', $contactMember['role']);
-        $this->assertEquals('Emergency contact member', $contactMember['note']);
-
-        // Clean up test contact
-        QueryUtils::sqlStatementThrowException(
-            "DELETE FROM contact WHERE id = ?",
-            [$contactId]
-        );
+            // Verify the contact member row was inserted into care_team_member
+            /** @var array<string, mixed>|false $contactMember */
+            $contactMember = QueryUtils::querySingleRow(
+                "SELECT * FROM care_team_member WHERE care_team_id = ? AND contact_id = ? AND status = 'active'",
+                [$teamId, $contactId]
+            );
+            $this->assertIsArray($contactMember);
+            $this->assertEquals('emergency_contact', $contactMember['role']);
+            $this->assertEquals('Emergency contact member', $contactMember['note']);
+        } finally {
+            // Always clean up the test contact row
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM contact WHERE id = ?",
+                [$contactId]
+            );
+        }
     }
 }

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -904,7 +904,7 @@ class CareTeamServiceTest extends TestCase
             // Look up the team by name since saveCareTeam() returns void
             /** @var array<string, mixed>|false $teamRow */
             $teamRow = QueryUtils::querySingleRow(
-                "SELECT id FROM care_team WHERE pid = ? AND team_name = ? LIMIT 1",
+                "SELECT id FROM care_teams WHERE pid = ? AND team_name = ? LIMIT 1",
                 [$this->testPid, self::TEST_TEAM_NAME]
             );
             $this->assertIsArray($teamRow);

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -26,6 +26,9 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
+// The services test suite runs outside the coverage-producing CI job. Exclude
+// this test harness itself so Codecov measures application code, not test code.
+// @codeCoverageIgnoreStart
 class CareTeamServiceTest extends TestCase
 {
     private CareTeamService $service;
@@ -932,3 +935,4 @@ class CareTeamServiceTest extends TestCase
         }
     }
 }
+// @codeCoverageIgnoreEnd

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -21,13 +21,15 @@ use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\CareTeamService;
 use OpenEMR\Services\Search\TokenSearchField;
 use OpenEMR\Tests\Fixtures\CareTeamFixtureManager;
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 
 class CareTeamServiceTest extends TestCase
 {
     private CareTeamService $service;
     private CareTeamFixtureManager $fixtureManager;
+
+    /** @var array<mixed> */
     private array $backupSession = [];
 
     /**
@@ -160,7 +162,6 @@ class CareTeamServiceTest extends TestCase
         );
 
         $this->assertNotEmpty($row);
-        $this->assertIsArray($row);
         $this->assertEquals(self::TEST_TEAM_NAME, $row['team_name']);
         $this->assertEquals('active', $row['status']);
         // @phpstan-ignore cast.int
@@ -186,7 +187,6 @@ class CareTeamServiceTest extends TestCase
 
         $this->assertIsArray($row);
         $this->assertNotEmpty($row['uuid']);
-        // @phpstan-ignore argument.type
         $uuidString = UuidRegistry::uuidToString($row['uuid']);
         $this->assertNotEmpty($uuidString);
         $this->assertMatchesRegularExpression(
@@ -465,7 +465,6 @@ class CareTeamServiceTest extends TestCase
         );
 
         $result = $this->service->getCareTeamData($this->testPid);
-        $this->assertIsArray($result);
 
         $this->assertEquals(self::TEST_TEAM_NAME, $result['team_name']);
         $this->assertEquals('active', $result['team_status']);
@@ -581,12 +580,13 @@ class CareTeamServiceTest extends TestCase
             [self::TEST_TEAM_NAME]
         );
         $this->assertIsArray($row);
-        // @phpstan-ignore argument.type
         $uuidString = UuidRegistry::uuidToString($row['uuid']);
 
         $result = $this->service->getOne($uuidString);
 
-        $this->assertCount(0, $result->getValidationMessages());
+        $validationMessages = $result->getValidationMessages();
+        $this->assertIsArray($validationMessages);
+        $this->assertCount(0, $validationMessages);
 
         $data = $result->getData();
         $this->assertIsArray($data);
@@ -602,8 +602,10 @@ class CareTeamServiceTest extends TestCase
     {
         $result = $this->service->getOne("not-a-valid-uuid");
 
-        $this->assertNotEmpty($result->getValidationMessages());
-        $this->assertArrayHasKey('uuid', $result->getValidationMessages());
+        $validationMessages = $result->getValidationMessages();
+        $this->assertIsArray($validationMessages);
+        $this->assertNotEmpty($validationMessages);
+        $this->assertArrayHasKey('uuid', $validationMessages);
         $this->assertEmpty($result->getData());
     }
 
@@ -625,7 +627,6 @@ class CareTeamServiceTest extends TestCase
             [self::TEST_TEAM_NAME]
         );
         $this->assertIsArray($teamRow);
-        // @phpstan-ignore argument.type
         $teamUuid = UuidRegistry::uuidToString($teamRow['uuid']);
 
         // Get the patient UUID
@@ -635,7 +636,6 @@ class CareTeamServiceTest extends TestCase
             [$this->testPid]
         );
         $this->assertIsArray($patientRow);
-        // @phpstan-ignore argument.type
         $patientUuid = UuidRegistry::uuidToString($patientRow['uuid']);
 
         $result = $this->service->getOne($teamUuid, $patientUuid);
@@ -671,6 +671,7 @@ class CareTeamServiceTest extends TestCase
         // Verify at least one of the results is our test team
         $found = false;
         foreach ($data as $record) {
+            $this->assertIsArray($record);
             if ($record['team_name'] === self::TEST_TEAM_NAME) {
                 $found = true;
                 break;
@@ -697,7 +698,6 @@ class CareTeamServiceTest extends TestCase
             [$this->testPid]
         );
         $this->assertIsArray($patientRow);
-        // @phpstan-ignore argument.type
         $patientUuid = UuidRegistry::uuidToString($patientRow['uuid']);
 
         $result = $this->service->getAll([], true, $patientUuid);
@@ -708,6 +708,7 @@ class CareTeamServiceTest extends TestCase
 
         // All returned records should belong to our test patient
         foreach ($data as $record) {
+            $this->assertIsArray($record);
             $this->assertEquals($patientUuid, $record['puuid']);
         }
     }
@@ -753,7 +754,6 @@ class CareTeamServiceTest extends TestCase
             [self::TEST_TEAM_NAME]
         );
         $this->assertIsArray($teamRow);
-        // @phpstan-ignore argument.type
         $teamUuid = UuidRegistry::uuidToString($teamRow['uuid']);
 
         $search = ['uuid' => new TokenSearchField('uuid', $teamUuid, true)];
@@ -806,7 +806,6 @@ class CareTeamServiceTest extends TestCase
             [self::TEST_TEAM_NAME]
         );
         $this->assertIsArray($teamRow);
-        // @phpstan-ignore argument.type
         $teamUuid = UuidRegistry::uuidToString($teamRow['uuid']);
 
         $search = ['uuid' => new TokenSearchField('uuid', $teamUuid, true)];

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -14,6 +14,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Tests\Services;
 
 use OpenEMR\Common\Database\QueryUtils;

--- a/tests/Tests/Services/CareTeamServiceTest.php
+++ b/tests/Tests/Services/CareTeamServiceTest.php
@@ -17,17 +17,20 @@
 namespace OpenEMR\Tests\Services;
 
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\CareTeamService;
 use OpenEMR\Services\Search\TokenSearchField;
 use OpenEMR\Tests\Fixtures\CareTeamFixtureManager;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class CareTeamServiceTest extends TestCase
 {
     private CareTeamService $service;
     private CareTeamFixtureManager $fixtureManager;
+    private SessionInterface $session;
 
     /** @var array<mixed> */
     private array $backupSession = [];
@@ -57,7 +60,8 @@ class CareTeamServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->backupSession = $_SESSION ?? [];
+        $this->session = SessionWrapperFactory::getInstance()->getActiveSession();
+        $this->backupSession = $this->session->all();
         $this->service = new CareTeamService();
         $this->fixtureManager = new CareTeamFixtureManager();
         $deps = $this->fixtureManager->installDependencies();
@@ -77,14 +81,13 @@ class CareTeamServiceTest extends TestCase
         // @phpstan-ignore cast.int
         $this->testSecondProviderId = (int) $secondProvider['id'];
 
-        // saveCareTeam reads $_SESSION['authUserID'] via SessionWrapperFactory
-        $_SESSION['authUserID'] = 1;
+        $this->session->set('authUserID', 1);
     }
 
     protected function tearDown(): void
     {
         $this->fixtureManager->removeFixtures();
-        $_SESSION = $this->backupSession;
+        $this->session->replace($this->backupSession);
     }
 
     // =========================================================================


### PR DESCRIPTION
## Description

Adds comprehensive PHPUnit test coverage for `CareTeamService` with **24 tests** covering all public methods.

### Tests Added

**CareTeamServiceTest** (`tests/Tests/Services/CareTeamServiceTest.php`):
- `getUuidFields` — returns expected UUID field names
- `hasActiveCareTeam` — true for active teams, false for inactive/no teams
- `saveCareTeam` — creates new teams with UUID, adds provider members with roles/facilities, updates existing teams, adds new members, marks removed members as inactive
- `getCareTeamData` — returns empty structure when no team, returns team with member details, prefers active over inactive, excludes inactive members
- `getOne` — valid UUID returns data, invalid UUID returns validation messages, respects patient UUID binding
- `getAll` — returns results, filters by patient UUID binding, validates invalid patient UUID
- `search` — returns results with providers and facilities, empty for non-matching criteria
- `createResultRecordFromDatabaseResult` — sets correct default values

**CareTeamFixtureManager** (`tests/Tests/Fixtures/CareTeamFixtureManager.php`):
- Manages patient, facility, and practitioner dependencies
- Provides test data IDs for care team operations
- Cleans up care_team_member, care_teams, and uuid_registry entries

### How Has This Been Tested?

All 24 tests pass via `docker compose exec openemr /root/devtools services-test`.
No pre-existing tests were affected.

### AI Disclosure

Yes — Claude Code (Anthropic) used for implementation. All AI-generated files include the standard disclosure comment header.