### PR TITLE
chore(testing): show PHPUnit deprecation details in test output

### DIFF
--- a/phpunit-isolated.xml
+++ b/phpunit-isolated.xml
@@ -23,6 +23,7 @@ This file configures the kind that does not require initialization.
          displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnPhpunitDeprecations="true"
          testdox="false">
 
   <php>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@ OpenEMR has two different kinds of tests:
 This file configures the kind that requires initialization.
 -->
 
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" backupGlobals="false" bootstrap="tests/bootstrap.php" colors="false" processIsolation="false" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" stopOnRisky="false" displayDetailsOnTestsThatTriggerDeprecations="true" displayDetailsOnTestsThatTriggerErrors="true" displayDetailsOnTestsThatTriggerWarnings="true" displayDetailsOnTestsThatTriggerNotices="true" testdox="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" backupGlobals="false" bootstrap="tests/bootstrap.php" colors="false" processIsolation="false" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" stopOnRisky="false" displayDetailsOnTestsThatTriggerDeprecations="true" displayDetailsOnTestsThatTriggerErrors="true" displayDetailsOnTestsThatTriggerWarnings="true" displayDetailsOnTestsThatTriggerNotices="true" displayDetailsOnPhpunitDeprecations="true" testdox="false">
   <coverage> </coverage>
   <php>
     <ini name="error_reporting" value="-1"/>


### PR DESCRIPTION
Fixes #11116

#### Short description of what this resolves:
PHPUnit's own deprecation warnings are suppressed by default, hiding valuable feedback that could result in future breakage during test tool updates.

#### Changes proposed in this pull request:
- Add `displayDetailsOnPhpunitDeprecations="true"` to both `phpunit.xml` and `phpunit-isolated.xml`, completing the set of `displayDetailsOn*` attributes already enabled for errors, warnings, notices, and PHP deprecations.