### PR TITLE
fix(security): check sensitivity from correct table for group encounters

### DIFF
--- a/.phpstan/baseline/identical.alwaysTrue.php
+++ b/.phpstan/baseline/identical.alwaysTrue.php
@@ -17,6 +17,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Immunization/src/Immunization/Controller/ImmunizationController.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Strict comparison using \\=\\=\\= between \'pid\' and \'pid\' will always evaluate to true\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/patient_file/encounter/forms.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Strict comparison using \\=\\=\\= between \'\' and \'\' will always evaluate to true\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../library/clinical_rules.php',

--- a/.phpstan/baseline/nullCoalesce.variable.php
+++ b/.phpstan/baseline/nullCoalesce.variable.php
@@ -497,6 +497,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/orders/procedure_provider_edit.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Variable \\$attendant_type on left side of \\?\\? is never defined\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/patient_file/encounter/forms.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Variable \\$pid on left side of \\?\\? always exists and is not nullable\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/patient_file/encounter/forms.php',

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -3018,7 +3018,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
-    'count' => 5,
+    'count' => 6,
     'path' => __DIR__ . '/../../interface/patient_file/encounter/forms.php',
 ];
 $ignoreErrors[] = [

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -557,8 +557,10 @@ if (OEGlobalsBag::getInstance()->getBoolean('google_signin_enabled') && !empty(O
         $menuArray = $menuEvent->getMenuData();
         $reg = getFormsByCategory();
         // Check sensitivity from the appropriate table based on encounter type
-        $sensitivityTable = ($attendant_type ?? 'pid') === 'pid' ? 'form_encounter' : 'form_groups_encounter';
-        $sensitivity = sqlQuery("SELECT sensitivity FROM " . escape_table_name($sensitivityTable) . " WHERE encounter = ?", [OEGlobalsBag::getInstance()->get("encounter") ?? null])['sensitivity'] ?? null;
+        $sensitivityQuery = ($attendant_type ?? 'pid') === 'pid'
+            ? "SELECT sensitivity FROM form_encounter WHERE encounter = ?"
+            : "SELECT sensitivity FROM form_groups_encounter WHERE encounter = ?";
+        $sensitivity = sqlQuery($sensitivityQuery, [OEGlobalsBag::getInstance()->get("encounter") ?? null])['sensitivity'] ?? null;
         $pass_sens = true;
         if (($sensitivity && !AclMain::aclCheckCore('sensitivities', $sensitivity))) {
             $pass_sens = false;

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -7,8 +7,10 @@
 * @link      https://www.open-emr.org
 * @author    Brady Miller <brady.g.miller@gmail.com>
 * @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Michael A. Smith <michael@opencoreemr.com>
 * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
 * @copyright Copyright (c) 2018-2021 Jerry Padgett <sjpadgett@gmail.com>
+* @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
 * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
 */
 
@@ -554,7 +556,9 @@ if (OEGlobalsBag::getInstance()->getBoolean('google_signin_enabled') && !empty(O
     $eventDispatcher->addListener(EncounterMenuEvent::MENU_RENDER, function (EncounterMenuEvent $menuEvent) {
         $menuArray = $menuEvent->getMenuData();
         $reg = getFormsByCategory();
-        $sensitivity = sqlQuery("SELECT sensitivity FROM form_encounter WHERE encounter = ?", [OEGlobalsBag::getInstance()->get("encounter") ?? null])['sensitivity'] ?? null;
+        // Check sensitivity from the appropriate table based on encounter type
+        $sensitivityTable = ($attendant_type ?? 'pid') === 'pid' ? 'form_encounter' : 'form_groups_encounter';
+        $sensitivity = sqlQuery("SELECT sensitivity FROM " . escape_table_name($sensitivityTable) . " WHERE encounter = ?", [OEGlobalsBag::getInstance()->get("encounter") ?? null])['sensitivity'] ?? null;
         $pass_sens = true;
         if (($sensitivity && !AclMain::aclCheckCore('sensitivities', $sensitivity))) {
             $pass_sens = false;
@@ -681,7 +685,13 @@ if (OEGlobalsBag::getInstance()->getBoolean('google_signin_enabled') && !empty(O
                     }
 
                     // Check for no access to the encounter's sensitivity level.
-                    $sensitivity = (new EncounterService())->getSensitivity($pid, $encounter);
+                    // Use appropriate table based on whether this is a patient or group encounter
+                    if ($attendant_type === 'pid') {
+                        $sensitivity = (new EncounterService())->getSensitivity($pid, $encounter);
+                    } else {
+                        $sensitivityResult = sqlQuery("SELECT sensitivity FROM form_groups_encounter WHERE encounter = ?", [$encounter]);
+                        $sensitivity = $sensitivityResult['sensitivity'] ?? null;
+                    }
                     if (($sensitivity && !AclMain::aclCheckCore('sensitivities', $sensitivity)) || (!$authPostCalendarCategory ?? '')) {
                         $pass_sens_squad = false;
                     }


### PR DESCRIPTION
## Summary

Forward-port of the security fix from the 8.0.0.1 patch to `master`.

- Check sensitivity from the appropriate table (`form_encounter` vs `form_groups_encounter`) based on encounter type, so therapy group sensitivity ACL is properly enforced

Ref: GHSA-j4mm-wg7q-v57q / [CVE-2026-32123](https://nvd.nist.gov/vuln/detail/CVE-2026-32123)

## Test plan

- [ ] Verify individual encounter forms still respect sensitivity ACL
- [ ] Confirm group encounter forms check `form_groups_encounter` for sensitivity