### PR TITLE
refactor(issues): move ACL check before database fetch in add_edit_issue.php

### DIFF
--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -309,11 +309,14 @@ if (!empty($_POST['form_save'])) {
 
 $irow = [];
 if ($issue) {
-    $patientIssuesService = new PatientIssuesService();
-    $irow = $patientIssuesService->getOneById($issue);
-    if (!AclMain::aclCheckIssue($irow['type'], '', 'write')) {
+    // ACL check before fetching full row so unauthorized requests never load PHI into memory
+    $issueType = sqlQuery("SELECT `type` FROM `lists` WHERE `id` = ?", [$issue]);
+    if (!AclMain::aclCheckIssue($issueType['type'] ?? '', '', 'write')) {
         die(xlt("Edit is not authorized!"));
     }
+
+    $patientIssuesService = new PatientIssuesService();
+    $irow = $patientIssuesService->getOneById($issue);
 } elseif ($thistype) {
     $irow['type'] = $thistype;
 }


### PR DESCRIPTION
Fixes #11126

#### Short description of what this resolves:
In `add_edit_issue.php`, the full issue row (containing PHI) was fetched from the database before the ACL check ran. While the ACL check correctly blocked unauthorized access and no data leaked to the response, as a defense-in-depth measure the fetch should happen after authorization is confirmed.

#### Changes proposed in this pull request:
- Added a lightweight query to fetch only the issue `type` column before the ACL check
- Moved the full row fetch (`PatientIssuesService::getOneById`) to after the ACL check passes
- This ensures unauthorized requests never load PHI into memory

#### Does your code include anything generated by an AI Engine? Yes / No
Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)