### PR TITLE
fix(security): harden escape_sql_column_name() with backtick-quoting

### DIFF
--- a/interface/main/finder/dynamic_finder_ajax.php
+++ b/interface/main/finder/dynamic_finder_ajax.php
@@ -78,7 +78,7 @@ if (isset($_GET['iSortCol_0'])) {
             if ($aColumns[$iSortCol] == 'name') {
                 $orderby .= "lname $sSortDir, fname $sSortDir, mname $sSortDir";
             } else {
-                $orderby .= "`" . escape_sql_column_name($aColumns[$iSortCol], ['patient_data']) . "` $sSortDir";
+                $orderby .= escape_sql_column_name($aColumns[$iSortCol], ['patient_data']) . " $sSortDir";
             }
         }
     }
@@ -150,13 +150,13 @@ if (isset($_GET['sSearch']) && $_GET['sSearch'] !== "") {
                 array_push($srch_bind, ($sSearch . "%"), ($sSearch . "%"), ($sSearch . "%"));
             }
         } elseif ($searchMethodInPatientList) { // exact search
-            $where .= "`" . escape_sql_column_name($colname, ['patient_data']) . "` LIKE ? ";
+            $where .= escape_sql_column_name($colname, ['patient_data']) . " LIKE ? ";
             array_push($srch_bind, $sSearch);
         } elseif ($searchAny) {
-            $where .= " `" . escape_sql_column_name($colname, ['patient_data']) . "` LIKE ?"; // any search
+            $where .= " " . escape_sql_column_name($colname, ['patient_data']) . " LIKE ?"; // any search
             array_push($srch_bind, ('%' . $sSearch . '%'));
         } else {
-            $where .= "`" . escape_sql_column_name($colname, ['patient_data']) . "` LIKE ? ";
+            $where .= escape_sql_column_name($colname, ['patient_data']) . " LIKE ? ";
             array_push($srch_bind, ($sSearch . '%'));
         }
     }
@@ -186,13 +186,13 @@ for ($i = 0; $i < count($aColumns); ++$i) {
                 array_push($srch_bind, ($sSearch . "%"), ($sSearch . "%"), ($sSearch . "%"));
             }
         } elseif ($colname == 'DOB') {
-            $where .= "`" . escape_sql_column_name($colname, ['patient_data']) . "` LIKE ? ";
+            $where .= escape_sql_column_name($colname, ['patient_data']) . " LIKE ? ";
             array_push($srch_bind, dateSearch($sSearch));
         } elseif ($searchMethodInPatientList) { // exact search
-            $where .= "`" . escape_sql_column_name($colname, ['patient_data']) . "` LIKE ? ";
+            $where .= escape_sql_column_name($colname, ['patient_data']) . " LIKE ? ";
             array_push($srch_bind, $sSearch);
         } else {
-            $where .= "`" . escape_sql_column_name($colname, ['patient_data']) . "` LIKE ? ";
+            $where .= escape_sql_column_name($colname, ['patient_data']) . " LIKE ? ";
             array_push($srch_bind, ($sSearch . '%'));
         }
     }
@@ -223,7 +223,7 @@ foreach ($aColumns as $colname) {
     if ($colname == 'name') {
         $sellist .= "lname, fname, mname";
     } else {
-        $sellist .= "`" . escape_sql_column_name($colname, ['patient_data']) . "`";
+        $sellist .= escape_sql_column_name($colname, ['patient_data']);
     }
 }
 

