### PR TITLE
docs(ai): expand CLAUDE.md with PHP coding standards

### DIFF
--- a/.codespell-ignore-words.txt
+++ b/.codespell-ignore-words.txt
@@ -80,6 +80,9 @@ skelton
 # Smarty template modifier names
 spacify
 
+# Software design terminology
+wither
+
 # Third-party library terms
 afterall
 atleast

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,11 +125,41 @@ npm run gulp-build   # Build only (no watch)
 
 ## Coding Standards
 
+### Legacy Code Is Not the Standard
+
+OpenEMR's codebase predates modern PHP and contains many antipatterns: global
+state, stringly-typed parameters, `$_SESSION` and `$GLOBALS` as a service
+locator, untyped arrays passed through multiple layers, and pervasive use of
+`empty()` and loose comparisons. These patterns exist for historical reasons,
+not because they are correct. Never use existing legacy patterns as
+justification for writing new code the same way — follow the standards
+documented here instead.
+
+### Formatting and Structure
+
 - **Indentation:** 4 spaces
 - **Line endings:** LF (Unix)
-- **strict_types:** New files should use `declare(strict_types=1)` — adoption is growing
 - **Namespaces:** PSR-4 with `OpenEMR\` prefix for `/src/`
 - New code goes in `/src/`, legacy helpers in `/library/`
+
+### PSR Standards
+
+| Standard | Purpose |
+|----------|---------|
+| [PSR-1](https://www.php-fig.org/psr/psr-1/) | Basic coding standard (class naming, file structure) |
+| [PSR-4](https://www.php-fig.org/psr/psr-4/) | Autoloading |
+| [PSR-3](https://www.php-fig.org/psr/psr-3/) | Logger interface (`Psr\Log\LoggerInterface`) |
+| [PSR-11](https://www.php-fig.org/psr/psr-11/) | Container interface (`Psr\Container\ContainerInterface`) |
+| [PER-CS 3.0](https://www.php-fig.org/per/coding-style/) | Coding style (supersedes PSR-12; adds enums, match, union types) |
+
+Adopt where applicable: [PSR-7](https://www.php-fig.org/psr/psr-7/) (HTTP
+messages), [PSR-15](https://www.php-fig.org/psr/psr-15/) (middleware),
+[PSR-17](https://www.php-fig.org/psr/psr-17/) (HTTP factories),
+[PSR-18](https://www.php-fig.org/psr/psr-18/) (HTTP client),
+[PSR-20](https://www.php-fig.org/psr/psr-20/) (clock).
+
+### Database and Global Settings
+
 - **Database:** Use `QueryUtils` for queries. New schema changes use Doctrine
   Migrations. Do not instantiate database connections directly — use the
   centralized `DatabaseConnectionFactory`.
@@ -140,6 +170,168 @@ npm run gulp-build   # Build only (no watch)
   - `getBoolean($key)` instead of `(bool) get($key)`
   - `getKernel()` for the Kernel instance
   - Check the parent class for more: `getAlpha()`, `getAlnum()`, `getDigits()`, `getEnum()`
+
+### Strict Typing
+
+Every new PHP file starts with `declare(strict_types=1)`. Without strict types,
+PHP silently coerces `"123abc"` to `123` when passed to an `int` parameter,
+hiding bugs that surface later as data corruption.
+
+Every property, parameter, and return type should have a native type
+declaration. Reserve PHPDoc types for information native types cannot express
+(generics, array shapes, type narrowing).
+
+### Type System
+
+- **Nullable types:** Use `?Type` for nullable. Use `Type|null` only in unions
+  with three or more members.
+- **Avoid `mixed`:** Enumerate types explicitly. Reserve `mixed` for genuinely
+  polymorphic code and narrow it immediately via type checks.
+- **Enums over constants:** Use enums for any value drawn from a closed set.
+  Prefer unit enums (no backing type) for purely runtime state. Use backed enums
+  only when the value is persisted to a database, serialized to JSON, or
+  exchanged with an external system.
+- **Return types:** Use `void` for side-effect-only methods, `never` for methods
+  that always throw or exit, `self` for factories on `final` classes, `static`
+  for factories on non-final classes.
+
+### Immutability
+
+- Use `readonly` classes or `readonly` properties for value objects, DTOs, and
+  configuration. Mutable state should be the exception.
+- `final` on value objects to prevent mutable subclasses.
+- `DateTimeImmutable` over `DateTime` — always.
+- Wither methods (return a new instance) over setters on value objects.
+
+### Domain Primitives
+
+Wrap primitive values in typed classes when the primitive could be confused with
+another primitive of the same PHP type. This prevents argument transposition
+bugs that are invisible to PHP's type system:
+
+```php
+final readonly class PatientId
+{
+    public function __construct(public int $value)
+    {
+        if ($value <= 0) {
+            throw new \DomainException('Patient ID must be positive');
+        }
+    }
+}
+```
+
+Use for: IDs that could be confused (`PatientId` vs `EncounterId`), strings with
+semantic meaning (`Email`, `Npi`), numbers with constraints or units (`Money`).
+
+### Parse, Don't Validate
+
+At system boundaries (controllers, CLI handlers, message consumers), parse raw
+input into typed objects immediately. After parsing, the rest of the code works
+with types that guarantee their own validity — no re-validation downstream.
+
+### Exhaustive Matching
+
+Use `match` on enums without a `default` branch. PHPStan verifies that every
+case is handled. Adding a `default` silently absorbs new cases and suppresses
+the exhaustiveness check.
+
+### Error Handling and Logging
+
+**PSR-3 logging context:** Never concatenate or interpolate variables into log
+messages. Use PSR-3 context arrays:
+
+```php
+// Bad
+$this->logger->error("Failed for {$phone}: " . $e->getMessage());
+
+// Good
+$this->logger->error('Failed to send message', [
+    'phone' => $phone,
+    'exception' => $e,
+]);
+```
+
+**Catch `\Throwable`, not `\Exception`.** `\Exception` misses `\TypeError`,
+`\ParseError`, and other `\Error` subclasses.
+
+**Let exceptions propagate.** Only catch when the caller can meaningfully
+recover. Do not catch-log-continue — it hides failures from callers.
+
+**Never expose `$e->getMessage()` in user-facing output.** Exception messages
+may contain internal details (SQL, file paths). Log the exception and return a
+generic message to the user.
+
+**Exception chaining:** When wrapping an exception, use a generic message
+describing the failed operation. The original exception is accessible via
+`->getPrevious()` — do not embed its message in the wrapper.
+
+### Dependency Injection
+
+Inject all dependencies through the constructor. Never use `new` for
+service-layer objects inside business logic, never call static service locators,
+and never reach into global state (`$GLOBALS`, `$_SESSION`, `$_GET`, etc.) for
+dependencies.
+
+- **Interface-based dependencies** for cross-boundary code. Use concrete types
+  for internal collaborators where a single-implementation interface adds no
+  value.
+- **PSR-11 containers:** Wire in configuration, not in business logic. Business
+  logic classes should never know the container exists.
+- **Clock injection (PSR-20):** Inject `ClockInterface` instead of calling
+  `new \DateTimeImmutable()` or `time()` directly. This makes time-dependent
+  code deterministically testable.
+- **No direct superglobal access** in application code. Use PSR-7 request
+  objects, framework session abstractions, and container-provided configuration.
+  In legacy code where this is unavoidable, confine superglobal reads to the
+  outermost entry point and parse into typed objects immediately.
+
+### Null Safety
+
+- **Early returns:** Flatten null checks with early returns rather than nesting.
+- **Null coalescing:** `??` for defaults, `??=` for lazy initialization.
+- **Null-safe operator:** `?->` for optional chaining, but no more than two
+  levels deep.
+- **Never suppress nullable warnings.** If PHPStan says a value might be null,
+  handle the null case explicitly. Do not add `@var` casts or `@phpstan-ignore`
+  comments to silence it.
+
+### Static Analysis (PHPStan)
+
+PHPStan runs at level 10 (`max`). Key principles:
+
+- **Fix at the source, not the sink.** When PHPStan reports a type error, trace
+  it back to where the wrong type was introduced. Do not suppress at the point
+  where it manifests.
+- **Narrow, don't cast.** When a value is `mixed` or a union type, narrow with
+  `is_string()`, `instanceof`, etc. — do not cast with `(string)`, `(int)`.
+  Casts silently coerce invalid data.
+- **Avoid inline `@var` casts.** Each one should prompt the question: why does
+  the type not match, and can the source be fixed?
+- **Avoid baselines.** Never add new baseline entries — fix the underlying type
+  error. When modifying a file, fix any existing baseline entries for that file.
+- **Array typing progression** (worst to best): bare `array` → `array<K, V>` →
+  `list<T>` → `non-empty-list<T>` → array shape → `@phpstan-type` alias → DTO.
+  Convert shapes to DTOs when they exceed 3-4 keys or appear in multiple places.
+- **Always run on the full codebase** and filter output for changed files. Never
+  run on a subset — PHPStan's type inference depends on full-codebase context.
+
+### Authorization Modeling
+
+When an operation requires authorization, type the principal — do not pass
+authorization context as strings or bare integers:
+
+```php
+// Bad
+function approveOrder(int $userId, int $orderId): void {}
+
+// Good
+function approveOrder(ClinicalUser $approver, OrderId $orderId): void {}
+```
+
+When an operation is scoped to a facility or tenant, encode that scope in the
+type (e.g., a scoped repository) rather than relying on runtime checks scattered
+through the codebase.
 
 ## Commit Messages
 


### PR DESCRIPTION
## Summary

- Expand CLAUDE.md Coding Standards from 7 bullet points to 13 subsections covering modern PHP practices
- Add explicit guidance that legacy antipatterns should not be perpetuated in new code
- Document PSR standards, strict typing, type system, immutability, domain primitives, parse-don't-validate, exhaustive matching, error handling/logging, dependency injection, null safety, PHPStan practices, and authorization modeling
- Add "wither" to codespell ignore list (standard software design term)

All standards are industry-standard modern PHP practices — nothing proprietary or vendor-specific.

## Test plan

- [x] Review that all coding standards are accurate and appropriate for the OpenEMR project
- [x] Verify no proprietary or vendor-specific content was included
- [x] Confirm the document renders correctly on GitHub

Closes #11339

🤖 Generated with [Claude Code](https://claude.com/claude-code)