### PR TITLE
feat(background-services): add REST API endpoints for listing and triggering services

### DIFF
--- a/apis/routes/_rest_routes_standard.inc.php
+++ b/apis/routes/_rest_routes_standard.inc.php
@@ -22,6 +22,7 @@ use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\RestControllers\AllergyIntoleranceRestController;
 use OpenEMR\RestControllers\AppointmentRestController;
+use OpenEMR\RestControllers\BackgroundServiceRestController;
 use OpenEMR\RestControllers\ConditionRestController;
 // TODO: Remove this import when the OpenEMR\RestControllers\Config\RestConfig is no longer needed
 use OpenEMR\RestControllers\Config\RestConfig;
@@ -676,5 +677,29 @@ return [
     "DELETE /api/prescription/:uuid" => function ($uuid, HttpRestRequest $request) {
         RestConfig::request_authorization_check($request, "patients", "med");
         return (new PrescriptionRestController())->delete($uuid, $request);
-    }
+    },
+    "GET /api/background_service" => function (HttpRestRequest $request) {
+        RestConfig::request_authorization_check($request, "admin", "super");
+        return (new BackgroundServiceRestController())->listAll();
+    },
+    "GET /api/background_service/:name" => function (string $name, HttpRestRequest $request) {
+        RestConfig::request_authorization_check($request, "admin", "super");
+        return (new BackgroundServiceRestController())->getOne($name);
+    },
+    "POST /api/background_service/:name/run" => function (string $name, HttpRestRequest $request) {
+        RestConfig::request_authorization_check($request, "admin", "super");
+        $body = file_get_contents("php://input");
+        $data = [];
+        if (is_string($body) && $body !== '') {
+            $decoded = json_decode($body, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                return new \Symfony\Component\HttpFoundation\JsonResponse(
+                    ['error' => 'Invalid JSON payload'],
+                    \Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST,
+                );
+            }
+            $data = is_array($decoded) ? $decoded : [];
+        }
+        return (new BackgroundServiceRestController())->runService($name, $data);
+    },
 ];

--- a/src/RestControllers/BackgroundServiceRestController.php
+++ b/src/RestControllers/BackgroundServiceRestController.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * REST controller for background service listing and execution.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://www.opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\RestControllers;
+
+use OpenEMR\Services\Background\BackgroundServiceRegistry;
+use OpenEMR\Services\Background\BackgroundServiceRunner;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+class BackgroundServiceRestController
+{
+    private readonly BackgroundServiceRegistry $registry;
+    private readonly BackgroundServiceRunner $runner;
+
+    public function __construct()
+    {
+        $this->registry = new BackgroundServiceRegistry();
+        $this->runner = new BackgroundServiceRunner();
+    }
+
+    public function listAll(): Response
+    {
+        $definitions = $this->registry->list();
+        // Return only client-safe fields, omitting function/require_once
+        $data = array_map(
+            fn($def) => [
+                'name' => $def->name,
+                'title' => $def->title,
+                'active' => $def->active,
+                'running' => $def->running,
+                'execute_interval' => $def->executeInterval,
+                'next_run' => $def->nextRun,
+            ],
+            $definitions,
+        );
+        return new JsonResponse($data);
+    }
+
+    public function getOne(string $name): Response
+    {
+        $definition = $this->registry->get($name);
+        if ($definition === null) {
+            return new JsonResponse(['error' => 'Service not found'], Response::HTTP_NOT_FOUND);
+        }
+        return new JsonResponse([
+            'name' => $definition->name,
+            'title' => $definition->title,
+            'active' => $definition->active,
+            'running' => $definition->running,
+            'execute_interval' => $definition->executeInterval,
+            'next_run' => $definition->nextRun,
+        ]);
+    }
+
+    /**
+     * @param array<mixed> $data
+     */
+    public function runService(string $name, array $data = []): Response
+    {
+        $force = isset($data['force']) && $data['force'] === true;
+        $results = $this->runner->run($name, $force);
+
+        if ($results === [] || $results[0]['status'] === 'not_found') {
+            return new JsonResponse(['error' => 'Service not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $result = $results[0];
+        $statusCode = match ($result['status']) {
+            'error' => Response::HTTP_INTERNAL_SERVER_ERROR,
+            'locked', 'skipped' => Response::HTTP_CONFLICT,
+            default => Response::HTTP_OK,
+        };
+        return new JsonResponse(['service' => $result['name'], 'status' => $result['status']], $statusCode);
+    }
+}


### PR DESCRIPTION
## Summary

Adds three REST API endpoints gated by `admin/super` ACL:

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/api/background_service` | List all registered services |
| `GET` | `/api/background_service/:name` | Get a single service's details |
| `POST` | `/api/background_service/:name/run` | Trigger execution (optional `{"force": true}`) |

Uses `BackgroundServiceRegistry` for reads and `BackgroundServiceRunner` for execution. Returns `JsonResponse` directly (not `RestControllerHelper::responseHandler`) for correct empty-list and error handling.

Response status codes for the `run` endpoint:
- `200` with `{"status": "executed"}` — service ran successfully
- `404` with `{"error": "Service not found"}` — unknown service name
- `409` with `{"status": "locked"}` or `{"status": "skipped"}` — not due, inactive, or already running
- `500` with `{"status": "error"}` — service execution failed
- `400` with `{"error": "Invalid JSON payload"}` — malformed request body

API responses omit internal fields (`function`, `require_once`) for security.

## Test plan

- [x] `composer phpstan` — no errors, no new baseline entries
- [x] Pre-commit hooks pass
- [ ] Docker: generate access token, curl endpoints

Closes #11330

🤖 Generated with [Claude Code](https://claude.com/claude-code)