### PR TITLE
refactor(encryption): Message parser and format tooling

### DIFF
--- a/src/Encryption/Keys/Id.php
+++ b/src/Encryption/Keys/Id.php
@@ -4,7 +4,7 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Eric Stern <erics@opencoreemr.com>
- * @copyright Copyright (c) 2026 OpenCoreEMR
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/src/Encryption/Keys/Id.php
+++ b/src/Encryption/Keys/Id.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\Encryption\Keys;
+
+final readonly class Id
+{
+    public function __construct(public string $id)
+    {
+    }
+}

--- a/src/Encryption/Keys/Id.php
+++ b/src/Encryption/Keys/Id.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 declare(strict_types=1);
 
 namespace OpenEMR\Encryption\Keys;

--- a/src/Encryption/Message.php
+++ b/src/Encryption/Message.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 declare(strict_types=1);
 
 namespace OpenEMR\Encryption;

--- a/src/Encryption/Message.php
+++ b/src/Encryption/Message.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\Encryption;
+
+use UnexpectedValueException;
+
+final readonly class Message
+{
+    public function __construct(
+        public Keys\Id $keyId,
+        public Ciphertext $ciphertext,
+        public MessageFormat $format = MessageFormat::LATEST,
+    ) {
+    }
+
+    public static function parse(string $encodedMessage): Message
+    {
+        if (strlen($encodedMessage) < 3) {
+            throw new UnexpectedValueException('Message is missing expected prefix');
+        }
+        $format = MessageFormat::from(intval(substr($encodedMessage, 0, 3)));
+
+        // Backwards compatibility: versions 1-7 coupled the data storage with
+        // the key version.
+        $keyId = match ($format) {
+            MessageFormat::v1 => 'one',
+            MessageFormat::v2, // Intentional: v3 uses key id 'two' for historic reasons
+            MessageFormat::v3 => 'two',
+            MessageFormat::v4 => 'four',
+            MessageFormat::v5 => 'five',
+            MessageFormat::v6 => 'six',
+            MessageFormat::v7 => 'seven',
+            // v8 will look at the message for more keyId info
+        };
+
+        $ciphertext = base64_decode(substr($encodedMessage, 3), strict: true);
+        if ($ciphertext === false) {
+            throw new UnexpectedValueException('Could not parse ciphertext');
+        }
+
+        return new Message(
+            format: $format,
+            keyId: new Keys\Id($keyId),
+            ciphertext: new Ciphertext($ciphertext),
+        );
+    }
+
+    public function encode(): string
+    {
+        $prefix = sprintf('%03d', $this->format->value);
+
+        // if format encodes key id properly, add that in (new path?)
+
+        return sprintf('%s%s', $prefix, base64_encode($this->ciphertext->wrapped));
+    }
+}

--- a/src/Encryption/MessageFormat.php
+++ b/src/Encryption/MessageFormat.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 declare(strict_types=1);
 
 namespace OpenEMR\Encryption;

--- a/src/Encryption/MessageFormat.php
+++ b/src/Encryption/MessageFormat.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\Encryption;
+
+enum MessageFormat: int
+{
+    // Existing formats as of March 2026: these all mapped 1:1 with key ids and
+    // versions
+    case v1 = 1;
+    case v2 = 2;
+    case v3 = 3;
+    case v4 = 4;
+    case v5 = 5;
+    case v6 = 6;
+    case v7 = 7;
+    // Future: v8 will allow for actual key versioning without additional code
+    // changes. It will get different handling in Message.
+
+    const LATEST = self::v7;
+}

--- a/tests/Tests/Isolated/Encryption/Keys/IdTest.php
+++ b/tests/Tests/Isolated/Encryption/Keys/IdTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Encryption\Keys;

