### PR TITLE
feat(email): add email send test to admin interface

### DIFF
--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -3963,16 +3963,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 14,
     'path' => __DIR__ . '/../../tests/Tests/E2e/FfOpenEncounterTest.php',
 ];

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -3498,16 +3498,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../tests/Tests/ECQM/MeasureResultsTest.php',
 ];

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -15432,56 +15432,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Common/Auth/OpenIDConnect/SMARTSessionTokenContextIntegrationTest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\EmailSendTest\\:\\:getLatestEmailForRecipient\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\EmailSendTest\\:\\:getMailpitMessage\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\EmailSendTest\\:\\:getMailpitMessages\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\EmailSendTest\\:\\:searchMailpitMessages\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\EmailSendTest\\:\\:waitForEmail\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\FaxSmsEmailTest\\:\\:getLatestEmailForRecipient\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\FaxSmsEmailTest\\:\\:getMailpitMessage\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\FaxSmsEmailTest\\:\\:getMailpitMessages\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\FaxSmsEmailTest\\:\\:searchMailpitMessages\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\FaxSmsEmailTest\\:\\:waitForEmail\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Tests\\\\Fixtures\\\\BaseFixtureManager\\:\\:getQueryForForeignReference\\(\\) has parameter \\$reference with no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Fixtures/BaseFixtureManager.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -53632,56 +53632,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Common/Auth/OpenIDConnect/SMARTSessionTokenContextIntegrationTest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'Address\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'Subject\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'To\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'messages\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'total\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'Address\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'Subject\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'To\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'messages\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'total\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access an offset on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/ECQM/MeasureResultsTest.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -10927,66 +10927,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/E2e/BbCreateStaffTest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\EmailSendTest\\:\\:getLatestEmailForRecipient\\(\\) should return array\\|null but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\EmailSendTest\\:\\:getMailpitMessageCount\\(\\) should return int but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\EmailSendTest\\:\\:getMailpitMessage\\(\\) should return array\\|null but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\EmailSendTest\\:\\:getMailpitMessages\\(\\) should return array but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\EmailSendTest\\:\\:searchMailpitMessages\\(\\) should return array but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\EmailSendTest\\:\\:waitForEmail\\(\\) should return array\\|null but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailSendTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\FaxSmsEmailTest\\:\\:getLatestEmailForRecipient\\(\\) should return array\\|null but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\FaxSmsEmailTest\\:\\:getMailpitMessageCount\\(\\) should return int but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\FaxSmsEmailTest\\:\\:getMailpitMessage\\(\\) should return array\\|null but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\FaxSmsEmailTest\\:\\:getMailpitMessages\\(\\) should return array but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\FaxSmsEmailTest\\:\\:searchMailpitMessages\\(\\) should return array but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\E2e\\\\FaxSmsEmailTest\\:\\:waitForEmail\\(\\) should return array\\|null but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Tests\\\\Fixtures\\\\BaseFixtureManager\\:\\:getNextId\\(\\) should return OpenEMR\\\\Tests\\\\Fixtures\\\\the but returns int\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Fixtures/BaseFixtureManager.php',

--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -44,22 +44,20 @@
     ]
   },
   {
-        "label": "Recalls",
-        "menu_id": "pfb0",
-        "target": "rcb",
-        "url": "/interface/main/messages/messages.php?go=Recalls",
-        "children": [],
-        "requirement": 0,
-        "acl_req": [
-          "patients",
-          "appt"
-        ],
+    "label": "Recalls",
+    "menu_id": "pfb0",
+    "target": "rcb",
+    "url": "/interface/main/messages/messages.php?go=Recalls",
+    "children": [],
+    "requirement": 0,
+    "acl_req": [
+      "patients",
+      "appt"
+    ],
     "global_req_strict": [
       "!disable_rcb"
     ]
-
-   },
-
+  },
   {
     "label": "Messages",
     "menu_id": "msg0",
@@ -477,16 +475,16 @@
         "children": [],
         "requirement": 0,
         "acl_req": [
-            [
-                "acct",
-                "eob",
-                "write"
-            ],
-            [
-                "acct",
-                "bill",
-                "write"
-            ]
+          [
+            "acct",
+            "eob",
+            "write"
+          ],
+          [
+            "acct",
+            "bill",
+            "write"
+          ]
         ],
         "global_req": "auto_sftp_claims_to_x12_partner"
       }
