### PR TITLE
fix(menu): sync Custom.json with standard.json for email send test entry

### DIFF
--- a/sites/default/documents/custom_menus/Custom.json
+++ b/sites/default/documents/custom_menus/Custom.json
@@ -44,22 +44,20 @@
     ]
   },
   {
-        "label": "Recalls",
-        "menu_id": "pfb0",
-        "target": "rcb",
-        "url": "/interface/main/messages/messages.php?go=Recalls",
-        "children": [],
-        "requirement": 0,
-        "acl_req": [
-          "patients",
-          "appt"
-        ],
+    "label": "Recalls",
+    "menu_id": "pfb0",
+    "target": "rcb",
+    "url": "/interface/main/messages/messages.php?go=Recalls",
+    "children": [],
+    "requirement": 0,
+    "acl_req": [
+      "patients",
+      "appt"
+    ],
     "global_req_strict": [
       "!disable_rcb"
     ]
-
-   },
-
+  },
   {
     "label": "Messages",
     "menu_id": "msg0",
@@ -477,16 +475,16 @@
         "children": [],
         "requirement": 0,
         "acl_req": [
-            [
-                "acct",
-                "eob",
-                "write"
-            ],
-            [
-                "acct",
-                "bill",
-                "write"
-            ]
+          [
+            "acct",
+            "eob",
+            "write"
+          ],
+          [
+            "acct",
+            "bill",
+            "write"
+          ]
         ],
         "global_req": "auto_sftp_claims_to_x12_partner"
       }
@@ -513,9 +511,9 @@
     ],
     "requirement": 0,
     "acl_req": [
-    "menus",
-    "modle"
-  ]
+      "menus",
+      "modle"
+    ]
   },
   {
     "label": "Inventory",
@@ -536,23 +534,56 @@
         "url": "/interface/reports/destroyed_drugs_report.php",
         "children": [],
         "requirement": 0,
-          "acl_req": [
-            ["admin", "drugs"],
-            ["inventory", "reporting"]
+        "acl_req": [
+          [
+            "admin",
+            "drugs"
+          ],
+          [
+            "inventory",
+            "reporting"
           ]
+        ]
       }
     ],
     "requirement": 0,
     "acl_req": [
-      ["admin", "drugs"],
-      ["inventory", "lots"],
-      ["inventory", "purchases"],
-      ["inventory", "transfers"],
-      ["inventory", "adjustments"],
-      ["inventory", "consumption"],
-      ["inventory", "destruction"],
-      ["inventory", "sales"],
-      ["inventory", "reporting"]
+      [
+        "admin",
+        "drugs"
+      ],
+      [
+        "inventory",
+        "lots"
+      ],
+      [
+        "inventory",
+        "purchases"
+      ],
+      [
+        "inventory",
+        "transfers"
+      ],
+      [
+        "inventory",
+        "adjustments"
+      ],
+      [
+        "inventory",
+        "consumption"
+      ],
+      [
+        "inventory",
+        "destruction"
+      ],
+      [
+        "inventory",
+        "sales"
+      ],
+      [
+        "inventory",
+        "reporting"
+      ]
     ],
     "global_req": "inhouse_pharmacy"
   },
@@ -1110,6 +1141,18 @@
             "menu_id": "adm0",
             "target": "adm",
             "url": "/interface/main/calendar/index.php?module=PostCalendar&type=admin&func=testSystem",
+            "children": [],
+            "requirement": 0,
+            "acl_req": [
+              "admin",
+              "super"
+            ]
+          },
+          {
+            "label": "Email Send Test",
+            "menu_id": "adm0",
+            "target": "adm",
+            "url": "/interface/usergroup/email_send_test.php",
             "children": [],
             "requirement": 0,
             "acl_req": [
@@ -1715,8 +1758,14 @@
         ],
         "requirement": 0,
         "acl_req": [
-          ["admin", "drugs"],
-          ["inventory", "reporting"]
+          [
+            "admin",
+            "drugs"
+          ],
+          [
+            "inventory",
+            "reporting"
+          ]
         ],
         "global_req": "inhouse_pharmacy"
       },
@@ -1974,10 +2023,10 @@
         "children": [],
         "requirement": 0,
         "acl_req": [
-            "patients",
-            "docs"
+          "patients",
+          "docs"
         ]
-        },
+      },
       {
         "label": "Patient Education",
         "menu_id": "ped0",


### PR DESCRIPTION
## Summary

- Sync `sites/default/documents/custom_menus/Custom.json` with `standard.json` so installs using a custom menu role get the Email Send Test admin page

Closes #11382

## Test plan

- [ ] Select a custom menu role in Admin > Config and verify Email Send Test appears under Admin > System