### PR TITLE
refactor(globals): migrate library/ path reads to typed Kernel accessors

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -10922,16 +10922,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/usergroup/usergroup_admin_add.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Abstract/Configuration.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/esign…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Abstract/Configuration.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'\\?module\\=\' results in an error\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../library/ESign/Abstract/Configuration.php',
@@ -10952,21 +10942,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/ESign/Abstract/Controller.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/ViewableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Abstract/Controller.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Viewer\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Abstract/Controller.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/views\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Abstract/Controller.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/ESign/Abstract/Controller.php',
@@ -10977,226 +10952,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/ESign/Abstract/Model.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/ESign\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Encounter…\' results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../library/ESign/Api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/FactoryIF\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Form/Factory…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Form…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/SignableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/SignableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/ButtonIF.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/ViewableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/ButtonIF.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/SignableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/DbRow/Signable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Signature\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/DbRow/Signable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Utils…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/DbRow/Signable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/ButtonIF\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Button.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/ViewableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Button.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/views…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Button.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Abstract…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Configuration.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Abstract…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Controller.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Encounter…\' results in an error\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Controller.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Encounter…\' results in an error\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Factory.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/FactoryIF\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Factory.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/LogIF\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Log.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Viewer\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Log.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/views…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Log.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/DbRow…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Signable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Form/Factory…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Signable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/SignableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Signable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/ButtonIF\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Button.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Viewer\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Button.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/views/form…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Button.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Abstract…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Configuration.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Abstract…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Controller.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Form/Factory…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Controller.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Form/Log\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Controller.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Form…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Controller.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/FactoryIF\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Factory.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Form/Button…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Factory.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Form/LBF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Factory.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Form/Log\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Factory.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Form…\' results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../library/ESign/Form/Factory.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Form…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/LBF/Signable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/SignableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/LBF/Signable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/LogIF\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Log.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Viewer\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Log.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/views…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Log.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'\\{\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/ESign/Form/Signable.php',
@@ -11205,71 +10960,6 @@ $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'form_\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/ESign/Form/Signable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/DbRow…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Signable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/SignableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Signable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/SignableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/LogIF.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/ViewableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/LogIF.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Router.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Abstract…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Router.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/VerifiableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/SignableIF.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/SignatureIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Signature.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Utils…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Signature.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/VerifiableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/SignatureIF.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Utils/Verification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/Abstract…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Viewer.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ESign/ViewableIF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Viewer.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'Esign data…\' and mixed results in an error\\.$#',
@@ -11494,16 +11184,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' reply\' results in an error\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../library/MedEx/API.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/main…\' results in an error\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../library/MedEx/API.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/js/xl/jquery…\' results in an error\\.$#',
-    'count' => 2,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [
@@ -11742,11 +11422,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/auth.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/main/holidays…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/calendar.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "/" between numeric\\-string and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/checkout_receipt_array.inc.php',
@@ -11868,16 +11543,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'/documents/smarty…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Controller.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/smarty/smarty/libs…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Controller.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'error/\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Controller.class.php',
 ];
@@ -13242,24 +12907,9 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/custom_template/add_custombutton.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'\\<img src\\=\\\\\'\' and mixed results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../library/custom_template/ajax_code.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../library/custom_template/ajax_code.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/js/xl/select2\\.js…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/custom_template/custom_template.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/restoreSession\\.php\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/custom_template/custom_template.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and 0\\|0\\.0\\|array\\{\\}\\|string\\|false\\|null results in an error\\.$#',
@@ -13362,11 +13012,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/deletedrug.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/library/ajax…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/dicom_frame.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\-" between mixed and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
@@ -13397,11 +13042,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/public/certs…\' results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-empty\\-string and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
@@ -13410,11 +13050,6 @@ $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 7,
     'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/controllers/C…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/documents.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
@@ -14757,16 +14392,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/options.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'\\<link  href\\="\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/options.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'\\<link href\\="\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/options.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'addtolistclass_\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/options.inc.php',
@@ -14827,11 +14452,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/options.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/sites/\' results in an error\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../library/options.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'\\|\' results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../library/options.inc.php',
@@ -14848,7 +14468,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 49,
+    'count' => 44,
     'path' => __DIR__ . '/../../library/options.inc.php',
 ];
 $ignoreErrors[] = [
@@ -14947,11 +14567,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/registry.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and non\\-falsy\\-string results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/registry.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \',\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/reminders.php',
@@ -14978,11 +14593,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\+" between mixed and 0 results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/report.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/options\\.inc\\.php\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/report.inc.php',
 ];
