### PR TITLE
refactor(logging): Remove remaining dependence on errorLogCaller

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -5993,7 +5993,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'Failed to add \' and mixed results in an error\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-ehi-exporter/src/Services/EhiExporter.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -2572,7 +2572,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceDocumentRequestor.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
+    'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 5,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceDocumentRequestor.php',
 ];
@@ -5937,38 +5937,28 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Grant/CustomAuthCodeGrant.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 4,
+    'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
+    'count' => 9,
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Grant/CustomAuthCodeGrant.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method debug\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
+    'count' => 3,
+    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrant.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
+    'count' => 7,
+    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrant.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method debug\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
+    'count' => 7,
+    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 5,
-    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Grant/CustomAuthCodeGrant.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method debug\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrant.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 7,
-    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrant.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method debug\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 7,
-    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 3,
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php',
 ];
 $ignoreErrors[] = [
@@ -6037,7 +6027,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
+    'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Repositories/UserRepository.php',
 ];
@@ -6137,7 +6127,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Database/QueryUtils.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#',
+    'message' => '#^Cannot call method error\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Forms/FormReportRenderer.php',
 ];
@@ -6297,7 +6287,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Session/Predis/SentinelUtil.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#',
+    'message' => '#^Cannot call method error\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#',
     'count' => 11,
     'path' => __DIR__ . '/../../src/Common/Session/Predis/SentinelUtil.php',
 ];
@@ -6667,13 +6657,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/Authorization/BearerTokenAuthorizationStrategy.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/Authorization/BearerTokenAuthorizationStrategy.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 13,
+    'count' => 14,
     'path' => __DIR__ . '/../../src/RestControllers/Authorization/BearerTokenAuthorizationStrategy.php',
 ];
 $ignoreErrors[] = [
@@ -6702,13 +6687,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 16,
+    'count' => 20,
     'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
 ];
 $ignoreErrors[] = [
@@ -7797,7 +7777,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/Cda/CdaTextParser.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
+    'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/Cda/CdaValidateDocuments.php',
 ];
@@ -7867,11 +7847,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/EncounterService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Condition/FhirConditionEncounterDiagnosisService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getAll\\(\\) on mixed\\.$#',
     'count' => 8,
     'path' => __DIR__ . '/../../src/Services/FHIR/Condition/FhirConditionEncounterDiagnosisService.php',
@@ -7895,11 +7870,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot call method supportsCategory\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Condition/FhirConditionEncounterDiagnosisService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Condition/FhirConditionHealthConcernService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method getAll\\(\\) on mixed\\.$#',
@@ -7927,11 +7897,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/Condition/FhirConditionHealthConcernService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Condition/FhirConditionProblemListItemService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getAll\\(\\) on mixed\\.$#',
     'count' => 8,
     'path' => __DIR__ . '/../../src/Services/FHIR/Condition/FhirConditionProblemListItemService.php',
@@ -7955,16 +7920,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot call method supportsCategory\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Condition/FhirConditionProblemListItemService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportClinicalNotesService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method getCode\\(\\) on mixed\\.$#',
@@ -7992,36 +7947,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/Document/BaseDocumentDownloader.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/DocumentReference/FhirDocumentReferenceAdvanceCareDirectiveService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/DocumentReference/FhirPatientDocumentReferenceService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirAllergyIntoleranceService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirCarePlanService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirCareTeamService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getCodeWithType\\(\\) on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirCareTeamService.php',
@@ -8035,11 +7960,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot call method parseCode\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirCareTeamService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirConditionService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method getAll\\(\\) on mixed\\.$#',
@@ -8080,21 +8000,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot call method supportsCode\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirConditionService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirCoverageService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirDeviceService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirDiagnosticReportService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method getAll\\(\\) on mixed\\.$#',
@@ -8162,11 +8067,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirDocRefService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirDocumentReferenceService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getAll\\(\\) on mixed\\.$#',
     'count' => 9,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirDocumentReferenceService.php',
@@ -8207,11 +8107,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirDocumentReferenceService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirEncounterService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method debug\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirExportJobService.php',
@@ -8220,11 +8115,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot call method error\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirExportJobService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirGoalService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method getAll\\(\\) on mixed\\.$#',
@@ -8242,16 +8132,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirGroupService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirImmunizationService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirLocationService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method get\\(\\) on Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\|null\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirLocationService.php',
@@ -8260,11 +8140,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot call method setModifier\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirMediaService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirMedicationDispenseService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method getAll\\(\\) on mixed\\.$#',
@@ -8302,23 +8177,13 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirMedicationDispenseService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirMedicationRequestService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
+    'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirMedicationService.php',
+    'path' => __DIR__ . '/../../src/Services/FHIR/FhirMedicationRequestService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method debug\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirObservationService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirObservationService.php',
 ];
 $ignoreErrors[] = [
@@ -8362,11 +8227,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirObservationService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirOrganizationService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirOrganizationService.php',
@@ -8392,11 +8252,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirOrganizationService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirPatientService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirPatientService.php',
@@ -8417,21 +8272,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirPatientService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirPractitionerRoleService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirPractitionerService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirProcedureService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getAll\\(\\) on mixed\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirProcedureService.php',
@@ -8447,17 +8287,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirProcedureService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirProvenanceService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method addProcessingResult\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirQuestionnaireResponseService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirQuestionnaireResponseService.php',
 ];
@@ -8522,11 +8352,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirQuestionnaireService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/FhirRelatedPersonService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method addData\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirServiceBase.php',
@@ -8577,11 +8402,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/Group/FhirPatientProviderGroupService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/MedicationDispense/FhirMedicationDispenseLocalDispensaryService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/MedicationDispense/FhirMedicationDispenseLocalDispensaryService.php',
@@ -8607,11 +8427,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationAdvanceDirectiveService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationAdvanceDirectiveService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationAdvanceDirectiveService.php',
@@ -8622,11 +8437,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationAdvanceDirectiveService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationCareExperiencePreferenceService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getCode\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationCareExperiencePreferenceService.php',
@@ -8642,11 +8452,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationCareExperiencePreferenceService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationEmployerService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getCode\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationEmployerService.php',
@@ -8657,11 +8462,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationEmployerService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationHistorySdohService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getCode\\(\\) on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationHistorySdohService.php',
@@ -8670,11 +8470,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot call method warning\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationHistorySdohService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationLaboratoryService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method warning\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
@@ -8682,11 +8477,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationLaboratoryService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationObservationFormService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getCode\\(\\) on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationObservationFormService.php',
@@ -8702,8 +8492,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationObservationFormService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 2,
+    'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationPatientService.php',
 ];
 $ignoreErrors[] = [
@@ -8717,19 +8507,9 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationPatientService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationQuestionnaireItemService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method warning\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationQuestionnaireItemService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method getCode\\(\\) on mixed\\.$#',
@@ -8740,11 +8520,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot call method warning\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationTreatmentInterventionPreferenceService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method getCode\\(\\) on mixed\\.$#',
@@ -8762,8 +8537,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationTreatmentInterventionPreferenceService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 2,
+    'message' => '#^Cannot call method error\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationVitalsService.php',
 ];
 $ignoreErrors[] = [
@@ -8780,16 +8555,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot call method setDisplay\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationVitalsService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Procedure/FhirProcedureOEProcedureService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method errorLogCaller\\(\\) on OpenEMR\\\\Common\\\\Logging\\\\SystemLogger\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Procedure/FhirProcedureSurgeryService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method search\\(\\) on OpenEMR\\\\Services\\\\QuestionnaireService\\|null\\.$#',

--- a/.phpstan/baseline/method.notFound.php
+++ b/.phpstan/baseline/method.notFound.php
@@ -897,11 +897,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Command/CreateReleaseChangelogCommand.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Psr\\\\Log\\\\LoggerInterface\\:\\:errorLogCaller\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Common/Forms/FormLocator.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to an undefined method OpenEMR\\\\Common\\\\ORDataObject\\\\ORDataObject\\:\\:get_id\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',

--- a/interface/forms/newpatient/C_EncounterVisitForm.class.php
+++ b/interface/forms/newpatient/C_EncounterVisitForm.class.php
@@ -571,7 +571,7 @@ class C_EncounterVisitForm
             $validationConstraints = json_decode((string) $validationConstraints["new_encounter"]["rules"], true);
             if ($validationConstraints === false) {
                 $validationConstraints = [];
-                (new \OpenEMR\Common\Logging\SystemLogger())->errorLogCaller("Error decoding validation constraints for encounter form");
+                (new \OpenEMR\Common\Logging\SystemLogger())->error("C_EncounterVisitForm: Error decoding validation constraints for encounter form");
             }
         }
 

