### PR TITLE
fix(encounter): enforce newest-first sort in encounters report

### DIFF
--- a/interface/reports/encounters_report.php
+++ b/interface/reports/encounters_report.php
@@ -43,11 +43,11 @@ $alertmsg = ''; // not used yet but maybe later
 // For each sorting option, specify the ORDER BY argument.
 //
 $ORDERHASH = [
-  'doctor'  => 'lower(u.lname), lower(u.fname), fe.date',
-  'patient' => 'lower(p.lname), lower(p.fname), fe.date',
-  'pubpid'  => 'lower(p.pubpid), fe.date',
-  'time'    => 'fe.date, lower(u.lname), lower(u.fname)',
-  'encounter'    => 'fe.encounter, fe.date, lower(u.lname), lower(u.fname)',
+  'doctor'  => 'lower(u.lname), lower(u.fname), fe.date DESC, fe.encounter DESC',
+  'patient' => 'lower(p.lname), lower(p.fname), fe.date DESC, fe.encounter DESC',
+  'pubpid'  => 'lower(p.pubpid), fe.date DESC, fe.encounter DESC',
+  'time'    => 'fe.date DESC, fe.encounter DESC, lower(u.lname), lower(u.fname)',
+  'encounter'    => 'fe.encounter DESC, fe.date DESC, lower(u.lname), lower(u.fname)',
 ];
 
 function show_doc_total($lastdocname, $doc_encounters): void


### PR DESCRIPTION
## Summary
Fixes incorrect encounter date ordering in the encounters report by making date sort direction explicit and reverse-chronological.

Fixes #10270

## Changes
- `interface/reports/encounters_report.php`
  - Updated `$ORDERHASH` date-related sort clauses to use `fe.date DESC`
  - Added `fe.encounter DESC` as tie-breaker where appropriate
  - Updated `time` and `encounter` sort options to keep newest records first

## Why
Previously, date sort direction was implicit (ascending by default), causing report ordering inconsistencies and older encounters appearing before newer ones.
