### PR TITLE
fix(apptstat): accept #RRGGBB in status color field

### DIFF
--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -524,7 +524,7 @@ function writeOptionLine($option_id, $title, $seq, $default, $value, $mapping = 
         [$apptstat_color, $apptstat_timealert] = explode("|", (string) $notes);
         echo "  <td>";
         echo "<input type='text' class='optin' data-jscolor='' name='opt[" . attr($opt_line_no) . "][apptstat_color]' value='" .
-            attr($apptstat_color) . "' size='6' maxlength='6' />";
+            attr($apptstat_color) . "' size='7' maxlength='7' />";
         echo "</td>\n";
         echo "  <td>";
         echo "<input type='text' name='opt[" . attr($opt_line_no) . "][apptstat_timealert]' value='" .


### PR DESCRIPTION
## Summary
Allows appointment status color input to accept a leading `#` (for standard `#RRGGBB` values) in Admin -> Lists -> Appointment Status.

Fixes #9402

## Changes
- `interface/super/edit_list.php`
  - Increased `apptstat_color` input from `maxlength=6` to `maxlength=7`
  - Increased input size from `6` to `7` for consistent UX

## Notes
- Existing downstream color usage already strips a leading `#` where needed, so this is a UI acceptance fix with no behavior regression.
