### PR TITLE
fix(security): prevent XSS in portal signer modal

### DIFF
--- a/portal/sign/assets/signer_api.js
+++ b/portal/sign/assets/signer_api.js
@@ -2,7 +2,9 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2016-2022 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -276,7 +278,10 @@ function initSignerApi() {
         let signerName = e.data.signerName || '';
 
         $('#openSignModal #name').val(signerName);
-        $('#openSignModal #labelName').html("&nbsp;" + msgSignator + ":&nbsp;<b>" + signerName + "</b>");
+        // Use safe DOM methods to prevent XSS - signerName may contain untrusted user input
+        $('#openSignModal #labelName').empty()
+            .append(document.createTextNode("\u00a0" + msgSignator + ":\u00a0"))
+            .append($("<b>").text(signerName));
         $('#openSignModal #pid').val(cpid);
         $('#openSignModal #user').val(cuser);
         $('#openSignModal #signatureModal').data('type', type);


### PR DESCRIPTION
## Summary

Forward-port of the security fix from the 8.0.0.1 patch to `master`.

- Replace unsafe `.html()` call with safe DOM methods in portal signer modal to prevent stored DOM XSS

Ref: GHSA-68fr-xm3v-p4vw / [CVE-2026-32121](https://nvd.nist.gov/vuln/detail/CVE-2026-32121)

## Test plan

- [ ] Verify portal signer modal still renders correctly
- [ ] Confirm XSS payloads in signer data are not executed