### PR TITLE
ci(deps): add rector and shipmonk to dependabot development group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,162 +1,164 @@
 version: 2
 updates:
   # PHP dependencies
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
-    rebase-strategy: "disabled"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-      - "php"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    groups:
-      symfony:
-        patterns:
-          - "symfony/*"
-        update-types:
-          - "minor"
-          - "patch"
-      laminas:
-        patterns:
-          - "laminas/*"
-        update-types:
-          - "minor"
-          - "patch"
-      development:
-        patterns:
-          - "phpunit/*"
-          - "phpstan/*"
-          - "friendsofphp/*"
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
+- package-ecosystem: composer
+  directory: /
+  schedule:
+    interval: weekly
+    day: monday
+    time: 08:00
+  rebase-strategy: disabled
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+  - php
+  commit-message:
+    prefix: chore
+    include: scope
+  groups:
+    symfony:
+      patterns:
+      - symfony/*
+      update-types:
+      - minor
+      - patch
+    laminas:
+      patterns:
+      - laminas/*
+      update-types:
+      - minor
+      - patch
+    development:
+      patterns:
+      - phpunit/*
+      - phpstan/*
+      - rector/rector
+      - shipmonk/*
+      - friendsofphp/*
+      update-types:
+      - minor
+      - patch
+  ignore:
       # Don't update major versions automatically
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+  - dependency-name: '*'
+    update-types: [version-update:semver-major]
       # submodules are causing problems, so ignore them
-      - dependency-name: "*/onc-certification-g10-test-kit"
-      - dependency-name: "*/inferno-files"
+  - dependency-name: '*/onc-certification-g10-test-kit'
+  - dependency-name: '*/inferno-files'
 
   # JavaScript dependencies (not including ccdaservice)
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-      - "javascript"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    groups:
-      jquery-bootstrap:
-        patterns:
-          - "jquery"
-          - "jquery-*"
-          - "bootstrap"
-          - "@popperjs/core"
-        update-types:
-          - "minor"
-          - "patch"
-      ui-components:
-        patterns:
-          - "datatables.net*"
-          - "select2"
-          - "chart.js"
-          - "summernote"
-        update-types:
-          - "minor"
-          - "patch"
-      testing:
-        patterns:
-          - "jest"
-          - "@types/jest"
-          - "jest-*"
-        update-types:
-          - "minor"
-          - "patch"
-      build-tools:
-        patterns:
-          - "gulp*"
-          - "eslint*"
-          - "stylelint*"
-          - "prettier"
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: weekly
+    day: monday
+    time: 08:00
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+  - javascript
+  commit-message:
+    prefix: chore
+    include: scope
+  groups:
+    jquery-bootstrap:
+      patterns:
+      - jquery
+      - jquery-*
+      - bootstrap
+      - '@popperjs/core'
+      update-types:
+      - minor
+      - patch
+    ui-components:
+      patterns:
+      - datatables.net*
+      - select2
+      - chart.js
+      - summernote
+      update-types:
+      - minor
+      - patch
+    testing:
+      patterns:
+      - jest
+      - '@types/jest'
+      - jest-*
+      update-types:
+      - minor
+      - patch
+    build-tools:
+      patterns:
+      - gulp*
+      - eslint*
+      - stylelint*
+      - prettier
+      update-types:
+      - minor
+      - patch
+  ignore:
       # Don't update major versions automatically
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+  - dependency-name: '*'
+    update-types: [version-update:semver-major]
       # Specific packages to keep stable
-      - dependency-name: "bootstrap"
-        versions: ["5.x", "6.x"] # Stay on Bootstrap 4 for compatibility
-      - dependency-name: "angular"
-        versions: [">1.8.x"] # Legacy AngularJS, don't update
+  - dependency-name: bootstrap
+    versions: [5.x, 6.x]         # Stay on Bootstrap 4 for compatibility
+  - dependency-name: angular
+    versions: ['>1.8.x']     # Legacy AngularJS, don't update
 
   # GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    labels:
-      - "dependencies"
-      - "github-actions"
-    commit-message:
-      prefix: "ci"
-      include: "scope"
-    open-pull-requests-limit: 5
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+    day: monday
+  labels:
+  - dependencies
+  - github-actions
+  commit-message:
+    prefix: ci
+    include: scope
+  open-pull-requests-limit: 5
 
   # Docker selenium docker updates in 4 places in the repo as a group
-  - package-ecosystem: "docker-compose"
-    directories:
-      - "ci/compose-shared-selenium/"
-      - "docker/development-easy/"
-      - "docker/development-easy-redis/"
-      - "docker/development-insane/"
-    schedule:
-      interval: "weekly"
-    allow:
-      - dependency-name: "selenium/standalone-chromium"
-    ignore:
-      - dependency-name: "selenium/standalone-chromium"
-        versions: [">=50"]
-    groups:
-      selenium-updates:
-        patterns:
-          - "selenium/standalone-chromium"
-    labels:
-      - "dependencies"
-      - "selenium"
-      - "docker"
+- package-ecosystem: docker-compose
+  directories:
+  - ci/compose-shared-selenium/
+  - docker/development-easy/
+  - docker/development-easy-redis/
+  - docker/development-insane/
+  schedule:
+    interval: weekly
+  allow:
+  - dependency-name: selenium/standalone-chromium
+  ignore:
+  - dependency-name: selenium/standalone-chromium
+    versions: ['>=50']
+  groups:
+    selenium-updates:
+      patterns:
+      - selenium/standalone-chromium
+  labels:
+  - dependencies
+  - selenium
+  - docker
 
   # JavaScript dependencies (ccdaservice)
-  - package-ecosystem: "npm"
-    directory: "/ccdaservice"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-      - "javascript"
-      - "CCDA Service"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    ignore:
+- package-ecosystem: npm
+  directory: /ccdaservice
+  schedule:
+    interval: weekly
+    day: monday
+    time: 08:00
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+  - javascript
+  - CCDA Service
+  commit-message:
+    prefix: chore
+    include: scope
+  ignore:
       # Don't update major versions automatically
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+  - dependency-name: '*'
+    update-types: [version-update:semver-major]


### PR DESCRIPTION
## Summary
- Add `rector/rector` and `shipmonk/*` to the existing `development` Dependabot group
- These dev-only tools will now be batched with phpunit, phpstan, and friendsofphp into a single PR instead of separate ones