### PR TITLE
fix(oauth): guard against missing grant_type in token request

### DIFF
--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -1336,7 +1336,7 @@ class AuthorizationController
         // by the authorization grant flow.
         $code = $request->getParsedBody()['code'] ?? null;
         // grantType could be authorization_code, password or refresh_token.
-        $this->grantType = $request->getParsedBody()['grant_type'];
+        $this->grantType = $request->getParsedBody()['grant_type'] ?? '';
         $this->getSystemLogger()->debug("AuthorizationController->oauthAuthorizeToken() grant type received", ['grant_type' => $this->grantType]);
         if ($this->grantType === 'authorization_code') {
             // re-populate from saved session cache populated in authorizeUser().

--- a/tests/Tests/RestControllers/Authorization/AuthorizationControllerTest.php
+++ b/tests/Tests/RestControllers/Authorization/AuthorizationControllerTest.php
@@ -138,4 +138,16 @@ class AuthorizationControllerTest extends TestCase
         $response = $authorizationController->oauthAuthorizationFlow($request);
         $this->assertEquals(Response::HTTP_TEMPORARY_REDIRECT, $response->getStatusCode(), "Expected 407 location redirect");
     }
+
+    public function testOauthAuthorizeTokenMissingGrantType(): void
+    {
+        $request = HttpRestRequest::create('/oauth2/default/token', 'POST');
+        $session = $this->getMockSessionForRequest($request);
+        $request->setSession($session);
+        // Deliberately omit grant_type from the request body
+        $request->request->set('code', 'test_authorization_code');
+        $authorizationController = $this->getDefaultAuthorizationControllerForRequest($request);
+        $response = $authorizationController->oauthAuthorizeToken($request);
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), "Expected 400 Bad Request when grant_type is missing");
+    }
 }


### PR DESCRIPTION
## Summary

- Add null coalescing operator (`?? ''`) to `getParsedBody()['grant_type']` access in `AuthorizationController::oauthAuthorizeToken()`

### Background

The token endpoint accesses `$request->getParsedBody()['grant_type']` without null coalescing (line 1339), while the adjacent `code` key access (line 1337) correctly uses `?? null`. When `grant_type` is missing from the POST body, this causes:

1. PHP 8.x "Undefined array key" warning
2. A subsequent TypeError trying to assign `null` to the `string`-typed `$grantType` property

This is visible in the [demo server error log](https://demo.openemr.io/log/logPhp.txt).

With the `?? ''` default, the empty string safely fails all grant type comparisons (`=== 'authorization_code'`, `=== 'refresh_token'`, etc.), allowing the OAuth2 server to return the proper error response.

Ref #7598

## Test plan

- [ ] Send a POST to the token endpoint without `grant_type` — verify no PHP warning and proper OAuth2 error response
- [ ] Normal OAuth2 flows (authorization_code, refresh_token) continue to work