### PR TITLE
refactor(config): replace encrypted more_secure globals with constants

### DIFF
--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -3498,11 +3498,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../sites/default/config.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 8,
     'path' => __DIR__ . '/../../sites/default/statement.inc.php',
 ];

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -2218,11 +2218,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../sites/default/config.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../sites/default/statement.inc.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -4807,11 +4807,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'hylafax_enscript\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'name\' on array\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
@@ -40012,11 +40007,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../sites/default/config.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'hylafax_enscript\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../sites/default/config.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'left\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../sites/default/config.php',
@@ -40049,11 +40039,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'prescriptions\' on mixed\\.$#',
     'count' => 4,
-    'path' => __DIR__ . '/../../sites/default/config.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'print_command\' on mixed\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../sites/default/config.php',
 ];
 $ignoreErrors[] = [
@@ -40098,11 +40083,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'use_signature\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../sites/default/config.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset mixed on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../sites/default/config.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenGlobalsAccess.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalsAccess.php
@@ -33,7 +33,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$GLOBALS is forbidden\\. Use OEGlobalsBag\\:\\:getInstance\\(\\)\\-\\>get\\(\\) instead\\.$#',
-    'count' => 32,
+    'count' => 27,
     'path' => __DIR__ . '/../../sites/default/config.php',
 ];
 

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -50,9 +50,8 @@ require_once("../globals.php");
 require_once("$srcdir/patient.inc.php");
 require_once("$srcdir/appointments.inc.php");
 require_once(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/statement.inc.php");
-// statement.inc.php sets $STMT_TEMP_FILE and $STMT_PRINT_CMD
+// statement.inc.php sets $STMT_TEMP_FILE
 assert(isset($STMT_TEMP_FILE));
-assert(isset($STMT_PRINT_CMD));
 require_once("$srcdir/api.inc.php");
 require_once("$srcdir/forms.inc.php");
 require_once("$srcdir/../controllers/C_Document.class.php");
@@ -629,7 +628,7 @@ if (
         if ($DEBUG) {
             $alertmsg = xl("Printing skipped; see test output in") . ' ' . $STMT_TEMP_FILE;
         } else {
-            exec(escapeshellcmd($STMT_PRINT_CMD) . " " . escapeshellarg((string) $STMT_TEMP_FILE));
+            exec(escapeshellcmd(OPENEMR_PRINT_COMMAND) . " " . escapeshellarg((string) $STMT_TEMP_FILE));
             if ($_REQUEST['form_without']) {
                 $alertmsg = xl('Now printing') . ' ' . $stmt_count . ' ' . xl('statements; invoices will not be updated.');
             } else {

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -19,7 +19,6 @@ require_once("$srcdir/forms.inc.php");
 require_once("$srcdir/options.inc.php");
 require_once("$srcdir/gprelations.inc.php");
 
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -313,7 +312,7 @@ if ($_POST['form_save']) {
         $cpstring = str_replace('{MESSAGE}', $form_message, $cpstring);
         fwrite($tmph, $cpstring);
         fclose($tmph);
-        $tmp0 = exec("cd " . escapeshellarg($webserver_root . '/custom') . "; " . escapeshellcmd((ServiceContainer::getCrypto())->decryptStandard(OEGlobalsBag::getInstance()->get('more_secure')['hylafax_enscript'])) .
+        $tmp0 = exec("cd " . escapeshellarg($webserver_root . '/custom') . "; " . escapeshellcmd(OPENEMR_HYLAFAX_ENSCRIPT) .
         " -o " . escapeshellarg($tmpfn2) . " " . escapeshellarg($tmpfn1), $tmp1, $tmp2);
         if ($tmp2) {
               $info_msg .= "enscript returned $tmp2: $tmp0 ";

--- a/sites/default/config.php
+++ b/sites/default/config.php
@@ -1,28 +1,16 @@
 <?php
 
-use OpenEMR\BC\ServiceContainer;
+// Print command for spooling to printers, used by statement.inc.php.
+// This is the command to be used for printing (without the filename).
+// The word following "-P" should be the name of your printer. This
+// example is designed for 8.5x11-inch paper with 1-inch margins,
+// 10 CPI, 6 LPI, 65 columns, 54 lines per page.
+// If lpr services are installed on Windows this setting will be similar.
+// Otherwise configure it as needed (print /d:PRN) might be an option for Windows parallel printers.
+const OPENEMR_PRINT_COMMAND = 'lpr -P HPLaserjet6P -o cpi=10 -o lpi=6 -o page-left=72 -o page-top=72';
 
-// globals that require more security
-//  The set of globals below can only be modified directly in this script (ie. can not be set while using OpenEMR) and
-//  they will be encrypted while stored in globals object in memory (to not allow overriding of the global if bad actor
-//  somehow gets access to globals).
-// note that need to skip this block of code during upgrading (or else will have database issues since no keys table)
-if (empty($GLOBALS['ongoing_sql_upgrade'])) {
-    $cryptoGen = ServiceContainer::getCrypto();
-    // Print command for spooling to printers, used by statements.inc.php
-    //   This is the command to be used for printing (without the filename).
-    //   The word following "-P" should be the name of your printer.  This
-    //   example is designed for 8.5x11-inch paper with 1-inch margins,
-    //   10 CPI, 6 LPI, 65 columns, 54 lines per page.
-    // If lpr services are installed on Windows this setting will be similar
-    //   Otherwise configure it as needed (print /d:PRN) might be an option for Windows parallel printers
-    $GLOBALS['more_secure']['print_command'] = 'lpr -P HPLaserjet6P -o cpi=10 -o lpi=6 -o page-left=72 -o page-top=72';
-    //Enscript command used by Hylafax.
-    $GLOBALS['more_secure']['hylafax_enscript'] = 'enscript -M Letter -B -e^ --margins=36:36:36:36';
-    foreach ($GLOBALS['more_secure'] as $key => $value) {
-        $GLOBALS['more_secure'][$key] = $cryptoGen->encryptStandard(is_string($value) ? $value : null);
-    }
-}
+// Enscript command used by HylaFAX (fax_dispatch.php).
+const OPENEMR_HYLAFAX_ENSCRIPT = 'enscript -M Letter -B -e^ --margins=36:36:36:36';
 
 //used differently by different applications, intuit programs only like numbers
 $GLOBALS['oer_config']['ofx']['bankid']     = "123456789";

--- a/sites/default/statement.inc.php
+++ b/sites/default/statement.inc.php
@@ -25,7 +25,6 @@
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 
 // The location/name of a temporary file to hold printable statements.
@@ -33,9 +32,6 @@ use OpenEMR\Core\OEGlobalsBag;
 
 $STMT_TEMP_FILE = OEGlobalsBag::getInstance()->getString('temporary_files_dir') . "/openemr_statements.txt";
 $STMT_TEMP_FILE_PDF = OEGlobalsBag::getInstance()->getString('temporary_files_dir') . "/openemr_statements.pdf";
-/** @var array{print_command?: string} $moreSecure */
-$moreSecure = OEGlobalsBag::getInstance()->get('more_secure');
-$STMT_PRINT_CMD = (ServiceContainer::getCrypto())->decryptStandard($moreSecure['print_command'] ?? null);
 
 /** There are two options to print a batch of PDF statements:
  *  1.  The original statement, a text based statement, using CezPDF


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #11403

Note: this is technically a very small BC break for the rare case of anyone both having customized `sites/{}/config.php` file in their installation AND using one of these paths, but it's far more more likely that other recent changes would have already caused snags. This will actually reduce the chance of future disruption.

#### Changes proposed in this pull request:

The `more_secure` mechanism in `config.php` encrypted shell commands (`print_command` for `lpr`, `hylafax_enscript` for fax) in memory to protect against runtime `$GLOBALS` manipulation.

This complexity is no longer necessary:
- The commands are hardcoded in `config.php` and not user-editable
- Simple constants provide the same protection with less overhead

This PR replaces the encrypted globals with simple constants:
- `OPENEMR_PRINT_COMMAND` - used by statement printing
- `OPENEMR_HYLAFAX_ENSCRIPT` - used by fax dispatch

Net result: -63 lines, no runtime encryption overhead, clearer code.

#### Was an AI assistant used? Yes

🤖 Generated with [Claude Code](https://claude.ai/code)