### PR TITLE
fix(e2e): resolve flaky User add test under coverage

### DIFF
--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -552,10 +552,11 @@ if (isset($_GET["mode"])) {
         }
     }
 }
-// added for form submits from usergroup_admin_add and user_admin.php
-// sjp 12/29/17
+// AJAX form submits from usergroup_admin_add and user_admin.php
+// return the alert message (empty on success) and stop rendering the page
 if (isset($_REQUEST["mode"])) {
-    exit(text(trim($alertmsg)));
+    echo text(trim($alertmsg));
+    return;
 }
 
 $form_inactive = !empty($_POST['form_inactive']);

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -186,6 +186,8 @@ function submitform() {
         } else {
             dlgclose('reload', false);
         }
+    }).fail(function (xhr, status, error) {
+        alert(<?php echo xlj('Error creating user'); ?> + ': ' + status);
     });
 
     return false;

--- a/tests/Tests/E2e/User/UserAddTrait.php
+++ b/tests/Tests/E2e/User/UserAddTrait.php
@@ -109,12 +109,13 @@ trait UserAddTrait
         // The dialog calls dlgclose('reload', false) on success, which closes the modal
         // and triggers a reload of the admin iframe.
         //
-        // Use a short initial timeout to detect failure quickly. If the modal
-        // doesn't close, gather diagnostics and retry once with a fresh session.
-        if (!$this->waitForModalClose(10)) {
+        // Scale the timeout with the page load timeout — coverage mode makes
+        // the AJAX round-trip (bcrypt + DB writes + instrumented PHP) much slower.
+        $modalTimeout = max(10, (int) ((int) (getenv("SELENIUM_PAGE_LOAD_TIMEOUT") ?: 60) / 2));
+        if (!$this->waitForModalClose($modalTimeout)) {
             // Modal didn't close - gather diagnostics before retrying
             $diagnostics = $this->gatherModalDiagnostics($username);
-            fwrite(STDERR, "[E2E] Modal failed to close after user creation. Diagnostics: {$diagnostics}\n");
+            fwrite(STDERR, "[E2E] Modal failed to close after user creation (waited {$modalTimeout}s). Diagnostics: {$diagnostics}\n");
 
             // Check if user was actually created despite modal not closing
             if ($this->isUserExist($username)) {
@@ -122,6 +123,9 @@ trait UserAddTrait
                 // Force close by refreshing the page - modal state is broken but data is saved
                 $this->client->request('GET', '/interface/main/main_screen.php');
                 $this->waitForAppReady(10);
+                // Navigate back to Admin > Users since force refresh loads the default view
+                $this->goToMainMenuLink('Admin||Users');
+                $this->assertActiveTab("User / Groups");
             } elseif ($isRetry) {
                 // Already retried once - fail with diagnostics
                 throw new TimeoutException(


### PR DESCRIPTION
## Summary

- Scale the modal close timeout with `SELENIUM_PAGE_LOAD_TIMEOUT` (90s in coverage mode vs 30s normally) so the AJAX round-trip has adequate time to complete
- Fix the fallback recovery path to navigate back to Admin > Users after a force refresh — previously it expected the `adm` iframe to exist on the default view, causing a secondary timeout
- Replace `exit()` with `echo` + `return` in `usergroup_admin.php` for the AJAX response path
- Add a `.fail()` handler to the user creation AJAX call so network errors surface as alerts instead of being silently swallowed

Addresses the flaky failure seen in https://github.com/openemr/openemr/actions/runs/23586858951 where the modal close times out under coverage but the user is successfully created in the database.

## Test plan

- [ ] CI e2e tests pass (particularly "User add" in the coverage-enabled matrix entry)
- [ ] Manual: create a user via Admin > Users — modal should close on success
- [ ] Manual: verify AJAX error handling by simulating a network failure (e.g., offline mode in DevTools) — an error alert should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)