### PR TITLE
fix(background-services): fix OPENEMR__NO_BACKGROUND_TASKS env var reliability and scope

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Possible options are prod or dev. No spaces, no quotes.
 OPENEMR__ENVIRONMENT=
-# Possible options are true to prevent dated reminders and background apps.Else empty or false. No spaces, no quotes.
+# Set to true to disable periodic background service execution (Ajax piggybacking).
+# Session timeouts and notification badges remain active. Accepts true/1 or false/0.
 OPENEMR__NO_BACKGROUND_TASKS=

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -1842,11 +1842,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/tabs/main.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_SERVER is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/tabs/main.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/public/EraDownload.php',

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -28,6 +28,7 @@ use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
+use OpenEMR\Core\OEEnvBag;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Main\Tabs\RenderEvent;
 use OpenEMR\Menu\MainMenuRole;
@@ -50,12 +51,9 @@ $allowTelemetry = $product_row['allowTelemetry'] ?? null; // for dialog
 $allowEmail = $product_row['allowEmail'] ?? null; // for dialog
 
 // Check if telemetry is disabled via environment variable
-// Telemetry disable flag (set env var to: 1/true)
-$val = getenv(ENV_DISABLE_TELEMETRY);
-if ($val === false || $val === '') {
-    $val = $_ENV[ENV_DISABLE_TELEMETRY] ?? $_SERVER[ENV_DISABLE_TELEMETRY] ?? null;
-}
-$disableTelemetry = ($val !== null) && filter_var($val, FILTER_VALIDATE_BOOLEAN);
+$disableTelemetry = OEEnvBag::getInstance()->getBoolean(ENV_DISABLE_TELEMETRY);
+// Check if background service piggybacking is disabled via environment variable
+$noBackgroundTasks = OEEnvBag::getInstance()->getBoolean('OPENEMR__NO_BACKGROUND_TASKS');
 if ($disableTelemetry) {
     $allowRegisterDialog = false;
     $allowTelemetry = false;
@@ -145,6 +143,7 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
         const isFax = "<?php echo !empty(OEGlobalsBag::getInstance()->get('oefax_enable_fax')) ?? null?>";
         const isServicesOther = (isSms || isFax);
         var telemetryEnabled = <?php echo js_escape((new TelemetryService())->isTelemetryEnabled()); ?>;
+        var noBackgroundTasks = <?php echo $noBackgroundTasks ? 'true' : 'false'; ?>;
 
         /**
          * Async function to get session value from the server
@@ -250,24 +249,26 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
             // run background-services
             // delay 10 seconds to prevent both utility trigger at close to same time.
             // Both call globals so that is my concern.
-            setTimeout(function () {
-                restoreSession();
-                request = new FormData;
-                request.append("skip_timeout_reset", "1");
-                request.append("ajax", "1");
-                request.append("csrf_token_form", csrf_token_js);
-                fetch(webroot_url + "/library/ajax/execute_background_services.php", {
-                    method: 'POST',
-                    credentials: 'same-origin',
-                    body: request
-                }).then((response) => {
-                    if (response.status !== 200) {
-                        console.log('Background Service start failed. Status Code: ' + response.status);
-                    }
-                }).catch(function (error) {
-                    console.log('HTML Background Service start Request failed: ', error);
-                });
-            }, 10000);
+            if (!noBackgroundTasks) {
+                setTimeout(function () {
+                    restoreSession();
+                    request = new FormData;
+                    request.append("skip_timeout_reset", "1");
+                    request.append("ajax", "1");
+                    request.append("csrf_token_form", csrf_token_js);
+                    fetch(webroot_url + "/library/ajax/execute_background_services.php", {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        body: request
+                    }).then((response) => {
+                        if (response.status !== 200) {
+                            console.log('Background Service start failed. Status Code: ' + response.status);
+                        }
+                    }).catch(function (error) {
+                        console.log('HTML Background Service start Request failed: ', error);
+                    });
+                }, 10000);
+            }
 
             // auto run this function every 60 seconds
             var repeater = setTimeout("goRepeaterServices()", 60000);
@@ -535,11 +536,9 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
             }
         });
         document.addEventListener('touchstart', {}); //specifically added for iOS devices, especially in iframes
-        <?php if (($_ENV['OPENEMR__NO_BACKGROUND_TASKS'] ?? 'false') !== 'true') { ?>
         $(function () {
             goRepeaterServices();
         });
-        <?php } ?>
     </script>
     <?php
 

--- a/src/Core/OEEnvBag.php
+++ b/src/Core/OEEnvBag.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://www.opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Core;
+
+use OpenEMR\Core\Traits\SingletonTrait;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+/**
+ * Typed access to environment variables. Extends Symfony ParameterBag.
+ *
+ * Merges values from $_SERVER, $_ENV, and getenv() (later sources win),
+ * matching the priority used by Symfony DotEnv.
+ *
+ * Inherits typed getters from ParameterBag:
+ *
+ * @see ParameterBag::getString()   getString(string $key, string $default = ''): string
+ * @see ParameterBag::getInt()      getInt(string $key, int $default = 0): int
+ * @see ParameterBag::getBoolean()  getBoolean(string $key, bool $default = false): bool
+ * @see ParameterBag::getAlpha()    getAlpha(string $key, string $default = ''): string
+ * @see ParameterBag::getAlnum()    getAlnum(string $key, string $default = ''): string
+ * @see ParameterBag::getDigits()   getDigits(string $key, string $default = ''): string
+ * @see ParameterBag::getEnum()     getEnum(string $key, string $class, ?BackedEnum $default = null): ?BackedEnum
+ */
+class OEEnvBag extends ParameterBag
+{
+    use SingletonTrait;
+
+    protected static function createInstance(): static
+    {
+        return new static(array_merge($_SERVER, $_ENV, getenv())); // @phpstan-ignore new.static
+    }
+}

--- a/tests/PHPStan/Rules/ForbiddenRequestGlobalsRule.php
+++ b/tests/PHPStan/Rules/ForbiddenRequestGlobalsRule.php
@@ -48,6 +48,7 @@ class ForbiddenRequestGlobalsRule implements Rule
      */
     private const ABSTRACTION_CLASSES = [
         \OpenEMR\Common\Http\HttpRestRequest::class,
+        \OpenEMR\Core\OEEnvBag::class,
     ];
 
     public function getNodeType(): string

--- a/tests/Tests/Isolated/Core/OEEnvBagIsolatedTest.php
+++ b/tests/Tests/Isolated/Core/OEEnvBagIsolatedTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://www.opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Core;
+
+use OpenEMR\Core\OEEnvBag;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+#[Group('core')]
+class OEEnvBagIsolatedTest extends TestCase
+{
+    public function testConstructFromExplicitParameters(): void
+    {
+        $bag = new OEEnvBag(['FOO' => 'bar']);
+
+        $this->assertTrue($bag->has('FOO'));
+        $this->assertSame('bar', $bag->getString('FOO'));
+    }
+
+    public function testGetBooleanWithTruthyValues(): void
+    {
+        $bag = new OEEnvBag([
+            'A' => 'true',
+            'B' => '1',
+            'C' => 'yes',
+            'D' => 'on',
+        ]);
+
+        $this->assertTrue($bag->getBoolean('A'));
+        $this->assertTrue($bag->getBoolean('B'));
+        // ParameterBag::getBoolean uses filter_var FILTER_VALIDATE_BOOLEAN
+        $this->assertTrue($bag->getBoolean('C'));
+        $this->assertTrue($bag->getBoolean('D'));
+    }
+
+    public function testGetBooleanWithFalsyValues(): void
+    {
+        $bag = new OEEnvBag([
+            'A' => 'false',
+            'B' => '0',
+            'C' => '',
+            'D' => 'no',
+        ]);
+
+        $this->assertFalse($bag->getBoolean('A'));
+        $this->assertFalse($bag->getBoolean('B'));
+        $this->assertFalse($bag->getBoolean('C'));
+        $this->assertFalse($bag->getBoolean('D'));
+    }
+
+    public function testGetBooleanDefaultForMissingKey(): void
+    {
+        $bag = new OEEnvBag([]);
+
+        $this->assertFalse($bag->getBoolean('MISSING'));
+        $this->assertTrue($bag->getBoolean('MISSING', true));
+    }
+
+    public function testMergePriority(): void
+    {
+        // Later sources in array_merge win. Verify by constructing directly
+        // with a known merge order.
+        $server = ['SHARED' => 'from_server', 'SERVER_ONLY' => 'server'];
+        $env = ['SHARED' => 'from_env', 'ENV_ONLY' => 'env'];
+        $getenv = ['SHARED' => 'from_getenv', 'GETENV_ONLY' => 'getenv'];
+
+        $bag = new OEEnvBag(array_merge($server, $env, $getenv));
+
+        $this->assertSame('from_getenv', $bag->getString('SHARED'));
+        $this->assertSame('server', $bag->getString('SERVER_ONLY'));
+        $this->assertSame('env', $bag->getString('ENV_ONLY'));
+        $this->assertSame('getenv', $bag->getString('GETENV_ONLY'));
+    }
+
+    public function testGetIntAndGetString(): void
+    {
+        $bag = new OEEnvBag(['PORT' => '8080', 'NAME' => 'openemr']);
+
+        $this->assertSame(8080, $bag->getInt('PORT'));
+        $this->assertSame('openemr', $bag->getString('NAME'));
+    }
+
+    public function testCreateInstanceMergesEnvSources(): void
+    {
+        $key = 'OEENVBAG_TEST_' . bin2hex(random_bytes(4));
+        try {
+            putenv("{$key}=from_getenv");
+            $_ENV[$key] = 'from_env';
+            $_SERVER[$key] = 'from_server';
+
+            $bag = OEEnvBag::getInstance();
+
+            // getenv() values win over $_ENV and $_SERVER
+            $this->assertSame('from_getenv', $bag->getString($key));
+        } finally {
+            putenv($key); // unset
+            unset($_ENV[$key], $_SERVER[$key]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #11326 (part 1 of #11325)

- Introduces `OEEnvBag` — a singleton `ParameterBag` for typed environment variable access (mirrors `OEGlobalsBag` for `$GLOBALS`). Merges `$_SERVER`, `$_ENV`, and `getenv()` with later sources winning.
- Fixes unreliable env var reading: the check only used `$_ENV`, which is empty when PHP's `variables_order` omits `E`.
- Fixes overly broad scope: the env var gated the entire `goRepeaterServices()` function, disabling session timeouts, notification badges, and dated reminders along with background tasks. Now it gates only the `execute_background_services.php` fetch block.
- Refactors the telemetry env var check to also use `OEEnvBag`
- Adds `OEEnvBag` to the `ForbiddenRequestGlobalsRule` abstraction allowlist
- Removes the now-unneeded `$_SERVER` baseline entry for `main.php`

## Test plan

- [x] `composer phpunit-isolated` — 7 `OEEnvBagIsolatedTest` tests pass (including singleton merge priority)
- [x] `composer phpstan` — no errors
- [ ] Set `OPENEMR__NO_BACKGROUND_TASKS=true` via Docker environment, verify background services fetch is suppressed in browser network tab while session timeout and notification badges still work

Closes #11326

🤖 Generated with [Claude Code](https://claude.com/claude-code)