### PR TITLE
fix(users): allow clearing user profile fields

### DIFF
--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -1828,7 +1828,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 13,
+    'count' => 15,
     'path' => __DIR__ . '/../../interface/usergroup/usergroup_admin.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -4468,7 +4468,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 47,
+    'count' => 36,
     'path' => __DIR__ . '/../../interface/usergroup/usergroup_admin.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -3733,7 +3733,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 168,
+    'count' => 136,
     'path' => __DIR__ . '/../../interface/usergroup/usergroup_admin.php',
 ];
 $ignoreErrors[] = [

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -108,47 +108,47 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
             sqlStatement("update `groups` set user=? where user= ?", [trim((string) $_POST["username"]), $user_data["username"]]);
         }
 
-        if ($_POST["taxid"]) {
+        if (isset($_POST["taxid"])) {
             sqlStatement("update users set federaltaxid=? where id= ? ", [$_POST["taxid"], $_POST["id"]]);
         }
 
-        if ($_POST["state_license_number"]) {
+        if (isset($_POST["state_license_number"])) {
             sqlStatement("update users set state_license_number=? where id= ? ", [$_POST["state_license_number"], $_POST["id"]]);
         }
 
-        if ($_POST["drugid"]) {
+        if (isset($_POST["drugid"])) {
             sqlStatement("update users set federaldrugid=? where id= ? ", [$_POST["drugid"], $_POST["id"]]);
         }
 
-        if ($_POST["upin"]) {
+        if (isset($_POST["upin"])) {
             sqlStatement("update users set upin=? where id= ? ", [$_POST["upin"], $_POST["id"]]);
         }
 
-        if ($_POST["npi"]) {
+        if (isset($_POST["npi"])) {
             sqlStatement("update users set npi=? where id= ? ", [$_POST["npi"], $_POST["id"]]);
         }
 
-        if ($_POST["taxonomy"]) {
+        if (isset($_POST["taxonomy"])) {
             sqlStatement("update users set taxonomy = ? where id= ? ", [$_POST["taxonomy"], $_POST["id"]]);
         }
 
-        if ($_POST["lname"]) {
+        if (isset($_POST["lname"])) {
             sqlStatement("update users set lname=? where id= ? ", [$_POST["lname"], $_POST["id"]]);
         }
 
-        if ($_POST["suffix"]) {
+        if (isset($_POST["suffix"])) {
             sqlStatement("update users set suffix=? where id= ? ", [$_POST["suffix"], $_POST["id"]]);
         }
 
-        if ($_POST["valedictory"]) {
+        if (isset($_POST["valedictory"])) {
             sqlStatement("update users set valedictory=? where id= ? ", [$_POST["valedictory"], $_POST["id"]]);
         }
 
-        if ($_POST["job"]) {
+        if (isset($_POST["job"])) {
             sqlStatement("update users set specialty=? where id= ? ", [$_POST["job"], $_POST["id"]]);
         }
 
-        if ($_POST["mname"]) {
+        if (isset($_POST["mname"])) {
             sqlStatement("update users set mname=? where id= ? ", [$_POST["mname"], $_POST["id"]]);
         }
 
@@ -223,7 +223,7 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
             }
         }
 
-        if ($_POST["fname"]) {
+        if (isset($_POST["fname"])) {
             sqlStatement("update users set fname=? where id= ? ", [$_POST["fname"], $_POST["id"]]);
         }
 

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -129,12 +129,30 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
 
         $changedFields = [];
         foreach ($stringFields as $postKey => $dbColumn) {
-            if (isset($_POST[$postKey]) && (string) $_POST[$postKey] !== (string) ($user_data[$dbColumn] ?? '')) {
-                $changedFields[$dbColumn] = $_POST[$postKey];
+            if (isset($_POST[$postKey])) {
+                $submittedValue = (string) $_POST[$postKey];
+                $currentValue = is_array($user_data) && array_key_exists($dbColumn, $user_data)
+                    ? $user_data[$dbColumn]
+                    : null;
+                $currentStringValue = $currentValue === null ? null : (string) $currentValue;
+
+                if ($currentStringValue !== $submittedValue) {
+                    $changedFields[$dbColumn] = $_POST[$postKey];
+                }
             }
         }
 
         if ($changedFields !== []) {
+            $preserveUserValue = static function (string $dbColumn) use ($changedFields, $user_data) {
+                if (array_key_exists($dbColumn, $changedFields)) {
+                    return $changedFields[$dbColumn];
+                }
+
+                return is_array($user_data) && array_key_exists($dbColumn, $user_data)
+                    ? $user_data[$dbColumn]
+                    : null;
+            };
+
             sqlStatement(
                 "UPDATE users SET"
                 . " federaltaxid = ?, state_license_number = ?,"
@@ -143,18 +161,18 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
                 . " specialty = ?, mname = ?"
                 . " WHERE id = ?",
                 [
-                    $changedFields['federaltaxid'] ?? $user_data['federaltaxid'] ?? '',
-                    $changedFields['state_license_number'] ?? $user_data['state_license_number'] ?? '',
-                    $changedFields['federaldrugid'] ?? $user_data['federaldrugid'] ?? '',
-                    $changedFields['upin'] ?? $user_data['upin'] ?? '',
-                    $changedFields['npi'] ?? $user_data['npi'] ?? '',
-                    $changedFields['taxonomy'] ?? $user_data['taxonomy'] ?? '',
-                    $changedFields['lname'] ?? $user_data['lname'] ?? '',
-                    $changedFields['fname'] ?? $user_data['fname'] ?? '',
-                    $changedFields['suffix'] ?? $user_data['suffix'] ?? '',
-                    $changedFields['valedictory'] ?? $user_data['valedictory'] ?? '',
-                    $changedFields['specialty'] ?? $user_data['specialty'] ?? '',
-                    $changedFields['mname'] ?? $user_data['mname'] ?? '',
+                    $preserveUserValue('federaltaxid'),
+                    $preserveUserValue('state_license_number'),
+                    $preserveUserValue('federaldrugid'),
+                    $preserveUserValue('upin'),
+                    $preserveUserValue('npi'),
+                    $preserveUserValue('taxonomy'),
+                    $preserveUserValue('lname'),
+                    $preserveUserValue('fname'),
+                    $preserveUserValue('suffix'),
+                    $preserveUserValue('valedictory'),
+                    $preserveUserValue('specialty'),
+                    $preserveUserValue('mname'),
                     $_POST["id"],
                 ]
             );

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -108,9 +108,10 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
             sqlStatement("update `groups` set user=? where user= ?", [trim((string) $_POST["username"]), $user_data["username"]]);
         }
 
-        // Map POST keys to DB columns for simple string fields.
-        // Built as a single UPDATE and only includes fields whose value
-        // actually changed, so we avoid unnecessary writes and audit noise.
+        // Map POST keys → DB columns for simple string fields.
+        // Collect new values for fields that actually changed, then issue
+        // a single fixed-shape UPDATE.  Fields that did not change are
+        // excluded so we avoid unnecessary writes and audit-log noise.
         $stringFields = [
             'taxid' => 'federaltaxid',
             'state_license_number' => 'state_license_number',
@@ -126,20 +127,36 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
             'mname' => 'mname',
         ];
 
-        $setClauses = [];
-        $sqlBindArray = [];
+        $changedFields = [];
         foreach ($stringFields as $postKey => $dbColumn) {
             if (isset($_POST[$postKey]) && (string) $_POST[$postKey] !== (string) ($user_data[$dbColumn] ?? '')) {
-                $setClauses[] = "`$dbColumn` = ?";
-                $sqlBindArray[] = $_POST[$postKey];
+                $changedFields[$dbColumn] = $_POST[$postKey];
             }
         }
 
-        if ($setClauses !== []) {
-            $sqlBindArray[] = $_POST["id"];
+        if ($changedFields !== []) {
             sqlStatement(
-                "UPDATE users SET " . implode(", ", $setClauses) . " WHERE id = ?",
-                $sqlBindArray
+                "UPDATE users SET"
+                . " federaltaxid = ?, state_license_number = ?,"
+                . " federaldrugid = ?, upin = ?, npi = ?, taxonomy = ?,"
+                . " lname = ?, fname = ?, suffix = ?, valedictory = ?,"
+                . " specialty = ?, mname = ?"
+                . " WHERE id = ?",
+                [
+                    $changedFields['federaltaxid'] ?? $user_data['federaltaxid'] ?? '',
+                    $changedFields['state_license_number'] ?? $user_data['state_license_number'] ?? '',
+                    $changedFields['federaldrugid'] ?? $user_data['federaldrugid'] ?? '',
+                    $changedFields['upin'] ?? $user_data['upin'] ?? '',
+                    $changedFields['npi'] ?? $user_data['npi'] ?? '',
+                    $changedFields['taxonomy'] ?? $user_data['taxonomy'] ?? '',
+                    $changedFields['lname'] ?? $user_data['lname'] ?? '',
+                    $changedFields['fname'] ?? $user_data['fname'] ?? '',
+                    $changedFields['suffix'] ?? $user_data['suffix'] ?? '',
+                    $changedFields['valedictory'] ?? $user_data['valedictory'] ?? '',
+                    $changedFields['specialty'] ?? $user_data['specialty'] ?? '',
+                    $changedFields['mname'] ?? $user_data['mname'] ?? '',
+                    $_POST["id"],
+                ]
             );
         }
 

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -108,48 +108,39 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
             sqlStatement("update `groups` set user=? where user= ?", [trim((string) $_POST["username"]), $user_data["username"]]);
         }
 
-        if (isset($_POST["taxid"])) {
-            sqlStatement("update users set federaltaxid=? where id= ? ", [$_POST["taxid"], $_POST["id"]]);
+        // Map POST keys to DB columns for simple string fields.
+        // Built as a single UPDATE and only includes fields whose value
+        // actually changed, so we avoid unnecessary writes and audit noise.
+        $stringFields = [
+            'taxid' => 'federaltaxid',
+            'state_license_number' => 'state_license_number',
+            'drugid' => 'federaldrugid',
+            'upin' => 'upin',
+            'npi' => 'npi',
+            'taxonomy' => 'taxonomy',
+            'lname' => 'lname',
+            'fname' => 'fname',
+            'suffix' => 'suffix',
+            'valedictory' => 'valedictory',
+            'job' => 'specialty',
+            'mname' => 'mname',
+        ];
+
+        $setClauses = [];
+        $sqlBindArray = [];
+        foreach ($stringFields as $postKey => $dbColumn) {
+            if (isset($_POST[$postKey]) && (string) $_POST[$postKey] !== (string) ($user_data[$dbColumn] ?? '')) {
+                $setClauses[] = "`$dbColumn` = ?";
+                $sqlBindArray[] = $_POST[$postKey];
+            }
         }
 
-        if (isset($_POST["state_license_number"])) {
-            sqlStatement("update users set state_license_number=? where id= ? ", [$_POST["state_license_number"], $_POST["id"]]);
-        }
-
-        if (isset($_POST["drugid"])) {
-            sqlStatement("update users set federaldrugid=? where id= ? ", [$_POST["drugid"], $_POST["id"]]);
-        }
-
-        if (isset($_POST["upin"])) {
-            sqlStatement("update users set upin=? where id= ? ", [$_POST["upin"], $_POST["id"]]);
-        }
-
-        if (isset($_POST["npi"])) {
-            sqlStatement("update users set npi=? where id= ? ", [$_POST["npi"], $_POST["id"]]);
-        }
-
-        if (isset($_POST["taxonomy"])) {
-            sqlStatement("update users set taxonomy = ? where id= ? ", [$_POST["taxonomy"], $_POST["id"]]);
-        }
-
-        if (isset($_POST["lname"])) {
-            sqlStatement("update users set lname=? where id= ? ", [$_POST["lname"], $_POST["id"]]);
-        }
-
-        if (isset($_POST["suffix"])) {
-            sqlStatement("update users set suffix=? where id= ? ", [$_POST["suffix"], $_POST["id"]]);
-        }
-
-        if (isset($_POST["valedictory"])) {
-            sqlStatement("update users set valedictory=? where id= ? ", [$_POST["valedictory"], $_POST["id"]]);
-        }
-
-        if (isset($_POST["job"])) {
-            sqlStatement("update users set specialty=? where id= ? ", [$_POST["job"], $_POST["id"]]);
-        }
-
-        if (isset($_POST["mname"])) {
-            sqlStatement("update users set mname=? where id= ? ", [$_POST["mname"], $_POST["id"]]);
+        if ($setClauses !== []) {
+            $sqlBindArray[] = $_POST["id"];
+            sqlStatement(
+                "UPDATE users SET " . implode(", ", $setClauses) . " WHERE id = ?",
+                $sqlBindArray
+            );
         }
 
         if ($_POST["facility_id"]) {
@@ -221,10 +212,6 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
                     );
                 }
             }
-        }
-
-        if (isset($_POST["fname"])) {
-            sqlStatement("update users set fname=? where id= ? ", [$_POST["fname"], $_POST["id"]]);
         }
 
         if (isset($_POST['default_warehouse'])) {


### PR DESCRIPTION
Fixes #11317

This fixes the update path for user profile fields in `usergroup_admin.php`. Before this change, clearing fields like Valedictory or Federal Tax ID could silently keep the old value because the update logic treated empty strings as false and skipped the write.

The current version keeps the consolidated update flow, but only runs it when one of the string fields actually changed. Submitted empty strings are treated as intentional clears, while untouched fields keep their original database value exactly as stored, including `NULL`. That preserves the clearing behavior without rewriting unrelated nullable columns.

`facility_id` and `billing_facility_id` are still handled separately because they have additional facility lookup and sync logic.
