### PR TITLE
fix(session): replace direct $_SESSION writes with SessionUtil::setSession()

### DIFF
--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -3517,7 +3517,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'bill_date\' on array\\|false\\.$#',
+    'message' => '#^Cannot access offset \'bill_date\' on array\\<mixed\\>\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];
@@ -3602,7 +3602,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'hipaa_allowemail\' on array\\|false\\.$#',
+    'message' => '#^Cannot access offset \'hipaa_allowemail\' on array\\<mixed\\>\\|false\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];
@@ -3647,7 +3647,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'name\' on array\\|false\\.$#',
+    'message' => '#^Cannot access offset \'name\' on array\\<mixed\\>\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -452,11 +452,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
-    'count' => 7,
-    'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',

--- a/interface/forms/eye_mag/a_issue.php
+++ b/interface/forms/eye_mag/a_issue.php
@@ -24,6 +24,9 @@ TODO: Code cleanup */
 
 $form_folder = "eye_mag";
 require_once('../../globals.php');
+
+use OpenEMR\Common\Session\SessionUtil;
+
 require_once($GLOBALS['srcdir'] . '/lists.inc.php');
 require_once($GLOBALS['srcdir'] . '/patient.inc.php');
 require_once($GLOBALS['srcdir'] . '/options.inc.php');
@@ -71,7 +74,7 @@ $PMSFH = build_PMSFH($pid);
 $patient = getPatientData($pid, "*");
 $providerID = findProvider($pid, $encounter);
 if (!($_SESSION['providerID'] ?? '') && $providerID) {
-    ($_SESSION['providerID'] = $providerID);
+    SessionUtil::setSession('providerID', $providerID);
 }
 
 $irow = [];

--- a/interface/forms/gad7/save.php
+++ b/interface/forms/gad7/save.php
@@ -16,6 +16,7 @@ require_once("$srcdir/api.inc.php");
 require_once("$srcdir/forms.inc.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Session\SessionUtil;
 
 if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
     CsrfUtils::csrfNotVerified();
@@ -62,7 +63,7 @@ if ($_GET["mode"] == "new") {
     );
 }
 
-$_SESSION["encounter"] = $encounter;
+SessionUtil::setSession('encounter', $encounter);
 formHeader("Redirecting....");
 formJump();
 formFooter();

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
@@ -246,7 +246,7 @@ abstract class AppDispatch
      */
     static function setModuleType($type): void
     {
-        $_SESSION['oefax_current_module_type'] = $type;
+        SessionUtil::setSession('oefax_current_module_type', $type);
         self::$_apiModule = $type;
     }
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/RCVoice/VoiceFunctionsTrait.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/RCVoice/VoiceFunctionsTrait.php
@@ -12,6 +12,7 @@
 
 namespace OpenEMR\Modules\FaxSMS\RCVoice;
 
+use OpenEMR\Common\Session\SessionUtil;
 use RingCentral\SDK\Http\ApiException;
 use RingCentral\SDK\Platform\Platform;
 
@@ -143,7 +144,7 @@ trait VoiceFunctionsTrait
             if ($token == 'changeme') {
                 // Generate secure token
                 $token = bin2hex(random_bytes(16));
-                $_SESSION['ringcentral_voice_token'] = $token;
+                SessionUtil::setSession('ringcentral_voice_token', $token);
             }
             // Webhook endpoint
             $this->webhookUrl = $this->getWebhookUrl($token);

--- a/interface/modules/zend_modules/module/Application/ajax/reporting_period_handler.php
+++ b/interface/modules/zend_modules/module/Application/ajax/reporting_period_handler.php
@@ -14,6 +14,7 @@
 require_once("../../../../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Cqm\QrdaControllers\QrdaReportController;
 
 header('Content-Type: application/json');
@@ -60,7 +61,7 @@ function handleUpdateReportingPeriod()
 
     if ($result['count'] > 0) {
         // Update session
-        $_SESSION['selected_ecqm_period'] = $period;
+        SessionUtil::setSession('selected_ecqm_period', $period);
 
         // Update global
         $GLOBALS['cqm_performance_period'] = $period;

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGenerator.php
@@ -14,6 +14,7 @@
 namespace Carecoordination\Model;
 
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Session\SessionUtil;
 
 class CcdaGenerator
 {
@@ -79,7 +80,7 @@ class CcdaGenerator
                 , 'referral_reason' => (empty($referral_reason) ? "No referral reason" : "Has referral reason")
                 , 'date_options' => $date_options]);
         if ($sent_by != '') {
-            $_SESSION['authUserID'] = $sent_by;
+            SessionUtil::setSession('authUserID', $sent_by);
         }
 
         if (!$sections) {


### PR DESCRIPTION
## Summary

- Replace direct `$_SESSION` writes with `SessionUtil::setSession()` in 7 files that don't set `$sessionAllowWrite`
- Direct writes are silently lost in `read_and_close` mode (the default), because the session file is closed immediately after reading
- `SessionUtil::setSession()` correctly reopens the session in write mode, writes, and closes

## Affected files

| File | Session key |
|------|-------------|
| `interface/billing/sl_eob_search.php` | `portalUser` |
| `interface/forms/eye_mag/a_issue.php` | `providerID` |
| `interface/forms/gad7/save.php` | `encounter` |
| `interface/modules/zend_modules/.../reporting_period_handler.php` | `selected_ecqm_period` |
| `oe-module-faxsms/.../AppDispatch.php` | `oefax_current_module_type` |
| `oe-module-faxsms/.../VoiceFunctionsTrait.php` | `ringcentral_voice_token` |
| `Carecoordination/.../CcdaGenerator.php` | `authUserID` |

## Test plan

- [ ] Verify EOB search portal user tracking still works
- [ ] Verify eye exam provider ID is set correctly
- [ ] Verify GAD-7 form save updates encounter in session
- [ ] Verify eCQM reporting period selection persists
- [ ] Verify fax/SMS module type selection persists
- [ ] Verify CCDA generation sets authUserID correctly

Fixes #10934

🤖 Generated with [Claude Code](https://claude.com/claude-code)