### PR TITLE
Remove unused laminas dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,6 @@
         "laminas/laminas-filter": "^2.42.0",
         "laminas/laminas-form": "^3.24.0",
         "laminas/laminas-inputfilter": "^2.34.0",
-        "laminas/laminas-json-server": "^3.9.0",
         "laminas/laminas-loader": "^2.11.1",
         "laminas/laminas-mvc": "^3.8.0",
         "laminas/laminas-mvc-i18n": "^1.9.0",

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,6 @@
         "knplabs/knp-snappy": "^1.5.1",
         "laminas/laminas-code": "^4.16",
         "laminas/laminas-config": "^3.10.1",
-        "laminas/laminas-escaper": "^2.18.0",
         "laminas/laminas-eventmanager": "^3.15.0",
         "laminas/laminas-filter": "^2.42.0",
         "laminas/laminas-form": "^3.24.0",

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,6 @@
         "laminas/laminas-servicemanager": "^3.24.0",
         "laminas/laminas-soap": "^2.14.0",
         "laminas/laminas-stdlib": "^3.21.0",
-        "laminas/laminas-xmlrpc": "^2.22.0",
         "lcobucci/clock": "^2.3",
         "lcobucci/jwt": "^4.3.0",
         "league/csv": "^9.28.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3074c51a4fa9ec76cef52188d9a9f9f",
+    "content-hash": "131cba16f5784a8926ecc02b8641a526",
     "packages": [
         {
             "name": "academe/authorizenet-objects",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "105d0f7f5602e31adfa703a5164e7a7d",
+    "content-hash": "d3074c51a4fa9ec76cef52188d9a9f9f",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -3137,73 +3137,6 @@
             ],
             "abandoned": true,
             "time": "2026-01-23T11:10:11+00:00"
-        },
-        {
-            "name": "laminas/laminas-json-server",
-            "version": "3.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-json-server.git",
-                "reference": "08fd8019d03fdd91ea4a60c8ede3af32fd97d15c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-json-server/zipball/08fd8019d03fdd91ea4a60c8ede3af32fd97d15c",
-                "reference": "08fd8019d03fdd91ea4a60c8ede3af32fd97d15c",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-http": "^2.19.0",
-                "laminas/laminas-json": "^3.6.0",
-                "laminas/laminas-server": "^2.16.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "conflict": {
-                "laminas/laminas-stdlib": "<3.2.1"
-            },
-            "replace": {
-                "zendframework/zend-json-server": "^3.2.0"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.17"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Json\\Server\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Laminas Json-Server is a JSON-RPC server implementation.",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "json",
-                "json-server",
-                "laminas",
-                "server"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-json-server/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-json-server/issues",
-                "rss": "https://github.com/laminas/laminas-json-server/releases.atom",
-                "source": "https://github.com/laminas/laminas-json-server"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2023-12-06T00:06:51+00:00"
         },
         {
             "name": "laminas/laminas-loader",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b878f44d3f5d0251c9a9ab7ee26685de",
+    "content-hash": "105d0f7f5602e31adfa703a5164e7a7d",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -4144,134 +4144,6 @@
                 }
             ],
             "time": "2025-10-13T13:07:56+00:00"
-        },
-        {
-            "name": "laminas/laminas-xml",
-            "version": "1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-xml.git",
-                "reference": "3a7850dec668a89807accfa4826a2ff11497fe74"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-xml/zipball/3a7850dec668a89807accfa4826a2ff11497fe74",
-                "reference": "3a7850dec668a89807accfa4826a2ff11497fe74",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-simplexml": "*",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "conflict": {
-                "zendframework/zendxml": "*"
-            },
-            "require-dev": {
-                "ext-iconv": "*",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "phpunit/phpunit": "^10.5.35 || ^11.4",
-                "squizlabs/php_codesniffer": "3.10.3 as 2.9999999.9999999"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Xml\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Utility library for XML usage, best practices, and security in PHP",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "security",
-                "xml"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-xml/issues",
-                "rss": "https://github.com/laminas/laminas-xml/releases.atom",
-                "source": "https://github.com/laminas/laminas-xml"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2024-10-11T08:45:59+00:00"
-        },
-        {
-            "name": "laminas/laminas-xmlrpc",
-            "version": "2.22.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-xmlrpc.git",
-                "reference": "f251670ce1b7add203a6cfd91d5e58a724cec27a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-xmlrpc/zipball/f251670ce1b7add203a6cfd91d5e58a724cec27a",
-                "reference": "f251670ce1b7add203a6cfd91d5e58a724cec27a",
-                "shasum": ""
-            },
-            "require": {
-                "brick/math": "^0.13.1",
-                "ext-simplexml": "*",
-                "laminas/laminas-code": "^4.4",
-                "laminas/laminas-http": "^2.15",
-                "laminas/laminas-server": "^2.11",
-                "laminas/laminas-stdlib": "^3.10.1",
-                "laminas/laminas-xml": "^1.4.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "conflict": {
-                "zendframework/zend-xmlrpc": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~3.1.0",
-                "phpunit/phpunit": "^10.5.36",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.26.1"
-            },
-            "suggest": {
-                "laminas/laminas-cache": "To support Laminas\\XmlRpc\\Server\\Cache usage"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\XmlRpc\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Fully-featured XML-RPC server and client implementations",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "xmlrpc"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-xmlrpc/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-xmlrpc/issues",
-                "rss": "https://github.com/laminas/laminas-xmlrpc/releases.atom",
-                "source": "https://github.com/laminas/laminas-xmlrpc"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-11-11T22:34:06+00:00"
         },
         {
             "name": "lcobucci/clock",


### PR DESCRIPTION
Towards #11203 (and others)

#### Short description of what this resolves:
Unused laminas dependencies that were blocking PHP updates

#### Changes proposed in this pull request:
Removes json-server and xmlrpc laminas dependencies. Also removes escaper as a direct requirement, though it stays in place transitively.

#### Does your code include anything generated by an AI Engine? Yes / No
No, thought I used Claude to detect the easy removals.