### PR TITLE
fix(sdoh): add missing site parameter to SDOH assessment URLs

### DIFF
--- a/interface/patient_file/history/history_sdoh_widget.php
+++ b/interface/patient_file/history/history_sdoh_widget.php
@@ -21,11 +21,13 @@ require_once($srcdir . "/options.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Menu\PatientMenuRole;
 use OpenEMR\Services\SDOH\HistorySdohService;
 
 $logger = new SystemLogger();
+$session = SessionWrapperFactory::getInstance()->getWrapper();
 
 /** Lookup a list option title by (list_id, option_id). */
 function hs_lo_title(string $listId, ?string $value): string
@@ -79,6 +81,7 @@ function hs_badge_class(?string $val): string
 }
 
 $authorized = AclMain::aclCheckCore('patients', 'med');
+$siteId = $session->get('site_id');
 $self_form = $GLOBALS['webroot'] . "/interface/patient_file/history/history_sdoh.php";
 $list_url  = $GLOBALS['webroot'] . "/interface/patient_file/history/history_sdoh_list.php";
 
@@ -189,12 +192,12 @@ $totalScore = (string) (($info['instrument_score'] ?? '') !== '' ? (int)$info['i
                     <span class="font-weight-bold"><?php echo xlt("SDOH (USCDI v3)"); ?></span>
                     <span class="btn-group btn-group-sm">
                     <?php
-                    $newUrl  = $self_form . '?' . http_build_query(['pid' => $pid, 'new' => 1, 'site' => $_SESSION['site_id']]);
-                    $listUrl = $list_url  . '?' . http_build_query(['pid' => $pid, 'site' => $_SESSION['site_id']]);
+                    $newUrl  = $self_form . '?' . http_build_query(['pid' => $pid, 'new' => 1, 'site' => $siteId]);
+                    $listUrl = $list_url  . '?' . http_build_query(['pid' => $pid, 'site' => $siteId]);
                     ?>
                     <a class="btn btn-outline-primary" href="<?php echo attr($newUrl); ?>"><?php echo xlt("New Assessment"); ?></a>
                     <?php if (!empty($info['id'])) :
-                        $editUrl = $self_form . '?' . http_build_query(['pid' => $pid, 'id' => (int)$info['id'], 'site' => $_SESSION['site_id']]);
+                        $editUrl = $self_form . '?' . http_build_query(['pid' => $pid, 'id' => (int)$info['id'], 'site' => $siteId]);
                         ?>
                         <a class="btn btn-primary" href="<?php echo attr($editUrl); ?>"><?php echo xlt("Edit"); ?></a>
                     <?php endif; ?>


### PR DESCRIPTION
Fixes #10725

#### Short description of what this resolves:
SDOH Assessment widget URLs (New Assessment, Edit, View All) were missing the `site` query parameter, causing 'Site ID is missing from session data!' error on multi-site installations.

#### Changes proposed in this pull request:
site id added on link formation in interface/patient_file/history/history_sdoh_widget.php

#### Does your code include anything generated by an AI Engine? No