### PR TITLE
fix(ci): quote time values in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   schedule:
     interval: weekly
     day: monday
-    time: 08:00
+    time: "08:00"
   rebase-strategy: disabled
   open-pull-requests-limit: 10
   labels:
@@ -52,7 +52,7 @@ updates:
   schedule:
     interval: weekly
     day: monday
-    time: 08:00
+    time: "08:00"
   open-pull-requests-limit: 10
   labels:
   - dependencies
@@ -149,7 +149,7 @@ updates:
   schedule:
     interval: weekly
     day: monday
-    time: 08:00
+    time: "08:00"
   open-pull-requests-limit: 10
   labels:
   - dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,7 @@ repos:
     args:
     - --autofix
     - --indent=2
+    - --preserve-quotes
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.4.1


### PR DESCRIPTION
## Summary
- Quote `time: 08:00` values in `.github/dependabot.yml` so they're parsed as strings, not sexagesimal integers
- Add `--preserve-quotes` to the `pretty-format-yaml` pre-commit hook to prevent it from stripping the quotes again

The YAML formatter (ruamel.yaml, YAML 1.2) treats `08:00` as a plain string and strips quotes. Dependabot (Ruby Psych, YAML 1.1) parses unquoted `08:00` as a sexagesimal integer (480), causing schema validation failure.

## Test plan
- [ ] Dependabot config validation passes (no more "type integer did not match type string" errors)
- [ ] Pre-commit hook no longer strips quotes from time values