### PR TITLE
docs: document OEGlobalsBag typed getters from ParameterBag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,13 @@ npm run gulp-build   # Build only (no watch)
 - **Database:** Use `QueryUtils` for queries. New schema changes use Doctrine
   Migrations. Do not instantiate database connections directly — use the
   centralized `DatabaseConnectionFactory`.
+- **Global settings:** Use `OEGlobalsBag` (extends Symfony `ParameterBag`) instead
+  of `$GLOBALS`. Prefer typed getters over `get()` + cast:
+  - `getString($key)` instead of `(string) get($key)`
+  - `getInt($key)` instead of `(int) get($key)`
+  - `getBoolean($key)` instead of `(bool) get($key)`
+  - `getKernel()` for the Kernel instance
+  - Check the parent class for more: `getAlpha()`, `getAlnum()`, `getDigits()`, `getEnum()`
 
 ## Commit Messages
 

--- a/src/Core/OEGlobalsBag.php
+++ b/src/Core/OEGlobalsBag.php
@@ -17,7 +17,22 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 
 use function array_key_exists;
 
-/** @final */ class OEGlobalsBag extends ParameterBag
+/**
+ * Typed wrapper around $GLOBALS. Extends Symfony ParameterBag.
+ *
+ * Prefer typed getters over get() + cast:
+ *
+ * @see ParameterBag::getString()   getString(string $key, string $default = ''): string
+ * @see ParameterBag::getInt()      getInt(string $key, int $default = 0): int
+ * @see ParameterBag::getBoolean()  getBoolean(string $key, bool $default = false): bool
+ * @see ParameterBag::getAlpha()    getAlpha(string $key, string $default = ''): string — letters only
+ * @see ParameterBag::getAlnum()    getAlnum(string $key, string $default = ''): string — alphanumeric only
+ * @see ParameterBag::getDigits()   getDigits(string $key, string $default = ''): string — digits only
+ * @see ParameterBag::getEnum()     getEnum(string $key, string $class, ?BackedEnum $default = null): ?BackedEnum
+ *
+ * @final — not enforced at runtime because tests mock this class
+ */
+class OEGlobalsBag extends ParameterBag
 {
     use SingletonTrait;
 


### PR DESCRIPTION
## Summary

- Add `@see` annotations to `OEGlobalsBag` listing typed getters inherited from
  Symfony `ParameterBag` (`getString`, `getInt`, `getBoolean`, etc.)
- Add coding standards note to `CLAUDE.md` to prefer typed getters over `get()` + cast
- Annotate why `@final` can't be a native `final` keyword (tests mock this class)

closes: #11009

## Test plan

- [x] PHPStan passes
- [x] No runtime impact (documentation-only changes to `OEGlobalsBag`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)