### PR TITLE
feat(branding): make main menu logo link and title configurable (#10986)

### DIFF
--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -459,24 +459,19 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
     ?>
     <div id="mainBox" <?php echo $disp_mainBox ?>>
         <nav class="navbar navbar-expand-xl navbar-light bg-light py-0">
-            <?php if ($GLOBALS['display_main_menu_logo'] === '1') : ?>
-                <?php
+            <?php if ($GLOBALS['display_main_menu_logo'] === '1') {
                 $bag = OEGlobalsBag::getInstance();
-                $logoLinkRaw  = $bag->get('main_menu_logo_link');
-                $logoTitleRaw = $bag->get('main_menu_logo_title');
-                $logoLink  = trim(is_string($logoLinkRaw) ? $logoLinkRaw : '');
-                $logoTitle = trim(is_string($logoTitleRaw) ? $logoTitleRaw : '');
-                if ($logoTitle === '') {
-                    $logoTitle = xl('OpenEMR Website');
-                }
+                $logoLinkDefault = 'https://www.open-emr.org/';
+                $logoTitleDefault = xl('OpenEMR Website');
+                $logoLink = trim($bag->getString('main_menu_logo_link', $logoLinkDefault));
+                $logoTitle = trim($bag->getString('main_menu_logo_title', $logoTitleDefault));
                 $logoImg = '<img src="' . attr($menuLogo) . '" class="d-inline-block align-middle" height="16" alt="' . xla('Main Menu Logo') . '">';
                 if ($logoLink !== '') {
                     echo '<a class="navbar-brand" href="' . attr($logoLink) . '" title="' . attr($logoTitle) . '" rel="noopener" target="_blank">' . $logoImg . '</a>' . "\n";
                 } else {
                     echo '<span class="navbar-brand">' . $logoImg . '</span>' . "\n";
                 }
-                ?>
-            <?php endif; ?>
+            } ?>
             <button class="navbar-toggler mr-auto" type="button" data-toggle="collapse" data-target="#mainMenu" aria-controls="mainMenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -449,7 +449,7 @@ $GLOBALS_METADATA = [
         'main_menu_logo_link' => [
             xl('Main menu logo link URL'),
             'text',
-            'https://www.open-emr.org',
+            'https://www.open-emr.org/',
             xl('URL the main menu logo links to. Leave blank to make the logo non-clickable.'),
         ],
 

--- a/src/Core/OEGlobalsBag.php
+++ b/src/Core/OEGlobalsBag.php
@@ -44,6 +44,21 @@ use function array_key_exists;
         return parent::get($key, $default);
     }
 
+    /**
+     * Return the value for $key as a string.
+     *
+     * If the stored value is not a string (e.g. null or an array), $default
+     * is returned instead. This avoids the PHPStan "Cannot cast mixed to
+     * string" error that arises when using (string) on the result of get().
+     *
+     * @param string $default Fallback value when the stored value is not a string.
+     */
+    public function getString(string $key, string $default = ''): string
+    {
+        $value = $this->get($key, $default);
+        return is_string($value) ? $value : $default;
+    }
+
     public function has(string $key): bool
     {
         if (parent::has($key)) {


### PR DESCRIPTION
## Summary

Fixes #10986.

The main menu logo had a hardcoded `href="https://www.open-emr.org"` and `title`. This PR adds two new Branding globals so deployments can configure them via **Admin > Globals**:

- `main_menu_logo_link` — URL the logo links to (default: `https://www.open-emr.org`; blank = non-clickable span)
- `main_menu_logo_title` — tooltip text (default: `OpenEMR Website` via `xl()`)

## Changes

- `library/globals.inc.php`: two new text globals in the Branding section
- `interface/main/tabs/main.php`: reads globals; renders `<a>` when link is set, `<span>` when blank; all values escaped with `attr()`/`xl()`

## Backward compatibility

Default values preserve the existing behaviour exactly.