### PR TITLE
refactor(db): Simplify config file reading

### DIFF
--- a/src/BC/DatabaseConnectionOptions.php
+++ b/src/BC/DatabaseConnectionOptions.php
@@ -165,12 +165,11 @@ final readonly class DatabaseConnectionOptions
      */
     private static function loadSqlconf(string $siteDir): array
     {
-        $configFile = 'sqlconf.php';
-        $sqlconfPath = $siteDir . '/' . $configFile;
+        $sqlconfPath = $siteDir . '/sqlconf.php';
         if (!file_exists($sqlconfPath)) {
             throw new RuntimeException(sprintf(
                 '%s not found in %s. Is the site configured?',
-                $configFile,
+                'sqlconf.php',
                 $siteDir,
             ));
         }


### PR DESCRIPTION
#### Changes proposed in this pull request:
This removes the option to specify the filename of `sqlconf.php` from the db config tooling. it was originally intended to support `secure_sqlconf.php` but it's become obsolete and wouldn't have worked anyway since that file used a different internal format.

#### Does your code include anything generated by an AI Engine? Yes / No
No