### PR TITLE
chore(testing): migrate @dataProvider annotations to PHP 8 attributes

### DIFF
--- a/phpunit-isolated.xml
+++ b/phpunit-isolated.xml
@@ -24,6 +24,7 @@ This file configures the kind that does not require initialization.
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnPhpunitDeprecations="true"
+         failOnPhpunitDeprecation="true"
          testdox="false">
 
   <php>

--- a/tests/Tests/Isolated/Common/Utils/MeasurementUtilsTest.php
+++ b/tests/Tests/Isolated/Common/Utils/MeasurementUtilsTest.php
@@ -17,13 +17,12 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Isolated\Common\Utils;
 
 use OpenEMR\Common\Utils\MeasurementUtils;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class MeasurementUtilsTest extends TestCase
 {
-    /**
-     * @dataProvider kgToLbProvider
-     */
+    #[DataProvider('kgToLbProvider')]
     public function testKgToLb(float $kg, string $expectedLb): void
     {
         $this->assertSame($expectedLb, MeasurementUtils::kgToLb($kg));
@@ -44,9 +43,7 @@ class MeasurementUtilsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider lbToKgProvider
-     */
+    #[DataProvider('lbToKgProvider')]
     public function testLbToKg(float $lb, string $expectedKg): void
     {
         $this->assertSame($expectedKg, MeasurementUtils::lbToKg($lb));
@@ -66,9 +63,7 @@ class MeasurementUtilsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider cmToInchesProvider
-     */
+    #[DataProvider('cmToInchesProvider')]
     public function testCmToInches(float $cm, string $expectedInches): void
     {
         $this->assertSame($expectedInches, MeasurementUtils::cmToInches($cm));
@@ -88,9 +83,7 @@ class MeasurementUtilsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider inchesToCmProvider
-     */
+    #[DataProvider('inchesToCmProvider')]
     public function testInchesToCm(float $inches, string $expectedCm): void
     {
         $this->assertSame($expectedCm, MeasurementUtils::inchesToCm($inches));
@@ -110,9 +103,7 @@ class MeasurementUtilsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider fhToCelsiusProvider
-     */
+    #[DataProvider('fhToCelsiusProvider')]
     public function testFhToCelsius(float $fahrenheit, string $expectedCelsius): void
     {
         $this->assertSame($expectedCelsius, MeasurementUtils::fhToCelsius($fahrenheit));
@@ -133,9 +124,7 @@ class MeasurementUtilsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider celsiusToFhProvider
-     */
+    #[DataProvider('celsiusToFhProvider')]
     public function testCelsiusToFh(float $celsius, string $expectedFahrenheit): void
     {
         $this->assertSame($expectedFahrenheit, MeasurementUtils::celsiusToFh($celsius));

--- a/tests/Tests/Isolated/Common/Utils/StringUtilsTest.php
+++ b/tests/Tests/Isolated/Common/Utils/StringUtilsTest.php
@@ -17,13 +17,12 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Isolated\Common\Utils;
 
 use OpenEMR\Common\Utils\StringUtils;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class StringUtilsTest extends TestCase
 {
-    /**
-     * @dataProvider trimExcessWhitespaceProvider
-     */
+    #[DataProvider('trimExcessWhitespaceProvider')]
     public function testTrimExcessWhitespace(mixed $input, string $expected): void
     {
         $this->assertSame($expected, StringUtils::trimExcessWhitespace($input));

--- a/tests/Tests/Isolated/library/SafeHrefTest.php
+++ b/tests/Tests/Isolated/library/SafeHrefTest.php
@@ -15,13 +15,12 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../../../../library/htmlspecialchars.inc.php';
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class SafeHrefTest extends TestCase
 {
-    /**
-     * @dataProvider safeUrlProvider
-     */
+    #[DataProvider('safeUrlProvider')]
     public function testSafeUrlsAreAllowed(string $input, string $expected): void
     {
         $this->assertSame($expected, safe_href($input));
@@ -48,9 +47,7 @@ class SafeHrefTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dangerousUrlProvider
-     */
+    #[DataProvider('dangerousUrlProvider')]
     public function testDangerousUrlsAreBlocked(string $input): void
     {
         $this->assertSame('#', safe_href($input));


### PR DESCRIPTION
## Summary

Convert all 9 `@dataProvider` doc-comment annotations in isolated tests to `#[DataProvider()]` PHP 8 attributes, and enable `failOnPhpunitDeprecation` to prevent regressions.

Closes #11074

## Changes

### Annotation → Attribute (9 conversions)

```php
// Before:
/** @dataProvider fooProvider */
public function testFoo(...): void

// After:
#[DataProvider('fooProvider')]
public function testFoo(...): void
```

| File | Annotations converted |
|------|----------------------|
| `MeasurementUtilsTest.php` | 6 (`kgToLb`, `lbToKg`, `cmToInches`, `inchesToCm`, `fhToCelsius`, `celsiusToFh`) |
| `StringUtilsTest.php` | 1 (`trimExcessWhitespace`) |
| `SafeHrefTest.php` | 2 (`safeUrl`, `dangerousUrl`) |

### Regression prevention

Added `failOnPhpunitDeprecation="true"` to `phpunit-isolated.xml` so future `@dataProvider` additions will fail CI immediately.

## Verification

```
$ composer phpunit-isolated
Tests: 1842, Assertions: 4967, Warnings: 6, Deprecations: 11, Incomplete: 3.
```

All 1842 tests pass. The remaining 11 deprecations are PHP 8.5 PDO constant deprecations (unrelated).