### PR TITLE
fix(reports): include custom LBF layout forms in patient report

### DIFF
--- a/interface/patient_file/report/patient_report.php
+++ b/interface/patient_file/report/patient_report.php
@@ -393,6 +393,16 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                                             }
                                                         }
                                                     }
+                                                    // AI-generated code (Claude Code) - start
+                                                    // Print any forms not in the registry (e.g. custom LBF layouts)
+                                                    foreach ($html_strings as $key => $toprint) {
+                                                        if (!in_array($key, $registry_form_name, true)) {
+                                                            foreach ($toprint as $item) {
+                                                                print $item;
+                                                            }
+                                                        }
+                                                    }
+                                                    // AI-generated code (Claude Code) - end
                                                     $html_strings = [];
                                                     echo "</div>\n"; // end DIV encounter_forms
                                                     echo "</div>\n\n";  //end DIV encounter_data
@@ -459,6 +469,16 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                                 }
                                             }
                                         }
+                                        // AI-generated code (Claude Code) - start
+                                        // Print any forms not in the registry (e.g. custom LBF layouts)
+                                        foreach ($html_strings as $key => $toprint) {
+                                            if (!in_array($key, $registry_form_name, true)) {
+                                                foreach ($toprint as $item) {
+                                                    print $item;
+                                                }
+                                            }
+                                        }
+                                        // AI-generated code (Claude Code) - end
                                         ?>
 
                                         <?php


### PR DESCRIPTION
<!--Thanks for sending a pull request!
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #11141

<!-- PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details -->

#### Short description of what this resolves:
Custom layout forms (LBF) created via Admin > Forms > Layouts are missing from the Patient Report. This regression was introduced by PR #8949 which converted `strpos($form_name, $var) == 0` to `str_starts_with($form_name, $var)`, exposing a pre-existing bug where the report print loop only iterates over registry table names, silently dropping any form not in the registry.

#### Changes proposed in this pull request:
- Added a second pass after each registry print loop in `patient_report.php` to print forms whose names are not in the registry (e.g. custom LBF layouts)
- Both print loops are patched: the between-encounters loop and the final loop

#### Does your code include anything generated by an AI Engine? Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.

Changes were generated with assistance from Claude Code. The modifications are minimal (two identical loop blocks added) and have been manually verified.