@@ -15045,11 +14655,6 @@ $ignoreErrors[] = [
     'message' => '#^Binary operation "\\+" between mixed and 0 results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/sanitize.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/js/xl/jquery…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/smarty/plugins/function.datetimepickerSupport.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and non\\-falsy\\-string results in an error\\.$#',
@@ -15637,11 +15242,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/plugins/modifier.truncate.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/js/xl/jquery…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/specialty_forms.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\+" between mixed and 0 results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../library/spreadsheet.inc.php',
@@ -15674,11 +15274,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'form_\' and mixed results in an error\\.$#',
     'count' => 19,
-    'path' => __DIR__ . '/../../library/spreadsheet.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/js/xl/jquery…\' results in an error\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../library/spreadsheet.inc.php',
 ];
 $ignoreErrors[] = [
@@ -15762,19 +15357,9 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/validation/validate_core.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/validation…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/validation/validate_core.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/validation/validate_core.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/validation/LBF…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/validation/validation_script.js.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'Patient credential…\' and mixed results in an error\\.$#',

--- a/.phpstan/baseline/echo.nonString.php
+++ b/.phpstan/baseline/echo.nonString.php
@@ -968,7 +968,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 48,
+    'count' => 40,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [
@@ -1014,17 +1014,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../library/custom_template/add_context.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 3,
     'path' => __DIR__ . '/../../library/custom_template/custom_template.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/custom_template/delete_category.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
@@ -1043,23 +1033,8 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../library/options.js.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/options_listadd.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/reminders.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/restoreSession.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
@@ -1078,7 +1053,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 5,
+    'count' => 2,
     'path' => __DIR__ . '/../../library/validation/validation_script.js.php',
 ];
 $ignoreErrors[] = [

--- a/library/ESign/Abstract/Configuration.php
+++ b/library/ESign/Abstract/Configuration.php
@@ -18,7 +18,7 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/ConfigurationIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/ConfigurationIF.php';
 
 abstract class Abstract_Configuration implements ConfigurationIF
 {
@@ -39,7 +39,7 @@ abstract class Abstract_Configuration implements ConfigurationIF
 
     public function getBaseUrl()
     {
-        return OEGlobalsBag::getInstance()->get('webroot') . "/interface/esign/index.php";
+        return OEGlobalsBag::getInstance()->getWebRoot() . "/interface/esign/index.php";
     }
 
     public function getLogViewAction()

--- a/library/ESign/Abstract/Controller.php
+++ b/library/ESign/Abstract/Controller.php
@@ -17,8 +17,8 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Viewer.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/ViewableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Viewer.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/ViewableIF.php';
 
 abstract class Abstract_Controller implements ViewableIF
 {
@@ -37,7 +37,7 @@ abstract class Abstract_Controller implements ViewableIF
     {
         $this->_request = $request;
         $this->_method = $this->_request->getParam('method');
-        $this->_viewDir = OEGlobalsBag::getInstance()->get('srcdir') . "/ESign/views";
+        $this->_viewDir = OEGlobalsBag::getInstance()->getSrcDir() . "/ESign/views";
         $this->_viewScript = 'esign_error.php';
         $this->_view = new Viewer();
     }

--- a/library/ESign/Api.php
+++ b/library/ESign/Api.php
@@ -16,14 +16,14 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/ESign.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/FactoryIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/ConfigurationIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/SignableIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Form/Factory.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Form/Configuration.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Encounter/Factory.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Encounter/Configuration.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/ESign.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/FactoryIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/ConfigurationIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/SignableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Form/Factory.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Form/Configuration.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Encounter/Factory.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Encounter/Configuration.php';
 
 class Api
 {

--- a/library/ESign/ButtonIF.php
+++ b/library/ESign/ButtonIF.php
@@ -17,8 +17,8 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/ViewableIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/SignableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/ViewableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/SignableIF.php';
 
 interface ButtonIF extends ViewableIF
 {

--- a/library/ESign/DbRow/Signable.php
+++ b/library/ESign/DbRow/Signable.php
@@ -17,9 +17,9 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/SignableIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Signature.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Utils/Verification.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/SignableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Signature.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Utils/Verification.php';
 
 abstract class DbRow_Signable implements SignableIF
 {

--- a/library/ESign/Encounter/Button.php
+++ b/library/ESign/Encounter/Button.php
@@ -16,8 +16,8 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/ButtonIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/ViewableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/ButtonIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/ViewableIF.php';
 
 class Encounter_Button implements ButtonIF
 {
@@ -37,7 +37,7 @@ class Encounter_Button implements ButtonIF
 
     public function getViewScript()
     {
-        return OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/views/encounter/esign_button.php';
+        return OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/views/encounter/esign_button.php';
     }
 
     public function render(?SignableIF $signable = null)

--- a/library/ESign/Encounter/Configuration.php
+++ b/library/ESign/Encounter/Configuration.php
@@ -16,7 +16,7 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Abstract/Configuration.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Abstract/Configuration.php';
 
 class Encounter_Configuration extends Abstract_Configuration implements ConfigurationIF
 {

--- a/library/ESign/Encounter/Controller.php
+++ b/library/ESign/Encounter/Controller.php
@@ -16,10 +16,10 @@
 
 namespace ESign;
 
-require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Abstract/Controller.php';
-require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Encounter/Configuration.php';
-require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Encounter/Signable.php';
-require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Encounter/Log.php';
+require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Abstract/Controller.php';
+require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Encounter/Configuration.php';
+require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Encounter/Signable.php';
+require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Encounter/Log.php';
 
 use OpenEMR\Common\Auth\AuthUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;

--- a/library/ESign/Encounter/Factory.php
+++ b/library/ESign/Encounter/Factory.php
@@ -17,11 +17,11 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/FactoryIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Encounter/Configuration.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Encounter/Signable.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Encounter/Button.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Encounter/Log.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/FactoryIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Encounter/Configuration.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Encounter/Signable.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Encounter/Button.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Encounter/Log.php';
 
 class Encounter_Factory implements FactoryIF
 {

--- a/library/ESign/Encounter/Log.php
+++ b/library/ESign/Encounter/Log.php
@@ -17,8 +17,8 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/LogIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Viewer.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/LogIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Viewer.php';
 
 class Encounter_Log implements LogIF
 {
@@ -56,7 +56,7 @@ class Encounter_Log implements LogIF
 
     public function getViewScript()
     {
-        return OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/views/default/esign_signature_log.php';
+        return OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/views/default/esign_signature_log.php';
     }
 
     /**

--- a/library/ESign/Encounter/Signable.php
+++ b/library/ESign/Encounter/Signable.php
@@ -17,9 +17,9 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/DbRow/Signable.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/SignableIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Form/Factory.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/DbRow/Signable.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/SignableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Form/Factory.php';
 
 class Encounter_Signable extends DbRow_Signable implements SignableIF
 {

--- a/library/ESign/Form/Button.php
+++ b/library/ESign/Form/Button.php
@@ -17,8 +17,8 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/ButtonIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Viewer.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/ButtonIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Viewer.php';
 
 class Form_Button implements ButtonIF
 {
@@ -41,7 +41,7 @@ class Form_Button implements ButtonIF
 
     public function getViewScript()
     {
-        return OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/views/form/esign_button.php';
+        return OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/views/form/esign_button.php';
     }
 
     public function render(?SignableIF $signable = null)

--- a/library/ESign/Form/Configuration.php
+++ b/library/ESign/Form/Configuration.php
@@ -16,7 +16,7 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Abstract/Configuration.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Abstract/Configuration.php';
 
 class Form_Configuration extends Abstract_Configuration implements ConfigurationIF
 {

--- a/library/ESign/Form/Controller.php
+++ b/library/ESign/Form/Controller.php
@@ -17,10 +17,10 @@
 
 namespace ESign;
 
-require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Abstract/Controller.php';
-require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Form/Configuration.php';
-require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Form/Factory.php';
-require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Form/Log.php';
+require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Abstract/Controller.php';
+require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Form/Configuration.php';
+require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Form/Factory.php';
+require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Form/Log.php';
 
 use OpenEMR\Common\Auth\AuthUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;

--- a/library/ESign/Form/Factory.php
+++ b/library/ESign/Form/Factory.php
@@ -17,12 +17,12 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/FactoryIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Form/Configuration.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Form/Signable.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Form/LBF/Signable.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Form/Button.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Form/Log.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/FactoryIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Form/Configuration.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Form/Signable.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Form/LBF/Signable.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Form/Button.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Form/Log.php';
 
 class Form_Factory implements FactoryIF
 {

--- a/library/ESign/Form/LBF/Signable.php
+++ b/library/ESign/Form/LBF/Signable.php
@@ -17,8 +17,8 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Form/Signable.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/SignableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Form/Signable.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/SignableIF.php';
 
 class Form_LBF_Signable extends Form_Signable implements SignableIF
 {

--- a/library/ESign/Form/Log.php
+++ b/library/ESign/Form/Log.php
@@ -17,8 +17,8 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/LogIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Viewer.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/LogIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Viewer.php';
 
 class Form_Log implements LogIF
 {
@@ -60,7 +60,7 @@ class Form_Log implements LogIF
 
     public function getViewScript()
     {
-        return OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/views/default/esign_signature_log.php';
+        return OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/views/default/esign_signature_log.php';
     }
 
     /**

--- a/library/ESign/Form/Signable.php
+++ b/library/ESign/Form/Signable.php
@@ -17,8 +17,8 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/DbRow/Signable.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/SignableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/DbRow/Signable.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/SignableIF.php';
 
 class Form_Signable extends DbRow_Signable implements SignableIF
 {

--- a/library/ESign/LogIF.php
+++ b/library/ESign/LogIF.php
@@ -16,8 +16,8 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/ViewableIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/SignableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/ViewableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/SignableIF.php';
 
 interface LogIF extends ViewableIF
 {

--- a/library/ESign/Router.php
+++ b/library/ESign/Router.php
@@ -17,7 +17,7 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Abstract/Controller.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Abstract/Controller.php';
 
 class Router
 {
@@ -26,7 +26,7 @@ class Router
         $request = new Request();
         $moduleParam = $request->getParam('module');
         $Module = ucfirst((string) $moduleParam);
-        require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/' . $Module . '/Controller.php';
+        require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/' . $Module . '/Controller.php';
         $controllerClass = "\\ESign\\" . $Module . "_Controller";
         $controller = new $controllerClass($request);
         if ($controller instanceof Abstract_Controller) {

--- a/library/ESign/SignableIF.php
+++ b/library/ESign/SignableIF.php
@@ -17,7 +17,7 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/VerifiableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/VerifiableIF.php';
 
 interface SignableIF extends VerifiableIF
 {

--- a/library/ESign/Signature.php
+++ b/library/ESign/Signature.php
@@ -16,8 +16,8 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/SignatureIF.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Utils/Verification.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/SignatureIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Utils/Verification.php';
 
 class Signature implements SignatureIF
 {

--- a/library/ESign/SignatureIF.php
+++ b/library/ESign/SignatureIF.php
@@ -16,7 +16,7 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/VerifiableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/VerifiableIF.php';
 
 interface SignatureIF extends VerifiableIF
 {

--- a/library/ESign/Utils/Verification.php
+++ b/library/ESign/Utils/Verification.php
@@ -16,7 +16,7 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/VerificationIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/VerificationIF.php';
 
 class Utils_Verification implements VerificationIF
 {

--- a/library/ESign/Viewer.php
+++ b/library/ESign/Viewer.php
@@ -17,8 +17,8 @@ namespace ESign;
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/Abstract/Model.php';
-require_once OEGlobalsBag::getInstance()->get('srcdir') . '/ESign/ViewableIF.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Abstract/Model.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/ViewableIF.php';
 
 class Viewer extends Abstract_Model
 {

--- a/library/MedEx/API.php
+++ b/library/MedEx/API.php
@@ -1512,7 +1512,7 @@ class Display extends Base
         function toggle_menu() {
                 var x = document.getElementById('hide_nav');
                 if (x.style.display === 'none') {
-                    $.post( "<?php echo OEGlobalsBag::getInstance()->get('webroot') . "/interface/main/messages/messages.php"; ?>", {
+                    $.post( "<?php echo OEGlobalsBag::getInstance()->getWebRoot() . "/interface/main/messages/messages.php"; ?>", {
                         'setting_bootstrap_submenu' : 'show',
                         success: function (data) {
                             x.style.display = 'block';
@@ -1520,7 +1520,7 @@ class Display extends Base
                         });
 
                 } else {
-                    $.post( "<?php echo OEGlobalsBag::getInstance()->get('webroot') . "/interface/main/messages/messages.php"; ?>", {
+                    $.post( "<?php echo OEGlobalsBag::getInstance()->getWebRoot() . "/interface/main/messages/messages.php"; ?>", {
                         'setting_bootstrap_submenu' : 'hide',
                         success: function (data) {
                             x.style.display = 'none';
@@ -1532,7 +1532,7 @@ class Display extends Base
 
         function SMS_bot_list() {
             top.restoreSession();
-            var myWindow = window.open('<?php echo OEGlobalsBag::getInstance()->get('webroot'); ?>/interface/main/messages/messages.php?nomenu=1&go=SMS_bot&dir=back&show=new','SMS_bot', 'width=400,height=650');
+            var myWindow = window.open('<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/main/messages/messages.php?nomenu=1&go=SMS_bot&dir=back&show=new','SMS_bot', 'width=400,height=650');
             myWindow.focus();
             return false;
         }
@@ -1564,7 +1564,7 @@ class Display extends Base
                                     } else {
                                         ?>
                                         <li id="menu_PREFERENCES"  name="menu_PREFERENCES" class="">
-                                        <a class="dropdown-item" href="<?php echo OEGlobalsBag::getInstance()->get('web_root'); ?>/interface/main/messages/messages.php?go=setup&stage=1"><?php echo xlt("Setup MedEx"); ?></a></li>
+                                        <a class="dropdown-item" href="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/main/messages/messages.php?go=setup&stage=1"><?php echo xlt("Setup MedEx"); ?></a></li>
                                     <?php } ?>
                                  </ul>
                             </li>
@@ -1573,13 +1573,13 @@ class Display extends Base
                         <li class="nav-item dropdown">
                             <a class="nav-link" data-toggle="dropdown" id="menu_dropdown_msg" role="button" aria-expanded="true"><?php echo xlt("Messages"); ?> </a>
                             <ul class="bgcolor2 dropdown-menu" aria-labelledby="menu_dropdown_msg">
-                                <li id="menu_new_msg"> <a class="dropdown-item" href="<?php echo OEGlobalsBag::getInstance()->get('web_root'); ?>/interface/main/messages/messages.php?showall=no&sortby=users.lname&sortorder=asc&begin=0&task=addnew&form_active=1"> <?php echo xlt("New Message"); ?></a></li>
+                                <li id="menu_new_msg"> <a class="dropdown-item" href="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/main/messages/messages.php?showall=no&sortby=users.lname&sortorder=asc&begin=0&task=addnew&form_active=1"> <?php echo xlt("New Message"); ?></a></li>
                                 <li class="dropdown-divider"></li>
-                                <li id="menu_new_msg"> <a class="dropdown-item" href="<?php echo OEGlobalsBag::getInstance()->get('web_root'); ?>/interface/main/messages/messages.php?show_all=no&form_active=1"> <?php echo xlt("My Messages"); ?></a></li>
-                                <li id="menu_all_msg"> <a class="dropdown-item" href="<?php echo OEGlobalsBag::getInstance()->get('web_root'); ?>/interface/main/messages/messages.php?show_all=yes&form_active=1"> <?php echo xlt("All Messages"); ?></a></li>
+                                <li id="menu_new_msg"> <a class="dropdown-item" href="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/main/messages/messages.php?show_all=no&form_active=1"> <?php echo xlt("My Messages"); ?></a></li>
+                                <li id="menu_all_msg"> <a class="dropdown-item" href="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/main/messages/messages.php?show_all=yes&form_active=1"> <?php echo xlt("All Messages"); ?></a></li>
                                 <li class="dropdown-divider"></li>
-                                <li id="menu_active_msg"> <a class="dropdown-item" href="<?php echo OEGlobalsBag::getInstance()->get('web_root'); ?>/interface/main/messages/messages.php?show_all=yes&form_active=1"> <?php echo xlt("Active Messages"); ?></a></li>
-                                <li id="menu_inactive_msg"> <a class="dropdown-item" href="<?php echo OEGlobalsBag::getInstance()->get('web_root'); ?>/interface/main/messages/messages.php?form_inactive=1"> <?php echo xlt("Inactive Messages"); ?></a></li>
+                                <li id="menu_active_msg"> <a class="dropdown-item" href="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/main/messages/messages.php?show_all=yes&form_active=1"> <?php echo xlt("Active Messages"); ?></a></li>
+                                <li id="menu_inactive_msg"> <a class="dropdown-item" href="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/main/messages/messages.php?form_inactive=1"> <?php echo xlt("Inactive Messages"); ?></a></li>
                                 <li id="menu_log_msg"> <a class="dropdown-item" onclick="openLogScreen();" > <?php echo xlt("Message Log"); ?></a></li>
                             </ul>
                         </li>
@@ -2060,7 +2060,7 @@ class Display extends Base
     <script>
         function toggleRcbSelectors() {
             if ($("#rcb_selectors").css('display') === 'none') {
-                $.post( "<?php echo OEGlobalsBag::getInstance()->get('webroot') . "/interface/main/messages/messages.php"; ?>", {
+                $.post( "<?php echo OEGlobalsBag::getInstance()->getWebRoot() . "/interface/main/messages/messages.php"; ?>", {
                     'rcb_selectors' : 'block',
                     success: function (data) {
                         $("#rcb_selectors").slideToggle();
@@ -2068,7 +2068,7 @@ class Display extends Base
                     }
                 });
             } else {
-                $.post( "<?php echo OEGlobalsBag::getInstance()->get('webroot') . "/interface/main/messages/messages.php"; ?>", {
+                $.post( "<?php echo OEGlobalsBag::getInstance()->getWebRoot() . "/interface/main/messages/messages.php"; ?>", {
                     'rcb_selectors' : 'none',
                     success: function (data) {
                         $("#rcb_selectors").slideToggle();
@@ -2082,7 +2082,7 @@ class Display extends Base
         function SMS_bot(pid) {
             top.restoreSession();
             pid = pid.replace('recall_','');
-            window.open('<?php echo OEGlobalsBag::getInstance()->get('webroot'); ?>/interface/main/messages/messages.php?nomenu=1&go=SMS_bot&pid=' + pid,'SMS_bot', 'width=370,height=600,resizable=0');
+            window.open('<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/main/messages/messages.php?nomenu=1&go=SMS_bot&pid=' + pid,'SMS_bot', 'width=370,height=600,resizable=0');
             return false;
         }
         $(function () {
@@ -2092,7 +2092,7 @@ class Display extends Base
                 <?php $datetimepicker_timepicker = false; ?>
                 <?php $datetimepicker_showseconds = false; ?>
                 <?php $datetimepicker_formatInput = true; ?>
-                <?php require(OEGlobalsBag::getInstance()->get('srcdir') . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
+                <?php require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
                 <?php // can add any additional javascript settings to datetimepicker here; need to prepend first setting with a comma ?>
             });
         });
@@ -2818,7 +2818,7 @@ class Display extends Base
                         <?php $datetimepicker_timepicker = false; ?>
                         <?php $datetimepicker_showseconds = false; ?>
                         <?php $datetimepicker_formatInput = true; ?>
-                        <?php require(OEGlobalsBag::getInstance()->get('srcdir') . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
+                        <?php require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
                         <?php // can add any additional javascript settings to datetimepicker here; need to prepend first setting with a comma ?>
                 });
             });

--- a/library/calendar.inc.php
+++ b/library/calendar.inc.php
@@ -13,7 +13,7 @@
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once(OEGlobalsBag::getInstance()->get('incdir') . "/main/holidays/Holidays_Controller.php");
+require_once(OEGlobalsBag::getInstance()->getKernel()->getIncludeRoot() . "/main/holidays/Holidays_Controller.php");
 
 // Returns an array of the facility ids and names that the user is allowed to access.
 // Access might be for inventory purposes ($inventory=true) or calendar purposes.

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -53,7 +53,7 @@ class Controller extends Smarty implements ControllerInterface
          $this->_state = true;
          $this->setCompileDir(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . '/documents/smarty/main');
          $this->setCompileCheck(true);
-         $this->setPluginsDir([__DIR__ . "/../smarty/plugins", OEGlobalsBag::getInstance()->get('vendor_dir') . "/smarty/smarty/libs/plugins"]);
+         $this->setPluginsDir([__DIR__ . "/../smarty/plugins", OEGlobalsBag::getInstance()->getKernel()->getVendorDir() . "/smarty/smarty/libs/plugins"]);
          $this->assign("PROCESS", "true");
          $this->assign("HEADER", "<html><head></head><body>");
          $this->assign("FOOTER", "</body></html>");
@@ -98,7 +98,7 @@ class Controller extends Smarty implements ControllerInterface
 
     public function function_argument_error(): never
     {
-         $this->display(OEGlobalsBag::getInstance()->get('template_dir') . "error/" . $this->template_mod . "_function_argument.html");
+         $this->display(OEGlobalsBag::getInstance()->getKernel()->getTemplateDir() . "error/" . $this->template_mod . "_function_argument.html");
          exit;
     }
 
@@ -196,7 +196,7 @@ class Controller extends Smarty implements ControllerInterface
         }
 
         // Load controller file
-        $controllerFile = OEGlobalsBag::getInstance()->getString('fileroot') . "/controllers/$className.class.php";
+        $controllerFile = OEGlobalsBag::getInstance()->getProjectDir() . "/controllers/$className.class.php";
         if (!$this->i_once($controllerFile)) {
             throw new NotFoundHttpException("Unable to load controller: $className");
         }

--- a/library/custom_template/add_context.php
+++ b/library/custom_template/add_context.php
@@ -186,8 +186,8 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                             <tr class="text <?php echo $class;?>">
                                 <td class="right bottom left"><?php echo htmlspecialchars($i, ENT_QUOTES);?></td>
                                 <td class="right bottom"><?php echo htmlspecialchars(xl($row['cl_list_item_long']), ENT_QUOTES);?></td>
-                                <td class="right bottom"><a href="#" onclick='editme("<?php echo htmlspecialchars((string) $row['cl_list_slno'], ENT_QUOTES);?>","<?php echo htmlspecialchars((string) $row['cl_list_item_long'], ENT_QUOTES);?>")'><img src='<?php echo OEGlobalsBag::getInstance()->get('images_static_relative'); ?>/b_edit.png' border=0></a></td>
-                                <td class="right bottom"><a href="#" onclick="deleteme(<?php echo htmlspecialchars((string) $row['cl_list_slno'], ENT_QUOTES);?>)"><img src='<?php echo OEGlobalsBag::getInstance()->get('images_static_relative'); ?>/deleteBtn.png' border=0></a></td>
+                                <td class="right bottom"><a href="#" onclick='editme("<?php echo htmlspecialchars((string) $row['cl_list_slno'], ENT_QUOTES);?>","<?php echo htmlspecialchars((string) $row['cl_list_item_long'], ENT_QUOTES);?>")'><img src='<?php echo OEGlobalsBag::getInstance()->getKernel()->getImagesRelative(); ?>/b_edit.png' border=0></a></td>
+                                <td class="right bottom"><a href="#" onclick="deleteme(<?php echo htmlspecialchars((string) $row['cl_list_slno'], ENT_QUOTES);?>)"><img src='<?php echo OEGlobalsBag::getInstance()->getKernel()->getImagesRelative(); ?>/deleteBtn.png' border=0></a></td>
                             </tr>
                             <?php
                         }

--- a/library/custom_template/ajax_code.php
+++ b/library/custom_template/ajax_code.php
@@ -164,11 +164,11 @@ if ($Source != "add_template") {
         $i++;
         echo "<li class='bg-dark text-light' id='clorder_" . attr($row['cl_list_slno']) . "' style='cursor:pointer'><span class='bg-dark text-light'>";
         if (AclMain::aclCheckCore('nationnotes', 'nn_configure')) {
-            echo "<img src='" . OEGlobalsBag::getInstance()->get('images_static_relative') . "/b_edit.png' onclick='update_item_div(" . attr_js($row['cl_list_slno']) . ")'>";
+            echo "<img src='" . OEGlobalsBag::getInstance()->getKernel()->getImagesRelative() . "/b_edit.png' onclick='update_item_div(" . attr_js($row['cl_list_slno']) . ")'>";
         }
         echo "<div style='display:inline' id='" . attr($row['cl_list_slno']) . "' onclick='moveOptions_11(" . attr_js($row['cl_list_slno']) . ", \"textarea1\")'>" . text($row['cl_list_item_long']) . "</div>";
         if (AclMain::aclCheckCore('nationnotes', 'nn_configure')) {
-            echo "<img src='" . OEGlobalsBag::getInstance()->get('images_static_relative') . "/deleteBtn.png' onclick='delete_item(" . attr_js($row['cl_list_slno']) . ")'>";
+            echo "<img src='" . OEGlobalsBag::getInstance()->getKernel()->getImagesRelative() . "/deleteBtn.png' onclick='delete_item(" . attr_js($row['cl_list_slno']) . ")'>";
             echo "<div id='update_item" . attr($row['cl_list_slno']) . "' style='display:none'><textarea name='update_item_txt" . attr($row['cl_list_slno']) . "' id='update_item_txt" . attr($row['cl_list_slno']) . "' class='w-100'>" . text($row['cl_list_item_long']) . "</textarea><br />";
             echo "<input type='button' name='update' onclick='update_item(" . attr_js($row['cl_list_slno']) . ")' value='" . xla('Update') . "'><input type='button' name='cancel' value='" . xla('Cancel') . "' onclick='cancel_item(" . attr_js($row['cl_list_slno']) . ")'></div>";
         }

--- a/library/custom_template/custom_template.php
+++ b/library/custom_template/custom_template.php
@@ -89,7 +89,7 @@ if ($isNN) {
 }
     Header::setupHeader(['common', 'opener', 'select2', 'ckeditor', $ckeditorConfig]);
 ?>
-<script src="<?php echo OEGlobalsBag::getInstance()->get('webroot') ?>/library/js/ajax_functions_writer.js"></script>
+<script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/ajax_functions_writer.js"></script>
 
 <script>
     // note these variables are set on backend server side, leaving comment for server side readers
@@ -118,7 +118,7 @@ if ($isNN) {
                     },
                     dataType: 'json',
                 },
-                <?php require(OEGlobalsBag::getInstance()->get('srcdir') . '/js/xl/select2.js.php'); ?>
+                <?php require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/select2.js.php'); ?>
             });
 
             $('#contextSearch').on('select2:select', function (e) {
@@ -254,7 +254,7 @@ if ($isNN) {
     });
 </script>
 <script>
-    <?php require(OEGlobalsBag::getInstance()->get('srcdir') . "/restoreSession.php"); ?>
+    <?php require(OEGlobalsBag::getInstance()->getSrcDir() . "/restoreSession.php"); ?>
 </script>
 </head>
 <body class="body_top">

--- a/library/custom_template/delete_category.php
+++ b/library/custom_template/delete_category.php
@@ -39,7 +39,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
     <head>
         <title><!-- Insert your title here --></title>
         <?php Header::setupHeader('opener'); ?>
-        <script src="<?php echo OEGlobalsBag::getInstance()->get('webroot') ?>/library/js/ajax_functions_writer.js"></script>
+        <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/ajax_functions_writer.js"></script>
 
         <script>
         function delete_full_category(id){

--- a/library/dicom_frame.php
+++ b/library/dicom_frame.php
@@ -40,12 +40,12 @@ if ($web_path) {
     }
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
     $csrf = CsrfUtils::collectCsrfToken(session: $session);
-    $state_url = OEGlobalsBag::getInstance()->get('web_root') . "/library/ajax/upload.php";
+    $state_url = OEGlobalsBag::getInstance()->getWebRoot() . "/library/ajax/upload.php";
     $web_path = attr($web_path) . '&retrieve&patient_id=' . attr_url($patid) . '&document_id=' . attr_url($docid) . '&as_file=false&type=' . attr_url($type);
 }
 $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig();
 echo $twig->render("dicom/dicom-viewer.html.twig", [
-    'assets_static_relative' => OEGlobalsBag::getInstance()->get('assets_static_relative')
+    'assets_static_relative' => OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative()
     ,'web_root' => $web_root
     ,'web_path' => $web_path
     ,'state_url' => $state_url ?? null

--- a/library/direct_message_check.inc.php
+++ b/library/direct_message_check.inc.php
@@ -54,9 +54,9 @@ function phimail_connect(&$phimail_error)
 
     // if test mode is disabled we use the production cert, otherwise we use the test certificate.
     if (OEGlobalsBag::getInstance()->has('phimail_testmode_disabled') && OEGlobalsBag::getInstance()->getBoolean('phimail_testmode_disabled')) {
-        $phimail_cafile = OEGlobalsBag::getInstance()->get('fileroot') . '/public/certs/phimail/phimail_server.pem';
+        $phimail_cafile = OEGlobalsBag::getInstance()->getProjectDir() . '/public/certs/phimail/phimail_server.pem';
     } else {
-        $phimail_cafile = OEGlobalsBag::getInstance()->get('fileroot') . '/public/certs/phimail/EMRDirectTestCA.pem';
+        $phimail_cafile = OEGlobalsBag::getInstance()->getProjectDir() . '/public/certs/phimail/EMRDirectTestCA.pem';
         ServiceContainer::getLogger()->debug("running phimail_connect in test mode.  This should not be used for production", ['ca' => $phimail_cafile, 'testmode' => OEGlobalsBag::getInstance()->getBoolean('phimail_testmode_disabled')]);
     }
     if (!file_exists($phimail_cafile)) {

--- a/library/documents.php
+++ b/library/documents.php
@@ -21,7 +21,7 @@
  * @link    https://www.open-emr.org
  */
 
-require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->get('fileroot') . "/controllers/C_Document.class.php");
+require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getProjectDir() . "/controllers/C_Document.class.php");
 use OpenEMR\Common\Session\SessionWrapperFactory;
 
 /**

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -1528,7 +1528,7 @@ function generate_form_field($frow, $currvalue): void
         if (empty($currvalue)) {
             if (preg_match('/\\bimage=([a-zA-Z0-9._-]*)/', (string) $frow['description'], $matches)) {
                 // If defined this is the filename of the default starting image.
-                $currvalue = OEGlobalsBag::getInstance()->get('web_root') . '/sites/' . $session->get('site_id') . '/images/' . $matches[1];
+                $currvalue = OEGlobalsBag::getInstance()->getWebRoot() . '/sites/' . $session->get('site_id') . '/images/' . $matches[1];
             }
         }
         $mywidth  = 50 + ($canWidth  > 250 ? $canWidth  : 250);
@@ -2281,7 +2281,7 @@ function generate_print_field($frow, $currvalue, $value_allowed = true): void
     } elseif ($data_type == 40) { // Image from canvas drawing
         if (empty($currvalue)) {
             if (preg_match('/\\bimage=([a-zA-Z0-9._-]*)/', (string) $frow['description'], $matches)) {
-                $currvalue = OEGlobalsBag::getInstance()->get('web_root') . '/sites/' . $session->get('site_id') . '/images/' . $matches[1];
+                $currvalue = OEGlobalsBag::getInstance()->getWebRoot() . '/sites/' . $session->get('site_id') . '/images/' . $matches[1];
             }
         }
         if ($currvalue) {
@@ -2777,7 +2777,7 @@ function generate_display_field($frow, $currvalue)
     } elseif ($data_type == 40) { // Image from canvas drawing
         if (empty($currvalue)) {
             if (preg_match('/\\bimage=([a-zA-Z0-9._-]*)/', (string) $frow['description'], $matches)) {
-                $currvalue = OEGlobalsBag::getInstance()->get('web_root') . '/sites/' . $session->get('site_id') . '/images/' . $matches[1];
+                $currvalue = OEGlobalsBag::getInstance()->getWebRoot() . '/sites/' . $session->get('site_id') . '/images/' . $matches[1];
             }
         }
         if ($currvalue) {
@@ -4797,7 +4797,7 @@ function lbf_current_value($frow, $formid, $encounter)
 
 function signer_head()
 {
-    return "<link href=\"" . OEGlobalsBag::getInstance()->get('web_root') . "/portal/sign/css/signer_modal.css?v=" . OEGlobalsBag::getInstance()->get('v_js_includes') . "\" rel=\"stylesheet\"/>\n<script src=\"" . OEGlobalsBag::getInstance()->get('web_root') . "/portal/sign/assets/signature_pad.umd.js?v=" . OEGlobalsBag::getInstance()->get('v_js_includes') . "\"></script>\n<script src=\"" . OEGlobalsBag::getInstance()->get('web_root') . "/portal/sign/assets/signer_api.js?v=" . OEGlobalsBag::getInstance()->get('v_js_includes') . "\"></script>";
+    return "<link href=\"" . OEGlobalsBag::getInstance()->getWebRoot() . "/portal/sign/css/signer_modal.css?v=" . OEGlobalsBag::getInstance()->get('v_js_includes') . "\" rel=\"stylesheet\"/>\n<script src=\"" . OEGlobalsBag::getInstance()->getWebRoot() . "/portal/sign/assets/signature_pad.umd.js?v=" . OEGlobalsBag::getInstance()->get('v_js_includes') . "\"></script>\n<script src=\"" . OEGlobalsBag::getInstance()->getWebRoot() . "/portal/sign/assets/signer_api.js?v=" . OEGlobalsBag::getInstance()->get('v_js_includes') . "\"></script>";
 }
 
 // This returns stuff that needs to go into the <head> section of a caller using
@@ -4806,7 +4806,7 @@ function signer_head()
 //
 function lbf_canvas_head($small = true)
 {
-    $s = "<link  href=\"" . OEGlobalsBag::getInstance()->get('assets_static_relative') . "/literallycanvas/css/literallycanvas.css\" rel=\"stylesheet\" />\n<script src=\"" . OEGlobalsBag::getInstance()->get('assets_static_relative') . "/react/build/react-with-addons.min.js\"></script>\n<script src=\"" . OEGlobalsBag::getInstance()->get('assets_static_relative') . "/react/build/react-dom.min.js\"></script>\n<script src=\"" . OEGlobalsBag::getInstance()->get('assets_static_relative') . "/literallycanvas/js/literallycanvas.min.js\"></script>";
+    $s = "<link  href=\"" . OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative() . "/literallycanvas/css/literallycanvas.css\" rel=\"stylesheet\" />\n<script src=\"" . OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative() . "/react/build/react-with-addons.min.js\"></script>\n<script src=\"" . OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative() . "/react/build/react-dom.min.js\"></script>\n<script src=\"" . OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative() . "/literallycanvas/js/literallycanvas.min.js\"></script>";
     if ($small) {
         $s .= <<<EOD
 <style>

--- a/library/options.js.php
+++ b/library/options.js.php
@@ -307,7 +307,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
     strokeWidths: [1, 2, 3, 5, 8, 12],
     defaultStrokeWidth: 2,
     backgroundShapes: [shape],
-    imageURLPrefix: '<?php echo OEGlobalsBag::getInstance()->get('assets_static_relative') ?>/literallycanvas/img'
+    imageURLPrefix: '<?php echo OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative() ?>/literallycanvas/img'
 });
     if (canHeight > 261) {
     // TBD: Do something to make the widget bigger?
@@ -368,14 +368,14 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
     function sel_patient(ename, epid) {
     elem_patient_name = ename;
     elem_patient_id = epid;
-    dlgopen('<?php echo OEGlobalsBag::getInstance()->get('webroot'); ?>/interface/main/calendar/find_patient_popup.php', '_blank', 500, 400);
+    dlgopen('<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/main/calendar/find_patient_popup.php', '_blank', 500, 400);
 }
 
     // This is a wrapper for specialty forms dialog
     // ajax mode allows calling script to be in the same scope as options.inc.php.
     function specialtyFormDialog(mode = 'iframe', size = 'modal-sm', formHandler = 'name_history') {
     event.preventDefault();
-    let url = '<?php echo OEGlobalsBag::getInstance()->get('webroot'); ?>/library/specialty_forms.php?';
+    let url = '<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/library/specialty_forms.php?';
     url += "form_handler=" + encodeURIComponent(formHandler);
     url += "&csrf_token_form=" + <?php echo js_escape(CsrfUtils::collectCsrfToken(session: $session)); ?>;
     let title = xl("Add to History");

--- a/library/options_listadd.inc.php
+++ b/library/options_listadd.inc.php
@@ -172,7 +172,7 @@ $(function () {
         // make the AJAX call to save the new value to the specified list
         // upon returning successfully, refresh the list box and select
         // the new list item
-        $.getJSON("<?php echo OEGlobalsBag::getInstance()->get('webroot'); ?>/library/ajax/addlistitem.php",
+        $.getJSON("<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/library/ajax/addlistitem.php",
                     {csrf_token_form: <?php echo js_escape(CsrfUtils::collectCsrfToken(session: $session)); ?>,
                     listid: listid,
              newitem: newitem,

--- a/library/registry.inc.php
+++ b/library/registry.inc.php
@@ -9,7 +9,7 @@ function registerForm($directory, $sql_run = 0, $unpackaged = 1, $state = 0)
 {
     $check = sqlQuery("select state from registry where directory=?", [$directory]);
     if ($check == false) {
-        $lines = @file(OEGlobalsBag::getInstance()->get('srcdir') . "/../interface/forms/$directory/info.txt");
+        $lines = @file(OEGlobalsBag::getInstance()->getSrcDir() . "/../interface/forms/$directory/info.txt");
         if ($lines) {
             $name = $lines[0];
             $category ??= $lines[1] ?? 'Miscellaneous';

--- a/library/report.inc.php
+++ b/library/report.inc.php
@@ -10,7 +10,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->get("srcdir") . "/options.inc.php");
+require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/options.inc.php");
 
 use OpenEMR\BC\Utilities;
 use OpenEMR\Common\Acl\AclMain;
@@ -315,7 +315,7 @@ function getPatientBillingEncounter($pid, $encounter)
 function printPatientForms($pid, $cols): void
 {
     //this function takes a $pid
-    $formsBaseDir = OEGlobalsBag::getInstance()->getString('incdir') . "/forms";
+    $formsBaseDir = OEGlobalsBag::getInstance()->getKernel()->getIncludeRoot() . "/forms";
     $inclookupres = sqlStatement("select distinct formdir from forms where pid=? AND deleted=0", [$pid]);
     while ($result = sqlFetchArray($inclookupres)) {
         $formDir = $result["formdir"];

--- a/library/restoreSession.php
+++ b/library/restoreSession.php
@@ -130,7 +130,7 @@ function printLogPrint(elem) {
 <?php if (!empty(OEGlobalsBag::getInstance()->get('gbl_print_log_option'))) { ?>
  comments = win.printlogdata || win.document.body.innerHTML;
  top.restoreSession();
- $.post("<?php echo OEGlobalsBag::getInstance()->get('webroot'); ?>/library/ajax/log_print_action_ajax.php",
+ $.post("<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/library/ajax/log_print_action_ajax.php",
   {
     comments: comments,
     csrf_token_form: <?php echo json_encode(CsrfUtils::collectCsrfToken(session: $session)); ?>

--- a/library/smarty/plugins/function.datetimepickerSupport.php
+++ b/library/smarty/plugins/function.datetimepickerSupport.php
@@ -45,7 +45,7 @@ function smarty_function_datetimepickerSupport($params, &$smarty): void
 
     $datetimepicker_formatInput = !empty($params['input']) && $params['input'] == 'format' ? true : false;
 
-    require(OEGlobalsBag::getInstance()->get('srcdir') . '/js/xl/jquery-datetimepicker-2-5-4.js.php');
+    require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/jquery-datetimepicker-2-5-4.js.php');
 
     echo " });";
 

--- a/library/specialty_forms.php
+++ b/library/specialty_forms.php
@@ -64,7 +64,7 @@ echo "<script>var form=" . js_escape($form) . "</script>";
                 <?php $datetimepicker_timepicker = false; ?>
                 <?php $datetimepicker_showseconds = false; ?>
                 <?php $datetimepicker_formatInput = true; ?>
-                <?php require(OEGlobalsBag::getInstance()->get('srcdir') . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
+                <?php require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
             });
         });
     </script>

--- a/library/spreadsheet.inc.php
+++ b/library/spreadsheet.inc.php
@@ -594,7 +594,7 @@ foreach ($bcodes['Phys']['Physiotherapy Procedures'] as $key => $value) {
             <?php $datetimepicker_timepicker = false; ?>
             <?php $datetimepicker_showseconds = false; ?>
             <?php $datetimepicker_formatInput = false; ?>
-            <?php require(OEGlobalsBag::getInstance()->get('srcdir') . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
+            <?php require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
             <?php // can add any additional javascript settings to datetimepicker here; need to prepend first setting with a comma ?>
         });
     });

--- a/library/templates/address_form.php
+++ b/library/templates/address_form.php
@@ -97,7 +97,7 @@ $templateVars = [
     'widget_constants' => $widgetConstants,
     'edit_options' => $edit_options ?? null,
     'contact_id' => $contact ? $contact->get_id() : null,
-    'srcdir' => OEGlobalsBag::getInstance()->get('srcdir')
+    'srcdir' => OEGlobalsBag::getInstance()->getSrcDir()
 ];
 
 // Render Twig template

--- a/library/templates/relation_form.php
+++ b/library/templates/relation_form.php
@@ -201,8 +201,8 @@ $templateVars = [
     'owner_id' => $foreign_id,
     'owner_contact_id' => $ownerContactId,
     'target_contact_id' => $targetContactId,
-    'webroot' => OEGlobalsBag::getInstance()->get('webroot'),
-    'srcdir' => OEGlobalsBag::getInstance()->get('srcdir'),
+    'webroot' => OEGlobalsBag::getInstance()->getWebRoot(),
+    'srcdir' => OEGlobalsBag::getInstance()->getSrcDir(),
     'csrfToken' => CsrfUtils::collectCsrfToken(session: $session)
 ];
 

--- a/library/templates/telecom_form.php
+++ b/library/templates/telecom_form.php
@@ -83,7 +83,7 @@ $templateVars = [
     'widget_constants' => $widgetConstants,
     'edit_options' => $edit_options ?? null,
     'contact_id' => $contact ? $contact->get_id() : null,
-    'srcdir' => OEGlobalsBag::getInstance()->get('srcdir')
+    'srcdir' => OEGlobalsBag::getInstance()->getSrcDir()
 ];
 
 // Render Twig template

--- a/library/validation/validate_core.php
+++ b/library/validation/validate_core.php
@@ -49,7 +49,7 @@ function validateUsingPageRules($fileNamePath): void
 
     $path = '';
 
-    $path = OEGlobalsBag::getInstance()->get('webroot') != '' ? str_replace(OEGlobalsBag::getInstance()->get('webroot'), '', $fileNamePath) : $fileNamePath;
+    $path = OEGlobalsBag::getInstance()->getWebRoot() != '' ? str_replace(OEGlobalsBag::getInstance()->getWebRoot(), '', $fileNamePath) : $fileNamePath;
 
     print '<!--Page Form Validations-->';
 //if we would like to get all the page forms rules we need to call collectValidationPageRules($title) this way there is a
@@ -60,7 +60,7 @@ function validateUsingPageRules($fileNamePath): void
         echo("\r\n");
         //Not lbf forms use the new validation, please make sure you have the corresponding values in the list Page validation
         $use_validate_js = 1;
-        require_once(OEGlobalsBag::getInstance()->get('srcdir') . "/validation/validation_script.js.php");
+        require_once(OEGlobalsBag::getInstance()->getSrcDir() . "/validation/validation_script.js.php");
         echo("\r\n");
         print '<script>';
         echo ("$(function () {");

--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -26,15 +26,15 @@
 
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once(OEGlobalsBag::getInstance()->get('srcdir') . "/validation/LBF_Validation.php");
+require_once(OEGlobalsBag::getInstance()->getSrcDir() . "/validation/LBF_Validation.php");
 
 /*LBF form take the valude from the global $GLOBALS['new_validate'];*/
 /*Other pages depend if the page in the lists options (page validation)is active and exists)*/
 if ($use_validate_js) {
     ?>
-    <script src="<?php echo OEGlobalsBag::getInstance()->get('assets_static_relative') ?>/moment/moment.js"></script>
-    <script src="<?php echo OEGlobalsBag::getInstance()->get('rootdir') ?>/../library/js/vendors/validate/validate_modified.js"></script>
-    <script src="<?php echo OEGlobalsBag::getInstance()->get('rootdir') ?>/../library/js/vendors/validate/validate_extend.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative() ?>/moment/moment.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getRootDir() ?>/../library/js/vendors/validate/validate_modified.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getRootDir() ?>/../library/js/vendors/validate/validate_extend.js"></script>
 
     <style type="text/css">
     .error-message {


### PR DESCRIPTION
## Summary

Third slice of #11258 (Kernel typed path accessors). #11570 migrated `src/`; this slice migrates the legacy `library/` tree.

- 49 files, 126 call sites in `library/` migrated from `OEGlobalsBag::getInstance()->get('<path-key>')` to typed Kernel accessors
- Prefer the OEGlobalsBag convenience wrappers (`getWebRoot()`, `getSrcDir()`, `getProjectDir()`) where they exist — these fall back to the bag when the Kernel is not yet initialized (CLI `--skip-globals`, early bootstrap)
- Use `getKernel()->get<Xxx>()` for path accessors that don't have a fallback wrapper (`getRootDir`, `getIncludeRoot`, `getVendorDir`, `getTemplateDir`, `getAssetsRelative`, `getImagesRelative`)

### Mapping

| Old | New |
|-----|-----|
| `get('webroot')` / `get('web_root')` | `getWebRoot()` |
| `get('srcdir')` | `getSrcDir()` |
| `get('fileroot')` | `getProjectDir()` |
| `get('rootdir')` | `getKernel()->getRootDir()` |
| `get('incdir')` | `getKernel()->getIncludeRoot()` |
| `get('vendor_dir')` | `getKernel()->getVendorDir()` |
| `get('template_dir')` | `getKernel()->getTemplateDir()` |
| `get('assets_static_relative')` | `getKernel()->getAssetsRelative()` |
| `get('images_static_relative')` | `getKernel()->getImagesRelative()` |

### Baseline impact

Regenerated the PHPStan baseline: 448 entries cleared across `binaryOp.invalid`, `echo.nonString`, and `argument.type`. The typed accessors return `string` instead of `mixed`, so the noise these call sites were generating is gone.

### Still to do

- `interface/` migration (~300 files) — the largest remaining slice
- Sibling #11264 — move `OE_SITE_DIR` / `OE_SITE_WEBROOT` to the session wrapper

## Test plan

- [x] `php -l` clean on every changed file
- [x] `composer phpstan` clean (level 10, 4238 files)
- [x] All pre-commit hooks pass (phpcs, rector, phpstan, composer-require-checker, codespell)
- [ ] CI checks
