### PR TITLE
fix(appt): avoid HTML-encoded status text in demographics widgets

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1869,7 +1869,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             }
 
                             $row['pc_eventTime'] = sprintf("%02d", $disphour) . ":{$dispmin}";
-                            $row['pc_status'] = generate_display_field(['data_type' => '1', 'list_id' => 'apptstat'], $row['pc_apptstatus']);
+                            $row['pc_status'] = generate_plaintext_field(['data_type' => '1', 'list_id' => 'apptstat'], $row['pc_apptstatus']);
                             if ($row['pc_status'] == 'None') {
                                 $row['pc_status'] = 'Scheduled';
                             }
@@ -1975,7 +1975,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             }
                             $row['etitle'] = $petitle;
 
-                            $row['pc_status'] = generate_display_field(['data_type' => '1', 'list_id' => 'apptstat'], $row['pc_apptstatus']);
+                            $row['pc_status'] = generate_plaintext_field(['data_type' => '1', 'list_id' => 'apptstat'], $row['pc_apptstatus']);
 
                             $row['dayName'] = $dayname;
                             $row['displayMeridiem'] = $displayMeridiem;


### PR DESCRIPTION
## Summary
Fixes appointment status display in demographics appointment widgets so statuses with symbols (for example `<`) render as expected instead of showing HTML entities like `&lt;`.

Fixes #7290

## Changes
- `interface/patient_file/summary/demographics.php`
  - Switched appointment status rendering from `generate_display_field()` to `generate_plaintext_field()` in both upcoming and past appointment card paths.

## Notes
- This keeps output safe while preventing double-encoded list-label artifacts in UI text.
