### PR TITLE
refactor(background-services): add BackgroundServiceRegistry for module registration

### DIFF
--- a/src/Services/Background/BackgroundServiceDefinition.php
+++ b/src/Services/Background/BackgroundServiceDefinition.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Immutable value object representing a registered background service.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://www.opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\Background;
+
+use OpenEMR\Common\Database\TableTypes;
+
+/**
+ * @phpstan-import-type BackgroundServicesRow from TableTypes
+ */
+final readonly class BackgroundServiceDefinition
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $title,
+        public readonly string $function,
+        public readonly ?string $requireOnce = null,
+        public readonly int $executeInterval = 0,
+        public readonly int $sortOrder = 100,
+        public readonly bool $active = false,
+        public readonly bool $running = false,
+        public readonly ?string $nextRun = null,
+    ) {
+    }
+
+    /**
+     * @param BackgroundServicesRow $row
+     */
+    public static function fromDatabaseRow(array $row): self
+    {
+        return new self(
+            name: $row['name'],
+            title: $row['title'],
+            function: $row['function'],
+            requireOnce: $row['require_once'],
+            executeInterval: (int) $row['execute_interval'],
+            sortOrder: (int) $row['sort_order'],
+            active: (int) $row['active'] !== 0,
+            running: (int) $row['running'] > 0,
+            nextRun: $row['next_run'],
+        );
+    }
+
+    /**
+     * @return BackgroundServicesRow
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'title' => $this->title,
+            'active' => $this->active ? '1' : '0',
+            'running' => $this->running ? '1' : '0',
+            'next_run' => $this->nextRun ?? '1970-01-01 00:00:00',
+            'execute_interval' => (string) $this->executeInterval,
+            'function' => $this->function,
+            'require_once' => $this->requireOnce,
+            'sort_order' => (string) $this->sortOrder,
+        ];
+    }
+}

--- a/src/Services/Background/BackgroundServiceRegistry.php
+++ b/src/Services/Background/BackgroundServiceRegistry.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Registry for managing background service registrations.
+ *
+ * Replaces ad-hoc SQL INSERT/UPDATE/DELETE patterns used by modules
+ * with a consistent API backed by the background_services table.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://www.opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\Background;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Database\TableTypes;
+
+/**
+ * @phpstan-import-type BackgroundServicesRow from TableTypes
+ */
+class BackgroundServiceRegistry
+{
+    /**
+     * Register or update a background service (idempotent upsert).
+     *
+     * The ON DUPLICATE KEY UPDATE intentionally does NOT update `active`.
+     * This preserves the admin's enable/disable decision. Use setActive()
+     * to change a service's enabled state.
+     */
+    public function register(BackgroundServiceDefinition $definition): void
+    {
+        $sql = <<<'SQL'
+            INSERT INTO `background_services`
+                (`name`, `title`, `function`, `require_once`, `execute_interval`, `sort_order`, `active`)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                `title` = VALUES(`title`),
+                `function` = VALUES(`function`),
+                `require_once` = VALUES(`require_once`),
+                `execute_interval` = VALUES(`execute_interval`),
+                `sort_order` = VALUES(`sort_order`)
+            SQL;
+
+        QueryUtils::sqlStatementThrowException($sql, [
+            $definition->name,
+            $definition->title,
+            $definition->function,
+            $definition->requireOnce,
+            $definition->executeInterval,
+            $definition->sortOrder,
+            $definition->active ? 1 : 0,
+        ], true);
+    }
+
+    /**
+     * Remove a background service by name.
+     */
+    public function unregister(string $name): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `background_services` WHERE `name` = ?',
+            [$name],
+            true,
+        );
+    }
+
+    /**
+     * Get a single service by name, or null if not found.
+     */
+    public function get(string $name): ?BackgroundServiceDefinition
+    {
+        /** @var list<BackgroundServicesRow> $rows */
+        $rows = QueryUtils::fetchRecordsNoLog(
+            'SELECT * FROM `background_services` WHERE `name` = ?',
+            [$name],
+        );
+
+        if ($rows === []) {
+            return null;
+        }
+
+        return BackgroundServiceDefinition::fromDatabaseRow($rows[0]);
+    }
+
+    /**
+     * List all registered services, optionally filtering by active status.
+     *
+     * @return list<BackgroundServiceDefinition>
+     */
+    public function list(?bool $activeFilter = null): array
+    {
+        $sql = 'SELECT * FROM `background_services`';
+        $binds = [];
+
+        if ($activeFilter !== null) {
+            $sql .= ' WHERE `active` = ?';
+            $binds[] = $activeFilter ? 1 : 0;
+        }
+
+        $sql .= ' ORDER BY `sort_order`';
+
+        /** @var list<BackgroundServicesRow> $rows */
+        $rows = QueryUtils::fetchRecordsNoLog($sql, $binds);
+
+        return array_map(
+            BackgroundServiceDefinition::fromDatabaseRow(...),
+            $rows,
+        );
+    }
+
+    /**
+     * Enable or disable a service.
+     */
+    public function setActive(string $name, bool $active): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE `background_services` SET `active` = ? WHERE `name` = ?',
+            [$active ? 1 : 0, $name],
+            true,
+        );
+    }
+
+    /**
+     * Check if a service with the given name exists.
+     */
+    public function exists(string $name): bool
+    {
+        $rows = QueryUtils::fetchRecordsNoLog(
+            'SELECT 1 FROM `background_services` WHERE `name` = ? LIMIT 1',
+            [$name],
+        );
+
+        return $rows !== [];
+    }
+}

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceDefinitionTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceDefinitionTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://www.opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Background;
+
+use OpenEMR\Services\Background\BackgroundServiceDefinition;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+#[Group('background-services')]
+class BackgroundServiceDefinitionTest extends TestCase
+{
+    public function testConstructorSetsProperties(): void
+    {
+        $def = new BackgroundServiceDefinition(
+            name: 'test_svc',
+            title: 'Test Service',
+            function: 'runTestService',
+            requireOnce: '/path/to/file.php',
+            executeInterval: 5,
+            sortOrder: 50,
+            active: true,
+            running: false,
+            nextRun: '2026-03-28 10:00:00',
+        );
+
+        $this->assertSame('test_svc', $def->name);
+        $this->assertSame('Test Service', $def->title);
+        $this->assertSame('runTestService', $def->function);
+        $this->assertSame('/path/to/file.php', $def->requireOnce);
+        $this->assertSame(5, $def->executeInterval);
+        $this->assertSame(50, $def->sortOrder);
+        $this->assertTrue($def->active);
+        $this->assertFalse($def->running);
+        $this->assertSame('2026-03-28 10:00:00', $def->nextRun);
+    }
+
+    public function testDefaultValues(): void
+    {
+        $def = new BackgroundServiceDefinition(
+            name: 'minimal',
+            title: 'Minimal',
+            function: 'doWork',
+        );
+
+        $this->assertNull($def->requireOnce);
+        $this->assertSame(0, $def->executeInterval);
+        $this->assertSame(100, $def->sortOrder);
+        $this->assertFalse($def->active);
+        $this->assertFalse($def->running);
+        $this->assertNull($def->nextRun);
+    }
+
+    public function testFromDatabaseRow(): void
+    {
+        // Use string values to match ADOdb runtime behavior (numeric-string)
+        $row = [
+            'name' => 'phimail',
+            'title' => 'phiMail Direct Messaging',
+            'function' => 'phimail_check',
+            'require_once' => '/library/phimail.php',
+            'execute_interval' => '5',
+            'sort_order' => '100',
+            'active' => '1',
+            'running' => '0',
+            'next_run' => '2026-03-28 10:15:00',
+        ];
+
+        $def = BackgroundServiceDefinition::fromDatabaseRow($row);
+
+        $this->assertSame('phimail', $def->name);
+        $this->assertSame('phiMail Direct Messaging', $def->title);
+        $this->assertSame('phimail_check', $def->function);
+        $this->assertSame('/library/phimail.php', $def->requireOnce);
+        $this->assertSame(5, $def->executeInterval);
+        $this->assertSame(100, $def->sortOrder);
+        $this->assertTrue($def->active);
+        $this->assertFalse($def->running);
+        $this->assertSame('2026-03-28 10:15:00', $def->nextRun);
+    }
+
+    public function testFromDatabaseRowWithNullRequireOnce(): void
+    {
+        $row = [
+            'name' => 'svc',
+            'title' => 'Service',
+            'function' => 'doWork',
+            'require_once' => null,
+            'execute_interval' => '10',
+            'sort_order' => '200',
+            'active' => '0',
+            'running' => '0',
+            'next_run' => '1970-01-01 00:00:00',
+        ];
+
+        $def = BackgroundServiceDefinition::fromDatabaseRow($row);
+
+        $this->assertNull($def->requireOnce);
+        $this->assertSame('1970-01-01 00:00:00', $def->nextRun);
+        $this->assertFalse($def->active);
+    }
+
+    public function testToArray(): void
+    {
+        $def = new BackgroundServiceDefinition(
+            name: 'test_svc',
+            title: 'Test',
+            function: 'runTest',
+            requireOnce: '/path.php',
+            executeInterval: 5,
+            sortOrder: 50,
+            active: true,
+            running: false,
+            nextRun: '2026-03-28 10:00:00',
+        );
+
+        $array = $def->toArray();
+
+        $this->assertSame('test_svc', $array['name']);
+        $this->assertSame('Test', $array['title']);
+        $this->assertSame('runTest', $array['function']);
+        $this->assertSame('/path.php', $array['require_once']);
+        $this->assertSame('5', $array['execute_interval']);
+        $this->assertSame('50', $array['sort_order']);
+        $this->assertSame('1', $array['active']);
+        $this->assertSame('0', $array['running']);
+    }
+
+    public function testRoundTrip(): void
+    {
+        $original = new BackgroundServiceDefinition(
+            name: 'roundtrip',
+            title: 'Roundtrip Test',
+            function: 'doRoundtrip',
+            requireOnce: '/lib/roundtrip.php',
+            executeInterval: 15,
+            sortOrder: 75,
+            active: true,
+            running: true,
+            nextRun: '2026-03-28 12:00:00',
+        );
+
+        $restored = BackgroundServiceDefinition::fromDatabaseRow($original->toArray());
+
+        $this->assertSame($original->name, $restored->name);
+        $this->assertSame($original->title, $restored->title);
+        $this->assertSame($original->function, $restored->function);
+        $this->assertSame($original->requireOnce, $restored->requireOnce);
+        $this->assertSame($original->executeInterval, $restored->executeInterval);
+        $this->assertSame($original->sortOrder, $restored->sortOrder);
+        $this->assertSame($original->active, $restored->active);
+        $this->assertSame($original->running, $restored->running);
+        $this->assertSame($original->nextRun, $restored->nextRun);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `BackgroundServiceRegistry` and `BackgroundServiceDefinition` to replace the 3+ ad-hoc SQL patterns modules use for registering background services (Telemetry, FaxSMS, ClaimRev, Weno).

- **`BackgroundServiceRegistry`** — `register()` (idempotent upsert via INSERT ON DUPLICATE KEY UPDATE), `unregister()`, `get()`, `list()`, `setActive()`, `exists()`
- **`BackgroundServiceDefinition`** — `final readonly` value object with `fromDatabaseRow()` and `toArray()`, using `BackgroundServicesRow` type stub with `(int)` casts for ADOdb `numeric-string` values

Table schema is unchanged. Existing SQL-based registrations continue to work. Module migration to the registry API is incremental.

## Test plan

- [x] `composer phpunit-isolated` — 6 `BackgroundServiceDefinitionTest` tests pass (including round-trip)
- [x] `composer phpstan` — no errors, no new baseline entries
- [x] Pre-commit hooks pass
- [ ] Docker: verify existing background services still function

Closes #11329

🤖 Generated with [Claude Code](https://claude.com/claude-code)