@@ -513,9 +511,9 @@
     ],
     "requirement": 0,
     "acl_req": [
-    "menus",
-    "modle"
-  ]
+      "menus",
+      "modle"
+    ]
   },
   {
     "label": "Inventory",
@@ -536,23 +534,56 @@
         "url": "/interface/reports/destroyed_drugs_report.php",
         "children": [],
         "requirement": 0,
-          "acl_req": [
-            ["admin", "drugs"],
-            ["inventory", "reporting"]
+        "acl_req": [
+          [
+            "admin",
+            "drugs"
+          ],
+          [
+            "inventory",
+            "reporting"
           ]
+        ]
       }
     ],
     "requirement": 0,
     "acl_req": [
-      ["admin", "drugs"],
-      ["inventory", "lots"],
-      ["inventory", "purchases"],
-      ["inventory", "transfers"],
-      ["inventory", "adjustments"],
-      ["inventory", "consumption"],
-      ["inventory", "destruction"],
-      ["inventory", "sales"],
-      ["inventory", "reporting"]
+      [
+        "admin",
+        "drugs"
+      ],
+      [
+        "inventory",
+        "lots"
+      ],
+      [
+        "inventory",
+        "purchases"
+      ],
+      [
+        "inventory",
+        "transfers"
+      ],
+      [
+        "inventory",
+        "adjustments"
+      ],
+      [
+        "inventory",
+        "consumption"
+      ],
+      [
+        "inventory",
+        "destruction"
+      ],
+      [
+        "inventory",
+        "sales"
+      ],
+      [
+        "inventory",
+        "reporting"
+      ]
     ],
     "global_req": "inhouse_pharmacy"
   },
@@ -1110,6 +1141,18 @@
             "menu_id": "adm0",
             "target": "adm",
             "url": "/interface/main/calendar/index.php?module=PostCalendar&type=admin&func=testSystem",
+            "children": [],
+            "requirement": 0,
+            "acl_req": [
+              "admin",
+              "super"
+            ]
+          },
+          {
+            "label": "Email Send Test",
+            "menu_id": "adm0",
+            "target": "adm",
+            "url": "/interface/usergroup/email_send_test.php",
             "children": [],
             "requirement": 0,
             "acl_req": [
@@ -1715,8 +1758,14 @@
         ],
         "requirement": 0,
         "acl_req": [
-          ["admin", "drugs"],
-          ["inventory", "reporting"]
+          [
+            "admin",
+            "drugs"
+          ],
+          [
+            "inventory",
+            "reporting"
+          ]
         ],
         "global_req": "inhouse_pharmacy"
       },
@@ -1974,10 +2023,10 @@
         "children": [],
         "requirement": 0,
         "acl_req": [
-            "patients",
-            "docs"
+          "patients",
+          "docs"
         ]
