### PR TITLE
chore(version): set version to 8.1.0 for release branch

### DIFF
--- a/version.php
+++ b/version.php
@@ -16,9 +16,9 @@
 // upgrade file is the starting point for the next upgrade.
 
 $v_major = '8';
-$v_minor = '0';
-$v_patch = '1';
-$v_tag   = '-dev'; // minor revision number, should be empty for production releases
+$v_minor = '1';
+$v_patch = '0';
+$v_tag   = ''; // minor revision number, should be empty for production releases
 
 // A real patch identifier. This is incremented when we release a patch for a
 // production release. Note the above $v_patch variable is a misnomer and actually


### PR DESCRIPTION
## Summary
- Set version to 8.1.0 (production) on the new rel-810 release branch
- `$v_tag` cleared to empty string for production release

## Test plan
- [ ] Verify version displays as 8.1.0 in the UI