### PR TITLE
fix(i18n): apply xlt filter in patient verify success email templates

### DIFF
--- a/templates/emails/patient/verify_email/message-verify-success.html.twig
+++ b/templates/emails/patient/verify_email/message-verify-success.html.twig
@@ -1,7 +1,7 @@
 <html>
     <body>
         <div class='wrapper'>
-            <p>{{ "We received a patient registration email verification request. The link to verify your email is below." }}</p>
+            <p>{{ "We received a patient registration email verification request. The link to verify your email is below."|xlt }}</p>
             <p>{{ "Please ignore this email if you did not make this request"|xlt }}</p>
             <p><strong>{{ "Below link is only valid for one hour."|xlt }}: </strong></p>
             <a href="{{ encoded_link|attr }}">{{ encoded_link|text }}</a>

--- a/templates/emails/patient/verify_email/message-verify-success.text.twig
+++ b/templates/emails/patient/verify_email/message-verify-success.text.twig
@@ -1,4 +1,4 @@
-{{ "We received a patient registration email verification request. The link to verify your email is below." }}
+{{ "We received a patient registration email verification request. The link to verify your email is below."|xlt }}
 {{ "Please ignore this email if you did not make this request"|xlt }}
 {{ "Below link is only valid for one hour."|xlt }}: {{ encoded_link|text }}
 {{ "Thank You."|xlt }}


### PR DESCRIPTION
## Summary
Adds missing xlt translation filter in both patient verification success email templates so the full message is translatable.

Fixes #10786

## Changes
- `templates/emails/patient/verify_email/message-verify-success.html.twig`
- `templates/emails/patient/verify_email/message-verify-success.text.twig`

## Notes
- Focused i18n fix only; no behavior change beyond translation support for existing message text.
