### PR TITLE
fix(security): replace addslashes() with js_escape() in JS contexts

### DIFF
--- a/ccr/createCCR.php
+++ b/ccr/createCCR.php
@@ -338,7 +338,7 @@ function sourceType($ccr, $uuid)
 
 function displayError($message): void
 {
-    echo '<script>alert("' . addslashes((string) $message) . '");</script>';
+    echo '<script>alert(' . js_escape((string) $message) . ');</script>';
 }
 
 

--- a/custom/import_xml.php
+++ b/custom/import_xml.php
@@ -194,7 +194,7 @@ if (!empty($_POST['form_import'])) {
 
     echo "<html>\n<body>\n<script>\n";
     if ($alertmsg) {
-        echo " alert('" . addslashes((string) $alertmsg) . "');\n";
+        echo " alert(" . js_escape((string) $alertmsg) . ");\n";
     }
 
     echo " if (!opener.closed && opener.refreshme) opener.refreshme();\n";

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -1350,7 +1350,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
     });
     <?php
     if ($alertmsg) {
-        echo "alert('" . addslashes((string) $alertmsg) . "');\n";
+        echo "alert(" . js_escape((string) $alertmsg) . ");\n";
     }
     ?>
     $(function () {

--- a/interface/drugs/add_edit_drug.php
+++ b/interface/drugs/add_edit_drug.php
@@ -398,7 +398,7 @@ if ((!empty($_POST['form_save']) || !empty($_POST['form_delete'])) && !$alertmsg
   //
     echo "<script>\n";
     if ($info_msg) {
-        echo " alert('" . addslashes($info_msg) . "');\n";
+        echo " alert(" . js_escape($info_msg) . ");\n";
     }
 
     echo " if (opener.refreshme) opener.refreshme();\n";
@@ -483,7 +483,7 @@ $title = $drug_id ? xl("Update Drug") : xl("Add Drug");
 
     <div class="form-group mt-3">
         <label><?php echo xlt('NDC Number'); ?>:</label>
-        <input class="form-control w-100" size="40" name="form_ndc_number" maxlength="20" value='<?php echo attr($row['ndc_number']) ?>' onkeyup='maskkeyup(this,"<?php echo attr(addslashes(OEGlobalsBag::getInstance()->getString('gbl_mask_product_id'))); ?>")' onblur='maskblur(this,"<?php echo attr(addslashes(OEGlobalsBag::getInstance()->getString('gbl_mask_product_id'))); ?>")' />
+        <input class="form-control w-100" size="40" name="form_ndc_number" maxlength="20" value='<?php echo attr($row['ndc_number']) ?>' onkeyup='maskkeyup(this,<?php echo attr(js_escape(OEGlobalsBag::getInstance()->getString('gbl_mask_product_id'))); ?>)' onblur='maskblur(this,<?php echo attr(js_escape(OEGlobalsBag::getInstance()->getString('gbl_mask_product_id'))); ?>)' />
     </div>
 
     <div class="form-group mt-3">
@@ -699,7 +699,7 @@ dispensable_changed();
 
 <?php
 if ($alertmsg) {
-    echo "alert('" . addslashes($alertmsg) . "');\n";
+    echo "alert(" . js_escape($alertmsg) . ");\n";
 }
 ?>
 

--- a/interface/drugs/add_edit_lot.php
+++ b/interface/drugs/add_edit_lot.php
@@ -783,7 +783,7 @@ if (!$drug_id) {
     <script>
         <?php
         if ($info_msg) {
-            echo " alert('" . addslashes($info_msg) . "');\n";
+            echo " alert(" . js_escape($info_msg) . ");\n";
             echo " window.close();\n";
         }
         ?>

--- a/interface/drugs/destroy_lot.php
+++ b/interface/drugs/destroy_lot.php
@@ -102,7 +102,7 @@ if ($_POST['form_save']) {
   //
     echo "<script>\n";
     if ($info_msg) {
-        echo " alert('" . addslashes($info_msg) . "');\n";
+        echo " alert(" . js_escape($info_msg) . ");\n";
     }
 
     echo " window.close();\n";

--- a/interface/drugs/drug_inventory.php
+++ b/interface/drugs/drug_inventory.php
@@ -141,7 +141,7 @@ function inventory_mapToTable($row): void
         echo " <tr class='detail'>\n";
         $lastid = $row['drug_id'];
         if ($auth_admin) {
-            echo "<td title='" . xla('Click to edit') . "' onclick='dodclick(" . attr(addslashes((string) $lastid)) . ")'>" .
+            echo "<td title='" . xla('Click to edit') . "' onclick='dodclick(" . attr(js_escape((string) $lastid)) . ")'>" .
             "<a href='' onclick='return false'>" .
             text($row['name']) . "</a></td>\n";
         } else {

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -397,7 +397,7 @@ if ($_POST['form_save']) {
         // Close this window and refresh the fax list.
         echo "<html>\n<body>\n<script>\n";
         if ($info_msg) {
-            echo " alert('" . addslashes($info_msg) . "');\n";
+            echo " alert(" . js_escape($info_msg) . ");\n";
         }
 
         echo " if (!opener.closed && opener.refreshme) opener.refreshme();\n";

--- a/interface/fax/faxq.php
+++ b/interface/fax/faxq.php
@@ -229,9 +229,9 @@ foreach ($mlines as $matches) {
     $ffbase = basename("/$ffname", '.tif');
     $bgcolor = (($encount & 1) ? "#ddddff" : "#ffdddd");
     echo "    <tr class='detail' bgcolor='" . attr($bgcolor) . "'>\n";
-    echo "     <td onclick='dodclick(\"" . attr(addslashes($ffname)) . "\")'>";
+    echo "     <td onclick='dodclick(" . attr(js_escape($ffname)) . ")'>";
     echo "<a href='fax_view.php?file=" . attr_url($ffname) . "&csrf_token_form=" . CsrfUtils::collectCsrfToken(session: $session) . "' onclick='return false'>" . text($ffbase) . "</a></td>\n";
-    echo "     <td onclick='domclick(\"" . attr(addslashes($ffname)) . "\")'>";
+    echo "     <td onclick='domclick(" . attr(js_escape($ffname)) . ")'>";
     echo "<a href='fax_dispatch.php?file=" . attr_url($ffname) . "&csrf_token_form=" . CsrfUtils::collectCsrfToken(session: $session) . "' onclick='return false'>" . xlt('Dispatch') . "</a></td>\n";
     echo "     <td>" . text($matches[3]) . "</td>\n";
     echo "     <td>" . text($matches[2]) . "</td>\n";
@@ -270,7 +270,7 @@ foreach ($dlines as $matches) {
 
     $bgcolor = (($encount & 1) ? "#ddddff" : "#ffdddd");
     echo "    <tr class='detail' bgcolor='" . attr($bgcolor) . "'>\n";
-    echo "     <td onclick='dojclick(\"" . attr(addslashes($jobid)) . "\")'>" .
+    echo "     <td onclick='dojclick(" . attr(js_escape($jobid)) . ")'>" .
      "<a href='fax_view.php?jid=" . attr_url($jobid) . "&csrf_token_form=" . CsrfUtils::collectCsrfToken(session: $session) . "' onclick='return false'>" .
      "$jobid</a></td>\n";
     echo "     <td>" . text($matches[5]) . "</td>\n";
@@ -300,10 +300,10 @@ foreach ($slines as $sline) {
     $sfname = $sline[0]; // filename
     $sfdate = date('Y-m-d H:i', $sline[9]);
     echo "    <tr class='detail' bgcolor='" . attr($bgcolor) . "'>\n";
-    echo "     <td onclick='dosvclick(\"" . attr(addslashes($sfname)) . "\")'>" .
+    echo "     <td onclick='dosvclick(" . attr(js_escape($sfname)) . ")'>" .
      "<a href='fax_view.php?scan=" . attr_url($sfname) . "&csrf_token_form=" . CsrfUtils::collectCsrfToken(session: $session) . "' onclick='return false'>" .
      "$sfname</a></td>\n";
-    echo "     <td onclick='dosdclick(\"" . attr(addslashes($sfname)) . "\")'>";
+    echo "     <td onclick='dosdclick(" . attr(js_escape($sfname)) . ")'>";
     echo "<a href='fax_dispatch.php?scan=" . attr_url($sfname) . "&csrf_token_form=" . CsrfUtils::collectCsrfToken(session: $session) . "' onclick='return false'>" . xlt('Dispatch') . "</a></td>\n";
     echo "     <td>" . text($sfdate) . "</td>\n";
     echo "     <td align='right'>" . text($sline[7]) . "</td>\n";

--- a/interface/forms/LBF/new.php
+++ b/interface/forms/LBF/new.php
@@ -742,7 +742,7 @@ if (
                 "<td class='text border-top-0'>" + desc + "&nbsp;</td>" +
                 "<td class='text border-top-0'>" +
                 "<select class='form-control' name='form_fs_bill[" + lino + "][provid]'>" +
-                "<?php echo addslashes((string) $fs->genProviderOptionList('-- ' . xl('Default') . ' --')) ?>" +
+                <?php echo js_escape((string) $fs->genProviderOptionList('-- ' . xl('Default') . ' --')) ?> +
                 "</select>&nbsp;" +
                 "</td>" +
                 "<td class='text border-top-0 text-right'>" + price + "&nbsp;</td>" +

--- a/interface/forms/eye_mag/SpectacleRx.php
+++ b/interface/forms/eye_mag/SpectacleRx.php
@@ -416,7 +416,7 @@ if ($_REQUEST['dispensed'] ?? '') {
                 ?>
                     <div class="position-relative text-center mt-2 mb-2 mx-auto" id="RXID_<?php echo attr($row['id']); ?>">
                         <i class="float-right fas fa-times"
-                           onclick="delete_me('<?php echo attr(addslashes((string) $row['id'])); ?>');"
+                           onclick="delete_me(<?php echo attr(js_escape((string) $row['id'])); ?>);"
                            title="<?php echo xla('Remove this Prescription from the list of RXs dispensed'); ?>"></i>
                         <div class="table-responsive">
                             <table class="table mt-1 mb-1 mx-auto">

--- a/interface/forms/eye_mag/a_issue.php
+++ b/interface/forms/eye_mag/a_issue.php
@@ -502,12 +502,12 @@ foreach (explode(',', $given) as $item) {
         function validate() {
             var f = document.forms[0];
             if (f.form_begin.value > f.form_end.value && (f.form_end.value)) {
-                alert("<?php echo addslashes(xl('Please Enter End Date greater than Begin Date!')); ?>");
+                alert(<?php echo js_escape(xl('Please Enter End Date greater than Begin Date!')); ?>);
                 return false;
             }
             if (f.form_type.value != 'ROS' && f.form_type.value != 'FH' && f.form_type.value != 'SOCH') {
                 if (!f.form_title.value) {
-                    alert("<?php echo addslashes(xl('Please enter a title!')); ?>");
+                    alert(<?php echo js_escape(xl('Please enter a title!')); ?>);
                     return false;
                 }
             }

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -832,7 +832,7 @@ if (!empty($_POST['form_action'])) {
     // Close this window and refresh the calendar (or the patient_tracker) display.
     echo "<html>\n<body>\n<script>\n";
     if ($info_msg) {
-        echo " alert('" . addslashes($info_msg) . "');\n";
+        echo " alert(" . js_escape($info_msg) . ");\n";
     }
     echo " if (opener && !opener.closed && opener.refreshme) {\n " .
       "  opener.refreshme();\n " . // This is for standard calendar page refresh
@@ -1808,7 +1808,7 @@ function HideRecurrPopup() {
 }
 
 function deleteEvent() {
-    if (confirm("<?php echo addslashes(xl('Deleting this event cannot be undone. It cannot be recovered once it is gone. Are you sure you wish to delete this event?')); ?>")) {
+    if (confirm(<?php echo js_escape(xl('Deleting this event cannot be undone. It cannot be recovered once it is gone. Are you sure you wish to delete this event?')); ?>)) {
         $('#form_action').val("delete");
 
         <?php if ($repeats) : ?>

--- a/interface/main/finder/multi_patients_finder.php
+++ b/interface/main/finder/multi_patients_finder.php
@@ -149,7 +149,7 @@ if (isset($_GET['patients'])) {
                             '<td>' . text($result['ss']) . '</td>' .
                             '<td>' . text(oeFormatShortDate($result['DOB'])) . '</td>' .
                             '<td>' . text($result['pubpid']) . '</td>' .
-                            '<td><i class="fas fa-trash-alt remove-patient" onclick="removePatient(' . attr(addslashes((string) $result['pid'])) . ')"></i></td>' .
+                            '<td><i class="fas fa-trash-alt remove-patient" onclick="removePatient(' . attr(js_escape((string) $result['pid'])) . ')"></i></td>' .
                         '<tr>';
                 }
             } ?>

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -671,7 +671,7 @@ if (!empty($_REQUEST['go'])) { ?>
                                 <tr id=\"row" . attr($count) . "\" height='24' class='messages-item-row' role='button'>
                                     <td align='center'>
                                         <input type='checkbox' id=\"check" . attr($count) . "\" name=\"delete_id[]\" value=\"" .
-                                        attr($myrow['id']) . "\" onclick=\"if(this.checked==true){ selectRow(" . attr(js_escape($count)) . "); }else{ deselectRow(" . attr(js_escape($count)) . "); }\"></td>
+                                        attr($myrow['id']) . "\" onclick=\"if(this.checked==true){ selectRow(" . attr(js_escape('row' . $count)) . "); }else{ deselectRow(" . attr(js_escape('row' . $count)) . "); }\"></td>
                                     <td>
                                         <div>" . text($name) . "</div>
                                     </td>

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -449,7 +449,7 @@ if (!empty($_REQUEST['go'])) { ?>
                                             <div class="col-6 col-md-4">
                                                 <?php
                                                 if ($task != "addnew" && $result['pid'] != 0) { ?>
-                                                    <a class="patLink" onclick="goPid('<?php echo attr(addslashes((string) $result['pid'])); ?>')" title='<?php echo xla('Click me to Open Patient Dashboard') ?>'><?php echo xlt('Patient'); ?>:</a><label for="form_patient">&nbsp</label>
+                                                    <a class="patLink" onclick="goPid(<?php echo attr(js_escape((string) $result['pid'])); ?>)" title='<?php echo xla('Click me to Open Patient Dashboard') ?>'><?php echo xlt('Patient'); ?>:</a><label for="form_patient">&nbsp</label>
                                                     <?php
                                                 } else { ?>
                                                     <span class='<?php echo($task == "addnew" ? "text-danger" : "") ?>'><?php echo xlt('Patient'); ?>:</span></a><label for="form_patient"></label>
@@ -671,7 +671,7 @@ if (!empty($_REQUEST['go'])) { ?>
                                 <tr id=\"row" . attr($count) . "\" height='24' class='messages-item-row' role='button'>
                                     <td align='center'>
                                         <input type='checkbox' id=\"check" . attr($count) . "\" name=\"delete_id[]\" value=\"" .
-                                        attr($myrow['id']) . "\" onclick=\"if(this.checked==true){ selectRow('row" . attr(addslashes($count)) . "'); }else{ deselectRow('row" . attr(addslashes($count)) . "'); }\"></td>
+                                        attr($myrow['id']) . "\" onclick=\"if(this.checked==true){ selectRow(" . attr(js_escape($count)) . "); }else{ deselectRow(" . attr(js_escape($count)) . "); }\"></td>
                                     <td>
                                         <div>" . text($name) . "</div>
                                     </td>

--- a/interface/patient_file/pos_checkout_ippf.php
+++ b/interface/patient_file/pos_checkout_ippf.php
@@ -2687,8 +2687,8 @@ if (!$current_irnumber) {
         </td>
         <td class='text' align='right' colspan='<?php echo $form_num_amount_columns; ?>'>
             <input type='text' name='form_irnumber' size='10' value=''
-                onkeyup='maskkeyup(this,"<?php echo addslashes(OEGlobalsBag::getInstance()->getString('gbl_mask_invoice_number')); ?>")'
-                onblur='maskblur(this,"<?php echo addslashes(OEGlobalsBag::getInstance()->getString('gbl_mask_invoice_number')); ?>")'
+                onkeyup='maskkeyup(this,<?php echo attr(js_escape(OEGlobalsBag::getInstance()->getString('gbl_mask_invoice_number'))); ?>)'
+                onblur='maskblur(this,<?php echo attr(js_escape(OEGlobalsBag::getInstance()->getString('gbl_mask_invoice_number'))); ?>)'
         />
         </td>
     </tr>

--- a/interface/reports/destroyed_drugs_report.php
+++ b/interface/reports/destroyed_drugs_report.php
@@ -64,7 +64,7 @@ function destroyed_mapToTable($row): void
         echo "<td>" . text($row["ndc_number"]) . " </td>\n";
         echo "<td>";
         foreach ($row['inventory_id'] as $key => $value) {
-            echo "<div onclick='doclick(" . attr(addslashes((string) $row['drug_id'])) . "," . attr(addslashes((string) $row['inventory_id'][$key])) . ")'>" .
+            echo "<div onclick='doclick(" . attr(js_escape((string) $row['drug_id'])) . "," . attr(js_escape((string) $row['inventory_id'][$key])) . ")'>" .
             "<a href='' onclick='return false'>" . text($row['lot_number'][$key]) . "</a></div>";
         }
         echo "</td>\n<td>";

--- a/library/custom_template/add_context.php
+++ b/library/custom_template/add_context.php
@@ -98,7 +98,7 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                     document.designation_managment.submit();
                 }
                 else{
-                    alert("<?php echo addslashes(xl('Context name can\'t be empty'));?>");
+                    alert(<?php echo js_escape(xl("Context name can't be empty"));?>);
                 }
             }
             function deleteme(id){
@@ -107,10 +107,10 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                 CheckContextLive(id);
                 stat = document.getElementById('stat').value;
                 if(stat==1){
-                    msg = "<?php echo addslashes(xl('This context contains categories, which will be deleted. Do you still want to continue?'));?>";
+                    msg = <?php echo js_escape(xl('This context contains categories, which will be deleted. Do you still want to continue?'));?>;
                 }
                 else{
-                    msg = "<?php echo addslashes(xl('Do you want to delete this?'));?>";
+                    msg = <?php echo js_escape(xl('Do you want to delete this?'));?>;
                 }
                 if(confirm(msg)){
                 document.getElementById('action').value='delete';
@@ -133,7 +133,7 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                 document.designation_managment.submit();
                 }
                 else{
-                   alert("<?php echo addslashes(xl('Context name can\'t be empty'));?>");
+                   alert(<?php echo js_escape(xl("Context name can't be empty"));?>);
                 }
             }
             function CheckContextLive(id){

--- a/library/custom_template/add_template.php
+++ b/library/custom_template/add_template.php
@@ -65,12 +65,12 @@ $list_id = $_REQUEST['list_id'];
                 async: false,
                 success: function(thedata){
                         if(thedata=="Fail"){
-                            alert(document.getElementById('template_name').value+" <?php echo addslashes(xl('already exists'));?>");
+                            alert(document.getElementById('template_name').value + " " + <?php echo js_escape(xl('already exists'));?>);
                             return false;
                         }
                         else{
                             mainform.getElementById('templateDD').innerHTML = thedata;
-                            alert("<?php echo addslashes(xl('Successfully added category'));?> "+document.getElementById('template_name').value);
+                            alert(<?php echo js_escape(xl('Successfully added category'));?> + " " + document.getElementById('template_name').value);
                             //window.opener.opener.location.reload();
                             dlgclose();
                         }
@@ -81,11 +81,11 @@ $list_id = $_REQUEST['list_id'];
                 });
                 }
                 else{
-                    alert("<?php echo addslashes(xl('You should select at least one context'));?>");
+                    alert(<?php echo js_escape(xl('You should select at least one context'));?>);
                 }
             }
             else{
-                alert("<?php echo addslashes(xl('Category name is empty'));?>");
+                alert(<?php echo js_escape(xl('Category name is empty'));?>);
                 return false;
             }
         }

--- a/library/custom_template/delete_category.php
+++ b/library/custom_template/delete_category.php
@@ -53,7 +53,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
                      source: "delete_full_category"
                 },
                 success: function(thedata){
-                            alert("<?php echo addslashes(xl('Deleted Successfully.'));?>");
+                            alert(<?php echo js_escape(xl('Deleted Successfully.'));?>);
                             document.location.reload();
                             },
                 error:function(){
@@ -63,7 +63,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
         }
         function delete_category(id){
             top.restoreSession();
-            if(confirm("<?php echo addslashes(xl('Do you want to delete?'));?>")){
+            if(confirm(<?php echo js_escape(xl('Do you want to delete?'));?>)){
                 $.ajax({
                 type: "POST",
                 url: "ajax_code.php",
@@ -74,7 +74,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
                 },
                 success: function(thedata){
                             if(thedata){
-                                alert("<?php echo addslashes('There are currently other users of the category you are trying to delete. Please contact them and ask them to delete it. Categories may not be deleted while in use. This Categories are currently used by \n');?>"+thedata);
+                                alert(<?php echo js_escape('There are currently other users of the category you are trying to delete. Please contact them and ask them to delete it. Categories may not be deleted while in use. This Categories are currently used by \n');?> + thedata);
                             }
                             else{
                                 delete_full_category(id);

--- a/library/dated_reminder_functions.php
+++ b/library/dated_reminder_functions.php
@@ -251,13 +251,13 @@ function getRemindersHTML($today, $reminders = []): string
         // end check if reminder is due or overdue
         // append to html string
         $pdHTML .= '<p id="p_' . attr($r['messageID']) . '">
-            <a onclick="openAddScreen(' . attr(addslashes((string) $r['messageID'])) . ')" class="dnForwarder btn btn-secondary btn-send-msg" id="' . attr($r['messageID']) . '" href="#"> ' . xlt('Forward') . ' </a>
-            <a class="dnRemover btn btn-secondary btn-save" onclick="updateme(' . "'" . attr(addslashes((string) $r['messageID'])) . "'" . ')" id="' . attr($r['messageID']) . '" href="#">
+            <a onclick="openAddScreen(' . attr(js_escape((string) $r['messageID'])) . ')" class="dnForwarder btn btn-secondary btn-send-msg" id="' . attr($r['messageID']) . '" href="#"> ' . xlt('Forward') . ' </a>
+            <a class="dnRemover btn btn-secondary btn-save" onclick="updateme(' . attr(js_escape((string) $r['messageID'])) . ')" id="' . attr($r['messageID']) . '" href="#">
             <span>' . xlt('Set As Completed') . '</span>
             </a>
             <span title="' . ($r['PatientID'] > 0 ? xla('Click Patient Name to Open Patient File') : '') . '" class="' . attr($class) . '">' .
             $warning . '
-            <span onclick="goPid(' . attr(addslashes((string) $r['PatientID'])) . ')" class="patLink" id="' . attr($r['PatientID']) . '">' .
+            <span onclick="goPid(' . attr(js_escape((string) $r['PatientID'])) . ')" class="patLink" id="' . attr($r['PatientID']) . '">' .
             text($r['PatientName']) . '
             </span> ' .
             text($r['message']) . ' - [' . text($r['fromName']) . ']


### PR DESCRIPTION
## Summary

Replace all `addslashes()` calls used for JavaScript string escaping with `js_escape()` across 22 files (~42 call sites).

`addslashes()` only escapes quotes, backslashes, and NUL bytes — it is **not sufficient for JavaScript escaping**. Characters like `</script>`, line terminators (U+2028, U+2029), and other special sequences are not handled. `js_escape()` uses `json_encode()` which correctly handles all JavaScript-sensitive characters per RFC 8259.

Since `js_escape()` returns a JSON-encoded value that includes its own quotes, all manually added surrounding quotes were removed to prevent double-quoting.

### Categories addressed

| Category | Count | Pattern |
|----------|-------|---------|
| JS `alert()`/`confirm()` calls | ~30 | `alert('" . addslashes($x) . "')` → `alert(" . js_escape($x) . ")` |
| `attr(addslashes())` in onclick handlers | ~12 | `attr(addslashes($x))` → `attr(js_escape($x))` |

### Categories NOT addressed (separate PRs per #11259)

- SQL/log string contexts (`gacl/admin/`, `payment.inc.php`, `eye_mag/save.php`)
- CSV contexts (`BillingExport.csv.php`)
- Smarty compiler internals and test helpers (leave alone per issue)

### Files changed (22)

`ccr/createCCR.php`, `custom/import_xml.php`, `interface/billing/sl_eob_search.php`, `interface/drugs/add_edit_drug.php`, `interface/drugs/add_edit_lot.php`, `interface/drugs/destroy_lot.php`, `interface/drugs/drug_inventory.php`, `interface/fax/fax_dispatch.php`, `interface/fax/faxq.php`, `interface/forms/CAMOS/new.php`, `interface/forms/LBF/new.php`, `interface/forms/eye_mag/SpectacleRx.php`, `interface/forms/eye_mag/a_issue.php`, `interface/main/calendar/add_edit_event.php`, `interface/main/finder/multi_patients_finder.php`, `interface/main/messages/messages.php`, `interface/patient_file/pos_checkout_ippf.php`, `interface/reports/destroyed_drugs_report.php`, `library/custom_template/add_context.php`, `library/custom_template/add_template.php`, `library/custom_template/delete_category.php`, `library/dated_reminder_functions.php`

## Test plan

- [ ] Verify `js_escape()` output includes quotes (e.g., `js_escape("hello")` → `"hello"`)
- [ ] Verify alert/confirm dialogs display correctly with special characters (quotes, backslashes, angle brackets)
- [ ] Verify onclick handlers pass correct values to JS functions
- [ ] Verify maskkeyup/maskblur handlers work with NDC mask patterns
- [ ] Check no double-quoting in any context

Ref #11259