### PR TITLE
refactor(logging): inject PSR Clock into EventAuditLogger

### DIFF
--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -23,6 +23,7 @@ use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Core\Traits\SingletonTrait;
+use Psr\Clock\ClockInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
@@ -87,6 +88,7 @@ class EventAuditLogger
             session: SessionWrapperFactory::getInstance()->getActiveSession(),
             config: $auditConfig,
             breakglassChecker: new BreakglassChecker($auditConn),
+            clock: ServiceContainer::getClock(),
         );
     }
 
@@ -100,6 +102,7 @@ class EventAuditLogger
         private readonly SessionInterface $session,
         private readonly AuditConfig $config,
         private readonly BreakglassCheckerInterface $breakglassChecker,
+        private readonly ClockInterface $clock,
     ) {
     }
 
@@ -242,14 +245,15 @@ class EventAuditLogger
             $cols = $params['cols'];
         }
 
-        $date1 = date("Y-m-d H:i:s", time());
-        if (isset($params['sdate']) && $params['sdate'] != "") {
-            $date1 = $params['sdate'];
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+        $date1 = $params['sdate'] ?? $now;
+        if ($date1 === '') {
+            $date1 = $now;
         }
 
-        $date2 = date("Y-m-d H:i:s", time());
-        if (isset($params['edate']) && $params['edate'] != "") {
-            $date2 = $params['edate'];
+        $date2 = $params['edate'] ?? $now;
+        if ($date2 === '') {
+            $date2 = $now;
         }
 
         $user = "";
@@ -652,7 +656,7 @@ class EventAuditLogger
         }
 
         // Collect timestamp and if pertinent, collect client cert name
-        $current_datetime = date("Y-m-d H:i:s");
+        $current_datetime = $this->clock->now()->format('Y-m-d H:i:s');
         $SSL_CLIENT_S_DN_CN = $_SERVER['SSL_CLIENT_S_DN_CN'] ?? '';
 
         // Note that no longer using checksum field in log table in OpenEMR 6.0 and onward since using the checksum in log_comment_encrypt table.

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Common\Logging;
 
+use Lcobucci\Clock\FrozenClock;
 use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Logging\Audit\Event;
 use OpenEMR\Common\Logging\Audit\SinkInterface;
@@ -22,6 +23,7 @@ use OpenEMR\Common\Logging\BreakglassCheckerInterface;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class EventAuditLoggerTest extends TestCase
@@ -30,6 +32,7 @@ class EventAuditLoggerTest extends TestCase
     private SessionInterface&MockObject $session;
     private AuditConfig $config;
     private BreakglassCheckerInterface&MockObject $breakglassChecker;
+    private ClockInterface $clock;
 
     protected function setUp(): void
     {
@@ -43,6 +46,7 @@ class EventAuditLoggerTest extends TestCase
             eventTypeFlags: [],
         );
         $this->breakglassChecker = $this->createMock(BreakglassCheckerInterface::class);
+        $this->clock = new FrozenClock(new \DateTimeImmutable('2026-01-15 10:30:00'));
     }
 
     public function testRecordLogItemDispatchesToAllSinks(): void
@@ -66,6 +70,7 @@ class EventAuditLoggerTest extends TestCase
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
         );
 
         $logger->recordLogItem(
@@ -100,6 +105,7 @@ class EventAuditLoggerTest extends TestCase
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
         );
 
         $logger->recordLogItem(
@@ -136,6 +142,7 @@ class EventAuditLoggerTest extends TestCase
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
         );
 
         $logger->recordLogItem(
@@ -165,6 +172,7 @@ class EventAuditLoggerTest extends TestCase
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
         );
 
         $logger->recordLogItem(
@@ -185,6 +193,7 @@ class EventAuditLoggerTest extends TestCase
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
         );
 
         $logger->recordLogItem(
@@ -218,6 +227,7 @@ class EventAuditLoggerTest extends TestCase
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
         );
 
         $logger->recordLogItem(
@@ -254,6 +264,7 @@ class EventAuditLoggerTest extends TestCase
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
         );
 
         $logger->recordLogItem(
@@ -292,6 +303,7 @@ class EventAuditLoggerTest extends TestCase
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
         );
 
         // Legacy code sometimes passes "NULL" as a string

