### PR TITLE
feat(mobile): add native-feeling responsive mobile shell (MVP)

### DIFF
--- a/Documentation/api/SMART_ON_FHIR.md
+++ b/Documentation/api/SMART_ON_FHIR.md
@@ -343,7 +343,7 @@ const response = await fetch('https://localhost:9300/apis/default/fhir/Patient/1
 
 #### Characteristics
 - ✅ Launched from OpenEMR UI
-- ✅ Patient context pre-selected
+- ✅ Patient context preselected
 - ✅ Encounter context available (SMART v2.2.0)
 - ✅ User already authenticated
 - ✅ Faster workflow for clinicians
@@ -530,7 +530,7 @@ SMART apps can receive contextual information about the launch environment.
 #### When Available
 - ✅ EHR launch from patient chart
 - ✅ Patient standalone apps (patient is authorized user)
-- ❌ Standalone provider apps (no pre-selected patient)
+- ❌ Standalone provider apps (no preselected patient)
 
 #### Requesting Patient Context
 

--- a/interface/main/holidays/Holidays_Storage.php
+++ b/interface/main/holidays/Holidays_Storage.php
@@ -104,7 +104,7 @@ class Holidays_Storage
     }
 
     /**
-     * This function opend the $file(csv) and parses it to insert the values in the calendar_external so later they can be imported as events
+     * This function opens the $file(csv) and parses it to insert the values in the calendar_external so later they can be imported as events
      * csv format -> date,description
      * Example:
      * 2016/12/24,Christmas

--- a/interface/mobile/README.md
+++ b/interface/mobile/README.md
@@ -1,0 +1,23 @@
+# OpenEMR Mobile Shell (MVP)
+
+This directory contains a mobile-first, responsive wrapper for OpenEMR intended to feel app-like on iOS/Android while reusing the existing web application.
+
+## Goals
+- Native-feeling shell (header, tab bar, fullscreen viewport)
+- Touch-friendly controls and safe-area support
+- Configurable installation URL for connecting to the correct OpenEMR instance
+- Progressive Web App setup (manifest + service worker)
+
+## Entry point
+- `index.php`
+
+## URL
+- Default base URL uses server `$GLOBALS['web_root']`
+- Can be overridden in the mobile settings panel and is persisted in `localStorage`
+
+## Next Iterations
+1. Add deep-link route mapping for key workflows (appointments, encounters, patient summary)
+2. Add authenticated quick actions and role-based tabs
+3. Add mobile-specific CSS overrides for high-traffic screens
+4. Add offline queue for drafts (notes/tasks) with retry
+5. Package with Capacitor for App Store / Play Store deployment

--- a/interface/mobile/index.php
+++ b/interface/mobile/index.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * OpenEMR Mobile Shell (responsive, app-like wrapper)
+ *
+ * @package OpenEMR
+ */
+
+require_once dirname(__FILE__, 2) . '/globals.php';
+
+$defaultBaseUrl = $GLOBALS['web_root'] ?? '/openemr';
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#0b57d0" />
+    <title><?php echo xlt('OpenEMR Mobile'); ?></title>
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="stylesheet" href="./mobile.css" />
+</head>
+<body>
+<div class="app" id="appRoot">
+    <header class="app-header">
+        <div class="app-title"><?php echo xlt('OpenEMR'); ?></div>
+        <button class="icon-btn" id="settingsBtn" aria-label="<?php echo xla('Settings'); ?>">⚙</button>
+    </header>
+
+    <main class="viewport">
+        <iframe id="openemrFrame" title="OpenEMR" loading="eager"></iframe>
+    </main>
+
+    <nav class="tabbar" id="tabbar">
+        <button data-target="/interface/login/login.php"><?php echo xlt('Home'); ?></button>
+        <button data-target="/interface/main/calendar/index.php"><?php echo xlt('Calendar'); ?></button>
+        <button data-target="/interface/main/finder/patient_select.php"><?php echo xlt('Patients'); ?></button>
+        <button data-target="/interface/main/messages/messages.php"><?php echo xlt('Messages'); ?></button>
+        <button data-target="/interface/super/main/main.php"><?php echo xlt('Admin'); ?></button>
+    </nav>
+</div>
+
+<div class="sheet hidden" id="settingsSheet" role="dialog" aria-modal="true">
+    <div class="sheet-card">
+        <h2><?php echo xlt('Mobile Settings'); ?></h2>
+        <label for="baseUrlInput"><?php echo xlt('OpenEMR Installation URL'); ?></label>
+        <input id="baseUrlInput" type="url" placeholder="https://example.com/openemr" />
+        <div class="row">
+            <button id="saveSettings"><?php echo xlt('Save'); ?></button>
+            <button id="closeSettings" class="btn-secondary"><?php echo xlt('Close'); ?></button>
+        </div>
+        <p class="hint"><?php echo xlt('Tip: Use your full install URL, for example https://your-domain/openemr'); ?></p>
+    </div>
+</div>
+
+<script>
+(() => {
+    const STORAGE_KEY = 'openemr.mobile.baseUrl';
+    const DEFAULT_BASE = <?php echo json_encode($defaultBaseUrl); ?>;
+
+    const frame = document.getElementById('openemrFrame');
+    const settingsSheet = document.getElementById('settingsSheet');
+    const settingsBtn = document.getElementById('settingsBtn');
+    const baseUrlInput = document.getElementById('baseUrlInput');
+
+    function normalizeBaseUrl(url) {
+        if (!url) {
+            return DEFAULT_BASE;
+        }
+        return url.replace(/\/$/, '');
+    }
+
+    function getBaseUrl() {
+        return normalizeBaseUrl(localStorage.getItem(STORAGE_KEY) || DEFAULT_BASE);
+    }
+
+    function setBaseUrl(url) {
+        localStorage.setItem(STORAGE_KEY, normalizeBaseUrl(url));
+    }
+
+    function navigate(path) {
+        const base = getBaseUrl();
+        frame.src = base + path;
+    }
+
+    document.querySelectorAll('.tabbar button').forEach((button) => {
+        button.addEventListener('click', () => navigate(button.dataset.target));
+    });
+
+    settingsBtn.addEventListener('click', () => {
+        baseUrlInput.value = getBaseUrl();
+        settingsSheet.classList.remove('hidden');
+    });
+
+    document.getElementById('closeSettings').addEventListener('click', () => {
+        settingsSheet.classList.add('hidden');
+    });
+
+    document.getElementById('saveSettings').addEventListener('click', () => {
+        setBaseUrl(baseUrlInput.value);
+        settingsSheet.classList.add('hidden');
+        navigate('/interface/login/login.php');
+    });
+
+    navigate('/interface/login/login.php');
+
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('./sw.js').catch(() => {});
+    }
+})();
+</script>
+</body>
+</html>