--- a/tests/Tests/Isolated/Encryption/Keys/IdTest.php
+++ b/tests/Tests/Isolated/Encryption/Keys/IdTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Encryption\Keys;
+
+use OpenEMR\Encryption\Keys\Id;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Id::class)]
+#[Small]
+class IdTest extends TestCase
+{
+    public function testWrapping(): void
+    {
+        $raw = 'some-key-123';
+        $id = new Id($raw);
+        self::assertSame($raw, $id->id);
+    }
+}

--- a/tests/Tests/Isolated/Encryption/Keys/IdTest.php
+++ b/tests/Tests/Isolated/Encryption/Keys/IdTest.php
@@ -7,7 +7,6 @@ namespace OpenEMR\Tests\Isolated\Encryption\Keys;
 use OpenEMR\Encryption\Keys\Id;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Id::class)]

--- a/tests/Tests/Isolated/Encryption/Keys/IdTest.php
+++ b/tests/Tests/Isolated/Encryption/Keys/IdTest.php
@@ -13,11 +13,9 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Isolated\Encryption\Keys;
 
 use OpenEMR\Encryption\Keys\Id;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(Id::class)]
 #[Small]
 class IdTest extends TestCase
 {

--- a/tests/Tests/Isolated/Encryption/MessageTest.php
+++ b/tests/Tests/Isolated/Encryption/MessageTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * Unit tests for Message class.
- *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Eric Stern <erics@opencoreemr.com>

--- a/tests/Tests/Isolated/Encryption/MessageTest.php
+++ b/tests/Tests/Isolated/Encryption/MessageTest.php
@@ -19,13 +19,11 @@ use OpenEMR\Encryption\{
     MessageFormat,
 };
 use OpenEMR\Tests\Fixtures\CryptoFixtureManager;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
 
-#[CoversClass(Message::class)]
 #[Small]
 class MessageTest extends TestCase
 {

--- a/tests/Tests/Isolated/Encryption/MessageTest.php
+++ b/tests/Tests/Isolated/Encryption/MessageTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Encryption;
+
+use OpenEMR\Encryption\{
+    Ciphertext,
+    Keys\Id,
+    Message,
+    MessageFormat,
+};
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Message::class)]
+#[Small]
+class MessageTest extends TestCase
+{
+    public function testParseRoundtrip(): void
+    {
+        $message = Message::parse($data);
+        $reencoded = $message->encode();
+        self::assertSame($data, $reencoded);
+    }
+
+    public function testConstructRoundtrip(): void
+    {
+        $keyId = new Id('test-key');
+        $ciphertext = new Ciphertext('some encrypted data');
+        $message = new Message($keyId, $ciphertext);
+        $encoded = $message->encode();
+        $parsed = Message::parse($encoded);
+        self::assertSame($keyId->id, $parsed->keyId->id, 'Key mismatch');
+
+    }
+
+    public function testParsingPreviousFormats(string $data): void
+    {
+
+    }
+}

--- a/tests/Tests/Isolated/Encryption/MessageTest.php
+++ b/tests/Tests/Isolated/Encryption/MessageTest.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Unit tests for Message class.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Encryption;
@@ -10,17 +20,53 @@ use OpenEMR\Encryption\{
     Message,
     MessageFormat,
 };
