### PR TITLE
chore(deps): bump immutable 4.3.7 → 4.3.8 in ccdaservice

### DIFF
--- a/ccdaservice/package-lock.json
+++ b/ccdaservice/package-lock.json
@@ -2000,7 +2000,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/immutable": {
-            "version": "4.3.7",
+            "version": "4.3.8",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+            "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
             "license": "MIT"
         },
         "node_modules/imurmurhash": {


### PR DESCRIPTION
## Summary

- Bump `immutable` from 4.3.7 to 4.3.8 in `ccdaservice/package-lock.json`
- Fixes prototype pollution vulnerability ([GHSA-wf6x-7x77-mvgw](https://github.com/advisories/GHSA-wf6x-7x77-mvgw))
- Dependabot couldn't resolve this automatically ("lockfile might be out of sync")
- Targeted `npm update immutable` — minimal 4-line diff, no other deps changed

## Test plan

- [ ] Verify ccdaservice still builds and runs correctly
- [ ] Confirm Dependabot alert #326 resolves after merge