### PR TITLE
fix: Fix clinical notes date formatting (Fixes #11290).

### DIFF
--- a/interface/forms/clinical_notes/clinical-notes.js
+++ b/interface/forms/clinical_notes/clinical-notes.js
@@ -1113,16 +1113,12 @@
                 datetimepickerTranslated('.datepicker', {
                     timepicker: false
                     , showSeconds: false
-                    , formatInput: false
+                    , formatInput: true
                 });
             });
 
             // initialize
             $(".clinical_notes_type").change(typeChange);
-
-            // init code values by triggering the change in case
-            // there are any default values set in the template
-            $(".clinical_notes_type").trigger("change");
             $(".btn-add").click(duplicateRow);
             $(".btn-delete").click(deleteRow);
             if (typeof config.alertMessage !== 'undefined' && config.alertMessage != '') {

--- a/interface/forms/clinical_notes/new.php
+++ b/interface/forms/clinical_notes/new.php
@@ -89,7 +89,7 @@ if ($formid) {
             ,'clinical_notes_type' => $defaultType
             ,'clinical_notes_category' => $defaultCategory
             ,'description' => ''
-            ,'date' => oeFormatShortDate(date('Y-m-d'))
+            ,'date' =>date('Y-m-d')
         ]
     ];
 }

--- a/interface/forms/clinical_notes/templates/partials/new/_clinical-notes-row.html.twig
+++ b/interface/forms/clinical_notes/templates/partials/new/_clinical-notes-row.html.twig
@@ -8,7 +8,7 @@
                 <div class="row pl-2">
                     <div class="col-12">
                         <label for="code_date_{{ index|attr }}" class="h5">{{ "Date"|xlt }}:</label>
-                        <input type='text' id="code_date_{{ index|attr }}" name='code_date[]' class="form-control code_date datepicker" value='{{ obj.date|default('')|attr }}' title='{{ 'yyyy-mm-dd Date of service'|xla }}' />
+                        <input type='text' id="code_date_{{ index|attr }}" name='code_date[]' class="form-control code_date datepicker" value='{{ obj.date|shortDate|default('')|attr }}' title='{{ 'yyyy-mm-dd Date of service'|xla }}' />
                     </div>
                     {% if clinical_notes_type|length > 0 %}
                         <div class="col-12">
@@ -61,7 +61,7 @@
                         <!-- Last edited date -->
                         <div class="col-12">
                             <label class="h6">{{ 'Last Updated'|xlt }}:</label>
-                            <span>{{ obj.last_updated|text }}</span>
+                            <span>{{ obj.last_updated|oeFormatDateTime|text }}</span>
                         </div>
                     </div>
                 </div>
@@ -107,7 +107,7 @@
                             {% if obj.linked_results is defined and obj.linked_results|length > 0 %}
                                 {% for result in obj.linked_results %}
                                     <div class="result-item badge badge-info mr-1 mb-1" data-uuid="{{ result.uuid|attr }}">
-                                        <span title="{{ result.procedure_name|attr }} {{ result.result_text|attr }}: {{ result.result|attr }} ({{ result.date|attr }})">
+                                        <span title="{{ result.procedure_name|attr }} {{ result.result_text|attr }}: {{ result.result|attr }} ({{ result.date|oeFormatDateTime|attr }})">
                                             {{ result.result_text|text }}: {{ result.result|text }}
                                         </span>
                                         <button type="button" class="btn-close-result ml-1" data-note-index="{{ index|attr }}" data-uuid="{{ result.uuid|attr }}" title="{{ 'Remove result'|xla }}">&times;</button>

--- a/interface/forms/clinical_notes/templates/report.html.twig
+++ b/interface/forms/clinical_notes/templates/report.html.twig
@@ -16,7 +16,7 @@ The Report template of the clinical note form.
             <header class="d-flex justify-content-between bg-light border border-dark p-1 sticky-top">
                 <div class="form-group mb-0">
                     <div class="font-weight-bold">{{ "Date"|xlt }}</div>
-                    <time datetime="{{ n.date|date()|attr }}">{{ n.date|date()|text }}</time>
+                    <time datetime="{{ n.date|shortDate|attr }}">{{ n.date|shortDate|text }}</time>
                 </div>
                 <div class="form-group mb-0">
                     <div class="font-weight-bold">{{ "Type"|xlt }}</div>
@@ -39,6 +39,16 @@ The Report template of the clinical note form.
                             {{ n.code|text }}
                         {% else %}
                             {{ "Unspecified"|xlt }}
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="form-group mb-0">
+                    <div class="font-weight-bold">{{ "Last Updated"|xlt }}</div>
+                    <div>
+                        {% if n.last_updated %}
+                            <time datetime="{{ n.last_updated|oeFormatDateTime|attr }}">{{ n.last_updated|oeFormatDateTime|text }}</time>
+                        {% else %}
+                            {{ "Unknown"|xlt }}
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #11290

This fixes the clinical note formatting with the dates.  The international date formatting was not being used.

Also removed a redundant triggerChanges call since the twig template already handles that.