### PR TITLE
fix(i18n): correct "Dislay" typo in main menu logo description

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -457,7 +457,7 @@ $GLOBALS_METADATA = [
             xl('Display main menu logo'),
             'bool',
             '1',
-            xl('Dislay main menu logo'),
+            xl('Display main menu logo'),
         ],
 
         'online_support_link' => [


### PR DESCRIPTION
## Summary

- Fix typo "Dislay" → "Display" in the `display_main_menu_logo` global setting description

## Test plan

- [ ] Verify the corrected string appears in Admin > Globals > Branding