### PR TITLE
fix(security): harden escape_table_name() with backtick-quoting

### DIFF
--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -202,7 +202,7 @@ class C_Prescription extends Controller
                 $nameList = [];
                 while ($name = sqlFetchArray($medList)) {
                     $drug = explode(" ", (string) $name['drug']);
-                    $rXn = sqlQuery("SELECT `rxcui` FROM `" . mitigateSqlTableUpperCase('RXNCONSO') . "` WHERE `str` LIKE ?", ["%" . $drug[0] . "%"]);
+                    $rXn = sqlQuery("SELECT `rxcui` FROM " . mitigateSqlTableUpperCase('RXNCONSO') . " WHERE `str` LIKE ?", ["%" . $drug[0] . "%"]);
                     $nameList[] = $rXn['rxcui'];
                 }
                 if (count($nameList) < 2) {

--- a/interface/forms/group_attendance/functions.php
+++ b/interface/forms/group_attendance/functions.php
@@ -222,7 +222,7 @@ function largest_id_plus_one($table)
  */
 function largest_id($table)
 {
-    $res = sqlStatement("SELECT MAX(id) as largestId FROM `" . escape_table_name($table) . "`");
+    $res = sqlStatement("SELECT MAX(id) as largestId FROM " . escape_table_name($table));
     $getMaxid = sqlFetchArray($res);
     return $getMaxid['largestId'];
 }

--- a/interface/patient_file/merge_patients.php
+++ b/interface/patient_file/merge_patients.php
@@ -547,7 +547,7 @@ if (!AclMain::aclCheckCore('admin', 'super')) {
                     // Don't mess with log data.
                 } else {
                     $crow = sqlQuery(
-                        "SHOW COLUMNS FROM `" . escape_table_name($tblname) . "` WHERE " .
+                        "SHOW COLUMNS FROM " . escape_table_name($tblname) . " WHERE " .
                         "`Field` LIKE 'pid' OR `Field` LIKE 'patient_id'"
                     );
                     if (!empty($crow['Field'])) {

--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -301,7 +301,7 @@ function addOrDeleteColumn($layout_id, $field_id, $add = true): void
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
     if ($add && !$column_exists) {
-        $addQuery = "ALTER TABLE `" . escape_table_name($tablename) . "` ADD `" . escape_identifier($field_id, 'a-zA-Z0-9_', true) . "` TEXT";
+        $addQuery = "ALTER TABLE " . escape_table_name($tablename) . " ADD `" . escape_identifier($field_id, 'a-zA-Z0-9_', true) . "` TEXT";
         sqlStatement($addQuery);
         EventAuditLogger::getInstance()->newEvent(
             "alter_table",
@@ -314,7 +314,7 @@ function addOrDeleteColumn($layout_id, $field_id, $add = true): void
         // Do not drop a column that has any data.
         $tmp = sqlQuery(
             "SELECT " . escape_sql_column_name($field_id, [$tablename]) .
-            " AS field_id FROM `" . escape_table_name($tablename) . "` WHERE " .
+            " AS field_id FROM " . escape_table_name($tablename) . " WHERE " .
             escape_sql_column_name($field_id, [$tablename]) . " IS NOT NULL AND "
             . escape_sql_column_name($field_id, [$tablename]) . " != '' LIMIT 1"
         );
@@ -330,7 +330,7 @@ function addOrDeleteColumn($layout_id, $field_id, $add = true): void
                 );
             }
             if (empty($lotmp['count'])) {
-                $dropQuery = "ALTER TABLE `" . escape_table_name($tablename) . "` " .
+                $dropQuery = "ALTER TABLE " . escape_table_name($tablename) . " " .
                     "DROP " . escape_sql_column_name($field_id, [$tablename]);
                 sqlStatement($dropQuery);
                 EventAuditLogger::getInstance()->newEvent(
@@ -363,13 +363,13 @@ function renameColumn($layout_id, $old_field_id, $new_field_id)
         return 4;
     }
     // Make sure old column exists.
-    $colarr = sqlQuery("SHOW COLUMNS FROM `" . escape_table_name($tablename) . "` LIKE '" . add_escape_custom($old_field_id) . "'");
+    $colarr = sqlQuery("SHOW COLUMNS FROM " . escape_table_name($tablename) . " LIKE '" . add_escape_custom($old_field_id) . "'");
     if (empty($colarr)) {
         // Error, old name does not exist.
         return 2;
     }
     // Make sure new column does not exist.
-    $tmp = sqlQuery("SHOW COLUMNS FROM `" . escape_table_name($tablename) . "` LIKE '" . add_escape_custom($new_field_id) . "'");
+    $tmp = sqlQuery("SHOW COLUMNS FROM " . escape_table_name($tablename) . " LIKE '" . add_escape_custom($new_field_id) . "'");
     if (!empty($tmp)) {
         // Error, new name already in use.
         return 3;
@@ -385,7 +385,7 @@ function renameColumn($layout_id, $old_field_id, $new_field_id)
     if ($colarr['Extra']) {
         $colstr .= " " . add_escape_custom($colarr['Extra']);
     }
-    $query = "ALTER TABLE `" . escape_table_name($tablename) . "` CHANGE " . escape_sql_column_name($old_field_id, [$tablename]) . " `" . escape_identifier($new_field_id, 'a-zA-Z0-9_', true) . "` $colstr";
+    $query = "ALTER TABLE " . escape_table_name($tablename) . " CHANGE " . escape_sql_column_name($old_field_id, [$tablename]) . " `" . escape_identifier($new_field_id, 'a-zA-Z0-9_', true) . "` $colstr";
     sqlStatement($query);
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
     EventAuditLogger::getInstance()->newEvent(

--- a/library/api.inc.php
+++ b/library/api.inc.php
@@ -111,13 +111,13 @@ function formJump($address = ''): void
 function formFetch($tableName, $id, $cols = "*", $activity = "1")
 {
         // Run through escape_table_name() function to support dynamic form names in addition to mitigate sql table casing issues.
-    return sqlQuery("select " . escape_sql_column_name(process_cols_escape($cols), [$tableName]) . " from `" . escape_table_name($tableName) . "` where id=? and pid = ? and activity like ? order by date DESC LIMIT 0,1", [$id,OEGlobalsBag::getInstance()->get('pid'),$activity]) ;
+    return sqlQuery("select " . escape_sql_column_name(process_cols_escape($cols), [$tableName]) . " from " . escape_table_name($tableName) . " where id=? and pid = ? and activity like ? order by date DESC LIMIT 0,1", [$id,OEGlobalsBag::getInstance()->get('pid'),$activity]) ;
 }
 
 function formDisappear($tableName, $id)
 {
         // Run through escape_table_name() function to support dynamic form names in addition to mitigate sql table casing issues.
-    if (sqlStatement("update `" . escape_table_name($tableName) . "` set activity = '0' where id=? and pid=?", [$id, $pid])) {
+    if (sqlStatement("update " . escape_table_name($tableName) . " set activity = '0' where id=? and pid=?", [$id, $pid])) {
         return true;
     }
 
@@ -127,7 +127,7 @@ function formDisappear($tableName, $id)
 function formReappear($tableName, $id)
 {
         // Run through escape_table_name() function to support dynamic form names in addition to mitigate sql table casing issues.
-    if (sqlStatement("update `" . escape_table_name($tableName) . "` set activity = '1' where id=? and pid=?", [$id, $pid])) {
+    if (sqlStatement("update " . escape_table_name($tableName) . " set activity = '1' where id=? and pid=?", [$id, $pid])) {
         return true;
     }
 

--- a/library/clinical_rules.php
+++ b/library/clinical_rules.php
@@ -2719,7 +2719,7 @@ function exist_database_item($patient_id, $table, ?string $column = null, $data_
     if (empty($column)) {
         // simple search for any table entries
         $sql = sqlStatementCdrEngine("SELECT * " .
-            "FROM `" . escape_table_name($table)  . "` " .
+            "FROM " . escape_table_name($table)  . " " .
             " " . $whereTables . " " .
             "WHERE " . add_escape_custom($patient_id_label) . "=? " . $customSQL, [$patient_id]);
     } else {
@@ -2737,7 +2737,7 @@ function exist_database_item($patient_id, $table, ?string $column = null, $data_
             $sql = sqlStatementCdrEngine(
                 "SELECT b." . escape_sql_column_name($column, [$table]) . " " .
                 "FROM forms a " .
-                "LEFT JOIN `" . escape_table_name($table) . "` " . " b " .
+                "LEFT JOIN " . escape_table_name($table) . " " . " b " .
                 "ON (a.form_id=b.id AND a.formdir LIKE '" . add_escape_custom(substr($table, 5)) . "') " .
                 "WHERE a.deleted != '1' " .
                 "AND b." . escape_sql_column_name($column, [$table]) . "" . $compSql .
@@ -2754,7 +2754,7 @@ function exist_database_item($patient_id, $table, ?string $column = null, $data_
 
             // search for number of specific items
             $sql = sqlStatementCdrEngine("SELECT " . escape_sql_column_name($column, [$table]) . " " .
-                "FROM `" . escape_table_name($table) . "` " .
+                "FROM " . escape_table_name($table) . " " .
                 " " . $whereTables . " " .
                 "WHERE " . escape_sql_column_name($column, [$table]) . "" . $compSql .
                 "AND " . add_escape_custom($patient_id_label) . "=? " . $customSQL .
@@ -2901,7 +2901,7 @@ function exist_custom_item($patient_id, $category, $item, $complete, $num_items_
 
     // search for number of specific items
     $sql = sqlStatementCdrEngine("SELECT `result` " .
-        "FROM `" . escape_table_name($table)  . "` " .
+        "FROM " . escape_table_name($table)  . " " .
         "WHERE `category`=? " .
         "AND `item`=? " .
         "AND `complete`=? " .

--- a/src/Common/Database/QueryUtils.php
+++ b/src/Common/Database/QueryUtils.php
@@ -42,6 +42,11 @@ class QueryUtils
 
     public static function escapeTableName(string $table): string
     {
+        // Reject table names containing backticks to prevent identifier-context injection
+        if (str_contains($table, '`')) {
+            throw new SqlQueryException("", "ERROR: OpenEMR SQL Escaping ERROR of the following string: " . \errorLogEscape($table));
+        }
+
         $res = self::sqlStatementThrowException("SHOW TABLES", [], noLog: true);
         $tables_array = [];
         while ($row = self::fetchArrayFromResultSet($res)) {
@@ -49,8 +54,9 @@ class QueryUtils
             $tables_array[] = $row[$keys_return[0]];
         }
 
-        // Now can escape(via whitelisting) the sql table name
-        return \escape_identifier($table, $tables_array, true, false);
+        // Whitelist against actual tables, then backtick-quote to keep in identifier context
+        $tableName = \escape_identifier($table, $tables_array, true, false);
+        return sprintf('`%s`', $tableName);
     }
 
     /**


### PR DESCRIPTION
## Summary

Follow-up to #11280 which hardened `escape_sql_column_name()`. Same treatment for `escape_table_name()`:

- `QueryUtils::escapeTableName()` validates table names against `SHOW TABLES` (whitelist) but returns the raw name without quoting
- Some callers manually wrap in backticks, most don't
- A table name containing SQL-meaningful characters could theoretically be parsed as syntax if placed in unquoted context

## Changes

- Reject table names containing backticks (prevents breakout from backtick-quoted context)
- Backtick-quote the return value so it always produces a safe SQL identifier
- Remove redundant backtick-wrapping from 16 call sites across 6 files

## Test plan

- [ ] `composer phpstan` — passes (no baseline changes)
- [ ] `composer rector-check` — no changes suggested
- [ ] Verify patient finder search works
- [ ] Verify layout editor field operations (add/rename/drop via `edit_layout.php`)
- [ ] Verify clinical rules display and editing
- [ ] Verify patient merge functionality
- [ ] Verify prescription/RxNorm lookup

Closes #11281