### PR TITLE
chore: add export-ignore rules to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,37 @@
 # Mark all PHPStan baseline files as generated
 .phpstan/baseline/ linguist-generated=true
+
+# Exclude dev-only infrastructure from release archives and Composer installs.
+# GitHub uses these rules when generating source downloads for tagged releases.
+# Keep anything needed to install, configure, or run OpenEMR.
+.github/                       export-ignore
+.phpstan/                      export-ignore
+ci/                            export-ignore
+docker/                        export-ignore
+tests/                         export-ignore
+tools/                         export-ignore
+.gitattributes                 export-ignore
+.gitignore                     export-ignore
+.gitmodules                    export-ignore
+.codespell*                    export-ignore
+.composer-require-checker.json export-ignore
+.dclintrc.yaml                 export-ignore
+.editorconfig                  export-ignore
+.hadolint.yaml                 export-ignore
+.pre-commit-config.yaml        export-ignore
+.shellcheckrc                  export-ignore
+.stylelintignore               export-ignore
+.stylelintrc.json              export-ignore
+build.xml                      export-ignore
+cloudbuild.yaml                export-ignore
+codecov.yml                    export-ignore
+eslint.config.mjs              export-ignore
+phpcs.xml.dist                 export-ignore
+phpstan.neon.dist              export-ignore
+phpunit*.xml                   export-ignore
+rector*.php                    export-ignore
+run-semgrep.sh                 export-ignore
+semgrep.yaml                   export-ignore
+CLAUDE.md                      export-ignore
+DOCKER_README.md               export-ignore
+README-Isolated-Testing.md     export-ignore


### PR DESCRIPTION
## Summary

- Add `export-ignore` rules so GitHub's auto-generated source archives (tar.gz/zip) exclude dev-only infrastructure: CI workflows, tests, linter configs, static analysis baselines, Docker dev configs, and dev tooling
- Keep everything needed to install and run OpenEMR: composer/npm manifests, documentation, and all runtime code
- Prepares for cleaner release archives and eventual Packagist publishing

## What's excluded

Directories: `.github/`, `.phpstan/`, `ci/`, `docker/`, `tests/`, `tools/`

Files: `.codespell*`, `.composer-require-checker.json`, `.dclintrc.yaml`, `.editorconfig`, `.gitattributes`, `.gitignore`, `.gitmodules`, `.hadolint.yaml`, `.pre-commit-config.yaml`, `.shellcheckrc`, `.stylelint*`, `build.xml`, `cloudbuild.yaml`, `codecov.yml`, `eslint.config.mjs`, `phpcs.xml.dist`, `phpstan.neon.dist`, `phpunit*.xml`, `rector*.php`, `run-semgrep.sh`, `semgrep.yaml`, `CLAUDE.md`, `DOCKER_README.md`, `README-Isolated-Testing.md`

## What's kept

`composer.json`, `composer.lock`, `package.json`, `package-lock.json`, `gulpfile.js`, all runtime code, `LICENSE`, `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and all other documentation.

## Test plan

- [x] Verified locally with `git archive` — excluded files absent
- [x] Verified via GitHub archive download from fork branch — excluded files absent, kept files present

Related: https://github.com/openemr/openemr-devops/issues/593

🤖 Generated with [Claude Code](https://claude.com/claude-code)