### PR TITLE
fix(api): align allergy begdate validation with YYYY-MM-DD docs

### DIFF
--- a/src/Validators/AllergyIntoleranceValidator.php
+++ b/src/Validators/AllergyIntoleranceValidator.php
@@ -29,9 +29,9 @@ class AllergyIntoleranceValidator extends BaseValidator
             self::DATABASE_INSERT_CONTEXT,
             function (Validator $context): void {
                 $context->required('title')->lengthBetween(2, 255);
-                $context->optional('begdate')->datetime('Y-m-d H:i:s');
+                $context->optional('begdate')->datetime('Y-m-d');
                 $context->optional('diagnosis')->lengthBetween(2, 255);
-                $context->optional('enddate')->datetime('Y-m-d H:i:s');
+                $context->optional('enddate')->datetime('Y-m-d');
                 $context->optional('comments');
                 $context->required("puuid", "Patient UUID")->callback(
                     fn($value) => $this->validateId("uuid", "patient_data", $value, true)

--- a/tests/Tests/Isolated/Validators/AllergyIntoleranceValidatorTest.php
+++ b/tests/Tests/Isolated/Validators/AllergyIntoleranceValidatorTest.php
@@ -96,9 +96,9 @@ class AllergyIntoleranceValidatorTest extends TestCase
         $validData = [
             'title' => 'Penicillin Allergy',
             'puuid' => '123e4567-e89b-12d3-a456-426614174000',
-            'begdate' => '2023-01-01 10:00:00',
+            'begdate' => '2023-01-01',
             'diagnosis' => 'Drug allergy',
-            'enddate' => '2023-12-31 23:59:59',
+            'enddate' => '2023-12-31',
             'comments' => 'Patient reported mild rash'
         ];
 
@@ -112,7 +112,7 @@ class AllergyIntoleranceValidatorTest extends TestCase
         $invalidData = [
             'title' => 'Penicillin Allergy',
             'puuid' => '123e4567-e89b-12d3-a456-426614174000',
-            'begdate' => '2023-13-40 25:70:80' // invalid date format
+            'begdate' => '2023-13-40' // invalid date format
         ];
 
         $result = $this->validator->validate($invalidData, BaseValidator::DATABASE_INSERT_CONTEXT);


### PR DESCRIPTION
## Summary
Fixes REST allergy date validation to accept `YYYY-MM-DD` format for `begdate`/`enddate`, matching API documentation and examples.

Fixes #9199

## Changes
- `src/Validators/AllergyIntoleranceValidator.php`
  - changed `begdate` and `enddate` validation from `Y-m-d H:i:s` to `Y-m-d`
- `tests/Tests/Isolated/Validators/AllergyIntoleranceValidatorTest.php`
  - updated valid/invalid date test cases to date-only format

## Why
The API schema and examples use date-only values (e.g. `2010-10-13`), but validator required datetime with time, causing documented requests to fail.
