### PR TITLE
test(csrf): add CSRF token round-trip tests with Symfony session

### DIFF
--- a/tests/Tests/Isolated/Common/Csrf/CsrfUtilsTest.php
+++ b/tests/Tests/Isolated/Common/Csrf/CsrfUtilsTest.php
@@ -16,6 +16,7 @@ namespace OpenEMR\Tests\Isolated\Common\Csrf;
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class CsrfUtilsTest extends TestCase
 {
@@ -23,5 +24,81 @@ class CsrfUtilsTest extends TestCase
     {
         CsrfUtils::csrfViolation(toScreen: false, toLog: false);
         $this->assertSame(403, http_response_code());
+    }
+
+    public function testRoundTrip(): void
+    {
+        $session = $this->createSessionStub();
+        CsrfUtils::setupCsrfKey($session);
+        $token = CsrfUtils::collectCsrfToken('default', $session);
+
+        $this->assertIsString($token);
+        $this->assertTrue(CsrfUtils::verifyCsrfToken($token, 'default', $session));
+    }
+
+    public function testWrongTokenRejected(): void
+    {
+        $session = $this->createSessionStub();
+        CsrfUtils::setupCsrfKey($session);
+
+        $this->assertFalse(CsrfUtils::verifyCsrfToken('bad-token', 'default', $session));
+    }
+
+    public function testDifferentSubjectsProduceDifferentTokens(): void
+    {
+        $session = $this->createSessionStub();
+        CsrfUtils::setupCsrfKey($session);
+
+        $default = CsrfUtils::collectCsrfToken('default', $session);
+        $api = CsrfUtils::collectCsrfToken('api', $session);
+
+        $this->assertIsString($default);
+        $this->assertIsString($api);
+        $this->assertNotSame($default, $api);
+    }
+
+    public function testCollectCsrfTokenReturnsFalseWithoutKey(): void
+    {
+        $session = $this->createSessionStub();
+
+        $this->assertFalse(CsrfUtils::collectCsrfToken('default', $session));
+    }
+
+    public function testTokenStability(): void
+    {
+        $session = $this->createSessionStub();
+        CsrfUtils::setupCsrfKey($session);
+
+        $first = CsrfUtils::collectCsrfToken('default', $session);
+        $second = CsrfUtils::collectCsrfToken('default', $session);
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testVerifyWithCorrectSubject(): void
+    {
+        $session = $this->createSessionStub();
+        CsrfUtils::setupCsrfKey($session);
+
+        $apiToken = CsrfUtils::collectCsrfToken('api', $session);
+
+        $this->assertIsString($apiToken);
+        $this->assertTrue(CsrfUtils::verifyCsrfToken($apiToken, 'api', $session));
+        $this->assertFalse(CsrfUtils::verifyCsrfToken($apiToken, 'default', $session));
+    }
+
+    private function createSessionStub(): SessionInterface
+    {
+        $store = [];
+        $session = $this->createStub(SessionInterface::class);
+        $session->method('set')
+            ->willReturnCallback(function (string $key, mixed $value) use (&$store): void {
+                $store[$key] = $value;
+            });
+        $session->method('get')
+            ->willReturnCallback(function (string $key, mixed $default = null) use (&$store): mixed {
+                return $store[$key] ?? $default;
+            });
+        return $session;
     }
 }


### PR DESCRIPTION
## Summary

- Add 6 isolated tests verifying the full CSRF token lifecycle through `SessionInterface`
- Cover round-trip, wrong token rejection, subject isolation, missing key, and token stability
- Use a `SessionInterface` stub backed by an in-memory array (no Docker/database needed)

Closes #11027

## Test plan

- [x] `composer phpunit-isolated -- --filter CsrfUtilsTest` passes (7 tests, 12 assertions)
- [x] PHPStan level 10: no errors
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)