### PR TITLE
refactor(db): Move dbal connection into factory

### DIFF
--- a/.phpstan/baseline/staticMethod.deprecatedClass.php
+++ b/.phpstan/baseline/staticMethod.deprecatedClass.php
@@ -32,6 +32,12 @@ New code should use existing DB tooling and not directly create new connections\
     'path' => __DIR__ . '/../../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQLi.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Call to method createDbal\\(\\) of deprecated class OpenEMR\\\\BC\\\\DatabaseConnectionFactory\\:
+New code should use existing DB tooling and not directly create new connections\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../src/BC/Database.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Call to method file\\(\\) of deprecated class Lcobucci\\\\JWT\\\\Signer\\\\Key\\\\LocalFileReference\\:
 please use \\{@see InMemory\\} instead$#',
     'count' => 2,

--- a/src/BC/Database.php
+++ b/src/BC/Database.php
@@ -14,7 +14,6 @@ namespace OpenEMR\BC;
 
 use Doctrine\DBAL\{
     Connection,
-    DriverManager,
     Exception as DBALException,
     Exception\DriverException,
     Result,
@@ -57,7 +56,7 @@ class Database
     {
         if (self::$instance === null) {
             $options = self::readLegacyConfig();
-            $connection = DriverManager::getConnection($options->toDbalParams());
+            $connection = DatabaseConnectionFactory::createDbal($options, false);
             // Legacy: disable strict SQL mode for backwards compatibility
             // When this becomes generalized to future code, this should NOT
             // run (or it should explicitly set full strict)

--- a/src/BC/DatabaseConnectionFactory.php
+++ b/src/BC/DatabaseConnectionFactory.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace OpenEMR\BC;
 
 use ADODB_mysqli_log;
+use Doctrine\DBAL\{
+    Connection,
+    DriverManager,
+};
 use mysqli;
 use OpenEMR\Common\Session\SessionWrapperInterface;
 use OpenEMR\Core\OEGlobalsBag;
@@ -66,6 +70,17 @@ class DatabaseConnectionFactory
         // Other paths may end up customizing this further.
 
         return $conn;
+    }
+
+    public static function createDbal(
+        DatabaseConnectionOptions $config,
+        bool $persistent,
+    ): Connection {
+        $params = $config->toDbalParams();
+        if ($persistent) {
+            $params['persistent'] = true;
+        }
+        return DriverManager::getConnection($params);
     }
 
     /**


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes an inconsistency in the DB connection setup code for the new layers; this will also ease an upcoming change relating to the query auditing layer.

#### Changes proposed in this pull request:
- DatabaseConnectionFactory exposes new `createDbal` method
- Database now uses that method

#### Does your code include anything generated by an AI Engine? Yes / No

No