### PR TITLE
style(custom): fix indentation in export_xml.php

### DIFF
--- a/custom/export_xml.php
+++ b/custom/export_xml.php
@@ -19,9 +19,9 @@
  use OpenEMR\Common\Acl\AclMain;
  use OpenEMR\Core\Header;
 
- if (!AclMain::aclCheckCore('patients', 'demo')) {
-     AccessDeniedHelper::denyWithTemplate("ACL check failed for patients/demo: Export Patient Demographics XML", xl("Export Patient Demographics XML"));
- }
+if (!AclMain::aclCheckCore('patients', 'demo')) {
+    AccessDeniedHelper::denyWithTemplate("ACL check failed for patients/demo: Export Patient Demographics XML", xl("Export Patient Demographics XML"));
+}
 
  $out = "";
  $indent = 0;


### PR DESCRIPTION
## Summary
- Fix 2 phpcs indentation errors in `custom/export_xml.php` (lines 22, 24) that cause the PHP styling CI check to fail on rel-800

## Test plan
- [x] `phpcs` passes locally on the file
- CI PHP styling check should pass