### PR TITLE
fix(install): remove OEGlobalsBag dependency from sql_upgrade.php

### DIFF
--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -17,12 +17,14 @@
 
 /* @TODO add language selection. needs RTL testing */
 
-\OpenEMR\Core\OEGlobalsBag::getInstance()->set('ongoing_sql_upgrade', true);
+// Set these via $GLOBALS before the autoloader is available (interface/globals.php
+// loads it later). The globals bag picks them up once globals.php runs.
+$GLOBALS['ongoing_sql_upgrade'] = true;
 
 if (php_sapi_name() === 'cli') {
     // setting for when running as command line script
     // need this for output to be readable when running as command line
-    \OpenEMR\Core\OEGlobalsBag::getInstance()->set('force_simple_sql_upgrade', true);
+    $GLOBALS['force_simple_sql_upgrade'] = true;
 }
 
 // Checks if the server's PHP version is compatible with OpenEMR:
@@ -43,7 +45,7 @@ if (ob_get_level() === 0) {
 
 $ignoreAuth = true; // no login required
 $sessionAllowWrite = true;
-\OpenEMR\Core\OEGlobalsBag::getInstance()->set('connection_pooling_off', true); // force off database connection pooling
+$GLOBALS['connection_pooling_off'] = true; // force off database connection pooling
 
 require_once('interface/globals.php');
 require_once('library/sql_upgrade_fx.php');

--- a/tests/PHPStan/Rules/ForbiddenGlobalsAccessRule.php
+++ b/tests/PHPStan/Rules/ForbiddenGlobalsAccessRule.php
@@ -27,6 +27,16 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 class ForbiddenGlobalsAccessRule implements Rule
 {
+    /**
+     * Files that set $GLOBALS before the Composer autoloader is available.
+     * These run before interface/globals.php and cannot use OEGlobalsBag.
+     *
+     * @var list<string>
+     */
+    private const PRE_AUTOLOADER_FILES = [
+        'sql_upgrade.php',
+    ];
+
     public function getNodeType(): string
     {
         return ArrayDimFetch::class;
@@ -46,6 +56,13 @@ class ForbiddenGlobalsAccessRule implements Rule
         // Allow $GLOBALS access in the OEGlobalsBag class itself
         if ($scope->isInClass() && $scope->getClassReflection()->getName() === \OpenEMR\Core\OEGlobalsBag::class) {
             return [];
+        }
+
+        // Allow $GLOBALS in files that run before the autoloader loads
+        foreach (self::PRE_AUTOLOADER_FILES as $filename) {
+            if (str_ends_with($scope->getFile(), DIRECTORY_SEPARATOR . $filename)) {
+                return [];
+            }
         }
 
         // Check if this is accessing $GLOBALS

--- a/tests/Tests/Isolated/SqlUpgradeBootstrapTest.php
+++ b/tests/Tests/Isolated/SqlUpgradeBootstrapTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Regression test for sql_upgrade.php pre-autoloader section.
+ *
+ * sql_upgrade.php sets several $GLOBALS flags before including
+ * interface/globals.php (which loads the Composer autoloader).
+ * Code before that require_once must not depend on the autoloader.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated;
+
+use PHPUnit\Framework\TestCase;
+
+class SqlUpgradeBootstrapTest extends TestCase
+{
+    /**
+     * Code before the autoloader loads must not use OEGlobalsBag.
+     *
+     * Extract everything before `require_once('interface/globals.php')`
+     * and verify it does not reference OEGlobalsBag, which requires
+     * the Composer autoloader. Explicitly required classes (like
+     * Compatibility\Checker) are fine.
+     */
+    public function testNoOEGlobalsBagBeforeAutoloader(): void
+    {
+        $file = dirname(__DIR__, 3) . '/sql_upgrade.php';
+        $this->assertFileExists($file);
+
+        $contents = file_get_contents($file);
+        $this->assertIsString($contents);
+
+        // Split at the globals.php include — only check code before it
+        $marker = "require_once('interface/globals.php')";
+        $pos = strpos($contents, $marker);
+        $this->assertIsInt($pos, "Expected to find globals.php require in sql_upgrade.php");
+
+        $preAutoloader = substr($contents, 0, $pos);
+
+        $this->assertStringNotContainsString(
+            'OEGlobalsBag',
+            $preAutoloader,
+            'sql_upgrade.php must not reference OEGlobalsBag before the autoloader loads. '
+            . 'Use raw $GLOBALS for pre-autoloader bootstrap flags.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Revert three pre-autoloader `OEGlobalsBag::getInstance()->set()` calls in `sql_upgrade.php` back to raw `$GLOBALS` — same pattern as #11053 (version.php / admin.php)
- Add `sql_upgrade.php` to the PHPStan `ForbiddenGlobalsAccessRule` pre-autoloader allowlist so it won't be flagged again
- Add `SqlUpgradeBootstrapTest` regression test to prevent future `OEGlobalsBag` references before the autoloader

Closes #11110

## Test plan

- [x] `composer phpunit-isolated -- --filter=SqlUpgradeBootstrapTest` passes
- [x] `composer phpstan` — no errors
- [x] All pre-commit hooks pass
- [ ] Manual: fresh install with demo data completes without fatal error

🤖 Generated with [Claude Code](https://claude.com/claude-code)