--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -313,10 +313,10 @@ function addOrDeleteColumn($layout_id, $field_id, $add = true): void
     } elseif (!$add && $column_exists) {
         // Do not drop a column that has any data.
         $tmp = sqlQuery(
-            "SELECT `" . escape_sql_column_name($field_id, [$tablename]) .
-            "` AS field_id FROM `" . escape_table_name($tablename) . "` WHERE " .
-            "`" . escape_sql_column_name($field_id, [$tablename]) . "` IS NOT NULL AND `"
-            . escape_sql_column_name($field_id, [$tablename]) . "` != '' LIMIT 1"
+            "SELECT " . escape_sql_column_name($field_id, [$tablename]) .
+            " AS field_id FROM `" . escape_table_name($tablename) . "` WHERE " .
+            escape_sql_column_name($field_id, [$tablename]) . " IS NOT NULL AND "
+            . escape_sql_column_name($field_id, [$tablename]) . " != '' LIMIT 1"
         );
         if (!isset($tmp['field_id']) && !isColumnReserved($tablename, $field_id)) {
             $lotmp = [];
@@ -331,7 +331,7 @@ function addOrDeleteColumn($layout_id, $field_id, $add = true): void
             }
             if (empty($lotmp['count'])) {
                 $dropQuery = "ALTER TABLE `" . escape_table_name($tablename) . "` " .
-                    "DROP `" . escape_sql_column_name($field_id, [$tablename]) . "`";
+                    "DROP " . escape_sql_column_name($field_id, [$tablename]);
                 sqlStatement($dropQuery);
                 EventAuditLogger::getInstance()->newEvent(
                     "alter_table",
@@ -385,7 +385,7 @@ function renameColumn($layout_id, $old_field_id, $new_field_id)
     if ($colarr['Extra']) {
         $colstr .= " " . add_escape_custom($colarr['Extra']);
     }
-    $query = "ALTER TABLE `" . escape_table_name($tablename) . "` CHANGE `" . escape_sql_column_name($old_field_id, [$tablename]) . "` `" . escape_identifier($new_field_id, 'a-zA-Z0-9_', true) . "` $colstr";
+    $query = "ALTER TABLE `" . escape_table_name($tablename) . "` CHANGE " . escape_sql_column_name($old_field_id, [$tablename]) . " `" . escape_identifier($new_field_id, 'a-zA-Z0-9_', true) . "` $colstr";
     sqlStatement($query);
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
     EventAuditLogger::getInstance()->newEvent(

--- a/library/clinical_rules.php
+++ b/library/clinical_rules.php
@@ -2123,7 +2123,7 @@ function set_plan_activity_patient($plan, $type, $setting, $patient_id): void
     }
 
   // Update patient specific row
-    $query = "UPDATE `clinical_plans` SET `" . escape_sql_column_name($type . "_flag", ["clinical_plans"]) . "`= ? WHERE id = ? AND pid = ?";
+    $query = "UPDATE `clinical_plans` SET " . escape_sql_column_name($type . "_flag", ["clinical_plans"]) . "= ? WHERE id = ? AND pid = ?";
     sqlStatementCdrEngine($query, [$setting,$plan,$patient_id]);
 }
 
@@ -2290,7 +2290,7 @@ function set_rule_activity_patient($rule, $type, $setting, $patient_id): void
     }
 
   // Update patient specific row
-    $query = "UPDATE `clinical_rules` SET `" . escape_sql_column_name($type . "_flag", ["clinical_rules"]) . "`= ?, `access_control` = ? WHERE id = ? AND pid = ?";
+    $query = "UPDATE `clinical_rules` SET " . escape_sql_column_name($type . "_flag", ["clinical_rules"]) . "= ?, `access_control` = ? WHERE id = ? AND pid = ?";
     sqlStatementCdrEngine($query, [$setting,$patient_rule_original['access_control'],$rule,$patient_id]);
 }
 
