### PR TITLE
fix(security): escape Track Anything graph titles and labels

### DIFF
--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -1933,7 +1933,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 5,
+    'count' => 7,
     'path' => __DIR__ . '/../../library/ajax/graph_track_anything.php',
 ];
 $ignoreErrors[] = [

--- a/library/ajax/graph_track_anything.php
+++ b/library/ajax/graph_track_anything.php
@@ -3,15 +3,17 @@
 /**
  * Trending script for graphing objects in track anything module.
  *
- * @package OpenEMR
- * @link    https://www.open-emr.org
- * @author  Brady Miller <brady.g.miller@gmail.com>
- * @author  Rod Roark <rod@sunsetsystems.com>
- * @author  Joe Slam <joe@produnis.de>
- * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Rod Roark <rod@sunsetsystems.com>
+ * @author    Joe Slam <joe@produnis.de>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  * @copyright Copyright (c) 2010-2018 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2011 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2014 Joe Slam <joe@produnis.de>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  */
 
 require_once(__DIR__ . "/../../interface/globals.php");
@@ -29,6 +31,12 @@ $the_value_array  = json_decode((string) $_POST['values'], true);
 $the_item_names   = json_decode((string) $_POST['items'], true);
 $the_checked_cols = json_decode((string) $_POST['thecheckboxes'], true);
 // ++++++/end get POSTed data
+
+// Escape title and item names to prevent XSS - Dygraph renders these via innerHTML
+$titleGraph = attr((string) $titleGraph);
+if (is_array($the_item_names)) {
+    $the_item_names = array_map(fn($name) => attr((string) $name), $the_item_names);
+}
 
 // check if something was sent
 // and quit if not


### PR DESCRIPTION
## Summary

Forward-port of the security fix from the 8.0.0.1 patch to `master`.

- Escape graph title and item names in Track Anything to prevent stored XSS via Dygraph rendering

Ref: GHSA-244w-vxhp-7x99 / [CVE-2026-32125](https://nvd.nist.gov/vuln/detail/CVE-2026-32125)

## Test plan

- [ ] Verify Track Anything graphs render correctly with special characters
- [ ] Confirm XSS payloads in graph titles/labels are escaped