### PR TITLE
fix(schema): use CURRENT_TIMESTAMP default for medex_recalls.r_created

### DIFF
--- a/sql/5_0_0-to-5_0_1_upgrade.sql
+++ b/sql/5_0_0-to-5_0_1_upgrade.sql
@@ -772,7 +772,7 @@ CREATE TABLE `medex_recalls` (
   `r_facility` int(11) NOT NULL,
   `r_provider` int(11) NOT NULL,
   `r_reason` varchar(255) DEFAULT NULL,
-  `r_created` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' ON UPDATE CURRENT_TIMESTAMP,
+  `r_created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`r_ID`),
   UNIQUE KEY `r_PRACTID` (`r_PRACTID`,`r_pid`)
 ) ENGINE=InnoDB;

--- a/sql/8_0_0-to-8_0_1_upgrade.sql
+++ b/sql/8_0_0-to-8_0_1_upgrade.sql
@@ -228,3 +228,12 @@ DELETE FROM `globals` WHERE `gl_name` IN (
 --
 
 DROP VIEW IF EXISTS `onsite_activity_view`;
+
+--
+-- Fix medex_recalls.r_created default for MySQL strict mode compatibility.
+-- See: https://github.com/openemr/openemr/issues/11179
+--
+
+#IfNotColumnTypeDefault medex_recalls r_created timestamp CURRENT_TIMESTAMP
+ALTER TABLE `medex_recalls` MODIFY `r_created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -13522,7 +13522,7 @@ CREATE TABLE `medex_recalls` (
   `r_facility` int(11) NOT NULL,
   `r_provider` int(11) NOT NULL,
   `r_reason` varchar(255) DEFAULT NULL,
-  `r_created` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' ON UPDATE CURRENT_TIMESTAMP,
+  `r_created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`r_ID`),
   UNIQUE KEY `r_PRACTID` (`r_PRACTID`,`r_pid`)
 ) ENGINE=InnoDB;


### PR DESCRIPTION
Ref: #11179

#### Short description of what this resolves:

The `medex_recalls.r_created` column uses `'0000-00-00 00:00:00'` as a default value, which is incompatible with MySQL strict mode (NO_ZERO_DATE).

#### Changes proposed in this pull request:

- Change default from `'0000-00-00 00:00:00'` to `CURRENT_TIMESTAMP` in `sql/database.sql`
- Fix the same in `sql/5_0_0-to-5_0_1_upgrade.sql` (where the table was introduced)
- Add upgrade migration in `sql/8_0_0-to-8_0_1_upgrade.sql` for existing installations

Note: there's nothing in the code that I could find that reads this data. Or writes it, for that matter.

#### Does your code include anything generated by an AI Engine? Yes

#### If you answered yes:

This PR was generated with assistance from Claude (Anthropic). The changes are schema modifications only.
