### PR TITLE
feat(fhir): add FHIR ServiceRequest write operations (POST/PUT)

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -92,8 +92,22 @@
     "sqlStatement",
     "sqlStatementNoLog",
     "sqlStatementThrowException",
+    "default_gen_hl7_order",
+    "default_loadPayerInfo",
+    "default_send_hl7_order",
+    "labcorp_gen_hl7_order",
+    "labcorp_loadPayerInfo",
+    "labcorp_send_hl7_order",
+    "poll_hl7_results",
+    "quest_gen_hl7_order",
+    "quest_loadPayerInfo",
+    "quest_send_hl7_order",
+    "receive_hl7_results",
     "ub04Dispose",
-    "ub04_dispose"
+    "ub04_dispose",
+    "universal_gen_hl7_order",
+    "universal_loadPayerInfo",
+    "universal_send_hl7_order"
   ],
   "php-core-extensions": [
     "Core",

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -19902,11 +19902,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirSpecimenRestController.php',

--- a/.phpstan/baseline/booleanAnd.rightAlwaysTrue.php
+++ b/.phpstan/baseline/booleanAnd.rightAlwaysTrue.php
@@ -4,6 +4,11 @@ $ignoreErrors = [];
 $ignoreErrors[] = [
     'message' => '#^Right side of && is always true\\.$#',
     'count' => 1,
+    'path' => __DIR__ . '/../../custom/code_types.inc.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Right side of && is always true\\.$#',
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/vitals/C_FormVitals.class.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/booleanNot.alwaysFalse.php
+++ b/.phpstan/baseline/booleanNot.alwaysFalse.php
@@ -123,8 +123,13 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Negated boolean expression is always false\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../library/sql.inc.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Negated boolean expression is always false\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/sqlconf.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Negated boolean expression is always false\\.$#',

--- a/.phpstan/baseline/class.notFound.php
+++ b/.phpstan/baseline/class.notFound.php
@@ -2052,11 +2052,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirProvenanceRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirServiceRequestRestController\\:\\:getAll\\(\\) has invalid return type OpenEMR\\\\RestControllers\\\\FHIR\\\\FHIR\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirSpecimenRestController\\:\\:getAll\\(\\) has invalid return type OpenEMR\\\\RestControllers\\\\FHIR\\\\FHIR\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirSpecimenRestController.php',

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -3634,21 +3634,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirOrganizationRestControllerTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirPatientRestControllerTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirPractitionerRestControllerTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/RestControllers/FacilityRestControllerTest.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -8294,31 +8294,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot call method createBundle\\(\\) on mixed\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method getAll\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method getData\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method getId\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method getOne\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method createBundle\\(\\) on mixed\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirSpecimenRestController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -15367,11 +15367,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Validators/Rules/ListOptionRule.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\Api\\\\AllergyIntoleranceFhirApiTest\\:\\:getJsonContents\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Api/AllergyIntoleranceFhirApiTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Tests\\\\Api\\\\AllergyIntoleranceFhirApiTest\\:\\:\\$fhirFixture type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Api/AllergyIntoleranceFhirApiTest.php',
@@ -15392,29 +15387,14 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Api/AuthorizationGrantFlowTest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\Api\\\\GroupExportFhirApiTest\\:\\:getJsonContents\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Api/GroupExportFhirApiTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Tests\\\\Api\\\\GroupExportFhirApiTest\\:\\:\\$fhirFixture type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Api/GroupExportFhirApiTest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\Api\\\\PatientFhirApiTest\\:\\:getJsonContents\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Api/PatientFhirApiTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Tests\\\\Api\\\\PatientFhirApiTest\\:\\:\\$fhirFixture type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Api/PatientFhirApiTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\Api\\\\ProvenanceFhirApiTest\\:\\:getJsonContents\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Api/ProvenanceFhirApiTest.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Tests\\\\Api\\\\ProvenanceFhirApiTest\\:\\:\\$fhirFixture type has no value type specified in iterable type array\\.$#',
@@ -16047,29 +16027,14 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/RestControllers/Authorization/BearerTokenAuthorizationStrategyTest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\RestControllers\\\\FHIR\\\\FhirOrganizationRestControllerTest\\:\\:getJsonContents\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirOrganizationRestControllerTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Tests\\\\RestControllers\\\\FHIR\\\\FhirOrganizationRestControllerTest\\:\\:\\$fhirFixture type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirOrganizationRestControllerTest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\RestControllers\\\\FHIR\\\\FhirPatientRestControllerTest\\:\\:getJsonContents\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirPatientRestControllerTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Tests\\\\RestControllers\\\\FHIR\\\\FhirPatientRestControllerTest\\:\\:\\$fhirFixture type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirPatientRestControllerTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\RestControllers\\\\FHIR\\\\FhirPractitionerRestControllerTest\\:\\:getJsonContents\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirPractitionerRestControllerTest.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Tests\\\\RestControllers\\\\FHIR\\\\FhirPractitionerRestControllerTest\\:\\:\\$fhirFixture type has no value type specified in iterable type array\\.$#',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -40277,26 +40277,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirRelatedPersonRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirServiceRequestRestController\\:\\:getAll\\(\\) has parameter \\$puuidBind with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirServiceRequestRestController\\:\\:getAll\\(\\) has parameter \\$searchParams with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirServiceRequestRestController\\:\\:getOne\\(\\) has parameter \\$fhirId with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirServiceRequestRestController\\:\\:getOne\\(\\) has parameter \\$puuidBind with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirSpecimenRestController\\:\\:getAll\\(\\) has parameter \\$puuidBind with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirSpecimenRestController.php',
@@ -44573,11 +44553,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\FHIR\\\\FhirServiceRequestService\\:\\:inferPerformerTypeFromCategory\\(\\) has parameter \\$procedureOrderType with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirServiceRequestService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\FHIR\\\\FhirServiceRequestService\\:\\:insertOpenEMRRecord\\(\\) has parameter \\$openEmrRecord with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirServiceRequestService.php',
 ];

--- a/.phpstan/baseline/missingType.property.php
+++ b/.phpstan/baseline/missingType.property.php
@@ -30527,16 +30527,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirRelatedPersonRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirServiceRequestRestController\\:\\:\\$fhirService has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirServiceRequestRestController\\:\\:\\$fhirServiceRequestService has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirSpecimenRestController\\:\\:\\$fhirService has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirSpecimenRestController.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -25842,11 +25842,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirProvenanceRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirServiceRequestRestController\\:\\:getOne\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirSpecimenRestController\\:\\:getOne\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirSpecimenRestController.php',
@@ -28488,11 +28483,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\FHIR\\\\UtilsService\\:\\:getLocalTimestampAsUTCDate\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/UtilsService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\FHIR\\\\UtilsService\\:\\:getUuidFromReference\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/UtilsService.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenInstantiation.php
+++ b/.phpstan/baseline/openemr.forbiddenInstantiation.php
@@ -1403,7 +1403,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
-    'count' => 3,
+    'count' => 4,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirServiceRequestService.php',
 ];
 $ignoreErrors[] = [
@@ -1599,6 +1599,11 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
     'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirServiceRequestRestControllerTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
+    'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirPractitionerRestControllerTest.php',
 ];
 $ignoreErrors[] = [
@@ -1650,6 +1655,11 @@ $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/FhirPatientServiceCrudTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/FhirServiceRequestServiceCrudTest.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',

--- a/.phpstan/baseline/openemr.forbiddenInstantiation.php
+++ b/.phpstan/baseline/openemr.forbiddenInstantiation.php
@@ -1599,17 +1599,17 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirServiceRequestRestControllerTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirPractitionerRestControllerTest.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirQuestionnaireRestControllerIntegrationTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/RestControllers/FHIR/FhirServiceRequestRestControllerTest.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
@@ -1659,11 +1659,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/FhirServiceRequestServiceCrudTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/FhirPatientServiceMappingTest.php',
 ];
 $ignoreErrors[] = [
@@ -1675,6 +1670,11 @@ $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/FhirPractitionerServiceCrudTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/FhirServiceRequestServiceCrudTest.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',

--- a/.phpstan/baseline/parameter.defaultValue.php
+++ b/.phpstan/baseline/parameter.defaultValue.php
@@ -527,11 +527,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirRelatedPersonService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Default value of the parameter \\#1 \\$fhirResource \\(array\\) of method OpenEMR\\\\Services\\\\FHIR\\\\FhirServiceRequestService\\:\\:parseFhirResource\\(\\) is incompatible with type OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRDomainResource\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirServiceRequestService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Default value of the parameter \\#1 \\$fhirResource \\(array\\) of method OpenEMR\\\\Services\\\\FHIR\\\\FhirSpecimenService\\:\\:parseFhirResource\\(\\) is incompatible with type OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRDomainResource\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirSpecimenService.php',

--- a/.phpstan/baseline/return.empty.php
+++ b/.phpstan/baseline/return.empty.php
@@ -527,16 +527,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirRelatedPersonService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\FHIR\\\\FhirServiceRequestService\\:\\:insertOpenEMRRecord\\(\\) should return OpenEMR\\\\Validators\\\\ProcessingResult but empty return statement found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirServiceRequestService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\FHIR\\\\FhirServiceRequestService\\:\\:parseFhirResource\\(\\) should return array but empty return statement found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirServiceRequestService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\FHIR\\\\FhirSpecimenService\\:\\:insertOpenEMRRecord\\(\\) should return OpenEMR\\\\Validators\\\\ProcessingResult but empty return statement found\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirSpecimenService.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -9137,11 +9137,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirQuestionnaireRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirServiceRequestRestController\\:\\:getAll\\(\\) should return OpenEMR\\\\RestControllers\\\\FHIR\\\\FHIR but returns Symfony\\\\Component\\\\HttpFoundation\\\\Response\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirServiceRequestRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirSpecimenRestController\\:\\:getAll\\(\\) should return OpenEMR\\\\RestControllers\\\\FHIR\\\\FHIR but returns Symfony\\\\Component\\\\HttpFoundation\\\\Response\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirSpecimenRestController.php',

--- a/apis/routes/_rest_routes_fhir_r4_us_core_3_1_0.inc.php
+++ b/apis/routes/_rest_routes_fhir_r4_us_core_3_1_0.inc.php
@@ -6402,12 +6402,14 @@ return [
      */
 
     "GET /fhir/ServiceRequest" => function (HttpRestRequest $request) {
+        /** @var array<string, mixed> $searchParams */
+        $searchParams = $request->getQueryParams();
         if ($request->isPatientRequest()) {
             // only allow access to data of binded patient
-            $return = (new FhirServiceRequestRestController())->getAll($request->getQueryParams(), $request->getPatientUUIDString());
+            $return = (new FhirServiceRequestRestController())->getAll($searchParams, $request->getPatientUUIDString());
         } else {
             RestConfig::request_authorization_check($request, "patients", "med");
-            $return = (new FhirServiceRequestRestController())->getAll($request->getQueryParams());
+            $return = (new FhirServiceRequestRestController())->getAll($searchParams);
         }
 
         return $return;
@@ -6491,7 +6493,7 @@ return [
      *      security={{"openemr_auth":{}}}
      *  )
      */
-    "GET /fhir/ServiceRequest/:uuid" => function ($uuid, HttpRestRequest $request) {
+    "GET /fhir/ServiceRequest/:uuid" => function (string $uuid, HttpRestRequest $request) {
         if ($request->isPatientRequest()) {
             // only allow access to data of binded patient
             $return = (new FhirServiceRequestRestController())->getOne($uuid, $request->getPatientUUIDString());
@@ -6501,6 +6503,20 @@ return [
         }
 
         return $return;
+    },
+
+    "POST /fhir/ServiceRequest" => function (HttpRestRequest $request) {
+        RestConfig::request_authorization_check($request, "patients", "med");
+        /** @var array<string, mixed> $data */
+        $data = (array) (json_decode((string) file_get_contents("php://input"), true));
+        return (new FhirServiceRequestRestController())->post($data);
+    },
+
+    "PUT /fhir/ServiceRequest/:uuid" => function (string $uuid, HttpRestRequest $request) {
+        RestConfig::request_authorization_check($request, "patients", "med");
+        /** @var array<string, mixed> $data */
+        $data = (array) (json_decode((string) file_get_contents("php://input"), true));
+        return (new FhirServiceRequestRestController())->patch($uuid, $data);
     },
 
     /**

--- a/src/RestControllers/FHIR/FhirServiceRequestRestController.php
+++ b/src/RestControllers/FHIR/FhirServiceRequestRestController.php
@@ -6,36 +6,50 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
  * @copyright Copyright (c) 2025 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 namespace OpenEMR\RestControllers\FHIR;
 
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRServiceRequest;
 use OpenEMR\Services\FHIR\FhirServiceRequestService;
 use OpenEMR\Services\FHIR\FhirResourcesService;
+use OpenEMR\Services\FHIR\FhirValidationService;
+use OpenEMR\Services\FHIR\Serialization\FhirServiceRequestSerializer;
 use OpenEMR\RestControllers\RestControllerHelper;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRBundle\FHIRBundleEntry;
+use Symfony\Component\HttpFoundation\Response;
 
 class FhirServiceRequestRestController
 {
-    private $fhirServiceRequestService;
-    private $fhirService;
+    private FhirServiceRequestService $fhirServiceRequestService;
+    private FhirResourcesService $fhirService;
+    private FhirValidationService $fhirValidationService;
 
     public function __construct()
     {
         $this->fhirServiceRequestService = new FhirServiceRequestService();
         $this->fhirService = new FhirResourcesService();
+        $this->fhirValidationService = new FhirValidationService();
+    }
+
+    public function setSystemLogger(SystemLogger $systemLogger): void
+    {
+        $this->fhirServiceRequestService->setSystemLogger($systemLogger);
     }
 
     /**
      * Queries for a single FHIR ServiceRequest resource by FHIR id
      *
-     * @param $fhirId    - The FHIR ServiceRequest resource id (uuid)
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @returns 200 if the operation completes successfully
+     * @param string $fhirId The FHIR ServiceRequest resource id (uuid)
+     * @param string|null $puuidBind Optional variable to only allow visibility of the patient with this puuid.
+     * @return Response
      */
-    public function getOne($fhirId, $puuidBind = null)
+    public function getOne(string $fhirId, ?string $puuidBind = null): Response
     {
         $processingResult = $this->fhirServiceRequestService->getOne($fhirId, $puuidBind);
         return RestControllerHelper::handleFhirProcessingResult($processingResult, 200);
@@ -43,20 +57,16 @@ class FhirServiceRequestRestController
 
     /**
      * Queries for FHIR ServiceRequest resources using various search parameters.
-     * Search parameters include:
-     * - patient (puuid)
-     * - category (order type)
-     * - code (procedure/test code)
-     * - authored (order date)
-     * - status (order status)
      *
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @return FHIR bundle with query results, if found
+     * @param array<string, mixed> $searchParams The search parameters
+     * @param string|null $puuidBind Optional variable to only allow visibility of the patient with this puuid.
+     * @return Response
      */
-    public function getAll($searchParams, $puuidBind = null)
+    public function getAll(array $searchParams, ?string $puuidBind = null): Response
     {
         $processingResult = $this->fhirServiceRequestService->getAll($searchParams, $puuidBind);
         $bundleEntries = [];
+        /** @var FHIRServiceRequest $searchResult */
         foreach ($processingResult->getData() as $searchResult) {
             $bundleEntry = [
                 'fullUrl' => $GLOBALS['site_addr_oath'] . ($_SERVER['REDIRECT_URL'] ?? '') . '/' . $searchResult->getId(),
@@ -68,5 +78,42 @@ class FhirServiceRequestRestController
         $bundleSearchResult = $this->fhirService->createBundle('ServiceRequest', $bundleEntries, false);
         $searchResponseBody = RestControllerHelper::responseHandler($bundleSearchResult, null, 200);
         return $searchResponseBody;
+    }
+
+    /**
+     * Creates a new FHIR ServiceRequest resource.
+     *
+     * @param array<string, mixed> $fhirJson The FHIR ServiceRequest resource as JSON array
+     * @return Response 201 if the resource is created, 400 if the resource is invalid
+     */
+    public function post(array $fhirJson): Response
+    {
+        $fhirValidationResult = $this->fhirValidationService->validate($fhirJson);
+        if ($fhirValidationResult !== null && $fhirValidationResult !== []) {
+            return RestControllerHelper::responseHandler($fhirValidationResult, null, 400);
+        }
+
+        $serviceRequest = FhirServiceRequestSerializer::deserialize($fhirJson);
+        $processingResult = $this->fhirServiceRequestService->insert($serviceRequest);
+        return RestControllerHelper::handleFhirProcessingResult($processingResult, 201);
+    }
+
+    /**
+     * Updates an existing FHIR ServiceRequest resource.
+     *
+     * @param string $fhirId The FHIR ServiceRequest resource id (uuid)
+     * @param array<string, mixed> $fhirJson The updated FHIR ServiceRequest resource
+     * @return Response 200 if the resource is updated, 400 if the resource is invalid
+     */
+    public function patch(string $fhirId, array $fhirJson): Response
+    {
+        $fhirValidationResult = $this->fhirValidationService->validate($fhirJson);
+        if ($fhirValidationResult !== null && $fhirValidationResult !== []) {
+            return RestControllerHelper::responseHandler($fhirValidationResult, null, 400);
+        }
+
+        $serviceRequest = FhirServiceRequestSerializer::deserialize($fhirJson);
+        $processingResult = $this->fhirServiceRequestService->update($fhirId, $serviceRequest);
+        return RestControllerHelper::handleFhirProcessingResult($processingResult, 200);
     }
 }

--- a/src/RestControllers/FHIR/FhirServiceRequestRestController.php
+++ b/src/RestControllers/FHIR/FhirServiceRequestRestController.php
@@ -6,9 +6,9 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
- * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @author    Josh Baiad <josh@joshbaiad.com>
  * @copyright Copyright (c) 2025 Jerry Padgett <sjpadgett@gmail.com>
- * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @copyright Copyright (c) 2026 Josh Baiad <josh@joshbaiad.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/src/RestControllers/FHIR/FhirServiceRequestRestController.php
+++ b/src/RestControllers/FHIR/FhirServiceRequestRestController.php
@@ -26,9 +26,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FhirServiceRequestRestController
 {
-    private FhirServiceRequestService $fhirServiceRequestService;
-    private FhirResourcesService $fhirService;
-    private FhirValidationService $fhirValidationService;
+    private readonly FhirServiceRequestService $fhirServiceRequestService;
+    private readonly FhirResourcesService $fhirService;
+    private readonly FhirValidationService $fhirValidationService;
 
     public function __construct()
     {

--- a/src/Services/FHIR/FhirServiceRequestService.php
+++ b/src/Services/FHIR/FhirServiceRequestService.php
@@ -867,11 +867,7 @@ class FhirServiceRequestService extends FhirServiceBase implements
                 $codesService = new CodeTypesService();
                 /** @var string|null $codeType */
                 $codeType = $codesService->getCodeTypeForSystemUrl($system);
-                if ($codeType !== null && $codeType !== '') {
-                    $data['procedure_code'] = $codeType . ':' . $codeValue;
-                } else {
-                    $data['procedure_code'] = $codeValue;
-                }
+                $data['procedure_code'] = $codeType !== null && $codeType !== '' ? $codeType . ':' . $codeValue : $codeValue;
             } elseif ($codeValue !== '') {
                 $data['procedure_code'] = $codeValue;
             }
@@ -1076,7 +1072,7 @@ class FhirServiceRequestService extends FhirServiceBase implements
     {
         try {
             $uuidBytes = UuidRegistry::uuidToBytes($uuid);
-        } catch (\Exception $e) {
+        } catch (\Throwable) {
             (new SystemLogger())->errorLogCaller(
                 "Invalid UUID format: " . $uuid,
                 ['table' => $table]

--- a/src/Services/FHIR/Serialization/FhirServiceRequestSerializer.php
+++ b/src/Services/FHIR/Serialization/FhirServiceRequestSerializer.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * FhirServiceRequestSerializer.php
+ * @package openemr
+ * @link      https://www.open-emr.org
+ * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services\FHIR\Serialization;
+
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRServiceRequest;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRAnnotation;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRCoding;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRReference;
+
+class FhirServiceRequestSerializer
+{
+    /**
+     * Takes a FHIR JSON array representing a ServiceRequest and returns the populated FHIRServiceRequest resource.
+     *
+     * The FHIR R4 constructors/setters do not recursively hydrate nested elements
+     * (e.g., CodeableConcept.coding stays as raw arrays). This method explicitly
+     * constructs typed FHIR objects for all nested elements that parseFhirResource accesses.
+     *
+     * @param array<string, mixed> $fhirJson
+     * @return FHIRServiceRequest
+     */
+    public static function deserialize(array $fhirJson): FHIRServiceRequest
+    {
+        // Extract fields that need manual hydration (constructors don't convert nested arrays to typed objects)
+        /** @var array<int, array<string, mixed>> $category */
+        $category = $fhirJson['category'] ?? [];
+        /** @var array<int, array<string, mixed>> $reasonCode */
+        $reasonCode = $fhirJson['reasonCode'] ?? [];
+        /** @var array<int, array<string, mixed>> $note */
+        $note = $fhirJson['note'] ?? [];
+        /** @var array<int, array<string, mixed>> $performer */
+        $performer = $fhirJson['performer'] ?? [];
+        /** @var array<string, mixed>|null $code */
+        $code = $fhirJson['code'] ?? null;
+        /** @var array<string, mixed>|null $subject */
+        $subject = $fhirJson['subject'] ?? null;
+        /** @var array<string, mixed>|null $encounter */
+        $encounter = $fhirJson['encounter'] ?? null;
+        /** @var array<string, mixed>|null $requester */
+        $requester = $fhirJson['requester'] ?? null;
+
+        unset(
+            $fhirJson['category'],
+            $fhirJson['reasonCode'],
+            $fhirJson['note'],
+            $fhirJson['performer'],
+            $fhirJson['code'],
+            $fhirJson['subject'],
+            $fhirJson['encounter'],
+            $fhirJson['requester']
+        );
+
+        $serviceRequest = new FHIRServiceRequest($fhirJson);
+
+        // Hydrate CodeableConcept arrays with proper FHIRCoding objects
+        foreach ($category as $item) {
+            $serviceRequest->addCategory(self::hydrateCodeableConcept($item));
+        }
+        foreach ($reasonCode as $item) {
+            $serviceRequest->addReasonCode(self::hydrateCodeableConcept($item));
+        }
+        foreach ($note as $item) {
+            $serviceRequest->addNote(new FHIRAnnotation($item));
+        }
+        foreach ($performer as $item) {
+            $serviceRequest->addPerformer(new FHIRReference($item));
+        }
+
+        // Hydrate single-value fields
+        if (is_array($code)) {
+            $serviceRequest->setCode(self::hydrateCodeableConcept($code));
+        }
+        if (is_array($subject)) {
+            $serviceRequest->setSubject(new FHIRReference($subject));
+        }
+        if (is_array($encounter)) {
+            $serviceRequest->setEncounter(new FHIRReference($encounter));
+        }
+        if (is_array($requester)) {
+            $serviceRequest->setRequester(new FHIRReference($requester));
+        }
+
+        return $serviceRequest;
+    }
+
+    /**
+     * Creates a FHIRCodeableConcept with properly typed FHIRCoding elements.
+     *
+     * @param array<string, mixed> $data
+     * @return FHIRCodeableConcept
+     */
+    private static function hydrateCodeableConcept(array $data): FHIRCodeableConcept
+    {
+        /** @var array<int, array<string, mixed>> $codings */
+        $codings = $data['coding'] ?? [];
+        unset($data['coding']);
+
+        $concept = new FHIRCodeableConcept($data);
+        foreach ($codings as $codingData) {
+            $concept->addCoding(new FHIRCoding($codingData));
+        }
+        return $concept;
+    }
+}

--- a/src/Services/FHIR/Serialization/FhirServiceRequestSerializer.php
+++ b/src/Services/FHIR/Serialization/FhirServiceRequestSerializer.php
@@ -4,8 +4,8 @@
  * FhirServiceRequestSerializer.php
  * @package openemr
  * @link      https://www.open-emr.org
- * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
- * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @author    Josh Baiad <josh@joshbaiad.com>
+ * @copyright Copyright (c) 2026 Josh Baiad <josh@joshbaiad.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/src/Services/FHIR/UtilsService.php
+++ b/src/Services/FHIR/UtilsService.php
@@ -105,10 +105,10 @@ class UtilsService
         return $parsed_url;
     }
 
-    public static function getUuidFromReference(FHIRReference $reference)
+    public static function getUuidFromReference(?FHIRReference $reference): ?string
     {
         $uuid = null;
-        if (!empty($reference->getReference())) {
+        if ($reference !== null && !empty($reference->getReference())) {
             $parts = explode("/", $reference->getReference());
             $uuid = $parts[1] ?? null;
         }

--- a/src/Validators/ProcedureOrderValidator.php
+++ b/src/Validators/ProcedureOrderValidator.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * ProcedureOrderValidator - Validates procedure order data for insert and update operations.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Validators;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use Particle\Validator\Chain;
+use Particle\Validator\Exception\InvalidValueException;
+use Particle\Validator\Validator;
+use Ramsey\Uuid\Exception\InvalidUuidStringException;
+
+class ProcedureOrderValidator extends BaseValidator
+{
+    /**
+     * Valid values for order_status (matches ord_status list_options)
+     */
+    private const ORDER_STATUSES = ['pending', 'routed', 'complete', 'canceled'];
+
+    /**
+     * Valid values for order_priority (matches ord_priority list_options)
+     */
+    private const ORDER_PRIORITIES = ['high', 'normal', 'routine', 'urgent', 'asap', 'stat'];
+
+    /**
+     * Valid values for order_intent (FHIR request-intent)
+     */
+    private const ORDER_INTENTS = ['order', 'plan', 'directive', 'proposal'];
+
+    /**
+     * Valid values for procedure_order_type (FHIR ServiceRequest category)
+     */
+    private const ORDER_TYPES = ['laboratory_test', 'imaging', 'clinical_test', 'procedure'];
+
+    /**
+     * Validates that a procedure order UUID exists in the database.
+     *
+     * @param string $uuid The UUID to check
+     * @return bool True if the UUID exists, false otherwise
+     */
+    public function isExistingUuid($uuid): bool
+    {
+        try {
+            $uuidLookup = UuidRegistry::uuidToBytes($uuid);
+        } catch (InvalidUuidStringException) {
+            return false;
+        }
+
+        $result = QueryUtils::querySingleRow(
+            'SELECT uuid AS uuid FROM procedure_order WHERE uuid = ?',
+            [$uuidLookup]
+        );
+
+        $existingUuid = $result['uuid'] ?? null;
+        return $existingUuid != null;
+    }
+
+    /**
+     * Configures validations for the Procedure Order DB Insert and Update use-case.
+     */
+    protected function configureValidator(): void
+    {
+        parent::configureValidator();
+
+        $validator = $this->getInnerValidator();
+
+        // insert validations
+        $validator->context(
+            self::DATABASE_INSERT_CONTEXT,
+            function (Validator $context): void {
+                // Required fields
+                $context->required('patient_id', 'Patient ID')->numeric();
+                $context->required('provider_id', 'Provider ID')->numeric();
+                $context->required('encounter_id', 'Encounter ID')->numeric();
+                $context->required('lab_id', 'Lab ID')->numeric();
+
+                // Optional enum fields
+                $context->optional('order_status', 'Order Status')
+                    ->inArray(self::ORDER_STATUSES);
+                $context->optional('order_priority', 'Order Priority')
+                    ->inArray(self::ORDER_PRIORITIES);
+                $context->optional('order_intent', 'Order Intent')
+                    ->inArray(self::ORDER_INTENTS);
+                $context->optional('procedure_order_type', 'Order Type')
+                    ->inArray(self::ORDER_TYPES);
+
+                // Optional format fields
+                $context->optional('date_ordered', 'Date Ordered')->datetime('Y-m-d');
+                $context->optional('date_collected', 'Date Collected')->datetime('Y-m-d');
+                $context->optional('order_diagnosis', 'Order Diagnosis')->lengthBetween(1, 255);
+                $context->optional('clinical_hx', 'Clinical History')->lengthBetween(1, 255);
+                $context->optional('patient_instructions', 'Patient Instructions');
+                $context->optional('billing_type', 'Billing Type')->lengthBetween(1, 4);
+                $context->optional('specimen_fasting', 'Specimen Fasting')->lengthBetween(1, 31);
+            }
+        );
+
+        // update validations copied from insert
+        $validator->context(
+            self::DATABASE_UPDATE_CONTEXT,
+            function (Validator $context): void {
+                $context->copyContext(
+                    self::DATABASE_INSERT_CONTEXT,
+                    function (array $rules): void {
+                        foreach ($rules as $chain) {
+                            \assert($chain instanceof Chain);
+                            $chain->required(false);
+                        }
+                    }
+                );
+                // additional uuid validations
+                $context->required("uuid", "uuid")->callback(function (string $value): true {
+                    if (!$this->isExistingUuid($value)) {
+                        throw new InvalidValueException(
+                            "UUID " . $value . " does not exist",
+                            $value
+                        );
+                    }
+                    return true;
+                })->string();
+            }
+        );
+    }
+}

--- a/src/Validators/ProcedureOrderValidator.php
+++ b/src/Validators/ProcedureOrderValidator.php
@@ -5,8 +5,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
- * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @author    Josh Baiad <josh@joshbaiad.com>
+ * @copyright Copyright (c) 2026 Josh Baiad <josh@joshbaiad.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/Isolated/Services/FHIR/FhirServiceRequestReverseMappingTest.php
+++ b/tests/Tests/Isolated/Services/FHIR/FhirServiceRequestReverseMappingTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * Isolated FhirServiceRequestService Reverse Mapping Test
+ *
+ * Reflection-based tests to verify the private reverse mapping methods
+ * (mapFhirStatusToOrderStatus, mapCategoryToOrderType, mapFhirPriorityToOrderPriority)
+ * without requiring a database connection.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Services\FHIR;
+
+require_once __DIR__ . '/../ProcedureServiceBootstrap.php';
+
+use OpenEMR\FHIR\R4\FHIRElement\FHIRCode;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRCoding;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRUri;
+use OpenEMR\Services\FHIR\FhirServiceRequestService;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class FhirServiceRequestReverseMappingTest extends TestCase
+{
+    /** @var \ReflectionClass<FhirServiceRequestService> */
+    private ReflectionClass $reflectionClass;
+    private FhirServiceRequestService $service;
+
+    protected function setUp(): void
+    {
+        $this->reflectionClass = new ReflectionClass(FhirServiceRequestService::class);
+        $this->service = $this->reflectionClass->newInstanceWithoutConstructor();
+    }
+
+    private function invokePrivateMethod(string $methodName, mixed ...$args): mixed
+    {
+        $method = $this->reflectionClass->getMethod($methodName);
+        return $method->invoke($this->service, ...$args);
+    }
+
+    // --- mapFhirStatusToOrderStatus tests ---
+
+    public function testMapFhirStatusToOrderStatusActive(): void
+    {
+        $this->assertSame('pending', $this->invokePrivateMethod('mapFhirStatusToOrderStatus', 'active'));
+    }
+
+    public function testMapFhirStatusToOrderStatusCompleted(): void
+    {
+        $this->assertSame('complete', $this->invokePrivateMethod('mapFhirStatusToOrderStatus', 'completed'));
+    }
+
+    public function testMapFhirStatusToOrderStatusRevoked(): void
+    {
+        $this->assertSame('canceled', $this->invokePrivateMethod('mapFhirStatusToOrderStatus', 'revoked'));
+    }
+
+    public function testMapFhirStatusToOrderStatusDraft(): void
+    {
+        $this->assertSame('draft', $this->invokePrivateMethod('mapFhirStatusToOrderStatus', 'draft'));
+    }
+
+    public function testMapFhirStatusToOrderStatusOnHold(): void
+    {
+        $this->assertSame('on-hold', $this->invokePrivateMethod('mapFhirStatusToOrderStatus', 'on-hold'));
+    }
+
+    public function testMapFhirStatusToOrderStatusUnknown(): void
+    {
+        $this->assertSame('pending', $this->invokePrivateMethod('mapFhirStatusToOrderStatus', 'unknown'));
+    }
+
+    public function testMapFhirStatusToOrderStatusDefault(): void
+    {
+        $this->assertSame('pending', $this->invokePrivateMethod('mapFhirStatusToOrderStatus', 'nonexistent-status'));
+    }
+
+    // --- mapCategoryToOrderType tests ---
+
+    private function buildCategory(string $code): FHIRCodeableConcept
+    {
+        $concept = new FHIRCodeableConcept();
+        $coding = new FHIRCoding();
+        $coding->setSystem(new FHIRUri('http://snomed.info/sct'));
+        $coding->setCode(new FHIRCode($code));
+        $concept->addCoding($coding);
+        return $concept;
+    }
+
+    public function testMapCategoryToOrderTypeLaboratory(): void
+    {
+        $this->assertSame('laboratory_test', $this->invokePrivateMethod('mapCategoryToOrderType', $this->buildCategory('108252007')));
+    }
+
+    public function testMapCategoryToOrderTypeImaging(): void
+    {
+        $this->assertSame('imaging', $this->invokePrivateMethod('mapCategoryToOrderType', $this->buildCategory('363679005')));
+    }
+
+    public function testMapCategoryToOrderTypeClinicalTest(): void
+    {
+        $this->assertSame('clinical_test', $this->invokePrivateMethod('mapCategoryToOrderType', $this->buildCategory('103693007')));
+    }
+
+    public function testMapCategoryToOrderTypeProcedure(): void
+    {
+        $this->assertSame('procedure', $this->invokePrivateMethod('mapCategoryToOrderType', $this->buildCategory('387713003')));
+    }
+
+    public function testMapCategoryToOrderTypeDefault(): void
+    {
+        $this->assertSame('laboratory_test', $this->invokePrivateMethod('mapCategoryToOrderType', $this->buildCategory('999999999')));
+    }
+
+    // --- mapFhirPriorityToOrderPriority tests ---
+
+    public function testMapFhirPriorityToOrderPriorityRoutine(): void
+    {
+        $this->assertSame('normal', $this->invokePrivateMethod('mapFhirPriorityToOrderPriority', 'routine'));
+    }
+
+    public function testMapFhirPriorityToOrderPriorityUrgent(): void
+    {
+        $this->assertSame('urgent', $this->invokePrivateMethod('mapFhirPriorityToOrderPriority', 'urgent'));
+    }
+
+    public function testMapFhirPriorityToOrderPriorityAsap(): void
+    {
+        $this->assertSame('asap', $this->invokePrivateMethod('mapFhirPriorityToOrderPriority', 'asap'));
+    }
+
+    public function testMapFhirPriorityToOrderPriorityStat(): void
+    {
+        $this->assertSame('stat', $this->invokePrivateMethod('mapFhirPriorityToOrderPriority', 'stat'));
+    }
+
+    public function testMapFhirPriorityToOrderPriorityDefault(): void
+    {
+        $this->assertSame('normal', $this->invokePrivateMethod('mapFhirPriorityToOrderPriority', 'nonexistent-priority'));
+    }
+}

--- a/tests/Tests/Isolated/Services/FHIR/FhirServiceRequestReverseMappingTest.php
+++ b/tests/Tests/Isolated/Services/FHIR/FhirServiceRequestReverseMappingTest.php
@@ -9,8 +9,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
- * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @author    Josh Baiad <josh@joshbaiad.com>
+ * @copyright Copyright (c) 2026 Josh Baiad <josh@joshbaiad.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/Isolated/Services/FHIR/FhirServiceRequestSerializerTest.php
+++ b/tests/Tests/Isolated/Services/FHIR/FhirServiceRequestSerializerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * Isolated FhirServiceRequestSerializer Test
+ *
+ * Tests for FhirServiceRequestSerializer::deserialize() without requiring a database.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Services\FHIR;
+
+require_once __DIR__ . '/../ProcedureServiceBootstrap.php';
+
+use OpenEMR\Services\FHIR\Serialization\FhirServiceRequestSerializer;
+use PHPUnit\Framework\TestCase;
+
+class FhirServiceRequestSerializerTest extends TestCase
+{
+    public function testDeserializeMinimalResource(): void
+    {
+        $json = [
+            'resourceType' => 'ServiceRequest',
+            'status' => 'active',
+            'intent' => 'order',
+        ];
+
+        $result = FhirServiceRequestSerializer::deserialize($json);
+
+        $this->assertSame('active', (string) $result->getStatus());
+        $this->assertSame('order', (string) $result->getIntent());
+    }
+
+    public function testDeserializeWithCategory(): void
+    {
+        $json = [
+            'resourceType' => 'ServiceRequest',
+            'status' => 'active',
+            'intent' => 'order',
+            'category' => [
+                ['coding' => [['system' => 'http://snomed.info/sct', 'code' => '108252007', 'display' => 'Laboratory procedure']]],
+            ],
+        ];
+
+        $result = FhirServiceRequestSerializer::deserialize($json);
+
+        $categories = $result->getCategory();
+        $this->assertCount(1, $categories);
+        $codings = $categories[0]->getCoding();
+        $this->assertSame('108252007', (string) $codings[0]->getCode());
+    }
+
+    public function testDeserializeWithNote(): void
+    {
+        $json = [
+            'resourceType' => 'ServiceRequest',
+            'status' => 'active',
+            'intent' => 'order',
+            'note' => [
+                ['text' => 'Patient reports nausea'],
+                ['text' => 'Follow up in 2 weeks'],
+            ],
+        ];
+
+        $result = FhirServiceRequestSerializer::deserialize($json);
+
+        $notes = $result->getNote();
+        $this->assertCount(2, $notes);
+        $this->assertSame('Patient reports nausea', (string) $notes[0]->getText());
+        $this->assertSame('Follow up in 2 weeks', (string) $notes[1]->getText());
+    }
+
+    public function testDeserializeWithPerformer(): void
+    {
+        $json = [
+            'resourceType' => 'ServiceRequest',
+            'status' => 'active',
+            'intent' => 'order',
+            'performer' => [
+                ['reference' => 'Organization/test-uuid-1'],
+            ],
+        ];
+
+        $result = FhirServiceRequestSerializer::deserialize($json);
+
+        $performers = $result->getPerformer();
+        $this->assertCount(1, $performers);
+        $this->assertSame('Organization/test-uuid-1', (string) $performers[0]->getReference());
+    }
+
+    public function testDeserializeWithReasonCode(): void
+    {
+        $json = [
+            'resourceType' => 'ServiceRequest',
+            'status' => 'active',
+            'intent' => 'order',
+            'reasonCode' => [
+                ['coding' => [['system' => 'http://hl7.org/fhir/sid/icd-10-cm', 'code' => 'E11.9']]],
+            ],
+        ];
+
+        $result = FhirServiceRequestSerializer::deserialize($json);
+
+        $reasonCodes = $result->getReasonCode();
+        $this->assertCount(1, $reasonCodes);
+        $codings = $reasonCodes[0]->getCoding();
+        $this->assertSame('E11.9', (string) $codings[0]->getCode());
+    }
+
+    public function testDeserializeWithAllFields(): void
+    {
+        $json = [
+            'resourceType' => 'ServiceRequest',
+            'status' => 'active',
+            'intent' => 'order',
+            'category' => [
+                ['coding' => [['system' => 'http://snomed.info/sct', 'code' => '108252007']]],
+            ],
+            'code' => [
+                'coding' => [['system' => 'http://loinc.org', 'code' => '24356-8', 'display' => 'Urinalysis complete']],
+                'text' => 'Urinalysis complete',
+            ],
+            'subject' => ['reference' => 'Patient/test-patient-uuid'],
+            'encounter' => ['reference' => 'Encounter/test-encounter-uuid'],
+            'requester' => ['reference' => 'Practitioner/test-practitioner-uuid'],
+            'authoredOn' => '2026-01-15T00:00:00+00:00',
+            'priority' => 'routine',
+            'patientInstruction' => 'Collect morning sample',
+            'note' => [['text' => 'UTI symptoms reported']],
+            'performer' => [['reference' => 'Organization/test-lab-uuid']],
+            'reasonCode' => [['coding' => [['system' => 'http://hl7.org/fhir/sid/icd-10-cm', 'code' => 'N39.0']]]],
+        ];
+
+        $result = FhirServiceRequestSerializer::deserialize($json);
+
+        $this->assertSame('active', (string) $result->getStatus());
+        $this->assertSame('order', (string) $result->getIntent());
+        $this->assertSame('Patient/test-patient-uuid', (string) $result->getSubject()->getReference());
+        $this->assertSame('Encounter/test-encounter-uuid', (string) $result->getEncounter()->getReference());
+        $this->assertSame('Practitioner/test-practitioner-uuid', (string) $result->getRequester()->getReference());
+        $this->assertSame('2026-01-15T00:00:00+00:00', (string) $result->getAuthoredOn());
+        $this->assertSame('routine', (string) $result->getPriority());
+        $this->assertSame('Collect morning sample', (string) $result->getPatientInstruction());
+        $this->assertCount(1, $result->getCategory());
+        $this->assertCount(1, $result->getNote());
+        $this->assertCount(1, $result->getPerformer());
+        $this->assertCount(1, $result->getReasonCode());
+
+        $codeCodings = $result->getCode()->getCoding();
+        $this->assertSame('24356-8', (string) $codeCodings[0]->getCode());
+        $this->assertSame('Urinalysis complete', (string) $result->getCode()->getText());
+    }
+}

--- a/tests/Tests/Isolated/Services/FHIR/FhirServiceRequestSerializerTest.php
+++ b/tests/Tests/Isolated/Services/FHIR/FhirServiceRequestSerializerTest.php
@@ -7,8 +7,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
- * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @author    Josh Baiad <josh@joshbaiad.com>
+ * @copyright Copyright (c) 2026 Josh Baiad <josh@joshbaiad.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/Isolated/Services/FHIR/FhirServiceRequestServiceWriteTest.php
+++ b/tests/Tests/Isolated/Services/FHIR/FhirServiceRequestServiceWriteTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Isolated FhirServiceRequestService Write Test
+ *
+ * Reflection-based tests to verify the write API contract
+ * (parseFhirResource, insertOpenEMRRecord, updateOpenEMRRecord)
+ * without requiring a database connection.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Services\FHIR;
+
+require_once __DIR__ . '/../ProcedureServiceBootstrap.php';
+
+use OpenEMR\FHIR\R4\FHIRResource\FHIRDomainResource;
+use OpenEMR\Services\FHIR\FhirServiceRequestService;
+use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
+use OpenEMR\Validators\ProcessingResult;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionNamedType;
+
+class FhirServiceRequestServiceWriteTest extends TestCase
+{
+    /** @var \ReflectionClass<FhirServiceRequestService> */
+    private ReflectionClass $reflectionClass;
+
+    protected function setUp(): void
+    {
+        $this->reflectionClass = new ReflectionClass(FhirServiceRequestService::class);
+    }
+
+    public function testParseFhirResourceMethodExists(): void
+    {
+        $this->assertTrue(
+            $this->reflectionClass->hasMethod('parseFhirResource'),
+            'FhirServiceRequestService must have a parseFhirResource() method'
+        );
+
+        $method = $this->reflectionClass->getMethod('parseFhirResource');
+        $this->assertTrue($method->isPublic(), 'parseFhirResource() must be public');
+    }
+
+    public function testParseFhirResourceAcceptsFhirDomainResource(): void
+    {
+        $method = $this->reflectionClass->getMethod('parseFhirResource');
+        $params = $method->getParameters();
+        $this->assertCount(1, $params, 'parseFhirResource() must accept exactly 1 parameter');
+        $this->assertSame('fhirResource', $params[0]->getName());
+
+        $type = $params[0]->getType();
+        $this->assertNotNull($type, 'parseFhirResource() parameter must be typed');
+        $this->assertInstanceOf(ReflectionNamedType::class, $type);
+        $this->assertSame(FHIRDomainResource::class, $type->getName());
+    }
+
+    public function testInsertOpenEMRRecordMethodExists(): void
+    {
+        $this->assertTrue(
+            $this->reflectionClass->hasMethod('insertOpenEMRRecord'),
+            'FhirServiceRequestService must have an insertOpenEMRRecord() method'
+        );
+    }
+
+    public function testUpdateOpenEMRRecordMethodExists(): void
+    {
+        $this->assertTrue(
+            $this->reflectionClass->hasMethod('updateOpenEMRRecord'),
+            'FhirServiceRequestService must have an updateOpenEMRRecord() method'
+        );
+
+        $method = $this->reflectionClass->getMethod('updateOpenEMRRecord');
+        $this->assertTrue($method->isPublic(), 'updateOpenEMRRecord() must be public');
+    }
+
+    public function testTraitNotUsed(): void
+    {
+        $traits = $this->reflectionClass->getTraitNames();
+        $this->assertNotContains(
+            FhirServiceBaseEmptyTrait::class,
+            $traits,
+            'FhirServiceRequestService must NOT use FhirServiceBaseEmptyTrait (real implementations required)'
+        );
+    }
+
+    public function testReverseMappingMethodsExist(): void
+    {
+        $this->assertTrue(
+            $this->reflectionClass->hasMethod('mapFhirStatusToOrderStatus'),
+            'FhirServiceRequestService must have mapFhirStatusToOrderStatus()'
+        );
+        $this->assertTrue(
+            $this->reflectionClass->hasMethod('mapCategoryToOrderType'),
+            'FhirServiceRequestService must have mapCategoryToOrderType()'
+        );
+        $this->assertTrue(
+            $this->reflectionClass->hasMethod('mapFhirPriorityToOrderPriority'),
+            'FhirServiceRequestService must have mapFhirPriorityToOrderPriority()'
+        );
+    }
+}

--- a/tests/Tests/Isolated/Services/FHIR/FhirServiceRequestServiceWriteTest.php
+++ b/tests/Tests/Isolated/Services/FHIR/FhirServiceRequestServiceWriteTest.php
@@ -9,8 +9,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
- * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @author    Josh Baiad <josh@joshbaiad.com>
+ * @copyright Copyright (c) 2026 Josh Baiad <josh@joshbaiad.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/Isolated/Services/FHIR/UtilsServiceTest.php
+++ b/tests/Tests/Isolated/Services/FHIR/UtilsServiceTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * UtilsService Isolated Tests
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Services\FHIR;
+
+use OpenEMR\FHIR\R4\FHIRElement\FHIRReference;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRString;
+use OpenEMR\Services\FHIR\UtilsService;
+use PHPUnit\Framework\TestCase;
+
+class UtilsServiceTest extends TestCase
+{
+    public function testGetUuidFromReferenceReturnsNullForNullInput(): void
+    {
+        $result = UtilsService::getUuidFromReference(null);
+        $this->assertNull($result);
+    }
+
+    public function testGetUuidFromReferenceExtractsUuid(): void
+    {
+        $reference = new FHIRReference();
+        $reference->setReference(new FHIRString('Patient/test-uuid-123'));
+        $result = UtilsService::getUuidFromReference($reference);
+        $this->assertSame('test-uuid-123', $result);
+    }
+
+    public function testGetUuidFromReferenceReturnsNullForEmptyReference(): void
+    {
+        $reference = new FHIRReference();
+        $result = UtilsService::getUuidFromReference($reference);
+        $this->assertNull($result);
+    }
+}

--- a/tests/Tests/Isolated/Services/FHIR/UtilsServiceTest.php
+++ b/tests/Tests/Isolated/Services/FHIR/UtilsServiceTest.php
@@ -5,8 +5,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
- * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @author    Josh Baiad <josh@joshbaiad.com>
+ * @copyright Copyright (c) 2026 Josh Baiad <josh@joshbaiad.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/Isolated/Services/ProcedureServiceBootstrap.php
+++ b/tests/Tests/Isolated/Services/ProcedureServiceBootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Bootstrap for ProcedureServiceTest
+ *
+ * Defines OPENEMR_STATIC_ANALYSIS to prevent code_types.inc.php from
+ * executing SQL queries when BaseService is autoloaded. This is required
+ * because BaseService has a file-scope require_once that loads
+ * code_types.inc.php which calls sqlStatement().
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+if (!defined('OPENEMR_STATIC_ANALYSIS')) {
+    define('OPENEMR_STATIC_ANALYSIS', true);
+}

--- a/tests/Tests/Isolated/Services/ProcedureServiceTest.php
+++ b/tests/Tests/Isolated/Services/ProcedureServiceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Isolated ProcedureService Test
+ *
+ * Reflection-based tests to verify the insert() and update() API contract
+ * without requiring a database connection (ProcedureService constructor
+ * calls parent::__construct() which runs SQL queries).
+ *
+ * BaseService has a file-scope require_once for code_types.inc.php which
+ * calls sqlStatement(). The bootstrap defines OPENEMR_STATIC_ANALYSIS to
+ * skip those database calls at include time.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Services;
+
+require_once __DIR__ . '/ProcedureServiceBootstrap.php';
+
+use OpenEMR\Services\ProcedureService;
+use OpenEMR\Validators\ProcedureOrderValidator;
+use OpenEMR\Validators\ProcessingResult;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class ProcedureServiceTest extends TestCase
+{
+    private ReflectionClass $reflectionClass;
+
+    protected function setUp(): void
+    {
+        $this->reflectionClass = new ReflectionClass(ProcedureService::class);
+    }
+
+    public function testInsertMethodExists(): void
+    {
+        $this->assertTrue(
+            $this->reflectionClass->hasMethod('insert'),
+            'ProcedureService must have an insert() method'
+        );
+    }
+
+    public function testInsertMethodSignature(): void
+    {
+        $method = $this->reflectionClass->getMethod('insert');
+
+        $this->assertTrue($method->isPublic(), 'insert() must be public');
+
+        $params = $method->getParameters();
+        $this->assertCount(1, $params, 'insert() must accept exactly 1 parameter');
+        $this->assertSame('data', $params[0]->getName());
+        $this->assertSame('array', $params[0]->getType()->getName());
+
+        $returnType = $method->getReturnType();
+        $this->assertNotNull($returnType, 'insert() must declare a return type');
+        $this->assertSame(ProcessingResult::class, $returnType->getName());
+    }
+
+    public function testUpdateMethodExists(): void
+    {
+        $this->assertTrue(
+            $this->reflectionClass->hasMethod('update'),
+            'ProcedureService must have an update() method'
+        );
+    }
+
+    public function testUpdateMethodSignature(): void
+    {
+        $method = $this->reflectionClass->getMethod('update');
+
+        $this->assertTrue($method->isPublic(), 'update() must be public');
+
+        $params = $method->getParameters();
+        $this->assertCount(2, $params, 'update() must accept exactly 2 parameters');
+
+        $this->assertSame('uuid', $params[0]->getName());
+        $this->assertSame('string', $params[0]->getType()->getName());
+
+        $this->assertSame('data', $params[1]->getName());
+        $this->assertSame('array', $params[1]->getType()->getName());
+
+        $returnType = $method->getReturnType();
+        $this->assertNotNull($returnType, 'update() must declare a return type');
+        $this->assertSame(ProcessingResult::class, $returnType->getName());
+    }
+
+    public function testServiceHasValidatorProperty(): void
+    {
+        $this->assertTrue(
+            $this->reflectionClass->hasProperty('procedureOrderValidator'),
+            'ProcedureService must have a procedureOrderValidator property'
+        );
+
+        $property = $this->reflectionClass->getProperty('procedureOrderValidator');
+        $this->assertTrue($property->isPrivate(), 'procedureOrderValidator must be private');
+        $this->assertTrue($property->isReadOnly(), 'procedureOrderValidator must be readonly');
+
+        $type = $property->getType();
+        $this->assertNotNull($type, 'procedureOrderValidator must be typed');
+        $this->assertSame(ProcedureOrderValidator::class, $type->getName());
+    }
+}

--- a/tests/Tests/Isolated/Services/ProcedureServiceTest.php
+++ b/tests/Tests/Isolated/Services/ProcedureServiceTest.php
@@ -13,8 +13,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
- * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @author    Josh Baiad <josh@joshbaiad.com>
+ * @copyright Copyright (c) 2026 Josh Baiad <josh@joshbaiad.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/Isolated/Services/ProcedureServiceTest.php
+++ b/tests/Tests/Isolated/Services/ProcedureServiceTest.php
@@ -30,6 +30,7 @@ use ReflectionClass;
 
 class ProcedureServiceTest extends TestCase
 {
+    /** @var ReflectionClass<ProcedureService> */
     private ReflectionClass $reflectionClass;
 
     protected function setUp(): void
@@ -54,10 +55,12 @@ class ProcedureServiceTest extends TestCase
         $params = $method->getParameters();
         $this->assertCount(1, $params, 'insert() must accept exactly 1 parameter');
         $this->assertSame('data', $params[0]->getName());
-        $this->assertSame('array', $params[0]->getType()->getName());
+        $paramType = $params[0]->getType();
+        $this->assertInstanceOf(\ReflectionNamedType::class, $paramType);
+        $this->assertSame('array', $paramType->getName());
 
         $returnType = $method->getReturnType();
-        $this->assertNotNull($returnType, 'insert() must declare a return type');
+        $this->assertInstanceOf(\ReflectionNamedType::class, $returnType, 'insert() must declare a return type');
         $this->assertSame(ProcessingResult::class, $returnType->getName());
     }
 
@@ -79,13 +82,17 @@ class ProcedureServiceTest extends TestCase
         $this->assertCount(2, $params, 'update() must accept exactly 2 parameters');
 
         $this->assertSame('uuid', $params[0]->getName());
-        $this->assertSame('string', $params[0]->getType()->getName());
+        $uuidType = $params[0]->getType();
+        $this->assertInstanceOf(\ReflectionNamedType::class, $uuidType);
+        $this->assertSame('string', $uuidType->getName());
 
         $this->assertSame('data', $params[1]->getName());
-        $this->assertSame('array', $params[1]->getType()->getName());
+        $dataType = $params[1]->getType();
+        $this->assertInstanceOf(\ReflectionNamedType::class, $dataType);
+        $this->assertSame('array', $dataType->getName());
 
         $returnType = $method->getReturnType();
-        $this->assertNotNull($returnType, 'update() must declare a return type');
+        $this->assertInstanceOf(\ReflectionNamedType::class, $returnType, 'update() must declare a return type');
         $this->assertSame(ProcessingResult::class, $returnType->getName());
     }
 
@@ -101,7 +108,7 @@ class ProcedureServiceTest extends TestCase
         $this->assertTrue($property->isReadOnly(), 'procedureOrderValidator must be readonly');
 
         $type = $property->getType();
-        $this->assertNotNull($type, 'procedureOrderValidator must be typed');
+        $this->assertInstanceOf(\ReflectionNamedType::class, $type, 'procedureOrderValidator must be typed');
         $this->assertSame(ProcedureOrderValidator::class, $type->getName());
     }
 }

--- a/tests/Tests/Isolated/Validators/ProcedureOrderValidatorTest.php
+++ b/tests/Tests/Isolated/Validators/ProcedureOrderValidatorTest.php
@@ -1,0 +1,443 @@
+<?php
+
+/**
+ * Isolated ProcedureOrderValidator Test
+ *
+ * Tests ProcedureOrderValidator validation logic without database dependencies.
+ * Uses test stubs to avoid database calls in BaseValidator.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Validators;
+
+use OpenEMR\Validators\BaseValidator;
+use OpenEMR\Validators\ProcessingResult;
+use OpenEMR\Validators\ProcedureOrderValidator;
+use PHPUnit\Framework\TestCase;
+
+class ProcedureOrderValidatorTest extends TestCase
+{
+    private ProcedureOrderValidatorStub $validator;
+
+    /** @var array<string, int> */
+    private array $validInsertData;
+
+    protected function setUp(): void
+    {
+        $this->validator = new ProcedureOrderValidatorStub();
+        $this->validInsertData = [
+            'patient_id' => 1,
+            'provider_id' => 2,
+            'encounter_id' => 100,
+            'lab_id' => 5,
+        ];
+    }
+
+    /**
+     * Helper to validate and return a typed ProcessingResult.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function validateData(array $data, string $context, ?ProcedureOrderValidator $validatorOverride = null): ProcessingResult
+    {
+        $v = $validatorOverride ?? $this->validator;
+        $result = $v->validate($data, $context);
+        $this->assertInstanceOf(ProcessingResult::class, $result);
+        return $result;
+    }
+
+    /**
+     * Helper to get validation messages as a typed array.
+     *
+     * @return array<string, mixed>
+     */
+    private function getMessages(ProcessingResult $result): array
+    {
+        $messages = $result->getValidationMessages();
+        $this->assertIsArray($messages);
+        /** @var array<string, mixed> $messages */
+        return $messages;
+    }
+
+    // ---------------------------------------------------------------
+    // INSERT context — required field tests
+    // ---------------------------------------------------------------
+
+    public function testInsertValidationRequiredFields(): void
+    {
+        $result = $this->validateData($this->validInsertData, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertTrue($result->isValid(), 'Valid data with all required fields should pass validation');
+        $this->assertEmpty($this->getMessages($result), 'No validation errors expected');
+    }
+
+    public function testInsertValidationMissingPatientId(): void
+    {
+        $data = $this->validInsertData;
+        unset($data['patient_id']);
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertFalse($result->isValid(), 'Missing patient_id should fail validation');
+        $this->assertArrayHasKey('patient_id', $this->getMessages($result));
+    }
+
+    public function testInsertValidationMissingProviderId(): void
+    {
+        $data = $this->validInsertData;
+        unset($data['provider_id']);
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertFalse($result->isValid(), 'Missing provider_id should fail validation');
+        $this->assertArrayHasKey('provider_id', $this->getMessages($result));
+    }
+
+    public function testInsertValidationMissingEncounterId(): void
+    {
+        $data = $this->validInsertData;
+        unset($data['encounter_id']);
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertFalse($result->isValid(), 'Missing encounter_id should fail validation');
+        $this->assertArrayHasKey('encounter_id', $this->getMessages($result));
+    }
+
+    public function testInsertValidationMissingLabId(): void
+    {
+        $data = $this->validInsertData;
+        unset($data['lab_id']);
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertFalse($result->isValid(), 'Missing lab_id should fail validation');
+        $this->assertArrayHasKey('lab_id', $this->getMessages($result));
+    }
+
+    // ---------------------------------------------------------------
+    // INSERT context — enum validation tests
+    // ---------------------------------------------------------------
+
+    public function testInsertValidationValidOrderStatus(): void
+    {
+        $data = $this->validInsertData;
+        $data['order_status'] = 'pending';
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertTrue($result->isValid(), "'pending' should be a valid order_status");
+    }
+
+    public function testInsertValidationInvalidOrderStatus(): void
+    {
+        $data = $this->validInsertData;
+        $data['order_status'] = 'unknown';
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertFalse($result->isValid(), "'unknown' should be an invalid order_status");
+        $this->assertArrayHasKey('order_status', $this->getMessages($result));
+    }
+
+    public function testInsertValidationValidOrderPriority(): void
+    {
+        $data = $this->validInsertData;
+        $data['order_priority'] = 'stat';
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertTrue($result->isValid(), "'stat' should be a valid order_priority");
+    }
+
+    public function testInsertValidationInvalidOrderPriority(): void
+    {
+        $data = $this->validInsertData;
+        $data['order_priority'] = 'invalid';
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertFalse($result->isValid(), "'invalid' should be an invalid order_priority");
+        $this->assertArrayHasKey('order_priority', $this->getMessages($result));
+    }
+
+    public function testInsertValidationValidOrderIntent(): void
+    {
+        $data = $this->validInsertData;
+        $data['order_intent'] = 'order';
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertTrue($result->isValid(), "'order' should be a valid order_intent");
+    }
+
+    public function testInsertValidationInvalidOrderIntent(): void
+    {
+        $data = $this->validInsertData;
+        $data['order_intent'] = 'invalid';
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertFalse($result->isValid(), "'invalid' should be an invalid order_intent");
+        $this->assertArrayHasKey('order_intent', $this->getMessages($result));
+    }
+
+    public function testInsertValidationValidProcedureOrderType(): void
+    {
+        $data = $this->validInsertData;
+        $data['procedure_order_type'] = 'laboratory_test';
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertTrue($result->isValid(), "'laboratory_test' should be a valid procedure_order_type");
+    }
+
+    public function testInsertValidationInvalidProcedureOrderType(): void
+    {
+        $data = $this->validInsertData;
+        $data['procedure_order_type'] = 'unknown_type';
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertFalse($result->isValid(), "'unknown_type' should be an invalid procedure_order_type");
+        $this->assertArrayHasKey('procedure_order_type', $this->getMessages($result));
+    }
+
+    // ---------------------------------------------------------------
+    // INSERT context — format validation tests
+    // ---------------------------------------------------------------
+
+    public function testInsertValidationValidDateOrdered(): void
+    {
+        $data = $this->validInsertData;
+        $data['date_ordered'] = '2026-01-15';
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertTrue($result->isValid(), 'Valid date_ordered should pass validation');
+    }
+
+    public function testInsertValidationInvalidDateOrdered(): void
+    {
+        $data = $this->validInsertData;
+        $data['date_ordered'] = 'not-a-date';
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertFalse($result->isValid(), 'Invalid date_ordered format should fail validation');
+        $this->assertArrayHasKey('date_ordered', $this->getMessages($result));
+    }
+
+    public function testInsertValidationValidDateCollected(): void
+    {
+        $data = $this->validInsertData;
+        $data['date_collected'] = '2026-01-16';
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertTrue($result->isValid(), 'Valid date_collected should pass validation');
+    }
+
+    public function testInsertValidationInvalidDateCollected(): void
+    {
+        $data = $this->validInsertData;
+        $data['date_collected'] = 'not-a-date';
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertFalse($result->isValid(), 'Invalid date_collected format should fail validation');
+        $this->assertArrayHasKey('date_collected', $this->getMessages($result));
+    }
+
+    public function testInsertValidationOrderDiagnosisTooLong(): void
+    {
+        $data = $this->validInsertData;
+        $data['order_diagnosis'] = str_repeat('A', 256);
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertFalse($result->isValid(), 'order_diagnosis over 255 chars should fail validation');
+        $this->assertArrayHasKey('order_diagnosis', $this->getMessages($result));
+    }
+
+    public function testInsertValidationClinicalHxTooLong(): void
+    {
+        $data = $this->validInsertData;
+        $data['clinical_hx'] = str_repeat('B', 256);
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertFalse($result->isValid(), 'clinical_hx over 255 chars should fail validation');
+        $this->assertArrayHasKey('clinical_hx', $this->getMessages($result));
+    }
+
+    // ---------------------------------------------------------------
+    // INSERT context — optional field tests
+    // ---------------------------------------------------------------
+
+    public function testInsertValidationWithAllOptionalFields(): void
+    {
+        $data = array_merge($this->validInsertData, [
+            'order_status' => 'pending',
+            'order_priority' => 'normal',
+            'order_intent' => 'order',
+            'procedure_order_type' => 'laboratory_test',
+            'date_ordered' => '2026-01-15',
+            'date_collected' => '2026-01-16',
+            'order_diagnosis' => 'ICD10:Z00.00',
+            'clinical_hx' => 'Annual checkup',
+            'patient_instructions' => 'Fasting required for 12 hours before the test.',
+            'billing_type' => 'T',
+            'specimen_fasting' => 'YES',
+        ]);
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertTrue($result->isValid(), 'All optional fields with valid values should pass validation');
+        $this->assertEmpty($this->getMessages($result), 'No validation errors expected');
+    }
+
+    public function testInsertValidationWithMinimalRequiredFields(): void
+    {
+        $result = $this->validateData($this->validInsertData, BaseValidator::DATABASE_INSERT_CONTEXT);
+
+        $this->assertTrue($result->isValid(), 'Only required fields should pass validation');
+    }
+
+    // ---------------------------------------------------------------
+    // UPDATE context tests
+    // ---------------------------------------------------------------
+
+    public function testUpdateValidationWithValidUuid(): void
+    {
+        $data = [
+            'uuid' => '987fcdeb-51a2-43d1-9f12-345678901234',
+            'order_status' => 'complete',
+        ];
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_UPDATE_CONTEXT);
+
+        $this->assertTrue($result->isValid(), 'Update with valid uuid and optional field should pass');
+    }
+
+    public function testUpdateValidationMissingUuid(): void
+    {
+        $data = [
+            'order_status' => 'pending',
+        ];
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_UPDATE_CONTEXT);
+
+        $this->assertFalse($result->isValid(), 'Update missing uuid should fail validation');
+        $this->assertArrayHasKey('uuid', $this->getMessages($result));
+    }
+
+    public function testUpdateValidationAllFieldsOptional(): void
+    {
+        $data = [
+            'uuid' => '987fcdeb-51a2-43d1-9f12-345678901234',
+            'patient_instructions' => 'Updated instructions',
+        ];
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_UPDATE_CONTEXT);
+
+        $this->assertTrue($result->isValid(), 'Update with uuid and single optional field should pass');
+    }
+
+    public function testUpdateValidationInvalidEnumOnUpdate(): void
+    {
+        $data = [
+            'uuid' => '987fcdeb-51a2-43d1-9f12-345678901234',
+            'order_status' => 'invalid_status',
+        ];
+
+        $result = $this->validateData($data, BaseValidator::DATABASE_UPDATE_CONTEXT);
+
+        $this->assertFalse($result->isValid(), 'Update with invalid enum value should fail validation');
+        $this->assertArrayHasKey('order_status', $this->getMessages($result));
+    }
+
+    // ---------------------------------------------------------------
+    // UUID validation tests
+    // ---------------------------------------------------------------
+
+    public function testIsExistingUuidMethodExists(): void
+    {
+        $reflection = new \ReflectionClass($this->validator);
+        $method = $reflection->getMethod('isExistingUuid');
+        $this->assertTrue($method->isPublic());
+        $this->assertEquals(1, $method->getNumberOfParameters());
+    }
+
+    public function testIsExistingUuidWithValidUuid(): void
+    {
+        $validUuid = '123e4567-e89b-12d3-a456-426614174000';
+        $result = $this->validator->isExistingUuid($validUuid);
+        $this->assertTrue($result, 'Valid UUID should exist (via stub)');
+    }
+
+    public function testIsExistingUuidWithInvalidFormat(): void
+    {
+        $nonExistentValidator = new ProcedureOrderValidatorNonExistentUuidStub();
+        $invalidUuid = 'not-a-valid-uuid';
+        $result = $nonExistentValidator->isExistingUuid($invalidUuid);
+        $this->assertFalse($result, 'Invalid UUID format should return false');
+    }
+
+    public function testIsExistingUuidWithNonExistentUuid(): void
+    {
+        $nonExistentValidator = new ProcedureOrderValidatorNonExistentUuidStub();
+        $nonExistentUuid = '999e4567-e89b-12d3-a456-426614179999';
+        $result = $nonExistentValidator->isExistingUuid($nonExistentUuid);
+        $this->assertFalse($result, 'Non-existent UUID should return false');
+    }
+}
+
+/**
+ * Test stub that overrides database-dependent methods.
+ * All IDs and UUIDs are treated as valid.
+ */
+class ProcedureOrderValidatorStub extends ProcedureOrderValidator
+{
+    public static function validateId(mixed $field, mixed $table, mixed $lookupId, mixed $isUuid = false): true
+    {
+        return true;
+    }
+
+    public function isExistingUuid($uuid): bool
+    {
+        return true;
+    }
+}
+
+/**
+ * Test stub for testing non-existent UUID scenarios.
+ * Returns false for invalid format and specific "non-existent" UUIDs.
+ */
+class ProcedureOrderValidatorNonExistentUuidStub extends ProcedureOrderValidator
+{
+    public static function validateId(mixed $field, mixed $table, mixed $lookupId, mixed $isUuid = false): true
+    {
+        return true;
+    }
+
+    public function isExistingUuid($uuid): bool
+    {
+        if (!preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', (string) $uuid)) {
+            return false;
+        }
+
+        if ($uuid === '999e4567-e89b-12d3-a456-426614179999') {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/Tests/Isolated/Validators/ProcedureOrderValidatorTest.php
+++ b/tests/Tests/Isolated/Validators/ProcedureOrderValidatorTest.php
@@ -8,8 +8,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
- * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @author    Josh Baiad <josh@joshbaiad.com>
+ * @copyright Copyright (c) 2026 Josh Baiad <josh@joshbaiad.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/RestControllers/FHIR/FhirServiceRequestRestControllerTest.php
+++ b/tests/Tests/RestControllers/FHIR/FhirServiceRequestRestControllerTest.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * FHIR ServiceRequest REST Controller Integration Tests
+ *
+ * Tests the REST controller layer for ServiceRequest CRUD operations
+ * with a real database connection.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\RestControllers\FHIR;
+
+use Monolog\Level;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRServiceRequest;
+use OpenEMR\RestControllers\FHIR\FhirServiceRequestRestController;
+use OpenEMR\Tests\Fixtures\EncounterFixtureManager;
+use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
+use OpenEMR\Tests\RestControllers\FHIR\Trait\FhirResponseAssertionTrait;
+use OpenEMR\Tests\RestControllers\FHIR\Trait\JsonResponseHandlerTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class FhirServiceRequestRestControllerTest extends TestCase
+{
+    use JsonResponseHandlerTrait;
+    use FhirResponseAssertionTrait;
+
+    private const LOG_LEVEL = Level::Emergency;
+
+    private FhirServiceRequestRestController $controller;
+    private EncounterFixtureManager $encounterFixtureManager;
+    private PractitionerFixtureManager $practitionerFixtureManager;
+
+    /** @var array<string, mixed> */
+    private array $fhirFixture;
+
+    private string $labUuid;
+    private string $patientUuid;
+
+    protected function setUp(): void
+    {
+        $this->encounterFixtureManager = new EncounterFixtureManager();
+        $this->encounterFixtureManager->installFixtures();
+
+        $this->practitionerFixtureManager = new PractitionerFixtureManager();
+        $this->practitionerFixtureManager->installPractitionerFixtures();
+
+        // Create a procedure_providers record for the performer/lab_id reference
+        $labUuidBytes = (new UuidRegistry(['table_name' => 'procedure_providers']))->createUuid();
+        $this->labUuid = UuidRegistry::uuidToString($labUuidBytes);
+        QueryUtils::sqlInsert(
+            "INSERT INTO procedure_providers SET uuid = ?, name = 'test-fixture-Lab'",
+            [$labUuidBytes]
+        );
+
+        // Resolve fixture UUIDs
+        $patientRecord = QueryUtils::querySingleRow(
+            "SELECT uuid FROM patient_data WHERE pubpid = ?",
+            ['test-fixture-789456']
+        );
+        $this->assertIsArray($patientRecord, 'Patient fixture not found');
+        $this->patientUuid = UuidRegistry::uuidToString($patientRecord['uuid']);
+
+        $encounterRecord = QueryUtils::querySingleRow(
+            "SELECT uuid FROM form_encounter WHERE reason LIKE 'test-fixture-%' LIMIT 1",
+            []
+        );
+        $this->assertIsArray($encounterRecord, 'Encounter fixture not found');
+        $encounterUuid = UuidRegistry::uuidToString($encounterRecord['uuid']);
+
+        $practitionerRecord = QueryUtils::querySingleRow(
+            "SELECT uuid FROM users WHERE fname LIKE 'test-fixture-%' LIMIT 1",
+            []
+        );
+        $this->assertIsArray($practitionerRecord, 'Practitioner fixture not found');
+        $practitionerUuid = UuidRegistry::uuidToString($practitionerRecord['uuid']);
+
+        $this->fhirFixture = [
+            'resourceType' => 'ServiceRequest',
+            'status' => 'active',
+            'intent' => 'order',
+            'category' => [
+                ['coding' => [['system' => 'http://snomed.info/sct', 'code' => '108252007', 'display' => 'Laboratory procedure']]],
+            ],
+            'code' => [
+                'coding' => [['system' => 'http://loinc.org', 'code' => '24356-8', 'display' => 'Urinalysis complete']],
+                'text' => 'Urinalysis complete',
+            ],
+            'subject' => ['reference' => "Patient/{$this->patientUuid}"],
+            'encounter' => ['reference' => "Encounter/{$encounterUuid}"],
+            'requester' => ['reference' => "Practitioner/{$practitionerUuid}"],
+            'performer' => [['reference' => "Organization/{$this->labUuid}"]],
+            'authoredOn' => '2026-01-15',
+            'priority' => 'routine',
+            'patientInstruction' => 'test-fixture-Collect morning sample',
+            'note' => [['text' => 'test-fixture-Patient reports recent UTI symptoms']],
+        ];
+
+        $this->controller = new FhirServiceRequestRestController();
+        $this->controller->setSystemLogger(new SystemLogger(self::LOG_LEVEL));
+    }
+
+    protected function tearDown(): void
+    {
+        // Delete procedure_order_code entries (foreign key child)
+        QueryUtils::sqlStatementThrowException(
+            "DELETE poc FROM procedure_order_code poc"
+            . " INNER JOIN procedure_order po ON poc.procedure_order_id = po.procedure_order_id"
+            . " WHERE po.clinical_hx LIKE 'test-fixture-%'",
+            []
+        );
+
+        // Delete procedure_order entries
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM procedure_order WHERE clinical_hx LIKE 'test-fixture-%'",
+            []
+        );
+
+        // Delete test procedure_providers record
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM procedure_providers WHERE name = 'test-fixture-Lab'",
+            []
+        );
+
+        $this->encounterFixtureManager->removeFixtures();
+        $this->practitionerFixtureManager->removePractitionerFixtures();
+    }
+
+    public function testPost(): void
+    {
+        $actualResult = $this->controller->post($this->fhirFixture);
+        $this->assertEquals(Response::HTTP_CREATED, $actualResult->getStatusCode());
+
+        $contents = $this->getJsonContents($actualResult);
+        $this->assertArrayHasKey('uuid', $contents);
+        $this->assertNotEmpty($contents['uuid']);
+    }
+
+    public function testInvalidPost(): void
+    {
+        // Remove subject (required for patient_id) and performer (required for lab_id)
+        unset($this->fhirFixture['subject']);
+        unset($this->fhirFixture['performer']);
+
+        $actualResult = $this->controller->post($this->fhirFixture);
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $actualResult->getStatusCode());
+    }
+
+    public function testPatch(): void
+    {
+        $actualResult = $this->controller->post($this->fhirFixture);
+        $contents = $this->getJsonContents($actualResult);
+        /** @var string $fhirId */
+        $fhirId = $contents['uuid'];
+
+        $this->fhirFixture['priority'] = 'urgent';
+        $actualResult = $this->controller->patch($fhirId, $this->fhirFixture);
+        $this->assertEquals(Response::HTTP_OK, $actualResult->getStatusCode());
+
+        $contents = $this->getJsonContents($actualResult);
+        $this->assertEquals($fhirId, $contents['id']);
+    }
+
+    public function testInvalidPatch(): void
+    {
+        $this->controller->post($this->fhirFixture);
+
+        $actualResult = $this->controller->patch('bad-uuid', $this->fhirFixture);
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $actualResult->getStatusCode());
+
+        $contents = $this->getJsonContents($actualResult);
+        /** @var array<string, mixed> $validationErrors */
+        $validationErrors = $contents['validationErrors'];
+        $this->assertGreaterThan(0, count($validationErrors));
+    }
+
+    public function testGetOne(): void
+    {
+        $actualResult = $this->controller->post($this->fhirFixture);
+        $contents = $this->getJsonContents($actualResult);
+        /** @var string $fhirId */
+        $fhirId = $contents['uuid'];
+
+        $actualResult = $this->controller->getOne($fhirId);
+        $this->assertEquals(Response::HTTP_OK, $actualResult->getStatusCode());
+
+        $contents = $this->getJsonContents($actualResult);
+        $this->assertNotEmpty($contents);
+    }
+
+    public function testGetAll(): void
+    {
+        $this->controller->post($this->fhirFixture);
+
+        $searchParams = ['patient' => $this->patientUuid];
+        $actualResult = $this->controller->getAll($searchParams);
+
+        $fhirServiceRequest = new FHIRServiceRequest();
+        $this->assertFhirBundleResponse($actualResult, Response::HTTP_OK, $fhirServiceRequest->get_fhirElementName());
+    }
+}

--- a/tests/Tests/RestControllers/FHIR/FhirServiceRequestRestControllerTest.php
+++ b/tests/Tests/RestControllers/FHIR/FhirServiceRequestRestControllerTest.php
@@ -8,8 +8,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
- * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @author    Josh Baiad <josh@joshbaiad.com>
+ * @copyright Copyright (c) 2026 Josh Baiad <josh@joshbaiad.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/RestControllers/FHIR/Trait/FhirResponseAssertionTrait.php
+++ b/tests/Tests/RestControllers/FHIR/Trait/FhirResponseAssertionTrait.php
@@ -16,11 +16,14 @@ trait FhirResponseAssertionTrait
         $fhirBundle = new FHIRBundle();
         $this->assertEquals($fhirBundle->get_fhirElementName(), $contents['resourceType'], "Unexpected resource type in response");
 
-        if (isset($contents['entry'])) {
+        if (isset($contents['entry']) && is_array($contents['entry'])) {
+            /** @var array<string, mixed> $entry */
             foreach ($contents['entry'] as $entry) {
                 $this->assertArrayHasKey('resource', $entry, "Each entry should contain a 'resource'");
-                $this->assertArrayHasKey('id', $entry['resource'], "Each resource should have an 'id'");
-                $this->assertEquals($expectedResourceType, $entry['resource']['resourceType'], "Resource type in entry does not match expected type");
+                $resource = $entry['resource'];
+                $this->assertIsArray($resource);
+                $this->assertArrayHasKey('id', $resource, "Each resource should have an 'id'");
+                $this->assertEquals($expectedResourceType, $resource['resourceType'], "Resource type in entry does not match expected type");
             }
         }
     }

--- a/tests/Tests/RestControllers/FHIR/Trait/JsonResponseHandlerTrait.php
+++ b/tests/Tests/RestControllers/FHIR/Trait/JsonResponseHandlerTrait.php
@@ -6,12 +6,16 @@ use Symfony\Component\HttpFoundation\Response;
 
 trait JsonResponseHandlerTrait
 {
+    /**
+     * @return array<string, mixed>
+     */
     protected function getJsonContents(Response $response): array
     {
         $contents = $response->getContent();
         $this->assertNotEmpty($contents, "Response body should not be empty");
         $decodedContents = json_decode($contents, true);
         $this->assertIsArray($decodedContents, "Response body should be a valid JSON array");
+        /** @var array<string, mixed> $decodedContents */
         return $decodedContents;
     }
 }

--- a/tests/Tests/Services/FHIR/FhirServiceRequestServiceCrudTest.php
+++ b/tests/Tests/Services/FHIR/FhirServiceRequestServiceCrudTest.php
@@ -1,0 +1,250 @@
+<?php
+
+/**
+ * FHIR ServiceRequest Service CRUD Integration Tests
+ *
+ * Tests insert and update operations through the FhirServiceRequestService layer
+ * with a real database connection.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services\FHIR;
+
+use Monolog\Level;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRServiceRequest;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
+use OpenEMR\Services\FHIR\FhirServiceRequestService;
+use OpenEMR\Services\FHIR\Serialization\FhirServiceRequestSerializer;
+use OpenEMR\Tests\Fixtures\EncounterFixtureManager;
+use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
+use PHPUnit\Framework\TestCase;
+
+class FhirServiceRequestServiceCrudTest extends TestCase
+{
+    private EncounterFixtureManager $encounterFixtureManager;
+    private PractitionerFixtureManager $practitionerFixtureManager;
+    private FhirServiceRequestService $fhirService;
+
+    /** @var array<string, mixed> */
+    private array $fhirFixture;
+
+    private string $labUuid;
+
+    protected function setUp(): void
+    {
+        $this->encounterFixtureManager = new EncounterFixtureManager();
+        $this->encounterFixtureManager->installFixtures();
+
+        $this->practitionerFixtureManager = new PractitionerFixtureManager();
+        $this->practitionerFixtureManager->installPractitionerFixtures();
+
+        // Create a procedure_providers record for the performer/lab_id reference
+        $labUuidBytes = (new UuidRegistry(['table_name' => 'procedure_providers']))->createUuid();
+        $this->labUuid = UuidRegistry::uuidToString($labUuidBytes);
+        QueryUtils::sqlInsert(
+            "INSERT INTO procedure_providers SET uuid = ?, name = 'test-fixture-Lab'",
+            [$labUuidBytes]
+        );
+
+        // Resolve fixture UUIDs
+        $patientRecord = QueryUtils::querySingleRow(
+            "SELECT uuid FROM patient_data WHERE pubpid = ?",
+            ['test-fixture-789456']
+        );
+        $this->assertIsArray($patientRecord, 'Patient fixture not found');
+        $patientUuid = UuidRegistry::uuidToString($patientRecord['uuid']);
+
+        $encounterRecord = QueryUtils::querySingleRow(
+            "SELECT uuid FROM form_encounter WHERE reason LIKE 'test-fixture-%' LIMIT 1",
+            []
+        );
+        $this->assertIsArray($encounterRecord, 'Encounter fixture not found');
+        $encounterUuid = UuidRegistry::uuidToString($encounterRecord['uuid']);
+
+        $practitionerRecord = QueryUtils::querySingleRow(
+            "SELECT uuid FROM users WHERE fname LIKE 'test-fixture-%' LIMIT 1",
+            []
+        );
+        $this->assertIsArray($practitionerRecord, 'Practitioner fixture not found');
+        $practitionerUuid = UuidRegistry::uuidToString($practitionerRecord['uuid']);
+
+        $this->fhirFixture = [
+            'resourceType' => 'ServiceRequest',
+            'status' => 'active',
+            'intent' => 'order',
+            'category' => [
+                ['coding' => [['system' => 'http://snomed.info/sct', 'code' => '108252007', 'display' => 'Laboratory procedure']]],
+            ],
+            'code' => [
+                'coding' => [['system' => 'http://loinc.org', 'code' => '24356-8', 'display' => 'Urinalysis complete']],
+                'text' => 'Urinalysis complete',
+            ],
+            'subject' => ['reference' => "Patient/{$patientUuid}"],
+            'encounter' => ['reference' => "Encounter/{$encounterUuid}"],
+            'requester' => ['reference' => "Practitioner/{$practitionerUuid}"],
+            'performer' => [['reference' => "Organization/{$this->labUuid}"]],
+            'authoredOn' => '2026-01-15',
+            'priority' => 'routine',
+            'patientInstruction' => 'test-fixture-Collect morning sample',
+            'note' => [['text' => 'test-fixture-Patient reports recent UTI symptoms']],
+        ];
+
+        $this->fhirService = new FhirServiceRequestService();
+        $this->fhirService->setSystemLogger(new SystemLogger(Level::Critical));
+    }
+
+    protected function tearDown(): void
+    {
+        // Delete procedure_order_code entries (foreign key child)
+        QueryUtils::sqlStatementThrowException(
+            "DELETE poc FROM procedure_order_code poc"
+            . " INNER JOIN procedure_order po ON poc.procedure_order_id = po.procedure_order_id"
+            . " WHERE po.clinical_hx LIKE 'test-fixture-%'",
+            []
+        );
+
+        // Delete procedure_order entries
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM procedure_order WHERE clinical_hx LIKE 'test-fixture-%'",
+            []
+        );
+
+        // Delete test procedure_providers record
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM procedure_providers WHERE name = 'test-fixture-Lab'",
+            []
+        );
+
+        $this->encounterFixtureManager->removeFixtures();
+        $this->practitionerFixtureManager->removePractitionerFixtures();
+    }
+
+    public function testInsert(): void
+    {
+        $serviceRequest = FhirServiceRequestSerializer::deserialize($this->fhirFixture);
+        $processingResult = $this->fhirService->insert($serviceRequest);
+
+        $this->assertTrue($processingResult->isValid(), 'Insert should succeed: '
+            . json_encode($processingResult->getValidationMessages()));
+
+        /** @var list<array{uuid: string, id: int}> $insertData */
+        $insertData = $processingResult->getData();
+        $dataResult = $insertData[0];
+        $this->assertNotEmpty($dataResult['uuid']);
+        $this->assertGreaterThan(0, $dataResult['id']);
+    }
+
+    public function testInsertRoundTrip(): void
+    {
+        // Insert
+        $serviceRequest = FhirServiceRequestSerializer::deserialize($this->fhirFixture);
+        $processingResult = $this->fhirService->insert($serviceRequest);
+        $this->assertTrue($processingResult->isValid(), 'Insert should succeed: '
+            . json_encode($processingResult->getValidationMessages()));
+
+        /** @var list<array{uuid: string, id: int}> $insertData */
+        $insertData = $processingResult->getData();
+        $fhirId = $insertData[0]['uuid'];
+
+        // Read back
+        $getResult = $this->fhirService->getOne($fhirId);
+        $this->assertTrue($getResult->isValid(), 'getOne should succeed');
+
+        /** @var list<FHIRServiceRequest> $getData */
+        $getData = $getResult->getData();
+        $this->assertCount(1, $getData);
+        $returned = $getData[0];
+
+        // Verify key fields survived the write→read round-trip
+        $this->assertEquals($fhirId, (string) $returned->getId());
+        $this->assertEquals('active', (string) $returned->getStatus());
+        $this->assertEquals('order', (string) $returned->getIntent());
+        $this->assertEquals('routine', (string) $returned->getPriority());
+
+        // Subject reference preserved
+        $subjectRef = (string) $returned->getSubject()->getReference();
+        $this->assertStringContainsString('Patient/', $subjectRef);
+
+        // Encounter reference preserved
+        $encounterRef = (string) $returned->getEncounter()->getReference();
+        $this->assertStringContainsString('Encounter/', $encounterRef);
+
+        // Requester reference preserved
+        $requesterRef = (string) $returned->getRequester()->getReference();
+        $this->assertStringContainsString('Practitioner/', $requesterRef);
+
+        // Category preserved (laboratory)
+        $categories = $returned->getCategory();
+        $this->assertNotEmpty($categories);
+
+        // Patient instruction preserved
+        $this->assertEquals(
+            'test-fixture-Collect morning sample',
+            (string) $returned->getPatientInstruction()
+        );
+    }
+
+    public function testInsertWithErrors(): void
+    {
+        // Remove subject (required field for patient_id resolution)
+        unset($this->fhirFixture['subject']);
+        // Remove performer (required lab_id)
+        unset($this->fhirFixture['performer']);
+
+        $serviceRequest = FhirServiceRequestSerializer::deserialize($this->fhirFixture);
+        $processingResult = $this->fhirService->insert($serviceRequest);
+
+        $this->assertFalse($processingResult->isValid());
+        /** @var list<mixed> $errorData */
+        $errorData = $processingResult->getData();
+        $this->assertCount(0, $errorData);
+    }
+
+    public function testUpdate(): void
+    {
+        // Insert first
+        $serviceRequest = FhirServiceRequestSerializer::deserialize($this->fhirFixture);
+        $processingResult = $this->fhirService->insert($serviceRequest);
+        $this->assertTrue($processingResult->isValid(), 'Insert should succeed: '
+            . json_encode($processingResult->getValidationMessages()));
+
+        /** @var list<array{uuid: string, id: int}> $insertData */
+        $insertData = $processingResult->getData();
+        $fhirId = $insertData[0]['uuid'];
+
+        // Update with new priority
+        $this->fhirFixture['priority'] = 'urgent';
+        $updatedServiceRequest = FhirServiceRequestSerializer::deserialize($this->fhirFixture);
+        $updatedServiceRequest->setId(new FHIRId($fhirId));
+
+        $updateResult = $this->fhirService->update($fhirId, $updatedServiceRequest);
+        $this->assertTrue($updateResult->isValid(), 'Update should succeed: '
+            . json_encode($updateResult->getValidationMessages()));
+
+        /** @var list<FHIRServiceRequest> $updateData */
+        $updateData = $updateResult->getData();
+        $this->assertEquals($fhirId, (string) $updateData[0]->getId());
+    }
+
+    public function testUpdateWithErrors(): void
+    {
+        $serviceRequest = FhirServiceRequestSerializer::deserialize($this->fhirFixture);
+        $updateResult = $this->fhirService->update('bad-uuid', $serviceRequest);
+
+        $this->assertFalse($updateResult->isValid());
+        /** @var array<string, mixed> $validationMessages */
+        $validationMessages = $updateResult->getValidationMessages();
+        $this->assertGreaterThan(0, count($validationMessages));
+        /** @var list<mixed> $updateErrorData */
+        $updateErrorData = $updateResult->getData();
+        $this->assertCount(0, $updateErrorData);
+    }
+}

--- a/tests/Tests/Services/FHIR/FhirServiceRequestServiceCrudTest.php
+++ b/tests/Tests/Services/FHIR/FhirServiceRequestServiceCrudTest.php
@@ -8,8 +8,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Joshua Baiad <jbaiad@users.noreply.github.com>
- * @copyright Copyright (c) 2026 Joshua Baiad <jbaiad@users.noreply.github.com>
+ * @author    Josh Baiad <josh@joshbaiad.com>
+ * @copyright Copyright (c) 2026 Josh Baiad <josh@joshbaiad.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 


### PR DESCRIPTION
## Summary

Refs #10910
Depends on #10925

Implements FHIR R4 ServiceRequest write support for procedure orders, enabling external systems to create and update lab/imaging orders via the FHIR API.

**Note:** This PR depends on #10925 (ProcedureOrderValidator + ProcedureService write ops) and should be merged after it.

## Changes

**FHIR ServiceRequest Service:**
- Add `parseFhirResource()` with reverse mappings (FHIR status/category/priority → OpenEMR enums)
- Add `insertOpenEMRRecord()` and `updateOpenEMRRecord()` delegating to `ProcedureService`
- Fix `date_collected` undefined key in `parseOpenEMRRecord()`

**Serialization:**
- Add `FhirServiceRequestSerializer` for FHIR → OpenEMR deserialization
- Support subject, requester, performer, category, priority, status, notes, reason codes

**REST Controller & Routes:**
- Register POST/PUT routes in FHIR R4 US Core routing
- Add `setSystemLogger()` for test observability
- Add `readonly` properties (Rector compliance)

**UtilsService:**
- Fix `getUuidFromReference()` to accept nullable parameter

**Tests:**
- 4 isolated test files: serializer, reverse mapping, contract, UtilsService (32 tests)
- 1 REST controller test with response handler traits
- 1 service CRUD integration test with round-trip verification

**CI Fixes:**
- Update PHPStan baselines (remove 17 stale entries)
- Add procedural HL7 function names to composer-require-checker allowlist

## Test Plan

- [x] Run `composer phpunit-isolated` — all 1690 tests pass, no regressions
- [x] Run `composer phpstan` — no errors
- [ ] CI should pass all 28 checks

Code generated with the assistance of Claude (Anthropic)