### PR TITLE
fix(security): remove user input from SQL alias in graphs

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -12372,11 +12372,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/ajax/graphs.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'SELECT ld\\.field…\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ajax/graphs.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 5,
     'path' => __DIR__ . '/../../library/ajax/graphs.php',

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -3892,11 +3892,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/ajax/facility_ajax_code.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$name_alt \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../library/ajax/graphs.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$srcdir \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/ajax/messages/validate_messages_document_ajax.php',

--- a/.phpstan/baseline/offsetAccess.invalidOffset.php
+++ b/.phpstan/baseline/offsetAccess.invalidOffset.php
@@ -623,7 +623,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 4,
+    'count' => 8,
     'path' => __DIR__ . '/../../library/ajax/graphs.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -15288,7 +15288,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Variable \\$name_alt might not be defined\\.$#',
-    'count' => 6,
+    'count' => 3,
     'path' => __DIR__ . '/../../library/ajax/graphs.php',
 ];
 $ignoreErrors[] = [

--- a/library/ajax/graphs.php
+++ b/library/ajax/graphs.php
@@ -71,9 +71,11 @@ function graphsGetValues($name)
     global $is_lbf, $pid, $table;
     if ($is_lbf) {
         // Like below, but for LBF data.
+        // Use a fixed alias to keep user input out of the SQL structure.
+        // The result column is read via graphsGetValueKey().
         $values = sqlStatement(
             "SELECT " .
-            "ld.field_value AS " . add_escape_custom($name) . ", " .
+            "ld.field_value, " .
             // If data was entered retroactively then cannot use the data entry date.
             "IF (LEFT(f.date, 10) = LEFT(fe.date, 10), f.date, fe.date) AS date " .
             "FROM forms AS f, form_encounter AS fe, lbf_data AS ld WHERE " .
@@ -222,18 +224,19 @@ if ($is_lbf) {
 
 // Prepare data
 $data = [];
+$valueKey = $is_lbf ? 'field_value' : $name;
 while ($row = sqlFetchArray($values)) {
-    if ($row["$name"]) {
+    if ($row[$valueKey]) {
         $x = $row['date'];
         if ($multiplier ?? null) {
             // apply unit conversion multiplier
-            $y = $row["$name"] * $multiplier;
+            $y = $row[$valueKey] * $multiplier;
         } elseif ($isConvertFtoC ?? null) {
             // apply temp F to C conversion
-            $y = convertFtoC($row["$name"]);
+            $y = convertFtoC($row[$valueKey]);
         } else {
            // no conversion, so use raw value
-            $y = $row["$name"];
+            $y = $row[$valueKey];
         }
 
         $data[$x][$name] = $y;
@@ -242,18 +245,19 @@ while ($row = sqlFetchArray($values)) {
 
 if ($isBP) {
   //set up the other blood pressure line
+    $valueKeyAlt = $is_lbf ? 'field_value' : $name_alt;
     while ($row = sqlFetchArray($values_alt)) {
-        if ($row["$name_alt"]) {
+        if ($row[$valueKeyAlt]) {
             $x = $row['date'];
             if ($multiplier ?? null) {
                 // apply unit conversion multiplier
-                $y = $row["$name_alt"] * $multiplier;
+                $y = $row[$valueKeyAlt] * $multiplier;
             } elseif ($isConvertFtoC ?? null) {
                 // apply temp F to C conversion
-                $y = convertFtoC($row["$name_alt"]);
+                $y = convertFtoC($row[$valueKeyAlt]);
             } else {
                // no conversion, so use raw value
-                $y = $row["$name_alt"];
+                $y = $row[$valueKeyAlt];
             }
 
             $data[$x][$name_alt] = $y;


### PR DESCRIPTION
## Summary

Forward-port of the security fix from the 8.0.0.1 patch to `master`.

- Remove user-controlled input from SQL alias in the ajax graphs library to prevent SQL injection

Ref: GHSA-v8q6-h79f-736x / [CVE-2026-32127](https://nvd.nist.gov/vuln/detail/CVE-2026-32127)

## Test plan

- [ ] Verify graphs still render correctly with valid input
- [ ] Confirm SQL injection payloads in graph parameters are neutralized