### PR TITLE
fix(session): prevent double session start with read_and_close

### DIFF
--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -648,7 +648,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 35,
+    'count' => 34,
     'path' => __DIR__ . '/../../interface/globals.php',
 ];
 $ignoreErrors[] = [

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -719,7 +719,7 @@ class C_Document extends Controller
                 die(xlt("File retrieval from CouchDB failed"));
             }
             if ($d->get_encrypted() == 1) {
-                $filetext = $this->cryptoGen->decryptStandard($content, null, KeySource::Database);
+                $filetext = $this->cryptoGen->decryptStandard($content, KeySource::Database);
             } else {
                 $filetext = base64_decode((string) $content);
             }
@@ -758,7 +758,7 @@ class C_Document extends Controller
                 $couchM = new CouchDB();
                 $respM = $couchM->retrieve_doc($couch_docid);
                 if ($d->get_encrypted() == 1) {
-                    $contentM = $this->cryptoGen->decryptStandard($respM->data, null, KeySource::Database);
+                    $contentM = $this->cryptoGen->decryptStandard($respM->data, KeySource::Database);
                 } else {
                     $contentM = base64_decode((string) $respM->data);
                 }
@@ -801,14 +801,14 @@ class C_Document extends Controller
                 $couchF = new CouchDB();
                 $respF = $couchF->retrieve_doc("converted_" . $couch_docid);
                 if ($d->get_encrypted() == 1) {
-                    $content = $this->cryptoGen->decryptStandard($respF->data, null, KeySource::Database);
+                    $content = $this->cryptoGen->decryptStandard($respF->data, KeySource::Database);
                 } else {
                     $content = base64_decode((string) $respF->data);
                 }
             } else {
                 // decrypt/decode when converted jpg already exists
                 if ($d->get_encrypted() == 1) {
-                    $content = $this->cryptoGen->decryptStandard($resp->data, null, KeySource::Database);
+                    $content = $this->cryptoGen->decryptStandard($resp->data, KeySource::Database);
                 } else {
                     $content = base64_decode((string) $resp->data);
                 }
@@ -891,7 +891,7 @@ class C_Document extends Controller
         if ($original_file) {
             //normal case when serving the file referenced in database
             if ($d->get_encrypted() == 1) {
-                $filetext = $this->cryptoGen->decryptStandard(file_get_contents($url), null, KeySource::Database);
+                $filetext = $this->cryptoGen->decryptStandard(file_get_contents($url), KeySource::Database);
             } else {
                 if (!is_dir($url)) {
                     $filetext = file_get_contents($url);
@@ -932,7 +932,7 @@ class C_Document extends Controller
             if (!is_file($url)) {
                 if ($d->get_encrypted() == 1) {
                     // decrypt the from-file into a temporary file
-                    $from_file_unencrypted = $this->cryptoGen->decryptStandard(file_get_contents($originalUrl), null, KeySource::Database);
+                    $from_file_unencrypted = $this->cryptoGen->decryptStandard(file_get_contents($originalUrl), KeySource::Database);
                     $from_file_tmp_name = tempnam(OEGlobalsBag::getInstance()->get('temporary_files_dir'), "oer");
                     file_put_contents($from_file_tmp_name, $from_file_unencrypted);
                     // prepare a temporary file for the unencrypted to-file
@@ -957,7 +957,7 @@ class C_Document extends Controller
             }
             if (is_file($url)) {
                 if ($d->get_encrypted() == 1) {
-                    $filetext = $this->cryptoGen->decryptStandard(file_get_contents($url), null, KeySource::Database);
+                    $filetext = $this->cryptoGen->decryptStandard(file_get_contents($url), KeySource::Database);
                 } else {
                     $filetext = file_get_contents($url);
                 }
@@ -1032,7 +1032,7 @@ class C_Document extends Controller
             $couch = new CouchDB();
             $resp = $couch->retrieve_doc($d->couch_docid);
             if ($d->get_encrypted() == 1) {
-                $content = $this->cryptoGen->decryptStandard($resp->data, null, KeySource::Database);
+                $content = $this->cryptoGen->decryptStandard($resp->data, KeySource::Database);
             } else {
                 $content = base64_decode((string) $resp->data);
             }
@@ -1070,7 +1070,7 @@ class C_Document extends Controller
             }
 
             if ($d->get_encrypted() == 1) {
-                $content = $this->cryptoGen->decryptStandard(file_get_contents($url), null, KeySource::Database);
+                $content = $this->cryptoGen->decryptStandard(file_get_contents($url), KeySource::Database);
             } else {
                 $content = file_get_contents($url);
             }
@@ -1291,7 +1291,7 @@ class C_Document extends Controller
         $LOG = file_get_contents($log_path . $log_file);
 
         if ($this->cryptoGen->cryptCheckStandard($LOG)) {
-            $LOG = $this->cryptoGen->decryptStandard($LOG, null, KeySource::Database);
+            $LOG = $this->cryptoGen->decryptStandard($LOG, KeySource::Database);
         }
 
         $LOG .= $content;

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -235,10 +235,14 @@ $globalsBag->set('eventDispatcher', $eventDispatcher ?? null);
 $globalsBag->set('ignoreAuth_onsite_portal', $ignoreAuth_onsite_portal);
 $read_only = empty($sessionAllowWrite);
 $session = SessionWrapperFactory::getInstance()->getWrapper();
-if (session_status() === PHP_SESSION_NONE && !$session->isSymfonySession()) {
-    //error_log("1. LOCK ".GetCallingScriptName()); // debug start lock
+$factory = SessionWrapperFactory::getInstance();
+// PHPSessionWrapper starts the session in its constructor (respecting sessionAllowWrite via
+// OEGlobalsBag). Only start here if no wrapper has started a session yet — this prevents the
+// double session-file read that occurred when read_and_close closed the session and
+// session_status() returned PHP_SESSION_NONE.
+if (!$factory->isCoreSessionStarted() && session_status() === PHP_SESSION_NONE && !$session->isSymfonySession()) {
     SessionUtil::coreSessionStart($web_root, $read_only);
-    //error_log("2. FREE ".GetCallingScriptName()); // debug unlocked
+    $factory->setCoreSessionStarted(true);
 }
 
 // Set the site ID if required.  This must be done before any database

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -233,6 +233,15 @@ $globalsBag->set('OE_SITES_BASE', $GLOBALS['OE_SITES_BASE'] ?? "$webserver_root/
 $globalsBag->set('debug_ssl_mysql_connection', $GLOBALS['debug_ssl_mysql_connection'] ?? false);
 $globalsBag->set('eventDispatcher', $eventDispatcher ?? null);
 $globalsBag->set('ignoreAuth_onsite_portal', $ignoreAuth_onsite_portal);
+
+// Propagate $sessionAllowWrite to OEGlobalsBag so PHPSessionWrapper (which reads from
+// OEGlobalsBag, not local scope) starts the session with the correct read/write mode.
+// Scripts like login.php, main_screen.php, logout.php set $sessionAllowWrite = true as a
+// local variable before including this file. Without this bridge, PHPSessionWrapper would
+// always start in read_and_close mode for core requests, causing silent $_SESSION write failures.
+if (!empty($sessionAllowWrite)) {
+    $globalsBag->set('sessionAllowWrite', true);
+}
 $read_only = empty($sessionAllowWrite);
 $session = SessionWrapperFactory::getInstance()->getWrapper();
 $factory = SessionWrapperFactory::getInstance();

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -239,10 +239,10 @@ $globalsBag->set('ignoreAuth_onsite_portal', $ignoreAuth_onsite_portal);
 // Scripts like login.php, main_screen.php, logout.php set $sessionAllowWrite = true as a
 // local variable before including this file. Without this bridge, PHPSessionWrapper would
 // always start in read_and_close mode for core requests, causing silent $_SESSION write failures.
-if (!empty($sessionAllowWrite)) {
+if (isset($sessionAllowWrite) && $sessionAllowWrite) {
     $globalsBag->set('sessionAllowWrite', true);
 }
-$read_only = empty($sessionAllowWrite);
+$read_only = !isset($sessionAllowWrite) || !$sessionAllowWrite;
 $session = SessionWrapperFactory::getInstance()->getWrapper();
 $factory = SessionWrapperFactory::getInstance();
 // PHPSessionWrapper starts the session in its constructor (respecting sessionAllowWrite via

--- a/src/Common/Session/PHPSessionWrapper.php
+++ b/src/Common/Session/PHPSessionWrapper.php
@@ -24,6 +24,7 @@ class PHPSessionWrapper implements SessionWrapperInterface
     {
         // Skip if session already active (e.g., API/OAuth context where Symfony session exists)
         if (session_status() === PHP_SESSION_ACTIVE) {
+            SessionWrapperFactory::getInstance()->setCoreSessionStarted(true);
             return;
         }
 
@@ -37,6 +38,7 @@ class PHPSessionWrapper implements SessionWrapperInterface
         $sessionAllowWrite = $globalsBag->getBoolean('sessionAllowWrite');
 
         SessionUtil::coreSessionStart($webroot, !$sessionAllowWrite);
+        SessionWrapperFactory::getInstance()->setCoreSessionStarted(true);
     }
 
     public function getId(): string

--- a/src/Common/Session/SessionWrapperFactory.php
+++ b/src/Common/Session/SessionWrapperFactory.php
@@ -24,6 +24,23 @@ class SessionWrapperFactory
 
     private ?SessionWrapperInterface $sessionWrapper = null;
 
+    /**
+     * Tracks whether the core PHP session was already started by a wrapper.
+     * Prevents globals.php from redundantly re-starting a read_and_close session
+     * (which would cause a double file read on every request).
+     */
+    private bool $coreSessionStarted = false;
+
+    public function isCoreSessionStarted(): bool
+    {
+        return $this->coreSessionStarted;
+    }
+
+    public function setCoreSessionStarted(bool $started): void
+    {
+        $this->coreSessionStarted = $started;
+    }
+
     public function getWrapper(array $initData = []): SessionWrapperInterface
     {
         if (!$this->sessionWrapper) {

--- a/src/RestControllers/Subscriber/SiteSetupListener.php
+++ b/src/RestControllers/Subscriber/SiteSetupListener.php
@@ -8,6 +8,7 @@ use OpenEMR\Common\Auth\OAuth2KeyException;
 use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Common\Http\HttpSessionFactory;
 use OpenEMR\Common\Logging\SystemLoggerAwareTrait;
+use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Core\OEHttpKernel;
 use OpenEMR\FHIR\Config\ServerConfig;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -185,7 +186,11 @@ class SiteSetupListener implements EventSubscriberInterface
     protected function loadApplicationGlobals(RequestEvent $event, bool $ignoreAuth): mixed
     {
         // globals.php line 236: $read_only = empty($sessionAllowWrite)
+        // Set both local (for globals.php include scope) and OEGlobalsBag (for PHPSessionWrapper
+        // which reads via OEGlobalsBag). Without the OEGlobalsBag assignment, PHPSessionWrapper
+        // would not see this local variable and would start the session as read_and_close.
         $sessionAllowWrite = true;
+        OEGlobalsBag::getInstance()->set('sessionAllowWrite', true);
 
         // globals.php line 220: if (isset($globalsBag)) — reuse the kernel's bag
         // globals.php line 234: $globalsBag->set('eventDispatcher', $eventDispatcher ?? null)

--- a/tests/Tests/Unit/Common/Session/SessionWrapperFactoryTest.php
+++ b/tests/Tests/Unit/Common/Session/SessionWrapperFactoryTest.php
@@ -19,6 +19,7 @@ namespace OpenEMR\Tests\Unit\Common\Session;
 use OpenEMR\Common\Session\PHPSessionWrapper;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\OEGlobalsBag;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -1027,5 +1028,142 @@ class SessionWrapperFactoryTest extends TestCase
             $newFactory->isCoreSessionStarted(),
             'coreSessionStarted should be false after singleton reset'
         );
+    }
+
+    /**
+     * Test that PHPSessionWrapper starts in writable mode when sessionAllowWrite is set in OEGlobalsBag.
+     *
+     * This simulates the globals.php flow: scripts like login.php, main_screen.php, and logout.php
+     * set $sessionAllowWrite = true before including globals.php. The fix in globals.php propagates
+     * this to OEGlobalsBag so PHPSessionWrapper reads it and starts the session without read_and_close.
+     *
+     * Without this propagation, PHPSessionWrapper always starts in read_and_close mode for core
+     * requests, the coreSessionStarted guard prevents the fallback session start, and session
+     * writes are silently lost.
+     */
+    public function testSessionAllowWritePropagatedToOEGlobalsBagStartsWritableSession(): void
+    {
+        // Close any active session from prior tests
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+
+        // Reset OEGlobalsBag singleton to get a clean instance
+        $globalsBagReflection = new ReflectionClass(OEGlobalsBag::class);
+        $instancesProperty = $globalsBagReflection->getProperty('instances');
+        $originalInstances = $instancesProperty->getValue(null);
+        $instancesProperty->setValue(null, []);
+
+        // Simulate what globals.php does after the fix:
+        // propagate $sessionAllowWrite to OEGlobalsBag before creating PHPSessionWrapper
+        $GLOBALS['sessionAllowWrite'] = true;
+        $globalsBag = OEGlobalsBag::getInstance();
+        $globalsBag->set('sessionAllowWrite', true);
+
+        $this->assertTrue(
+            $globalsBag->getBoolean('sessionAllowWrite'),
+            'OEGlobalsBag should reflect sessionAllowWrite = true'
+        );
+
+        // Set up core session cookie
+        $_COOKIE[SessionUtil::APP_COOKIE_NAME] = SessionUtil::CORE_SESSION_ID;
+
+        // Create wrapper — PHPSessionWrapper constructor reads sessionAllowWrite from OEGlobalsBag
+        $factory = SessionWrapperFactory::getInstance();
+        $reflection = new ReflectionClass($factory);
+        $method = $reflection->getMethod('findSessionWrapper');
+        $wrapper = $method->invoke($factory, []);
+
+        $this->assertInstanceOf(PHPSessionWrapper::class, $wrapper);
+        $this->assertTrue(
+            $factory->isCoreSessionStarted(),
+            'PHPSessionWrapper should mark core session as started'
+        );
+
+        // The session should be active (writable, not closed by read_and_close)
+        $this->assertEquals(
+            PHP_SESSION_ACTIVE,
+            session_status(),
+            'Session should remain active (writable) when sessionAllowWrite is true. '
+            . 'If read_and_close was used, session_status() would be PHP_SESSION_NONE.'
+        );
+
+        // Verify we can write to the session
+        $_SESSION['test_write_key'] = 'test_value';
+        $this->assertEquals(
+            'test_value',
+            $_SESSION['test_write_key'],
+            'Should be able to write to $_SESSION when sessionAllowWrite is true'
+        );
+
+        // Clean up
+        unset($_SESSION['test_write_key']);
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+        unset($GLOBALS['sessionAllowWrite']);
+
+        // Restore OEGlobalsBag singleton
+        $instancesProperty->setValue(null, $originalInstances);
+    }
+
+    /**
+     * Test that PHPSessionWrapper starts in read_and_close mode when sessionAllowWrite is NOT set.
+     *
+     * This is the default for most core requests (AJAX calls, dated_reminders, etc.) where
+     * session lock contention needs to be minimized via read_and_close.
+     */
+    public function testSessionStartsReadOnlyWhenSessionAllowWriteNotSet(): void
+    {
+        // Close any active session from prior tests
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+
+        // Reset OEGlobalsBag singleton
+        $globalsBagReflection = new ReflectionClass(OEGlobalsBag::class);
+        $instancesProperty = $globalsBagReflection->getProperty('instances');
+        $originalInstances = $instancesProperty->getValue(null);
+        $instancesProperty->setValue(null, []);
+
+        // Ensure sessionAllowWrite is NOT set (default for most requests)
+        unset($GLOBALS['sessionAllowWrite']);
+        $globalsBag = OEGlobalsBag::getInstance();
+
+        $this->assertFalse(
+            $globalsBag->getBoolean('sessionAllowWrite'),
+            'OEGlobalsBag should return false for sessionAllowWrite when not set'
+        );
+
+        // Set up core session cookie
+        $_COOKIE[SessionUtil::APP_COOKIE_NAME] = SessionUtil::CORE_SESSION_ID;
+
+        // Create wrapper — should start in read_and_close mode
+        $factory = SessionWrapperFactory::getInstance();
+        $reflection = new ReflectionClass($factory);
+        $method = $reflection->getMethod('findSessionWrapper');
+        $wrapper = $method->invoke($factory, []);
+
+        $this->assertInstanceOf(PHPSessionWrapper::class, $wrapper);
+        $this->assertTrue(
+            $factory->isCoreSessionStarted(),
+            'PHPSessionWrapper should mark core session as started even in read-only mode'
+        );
+
+        // With read_and_close, the session should be closed immediately (PHP_SESSION_NONE)
+        $this->assertEquals(
+            PHP_SESSION_NONE,
+            session_status(),
+            'Session should be closed (PHP_SESSION_NONE) when sessionAllowWrite is not set, '
+            . 'because read_and_close should have auto-closed it.'
+        );
+
+        // Clean up
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+
+        // Restore OEGlobalsBag singleton
+        $instancesProperty->setValue(null, $originalInstances);
     }
 }

--- a/tests/Tests/Unit/Common/Session/SessionWrapperFactoryTest.php
+++ b/tests/Tests/Unit/Common/Session/SessionWrapperFactoryTest.php
@@ -921,4 +921,111 @@ class SessionWrapperFactoryTest extends TestCase
             'Portal session' => [SessionUtil::PORTAL_SESSION_ID],
         ];
     }
+
+    // =========================================================================
+    // coreSessionStarted Flag Tests — prevents double session start
+    // =========================================================================
+
+    /**
+     * Test that coreSessionStarted defaults to false on a fresh factory
+     */
+    public function testCoreSessionStartedDefaultsToFalse(): void
+    {
+        $factory = SessionWrapperFactory::getInstance();
+        $this->assertFalse(
+            $factory->isCoreSessionStarted(),
+            'coreSessionStarted should default to false on a fresh factory'
+        );
+    }
+
+    /**
+     * Test that setCoreSessionStarted / isCoreSessionStarted round-trip works
+     */
+    public function testCoreSessionStartedCanBeSetAndRead(): void
+    {
+        $factory = SessionWrapperFactory::getInstance();
+
+        $factory->setCoreSessionStarted(true);
+        $this->assertTrue($factory->isCoreSessionStarted());
+
+        $factory->setCoreSessionStarted(false);
+        $this->assertFalse($factory->isCoreSessionStarted());
+    }
+
+    /**
+     * Test that PHPSessionWrapper constructor sets coreSessionStarted flag
+     * when a session is already active
+     */
+    public function testPHPSessionWrapperSetsCoreSessionStartedWhenSessionActive(): void
+    {
+        $_COOKIE[SessionUtil::APP_COOKIE_NAME] = SessionUtil::CORE_SESSION_ID;
+
+        // Start a session before wrapper creation
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+
+        $factory = SessionWrapperFactory::getInstance();
+        $this->assertFalse($factory->isCoreSessionStarted(), 'Flag should be false before getWrapper');
+
+        $wrapper = $factory->getWrapper();
+
+        $this->assertInstanceOf(PHPSessionWrapper::class, $wrapper);
+        $this->assertTrue(
+            $factory->isCoreSessionStarted(),
+            'PHPSessionWrapper should set coreSessionStarted when session is already active'
+        );
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+    }
+
+    /**
+     * Test that coreSessionStarted flag persists across multiple getWrapper() calls
+     * (singleton returns cached wrapper, flag stays true)
+     */
+    public function testCoreSessionStartedPersistsAcrossGetWrapperCalls(): void
+    {
+        $_COOKIE[SessionUtil::APP_COOKIE_NAME] = SessionUtil::CORE_SESSION_ID;
+
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+
+        $factory = SessionWrapperFactory::getInstance();
+        $factory->getWrapper();
+        $this->assertTrue($factory->isCoreSessionStarted());
+
+        // Second call should still return true
+        $factory->getWrapper();
+        $this->assertTrue(
+            $factory->isCoreSessionStarted(),
+            'coreSessionStarted should remain true after repeated getWrapper() calls'
+        );
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+    }
+
+    /**
+     * Test that the coreSessionStarted flag is reset when the singleton is reset
+     * (important for test isolation and request boundaries)
+     */
+    public function testCoreSessionStartedResetsWithSingleton(): void
+    {
+        $factory = SessionWrapperFactory::getInstance();
+        $factory->setCoreSessionStarted(true);
+        $this->assertTrue($factory->isCoreSessionStarted());
+
+        // Reset singleton (simulates new request)
+        $this->resetSingleton();
+
+        $newFactory = SessionWrapperFactory::getInstance();
+        $this->assertFalse(
+            $newFactory->isCoreSessionStarted(),
+            'coreSessionStarted should be false after singleton reset'
+        );
+    }
 }


### PR DESCRIPTION
Improves #10931

#### Short description of what this resolves:
- **Session:** add coreSessionStarted flag to prevent `globals.php` from re-starting a `read_and_close` session that `PHPSessionWrapper` already started. Fix `sessionAllowWrite` scope in SiteSetupListener.
- **Crypto:** remove stale `null` argument from 8 `decryptStandard` calls in
  `C_Document` that broke after the signature change in 7f33297a5.

#### Does your code include anything generated by an AI Engine? Yes
