### PR TITLE
chore(docs): add missing GHSA and fix advisory URLs in 8.0.0.2 changelog

### DIFF
--- a/.phpstan/baseline/loader.php
+++ b/.phpstan/baseline/loader.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-// total 19048 errors
+// total 19050 errors
 
 return ['includes' => [
     __DIR__ . '/arguments.count.php',

--- a/.phpstan/baseline/openemr.forbiddenGlobalsAccess.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalsAccess.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-// total 3905 errors
+// total 3907 errors
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
@@ -905,7 +905,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$GLOBALS is forbidden\\. Use OEGlobalsBag\\:\\:getInstance\\(\\)\\-\\>get\\(\\) instead\\.$#',
-    'count' => 17,
+    'count' => 19,
     'path' => __DIR__ . '/../../interface/forms/vitals/C_FormVitals.class.php',
 ];
 $ignoreErrors[] = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,21 @@
 
 #### Security
 
-- **[Critical]** [RCE in backup.php command injection](https://github.com/openemr/openemr-ghsa-6pmc-3xm7-pm86)
-- **[High]** [Stored XSS in Eye Exam form answers](https://github.com/openemr/openemr-ghsa-pgvq-f22q-2whp)
-- **[High]** [SSRF via PDF generator](https://github.com/openemr/openemr-ghsa-5pc3-2crw-96rv)
-- **[High]** [Arbitrary file read via PDF generator](https://github.com/openemr/openemr-ghsa-v9v3-q973-xp2h)
-- **[High]** [zhAclCheck ignores explicit ACL denies](https://github.com/openemr/openemr-ghsa-v68v-pwc4-8p2m)
-- **[Medium]** [DICOM path traversal](https://github.com/openemr/openemr-ghsa-rppw-f689-6hrm)
-- **[Medium]** [Vitals IDOR (POST + PUT + legacy form)](https://github.com/openemr/openemr-ghsa-mv9m-j65p-g55f)
-- **[Medium]** [DOM XSS via SearchHighlight](https://github.com/openemr/openemr-ghsa-q283-5j7f-r6hp)
-- **[Medium]** [Stored XSS in portal credential print view](https://github.com/openemr/openemr-ghsa-cp37-pmfx-5mhm)
-- **[Medium]** [Authorization bypass in dated reminders log](https://github.com/openemr/openemr-ghsa-66j9-ffq4-h222)
-- **[Medium]** [Authorization bypass in FaxSMS AppDispatch](https://github.com/openemr/openemr-ghsa-r973-h5cq-35rc)
+- **[Critical]** [RCE in backup.php command injection](https://github.com/openemr/openemr/security/advisories/GHSA-6pmc-3xm7-pm86)
+- **[High]** [Stored XSS in Eye Exam form answers](https://github.com/openemr/openemr/security/advisories/GHSA-pgvq-f22q-2whp)
+- **[High]** [SSRF via PDF generator](https://github.com/openemr/openemr/security/advisories/GHSA-5pc3-2crw-96rv)
+- **[High]** [Arbitrary file read via PDF generator](https://github.com/openemr/openemr/security/advisories/GHSA-v9v3-q973-xp2h)
+- **[High]** [zhAclCheck ignores explicit ACL denies](https://github.com/openemr/openemr/security/advisories/GHSA-v68v-pwc4-8p2m)
+- **[High]** [Stored XSS in portal_payment.php via unescaped table_args](https://github.com/openemr/openemr/security/advisories/GHSA-qvf6-6xc6-9qv7)
+- **[Medium]** [DICOM path traversal](https://github.com/openemr/openemr/security/advisories/GHSA-rppw-f689-6hrm)
+- **[Medium]** [Vitals IDOR (POST + PUT + legacy form)](https://github.com/openemr/openemr/security/advisories/GHSA-mv9m-j65p-g55f)
+- **[Medium]** [DOM XSS via SearchHighlight](https://github.com/openemr/openemr/security/advisories/GHSA-q283-5j7f-r6hp)
+- **[Medium]** [Stored XSS in portal credential print view](https://github.com/openemr/openemr/security/advisories/GHSA-cp37-pmfx-5mhm)
+- **[Medium]** [Authorization bypass in dated reminders log](https://github.com/openemr/openemr/security/advisories/GHSA-66j9-ffq4-h222)
+- **[Medium]** [Authorization bypass in FaxSMS AppDispatch](https://github.com/openemr/openemr/security/advisories/GHSA-r973-h5cq-35rc)
 
 - PHPSessionWrapper constructor bypasses read_and_close session mode, causing lock contention ([#10931](https://github.com/openemr/openemr/issues/10931))
- 
+
 ### Changed
 - FHIR API documentation minor fixes ([#11104](https://github.com/openemr/openemr/pull/11104))
 - remove 2015 reference with schemaspy regen for rel-800 ([#11101](https://github.com/openemr/openemr/pull/11101))


### PR DESCRIPTION
## Summary
- Add missing [GHSA-qvf6-6xc6-9qv7](https://github.com/openemr/openemr/security/advisories/GHSA-qvf6-6xc6-9qv7) (stored XSS in portal_payment.php) to 8.0.0.2 changelog — it was fixed in the patch but omitted from the release notes
- Replace private fork URLs (`openemr-ghsa-*`) with public advisory URLs for all security entries
- Fix trailing whitespace in CHANGELOG.md (failing CI whitespace check)
- Regenerate PHPStan baseline (2-error drift in vitals form globals access)

## Test plan
- [ ] Verify all advisory links resolve correctly
- [ ] CI whitespace and PHPStan checks pass