### PR TITLE
fix(security): prevent open redirect in portal messaging (backport #11217)

### DIFF
--- a/portal/messaging/handle_note.php
+++ b/portal/messaging/handle_note.php
@@ -197,8 +197,6 @@ switch ($task) {
         break;
 }
 
-if (!empty($_POST["submit"])) {
-    $url = $_POST["submit"];
-    header("Location: " . $url);
-    exit();
+if (isset($_POST['submit'])) {
+    header('Location: messages.php');
 }


### PR DESCRIPTION
## Summary

Backport of #11217 to rel-800.

- Fix open redirect vulnerability in `portal/messaging/handle_note.php`
- Hardcode redirect target to `messages.php` instead of using user-controlled input

## Test plan

- [ ] Verify portal messaging redirect works correctly
- [ ] Verify no open redirect is possible via crafted form submission