### PR TITLE
fix: Fixes #11142 employer data not saving

### DIFF
--- a/interface/patient_file/summary/demographics_save.php
+++ b/interface/patient_file/summary/demographics_save.php
@@ -191,7 +191,7 @@ while ($frow = sqlFetchArray($fres)) {
 try {
     updatePatientData($pid, $newdata['patient_data']);
     if (!OEGlobalsBag::getInstance()->getBoolean('omit_employers')) {
-        updateEmployerData($pid, [], $newdata['employer_data']);
+        updateEmployerData($pid, $newdata['employer_data'], false, $newdata['patient_data']);
     }
 } catch (\Throwable $e) {
     $logger->error("Error updating patient/employer data", [


### PR DESCRIPTION
This fixes #11142 employer data not saving in the demographics_save.php

Opened it as a new PR, got tired of playing whack-a-mole with phpstan updating one function call to have it cascade into a bunch of other errors.  Kept the same function signature so we can get this into a patch.