--- a/interface/mobile/index.php
+++ b/interface/mobile/index.php
@@ -7,7 +7,9 @@
 
 require_once dirname(__FILE__, 2) . '/globals.php';
 
-$defaultBaseUrl = $GLOBALS['web_root'] ?? '/openemr';
+use OpenEMR\Core\OEGlobalsBag;
+
+$defaultBaseUrl = OEGlobalsBag::getInstance()->get('web_root') ?? '/openemr';
 ?>
 <!doctype html>
 <html lang="en">

--- a/interface/mobile/manifest.webmanifest
+++ b/interface/mobile/manifest.webmanifest
@@ -1,0 +1,10 @@
+{
+  "name": "OpenEMR Mobile",
+  "short_name": "OpenEMR",
+  "start_url": "./index.php",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0b57d0",
+  "description": "Mobile-first OpenEMR wrapper optimized for touch workflows.",
+  "icons": []
+}

--- a/interface/mobile/mobile.css
+++ b/interface/mobile/mobile.css
@@ -1,0 +1,156 @@
+:root {
+    --bg: #0f172a;
+    --surface: #ffffff;
+    --muted: #64748b;
+    --primary: #0b57d0;
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background: var(--bg);
+}
+
+.app {
+    height: 100dvh;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    background: var(--bg);
+}
+
+.app-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: #fff;
+    padding: calc(12px + var(--safe-top)) 16px 12px;
+    background: linear-gradient(180deg, #0b57d0 0%, #1d4ed8 100%);
+}
+
+.app-title {
+    font-weight: 600;
+    letter-spacing: 0.2px;
+}
+
+.icon-btn {
+    border: 0;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.15);
+    color: #fff;
+    min-width: 36px;
+    min-height: 36px;
+}
+
+.viewport {
+    min-height: 0;
+    background: var(--surface);
+}
+
+#openemrFrame {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background: #fff;
+}
+
+.tabbar {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 8px;
+    padding: 10px 10px calc(10px + var(--safe-bottom));
+    background: #fff;
+    border-top: 1px solid #e2e8f0;
+}
+
+.tabbar button {
+    border: 0;
+    border-radius: 10px;
+    padding: 10px 6px;
+    font-size: 12px;
+    color: #1e293b;
+    background: #f8fafc;
+}
+
+.tabbar button:active {
+    background: #e2e8f0;
+}
+
+.sheet {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.35);
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding: 12px;
+}
+
+.sheet.hidden {
+    display: none;
+}
+
+.sheet-card {
+    width: min(680px, 100%);
+    background: #fff;
+    border-radius: 16px;
+    padding: 16px;
+}
+
+.sheet-card h2 {
+    margin-top: 0;
+}
+
+.sheet-card label {
+    display: block;
+    margin-bottom: 8px;
+    color: #0f172a;
+    font-size: 14px;
+}
+
+.sheet-card input {
+    width: 100%;
+    border: 1px solid #cbd5e1;
+    border-radius: 10px;
+    padding: 10px 12px;
+}
+
+.row {
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.row button {
+    border: 0;
+    border-radius: 10px;
+    background: var(--primary);
+    color: #fff;
+    padding: 10px 14px;
+}
+
+.row .btn-secondary {
+    background: #334155;
+}
+
+.hint {
+    color: var(--muted);
+    font-size: 12px;
+}
+
+@media (min-width: 900px) {
+    .app {
+        max-width: 430px;
+        margin: 0 auto;
+        box-shadow: 0 0 0 12px #0b1220;
+    }
+}

--- a/interface/mobile/mobile.css
+++ b/interface/mobile/mobile.css
@@ -1,156 +1,156 @@
 :root {
-    --bg: #0f172a;
-    --surface: #ffffff;
-    --muted: #64748b;
-    --primary: #0b57d0;
-    --safe-top: env(safe-area-inset-top, 0px);
-    --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --bg: #0f172a;
+  --surface: #fff;
+  --muted: #64748b;
+  --primary: #0b57d0;
+  --safe-top: env(safe-area-inset-top, 0);
+  --safe-bottom: env(safe-area-inset-bottom, 0);
 }
 
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 html,
 body {
-    margin: 0;
-    padding: 0;
-    width: 100%;
-    height: 100%;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    background: var(--bg);
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  background: var(--bg);
 }
 
 .app {
-    height: 100dvh;
-    display: grid;
-    grid-template-rows: auto 1fr auto;
-    background: var(--bg);
+  height: 100dvh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  background: var(--bg);
 }
 
 .app-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    color: #fff;
-    padding: calc(12px + var(--safe-top)) 16px 12px;
-    background: linear-gradient(180deg, #0b57d0 0%, #1d4ed8 100%);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #fff;
+  padding: calc(12px + var(--safe-top)) 16px 12px;
+  background: linear-gradient(180deg, #0b57d0 0%, #1d4ed8 100%);
 }
 
 .app-title {
-    font-weight: 600;
-    letter-spacing: 0.2px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
 }
 
 .icon-btn {
-    border: 0;
-    border-radius: 10px;
-    background: rgba(255, 255, 255, 0.15);
-    color: #fff;
-    min-width: 36px;
-    min-height: 36px;
+  border: 0;
+  border-radius: 10px;
+  background: rgb(255 255 255 / 15%);
+  color: #fff;
+  min-width: 36px;
+  min-height: 36px;
 }
 
 .viewport {
-    min-height: 0;
-    background: var(--surface);
+  min-height: 0;
+  background: var(--surface);
 }
 
 #openemrFrame {
-    width: 100%;
-    height: 100%;
-    border: 0;
-    background: #fff;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #fff;
 }
 
 .tabbar {
-    display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-    gap: 8px;
-    padding: 10px 10px calc(10px + var(--safe-bottom));
-    background: #fff;
-    border-top: 1px solid #e2e8f0;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+  padding: 10px 10px calc(10px + var(--safe-bottom));
+  background: #fff;
+  border-top: 1px solid #e2e8f0;
 }
 
 .tabbar button {
-    border: 0;
-    border-radius: 10px;
-    padding: 10px 6px;
-    font-size: 12px;
-    color: #1e293b;
-    background: #f8fafc;
-}
-
-.tabbar button:active {
-    background: #e2e8f0;
+  border: 0;
+  border-radius: 10px;
+  padding: 10px 6px;
+  font-size: 12px;
+  color: #1e293b;
+  background: #f8fafc;
 }
 
 .sheet {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.35);
-    display: flex;
-    align-items: flex-end;
-    justify-content: center;
-    padding: 12px;
+  position: fixed;
+  inset: 0;
+  background: rgb(0 0 0 / 35%);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 12px;
 }
 
 .sheet.hidden {
-    display: none;
+  display: none;
 }
 
 .sheet-card {
-    width: min(680px, 100%);
-    background: #fff;
-    border-radius: 16px;
-    padding: 16px;
+  width: min(680px, 100%);
+  background: #fff;
+  border-radius: 16px;
+  padding: 16px;
 }
 
 .sheet-card h2 {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 .sheet-card label {
-    display: block;
-    margin-bottom: 8px;
-    color: #0f172a;
-    font-size: 14px;
+  display: block;
+  margin-bottom: 8px;
+  color: #0f172a;
+  font-size: 14px;
 }
 
 .sheet-card input {
-    width: 100%;
-    border: 1px solid #cbd5e1;
-    border-radius: 10px;
-    padding: 10px 12px;
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 10px 12px;
 }
 
 .row {
-    display: flex;
-    gap: 8px;
-    margin-top: 12px;
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
 }
 
 .row button {
-    border: 0;
-    border-radius: 10px;
-    background: var(--primary);
-    color: #fff;
-    padding: 10px 14px;
+  border: 0;
+  border-radius: 10px;
+  background: var(--primary);
+  color: #fff;
+  padding: 10px 14px;
 }
 
 .row .btn-secondary {
-    background: #334155;
+  background: #334155;
+}
+
+.tabbar button:active {
+  background: #e2e8f0;
 }
 
 .hint {
-    color: var(--muted);
-    font-size: 12px;
+  color: var(--muted);
+  font-size: 12px;
 }
 
-@media (min-width: 900px) {
-    .app {
-        max-width: 430px;
-        margin: 0 auto;
-        box-shadow: 0 0 0 12px #0b1220;
-    }
+@media (width >= 900px) {
+  .app {
+    max-width: 430px;
+    margin: 0 auto;
+    box-shadow: 0 0 0 12px #0b1220;
+  }
 }

--- a/interface/mobile/sw.js
+++ b/interface/mobile/sw.js
@@ -1,0 +1,25 @@
+const CACHE_NAME = 'openemr-mobile-shell-v1';
+const SHELL_ASSETS = [
+  './index.php',
+  './mobile.css',
+  './manifest.webmanifest'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(SHELL_ASSETS)));
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+  if (url.pathname.includes('/interface/mobile/')) {
+    event.respondWith(caches.match(event.request).then((cached) => cached || fetch(event.request)));
+  }
+});

