### PR TITLE
docs: update CLAUDE.md for recent codebase changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,9 @@ Preserve existing authors/copyrights when editing files.
 
 - Multiple template engines: check extension (.twig, .html, .php)
 - Event system uses Symfony EventDispatcher
-- Pre-commit hooks available via `.pre-commit-config.yaml`
+- **Pre-commit hooks:** Install with `prek install` (or `pre-commit install` if
+  prek is unavailable). Run `prek run --all-files` before committing to catch
+  issues early — the hooks run phpstan, rector, phpcs, codespell, and more.
 - Custom PHPStan rules in `tests/PHPStan/Rules/` enforce project conventions
   (forbidden globals, forbidden direct instantiations, namespace rules, etc.)
 - Commit messages are validated against Conventional Commits format in CI


### PR DESCRIPTION
## Summary

- Remove outdated "no strict_types" claim — new files should use it
- Update database description: Doctrine DBAL 4.x is the connection layer, ADODB is the legacy surface API
- Add PHPStan level 10 and custom rules to tech stack
- Document all composer scripts (`phpstan-baseline`, `rector-fix`, `require-checker`, `checks`, `codespell`, `conventional-commits:check`, `php-syntax-check`)
- Add database guidance (QueryUtils, DatabaseConnectionFactory, Doctrine Migrations)
- Note custom PHPStan rules and commit message validation in gotchas

Closes #10978

## Test plan

- [ ] Review that statements match current codebase state