### PR TITLE
fix(ci): backport PHPStan baseline upload path to rel-800

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -71,12 +71,14 @@ jobs:
       if: steps.phpstan-analyze.outcome == 'failure'
       run: composer run phpstan-baseline
       continue-on-error: true
+    # Upload the resulting baseline as an artifact. This is intended mostly for
+    # debugging and isn't actively used by GH workflows.
     - name: Upload PHPStan Baseline
       if: steps.phpstan-analyze.outcome == 'failure'
       uses: actions/upload-artifact@v6
       with:
         name: phpstan-baseline-php${{ matrix.php-version }}
-        path: .phpstan/phpstan-*-baseline.neon
+        path: .phpstan/baseline/*.php
       continue-on-error: true
     - name: Check PHPStan Results
       if: steps.phpstan-analyze.outcome == 'failure'


### PR DESCRIPTION
## Summary

- Cherry-pick of #10242 (46ae8dee67) to `rel-800`
- The upload-artifact step was looking for `.phpstan/phpstan-*-baseline.neon` but the baseline generator produces `.phpstan/baseline/*.php` files, so no artifacts were uploaded on failure

## Test plan

- [ ] Verify PHPStan workflow uploads baseline artifact when analysis fails on a `rel-800` PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)