### PR TITLE
fix(composer): use forward slashes in autoload-dev path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -185,7 +185,7 @@
         "psr-4": {
             "OpenEMR\\PHPStan\\Rules\\": "tests/PHPStan/Rules",
             "OpenEMR\\Rector\\Rules\\": "tests/Rector/Rules",
-            "OpenEMR\\Tests\\": "tests\\Tests"
+            "OpenEMR\\Tests\\": "tests/Tests"
         }
     },
     "config": {


### PR DESCRIPTION
## Summary

- Fix Windows-style backslashes in `autoload-dev` path for `OpenEMR\Tests\` namespace

The path was `tests\\Tests` (Windows-style) instead of `tests/Tests` (Unix-style). While Composer tolerates this on Unix systems, tools that strictly validate paths fail.

This bug was introduced in commit 51722f93c9e (2022-03-07) which was titled "removal of ^M line endings in composer.json" — a Windows artifact ironically introducing another Windows artifact.

## Test plan

- [x] Pre-commit hooks pass
- [x] `composer dump-autoload` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)