--- a/interface/forms/newpatient/save.php
+++ b/interface/forms/newpatient/save.php
@@ -40,7 +40,7 @@ $patientService = new PatientService();
  */
 $patient = $patientService->findByPid($pid);
 if (empty($patient)) {
-    (new \OpenEMR\Common\Logging\SystemLogger())->errorLogCaller("Patient not found, this should never happen");
+    (new \OpenEMR\Common\Logging\SystemLogger())->error("newpatient/save.php: Patient not found, this should never happen");
     die("Patient not found");
 }
 $puuid = UuidRegistry::uuidToString($patient['uuid']);

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthCalendarController.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthCalendarController.php
@@ -123,7 +123,7 @@ class TeleHealthCalendarController
                             $eventViewClasses[] = "event_telehealth_active";
                         }
                     } else if ($dateTime == false) {
-                        $this->logger->errorLogCaller("Failed to create DateTime object for calendar event", ['pc_eid' => $eventsByDay[$key][$i]['eid']]);
+                        $this->logger->error("TeleHealthCalendarController: Failed to create DateTime object for calendar event pc_eid={pc_eid}", ['pc_eid' => $eventsByDay[$key][$i]['eid']]);
                     }
                     $eventsByDay[$key][$i]['eventViewClass'] = implode(" ", $eventViewClasses);
                 }
