### PR TITLE
chore(database): rename Audit connection to NonAudited

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -35,12 +35,13 @@ return [
         $manager = new ConnectionManager();
         $opts = $c->get(DatabaseConnectionOptions::class);
 
-        // Audit connection: no middleware, used by EventAuditLogger
-        $manager->register(ConnectionType::Audit, fn () =>
-            DriverManager::getConnection($opts->toDbalParams()));
-
         // Main connection: middleware will be added here
         $manager->register(ConnectionType::Main, fn () =>
+            DriverManager::getConnection($opts->toDbalParams()));
+
+        // Audit connection: no middleware, used by EventAuditLogger and some
+        // application bootstrapping
+        $manager->register(ConnectionType::NonAudited, fn () =>
             DriverManager::getConnection($opts->toDbalParams()));
 
         return $manager;

--- a/src/Common/Database/ConnectionType.php
+++ b/src/Common/Database/ConnectionType.php
@@ -21,10 +21,11 @@ enum ConnectionType
      */
     case Main;
     /**
-     * Used during audit operations. Separate from the main because:
-     * - It enables offsite audit
-     * - It will not disrupt autoincrement ids from writing to the audit tables
+     * Used during audit operations and some application bootstrapping.
+     * Separate from the main connection because it:
+     * - Enables offsite audit
+     * - Will not disrupt autoincrement ids when writing to the audit tables
      * - Breaks a circular dependency when setting up auditing middleware
      */
-    case Audit;
+    case NonAudited;
 }

--- a/tests/Tests/Isolated/Common/Database/ConnectionManagerTest.php
+++ b/tests/Tests/Isolated/Common/Database/ConnectionManagerTest.php
@@ -61,13 +61,13 @@ class ConnectionManagerTest extends TestCase
         $auditConn = $this->createMock(Connection::class);
 
         $manager->register(ConnectionType::Main, fn() => $mainConn);
-        $manager->register(ConnectionType::Audit, fn() => $auditConn);
+        $manager->register(ConnectionType::NonAudited, fn() => $auditConn);
 
         self::assertSame($mainConn, $manager->get(ConnectionType::Main));
-        self::assertSame($auditConn, $manager->get(ConnectionType::Audit));
+        self::assertSame($auditConn, $manager->get(ConnectionType::NonAudited));
         self::assertNotSame(
             $manager->get(ConnectionType::Main),
-            $manager->get(ConnectionType::Audit)
+            $manager->get(ConnectionType::NonAudited)
         );
     }
 
@@ -78,10 +78,10 @@ class ConnectionManagerTest extends TestCase
         $mainConn = $this->createMock(Connection::class);
         $auditWasFetched = false;
 
-        $manager->register(ConnectionType::Audit, fn() => $auditConn);
+        $manager->register(ConnectionType::NonAudited, fn() => $auditConn);
         $manager->register(ConnectionType::Main, function () use ($manager, $mainConn, &$auditWasFetched) {
             // Simulate middleware setup that needs the audit connection
-            $manager->get(ConnectionType::Audit);
+            $manager->get(ConnectionType::NonAudited);
             $auditWasFetched = true;
             return $mainConn;
         });


### PR DESCRIPTION
#### Short description of what this changes or resolves:
The `Audit` case for the named connections in the DB refactor was named as such as it was intended for use by EventAuditLogger. In reality, there are some[^some] other places using the `noLog` family of SQL functions, which are operationally equivalent to how this connection will behave. While it's probably not necessary for all of them to use it, some do - especially in the earliest stages of the application lifecycle.

This changes the connection name to reflect that it's not exclusively for EventAuditLogger; it'll definitely be needed for reading key material from the database as well.

[^some]: 250+ :(

#### Changes proposed in this pull request:

Renamed `Audit` to `NonAudited` in ConnectionType enum

#### Was an AI assistant used? Yes / No
No