### PR TITLE
chore(deps): drop direct laminas/laminas-json requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,6 @@
         "laminas/laminas-filter": "^2.42.0",
         "laminas/laminas-form": "^3.24.0",
         "laminas/laminas-inputfilter": "^2.34.0",
-        "laminas/laminas-json": "^3.7.1",
         "laminas/laminas-json-server": "^3.9.0",
         "laminas/laminas-loader": "^2.11.1",
         "laminas/laminas-mvc": "^3.8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47465f16f328cadb2b891261f02666fe",
+    "content-hash": "b878f44d3f5d0251c9a9ab7ee26685de",
     "packages": [
         {
             "name": "academe/authorizenet-objects",


### PR DESCRIPTION
## Summary

- Remove `laminas/laminas-json` from the direct `require` in `composer.json`
- The package is [abandoned](https://packagist.org/packages/laminas/laminas-json) with no suggested replacement
- OpenEMR has zero direct usage — it's only pulled in transitively by `laminas/laminas-json-server` and `laminas/laminas-view`, so it remains available without being a direct dependency
- `composer-require-checker` confirms no undeclared symbol usage

Partial fix for #8252, relates to #8177.

## Test plan

- [ ] `composer install` succeeds
- [ ] `composer require-checker` passes
- [ ] No runtime regressions in Laminas module functionality