@@ -218,7 +218,7 @@ class TeleHealthCalendarController
         $eventDateTimeString = $row['pc_eventDate'] . " " . $row['pc_startTime'];
         $dateTime = \DateTime::createFromFormat("Y-m-d H:i:s", $eventDateTimeString);
         if ($dateTime === false) {
-            (new SystemLogger())->errorLogCaller("appointment date time string was invalid", ['pc_eid' => $row['pc_eid'], 'dateTime' => $eventDateTimeString]);
+            (new SystemLogger())->error("TeleHealthCalendarController: appointment date time string {dateTime} was invalid for pc_eid={pc_eid}", ['pc_eid' => $row['pc_eid'], 'dateTime' => $eventDateTimeString]);
             return;
         }
 

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleconferenceRoomController.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleconferenceRoomController.php
@@ -1152,14 +1152,14 @@ class TeleconferenceRoomController
             $appointment = $appointment[0];
         }
         if ($this->isPendingAppointment($appointment)) { // pending status
-            (new SystemLogger())->errorLogCaller("Telehealth appointment was launched for pending appointment.  This should not happen.", ['pc_eid' => $pc_eid, 'appointment' => $appointment]);
+            (new SystemLogger())->error("TeleconferenceRoomController: Telehealth appointment was launched for pending appointment pc_eid={pc_eid}. This should not happen.", ['pc_eid' => $pc_eid, 'appointment' => $appointment]);
             throw new InvalidArgumentException("appointment status cannot be initialized as the appointment was not confirmed by the provider" . $pc_eid);
         }
 
         if (!$appointmentService->isCheckInStatus($appointment['pc_apptstatus'])) {
             if ($appointmentService->isCheckOutStatus($appointment['pc_apptstatus'])) {
                 // we need to log this... we shouldn't even be launching a telehealth session if this is a checkout appointment
-                (new SystemLogger())->errorLogCaller("Telehealth appointment was launched for completed appointment", ['pc_eid' => $pc_eid, 'appointment' => $appointment]);
+                (new SystemLogger())->error("TeleconferenceRoomController: Telehealth appointment was launched for completed appointment pc_eid={pc_eid}", ['pc_eid' => $pc_eid, 'appointment' => $appointment]);
             } else {
                 // need to check them in.
                 // else set appointment to '@'

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Repository/TeleHealthPersonSettingsRepository.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Repository/TeleHealthPersonSettingsRepository.php
@@ -110,7 +110,7 @@ class TeleHealthPersonSettingsRepository
             if ($date !== false) {
                 $settings->setDateCreated($date);
             } else {
-                $this->logger->errorLogCaller('failed to create date_created', ['value' => $row['date_created']]);
+                $this->logger->error('TeleHealthPersonSettingsRepository: failed to create date_created from {value}', ['value' => $row['date_created']]);
             }
         }
         if (isset($row['date_updated'])) {
@@ -118,7 +118,7 @@ class TeleHealthPersonSettingsRepository
             if ($date !== false) {
                 $settings->setDateUpdated($date);
             } else {
-                $this->logger->errorLogCaller('failed to create date_updated', ['value' => $row['date_updated']]);
+                $this->logger->error('TeleHealthPersonSettingsRepository: failed to create date_updated from {value}', ['value' => $row['date_updated']]);
             }
         }
         return $settings;

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Repository/TeleHealthUserRepository.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Repository/TeleHealthUserRepository.php
@@ -108,7 +108,7 @@ class TeleHealthUserRepository extends BaseService
             if ($date !== false) {
                 $user->setDateRegistered($date);
             } else {
-                $this->logger->errorLogCaller('failed to create date_registered', ['value' => $row['date_registered']]);
+                $this->logger->error('TeleHealthUserRepository: failed to create date_registered from {value}', ['value' => $row['date_registered']]);
             }
         }
         if (isset($row['date_created'])) {
@@ -116,7 +116,7 @@ class TeleHealthUserRepository extends BaseService
             if ($date !== false) {
                 $user->setDateCreated($date);
             } else {
-                $this->logger->errorLogCaller('failed to create date_created', ['value' => $row['date_created']]);
+                $this->logger->error('TeleHealthUserRepository: failed to create date_created from {value}', ['value' => $row['date_created']]);
             }
         }
         if (isset($row['date_updated'])) {
@@ -124,7 +124,7 @@ class TeleHealthUserRepository extends BaseService
             if ($date !== false) {
                 $user->setDateUpdated($date);
             } else {
-                $this->logger->errorLogCaller('failed to create date_updated', ['value' => $row['date_updated']]);
+                $this->logger->error('TeleHealthUserRepository: failed to create date_updated from {value}', ['value' => $row['date_updated']]);
             }
         }
         return $user;

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/TeleHealthParticipantInvitationMailerService.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/TeleHealthParticipantInvitationMailerService.php
@@ -128,7 +128,7 @@ class TeleHealthParticipantInvitationMailerService
             if (isset($oneTime['encoded_link'])) {
                 return $oneTime['encoded_link'];
             } else {
-                (new SystemLogger())->errorLogCaller("Failed to generate encoded_link with onetime service");
+                (new SystemLogger())->error("TeleHealthParticipantInvitationMailerService: Failed to generate encoded_link with onetime service");
                 return $this->publicPathFQDN . "index-portal.php";
             }
         } else {

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/TeleHealthRemoteRegistrationService.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/TeleHealthRemoteRegistrationService.php
@@ -174,7 +174,7 @@ class TeleHealthRemoteRegistrationService
         $response = $this->sendAPIRequest($this->getEndpointUrl("userprovision"), $httpDataRequest);
 
         if ($response['status'] != 200) {
-            (new SystemLogger())->errorLogCaller("Failed to provision user", ['username' => $request->getUsername()
+            (new SystemLogger())->error("TeleHealthRemoteRegistrationService: Failed to provision user {username}", ['username' => $request->getUsername()
                 , 'response' => $response]);
             return false;
         } else {
@@ -239,7 +239,7 @@ class TeleHealthRemoteRegistrationService
         $response = $this->sendAPIRequest($this->getEndpointUrl("userupdate"), $httpDataRequest);
 
         if ($response['status'] != 200) {
-            $this->logger->errorLogCaller("Failed to update provisioned user", ['username' => $request->getUsername()
+            $this->logger->error("TeleHealthRemoteRegistrationService: Failed to update provisioned user {username}", ['username' => $request->getUsername()
                 , 'response' => $response]);
             return false;
         } else {
@@ -268,7 +268,7 @@ class TeleHealthRemoteRegistrationService
         unset($httpDataRequest['passwordString']);
 
         if ($response['status'] != 200) {
-            $this->logger->errorLogCaller("Failed to suspend user", ['username' => $username, 'response' => $response]);
+            $this->logger->error("TeleHealthRemoteRegistrationService: Failed to suspend user {username}", ['username' => $username, 'response' => $response]);
             return false;
         } else {
             $this->logger->debug("Suspended user on comlink api ", ['username' => $username]);
@@ -293,7 +293,7 @@ class TeleHealthRemoteRegistrationService
         $response = $this->sendAPIRequest($this->getEndpointUrl("userresume"), $httpDataRequest);
         $httpDataRequest = null; // clear out passwords in memory
         if ($response['status'] != 200) {
-            $this->logger->errorLogCaller("Failed to resume user", ['username' => $username, 'response' => $response]);
+            $this->logger->error("TeleHealthRemoteRegistrationService: Failed to resume user {username}", ['username' => $username, 'response' => $response]);
             return false;
         } else {
             $this->logger->debug("Resumed user on comlink api ", ['username' => $username]);
@@ -316,7 +316,7 @@ class TeleHealthRemoteRegistrationService
         $response = $this->sendAPIRequest($this->getEndpointUrl("userresume"), $httpDataRequest);
 
         if ($response['status'] != 200) {
-            $this->logger->errorLogCaller("Failed to deactivate user", ['username' => $username, 'response' => $response]);
+            $this->logger->error("TeleHealthRemoteRegistrationService: Failed to deactivate user {username}", ['username' => $username, 'response' => $response]);
             return false;
         } else {
             $this->logger->debug("Deactivated user on comlink api ", ['username' => $username]);
@@ -364,9 +364,9 @@ class TeleHealthRemoteRegistrationService
             $response->getBody()->rewind();
             $bodyResponse = $response->getBody()->getContents();
         } catch (GuzzleException $exception) {
-            $this->logger->errorLogCaller(
-                "Failed to send registration request Exception: " . $exception->getMessage(),
-                ['trace' => $exception->getTraceAsString(), 'endUrl' => $endpointUrl]
+            $this->logger->error(
+                "TeleHealthRemoteRegistrationService: Failed to send registration request to {endUrl}: " . $exception->getMessage(),
+                ['trace' => $exception->getTraceAsString(), 'endUrl' => $endpointUrl, 'exception' => $exception]
             );
             if ($exception->getCode() == 401) { // unauthorized exception meaning the credentials are incorrect
                 $statusCode = 401;

--- a/interface/modules/custom_modules/oe-module-ehi-exporter/src/Services/EhiExporter.php
+++ b/interface/modules/custom_modules/oe-module-ehi-exporter/src/Services/EhiExporter.php
@@ -496,7 +496,7 @@ class EhiExporter
             $taskResultContents = $this->getCsvFileContents($exportState, $result->tableName);
             $addedToZip = $zip->addFromString($result->tableName . '.csv', $taskResultContents);
             if (!$addedToZip) {
-                $this->logger->errorLogCaller("Failed to add " . $result->tableName . " to zip file");
+                $this->logger->error("EhiExporter: Failed to add {tableName} to zip file", ['tableName' => $result->tableName]);
                 throw new \Exception("Failed to add " . $result->tableName . " to zip file");
             }
         }
@@ -506,14 +506,14 @@ class EhiExporter
         $this->addDocumentationReadme($zip);
         $saved = $zip->close();
         if (!$saved) {
-            $this->logger->errorLogCaller("Failed to save zip file ", ['zipName' => $zipName]);
+            $this->logger->error("EhiExporter: Failed to save zip file {zipName}", ['zipName' => $zipName]);
             throw new \Exception("Failed to generate zip file for job " . $jobTask->ehi_task_id . " zip status is " . $zip->status);
         }
         unset($zip);
         $document = $this->createDatabaseDocumentFromZip($jobTask, $zipOutput, $zipName);
         // now we remove the zip file
         if (!unlink($zipOutput)) {
-            $this->logger->errorLogCaller("Failed to EHI zip file export", ['zipName' => $zipOutput]);
+            $this->logger->error("EhiExporter: Failed to unlink EHI zip file {zipName}", ['zipName' => $zipOutput]);
         }
         $this->clearResultFilesForJob($jobTask, $exportState);
         return $document;
@@ -526,7 +526,7 @@ class EhiExporter
         // unlink each file
         $files = glob($tempDir . '/*'); // get all file names
         if ($files === false) {
-            $this->logger->errorLogCaller("Failed to retrieve file list from temporary directory", ['tempDir' => $tempDir]);
+            $this->logger->error("EhiExporter: Failed to retrieve file list from temporary directory {tempDir}", ['tempDir' => $tempDir]);
             return;
         }
         foreach ($files as $file) { // iterate files
@@ -638,10 +638,10 @@ class EhiExporter
         foreach ($assets as $assetsToExport) {
             if (file_exists($assetsToExport['path'])) {
                 if (!$zip->addFile($assetsToExport['path'], $assetsToExport['name'])) {
-                    $this->logger->errorLogCaller("File exists but failed to export to zip", ['path' => $assetsToExport['path']]);
+                    $this->logger->error("EhiExporter: File exists but failed to export to zip", ['path' => $assetsToExport['path']]);
                 }
             } else {
-                $this->logger->errorLogCaller("Failed to export additional asset as file is missing", ['path' => $assetsToExport['path']]);
+                $this->logger->error("EhiExporter: Failed to export additional asset as file is missing at {path}", ['path' => $assetsToExport['path']]);
             }
         }
     }
@@ -703,14 +703,14 @@ class EhiExporter
                 // we want to make sure the documents are stored by patient id they can be distinguished here.
                 // store it inside of a folder called documents
                 if (!$zip->addFromString($docFolder . $docName, $documentContents)) {
-                    $this->logger->errorLogCaller("Failed to add document to zip file", ['document' => $docFolder . $docName, 'zipStatus' => $zip->status]);
+                    $this->logger->error("EhiExporter: Failed to add document {document} to zip file", ['document' => $docFolder . $docName, 'zipStatus' => $zip->status]);
                 } else {
                     $docCount++;
                 }
             } catch (\RuntimeException $exception) {
                 // if the file contents can not be retrieved we get a runtime exception
-                $this->logger->errorLogCaller(
-                    "Failed to add document to zip file as document contents could not be retrieved",
+                $this->logger->error(
+                    "EhiExporter: Failed to add document {document} to zip file as document contents could not be retrieved",
                     ['document' => $docFolder . $docName
                     ,
                     'zipStatus' => $zip->status,
@@ -748,7 +748,7 @@ class EhiExporter
             ,'certifiedReleaseVersion' => Bootstrap::CERTIFIED_RELEASE_VERSION
         ]);
         if (!$zip->addFromString("README", $readmeContents)) {
-            $this->logger->errorLogCaller("Failed to add README file");
+            $this->logger->error("EhiExporter: Failed to add README file to zip");
         }
     }
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
@@ -159,7 +159,7 @@ class NotificationEventListener implements EventSubscriberInterface
         $service = new OneTimeAuth();
         $oneTime = $service->createPortalOneTime($parameters);
         if (!isset($oneTime['encoded_link'])) {
-            (new SystemLogger())->errorLogCaller("Failed to generate encoded_link with onetime service");
+            (new SystemLogger())->error("NotificationEventListener: Failed to generate encoded_link with onetime service");
             return 'Failed! Redirect link.';
         }
 
@@ -259,7 +259,7 @@ class NotificationEventListener implements EventSubscriberInterface
         $oneTime = $service->createPortalOneTime($parameters); // create the token.
 
         if (!isset($oneTime['encoded_link'])) {
-            (new SystemLogger())->errorLogCaller("Failed to generate encoded_link with onetime service");
+            (new SystemLogger())->error("NotificationEventListener: Failed to generate encoded_link with onetime service");
             return 'Failed! Redirect link.';
         }
 

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
@@ -244,7 +244,7 @@ class EncounterccdadispatchController extends AbstractActionController
                 if ($view && !$downloadccda) {
                     if (str_starts_with($content, 'ERROR:')) {
                         echo "<h3>" . text($content) . "</h3>";
-                        (new SystemLogger())->errorLogCaller("Error generating CCDA", ['message' => $content]);
+                        (new SystemLogger())->error("EncounterccdadispatchController: Error generating CCDA: {message}", ['message' => $content]);
                         die();
                     }
                     $xml = simplexml_load_string($content);
@@ -260,7 +260,7 @@ class EncounterccdadispatchController extends AbstractActionController
                     $htmlContent = file_get_contents($outputFile);
                     $result = unlink($outputFile); // remove the file so we don't have PHI left around on the filesystem
                     if (!$result) {
-                        (new SystemLogger())->errorLogCaller("Failed to unlink temporary CDA output on hard drive. This could expose PHI and needs to be investigated.", ['filename' => $outputFile]);
+                        (new SystemLogger())->error("EncounterccdadispatchController: Failed to unlink temporary CDA output {filename}. This could expose PHI and needs to be investigated.", ['filename' => $outputFile]);
                     }
                     echo $htmlContent;
                 }
@@ -391,8 +391,9 @@ class EncounterccdadispatchController extends AbstractActionController
 
             return $content;
         } catch (\Throwable $e) {
-            (new SystemLogger())->errorLogCaller("Error generating consolidated QRDA III content", [
-                'message' => $e->getMessage()
+            (new SystemLogger())->error("EncounterccdadispatchController: Error generating consolidated QRDA III content: {message}", [
+                'message' => $e->getMessage(),
+                'exception' => $e
             ]);
 
             return "ERROR: " . $e->getMessage();

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceDocumentRequestor.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceDocumentRequestor.php
@@ -31,7 +31,7 @@ class CcdaServiceDocumentRequestor
         // we're local service
         if (OEGlobalsBag::getInstance()->get('ccda_alt_service_enable') > 0) {
         } else {
-            $this->getSystemLogger()->errorLogCaller("C-CDA Service is not enabled in Global Settings");
+            $this->getSystemLogger()->error("CcdaServiceDocumentRequestor: C-CDA Service is not enabled in Global Settings");
             throw new CcdaServiceConnectionException("Please Enable C-CDA Alternate Service in Global Settings");
         }
         $output = "";
@@ -59,7 +59,7 @@ class CcdaServiceDocumentRequestor
                     throw new CcdaServiceConnectionException("Failed to start local ccdaservice");
                 }
                 if (pclose($pipeHandle) === -1) {
-                    $this->getSystemLogger()->errorLogCaller("Failed to close pipehandle for ccdaservice");
+                    $this->getSystemLogger()->error("CcdaServiceDocumentRequestor: Failed to close pipehandle for ccdaservice");
                 }
             } else {
                 $command = 'node';
@@ -68,7 +68,7 @@ class CcdaServiceDocumentRequestor
                         // older or custom Ubuntu systems that have nodejs rather than node command
                         $command = 'nodejs';
                     } else {
-                        $this->getSystemLogger()->errorLogCaller("Node is not installed on the system.  Connection failed");
+                        $this->getSystemLogger()->error("CcdaServiceDocumentRequestor: Node is not installed on the system. Connection failed");
                         throw new CcdaServiceConnectionException('Connection Failed.');
                     }
                 }
@@ -82,7 +82,7 @@ class CcdaServiceDocumentRequestor
             if ($result === false) {
                 $errorCode = socket_last_error($socket);
                 $errorMsg = socket_strerror($errorCode);
-                $this->getSystemLogger()->errorLogCaller("Socket connection error $errorCode: $errorMsg");
+                $this->getSystemLogger()->error("CcdaServiceDocumentRequestor: Socket connection error {errorCode}: {errorMsg}", ['errorCode' => $errorCode, 'errorMsg' => $errorMsg]);
                 throw new CcdaServiceConnectionException("Connection Failed: $errorMsg");
             }
 
@@ -93,7 +93,7 @@ class CcdaServiceDocumentRequestor
         // Set default buffer size to target data array size.
         $good_buf = socket_set_option($socket, SOL_SOCKET, SO_SNDBUF, $len);
         if ($good_buf === false) { // Can't set buffer
-            $this->getSystemLogger()->errorLogCaller("Failed to set socket buffer to " . $len);
+            $this->getSystemLogger()->error("CcdaServiceDocumentRequestor: Failed to set socket buffer to {len}", ['len' => $len]);
         }
         // make writeSize chunk either the size set above or the default buffer size (64Kb).
         $writeSize = socket_get_option($socket, SOL_SOCKET, SO_SNDBUF);

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
@@ -988,7 +988,7 @@ class EncounterccdadispatchTable
         }
         if (!$details) {
             // at this point we really can't do anything as we can't provide an author piece
-            (new SystemLogger())->errorLogCaller("Failed to find author for c-cda document, no hie_author_id, authUserID in session, or provider relationship");
+            (new SystemLogger())->error("EncounterccdadispatchTable: Failed to find author for c-cda document, no hie_author_id, authUserID in session, or provider relationship");
             return null;
         }
 
@@ -1210,8 +1210,8 @@ class EncounterccdadispatchTable
                 $organization_uuid = UuidRegistry::uuidToString($details['facility_uuid']);
             } else {
                 $organization_uuid = ''; // leave it an empty string as we don't even know if we have a connected organization.
-                (new SystemLogger())->errorLogCaller(
-                    "Failed to find facility uuid for Carecoordination hie_office_contact, uuid is either missing or office contact has no connected organization",
+                (new SystemLogger())->error(
+                    "EncounterccdadispatchTable: Failed to find facility uuid for hie_office_contact {fname} {lname}, uuid is either missing or office contact has no connected organization",
                     ['fname' => $details['fname'], 'lname' => $details['lname'], 'organization' => $details['organization']
                         ,
                         'npi' => $details['facility_npi']]
@@ -4004,7 +4004,7 @@ class EncounterccdadispatchTable
     {
         if (empty($referralId)) {
             // user is sending a CCDA w/o any kind of connecting referral... we will log the error and continue
-            (new SystemLogger())->errorLogCaller("Failed to log amc information due to missing referral id.  User is sending CCDA w/o any connecting referral record", ['pid' => $pid]);
+            (new SystemLogger())->error("EncounterccdadispatchTable::logAmc: Failed to log amc information due to missing referral id. User is sending CCDA w/o any connecting referral record for pid {pid}", ['pid' => $pid]);
             return;
         }
 

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncountermanagerTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncountermanagerTable.php
@@ -296,7 +296,7 @@ class EncountermanagerTable
                 }
             }
         } catch (\Throwable $exception) {
-            (new SystemLogger())->errorLogCaller($exception->getMessage(), ['data' => $data]);
+            (new SystemLogger())->error("EncountermanagerTable: " . $exception->getMessage(), ['data' => $data, 'exception' => $exception]);
             return ("Delivery failed to send");
         }
 

--- a/interface/patient_file/history/history_sdoh_health_concerns.php
+++ b/interface/patient_file/history/history_sdoh_health_concerns.php
@@ -44,7 +44,7 @@ $logger = new SystemLogger();
 
 // TODO: @adunsulag all of this needs to be wrapped into a Response and Controller for better structure
 if (!$pid || !$sdoh_id) {
-    $logger->errorLogCaller("Missing required parameters", ['pid' => $pid, "sdoh_id" => $sdoh_id]);
+    $logger->error("history_sdoh_health_concerns: Missing required parameters pid={pid} sdoh_id={sdoh_id}", ['pid' => $pid, "sdoh_id" => $sdoh_id]);
     die(xlt("Missing required parameters."));
 }
 
@@ -55,7 +55,7 @@ if (!AclMain::aclCheckCore('patients', 'med', '', ['write', 'addonly'])) {
 $sdohService = new HistorySdohService();
 $result = $sdohService->search(['id' => $sdoh_id, 'pid' => $pid]);
 if (!$result->hasData()) {
-    $logger->errorLogCaller("SDOH assessment not found", ['pid' => $pid, "sdoh_id" => $sdoh_id]);
+    $logger->error("history_sdoh_health_concerns: SDOH assessment not found for pid={pid} sdoh_id={sdoh_id}", ['pid' => $pid, "sdoh_id" => $sdoh_id]);
     die("SDOH assessment not found.");
 }
 $assessmentConcerns = HistorySdohService::concernsFromAssessmentV3($result->getFirstDataResult());

--- a/interface/patient_file/history/history_sdoh_save.php
+++ b/interface/patient_file/history/history_sdoh_save.php
@@ -147,7 +147,7 @@ try {
         $data['updated_by'] = $uid;
         $result = $sdohService->update($rec_id, $data);
         if (!$result->isValid()) {
-            $logger->errorLogCaller("Failed to insert sdoh record", ['validationErrors' => $result->getValidationMessages(), 'internalErrors' => $result->getInternalErrors()]);
+            $logger->error("history_sdoh_save: Failed to update sdoh record", ['validationErrors' => $result->getValidationMessages(), 'internalErrors' => $result->getInternalErrors()]);
         }
         $id = $rec_id;
     } else {
@@ -156,7 +156,7 @@ try {
         $data['created_by'] = $uid;
         $result = $sdohService->insert($data);
         if (!$result->isValid()) {
-            $logger->errorLogCaller("Failed to insert sdoh record", ['validationErrors' => $result->getValidationMessages(), 'internalErrors' => $result->getInternalErrors()]);
+            $logger->error("history_sdoh_save: Failed to insert sdoh record", ['validationErrors' => $result->getValidationMessages(), 'internalErrors' => $result->getInternalErrors()]);
             throw new Exception("Failed to insert sdoh record.");
         } else {
             $id = $result->getFirstDataResult()['id'];

--- a/library/classes/rulesets/ReportManager.php
+++ b/library/classes/rulesets/ReportManager.php
@@ -56,7 +56,7 @@ class ReportManager
             $report->execute();
             $results = $report->getResults();
         } else {
-            (new SystemLogger())->errorLogCaller("Rule class does not implement valid interfaces", ['ruleId' => $ruleId, 'class' => ReportTypes::getClassName($ruleId)]);
+            (new SystemLogger())->error("Rule {ruleId} class {class} does not implement valid interfaces", ['ruleId' => $ruleId, 'class' => ReportTypes::getClassName($ruleId)]);
         }
 
         return RsHelper::formatClinicalRules($results);

--- a/library/direct_message_check.inc.php
+++ b/library/direct_message_check.inc.php
@@ -509,7 +509,7 @@ function phimail_close($fp): void
 function phimail_logit($success, $text, $pid = 0, $event = "direct-message-check"): void
 {
     if (!$success) {
-        (new SystemLogger())->errorLogCaller($event, ['success' => $success, 'text' => $text, 'pid' => $pid]);
+        (new SystemLogger())->error("phimail_logit {event}: {text}", ['event' => $event, 'text' => $text, 'pid' => $pid]);
     }
     EventAuditLogger::getInstance()->newEvent($event, "phimail-service", 0, $success, $text, $pid);
 }

--- a/library/pnotes.inc.php
+++ b/library/pnotes.inc.php
@@ -543,7 +543,7 @@ function updatePnotePatient($id, $patient_id): void
     $pid = $row['pid'];
 
     if ($pid != 0 || (int)$patient_id < 1) {
-        (new SystemLogger())->errorLogCaller("invalid operation", ['id' => $id, 'patient_id' => $patient_id, 'pid' => $pid]);
+        (new SystemLogger())->error("updatePnotePatient invalid operation for id {id}, patient_id {patient_id}, pid {pid}", ['id' => $id, 'patient_id' => $patient_id, 'pid' => $pid]);
         die("updatePnotePatient invalid operation");
     }
 

--- a/library/templates/relation_form.php
+++ b/library/templates/relation_form.php
@@ -64,7 +64,7 @@ try {
             $targetContact = $contactService->getOrCreateForEntity('person', $targetId);
             $targetContactId = $targetContact->get_id();
             if (empty($targetContactId)) {
-                $logger->errorLogCaller("No contact found for related person", [
+                $logger->error("No contact found for related person {person_id}", [
                     'person_id' => $targetId,
                     'owner_contact_relation_id' => $record['owner_contact_relation_id']
                 ]);

--- a/portal/index.php
+++ b/portal/index.php
@@ -153,7 +153,7 @@ if (!empty($_REQUEST['service_auth'] ?? null)) {
             exit();
         }
     } else {
-        (new SystemLogger())->errorLogCaller("Invalid service_auth request - should never reach here");
+        (new SystemLogger())->error("Invalid service_auth request - should never reach here");
         exit();
     }
 }

--- a/src/ClinicalDecisionRules/Interface/Controller/ControllerReview.php
+++ b/src/ClinicalDecisionRules/Interface/Controller/ControllerReview.php
@@ -82,7 +82,7 @@ class ControllerReview extends BaseController
         // note some browser implementations appear to screw up on html maxlength attribute due to line breaks and other weird characters
         // so we need to check the length here, but note that the client side may see a different length in certain edge cases.
         if (mb_strlen((string) $rule->getFeedback()) > 2048) {
-            (new SystemLogger())->errorLogCaller("Rule length exceeded, client side should have caught this", ['ruleId' => $ruleId]);
+            (new SystemLogger())->error("Rule {ruleId} feedback length exceeded, client side should have caught this", ['ruleId' => $ruleId]);
             return $this->redirect("index.php?action=review!view&rule_id=" . urlencode($ruleId) . '&pid=' . urlencode((string) $pid) . '&csrf_token_form=' . urlencode((string) CsrfUtils::collectCsrfToken())
                 . '&message=' . self::ERROR_MESSAGE_INVALID);
         }
@@ -107,7 +107,7 @@ class ControllerReview extends BaseController
                 . '&message=' . self::ERROR_MESSAGE_SUCCESS);
         } else {
             // TODO: if there is no feedback... we never should have gotten here... log an error and throw an exception
-            (new SystemLogger())->errorLogCaller("No rule found in clinical rule log. This should never have been reached", ['ruleId' => $ruleId]);
+            (new SystemLogger())->error("No rule {ruleId} found in clinical rule log. This should never have been reached", ['ruleId' => $ruleId]);
             return $this->redirect("index.php?action=review!view&rule_id=" . urlencode($ruleId) . '&pid=' . urlencode((string) $pid) . '&csrf_token_form=' . urlencode((string) CsrfUtils::collectCsrfToken())
                 . '&message=' . self::ERROR_MESSAGE_FAILED);
         }

--- a/src/Common/Auth/OpenIDConnect/Grant/CustomAuthCodeGrant.php
+++ b/src/Common/Auth/OpenIDConnect/Grant/CustomAuthCodeGrant.php
@@ -89,7 +89,7 @@ class CustomAuthCodeGrant extends AuthCodeGrant
         //  (note that this check is forced below if using launch scenario; so it is skipped here in the launch scenario)
         if (!empty($audience) && empty($launch)) {
             if (!in_array($audience, $this->expectedAudience)) {
-                $this->getSystemLogger()->errorLogCaller("CustomAuthCodeGrant::validateAuthorizationRequest:Aud parameter did not match authorized server in non-launch scenario", ['audience' => $audience, 'expected' => $this->expectedAudience]);
+                $this->getSystemLogger()->error("CustomAuthCodeGrant::validateAuthorizationRequest: Aud parameter {audience} did not match authorized server in non-launch scenario", ['audience' => $audience, 'expected' => $this->expectedAudience]);
                 throw OAuthServerException::invalidRequest("aud", "Aud parameter did not match authorized server");
             }
         } else if (empty($audience) && empty($launch)) {
@@ -99,7 +99,7 @@ class CustomAuthCodeGrant extends AuthCodeGrant
         // let's validate the launch param
         if (!empty($launch)) {
             if (!in_array($audience, $this->expectedAudience)) {
-                $this->getSystemLogger()->errorLogCaller("CustomAuthCodeGrant::validateAuthorizationRequest:Aud parameter did not match authorized server in launch scenario", ['audience' => $audience, 'expected' => $this->expectedAudience]);
+                $this->getSystemLogger()->error("CustomAuthCodeGrant::validateAuthorizationRequest: Aud parameter {audience} did not match authorized server in launch scenario", ['audience' => $audience, 'expected' => $this->expectedAudience]);
                 throw OAuthServerException::invalidRequest("aud", "Aud parameter did not match authorized server");
             }
             try {
@@ -219,13 +219,13 @@ class CustomAuthCodeGrant extends AuthCodeGrant
             $logger->debug('CustomAuthCodeGrant::validateClient: Using traditional client secret authentication');
             $client = parent::validateClient($request);
             if (!($client instanceof ClientEntity)) {
-                $logger->errorLogCaller("CustomAuthCodeGrant::validateClient client returned was not a valid ClientEntity ", ['client' => $client->getIdentifier()]);
+                $logger->error("CustomAuthCodeGrant::validateClient: Client {client} returned was not a valid ClientEntity", ['client' => $client->getIdentifier()]);
                 throw OAuthServerException::invalidClient($request);
             }
         }
 
         if (!$client->isEnabled()) {
-            $this->getSystemLogger()->errorLogCaller("client returned was not enabled", ['client' => $client->getIdentifier()]);
+            $this->getSystemLogger()->error("CustomAuthCodeGrant::validateClient: Client {client} returned was not enabled", ['client' => $client->getIdentifier()]);
             throw OAuthServerException::invalidClient($request);
         }
         $this->getSystemLogger()->debug("CustomAuthCodeGrant::validateClient exit");

--- a/src/Common/Auth/OpenIDConnect/Grant/CustomPasswordGrant.php
+++ b/src/Common/Auth/OpenIDConnect/Grant/CustomPasswordGrant.php
@@ -110,12 +110,12 @@ class CustomPasswordGrant extends PasswordGrant
     {
         $client = parent::validateClient($request);
         if (!($client instanceof ClientEntity)) {
-            $this->logger->errorLogCaller("client returned was not a valid ClientEntity ", ['client' => $client->getIdentifier()]);
+            $this->logger->error("Client {client} returned was not a valid ClientEntity", ['client' => $client->getIdentifier()]);
             throw OAuthServerException::invalidClient($request);
         }
 
         if (!$client->isEnabled()) {
-            $this->logger->errorLogCaller("client returned was not enabled", ['client' => $client->getIdentifier()]);
+            $this->logger->error("Client {client} returned was not enabled", ['client' => $client->getIdentifier()]);
             throw OAuthServerException::invalidClient($request);
         }
         return $client;

--- a/src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php
+++ b/src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php
@@ -183,12 +183,12 @@ class CustomRefreshTokenGrant extends RefreshTokenGrant
     {
         $client = parent::validateClient($request);
         if (!($client instanceof ClientEntity)) {
-            $this->getSystemLogger()->errorLogCaller("client returned was not a valid ClientEntity ", ['client' => $client->getIdentifier()]);
+            $this->getSystemLogger()->error("Client {client} returned was not a valid ClientEntity", ['client' => $client->getIdentifier()]);
             throw OAuthServerException::invalidClient($request);
         }
 
         if (!$client->isEnabled()) {
-            $this->getSystemLogger()->errorLogCaller("client returned was not enabled", ['client' => $client->getIdentifier()]);
+            $this->getSystemLogger()->error("Client {client} returned was not enabled", ['client' => $client->getIdentifier()]);
             throw OAuthServerException::invalidClient($request);
         }
         return $client;

--- a/src/Common/Auth/OpenIDConnect/Repositories/UserRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/UserRepository.php
@@ -95,7 +95,7 @@ class UserRepository implements UserRepositoryInterface, IdentityProviderInterfa
                 UuidRegistry::createMissingUuidsForTables(['users']);
                 $uuid = sqlQueryNoLog("SELECT `uuid` FROM `users` WHERE `id` = ?", [$id])['uuid'];
                 if (empty($uuid)) {
-                    $this->getSystemLogger()->errorLogCaller("OpenEMR Error: unable to map uuid for user when creating oauth password grant token");
+                    $this->getSystemLogger()->error("Unable to map uuid for user when creating oauth password grant token");
                     return false;
                 }
                 $user->setIdentifier(UuidRegistry::uuidToString($uuid));
@@ -137,7 +137,7 @@ class UserRepository implements UserRepositoryInterface, IdentityProviderInterfa
                 UuidRegistry::createMissingUuidsForTables(['patient_data']);
                 $uuid = sqlQueryNoLog("SELECT `uuid` FROM `patient_data` WHERE `pid` = ?", [$id])['uuid'];
                 if (empty($uuid)) {
-                    $this->getSystemLogger()->errorLogCaller("OpenEMR Error: unable to map uuid for patient when creating oauth password grant token");
+                    $this->getSystemLogger()->error("Unable to map uuid for patient when creating oauth password grant token");
                     return false;
                 }
                 $user->setIdentifier(UuidRegistry::uuidToString($uuid));

--- a/src/Common/Forms/FormLocator.php
+++ b/src/Common/Forms/FormLocator.php
@@ -73,14 +73,14 @@ class FormLocator
             if (ModulesApplication::isSafeModuleFileForInclude($finalPath)) {
                 return $finalPath;
             } else {
-                $this->logger->errorLogCaller(
-                    "Module attempted to load a file outside of its directory",
+                $this->logger->error(
+                    "Module attempted to load a file outside of its directory: {file} for form {formdir}",
                     ['file' => $event->getFormIncludePath(), 'formdir' => $event->getFormName()]
                 );
             }
         }
         if (!file_exists($finalPath)) {
-            $this->logger->errorLogCaller("form is missing report.php file", ['file' => $finalPath, 'formdir' => $formDir]);
+            $this->logger->error("Form {formdir} is missing report.php file at {file}", ['file' => $finalPath, 'formdir' => $formDir]);
         }
         // AI GENERATED CODE: HEADER START
 

--- a/src/Common/Forms/FormReportRenderer.php
+++ b/src/Common/Forms/FormReportRenderer.php
@@ -36,7 +36,7 @@ class FormReportRenderer
             if (function_exists($formDir . "_report")) {
                 ($formDir . "_report")($attendant_id, $encounter, $columns, $formId);
             } else {
-                $this->logger->errorLogCaller("form is missing report function", ['formdir' => $formDir, 'formId' => $formId]);
+                $this->logger->error("Form {formdir} is missing report function for formId {formId}", ['formdir' => $formDir, 'formId' => $formId]);
             }
         }
     }

--- a/src/Common/Session/Predis/SentinelUtil.php
+++ b/src/Common/Session/Predis/SentinelUtil.php
@@ -50,19 +50,19 @@ class SentinelUtil
         // required to ensure running correct mode
         $this->sessionStorageMode = getenv('SESSION_STORAGE_MODE', true) ?? null;
         if ($this->sessionStorageMode !== 'predis-sentinel') {
-            $this->logger->errorLogCaller("Invalid SESSION_STORAGE_MODE: " . $this->sessionStorageMode);
+            $this->logger->error("Invalid SESSION_STORAGE_MODE: " . $this->sessionStorageMode);
             throw new \Exception("Invalid SESSION_STORAGE_MODE. Expected 'predis-sentinel'.");
         }
 
         // required for listing of the sentinels (string delimited by |||)
         $predisSentinels = getenv('REDIS_SENTINELS', true) ?? null;
         if (empty($predisSentinels)) {
-            $this->logger->errorLogCaller("REDIS_SENTINELS environment variable is not set.");
+            $this->logger->error("REDIS_SENTINELS environment variable is not set.");
             throw new \Exception("REDIS_SENTINELS environment variable is not set.");
         }
         $this->predisSentinels = explode('|||', $predisSentinels);
         if (empty($this->predisSentinels)) {
-            $this->logger->errorLogCaller("REDIS_SENTINELS unable to explode any elements using the ||| delimiter.");
+            $this->logger->error("REDIS_SENTINELS unable to explode any elements using the ||| delimiter.");
             throw new \Exception("REDIS_SENTINELS unable to explode any elements using the ||| delimiter.");
         }
 
@@ -84,46 +84,46 @@ class SentinelUtil
         $this->predisX509 = ($predisX509 === 'yes');
         // note that TLS needs to be turned on if X509 is turned on
         if ($this->predisX509 && !$this->predisTls) {
-            $this->logger->errorLogCaller("REDIS_TLS must be set to 'yes' if REDIS_X509 is set to 'yes'.");
+            $this->logger->error("REDIS_TLS must be set to 'yes' if REDIS_X509 is set to 'yes'.");
             throw new \Exception("REDIS_TLS environment variable must be set to 'yes' if REDIS_X509 is set to 'yes'.");
         }
 
         // optional. If using TLS, then this is required.
         $this->predisSentinelCertKeyPath = getenv('REDIS_TLS_CERT_KEY_PATH', true) ?? null;
         if ($this->predisTls && empty($this->predisSentinelCertKeyPath)) {
-            $this->logger->errorLogCaller("REDIS_TLS_CERT_KEY_PATH environment variable is required when REDIS_TLS is set to 'yes'.");
+            $this->logger->error("REDIS_TLS_CERT_KEY_PATH environment variable is required when REDIS_TLS is set to 'yes'.");
             throw new \Exception("REDIS_TLS_CERT_KEY_PATH environment variable is required when REDIS_TLS is set to 'yes'.");
         }
 
         // collect pertinent certificate files and ensure they are readable
         $this->sentinelCaFile = $this->predisTls ? $this->predisSentinelCertKeyPath . '/' . self::$sentinelCa : null;
         if (!empty($this->sentinelCaFile) && !is_readable($this->sentinelCaFile)) {
-            $this->logger->errorLogCaller("Sentinel CA file does not exist or is not readable: " . $this->sentinelCaFile);
+            $this->logger->error("Sentinel CA file does not exist or is not readable: " . $this->sentinelCaFile);
             throw new \Exception("Sentinel CA file does not exist or is not readable: " . $this->sentinelCaFile);
         }
         $this->sentinelCertFile = $this->predisX509 ? $this->predisSentinelCertKeyPath . '/' . self::$sentinelCert : null;
         if (!empty($this->sentinelCertFile) && !is_readable($this->sentinelCertFile)) {
-            $this->logger->errorLogCaller("Sentinel certificate file does not exist or is not readable: " . $this->sentinelCertFile);
+            $this->logger->error("Sentinel certificate file does not exist or is not readable: " . $this->sentinelCertFile);
             throw new \Exception("Sentinel certificate file does not exist or is not readable: " . $this->sentinelCertFile);
         }
         $this->sentinelKeyFile = $this->predisX509 ? $this->predisSentinelCertKeyPath . '/' . self::$sentinelKey : null;
         if (!empty($this->sentinelKeyFile) && !is_readable($this->sentinelKeyFile)) {
-            $this->logger->errorLogCaller("Sentinel key file does not exist or is not readable: " . $this->sentinelKeyFile);
+            $this->logger->error("Sentinel key file does not exist or is not readable: " . $this->sentinelKeyFile);
             throw new \Exception("Sentinel key file does not exist or is not readable: " . $this->sentinelKeyFile);
         }
         $this->masterCaFile = $this->predisTls ? $this->predisSentinelCertKeyPath . '/' . self::$masterCa : null;
         if (!empty($this->masterCaFile) && !is_readable($this->masterCaFile)) {
-            $this->logger->errorLogCaller("Master CA file does not exist or is not readable: " . $this->masterCaFile);
+            $this->logger->error("Master CA file does not exist or is not readable: " . $this->masterCaFile);
             throw new \Exception("Master CA file does not exist or is not readable: " . $this->masterCaFile);
         }
         $this->masterCertFile = $this->predisX509 ? $this->predisSentinelCertKeyPath . '/' . self::$masterCert : null;
         if (!empty($this->masterCertFile) && !is_readable($this->masterCertFile)) {
-            $this->logger->errorLogCaller("Master certificate file does not exist or is not readable: " . $this->masterCertFile);
+            $this->logger->error("Master certificate file does not exist or is not readable: " . $this->masterCertFile);
             throw new \Exception("Master certificate file does not exist or is not readable: " . $this->masterCertFile);
         }
         $this->masterKeyFile = $this->predisX509 ? $this->predisSentinelCertKeyPath . '/' . self::$masterKey : null;
         if (!empty($this->masterKeyFile) && !is_readable($this->masterKeyFile)) {
-            $this->logger->errorLogCaller("Master key file does not exist or is not readable: " . $this->masterKeyFile);
+            $this->logger->error("Master key file does not exist or is not readable: " . $this->masterKeyFile);
             throw new \Exception("Master key file does not exist or is not readable: " . $this->masterKeyFile);
         }
 

--- a/src/Common/Session/SessionUtil.php
+++ b/src/Common/Session/SessionUtil.php
@@ -110,7 +110,7 @@ class SessionUtil
         if (isset($saveHandler)) {
             $success = session_set_save_handler($saveHandler, true);
             if (!$success) {
-                (new SystemLogger())->errorLogCaller("Failed to set session handler for Predis Sentinel.");
+                (new SystemLogger())->error("Failed to set session handler for Predis Sentinel.");
                 throw new \RuntimeException("Failed to set session handler for Predis Sentinel.");
             }
             (new SystemLogger())->debug("Successfully set session handler for Predis Sentinel.");

--- a/src/RestControllers/Authorization/BearerTokenAuthorizationStrategy.php
+++ b/src/RestControllers/Authorization/BearerTokenAuthorizationStrategy.php
@@ -373,7 +373,7 @@ class BearerTokenAuthorizationStrategy implements IAuthorizationStrategy
             (self::is_api_request($resource) && !in_array('api:oemr', $oauthScopes)) ||
             (self::is_portal_request($resource) && !in_array('api:port', $oauthScopes))
         ) {
-            $this->getSystemLogger()->errorLogCaller("api call with token that does not cover the requested route");
+            $this->getSystemLogger()->error("API call with token that does not cover the requested route");
             throw new HttpException(403, "OpenEMR Error: API call failed due to insufficient permissions for the requested resource.");
         }
         // ensure user role has access to the resource

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -797,7 +797,7 @@ class AuthorizationController
         $clientId = $session->get('client_id');
         if (empty($clientId)) {
             // why are we logging in... we need to terminate
-            $this->getSystemLogger()->errorLogCaller("application client_id was missing when it shouldn't have been");
+            $this->getSystemLogger()->error("Application client_id was missing when it shouldn't have been");
             return $this->renderTwigPage(
                 'oauth2/authorize/login',
                 "error/general_http_error.html.twig",
@@ -1210,7 +1210,7 @@ class AuthorizationController
                         $code,
                         $session_cache
                     )) {
-                        $this->getSystemLogger()->errorLogCaller("AuthorizationController->authorizeUser() failed to save trusted user session");
+                        $this->getSystemLogger()->error("AuthorizationController::authorizeUser() failed to save trusted user session");
                         throw OAuthServerException::serverError("Failed authorization due to internal server error.");
                     }
                 }
@@ -1406,7 +1406,7 @@ class AuthorizationController
         try {
             $id = $this->trustedUserService->saveTrustedUser($clientId, $userId, $scope, $persist, $code, $session, $grant);
             if (empty($id)) {
-                $this->getSystemLogger()->errorLogCaller("AuthorizationController->saveTrustedUser() failed to save trusted user");
+                $this->getSystemLogger()->error("AuthorizationController::saveTrustedUser() failed to save trusted user");
                 return false;
             }
             return true;
@@ -1473,7 +1473,7 @@ class AuthorizationController
                     ->withBody($factory->createStream($message));
             }
         } catch (OAuthServerException $exception) {
-            $this->getSystemLogger()->errorLogCaller($exception->getMessage(), ['client_id' => $client_id]);
+            $this->getSystemLogger()->error("OAuth error for client {client_id}: " . $exception->getMessage(), ['client_id' => $client_id]);
             $this->session->invalidate();
             return $exception->generateHttpResponse($response);
         }

--- a/src/Services/CDADocumentService.php
+++ b/src/Services/CDADocumentService.php
@@ -133,7 +133,7 @@ class CDADocumentService extends BaseService
         unset($result);
 
         if (str_starts_with($content, 'ERROR:')) {
-            (new SystemLogger())->errorLogCaller("Error generating CCDA", ['message' => $content]);
+            (new SystemLogger())->error("Error generating CCDA: {message}", ['message' => $content]);
             throw new Exception(xlt("Error generating CCDA") . ": " . $content);
         }
 
@@ -280,7 +280,7 @@ class CDADocumentService extends BaseService
         if ($xml === false) {
             $errors = libxml_get_errors();
             libxml_clear_errors();
-            (new SystemLogger())->errorLogCaller("Failed to parse CCDA XML", ['errors' => $errors]);
+            (new SystemLogger())->error("Failed to parse CCDA XML", ['errors' => $errors]);
             throw new RuntimeException(xlt("Failed to parse CCDA XML"));
         }
 
@@ -313,8 +313,8 @@ class CDADocumentService extends BaseService
         } finally {
             if (file_exists($outputFile)) {
                 if (!unlink($outputFile)) {
-                    (new SystemLogger())->errorLogCaller(
-                        "Failed to unlink temporary CDA output. This could expose PHI.",
+                    (new SystemLogger())->error(
+                        "Failed to unlink temporary CDA output {filename}. This could expose PHI.",
                         ['filename' => $outputFile]
                     );
                 }

--- a/src/Services/Cda/CdaTemplateImportDispose.php
+++ b/src/Services/Cda/CdaTemplateImportDispose.php
@@ -2160,8 +2160,8 @@ class CdaTemplateImportDispose
             $id_data = $insuranceData->insert($data);
         }
         if (!$id_data->isValid()) {
-            (new SystemLogger())->errorLogCaller(
-                'Error inserting insurance data',
+            (new SystemLogger())->error(
+                'Error inserting insurance data: {validationErrors} {internalErrors}',
                 [
                     'internalErrors' => $id_data->getInternalErrors(), 'validationErrors' => $id_data->getValidationMessages()
                 ]

--- a/src/Services/Cda/CdaValidateDocuments.php
+++ b/src/Services/Cda/CdaValidateDocuments.php
@@ -266,7 +266,7 @@ class CdaValidateDocuments
                 $xsd_log['xsd'][] = $detail;
             }
             libxml_clear_errors();
-            $this->getSystemLogger()->errorLogCaller("CDA XSD Validation Errors", ['errors' => $xsd_log['xsd']]);
+            $this->getSystemLogger()->error("CDA XSD Validation Errors", ['errors' => $xsd_log['xsd']]);
         }
 
         return $xsd_log;

--- a/src/Services/FHIR/FhirDocRefService.php
+++ b/src/Services/FHIR/FhirDocRefService.php
@@ -135,7 +135,7 @@ class FhirDocRefService
         $patientService = new PatientService();
         $patient = $patientService->search([$field => $newSearchField])->getData() ?? null;
         if (empty($patient)) {
-            (new SystemLogger())->errorLogCaller("Failed to find patient with uuid", ['uuids' => $searchPatient->getValues()]);
+            (new SystemLogger())->error("Failed to find patient with uuid {uuids}", ['uuids' => $searchPatient->getValues()]);
             throw new SearchFieldException($field, "Invalid argument");
         } else {
             $patient = $patient[0];

--- a/src/Services/FHIR/FhirMedicationRequestService.php
+++ b/src/Services/FHIR/FhirMedicationRequestService.php
@@ -406,7 +406,7 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
             $orgService = $this->getFhirOrganizationService();
             $primaryBusinessEntity = $orgService->getPrimaryBusinessEntityReference();
             if (empty($primaryBusinessEntity)) {
-                $this->getSystemLogger()->errorLogCaller("No primary organization found for reported field population in MedicationRequest FHIR resource.");
+                $this->getSystemLogger()->error("No primary organization found for reported field population in MedicationRequest FHIR resource");
                 // as a fallback we will set reported to true
                 $medRequestResource->setReportedBoolean('0' === ($dataRecord['is_primary_record'] ?? '1'));
             }

--- a/src/Services/FHIR/FhirProvenanceService.php
+++ b/src/Services/FHIR/FhirProvenanceService.php
@@ -237,7 +237,7 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
     {
         $processingResult = new ProcessingResult();
         if (empty($this->serviceLocator)) {
-            (new SystemLogger())->errorLogCaller("class was not properly configured with the service locator");
+            (new SystemLogger())->error("FhirProvenanceService was not properly configured with the service locator");
         }
 
         $searchParams = $this->filterSupportedSearchParams($fhirSearchParameters);
@@ -355,13 +355,13 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
 
         // lastUpdated is a timesecond instant so we are going to get int value for comparison
         if (empty($resource->getMeta())) {
-            (new SystemLogger())->errorLogCaller(
-                "Resource missing required Meta field",
+            (new SystemLogger())->error(
+                "Resource {resource} of type {type} missing required Meta field",
                 ['resource' => $resource->getId(), 'type' => $resource->get_fhirElementName()]
             );
         } else if (empty($resource->getMeta()->getLastUpdated())) {
-            (new SystemLogger())->errorLogCaller(
-                "Resource missing required Meta->lastUpdated field",
+            (new SystemLogger())->error(
+                "Resource {resource} of type {type} missing required Meta->lastUpdated field",
                 ['resource' => $resource->getId(), 'type' => $resource->get_fhirElementName()]
             );
         // patients were the only ones who actually were tracking a valid last updated date instead of the most

--- a/src/Services/FHIR/FhirServiceRequestService.php
+++ b/src/Services/FHIR/FhirServiceRequestService.php
@@ -301,7 +301,7 @@ class FhirServiceRequestService extends FhirServiceBase implements
         // Log validation issues
         if (!empty($validation['errors'])) {
             $errorMsg = "US Core 8.0 validation errors: " . implode("; ", $validation['errors']);
-            (new SystemLogger())->errorLogCaller($errorMsg, ['dataRecord_keys' => array_keys($dataRecord)]);
+            (new SystemLogger())->error($errorMsg, ['dataRecord_keys' => array_keys($dataRecord)]);
 
             // In strict mode, throw exception
             if ($this->strictValidation) {

--- a/src/Services/FHIR/Observation/FhirObservationPatientService.php
+++ b/src/Services/FHIR/Observation/FhirObservationPatientService.php
@@ -241,7 +241,7 @@ class FhirObservationPatientService extends FhirServiceBase implements IPatientC
                 continue;
             }
             if (!isset($uuidMappings[$code])) {
-                $this->getSystemLogger()->errorLogCaller("No UUID mapping for patient_data record ", ['uuid' => $record['uuid'], 'code' => $code]);
+                $this->getSystemLogger()->error("No UUID mapping for patient_data record {uuid} for code {code}", ['uuid' => $record['uuid'], 'code' => $code]);
                 continue;
             }
 

--- a/src/Services/FHIR/Observation/FhirObservationVitalsService.php
+++ b/src/Services/FHIR/Observation/FhirObservationVitalsService.php
@@ -564,7 +564,7 @@ class FhirObservationVitalsService extends FhirServiceBase implements IPatientCo
             }
             $codeMapping = self::COLUMN_MAPPINGS[$code];
             if (!isset($uuidMappings[$code])) {
-                $this->getSystemLogger()->errorLogCaller("FhirVitalsService->parseVitalsIntoObservationRecords() Cannot return vital sign record as mapping uuid is missing for code " . $code);
+                $this->getSystemLogger()->error("Cannot return vital sign record as mapping uuid is missing for code {code}", ['code' => $code]);
                 continue;
             }
             // uuid mappings are binary values, we need to convert them to string

--- a/src/Services/FHIR/Traits/VersionedProfileTrait.php
+++ b/src/Services/FHIR/Traits/VersionedProfileTrait.php
@@ -81,7 +81,7 @@ trait VersionedProfileTrait
         if (in_array($version, self::PROFILE_VERSIONS_ALL)) {
             $this->highestUSCoreProfileVersion = $version;
         } else {
-            $this->getSystemLogger()->errorLogCaller("Attempt to set unsupported US Core profile version", ['version' => $version]);
+            $this->getSystemLogger()->error("Attempt to set unsupported US Core profile version {version}", ['version' => $version]);
             throw new InvalidArgumentException("Unsupported US Core profile version " . $version);
         }
     }

--- a/src/Services/FHIR/Traits/VersionedProfileTrait.php
+++ b/src/Services/FHIR/Traits/VersionedProfileTrait.php
@@ -81,7 +81,7 @@ trait VersionedProfileTrait
         if (in_array($version, self::PROFILE_VERSIONS_ALL)) {
             $this->highestUSCoreProfileVersion = $version;
         } else {
-            $this->getSystemLogger()->error("Attempt to set unsupported US Core profile version {version}", ['version' => $version]);
+            $this->getSystemLogger()?->error("Attempt to set unsupported US Core profile version {version}", ['version' => $version]);
             throw new InvalidArgumentException("Unsupported US Core profile version " . $version);
         }
     }

--- a/src/Services/FHIR/UtilsService.php
+++ b/src/Services/FHIR/UtilsService.php
@@ -210,8 +210,8 @@ class UtilsService
             $format = str_contains((string) $dataRecord['period_start'], ':') ? "Y-m-d H:i:s" : "Y-m-d";
             $date = \DateTimeImmutable::createFromFormat($format, $dataRecord['period_start'], new \DateTimeZone(date('P')));
             if ($date === false) {
-                (new SystemLogger())->errorLogCaller(
-                    "Failed to format date record with date format ",
+                (new SystemLogger())->error(
+                    "Failed to format period_start date {start} for contact_address_id {contact_address_id}",
                     ['start' => $dataRecord['period_start'], 'contact_address_id' => ($dataRecord['contact_address_id'] ?? null)]
                 );
                 $date = new \DateTime('now', new \DateTimeZone(date('P')));
@@ -228,8 +228,8 @@ class UtilsService
         if (!empty($dataRecord['period_end'])) {
             $date = DateFormatterUtils::dateStringToDateTime($dataRecord['period_end'], true);
             if ($date === false) {
-                (new SystemLogger())->errorLogCaller(
-                    "Failed to format date record with date format ",
+                (new SystemLogger())->error(
+                    "Failed to format period_end date {date} for contact_address_id {contact_address_id}",
                     ['date' => $dataRecord['period_end'], 'contact_address_id' => ($dataRecord['contact_address_id'] ?? null)]
                 );
                 $date = new \DateTime();

--- a/src/Services/PatientAccessOnsiteService.php
+++ b/src/Services/PatientAccessOnsiteService.php
@@ -294,7 +294,7 @@ class PatientAccessOnsiteService
             return true;
         } else {
             $email_status = $mail->ErrorInfo;
-            $this->logger->errorLogCaller("Failed to send email through Mymailer ", ['ErrorInfo' => $email_status]);
+            $this->logger->error("Failed to send email through Mymailer: {ErrorInfo}", ['ErrorInfo' => $email_status]);
             return false;
         }
     }

--- a/tests/Tests/Api/ApiTestClient.php
+++ b/tests/Tests/Api/ApiTestClient.php
@@ -246,7 +246,7 @@ class ApiTestClient
             if (isset($errorBody->hint)) {
                 $errorMessage .= ": " . $errorBody->hint;
             }
-            $this->getSystemLogger()?->errorLogCaller($errorMessage);
+            $this->getSystemLogger()?->error("ApiTestClient: " . $errorMessage);
         }
 
         return $authResponse;
@@ -271,7 +271,7 @@ class ApiTestClient
         /** @var (\stdClass&object{client_id: string, client_secret: string})|null $clientResponseBody */
         $clientResponseBody = json_decode($clientResponseBodyRaw);
         if ($clientResponseBody === null) {
-            $this->getSystemLogger()?->errorLogCaller("Failed to decode client registration response: ", ['rawBody' => $clientResponseBodyRaw]);
+            $this->getSystemLogger()?->error("ApiTestClient: Failed to decode client registration response", ['rawBody' => $clientResponseBodyRaw]);
             throw new \RuntimeException("Client registration response could not be decoded");
         }
         $this->client_id = $clientResponseBody->client_id;


### PR DESCRIPTION
Unblocks #11020.

#### Short description of what this resolves:
Reworks calls to SystemLogger->errorLogCaller() to PSR-3 compliant ->error(), paving the way to relying on the interface throughout instead of the current implementation

#### Changes proposed in this pull request:
Updated remaining calls to `errorLogCaller()` to `error()`. Avoided losing the context it provided by one or more of the following:

- Passing a `Throwable` in the `exception` key of `$context` (missed a couple in last related change)
- Prefixing the error message with something useful
- In many cases, the errors were specific enough that it was redundant

Also fixed a number of spots where context may have been lost since the context keys weren't using the interpolation placeholder.

Finally, in one of the logging-related traits, added a null coalesce since the method signature indicated the logger could be null (it couldn't in practice but it still removes a bunch of warnings)

I think overall this sholdn't lose any important context from the change. If that turns out not to be the case, it's trivial to do something like `['exception' => new \Exception()]` to re-add a stack trace. I'm not doing it proactively since it can get quite noisy.

#### Does your code include anything generated by an AI Engine? Yes / No
Yes, claude did most updates