### PR TITLE
docs(api): fix copy-paste errors in OpenAPI annotations

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -162,7 +162,7 @@ use OpenEMR\RestControllers\Config\RestConfig;
  *              "user/vital.crus": "Create,Read,Update,Search vitals the user has access to (api:oemr)",
  *              "api:port": "Standard Patient Portal OpenEMR API",
  *              "patient/encounter.read": "Read encounters the patient has access to (api:port)",
- *              "patient/patient.read": "Write encounters the patient has access to (api:port)",
+ *              "patient/patient.read": "Read patient data the patient has access to (api:port)",
  *              "patient/appointment.read": "Read appointments the patient has access to (api:port)"
  *          }
  *      )

--- a/apis/routes/_rest_routes_fhir_r4_us_core_3_1_0.inc.php
+++ b/apis/routes/_rest_routes_fhir_r4_us_core_3_1_0.inc.php
@@ -2078,7 +2078,7 @@ return [
     /**
      *  @OA\Get(
      *      path="/fhir/Goal",
-     *      description="Returns a list of Condition resources.",
+     *      description="Returns a list of Goal resources.",
      *      tags={"fhir"},
      *      @OA\Parameter(
      *          name="_id",

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -5426,7 +5426,7 @@ paths:
     get:
       tags:
         - fhir
-      description: 'Returns a list of Condition resources.'
+      description: 'Returns a list of Goal resources.'
       parameters:
         -
           name: _id
@@ -10034,7 +10034,7 @@ components:
             user/vital.crus: 'Create,Read,Update,Search vitals the user has access to (api:oemr)'
             'api:port': 'Standard Patient Portal OpenEMR API'
             patient/encounter.read: 'Read encounters the patient has access to (api:port)'
-            patient/patient.read: 'Write encounters the patient has access to (api:port)'
+            patient/patient.read: 'Read patient data the patient has access to (api:port)'
             patient/appointment.read: 'Read appointments the patient has access to (api:port)'
 tags:
   -


### PR DESCRIPTION
## Summary
- Fix `/fhir/Goal` getAll description saying "Condition resources" instead of "Goal resources"
- Fix `patient/patient.read` OAuth scope description saying "Write encounters" instead of "Read patient data"

## Test plan
- [ ] Generated swagger output reflects corrected descriptions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)