### PR TITLE
fix(docs): correct spelling errors caught by codespell

### DIFF
--- a/Documentation/api/SMART_ON_FHIR.md
+++ b/Documentation/api/SMART_ON_FHIR.md
@@ -343,7 +343,7 @@ const response = await fetch('https://localhost:9300/apis/default/fhir/Patient/1
 
 #### Characteristics
 - ✅ Launched from OpenEMR UI
-- ✅ Patient context pre-selected
+- ✅ Patient context preselected
 - ✅ Encounter context available (SMART v2.2.0)
 - ✅ User already authenticated
 - ✅ Faster workflow for clinicians
@@ -530,7 +530,7 @@ SMART apps can receive contextual information about the launch environment.
 #### When Available
 - ✅ EHR launch from patient chart
 - ✅ Patient standalone apps (patient is authorized user)
-- ❌ Standalone provider apps (no pre-selected patient)
+- ❌ Standalone provider apps (no preselected patient)
 
 #### Requesting Patient Context
 

--- a/interface/main/holidays/Holidays_Storage.php
+++ b/interface/main/holidays/Holidays_Storage.php
@@ -104,7 +104,7 @@ class Holidays_Storage
     }
 
     /**
-     * This function opend the $file(csv) and parses it to insert the values in the calendar_external so later they can be imported as events
+     * This function opened the $file(csv) and parses it to insert the values in the calendar_external so later they can be imported as events
      * csv format -> date,description
      * Example:
      * 2016/12/24,Christmas

--- a/interface/orders/types.php
+++ b/interface/orders/types.php
@@ -151,7 +151,7 @@ if ($popup && $_POST['form_save'] ?? '') {
     ?>
 
     <?php
-    // Create array of IDs to pre-select, leaf to top.
+    // Create array of IDs to preselect, leaf to top.
     echo "preopen = [";
     echo $order > 0 ? $order : 0;
     for ($parentid = $order; $parentid > 0;) {


### PR DESCRIPTION
## Summary
- Fixes 4 spelling errors detected by codespell CI check
- `pre-selected` → `preselected` (SMART_ON_FHIR.md, 2 occurrences)
- `opend` → `opened` (Holidays_Storage.php)
- `pre-select` → `preselect` (types.php)

## Test plan
- [x] CI codespell check should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)