### PR TITLE
fix(encounter): hide dispensed medications section when inhouse_pharmacy is disabled

### DIFF
--- a/interface/forms/newpatient/report.php
+++ b/interface/forms/newpatient/report.php
@@ -68,7 +68,6 @@ function newpatient_report($pid, $encounter, $cols, $id): void
             'referringProvider' => $referringProvider,
             'posCode' => $posCode,
             'facility' => $facility_name,
-            'dispensedMedications' => []
         ];
         /**
          * @var OEGlobalsBag $globalsBag

--- a/interface/forms/newpatient/templates/newpatient/report.html.twig
+++ b/interface/forms/newpatient/templates/newpatient/report.html.twig
@@ -10,6 +10,8 @@
     {% if e.referringProvider %}
         <br />{{ "Referring Provider"|xlt }} - {{ e.referringProvider|text }}
     {% endif %}
-    {% include "templates/newpatient/partials/report/_dispensed-medications.html.twig" %}
+    {% if e.dispensedMedications is defined %}
+        {% include "templates/newpatient/partials/report/_dispensed-medications.html.twig" %}
+    {% endif %}
 {% endfor %}
 </div>


### PR DESCRIPTION

<!--Thanks for sending a pull request!
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #11098

<!-- PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details -->

#### Short description of what this resolves:
The Dispensed Medications section (heading, table, and "No medications dispensed" message) renders in the encounter report even when the `inhouse_pharmacy` global setting is disabled

#### Changes proposed in this pull request:
- Removed the default empty `dispensedMedications` array from the encounter record in `report.php`, so the key is only set when `inhouse_pharmacy` is enabled
- Wrapped the Twig template include with `{% if e.dispensedMedications is defined %}` to skip rendering when the key is absent

#### Does your code include anything generated by an AI Engine? Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.

Changes were generated with assistance from Claude Code. The modifications are minimal (one line removed, one conditional added) and have been manually verified.