### PR TITLE
chore(ci): Run PHPStan on 8.5

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         # Single-element matrix provides named variable and job title
-        php-version: ['8.4']
+        php-version: ['8.5']
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6


### PR DESCRIPTION
Fixes https://github.com/openemr/openemr-devops/issues/611

#### Short description of what this resolves:
PHPStan should run on the highest supported released version of PHP so its aware of forward capabilities.

It will still analyze against 8.2: https://phpstan.org/config-reference#phpversion