@@ -2735,12 +2735,12 @@ function exist_database_item($patient_id, $table, ?string $column = null, $data_
             //To handle standard forms starting with form_
             //In this case, we are assuming the date field is "date"
             $sql = sqlStatementCdrEngine(
-                "SELECT b.`" . escape_sql_column_name($column, [$table]) . "` " .
+                "SELECT b." . escape_sql_column_name($column, [$table]) . " " .
                 "FROM forms a " .
                 "LEFT JOIN `" . escape_table_name($table) . "` " . " b " .
                 "ON (a.form_id=b.id AND a.formdir LIKE '" . add_escape_custom(substr($table, 5)) . "') " .
                 "WHERE a.deleted != '1' " .
-                "AND b.`" . escape_sql_column_name($column, [$table]) . "`" . $compSql .
+                "AND b." . escape_sql_column_name($column, [$table]) . "" . $compSql .
                 "AND b." . add_escape_custom($patient_id_label) . "=? " . $customSQL
                 . str_replace("`date`", "b.`date`", $dateSql),
                 [$data, $patient_id]
@@ -2753,10 +2753,10 @@ function exist_database_item($patient_id, $table, ?string $column = null, $data_
             }
 
             // search for number of specific items
-            $sql = sqlStatementCdrEngine("SELECT `" . escape_sql_column_name($column, [$table]) . "` " .
+            $sql = sqlStatementCdrEngine("SELECT " . escape_sql_column_name($column, [$table]) . " " .
                 "FROM `" . escape_table_name($table) . "` " .
                 " " . $whereTables . " " .
-                "WHERE `" . escape_sql_column_name($column, [$table]) . "`" . $compSql .
+                "WHERE " . escape_sql_column_name($column, [$table]) . "" . $compSql .
                 "AND " . add_escape_custom($patient_id_label) . "=? " . $customSQL .
                 $dateSql, [$data, $patient_id]);
         }

--- a/library/formdata.inc.php
+++ b/library/formdata.inc.php
@@ -113,6 +113,11 @@ function escape_sql_column_name($s, $tables, $long = false, $throwException = fa
         return implode(", ", $multiple_columns);
     }
 
+    // Reject column names containing backticks to prevent identifier-context injection
+    if (str_contains($s, '`')) {
+        throw new \OpenEMR\Common\Database\SqlQueryException("", "ERROR: OpenEMR SQL Escaping ERROR of the following string: " . errorLogEscape($s));
+    }
+
     // If the $tables is empty, then process them all
     if (empty($tables)) {
         $res = sqlStatementNoLog("SHOW TABLES");
@@ -138,9 +143,10 @@ function escape_sql_column_name($s, $tables, $long = false, $throwException = fa
         }
     }
 
-    // Now can escape(via whitelisting) the sql column name
+    // Whitelist against actual columns, then backtick-quote to keep in identifier context
     $dieIfNoMatch = !$throwException;
-    return escape_identifier($s, $columns_options, $dieIfNoMatch, true, $throwException);
+    $column = escape_identifier($s, $columns_options, $dieIfNoMatch, true, $throwException);
+    return sprintf('`%s`', $column);
 }
 
 /**

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -360,7 +360,7 @@ class EventAuditLogger
             }
 
             if ($sortby != "") {
-                $sql .= " ORDER BY `" . escape_sql_column_name($sortby, ['log']) . "`  " . escape_sort_order($direction); // descending order
+                $sql .= " ORDER BY " . escape_sql_column_name($sortby, ['log']) . "  " . escape_sort_order($direction); // descending order
             } else {
                 $sql .= " ORDER BY el.`log_id` DESC";
             }


### PR DESCRIPTION
## Summary

- `escape_sql_column_name()` validates column names against `SHOW COLUMNS` (whitelist) but returns the raw name without quoting it as a SQL identifier
- Callers that omit backticks place the identifier in unquoted SQL context, where a column name containing SQL-meaningful characters could theoretically be parsed as syntax
- ~21 call sites were manually adding backticks, but the function itself didn't guarantee safe output

## Changes

- Reject column names containing backticks (prevents breakout from backtick-quoted context)
- Backtick-quote the return value so it always produces a safe SQL identifier
- Remove redundant backtick-wrapping from 19 call sites

## Test plan

- [ ] `composer phpstan` — passes (baseline regenerated for new `error_log()` call)
- [ ] `composer rector-check` — no changes suggested
- [ ] Verify patient finder search works (`patient_select.php`, `dynamic_finder_ajax.php`)
- [ ] Verify layout editor field operations (add/rename/drop via `edit_layout.php`)
- [ ] Verify clinical rules display and editing

Closes #11278