### PR TITLE
fix(security): prevent XSS in clickmap annotation legend

### DIFF
--- a/library/js/clickmap.js
+++ b/library/js/clickmap.js
@@ -4,7 +4,14 @@ var clickmap = function(args) {
 	let counter = 0;
 
 	const fn_buildMarker = function(x, y, pos, annotation) {
-        const legendItem = $("<li class='legend-item'><b>" + pos + "</b> " + decodeURIComponent(annotation) + "</li>");
+        // Build legend item safely using DOM methods to prevent XSS
+        const legendItem = $("<li class='legend-item'></li>");
+        const decodedAnnotation = annotation ? decodeURIComponent(annotation) : "";
+        legendItem.append(
+            $("<b></b>").text(pos),
+            " ",
+            document.createTextNode(decodedAnnotation)
+        );
         $(".legend .body ul").append(legendItem);
 
         const marker = $(".marker-template").clone();


### PR DESCRIPTION
## Summary

Forward-port of the security fix from the 8.0.0.1 patch to `master`.

- Escape annotation text before inserting into the clickmap legend to prevent stored XSS

Ref: GHSA-55qj-x8wh-m4rm / [CVE-2026-32118](https://nvd.nist.gov/vuln/detail/CVE-2026-32118)

## Test plan

- [ ] Verify clickmap annotations with special characters render correctly
- [ ] Confirm XSS payloads in annotation text are escaped in the legend