### PR TITLE
chore(crypto): replace mb_substr/mb_strlen with substr/strlen in binary operations

### DIFF
--- a/src/Common/Crypto/CryptoGen.php
+++ b/src/Common/Crypto/CryptoGen.php
@@ -79,7 +79,7 @@ class CryptoGen implements CryptoInterface
             $this->logger->error('Invalid encryption version prefix');
             return false;
         }
-        $trimmedValue = mb_substr($value, 3, null, '8bit');
+        $trimmedValue = substr($value, 3);
 
         if (!empty($minimumVersion)) {
             try {
@@ -213,9 +213,9 @@ class CryptoGen implements CryptoInterface
         }
 
         $ivLength = $this->getOpenSSLCipherIvLength('aes-256-cbc');
-        $hmacHash = mb_substr($raw, 0, 48, '8bit');
-        $iv = mb_substr($raw, 48, $ivLength, '8bit');
-        $encrypted_data = mb_substr($raw, ($ivLength + 48), null, '8bit');
+        $hmacHash = substr($raw, 0, 48);
+        $iv = substr($raw, 48, $ivLength);
+        $encrypted_data = substr($raw, $ivLength + 48);
 
         $calculatedHmacHash = $this->hashHmac('sha384', $iv . $encrypted_data, $sSecretKeyHmac, true);
 
@@ -264,9 +264,9 @@ class CryptoGen implements CryptoInterface
         }
 
         $ivLength = $this->getOpenSSLCipherIvLength('aes-256-cbc');
-        $hmacHash = mb_substr($raw, 0, 32, '8bit');
-        $iv = mb_substr($raw, 32, $ivLength, '8bit');
-        $encrypted_data = mb_substr($raw, ($ivLength + 32), null, '8bit');
+        $hmacHash = substr($raw, 0, 32);
+        $iv = substr($raw, 32, $ivLength);
+        $encrypted_data = substr($raw, $ivLength + 32);
 
         $calculatedHmacHash = $this->hashHmac('sha256', $iv . $encrypted_data, $sSecretKeyHmac, true);
 

