### PR TITLE
refactor(encryption): Add keychain component

### DIFF
--- a/src/Encryption/Keys/Keychain.php
+++ b/src/Encryption/Keys/Keychain.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Encryption\Keys;
+
+use OpenEMR\Encryption\Cipher\CipherInterface;
+use OutOfBoundsException;
+
+use function array_key_exists;
+
+/**
+ * An eager-loaded keychain, which holds all of the keys/ciphers for active use.
+ */
+class Keychain implements KeychainInterface
+{
+    /**
+     * @var array<string, CipherInterface>
+     */
+    private array $mappings = [];
+
+    public function addCipher(
+        Id $id,
+        CipherInterface $cipher,
+    ): void {
+        $this->mappings[$id->id] = $cipher;
+    }
+
+    public function getCipher(Id $keyId): CipherInterface
+    {
+        if ($this->hasKey($keyId)) {
+            return $this->mappings[$keyId->id];
+        }
+        throw new OutOfBoundsException('Key id not registered');
+    }
+
+    public function hasKey(Id $keyId): bool
+    {
+        return array_key_exists($keyId->id, $this->mappings);
+    }
+}

--- a/src/Encryption/Keys/KeychainInterface.php
+++ b/src/Encryption/Keys/KeychainInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Encryption\Keys;
+
+use OpenEMR\Encryption\Cipher\CipherInterface;
+
+/**
+ * Implementations of KeychainInterface are responsible for key management and
+ * cipher selection. How keys are stored and loaded are implementation-specific:
+ * these could be lazy-loaded, fetched from a remote service, or handled in
+ * other ways.
+ */
+interface KeychainInterface
+{
+    public function getCipher(Id $keyId): CipherInterface;
+
+    public function hasKey(Id $keyId): bool;
+}

--- a/tests/Tests/Isolated/Encryption/Keys/KeychainTest.php
+++ b/tests/Tests/Isolated/Encryption/Keys/KeychainTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Encryption\Keys;
+
+use OpenEMR\Encryption\Cipher\CipherInterface;
+use OpenEMR\Encryption\Keys\{
+    Id,
+    Keychain,
+};
+use OutOfBoundsException;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+#[Small]
+class KeychainTest extends TestCase
+{
+    public function testHasKey(): void
+    {
+        $keychain = new Keychain();
+        $id = new Id('abc');
+        self::assertFalse($keychain->hasKey($id), 'Initial state should have no keys');
+
+        $cipher = self::createStub(CipherInterface::class);
+        $keychain->addCipher($id, $cipher);
+        self::assertTrue($keychain->hasKey($id), 'Key should exist after adding');
+    }
+
+    public function testGetCipher(): void
+    {
+        $keychain = new Keychain();
+
+        $id1 = new Id('one');
+        $cipher1 = self::createStub(CipherInterface::class);
+        $keychain->addCipher($id1, $cipher1);
+
+        $id2 = new Id('two');
+        $cipher2 = self::createStub(CipherInterface::class);
+        $keychain->addCipher($id2, $cipher2);
+
+
+        assert($cipher1 !== $cipher2);
+
+        $retr1 = $keychain->getCipher($id1);
+        self::assertSame($cipher1, $retr1);
+        $retr2 = $keychain->getCipher($id2);
+        self::assertSame($cipher2, $retr2);
+    }
+
+    public function testGetNonexistentCipher(): void
+    {
+        $keychain = new Keychain();
+        self::expectException(OutOfBoundsException::class);
+        $keychain->getCipher(new Id('not registered'));
+    }
+}


### PR DESCRIPTION
Extracted from #11267

#### Short description of what this changes or resolves:
This is a new system in the encryption refactor that handles key and cipher management. It separates the pairing of `(key id, cipher)` from the storage format, which will help ease key rotation without code changes.

There will very likely be some additions to this as the overhaul matures, specifically in reference to the "active" keys, but the fundamentals here should cover the initial integration.

Note: `addCipher()` is _intentionally_ excluded from the interface, as described in its docblock. Other implementations can have completely different backends where that method wouldn't be used.

#### Changes proposed in this pull request:
- Adds KeychainInterface, eager-loaded implementation, and tests

#### Does your code include anything generated by an AI Engine? Yes / No
No