--- a/interface/orders/types.php
+++ b/interface/orders/types.php
@@ -151,7 +151,7 @@ if ($popup && $_POST['form_save'] ?? '') {
     ?>
 
     <?php
-    // Create array of IDs to pre-select, leaf to top.
+    // Create array of IDs to preselect, leaf to top.
     echo "preopen = [";
     echo $order > 0 ? $order : 0;
     for ($parentid = $order; $parentid > 0;) {


### PR DESCRIPTION
## Summary
Introduces a mobile-first, app-like responsive shell for OpenEMR as a first step toward a native-feeling mobile interface.

## What this adds
- `interface/mobile/index.php` app shell with:
  - top app bar
  - fullscreen OpenEMR viewport (`iframe`)
  - bottom tab navigation for key workflows
  - settings sheet for configuring installation URL
- `interface/mobile/mobile.css`
  - touch-first layout, safe-area support, responsive behavior
- `interface/mobile/manifest.webmanifest`
  - PWA metadata
- `interface/mobile/sw.js`
  - shell asset caching for fast loads
- `interface/mobile/README.md`
  - rollout notes and next iteration roadmap

## Why
This keeps the full existing web functionality while providing a mobile UX baseline that feels closer to a native app and can be iterated quickly.

## Next loop items
1. Role-based tabs and dynamic routing by context
2. Mobile overrides for top-used screens
3. Native packaging via Capacitor
4. Deep links to patient, encounter, and scheduling flows
