### PR TITLE
fix(email): remove SMTP_SECURE from isConfigured required keys

### DIFF
--- a/library/classes/postmaster.php
+++ b/library/classes/postmaster.php
@@ -46,7 +46,7 @@ class MyMailer extends PHPMailer
     {
         $requiredKeys = [];
         if (OEGlobalsBag::getInstance()->get('EMAIL_METHOD') === "SMTP") {
-            $requiredKeys = ['SMTP_HOST', 'SMTP_PORT', 'SMTP_SECURE'];
+            $requiredKeys = ['SMTP_HOST', 'SMTP_PORT'];
             if (!empty(OEGlobalsBag::getInstance()->get('SMTP_Auth'))) {
                 $requiredKeys[] = 'SMTP_USER';
                 $requiredKeys[] = 'SMTP_PASS';


### PR DESCRIPTION
## Summary

- Remove `SMTP_SECURE` from the required keys in `MyMailer::isConfigured()` so that an empty string (meaning "no encryption") is treated as a valid configuration
- This fixes `emailServiceRun()` refusing to send queued emails in environments where SMTP encryption is intentionally disabled (e.g., local dev with Mailpit, internal SMTP relays)

Closes #11380

## Test plan

- [ ] Set `SMTP_SECURE` to empty string in Admin > Config > Notifications
- [ ] Verify `MyMailer::isConfigured()` returns `true`
- [ ] Queue a test email and confirm `emailServiceRun()` sends it