### PR TITLE
fix(security): add ACL check to claim file tracker endpoint

### DIFF
--- a/library/ajax/billing_tracker_ajax.php
+++ b/library/ajax/billing_tracker_ajax.php
@@ -7,18 +7,28 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Ken Chapple <ken@mi-squared.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2021 Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 require_once __DIR__ . "/../../interface/globals.php";
 
 use OpenEMR\Billing\BillingProcessor\X12RemoteTracker;
+use OpenEMR\Common\Acl\AccessDeniedHelper;
+use OpenEMR\Common\Acl\AccessDeniedResponseFormat;
+use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 
 // verify csrf
 if (!CsrfUtils::verifyCsrfToken($_GET["csrf_token_form"])) {
     CsrfUtils::csrfNotVerified();
+}
+
+// Match the same ACL check as the parent UI (billing_tracker.php)
+if (!AclMain::aclCheckCore('acct', 'eob', '', 'write') && !AclMain::aclCheckCore('acct', 'bill', '', 'write')) {
+    AccessDeniedHelper::deny('Claim file tracker access denied', format: AccessDeniedResponseFormat::Json);
 }
 
 $remoteTracker = new X12RemoteTracker();


### PR DESCRIPTION
## Summary

Forward-port of the security fix from the 8.0.0.1 patch to `master`.

- Add authorization check to the claim file tracker AJAX endpoint to prevent unauthorized access

Ref: GHSA-rwf9-px3c-3prw / [CVE-2026-32122](https://nvd.nist.gov/vuln/detail/CVE-2026-32122)

## Test plan

- [ ] Verify authorized users can still access the claim file tracker
- [ ] Confirm unauthorized users receive an access denied response