### PR TITLE
chore(deps): bump minimatch to fix ReDoS (CVE-2026-26996)

### DIFF
--- a/ccdaservice/package-lock.json
+++ b/ccdaservice/package-lock.json
@@ -549,7 +549,9 @@
             }
         },
         "node_modules/cli/node_modules/minimatch": {
-            "version": "3.1.2",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2561,10 +2563,12 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.5",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"


### PR DESCRIPTION
## Summary
- Bump `minimatch` 9.0.5 → 9.0.9 in `ccdaservice/package-lock.json`
- Fixes GHSA-3ppc-4f35-3m26 / CVE-2026-26996 (high severity ReDoS via repeated wildcards)
- Dependabot detected the vulnerability but cannot auto-fix subdirectory lockfiles
- Also picks up `minimatch` 3.1.2 → 3.1.5 for the `cli` dev dependency

## Test plan
- [ ] CI passes (lockfile-only change, no functional impact)