### PR TITLE
refactor(auth): replace die() with RuntimeException in generatePortal…

### DIFF
--- a/src/Common/Utils/RandomGenUtils.php
+++ b/src/Common/Utils/RandomGenUtils.php
@@ -77,6 +77,6 @@ class RandomGenUtils
         // Something is seriously wrong since 1000 tries have not created a valid password
         $error_message = "OpenEMR Error: OpenEMR is not working because unable to create a valid password in $max_tries attempts.";
         error_log($error_message);
-        die($error_message);
+        throw new \RuntimeException($error_message);
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
\`RandomGenUtils::generatePortalPassword()\` uses \`die()\`, which is a bad practice itself.

#### Changes proposed in this pull request:
Replace \`die(\$error_message)\` with \`throw new \RuntimeException(\$error_message)\`. This allows callers to catch and handle the failure gracefully.


#### Does your code include anything generated by an AI Engine? No