### PR TITLE
fix(users): allow clearing email field in user admin update

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -11613,7 +11613,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 30,
+    'count' => 29,
     'path' => __DIR__ . '/../../interface/usergroup/usergroup_admin.php',
 ];
 $ignoreErrors[] = [


### PR DESCRIPTION
## Summary

Followup to #11056 — addresses review feedback from @bradymiller and @kojiromike.

- Removes the `$email !== ''` guard on the UPDATE path so admins can clear a previously-set email field
- The INSERT path (new user creation) already writes the email value unconditionally — this makes the two paths consistent

## Test plan

- [x] Edit a user, set an email address, save — email should persist
- [x] Edit the same user, clear the email field, save — email should be cleared
- [x] Create a new user with and without email — both should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)