### PR TITLE
fix(upgrade): disable audit logging before globals.php loads

### DIFF
--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -46,6 +46,7 @@ if (ob_get_level() === 0) {
 $ignoreAuth = true; // no login required
 $sessionAllowWrite = true;
 $GLOBALS['connection_pooling_off'] = true; // force off database connection pooling
+$skipAuditLog = true; // disable audit logging during upgrades
 
 require_once('interface/globals.php');
 require_once('library/sql_upgrade_fx.php');
@@ -56,9 +57,6 @@ use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\Utils\SQLUpgradeService;
 use OpenEMR\Services\VersionService;
-
-// Force logging off
-OEGlobalsBag::getInstance()->set("enable_auditlog", 0);
 
 $versions = [];
 $sqldir = "$webserver_root/sql";


### PR DESCRIPTION
## Summary
- Set `$skipAuditLog = true` before loading `globals.php` so the `EventAuditLogger` singleton is never constructed during upgrades
- Remove the now-redundant `OEGlobalsBag::getInstance()->set("enable_auditlog", 0)` which no longer worked after #11113 moved config into a DTO captured at construction time

## Context
After #11113, `AuditConfig` captures `enable_auditlog` once when the `EventAuditLogger` singleton is constructed. Since `globals.php` constructs the singleton (via `logHttpRequest()`), the subsequent disable in `sql_upgrade.php` had no effect — the DTO already had `enabled: true` baked in.

`$skipAuditLog` is checked in both `globals.php` (prevents singleton construction) and `ADODB_mysqli_log` (prevents per-query audit calls), so this fully suppresses audit logging during upgrades.

Fixes #11132

## Test plan
- [x] Run `openemr-cmd drid` with demo data from a v5 SQL dump — upgrade should complete without the `checksum_api` column error

🤖 Generated with [Claude Code](https://claude.com/claude-code)