### PR TITLE
fix(session): respect sessionAllowWrite global in PHPSessionWrapper (backport #11072)

### DIFF
--- a/src/Common/Session/PHPSessionWrapper.php
+++ b/src/Common/Session/PHPSessionWrapper.php
@@ -29,8 +29,14 @@ class PHPSessionWrapper implements SessionWrapperInterface
 
         $globalsBag = OEGlobalsBag::getInstance();
         // Empty webroot is valid - means OpenEMR is at document root
-        $webroot = $globalsBag->get('webroot') ?? '';
-        SessionUtil::coreSessionStart($webroot, false);
+        $webroot = $globalsBag->getString('webroot');
+
+        // Respect sessionAllowWrite global: if not set/empty, open in read-only mode.
+        // This follows the pattern in globals.php: $read_only = empty($sessionAllowWrite)
+        // Allows read_and_close mechanism to reduce session lock contention on concurrent requests.
+        $sessionAllowWrite = $globalsBag->getBoolean('sessionAllowWrite');
+
+        SessionUtil::coreSessionStart($webroot, !$sessionAllowWrite);
     }
 
     public function getId(): string


### PR DESCRIPTION
## Summary
- Backport of #11072 to rel-800
- Fixes #10931: PHPSessionWrapper hardcoded write mode, bypassing sessionAllowWrite

## Changes
- Check sessionAllowWrite global and pass it to `coreSessionStart()` so read-only sessions avoid exclusive locks
- Use typed `getString()` / `getBoolean()` accessors on OEGlobalsBag

## Test plan
- [ ] Verify session behavior with sessionAllowWrite enabled/disabled
- [ ] Confirm no regressions in session handling on rel-800