+use OpenEMR\Tests\Fixtures\CryptoFixtureManager;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
 #[CoversClass(Message::class)]
 #[Small]
 class MessageTest extends TestCase
 {
+    private CryptoFixtureManager $fixtures;
+
+    /**
+     * Expected key IDs for each message format version.
+     */
+    private const EXPECTED_KEY_IDS = [
+        1 => 'one',
+        2 => 'two',
+        3 => 'two', // v3 shares v2 keys
+        4 => 'four',
+        5 => 'five',
+        6 => 'six',
+        7 => 'seven',
+    ];
+
+    protected function setUp(): void
+    {
+        $this->fixtures = new CryptoFixtureManager('/dev/null');
+    }
+
+    /**
+     * @return iterable<string, array{version: int, expectedKeyId: string}>
+     */
+    public static function previousFormatsProvider(): iterable
+    {
+        foreach (self::EXPECTED_KEY_IDS as $version => $keyId) {
+            yield "version $version" => [
+                'version' => $version,
+                'expectedKeyId' => $keyId,
+            ];
+        }
+    }
+
     public function testParseRoundtrip(): void
     {
+        $data = $this->fixtures->getCiphertext(7);
         $message = Message::parse($data);
         $reencoded = $message->encode();
         self::assertSame($data, $reencoded);
@@ -28,17 +74,76 @@ class MessageTest extends TestCase
 
     public function testConstructRoundtrip(): void
     {
-        $keyId = new Id('test-key');
+        // IMPORTANT: once we support message format v8, this test should start
+        // failing and get updated so the keys align again.
+        $keyId = new Id('some-key-id');
         $ciphertext = new Ciphertext('some encrypted data');
         $message = new Message($keyId, $ciphertext);
         $encoded = $message->encode();
         $parsed = Message::parse($encoded);
-        self::assertSame($keyId->id, $parsed->keyId->id, 'Key mismatch');
-
+        self::assertSame('seven', $parsed->keyId->id, 'Key mismatch');
+        self::assertSame($ciphertext->wrapped, $parsed->ciphertext->wrapped, 'Ciphertext mismatch');
     }
 
-    public function testParsingPreviousFormats(string $data): void
+    #[DataProvider('previousFormatsProvider')]
+    public function testParsingPreviousFormats(int $version, string $expectedKeyId): void
     {
+        $data = $this->fixtures->getCiphertext($version);
+        $message = Message::parse($data);
 
+        self::assertSame($version, $message->format->value);
+        self::assertSame($expectedKeyId, $message->keyId->id);
+        self::assertSame($data, $message->encode(), 'Roundtrip encoding failed');
+    }
+
+    public function testConstructWithExplicitFormat(): void
+    {
+        $keyId = new Id('four');
+        $ciphertext = new Ciphertext('test data');
+        $message = new Message($keyId, $ciphertext, MessageFormat::v4);
+
+        self::assertSame(MessageFormat::v4, $message->format);
+        self::assertStringStartsWith('004', $message->encode());
+    }
+
+    public function testParseThrowsOnTooShortMessage(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Message is missing expected prefix');
+        Message::parse('00');
+    }
+
+    public function testParseThrowsOnEmptyMessage(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Message is missing expected prefix');
+        Message::parse('');
+    }
+
+    public function testParseThrowsOnInvalidBase64(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Could not parse ciphertext');
+        Message::parse('007!!!invalid-base64!!!');
+    }
+
+    public function testParseThrowsOnInvalidVersion(): void
+    {
+        $this->expectException(\ValueError::class);
+        // Version 999 doesn't exist in MessageFormat enum
+        Message::parse('999' . base64_encode('test'));
+    }
+
+    public function testEncodeProducesCorrectPrefix(): void
+    {
+        $keyId = new Id('test');
+        $ciphertext = new Ciphertext('data');
+
+        foreach (MessageFormat::cases() as $format) {
+            $message = new Message($keyId, $ciphertext, $format);
+            $encoded = $message->encode();
+            $expectedPrefix = sprintf('%03d', $format->value);
+            self::assertStringStartsWith($expectedPrefix, $encoded, "Format {$format->name} should produce prefix $expectedPrefix");
+        }
     }
 }


### PR DESCRIPTION
Extracted from #11267

#### Short description of what this changes or resolves:
Adds new infrastructure for the encryption overhaul that improves type safety for several string-like primitives. This paves the way to separate the message format from the key identifiers, which have historically been coupled. 

A future addition will define _format_ `8`, which will likely encode into something like `008:keyid-base64:ciphertext`. There may be a change to the parsing logic that will pass through unencrypted data, but both of these are out of scope for now.

#### Changes proposed in this pull request:
- Key ID DTO class
- Message Format enum
- Message DTO class with parser

#### Does your code include anything generated by an AI Engine? Yes / No
Tests got a light AI assist