--- a/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Unit\Common\Logging;
 
+use Lcobucci\Clock\FrozenClock;
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Logging\AuditConfig;
@@ -22,6 +23,7 @@ use OpenEMR\Common\Logging\BreakglassCheckerInterface;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
 use ReflectionClass;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -58,6 +60,8 @@ final class EventAuditLoggerTest extends TestCase
     private AuditConfig $config;
 
     private BreakglassCheckerInterface&MockObject $breakglassChecker;
+
+    private ClockInterface $clock;
 
     /**
      * @var array<string, mixed> Original $_SESSION backup
@@ -106,6 +110,7 @@ final class EventAuditLoggerTest extends TestCase
             eventTypeFlags: [],
         );
         $this->breakglassChecker = $this->createMock(BreakglassCheckerInterface::class);
+        $this->clock = new FrozenClock(new \DateTimeImmutable('2026-01-15 10:30:00'));
 
         // Backup original superglobals
         /**
@@ -135,6 +140,7 @@ final class EventAuditLoggerTest extends TestCase
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
         );
 
         // Setup default test environment
@@ -515,6 +521,7 @@ final class EventAuditLoggerTest extends TestCase
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
         );
 
         // Call recordLogItem - will return early due to disabled audit logging
@@ -556,7 +563,15 @@ final class EventAuditLoggerTest extends TestCase
                 fn(string $value): string => 'encrypted_' . $value
             );
 
-        $eventAuditLogger = new EventAuditLogger(sinks: [], cryptoGen: $cryptoMock, shouldEncrypt: true, session: $this->session, config: $this->config, breakglassChecker: $this->breakglassChecker);
+        $eventAuditLogger = new EventAuditLogger(
+            sinks: [],
+            cryptoGen: $cryptoMock,
+            shouldEncrypt: true,
+            session: $this->session,
+            config: $this->config,
+            breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
+        );
 
         try {
             // This should execute the full recordLogItem flow including encryption
@@ -654,7 +669,15 @@ final class EventAuditLoggerTest extends TestCase
                 fn(string $value): string => 'encrypted_' . $value
             );
 
-        $eventAuditLogger = new EventAuditLogger(sinks: [], cryptoGen: $cryptoMock, shouldEncrypt: true, session: $this->session, config: $this->config, breakglassChecker: $this->breakglassChecker);
+        $eventAuditLogger = new EventAuditLogger(
+            sinks: [],
+            cryptoGen: $cryptoMock,
+            shouldEncrypt: true,
+            session: $this->session,
+            config: $this->config,
+            breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
+        );
 
         // Call recordLogItem with API data - this should execute the encryption code:
         // Line 767: $api['request_url'] = (!empty($api['request_url'])) ? $this->cryptoGen->encryptStandard($api['request_url']) : '';

--- a/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
@@ -259,7 +259,7 @@ final class EventAuditLoggerTest extends TestCase
             ->willReturnCallback(fn(string $key) => $sessionValues[$key] ?? null);
 
         // Return positional array matching constructor parameter order:
-        // sinks, cryptoGen, shouldEncrypt, session, config, breakglassChecker
+        // sinks, cryptoGen, shouldEncrypt, session, config, breakglassChecker, clock
         return [
             [],                                         // sinks
             $this->createMock(CryptoGen::class),        // cryptoGen
@@ -267,6 +267,7 @@ final class EventAuditLoggerTest extends TestCase
             $sessionMock,                               // session
             $config ?? $this->config,                   // config
             $this->breakglassChecker,                   // breakglassChecker
+            $this->clock,
         ];
     }
 


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Removes global state dependency on `date()` calls in EventAuditLogger by injecting a PSR-20 ClockInterface.

#### Changes proposed in this pull request:

- Add `ClockInterface` as a constructor dependency
- Replace `date("Y-m-d H:i:s")` calls with `$this->clock->now()->format('Y-m-d H:i:s')`
- Update `createInstance()` to inject clock from `ServiceContainer::getClock()`
- Update isolated and unit tests to provide a `FrozenClock` for deterministic testing

#### Was an AI assistant used? Yes

Claude Code - trailer added to commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)