--- a/src/Common/Crypto/PasswordBasedCrypto.php
+++ b/src/Common/Crypto/PasswordBasedCrypto.php
@@ -75,7 +75,7 @@ readonly class PasswordBasedCrypto
     ): string {
         $version = KeyVersion::fromPrefix($ciphertextWithVersion);
 
-        $ciphertext = mb_substr($ciphertextWithVersion, KeyVersion::PREFIX_LENGTH, null, '8bit');
+        $ciphertext = substr($ciphertextWithVersion, KeyVersion::PREFIX_LENGTH);
 
         $payload = base64_decode($ciphertext, true);
         if ($payload === false) {
@@ -88,7 +88,7 @@ readonly class PasswordBasedCrypto
             default => self::SALT_LENGTH + self::HMAC_LENGTH + self::IV_LENGTH + self::MIN_CIPHERTEXT_LENGTH,
         };
 
-        if (mb_strlen($payload, '8bit') < $minLength) {
+        if (strlen($payload) < $minLength) {
             throw new CryptoGenException('Ciphertext too short');
         }
 
@@ -106,8 +106,8 @@ readonly class PasswordBasedCrypto
         string $payload,
         #[SensitiveParameter] string $password,
     ): string {
-        $iv = mb_substr($payload, 0, self::IV_LENGTH, '8bit');
-        $encrypted = mb_substr($payload, self::IV_LENGTH, null, '8bit');
+        $iv = substr($payload, 0, self::IV_LENGTH);
+        $encrypted = substr($payload, self::IV_LENGTH);
 
         // V1 used sha256 hex as key (64 chars, OpenSSL truncates to 32 bytes)
         $key = hash('sha256', $password);
@@ -127,9 +127,9 @@ readonly class PasswordBasedCrypto
         string $payload,
         #[SensitiveParameter] string $password,
     ): string {
-        $hmac = mb_substr($payload, 0, self::V2_HMAC_LENGTH, '8bit');
-        $iv = mb_substr($payload, self::V2_HMAC_LENGTH, self::IV_LENGTH, '8bit');
-        $encrypted = mb_substr($payload, self::V2_HMAC_LENGTH + self::IV_LENGTH, null, '8bit');
+        $hmac = substr($payload, 0, self::V2_HMAC_LENGTH);
+        $iv = substr($payload, self::V2_HMAC_LENGTH, self::IV_LENGTH);
+        $encrypted = substr($payload, self::V2_HMAC_LENGTH + self::IV_LENGTH);
 
         $key = hash('sha256', $password, true);
 
@@ -155,14 +155,14 @@ readonly class PasswordBasedCrypto
         string $payload,
         #[SensitiveParameter] string $password,
     ): string {
-        $salt = mb_substr($payload, 0, self::SALT_LENGTH, '8bit');
-        $rest = mb_substr($payload, self::SALT_LENGTH, null, '8bit');
+        $salt = substr($payload, 0, self::SALT_LENGTH);
+        $rest = substr($payload, self::SALT_LENGTH);
 
         [$secretKey, $hmacKey] = $this->deriveKeys($password, $salt);
 
-        $hmac = mb_substr($rest, 0, self::HMAC_LENGTH, '8bit');
-        $iv = mb_substr($rest, self::HMAC_LENGTH, self::IV_LENGTH, '8bit');
-        $encrypted = mb_substr($rest, self::HMAC_LENGTH + self::IV_LENGTH, null, '8bit');
+        $hmac = substr($rest, 0, self::HMAC_LENGTH);
+        $iv = substr($rest, self::HMAC_LENGTH, self::IV_LENGTH);
+        $encrypted = substr($rest, self::HMAC_LENGTH + self::IV_LENGTH);
 
         $expectedHmac = hash_hmac(self::HASH_ALGO, $iv . $encrypted, $hmacKey, true);
         if (!hash_equals(known_string: $expectedHmac, user_string: $hmac)) {

--- a/src/Encryption/Cipher/Aes256CbcHmacSha256.php
+++ b/src/Encryption/Cipher/Aes256CbcHmacSha256.php
@@ -32,9 +32,9 @@ readonly class Aes256CbcHmacSha256 implements CipherInterface
     public function decrypt(Ciphertext $ciphertext): Plaintext
     {
         $ciphertext = $ciphertext->wrapped;
-        $hmac = mb_substr($ciphertext, 0, self::HMAC_LENGTH, '8bit');
-        $iv = mb_substr($ciphertext, self::HMAC_LENGTH, self::IV_LENGTH, '8bit');
-        $data = mb_substr($ciphertext, (self::HMAC_LENGTH + self::IV_LENGTH), null, '8bit');
+        $hmac = substr($ciphertext, 0, self::HMAC_LENGTH);
+        $iv = substr($ciphertext, self::HMAC_LENGTH, self::IV_LENGTH);
+        $data = substr($ciphertext, self::HMAC_LENGTH + self::IV_LENGTH);
 
         $expectedHmac = hash_hmac('sha256', $iv . $data, $this->hmacKey->key, true);
         if (!hash_equals(known_string: $expectedHmac, user_string: $hmac)) {

--- a/src/Encryption/Cipher/Aes256CbcHmacSha384.php
+++ b/src/Encryption/Cipher/Aes256CbcHmacSha384.php
@@ -29,9 +29,9 @@ readonly class Aes256CbcHmacSha384 implements CipherInterface
     public function decrypt(Ciphertext $ciphertext): Plaintext
     {
         $ciphertext = $ciphertext->wrapped;
-        $hmac = mb_substr($ciphertext, 0, self::HMAC_LENGTH, '8bit');
-        $iv = mb_substr($ciphertext, self::HMAC_LENGTH, self::IV_LENGTH, '8bit');
-        $data = mb_substr($ciphertext, (self::HMAC_LENGTH + self::IV_LENGTH), null, '8bit');
+        $hmac = substr($ciphertext, 0, self::HMAC_LENGTH);
+        $iv = substr($ciphertext, self::HMAC_LENGTH, self::IV_LENGTH);
+        $data = substr($ciphertext, self::HMAC_LENGTH + self::IV_LENGTH);
 
         $expectedHmac = hash_hmac('sha384', $iv . $data, $this->hmacKey->key, true);
         if (!hash_equals(known_string: $expectedHmac, user_string: $hmac)) {


### PR DESCRIPTION
## Summary

- Replace all `mb_substr($x, ..., '8bit')` with `substr($x, ...)` in cryptographic code
- Replace `mb_strlen($x, '8bit')` with `strlen($x)`
- Affected files (25 call sites total):
  - `src/Common/Crypto/CryptoGen.php` (7 calls)
  - `src/Common/Crypto/PasswordBasedCrypto.php` (12 calls)
  - `src/Encryption/Cipher/Aes256CbcHmacSha256.php` (3 calls)
  - `src/Encryption/Cipher/Aes256CbcHmacSha384.php` (3 calls)

### Background

The `'8bit'` encoding parameter on `mb_substr()` was a workaround for PHP's `mbstring.func_overload` setting (deprecated in PHP 7.2, removed in PHP 8.0). Since OpenEMR requires PHP 8.2+, this is no longer a concern.

For binary/cryptographic operations, plain `substr()` and `strlen()` are the correct byte-safe functions. They clearly communicate the intent of operating on raw bytes rather than multibyte characters.

This addresses part 1 of #11140 (removing unnecessary `'8bit'` encoding params). Part 2 (auditing missing `mb_*` usage in user-facing text) is tracked separately due to larger scope.

Ref #11140

## Test plan

- [ ] Existing crypto unit tests pass (encryption/decryption roundtrip)
- [ ] PHPStan passes at level 10
- [ ] No behavioral change — `substr()` and `mb_substr(..., '8bit')` are functionally identical for binary data in PHP 8.2+