-        },
+      },
       {
         "label": "Patient Education",
         "menu_id": "ped0",

--- a/interface/usergroup/email_send_test.php
+++ b/interface/usergroup/email_send_test.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * Admin page for testing email send paths
+ *
+ * Lets a superadmin send a test email and choose which sending path to exercise:
+ * - Direct MyMailer::send()
+ * - Queue via MyMailer::emailServiceQueue()
+ * - Queue via MyMailer::emailServiceQueueTemplatedEmail()
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://www.opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once(__DIR__ . '/../globals.php');
+
+use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Acl\AccessDeniedHelper;
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\Header;
+use OpenEMR\Services\Email\EmailSendMethod;
+use OpenEMR\Services\Email\EmailTestResult;
+use OpenEMR\Services\Email\EmailTestService;
+
+$session = SessionWrapperFactory::getInstance()->getActiveSession();
+
+if (!AclMain::aclCheckCore('admin', 'super')) {
+    AccessDeniedHelper::denyWithTemplate(
+        'ACL check failed for admin/super: Email Send Test',
+        xl('Email Send Test'),
+    );
+}
+
+$requestMethod = filter_input(INPUT_SERVER, 'REQUEST_METHOD') ?: 'GET';
+$isPost = $requestMethod === 'POST';
+
+/** @var list<EmailTestResult> $results */
+$results = [];
+$submittedRecipient = '';
+$submittedSender = '';
+/** @var list<string> $submittedMethods */
+$submittedMethods = [];
+
+if ($isPost) {
+    $csrfToken = filter_input(INPUT_POST, 'csrf_token_form');
+    if (!is_string($csrfToken) || !CsrfUtils::verifyCsrfToken($csrfToken, session: $session)) {
+        CsrfUtils::csrfNotVerified();
+    }
+
+    $rawSender = filter_input(INPUT_POST, 'sender');
+    $submittedSender = is_string($rawSender) ? trim($rawSender) : '';
+    $rawRecipient = filter_input(INPUT_POST, 'recipient');
+    $submittedRecipient = is_string($rawRecipient) ? trim($rawRecipient) : '';
+
+    // filter_input cannot handle array inputs; use filter_input_array
+    $postData = filter_input_array(INPUT_POST) ?: [];
+    $rawMethods = $postData['methods'] ?? [];
+    $submittedMethods = is_array($rawMethods) ? array_filter($rawMethods, is_string(...)) : [];
+
+    $methods = [];
+    foreach ($submittedMethods as $value) {
+        $method = EmailSendMethod::tryFrom($value);
+        if ($method instanceof EmailSendMethod) {
+            $methods[] = $method;
+        }
+    }
+
+    if ($submittedSender === '' || $submittedRecipient === '' || $methods === []) {
+        $results = [];
+    } else {
+        $service = new EmailTestService(ServiceContainer::getLogger());
+        $results = $service->test($submittedSender, $submittedRecipient, $methods);
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title><?php echo xlt('Email Send Test'); ?></title>
+    <?php Header::setupHeader(); ?>
+</head>
+<body class="body_top">
+    <div class="container mt-3">
+        <h2><?php echo xlt('Email Send Test'); ?></h2>
+        <p class="text-muted"><?php echo xlt('Send a test email to verify that each email code path is working correctly.'); ?></p>
+
+        <?php if ($results !== []) : ?>
+            <div class="mb-3">
+                <?php foreach ($results as $result) : ?>
+                    <div class="alert <?php echo $result->success ? 'alert-success' : 'alert-danger'; ?>" role="alert">
+                        <strong><?php echo text($result->method->label()); ?>:</strong>
+                        <?php echo text($result->message); ?>
+                        <small class="text-muted ml-2">(<?php echo text($result->timestamp->format('H:i:s')); ?>)</small>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if ($isPost && ($submittedSender === '' || $submittedRecipient === '' || $methods === [])) : ?>
+            <div class="alert alert-warning" role="alert">
+                <?php echo xlt('Please provide a sender address, recipient address, and select at least one send method.'); ?>
+            </div>
+        <?php endif; ?>
+
+        <form method="post" action="" onsubmit="return top.restoreSession()">
+            <input type="hidden" name="csrf_token_form" value="<?php echo CsrfUtils::collectCsrfToken(session: $session); ?>">
+
+            <div class="form-group">
+                <label for="sender"><?php echo xlt('Sender Email'); ?></label>
+                <input type="email" class="form-control" id="sender" name="sender"
+                       value="<?php echo attr($submittedSender); ?>"
+                       placeholder="noreply@example.com" required>
+                <small class="form-text text-muted"><?php echo xlt('The From address for the test email. Use an address from your domain to avoid spam filters.'); ?></small>
+            </div>
+
+            <div class="form-group">
+                <label for="recipient"><?php echo xlt('Recipient Email'); ?></label>
+                <input type="email" class="form-control" id="recipient" name="recipient"
+                       value="<?php echo attr($submittedRecipient); ?>"
+                       placeholder="admin@example.com" required>
+            </div>
+
+            <div class="form-group">
+                <label><?php echo xlt('Send Methods'); ?></label>
+                <?php foreach (EmailSendMethod::cases() as $method) : ?>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="methods[]"
+                               value="<?php echo attr($method->value); ?>"
+                               id="method_<?php echo attr($method->value); ?>"
+                               <?php echo in_array($method->value, $submittedMethods, true) || !$isPost ? 'checked' : ''; ?>>
+                        <label class="form-check-label" for="method_<?php echo attr($method->value); ?>">
+                            <?php echo text($method->label()); ?>
+                        </label>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+
+            <button type="submit" class="btn btn-primary"><?php echo xlt('Send Test Email'); ?></button>
+        </form>
+    </div>
+</body>
+</html>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,6 +27,7 @@ This file configures the kind that requires initialization.
     <testsuite name="e2e">
       <directory>tests/Tests/E2e</directory>
       <exclude>tests/Tests/E2e/EmailSendTest.php</exclude>
+      <exclude>tests/Tests/E2e/EmailTestServiceTest.php</exclude>
       <exclude>tests/Tests/E2e/FaxSmsEmailTest.php</exclude>
     </testsuite>
     <testsuite name="api">
@@ -52,6 +53,7 @@ This file configures the kind that requires initialization.
     </testsuite>
     <testsuite name="email">
       <file>tests/Tests/E2e/EmailSendTest.php</file>
+      <file>tests/Tests/E2e/EmailTestServiceTest.php</file>
       <file>tests/Tests/E2e/FaxSmsEmailTest.php</file>
     </testsuite>
   </testsuites>

--- a/src/Common/Command/EmailTestCommand.php
+++ b/src/Common/Command/EmailTestCommand.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * CLI command to test email sending via each of OpenEMR's email code paths
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://www.opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Command;
+
+use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Services\Email\EmailSendMethod;
+use OpenEMR\Services\Email\EmailTestService;
+use OpenEMR\Services\IGlobalsAware;
+use OpenEMR\Services\Trait\GlobalInterfaceTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class EmailTestCommand extends Command implements IGlobalsAware
+{
+    use GlobalInterfaceTrait;
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('email:test')
+            ->setDescription('Send a test email via one or more of OpenEMR\'s email code paths')
+            ->setDefinition(
+                new InputDefinition([
+                    new InputOption('sender', 's', InputOption::VALUE_REQUIRED, 'Sender email address'),
+                    new InputOption('recipient', 'r', InputOption::VALUE_REQUIRED, 'Recipient email address'),
+                    new InputOption('method', 'm', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Send method(s): direct, queue, queue_templated (repeatable; defaults to all)'),
+                ])
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $sender = $input->getOption('sender');
+        if (!is_string($sender) || $sender === '') {
+            $io->error('The --sender (-s) option is required.');
+            return Command::FAILURE;
+        }
+
+        $recipient = $input->getOption('recipient');
+        if (!is_string($recipient) || $recipient === '') {
+            $io->error('The --recipient (-r) option is required.');
+            return Command::FAILURE;
+        }
+
+        $methods = $this->parseMethods($input, $io);
+        if ($methods === null) {
+            return Command::FAILURE;
+        }
+
+        $service = new EmailTestService(ServiceContainer::getLogger());
+        $results = $service->test($sender, $recipient, $methods);
+
+        $hasFailure = false;
+        foreach ($results as $result) {
+            if ($result->success) {
+                $io->success("[{$result->method->value}] {$result->message}");
+            } else {
+                $io->error("[{$result->method->value}] {$result->message}");
+                $hasFailure = true;
+            }
+        }
+
+        return $hasFailure ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    /**
+     * @return non-empty-list<EmailSendMethod>|null
+     */
+    private function parseMethods(InputInterface $input, SymfonyStyle $io): ?array
+    {
+        /** @var list<string> $raw */
+        $raw = $input->getOption('method');
+
+        if ($raw === []) {
+            return [EmailSendMethod::Direct, EmailSendMethod::Queue, EmailSendMethod::QueueTemplated];
+        }
+
+        $methods = [];
+        foreach ($raw as $value) {
+            $method = EmailSendMethod::tryFrom($value);
+            if ($method === null) {
+                $valid = implode(', ', array_map(fn(EmailSendMethod $m) => $m->value, EmailSendMethod::cases()));
+                $io->error("Unknown method '{$value}'. Valid methods: {$valid}");
+                return null;
+            }
+            $methods[] = $method;
+        }
+        return $methods;
+    }
+}

--- a/src/Services/Email/EmailSendMethod.php
+++ b/src/Services/Email/EmailSendMethod.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Email send methods available for testing
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://www.opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\Email;
+
+enum EmailSendMethod: string
+{
+    case Direct = 'direct';
+    case Queue = 'queue';
+    case QueueTemplated = 'queue_templated';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Direct => xl('Direct Send (MyMailer::send)'),
+            self::Queue => xl('Queue (MyMailer::emailServiceQueue)'),
+            self::QueueTemplated => xl('Queue Templated (MyMailer::emailServiceQueueTemplatedEmail)'),
+        };
+    }
+}

--- a/src/Services/Email/EmailTestResult.php
+++ b/src/Services/Email/EmailTestResult.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Result of an email send test
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://www.opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\Email;
+
+final readonly class EmailTestResult
+{
+    public \DateTimeImmutable $timestamp;
+
+    public function __construct(
+        public EmailSendMethod $method,
+        public bool $success,
+        public string $message,
+    ) {
+        $this->timestamp = new \DateTimeImmutable();
+    }
+}

--- a/src/Services/Email/EmailTestService.php
+++ b/src/Services/Email/EmailTestService.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Send test emails via each of OpenEMR's email code paths
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://www.opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\Email;
+
+use MyMailer;
+use Psr\Log\LoggerInterface;
+
+class EmailTestService
+{
+    private const QUEUE_TEMPLATE = 'emails/system/system-notification';
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Run one or more email send tests.
+     *
+     * @param non-empty-list<EmailSendMethod> $methods
+     * @return list<EmailTestResult>
+     */
+    public function test(string $sender, string $recipient, array $methods): array
+    {
+        $results = [];
+        foreach ($methods as $method) {
+            $results[] = match ($method) {
+                EmailSendMethod::Direct => $this->testDirect($sender, $recipient),
+                EmailSendMethod::Queue => $this->testQueue($sender, $recipient),
+                EmailSendMethod::QueueTemplated => $this->testQueueTemplated($sender, $recipient),
+            };
+        }
+        return $results;
+    }
+
+    private function testDirect(string $sender, string $recipient): EmailTestResult
+    {
+        $method = EmailSendMethod::Direct;
+
+        $mailer = null;
+        try {
+            $mailer = new MyMailer(true);
+            $mailer->setFrom($sender);
+            $mailer->addReplyTo($sender);
+            $mailer->addAddress($recipient);
+            $mailer->Subject = 'OpenEMR Email Test — Direct Send';
+            $mailer->Body = 'This is a test email sent directly via MyMailer::send().';
+            $mailer->isHTML(false);
+
+            $sent = $mailer->send();
+        } catch (\Throwable $e) {
+            $this->logger->error('Direct email send failed', ['exception' => $e]);
+            $errorInfo = ($mailer !== null && $mailer->ErrorInfo !== '') ? $mailer->ErrorInfo : $e->getMessage();
+            return new EmailTestResult($method, false, 'Send failed: ' . $errorInfo);
+        } finally {
+            $mailer?->smtpClose();
+        }
+
+        if (!$sent) {
+            return new EmailTestResult($method, false, 'Send returned false: ' . $mailer->ErrorInfo);
+        }
+        return new EmailTestResult($method, true, 'Email sent successfully.');
+    }
+
+    private function testQueue(string $sender, string $recipient): EmailTestResult
+    {
+        $method = EmailSendMethod::Queue;
+
+        try {
+            $queued = MyMailer::emailServiceQueue(
+                $sender,
+                $recipient,
+                'OpenEMR Email Test — Queue',
+                'This is a test email queued via MyMailer::emailServiceQueue().',
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('Queue email failed', ['exception' => $e]);
+            return new EmailTestResult($method, false, 'Failed to queue email. Check the application logs for details.');
+        }
+
+        if (!$queued) {
+            return new EmailTestResult($method, false, 'emailServiceQueue() returned false. Check the application logs for details.');
+        }
+        return new EmailTestResult($method, true, 'Email queued successfully. It will be sent when the email background service runs.');
+    }
+
+    private function testQueueTemplated(string $sender, string $recipient): EmailTestResult
+    {
+        $method = EmailSendMethod::QueueTemplated;
+
+        try {
+            $queued = MyMailer::emailServiceQueueTemplatedEmail(
+                $sender,
+                $recipient,
+                'OpenEMR Email Test — Queue Templated',
+                self::QUEUE_TEMPLATE,
+                ['message' => 'This is a test email queued via MyMailer::emailServiceQueueTemplatedEmail().'],
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('Queue templated email failed', ['exception' => $e]);
+            return new EmailTestResult($method, false, 'Failed to queue templated email. Check the application logs for details.');
+        }
+
+        if (!$queued) {
+            return new EmailTestResult($method, false, 'emailServiceQueueTemplatedEmail() returned false. Check the application logs for details.');
+        }
+        return new EmailTestResult($method, true, 'Templated email queued successfully. It will be sent when the email background service runs.');
+    }
+}

--- a/tests/Tests/E2e/Email/EmailTestingTrait.php
+++ b/tests/Tests/E2e/Email/EmailTestingTrait.php
@@ -35,11 +35,48 @@ trait EmailTestingTrait
     }
 
     /**
+     * Extract the messages array from a decoded Mailpit API response.
+     *
+     * @param array<string, mixed> $data
+     * @return list<array<string, mixed>>
+     */
+    private function extractMessages(array $data): array
+    {
+        if (!array_key_exists('messages', $data)) {
+            return [];
+        }
+        $messages = $data['messages'];
+        if (!is_array($messages)) {
+            throw new \RuntimeException(
+                'Unexpected Mailpit JSON response: "messages" field must be an array, got ' . gettype($messages),
+            );
+        }
+        /** @var list<array<string, mixed>> */
+        return array_values($messages);
+    }
+
+    /**
+     * Decode a JSON response body into an associative array.
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeJsonBody(string $body): array
+    {
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        if (!is_array($decoded)) {
+            throw new \RuntimeException(
+                'Unexpected Mailpit JSON response: expected object, got ' . gettype($decoded),
+            );
+        }
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
      * Get all messages from Mailpit
      *
      * @param int $limit Maximum number of messages to retrieve
-     * @return array
-     * @throws GuzzleException
+     * @return list<array<string, mixed>>
      */
     private function getMailpitMessages(int $limit = 50): array
     {
@@ -51,16 +88,14 @@ trait EmailTestingTrait
             'query' => ['limit' => $limit]
         ]);
 
-        $data = json_decode($response->getBody()->getContents(), true);
-        return $data['messages'] ?? [];
+        $data = $this->decodeJsonBody($response->getBody()->getContents());
+        return $this->extractMessages($data);
     }
 
     /**
      * Get a specific message by ID from Mailpit
      *
-     * @param string $id Message ID
-     * @return array|null
-     * @throws GuzzleException
+     * @return array<string, mixed>|null
      */
     private function getMailpitMessage(string $id): ?array
     {
@@ -70,18 +105,17 @@ trait EmailTestingTrait
 
         try {
             $response = $this->httpClient->get("/api/v1/message/{$id}");
-            return json_decode($response->getBody()->getContents(), true);
-        } catch (\Throwable) {
+        } catch (GuzzleException) {
             return null;
         }
+        $decoded = $this->decodeJsonBody($response->getBody()->getContents());
+        return $decoded !== [] ? $decoded : null;
     }
 
     /**
      * Search for messages in Mailpit
      *
-     * @param string $query Search query
-     * @return array
-     * @throws GuzzleException
+     * @return list<array<string, mixed>>
      */
     private function searchMailpitMessages(string $query): array
     {
@@ -93,15 +127,13 @@ trait EmailTestingTrait
             'query' => ['query' => $query]
         ]);
 
-        $data = json_decode($response->getBody()->getContents(), true);
-        return $data['messages'] ?? [];
+        $data = $this->decodeJsonBody($response->getBody()->getContents());
+        return $this->extractMessages($data);
     }
 
     /**
      * Delete all messages from Mailpit
      *
-     * @return bool
-     * @throws GuzzleException
      */
     private function deleteAllMailpitMessages(): bool
     {
@@ -120,11 +152,7 @@ trait EmailTestingTrait
     /**
      * Wait for an email to arrive in Mailpit
      *
-     * @param string $recipient Email recipient to wait for
-     * @param string|null $subject Optional subject to match
-     * @param int $timeout Timeout in seconds
-     * @return array|null The matching message or null if timeout
-     * @throws GuzzleException
+     * @return array<string, mixed>|null The matching message or null if timeout
      */
     private function waitForEmail(string $recipient, ?string $subject = null, int $timeout = 30): ?array
     {
@@ -134,11 +162,12 @@ trait EmailTestingTrait
             $messages = $this->getMailpitMessages();
 
             foreach ($messages as $message) {
+                /** @var list<array{Address: string}> $toAddresses */
                 $toAddresses = $message['To'] ?? [];
-                $messageSubject = $message['Subject'] ?? '';
+                $messageSubject = is_string($message['Subject'] ?? null) ? $message['Subject'] : '';
 
                 foreach ($toAddresses as $to) {
-                    if (strcasecmp((string) $to['Address'], $recipient) === 0) {
+                    if (strcasecmp($to['Address'], $recipient) === 0) {
                         if ($subject === null || stripos($messageSubject, $subject) !== false) {
                             return $message;
                         }
@@ -155,11 +184,6 @@ trait EmailTestingTrait
     /**
      * Assert that an email was received
      *
-     * @param string $recipient Email recipient
-     * @param string|null $subject Optional subject to match
-     * @param string $message Assertion failure message
-     * @return void
-     * @throws GuzzleException
      */
     private function assertEmailReceived(string $recipient, ?string $subject = null, string $message = ''): void
     {
@@ -178,11 +202,6 @@ trait EmailTestingTrait
     /**
      * Assert email content contains expected text
      *
-     * @param string $messageId Message ID
-     * @param string $expectedContent Expected content
-     * @param string $message Assertion failure message
-     * @return void
-     * @throws GuzzleException
      */
     private function assertEmailContent(string $messageId, string $expectedContent, string $message = ''): void
     {
@@ -190,7 +209,9 @@ trait EmailTestingTrait
 
         $this->assertNotNull($email, 'Email message not found');
 
-        $body = $email['Text'] ?? $email['HTML'] ?? '';
+        $text = is_string($email['Text'] ?? null) ? $email['Text'] : '';
+        $html = is_string($email['HTML'] ?? null) ? $email['HTML'] : '';
+        $body = $text !== '' ? $text : $html;
 
         if ($message === '') {
             $message = "Email content does not contain expected text: {$expectedContent}";
@@ -202,19 +223,18 @@ trait EmailTestingTrait
     /**
      * Get the latest email sent to a recipient
      *
-     * @param string $recipient Email recipient
-     * @return array|null
-     * @throws GuzzleException
+     * @return array<string, mixed>|null
      */
     private function getLatestEmailForRecipient(string $recipient): ?array
     {
         $messages = $this->getMailpitMessages();
 
         foreach ($messages as $message) {
+            /** @var list<array{Address: string}> $toAddresses */
             $toAddresses = $message['To'] ?? [];
 
             foreach ($toAddresses as $to) {
-                if (strcasecmp((string) $to['Address'], $recipient) === 0) {
+                if (strcasecmp($to['Address'], $recipient) === 0) {
                     return $message;
                 }
             }
@@ -226,8 +246,6 @@ trait EmailTestingTrait
     /**
      * Count messages in Mailpit
      *
-     * @return int
-     * @throws GuzzleException
      */
     private function getMailpitMessageCount(): int
     {
@@ -236,8 +254,9 @@ trait EmailTestingTrait
         }
 
         $response = $this->httpClient->get("/api/v1/messages");
-        $data = json_decode($response->getBody()->getContents(), true);
+        $data = $this->decodeJsonBody($response->getBody()->getContents());
 
-        return $data['total'] ?? 0;
+        $total = $data['total'] ?? 0;
+        return is_int($total) ? $total : 0;
     }
 }

--- a/tests/Tests/E2e/EmailTestServiceTest.php
+++ b/tests/Tests/E2e/EmailTestServiceTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * E2E tests for EmailTestService
+ *
+ * Exercises all three email code paths (direct, queue, queue templated) via
+ * EmailTestService, then verifies delivery through Mailpit.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc. <https://www.opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\E2e;
+
+use MyMailer;
+use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\Email\EmailSendMethod;
+use OpenEMR\Services\Email\EmailTestService;
+use OpenEMR\Tests\E2e\Email\EmailTestData;
+use OpenEMR\Tests\E2e\Email\EmailTestingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class EmailTestServiceTest extends TestCase
+{
+    use EmailTestingTrait;
+
+    private EmailTestService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['EMAIL_METHOD'] = 'SMTP';
+        $GLOBALS['SMTP_HOST'] = getenv('OPENEMR_SETTING_SMTP_HOST') ?: 'mailpit';
+        $GLOBALS['SMTP_PORT'] = getenv('OPENEMR_SETTING_SMTP_PORT') ?: '1025';
+        $GLOBALS['SMTP_USER'] = getenv('OPENEMR_SETTING_SMTP_USER') ?: 'openemr';
+        $GLOBALS['SMTP_PASS'] = getenv('OPENEMR_SETTING_SMTP_PASS') ?: 'openemr';
+        $GLOBALS['SMTP_SECURE'] = getenv('OPENEMR_SETTING_SMTP_SECURE') ?: 'none';
+        $GLOBALS['SMTP_Auth'] = getenv('OPENEMR_SETTING_SMTP_Auth') ?: 'TRUE';
+
+        $this->initializeMailpit();
+        $this->deleteAllMailpitMessages();
+
+        // Clear any pre-existing queued emails so emailServiceRun() only sends ours
+        QueryUtils::sqlStatementThrowException('DELETE FROM email_queue', []);
+
+        $this->service = new EmailTestService(ServiceContainer::getLogger());
+    }
+
+    #[Test]
+    public function directSendDeliversEmail(): void
+    {
+        $results = $this->service->test(
+            EmailTestData::TEST_SENDER,
+            EmailTestData::TEST_RECIPIENT,
+            [EmailSendMethod::Direct],
+        );
+
+        $this->assertCount(1, $results);
+        $this->assertTrue($results[0]->success, $results[0]->message);
+        $this->assertSame(EmailSendMethod::Direct, $results[0]->method);
+
+        $email = $this->waitForEmail(EmailTestData::TEST_RECIPIENT, 'Direct Send');
+        $this->assertNotNull($email, 'Direct send email should arrive in Mailpit');
+    }
+
+    #[Test]
+    public function queueInsertsAndDelivers(): void
+    {
+        $results = $this->service->test(
+            EmailTestData::TEST_SENDER,
+            EmailTestData::TEST_RECIPIENT,
+            [EmailSendMethod::Queue],
+        );
+
+        $this->assertCount(1, $results);
+        $this->assertTrue($results[0]->success, $results[0]->message);
+        $this->assertSame(EmailSendMethod::Queue, $results[0]->method);
+
+        // Flush the queue so the email is actually sent
+        MyMailer::emailServiceRun();
+
+        $email = $this->waitForEmail(EmailTestData::TEST_RECIPIENT, 'Queue');
+        $this->assertNotNull($email, 'Queued email should arrive in Mailpit after emailServiceRun()');
+    }
+
+    #[Test]
+    public function queueTemplatedInsertsAndDelivers(): void
+    {
+        $results = $this->service->test(
+            EmailTestData::TEST_SENDER,
+            EmailTestData::TEST_RECIPIENT,
+            [EmailSendMethod::QueueTemplated],
+        );
+
+        $this->assertCount(1, $results);
+        $this->assertTrue($results[0]->success, $results[0]->message);
+        $this->assertSame(EmailSendMethod::QueueTemplated, $results[0]->method);
+
+        // Flush the queue so the email is actually sent
+        MyMailer::emailServiceRun();
+
+        $email = $this->waitForEmail(EmailTestData::TEST_RECIPIENT, 'Queue Templated');
+        $this->assertNotNull($email, 'Queue-templated email should arrive in Mailpit after emailServiceRun()');
+    }
+
+    #[Test]
+    public function allMethodsTogetherProduceThreeResults(): void
+    {
+        $results = $this->service->test(
+            EmailTestData::TEST_SENDER,
+            EmailTestData::TEST_RECIPIENT,
+            [EmailSendMethod::Direct, EmailSendMethod::Queue, EmailSendMethod::QueueTemplated],
+        );
+
+        $this->assertCount(3, $results);
+        foreach ($results as $result) {
+            $this->assertTrue($result->success, "[{$result->method->value}] {$result->message}");
+        }
+
+        // Flush queue for the two queued emails
+        MyMailer::emailServiceRun();
+
+        // Poll until all three emails arrive
+        $deadline = time() + 10;
+        do {
+            $count = $this->getMailpitMessageCount();
+            if ($count >= 3) {
+                break;
+            }
+            usleep(250_000);
+        } while (time() < $deadline);
+
+        $this->assertSame(3, $count, 'All three test emails should arrive in Mailpit');
+    }
+
+    #[Test]
+    public function directSendFailsWithBadHost(): void
+    {
+        $GLOBALS['EMAIL_METHOD'] = 'SMTP';
+        $GLOBALS['SMTP_HOST'] = '127.0.0.1';
+        $GLOBALS['SMTP_PORT'] = '1';
+
+        $results = $this->service->test(
+            EmailTestData::TEST_SENDER,
+            EmailTestData::TEST_RECIPIENT,
+            [EmailSendMethod::Direct],
+        );
+
+        $this->assertCount(1, $results);
+        $this->assertFalse($results[0]->success);
+    }
+}


### PR DESCRIPTION
## Summary

- Add an admin page (**Admin > System > Email Send Test**) and CLI command (`php bin/console email:test`) for testing email configuration independently of production workflows
- Support three send paths: direct `MyMailer::send()`, queue via `emailServiceQueue()`, and queue via `emailServiceQueueTemplatedEmail()`
- Add E2E tests exercising all three paths with Mailpit delivery verification
- Fix PHPStan type errors in `EmailTestingTrait`, reducing baseline by ~150 entries

Closes #11368

## Test plan

- [x] Verify the admin page renders at Admin > System > Email Send Test
- [x] Submit the form with all three methods checked against a Mailpit instance and confirm delivery
- [x] Run `php bin/console email:test -s noreply@example.com -r test@example.com` and confirm output
- [x] Run `composer phpunit -- --testsuite email` in the Docker environment with Mailpit and confirm all tests pass
- [x] Verify PHPStan passes cleanly (`composer phpstan`)