### PR TITLE
fix(security): escape code descriptions in dynamic code picker

### DIFF
--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -1368,7 +1368,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 9,
+    'count' => 13,
     'path' => __DIR__ . '/../../interface/patient_file/encounter/find_code_dynamic_ajax.php',
 ];
 $ignoreErrors[] = [

--- a/interface/patient_file/encounter/find_code_dynamic_ajax.php
+++ b/interface/patient_file/encounter/find_code_dynamic_ajax.php
@@ -9,9 +9,11 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2015-2017 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2017-2025 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -298,7 +300,8 @@ if ($what == 'fields' && $source == 'V') {
     foreach ($fe_array as $feitem) {
         $arow = ['DT_RowId' => genFieldIdString($feitem)];
         $arow[] = $feitem['field_id'];
-        $arow[] = $feitem['title'];
+        // Escape title to prevent XSS - DataTables renders cells via innerHTML
+        $arow[] = attr((string) $feitem['title']);
         $out['aaData'][] = $arow;
     }
 } elseif ($what == 'codes') {
@@ -349,7 +352,8 @@ if ($what == 'fields' && $source == 'V') {
                 'modifier' => $row['modifier'],
             ])];
             $arow[] = str_replace('|', ':', rtrim((string) $row['code'], '|'));
-            $arow[] = $row['code_text'];
+            // Escape code_text to prevent XSS - DataTables renders cells via innerHTML
+            $arow[] = attr((string) $row['code_text']);
             $arow[] = $row['modifier'];
             $out['aaData'][] = $arow;
             $count += 1;
@@ -368,10 +372,12 @@ if ($what == 'fields' && $source == 'V') {
         $arow = ['DT_RowId' => genFieldIdString($row)];
         if ($what == 'fields') {
             $arow[] = $row['field_id'];
-            $arow[] = $row['title'];
+            // Escape title to prevent XSS - DataTables renders cells via innerHTML
+            $arow[] = attr((string) $row['title']);
         } else {
             $arow[] = str_replace('|', ':', rtrim((string) $row['code'], '|'));
-            $arow[] = $row['description'] ?? "";
+            // Escape description to prevent XSS - DataTables renders cells via innerHTML
+            $arow[] = attr((string) ($row['description'] ?? ''));
             $arow[] = $row['modifier'] ?? "";
         }
         $out['aaData'][] = $arow;


### PR DESCRIPTION
## Summary

Forward-port of the security fix from the 8.0.0.1 patch to `master`.

- Escape code descriptions in the dynamic code picker to prevent stored XSS

Ref: GHSA-9hw7-22mr-qhfc / [CVE-2026-32124](https://nvd.nist.gov/vuln/detail/CVE-2026-32124)

## Test plan

- [ ] Verify code picker still renders descriptions correctly
- [ ] Confirm XSS payloads in code descriptions are escaped