### PR TITLE
chore(cleanup): Sort functions in autoloaded function file

### DIFF
--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -139,6 +139,50 @@ function cron_GetNotificationSettings(): array|false
 }
 
 /**
+ * Get patient data for phone alert notifications.
+ *
+ * @param string $type The notification type ('Phone')
+ * @param int $trigger_hours Hours before appointment to trigger
+ * @return array Array of patient appointment data
+ */
+function cron_getPhoneAlertpatientData($type, $trigger_hours)
+{
+    $ssql = '';
+    $check_date = '';
+
+    // Added by Yijin 1/12/10 to handle phone reminders.
+    // Patient needs to have hipaa Voice flag set to yes and a home phone
+    if ($type == 'Phone') {
+        $ssql = " and pd.hipaa_voice='YES' and pd.phone_home<>'' and ope.pc_sendalertsms='NO' and ope.pc_apptstatus != '*' ";
+
+        $check_date = date("Y-m-d", mktime(date("H") + $trigger_hours, 0, 0, date("m"), date("d"), date("Y")));
+    }
+
+    $patient_field = "pd.pid,pd.title,pd.fname,pd.lname,pd.mname,pd.phone_cell,pd.email,pd.hipaa_allowsms,pd.hipaa_allowemail,pd.phone_home,pd.hipaa_voice,";
+    $ssql .= " and (ope.pc_eventDate=?)";
+
+    $query = "select $patient_field pd.pid,ope.pc_eid,ope.pc_pid,ope.pc_title,
+            ope.pc_hometext,ope.pc_eventDate,ope.pc_endDate,
+            ope.pc_duration,ope.pc_alldayevent,ope.pc_startTime,ope.pc_endTime,ope.pc_facility
+        from
+            openemr_postcalendar_events as ope ,patient_data as pd
+        where
+            ope.pc_pid=pd.pid $ssql
+        order by
+            ope.pc_eventDate,ope.pc_endDate,pd.pid";
+
+    $db_patient = (sqlStatement($query, [$check_date]));
+    $patient_array = [];
+    $cnt = 0;
+    while ($prow = sqlFetchArray($db_patient)) {
+        $patient_array[$cnt] = $prow;
+        $cnt++;
+    }
+
+    return $patient_array;
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -362,50 +406,6 @@ function hl7Date($s)
 function hl7Priority($s)
 {
     return strtoupper(substr((string) $s, 0, 1)) === 'H' ? 'S' : 'R';
-}
-
-/**
- * Get patient data for phone alert notifications.
- *
- * @param string $type The notification type ('Phone')
- * @param int $trigger_hours Hours before appointment to trigger
- * @return array Array of patient appointment data
- */
-function cron_getPhoneAlertpatientData($type, $trigger_hours)
-{
-    $ssql = '';
-    $check_date = '';
-
-    // Added by Yijin 1/12/10 to handle phone reminders.
-    // Patient needs to have hipaa Voice flag set to yes and a home phone
-    if ($type == 'Phone') {
-        $ssql = " and pd.hipaa_voice='YES' and pd.phone_home<>'' and ope.pc_sendalertsms='NO' and ope.pc_apptstatus != '*' ";
-
-        $check_date = date("Y-m-d", mktime(date("H") + $trigger_hours, 0, 0, date("m"), date("d"), date("Y")));
-    }
-
-    $patient_field = "pd.pid,pd.title,pd.fname,pd.lname,pd.mname,pd.phone_cell,pd.email,pd.hipaa_allowsms,pd.hipaa_allowemail,pd.phone_home,pd.hipaa_voice,";
-    $ssql .= " and (ope.pc_eventDate=?)";
-
-    $query = "select $patient_field pd.pid,ope.pc_eid,ope.pc_pid,ope.pc_title,
-            ope.pc_hometext,ope.pc_eventDate,ope.pc_endDate,
-            ope.pc_duration,ope.pc_alldayevent,ope.pc_startTime,ope.pc_endTime,ope.pc_facility
-        from
-            openemr_postcalendar_events as ope ,patient_data as pd
-        where
-            ope.pc_pid=pd.pid $ssql
-        order by
-            ope.pc_eventDate,ope.pc_endDate,pd.pid";
-
-    $db_patient = (sqlStatement($query, [$check_date]));
-    $patient_array = [];
-    $cnt = 0;
-    while ($prow = sqlFetchArray($db_patient)) {
-        $patient_array[$cnt] = $prow;
-        $cnt++;
-    }
-
-    return $patient_array;
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -283,6 +283,24 @@ function genEndRow(): void
 }
 
 /**
+ * Start an HTML table row for statistics reports.
+ *
+ * @param string $att HTML attributes for the row
+ * @return void
+ * @global int $cellcount Cell counter
+ * @global int $form_output Output format (3 = CSV)
+ */
+function genStartRow($att): void
+{
+    global $cellcount, $form_output;
+    if ($form_output != 3) {
+        echo " <tr $att>\n";
+    }
+
+    $cellcount = 0;
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -366,24 +384,6 @@ function PrintEncHeader($dt, $rsn, $dr): void
     echo "<td colspan='5'><span class='font-weight-bold'>" . xlt('Provider') . ": </span><span class='detail'>" . text(User_Id_Look($dr)) . "</span></td>";
     echo "</tr>\n";
     $orow++;
-}
-
-/**
- * Start an HTML table row for statistics reports.
- *
- * @param string $att HTML attributes for the row
- * @return void
- * @global int $cellcount Cell counter
- * @global int $form_output Output format (3 = CSV)
- */
-function genStartRow($att): void
-{
-    global $cellcount, $form_output;
-    if ($form_output != 3) {
-        echo " <tr $att>\n";
-    }
-
-    $cellcount = 0;
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -340,6 +340,20 @@ function getLayoutRes(bool $shortForm)
 }
 
 /**
+ * Get the UOR (Use, Optional, Required) value for a layout field.
+ *
+ * @param string $form_id The form ID
+ * @param string $field_id The field ID
+ * @return int The UOR value (0=unused, 1=optional, 2=required)
+ */
+function getLayoutUOR($form_id, $field_id)
+{
+    $crow = sqlQuery("SELECT uor FROM layout_options WHERE " .
+        "form_id = ? AND field_id = ? LIMIT 1", [$form_id, $field_id]);
+    return 0 + $crow['uor'];
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -759,18 +773,3 @@ function markTaxes($taxrates): void
         }
     }
 }
-
-/**
- * Get the UOR (Use, Optional, Required) value for a layout field.
- *
- * @param string $form_id The form ID
- * @param string $field_id The field ID
- * @return int The UOR value (0=unused, 1=optional, 2=required)
- */
-function getLayoutUOR($form_id, $field_id)
-{
-    $crow = sqlQuery("SELECT uor FROM layout_options WHERE " .
-        "form_id = ? AND field_id = ? LIMIT 1", [$form_id, $field_id]);
-    return 0 + $crow['uor'];
-}
-

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -354,6 +354,33 @@ function getLayoutUOR($form_id, $field_id)
 }
 
 /**
+ * Get a list item title, translating if required.
+ *
+ * @param  string $listid List identifier.
+ * @param  string $value List item identifier.
+ * @return string  The item's title.
+ */
+function getListItem($listid, $value)
+{
+    $title = QueryUtils::fetchSingleValue(
+        <<<'SQL'
+        SELECT title
+        FROM list_options
+        WHERE list_id = ? AND option_id = ? AND activity = 1
+        LIMIT 1
+        SQL,
+        'title',
+        [$listid, $value]
+    );
+    $tmp = xl_list_label($title);
+    if (empty($tmp)) {
+        $tmp = (($value === '') ? '' : "($value)");
+    }
+
+    return $tmp;
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -724,33 +751,6 @@ function myCellText($s)
     }
 
     return text($s);
-}
-
-/**
- * Get a list item title, translating if required.
- *
- * @param  string $listid List identifier.
- * @param  string $value List item identifier.
- * @return string  The item's title.
- */
-function getListItem($listid, $value)
-{
-    $title = QueryUtils::fetchSingleValue(
-        <<<'SQL'
-        SELECT title
-        FROM list_options
-        WHERE list_id = ? AND option_id = ? AND activity = 1
-        LIMIT 1
-        SQL,
-        'title',
-        [$listid, $value]
-    );
-    $tmp = xl_list_label($title);
-    if (empty($tmp)) {
-        $tmp = (($value === '') ? '' : "($value)");
-    }
-
-    return $tmp;
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -458,6 +458,21 @@ function hl7RelationWord(string $s): string
 }
 
 /**
+ * Convert sex/gender to HL7 format (M, F, or U).
+ *
+ * @param string $s The input sex value
+ * @return string M, F, or U
+ */
+function hl7Sex($s)
+{
+    $s = strtoupper(substr((string) $s, 0, 1));
+    if ($s !== 'M' && $s !== 'F') {
+        $s = 'U';
+    }
+    return $s;
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -660,21 +675,6 @@ function hl7Text($s)
 function hl7Zip($s)
 {
     return hl7Text(preg_replace('/[-\s]*/', '', (string) $s));
-}
-
-/**
- * Convert sex/gender to HL7 format (M, F, or U).
- *
- * @param string $s The input sex value
- * @return string M, F, or U
- */
-function hl7Sex($s)
-{
-    $s = strtoupper(substr((string) $s, 0, 1));
-    if ($s !== 'M' && $s !== 'F') {
-        $s = 'U';
-    }
-    return $s;
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -65,6 +65,18 @@ function cbcell($name, $desc, $colname): string
     return "<td width='25%' nowrap>" . cbinput($name, $colname) . text($desc) . "</td>\n";
 }
 
+function cbinput($name, $colname): string
+{
+    global $row;
+    $ret  = "<input type='checkbox' name='" . attr($name) . "' value='1'";
+    if ($row[$colname]) {
+        $ret .= " checked";
+    }
+
+    $ret .= " />";
+    return $ret;
+}
+
 /**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
@@ -608,18 +620,6 @@ function rbinput($name, $value, $desc, $colname): string
 function rbcell($name, $value, $desc, $colname): string
 {
     return "<td width='25%' nowrap>" . rbinput($name, $value, $desc, $colname) . "</td>\n";
-}
-
-function cbinput($name, $colname): string
-{
-    global $row;
-    $ret  = "<input type='checkbox' name='" . attr($name) . "' value='1'";
-    if ($row[$colname]) {
-        $ret .= " checked";
-    }
-
-    $ret .= " />";
-    return $ret;
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -392,6 +392,28 @@ function hl7Date($s)
 }
 
 /**
+ * Format a phone number for HL7.
+ *
+ * @param string $s The phone number string
+ * @param bool $formatted Whether to include formatting like (555)123-4567 or just digits
+ * @return string The formatted phone number, or empty string if invalid
+ */
+function hl7Phone($s, bool $formatted)
+{
+    if (preg_match("/([2-9]\d\d)\D*(\d\d\d)\D*(\d\d\d\d)\D*$/", (string) $s, $tmp)) {
+        return $formatted
+            ? '(' . $tmp[1] . ')' . $tmp[2] . '-' . $tmp[3]
+            : $tmp[1] . $tmp[2] . $tmp[3];
+    }
+    if (preg_match("/(\d\d\d)\D*(\d\d\d\d)\D*$/", (string) $s, $tmp)) {
+        return $formatted
+            ? $tmp[1] . '-' . $tmp[2]
+            : $tmp[1] . $tmp[2];
+    }
+    return '';
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -634,28 +656,6 @@ function hl7Time($s, bool $withSeconds)
     }
     $format = $withSeconds ? 'YmdHis' : 'YmdHi';
     return date($format, strtotime((string) $s));
-}
-
-/**
- * Format a phone number for HL7.
- *
- * @param string $s The phone number string
- * @param bool $formatted Whether to include formatting like (555)123-4567 or just digits
- * @return string The formatted phone number, or empty string if invalid
- */
-function hl7Phone($s, bool $formatted)
-{
-    if (preg_match("/([2-9]\d\d)\D*(\d\d\d)\D*(\d\d\d\d)\D*$/", (string) $s, $tmp)) {
-        return $formatted
-            ? '(' . $tmp[1] . ')' . $tmp[2] . '-' . $tmp[3]
-            : $tmp[1] . $tmp[2] . $tmp[3];
-    }
-    if (preg_match("/(\d\d\d)\D*(\d\d\d\d)\D*$/", (string) $s, $tmp)) {
-        return $formatted
-            ? $tmp[1] . '-' . $tmp[2]
-            : $tmp[1] . $tmp[2];
-    }
-    return '';
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -652,6 +652,18 @@ function rbcell($name, $value, $desc, $colname): string
     return "<td width='25%' nowrap>" . rbinput($name, $value, $desc, $colname) . "</td>\n";
 }
 
+function rbinput($name, $value, $desc, $colname): string
+{
+    global $row;
+    $ret  = "<input type='radio' name='" . attr($name) . "' value='" . attr($value) . "'";
+    if ($row[$colname] == $value) {
+        $ret .= " checked";
+    }
+
+    $ret .= " />" . text($desc);
+    return $ret;
+}
+
 /**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
@@ -760,16 +772,4 @@ function rbvalue($rbname): string
     }
 
     return "$tmp";
-}
-
-function rbinput($name, $value, $desc, $colname): string
-{
-    global $row;
-    $ret  = "<input type='radio' name='" . attr($name) . "' value='" . attr($value) . "'";
-    if ($row[$colname] == $value) {
-        $ret .= " checked";
-    }
-
-    $ret .= " />" . text($desc);
-    return $ret;
 }

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -255,6 +255,18 @@ function display_desc($desc)
 }
 
 /**
+ * Format a money amount with decimals but no other decoration.
+ *
+ * @param float $value The value to format
+ * @param int $extradecimals Extra decimal places beyond currency standard
+ * @return string The formatted number
+ */
+function formatMoneyNumber($value, $extradecimals = 0)
+{
+    return sprintf('%01.' . (OEGlobalsBag::getInstance()->get('currency_decimals') + $extradecimals) . 'f', $value);
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -279,18 +291,6 @@ function OpenTag($tag): void
 
     ++$indent;
     $out .= "<$tag>\n";
-}
-
-/**
- * Format a money amount with decimals but no other decoration.
- *
- * @param float $value The value to format
- * @param int $extradecimals Extra decimal places beyond currency standard
- * @return string The formatted number
- */
-function formatMoneyNumber($value, $extradecimals = 0)
-{
-    return sprintf('%01.' . (OEGlobalsBag::getInstance()->get('currency_decimals') + $extradecimals) . 'f', $value);
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -324,6 +324,22 @@ function getAge($dob, $asof = '')
 }
 
 /**
+ * Get layout options for the demographics form.
+ *
+ * @param bool $shortForm Whether to filter for short form mode (only required fields or those with 'N' edit option)
+ * @return ADORecordSet_mysqli
+ */
+function getLayoutRes(bool $shortForm)
+{
+    $sql = "SELECT * FROM layout_options WHERE form_id = 'DEM' AND uor > 0 AND field_id != ''";
+    if ($shortForm) {
+        $sql .= " AND (uor > 1 OR edit_options LIKE '%N%')";
+    }
+    $sql .= " ORDER BY group_id, seq";
+    return sqlStatement($sql);
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -742,22 +758,6 @@ function markTaxes($taxrates): void
             $taxes[$value][2] = '1';
         }
     }
-}
-
-/**
- * Get layout options for the demographics form.
- *
- * @param bool $shortForm Whether to filter for short form mode (only required fields or those with 'N' edit option)
- * @return ADORecordSet_mysqli
- */
-function getLayoutRes(bool $shortForm)
-{
-    $sql = "SELECT * FROM layout_options WHERE form_id = 'DEM' AND uor > 0 AND field_id != ''";
-    if ($shortForm) {
-        $sql .= " AND (uor > 1 OR edit_options LIKE '%N%')";
-    }
-    $sql .= " ORDER BY group_id, seq";
-    return sqlStatement($sql);
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -83,6 +83,25 @@ function cbvalue($cbname): string
 }
 
 /**
+ * Close an XML tag with proper indentation.
+ *
+ * @param string $tag The tag name to close
+ * @return void
+ * @global string $out The output buffer
+ * @global int $indent The current indentation level
+ */
+function CloseTag($tag): void
+{
+    global $out, $indent;
+    --$indent;
+    for ($i = 0; $i < $indent; ++$i) {
+        $out .= "\t";
+    }
+
+    $out .= "</$tag>\n";
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -107,25 +126,6 @@ function OpenTag($tag): void
 
     ++$indent;
     $out .= "<$tag>\n";
-}
-
-/**
- * Close an XML tag with proper indentation.
- *
- * @param string $tag The tag name to close
- * @return void
- * @global string $out The output buffer
- * @global int $indent The current indentation level
- */
-function CloseTag($tag): void
-{
-    global $out, $indent;
-    --$indent;
-    for ($i = 0; $i < $indent; ++$i) {
-        $out .= "\t";
-    }
-
-    $out .= "</$tag>\n";
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -490,6 +490,24 @@ function hl7SSN($s, bool $withDashes)
 }
 
 /**
+ * Escape special characters for HL7 text fields.
+ *
+ * @param string $s The input string
+ * @return string The escaped string
+ * @see http://www.interfaceware.com/hl7_escape_protocol.html
+ */
+function hl7Text($s)
+{
+    $s = str_replace('\\', '\\E\\', $s);
+    $s = str_replace('^', '\\S\\', $s);
+    $s = str_replace('|', '\\F\\', $s);
+    $s = str_replace('~', '\\R\\', $s);
+    $s = str_replace('&', '\\T\\', $s);
+    $s = str_replace("\r", '\\X0d\\', $s);
+    return $s;
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -663,24 +681,6 @@ function issueTypeIndex($tstr)
         ++$i;
     }
     return $i;
-}
-
-/**
- * Escape special characters for HL7 text fields.
- *
- * @param string $s The input string
- * @return string The escaped string
- * @see http://www.interfaceware.com/hl7_escape_protocol.html
- */
-function hl7Text($s)
-{
-    $s = str_replace('\\', '\\E\\', $s);
-    $s = str_replace('^', '\\S\\', $s);
-    $s = str_replace('|', '\\F\\', $s);
-    $s = str_replace('~', '\\R\\', $s);
-    $s = str_replace('&', '\\T\\', $s);
-    $s = str_replace("\r", '\\X0d\\', $s);
-    return $s;
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -592,14 +592,6 @@ function myCellText($s)
 }
 
 /**
- * Reads $_POST and trims the value. New code should NOT use this function.
- */
-function trimPost(string $key): string
-{
-    return \trim($_POST[$key] ?? '');
-}
-
-/**
  * Open an XML tag with proper indentation.
  *
  * @param string $tag The tag name to open
@@ -616,6 +608,14 @@ function OpenTag($tag): void
 
     ++$indent;
     $out .= "<$tag>\n";
+}
+
+/**
+ * Reads $_POST and trims the value. New code should NOT use this function.
+ */
+function trimPost(string $key): string
+{
+    return \trim($_POST[$key] ?? '');
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -664,6 +664,16 @@ function rbinput($name, $value, $desc, $colname): string
     return $ret;
 }
 
+function rbvalue($rbname): string
+{
+    $tmp = $_POST[$rbname];
+    if (! $tmp) {
+        $tmp = '0';
+    }
+
+    return "$tmp";
+}
+
 /**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
@@ -762,14 +772,4 @@ function ucname($string): string
         }
     }
     return $string;
-}
-
-function rbvalue($rbname): string
-{
-    $tmp = $_POST[$rbname];
-    if (! $tmp) {
-        $tmp = '0';
-    }
-
-    return "$tmp";
 }

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -20,6 +20,47 @@ use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FacilityService;
 
 /**
+ * Compute taxes from a tax rate string and a possibly taxable amount.
+ *
+ * @param array $row Row containing 'taxrates' field (colon-separated rate IDs)
+ * @param float $amount The taxable amount
+ * @return float The total tax amount
+ */
+function calcTaxes($row, $amount)
+{
+    $total = 0;
+    if (empty($row['taxrates'])) {
+        return $total;
+    }
+
+    $arates = explode(':', (string) $row['taxrates']);
+    if (empty($arates)) {
+        return $total;
+    }
+
+    foreach ($arates as $value) {
+        if (empty($value)) {
+            continue;
+        }
+
+        $trow = sqlQuery(
+            "SELECT option_value FROM list_options WHERE " .
+            "list_id = 'taxrate' AND option_id = ? AND activity = 1 LIMIT 1",
+            [$value]
+        );
+        if (empty($trow['option_value'])) {
+            echo "<!-- Missing tax rate '" . text($value) . "'! -->\n";
+            continue;
+        }
+
+        $tax = sprintf("%01.2f", $amount * $trow['option_value']);
+        $total += $tax;
+    }
+
+    return $total;
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -622,47 +663,6 @@ function getListItem($listid, $value)
     }
 
     return $tmp;
-}
-
-/**
- * Compute taxes from a tax rate string and a possibly taxable amount.
- *
- * @param array $row Row containing 'taxrates' field (colon-separated rate IDs)
- * @param float $amount The taxable amount
- * @return float The total tax amount
- */
-function calcTaxes($row, $amount)
-{
-    $total = 0;
-    if (empty($row['taxrates'])) {
-        return $total;
-    }
-
-    $arates = explode(':', (string) $row['taxrates']);
-    if (empty($arates)) {
-        return $total;
-    }
-
-    foreach ($arates as $value) {
-        if (empty($value)) {
-            continue;
-        }
-
-        $trow = sqlQuery(
-            "SELECT option_value FROM list_options WHERE " .
-            "list_id = 'taxrate' AND option_id = ? AND activity = 1 LIMIT 1",
-            [$value]
-        );
-        if (empty($trow['option_value'])) {
-            echo "<!-- Missing tax rate '" . text($value) . "'! -->\n";
-            continue;
-        }
-
-        $tax = sprintf("%01.2f", $amount * $trow['option_value']);
-        $total += $tax;
-    }
-
-    return $total;
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -675,6 +675,23 @@ function rbvalue($rbname): string
 }
 
 /**
+ * Generate a base filename for patient reports.
+ *
+ * @param int $pid The patient ID
+ * @return array Contains 'base' filename, 'fname', and 'lname'
+ */
+function report_basename($pid)
+{
+    $ptd = getPatientData($pid, "fname,lname");
+    // escape names for pesky periods hyphen etc.
+    $esc = $ptd['fname'] . '_' . $ptd['lname'];
+    $esc = str_replace(['.', ',', ' '], '', $esc);
+    $fn = basename_international(strtolower($esc . '_' . $pid . '_' . xl('report')));
+
+    return ['base' => $fn, 'fname' => $ptd['fname'], 'lname' => $ptd['lname']];
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -702,23 +719,6 @@ function User_Id_Look($thisField)
     }
 
     return $ret;
-}
-
-/**
- * Generate a base filename for patient reports.
- *
- * @param int $pid The patient ID
- * @return array Contains 'base' filename, 'fname', and 'lname'
- */
-function report_basename($pid)
-{
-    $ptd = getPatientData($pid, "fname,lname");
-    // escape names for pesky periods hyphen etc.
-    $esc = $ptd['fname'] . '_' . $ptd['lname'];
-    $esc = str_replace(['.', ',', ' '], '', $esc);
-    $fn = basename_international(strtolower($esc . '_' . $pid . '_' . xl('report')));
-
-    return ['base' => $fn, 'fname' => $ptd['fname'], 'lname' => $ptd['lname']];
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -301,6 +301,29 @@ function genStartRow($att): void
 }
 
 /**
+ * Compute age in years given a DOB and "as of" date.
+ *
+ * @param string $dob Date of birth (YYYY-MM-DD format)
+ * @param string $asof The date to calculate age as of (defaults to today)
+ * @return int The age in years
+ */
+function getAge($dob, $asof = '')
+{
+    if (empty($asof)) {
+        $asof = date('Y-m-d');
+    }
+
+    $a1 = explode('-', substr((string) $dob, 0, 10));
+    $a2 = explode('-', substr((string) $asof, 0, 10));
+    $age = $a2[0] - $a1[0];
+    if ($a2[1] < $a1[1] || ($a2[1] == $a1[1] && $a2[2] < $a1[2])) {
+        --$age;
+    }
+
+    return $age;
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -384,29 +407,6 @@ function PrintEncHeader($dt, $rsn, $dr): void
     echo "<td colspan='5'><span class='font-weight-bold'>" . xlt('Provider') . ": </span><span class='detail'>" . text(User_Id_Look($dr)) . "</span></td>";
     echo "</tr>\n";
     $orow++;
-}
-
-/**
- * Compute age in years given a DOB and "as of" date.
- *
- * @param string $dob Date of birth (YYYY-MM-DD format)
- * @param string $asof The date to calculate age as of (defaults to today)
- * @return int The age in years
- */
-function getAge($dob, $asof = '')
-{
-    if (empty($asof)) {
-        $asof = date('Y-m-d');
-    }
-
-    $a1 = explode('-', substr((string) $dob, 0, 10));
-    $a2 = explode('-', substr((string) $asof, 0, 10));
-    $age = $a2[0] - $a1[0];
-    if ($a2[1] < $a1[1] || ($a2[1] == $a1[1] && $a2[2] < $a1[2])) {
-        --$age;
-    }
-
-    return $age;
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -381,6 +381,17 @@ function getListItem($listid, $value)
 }
 
 /**
+ * Convert a date string to HL7 format (digits only).
+ *
+ * @param string $s The date string
+ * @return string The date with only digits
+ */
+function hl7Date($s)
+{
+    return preg_replace('/[^\d]/', '', (string) $s);
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -464,17 +475,6 @@ function PrintEncHeader($dt, $rsn, $dr): void
     echo "<td colspan='5'><span class='font-weight-bold'>" . xlt('Provider') . ": </span><span class='detail'>" . text(User_Id_Look($dr)) . "</span></td>";
     echo "</tr>\n";
     $orow++;
-}
-
-/**
- * Convert a date string to HL7 format (digits only).
- *
- * @param string $s The date string
- * @return string The date with only digits
- */
-function hl7Date($s)
-{
-    return preg_replace('/[^\d]/', '', (string) $s);
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -555,6 +555,27 @@ function issueTypeIndex($tstr)
 }
 
 /**
+ * Mark the tax rates that are referenced in an invoice.
+ *
+ * @param string $taxrates Colon-separated tax rate IDs
+ * @return void
+ * @global array $taxes The taxes array (key=tax id, value=[description, rate, indicator])
+ */
+function markTaxes($taxrates): void
+{
+    global $taxes;
+    $arates = explode(':', (string) $taxrates);
+    if (empty($arates)) {
+        return;
+    }
+    foreach ($arates as $value) {
+        if (!empty($taxes[$value])) {
+            $taxes[$value][2] = '1';
+        }
+    }
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -751,25 +772,4 @@ function myCellText($s)
     }
 
     return text($s);
-}
-
-/**
- * Mark the tax rates that are referenced in an invoice.
- *
- * @param string $taxrates Colon-separated tax rate IDs
- * @return void
- * @global array $taxes The taxes array (key=tax id, value=[description, rate, indicator])
- */
-function markTaxes($taxrates): void
-{
-    global $taxes;
-    $arates = explode(':', (string) $taxrates);
-    if (empty($arates)) {
-        return;
-    }
-    foreach ($arates as $value) {
-        if (!empty($taxes[$value])) {
-            $taxes[$value][2] = '1';
-        }
-    }
 }

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -441,6 +441,23 @@ function hl7RelationCode(string $s, bool $childAsOther): string
 }
 
 /**
+ * Convert a relationship string to its word form for HL7.
+ *
+ * @param string $s The relationship string (e.g., 'self', 'spouse', 'child', 'other')
+ * @return string The normalized relationship word, or the original value if unrecognized
+ */
+function hl7RelationWord(string $s): string
+{
+    return match (strtolower($s)) {
+        '', 'self' => 'self',
+        'spouse' => 'spouse',
+        'child' => 'child',
+        'other' => 'other',
+        default => $s,
+    };
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -691,23 +708,6 @@ function hl7SSN($s, bool $withDashes)
             : $tmp[1] . $tmp[2] . $tmp[3];
     }
     return '';
-}
-
-/**
- * Convert a relationship string to its word form for HL7.
- *
- * @param string $s The relationship string (e.g., 'self', 'spouse', 'child', 'other')
- * @return string The normalized relationship word, or the original value if unrecognized
- */
-function hl7RelationWord(string $s): string
-{
-    return match (strtolower($s)) {
-        '', 'self' => 'self',
-        'spouse' => 'spouse',
-        'child' => 'child',
-        'other' => 'other',
-        default => $s,
-    };
 }
 
 function rbvalue($rbname): string

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -423,6 +423,24 @@ function hl7Priority($s)
 }
 
 /**
+ * Convert a relationship string to an HL7 Table 0063 relationship code.
+ *
+ * @param string $s The relationship string (e.g., 'self', 'spouse', 'child', 'other')
+ * @param bool $childAsOther Whether to treat 'child' as 'other' (code 8) instead of code 3
+ * @return string The HL7 relationship code, or the original value if unrecognized
+ */
+function hl7RelationCode(string $s, bool $childAsOther): string
+{
+    return match (strtolower($s)) {
+        '', 'self' => '1',
+        'spouse' => '2',
+        'child' => $childAsOther ? '8' : '3',
+        'other' => '8',
+        default => $s,
+    };
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -688,24 +706,6 @@ function hl7RelationWord(string $s): string
         'spouse' => 'spouse',
         'child' => 'child',
         'other' => 'other',
-        default => $s,
-    };
-}
-
-/**
- * Convert a relationship string to an HL7 Table 0063 relationship code.
- *
- * @param string $s The relationship string (e.g., 'self', 'spouse', 'child', 'other')
- * @param bool $childAsOther Whether to treat 'child' as 'other' (code 8) instead of code 3
- * @return string The HL7 relationship code, or the original value if unrecognized
- */
-function hl7RelationCode(string $s, bool $childAsOther): string
-{
-    return match (strtolower($s)) {
-        '', 'self' => '1',
-        'spouse' => '2',
-        'child' => $childAsOther ? '8' : '3',
-        'other' => '8',
         default => $s,
     };
 }

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -10,7 +10,7 @@
  * No new code should be authored into this file; use it only for consolidating
  * and refactoring existing functions.
  *
- * PLEASE KEEP THE FUNCTION DEFINITONS IN THIS FILE SORTED ALPHABETICALLY
+ * PLEASE KEEP THE FUNCTION DEFINITIONS IN THIS FILE SORTED ALPHABETICALLY
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -524,6 +524,17 @@ function hl7Time($s, bool $withSeconds)
 }
 
 /**
+ * Format a ZIP code for HL7, removing spaces and dashes.
+ *
+ * @param string $s The input ZIP code
+ * @return string The formatted ZIP code
+ */
+function hl7Zip($s)
+{
+    return hl7Text(preg_replace('/[-\s]*/', '', (string) $s));
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -697,17 +708,6 @@ function issueTypeIndex($tstr)
         ++$i;
     }
     return $i;
-}
-
-/**
- * Format a ZIP code for HL7, removing spaces and dashes.
- *
- * @param string $s The input ZIP code
- * @return string The formatted ZIP code
- */
-function hl7Zip($s)
-{
-    return hl7Text(preg_replace('/[-\s]*/', '', (string) $s));
 }
 
 function rbvalue($rbname): string

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -102,6 +102,31 @@ function CloseTag($tag): void
 }
 
 /**
+ * Get facilities data and build facility-to-message and facility-to-phone maps.
+ *
+ * @return array{msg_map: array<int, string>, phone_map: array<int, string>}
+ */
+function cron_getFacilitiesMap(FacilityService $facilityService)
+{
+    /** @var array<string, string> $message_map */
+    $message_map = OEGlobalsBag::getInstance()->get('phone_appt_message');
+    $facility_msg_map = [];
+    $facility_phone_map = [];
+
+    $facilities = $facilityService->getAllFacility();
+    foreach ($facilities as $row) {
+        /** @var array{id: int, name: string, phone: string} $row */
+        $facility_msg_map[$row['id']] = $message_map[$row['name']] ?? '';
+        $facility_phone_map[$row['id']] = $row['phone'];
+    }
+
+    return [
+        'msg_map' => $facility_msg_map,
+        'phone_map' => $facility_phone_map
+    ];
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -684,31 +709,6 @@ function markTaxes($taxrates): void
             $taxes[$value][2] = '1';
         }
     }
-}
-
-/**
- * Get facilities data and build facility-to-message and facility-to-phone maps.
- *
- * @return array{msg_map: array<int, string>, phone_map: array<int, string>}
- */
-function cron_getFacilitiesMap(FacilityService $facilityService)
-{
-    /** @var array<string, string> $message_map */
-    $message_map = OEGlobalsBag::getInstance()->get('phone_appt_message');
-    $facility_msg_map = [];
-    $facility_phone_map = [];
-
-    $facilities = $facilityService->getAllFacility();
-    foreach ($facilities as $row) {
-        /** @var array{id: int, name: string, phone: string} $row */
-        $facility_msg_map[$row['id']] = $message_map[$row['name']] ?? '';
-        $facility_phone_map[$row['id']] = $row['phone'];
-    }
-
-    return [
-        'msg_map' => $facility_msg_map,
-        'phone_map' => $facility_phone_map
-    ];
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -60,6 +60,11 @@ function calcTaxes($row, $amount)
     return $total;
 }
 
+function cbcell($name, $desc, $colname): string
+{
+    return "<td width='25%' nowrap>" . cbinput($name, $colname) . text($desc) . "</td>\n";
+}
+
 /**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
@@ -615,11 +620,6 @@ function cbinput($name, $colname): string
 
     $ret .= " />";
     return $ret;
-}
-
-function cbcell($name, $desc, $colname): string
-{
-    return "<td width='25%' nowrap>" . cbinput($name, $colname) . text($desc) . "</td>\n";
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -508,6 +508,22 @@ function hl7Text($s)
 }
 
 /**
+ * Convert a datetime string to HL7 timestamp format.
+ *
+ * @param string $s The datetime string
+ * @param bool $withSeconds Whether to include seconds (YmdHis) or not (YmdHi)
+ * @return string The formatted timestamp, or empty string if input is empty
+ */
+function hl7Time($s, bool $withSeconds)
+{
+    if (empty($s)) {
+        return '';
+    }
+    $format = $withSeconds ? 'YmdHis' : 'YmdHi';
+    return date($format, strtotime((string) $s));
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -692,22 +708,6 @@ function issueTypeIndex($tstr)
 function hl7Zip($s)
 {
     return hl7Text(preg_replace('/[-\s]*/', '', (string) $s));
-}
-
-/**
- * Convert a datetime string to HL7 timestamp format.
- *
- * @param string $s The datetime string
- * @param bool $withSeconds Whether to include seconds (YmdHis) or not (YmdHi)
- * @return string The formatted timestamp, or empty string if input is empty
- */
-function hl7Time($s, bool $withSeconds)
-{
-    if (empty($s)) {
-        return '';
-    }
-    $format = $withSeconds ? 'YmdHis' : 'YmdHi';
-    return date($format, strtotime((string) $s));
 }
 
 function rbvalue($rbname): string

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -576,6 +576,22 @@ function markTaxes($taxrates): void
 }
 
 /**
+ * Adapt text to be suitable as the contents of a table cell.
+ *
+ * @param  string $s Input text.
+ * @return string  Output text.
+ */
+function myCellText($s)
+{
+    $s = trim($s ?? '');
+    if ($s === '') {
+        return '&nbsp;';
+    }
+
+    return text($s);
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -756,20 +772,4 @@ function rbinput($name, $value, $desc, $colname): string
 function rbcell($name, $value, $desc, $colname): string
 {
     return "<td width='25%' nowrap>" . rbinput($name, $value, $desc, $colname) . "</td>\n";
-}
-
-/**
- * Adapt text to be suitable as the contents of a table cell.
- *
- * @param  string $s Input text.
- * @return string  Output text.
- */
-function myCellText($s)
-{
-    $s = trim($s ?? '');
-    if ($s === '') {
-        return '&nbsp;';
-    }
-
-    return text($s);
 }

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -77,6 +77,11 @@ function cbinput($name, $colname): string
     return $ret;
 }
 
+function cbvalue($cbname): string
+{
+    return $_POST[$cbname] ? '1' : '0';
+}
+
 /**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
@@ -598,11 +603,6 @@ function rbvalue($rbname): string
     }
 
     return "$tmp";
-}
-
-function cbvalue($cbname): string
-{
-    return $_POST[$cbname] ? '1' : '0';
 }
 
 function rbinput($name, $value, $desc, $colname): string

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -267,6 +267,22 @@ function formatMoneyNumber($value, $extradecimals = 0)
 }
 
 /**
+ * End an HTML table row for statistics reports.
+ *
+ * @return void
+ * @global int $form_output Output format (3 = CSV)
+ */
+function genEndRow(): void
+{
+    global $form_output;
+    if ($form_output == 3) {
+        echo "\n";
+    } else {
+        echo " </tr>\n";
+    }
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -368,22 +384,6 @@ function genStartRow($att): void
     }
 
     $cellcount = 0;
-}
-
-/**
- * End an HTML table row for statistics reports.
- *
- * @return void
- * @global int $form_output Output format (3 = CSV)
- */
-function genEndRow(): void
-{
-    global $form_output;
-    if ($form_output == 3) {
-        echo "\n";
-    } else {
-        echo " </tr>\n";
-    }
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -414,6 +414,15 @@ function hl7Phone($s, bool $formatted)
 }
 
 /**
+ * @param string
+ * @return string
+ */
+function hl7Priority($s)
+{
+    return strtoupper(substr((string) $s, 0, 1)) === 'H' ? 'S' : 'R';
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -497,15 +506,6 @@ function PrintEncHeader($dt, $rsn, $dr): void
     echo "<td colspan='5'><span class='font-weight-bold'>" . xlt('Provider') . ": </span><span class='detail'>" . text(User_Id_Look($dr)) . "</span></td>";
     echo "</tr>\n";
     $orow++;
-}
-
-/**
- * @param string
- * @return string
- */
-function hl7Priority($s)
-{
-    return strtoupper(substr((string) $s, 0, 1)) === 'H' ? 'S' : 'R';
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -647,6 +647,11 @@ function PrintEncHeader($dt, $rsn, $dr): void
     $orow++;
 }
 
+function rbcell($name, $value, $desc, $colname): string
+{
+    return "<td width='25%' nowrap>" . rbinput($name, $value, $desc, $colname) . "</td>\n";
+}
+
 /**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
@@ -767,9 +772,4 @@ function rbinput($name, $value, $desc, $colname): string
 
     $ret .= " />" . text($desc);
     return $ret;
-}
-
-function rbcell($name, $value, $desc, $colname): string
-{
-    return "<td width='25%' nowrap>" . rbinput($name, $value, $desc, $colname) . "</td>\n";
 }

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -27,10 +27,6 @@ function trimPost(string $key): string
     return \trim($_POST[$key] ?? '');
 }
 
-// ============================================================================
-// XML Export Functions (used by ippf_export.php, export_xml.php)
-// ============================================================================
-
 /**
  * Open an XML tag with proper indentation.
  *
@@ -68,10 +64,6 @@ function CloseTag($tag): void
 
     $out .= "</$tag>\n";
 }
-
-// ============================================================================
-// String/Number Utility Functions
-// ============================================================================
 
 /**
  * Remove all non-digits from a string.
@@ -148,10 +140,6 @@ function parse_note($note)
     return json_encode($matches[1]);
 }
 
-// ============================================================================
-// User/Patient Lookup Functions
-// ============================================================================
-
 /**
  * Look up a user's full name by ID.
  *
@@ -173,10 +161,6 @@ function User_Id_Look($thisField)
 
     return $ret;
 }
-
-// ============================================================================
-// Report Display Functions
-// ============================================================================
 
 /**
  * Print an encounter header row for patient ledger reports.
@@ -237,10 +221,6 @@ function genEndRow(): void
     }
 }
 
-// ============================================================================
-// Age Calculation Functions
-// ============================================================================
-
 /**
  * Compute age in years given a DOB and "as of" date.
  *
@@ -264,10 +244,6 @@ function getAge($dob, $asof = '')
     return $age;
 }
 
-// ============================================================================
-// HL7 Helper Functions
-// ============================================================================
-
 /**
  * Convert a date string to HL7 format (digits only).
  *
@@ -287,10 +263,6 @@ function hl7Priority($s)
 {
     return strtoupper(substr((string) $s, 0, 1)) === 'H' ? 'S' : 'R';
 }
-
-// ============================================================================
-// Cron/Notification Functions
-// ============================================================================
 
 /**
  * Get patient data for phone alert notifications.
@@ -335,10 +307,6 @@ function cron_getPhoneAlertpatientData($type, $trigger_hours)
 
     return $patient_array;
 }
-
-// ============================================================================
-// File/Report Functions
-// ============================================================================
 
 /**
  * Generate a base filename for patient reports.
@@ -392,10 +360,6 @@ function zip_content($source, $destination, $content = '', $create = true)
     return $zip->close();
 }
 
-// ============================================================================
-// Simple String Utility Functions
-// ============================================================================
-
 
 /**
  * Properly capitalize a name handling hyphens and apostrophes.
@@ -433,10 +397,6 @@ function issueTypeIndex($tstr)
     }
     return $i;
 }
-
-// ============================================================================
-// HL7 Order Generation Helper Functions
-// ============================================================================
 
 /**
  * Escape special characters for HL7 text fields.
@@ -664,10 +624,6 @@ function getListItem($listid, $value)
     return $tmp;
 }
 
-// ============================================================================
-// Tax Calculation Functions
-// ============================================================================
-
 /**
  * Compute taxes from a tax rate string and a possibly taxable amount.
  *
@@ -788,10 +744,6 @@ function cron_updateentry(string $type, $pid, $pc_eid): void
     sqlStatement($query, [$pid, $pc_eid]);
 }
 
-// ============================================================================
-// Layout Options Functions
-// ============================================================================
-
 /**
  * Get layout options for the demographics form.
  *
@@ -821,3 +773,4 @@ function getLayoutUOR($form_id, $field_id)
         "form_id = ? AND field_id = ? LIMIT 1", [$form_id, $field_id]);
     return 0 + $crow['uor'];
 }
+

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -700,6 +700,23 @@ function trimPost(string $key): string
 }
 
 /**
+ * Properly capitalize a name handling hyphens and apostrophes.
+ *
+ * @param string $string The name to capitalize
+ * @return string The properly capitalized name
+ */
+function ucname($string): string
+{
+    $string = ucwords(strtolower((string) $string));
+    foreach (['-', '\''] as $delimiter) {
+        if (str_contains($string, $delimiter)) {
+            $string = implode($delimiter, array_map(ucfirst(...), explode($delimiter, $string)));
+        }
+    }
+    return $string;
+}
+
+/**
  * Look up a user's full name by ID.
  *
  * @param int|string $thisField The user ID
@@ -754,22 +771,4 @@ function zip_content($source, $destination, $content = '', $create = true)
     }
 
     return $zip->close();
-}
-
-
-/**
- * Properly capitalize a name handling hyphens and apostrophes.
- *
- * @param string $string The name to capitalize
- * @return string The properly capitalized name
- */
-function ucname($string): string
-{
-    $string = ucwords(strtolower((string) $string));
-    foreach (['-', '\''] as $delimiter) {
-        if (str_contains($string, $delimiter)) {
-            $string = implode($delimiter, array_map(ucfirst(...), explode($delimiter, $string)));
-        }
-    }
-    return $string;
 }

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -204,6 +204,31 @@ function cron_updateentry(string $type, $pid, $pc_eid): void
 }
 
 /**
+ * Put dashes, colons, etc. back into a timestamp based on a format string.
+ * The format uses '.' as a placeholder for each character from the input.
+ *
+ * @param string $fmt The format string (e.g., '....-..-..' for dates)
+ * @param string $str The input string to decorate
+ * @return string The decorated string
+ */
+function decorateString($fmt, $str)
+{
+    $res = '';
+    while ($fmt) {
+        $fc = substr((string) $fmt, 0, 1);
+        $fmt = substr((string) $fmt, 1);
+        if ($fc == '.') {
+            $res .= substr((string) $str, 0, 1);
+            $str = substr((string) $str, 1);
+        } else {
+            $res .= $fc;
+        }
+    }
+
+    return $res;
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -239,31 +264,6 @@ function OpenTag($tag): void
 function Digits($field)
 {
     return preg_replace("/\D/", "", (string) $field);
-}
-
-/**
- * Put dashes, colons, etc. back into a timestamp based on a format string.
- * The format uses '.' as a placeholder for each character from the input.
- *
- * @param string $fmt The format string (e.g., '....-..-..' for dates)
- * @param string $str The input string to decorate
- * @return string The decorated string
- */
-function decorateString($fmt, $str)
-{
-    $res = '';
-    while ($fmt) {
-        $fc = substr((string) $fmt, 0, 1);
-        $fmt = substr((string) $fmt, 1);
-        if ($fc == '.') {
-            $res .= substr((string) $str, 0, 1);
-            $str = substr((string) $str, 1);
-        } else {
-            $res .= $fc;
-        }
-    }
-
-    return $res;
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -623,6 +623,31 @@ function parse_note($note)
 }
 
 /**
+ * Print an encounter header row for patient ledger reports.
+ *
+ * @param string $dt The encounter date
+ * @param string $rsn The reason for visit
+ * @param int|string $dr The provider ID
+ * @return void
+ * @global string $bgcolor The current background color
+ * @global int $orow The row counter
+ */
+function PrintEncHeader($dt, $rsn, $dr): void
+{
+    global $bgcolor, $orow;
+    $bgcolor = (($bgcolor == "#FFFFDD") ? "#FFDDDD" : "#FFFFDD");
+    echo "<tr class='bg-white'>";
+    if (strlen((string) $rsn) > 50) {
+        $rsn = substr((string) $rsn, 0, 50) . '...';
+    }
+
+    echo "<td colspan='4'><span class='font-weight-bold'>" . xlt('Encounter Dt / Rsn') . ": </span><span class='detail'>" . text(substr((string) $dt, 0, 10)) . " / " . text($rsn) . "</span></td>";
+    echo "<td colspan='5'><span class='font-weight-bold'>" . xlt('Provider') . ": </span><span class='detail'>" . text(User_Id_Look($dr)) . "</span></td>";
+    echo "</tr>\n";
+    $orow++;
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -650,31 +675,6 @@ function User_Id_Look($thisField)
     }
 
     return $ret;
-}
-
-/**
- * Print an encounter header row for patient ledger reports.
- *
- * @param string $dt The encounter date
- * @param string $rsn The reason for visit
- * @param int|string $dr The provider ID
- * @return void
- * @global string $bgcolor The current background color
- * @global int $orow The row counter
- */
-function PrintEncHeader($dt, $rsn, $dr): void
-{
-    global $bgcolor, $orow;
-    $bgcolor = (($bgcolor == "#FFFFDD") ? "#FFDDDD" : "#FFFFDD");
-    echo "<tr class='bg-white'>";
-    if (strlen((string) $rsn) > 50) {
-        $rsn = substr((string) $rsn, 0, 50) . '...';
-    }
-
-    echo "<td colspan='4'><span class='font-weight-bold'>" . xlt('Encounter Dt / Rsn') . ": </span><span class='detail'>" . text(substr((string) $dt, 0, 10)) . " / " . text($rsn) . "</span></td>";
-    echo "<td colspan='5'><span class='font-weight-bold'>" . xlt('Provider') . ": </span><span class='detail'>" . text(User_Id_Look($dr)) . "</span></td>";
-    echo "</tr>\n";
-    $orow++;
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -240,6 +240,21 @@ function Digits($field)
 }
 
 /**
+ * Extract description from a string, removing any prefix before colon.
+ *
+ * @param string $desc The description string
+ * @return string The cleaned description
+ */
+function display_desc($desc)
+{
+    if (preg_match('/^\S*?:(.+)$/', (string) $desc, $matches)) {
+        $desc = $matches[1];
+    }
+
+    return $desc;
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -264,21 +279,6 @@ function OpenTag($tag): void
 
     ++$indent;
     $out .= "<$tag>\n";
-}
-
-/**
- * Extract description from a string, removing any prefix before colon.
- *
- * @param string $desc The description string
- * @return string The cleaned description
- */
-function display_desc($desc)
-{
-    if (preg_match('/^\S*?:(.+)$/', (string) $desc, $matches)) {
-        $desc = $matches[1];
-    }
-
-    return $desc;
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -183,6 +183,27 @@ function cron_getPhoneAlertpatientData($type, $trigger_hours)
 }
 
 /**
+ * Update calendar event to mark that an alert was sent to the patient.
+ *
+ * @param string $type The notification type ('SMS', 'Email', or 'Phone')
+ * @param int|string $pid The patient ID
+ * @param int|string $pc_eid The calendar event ID
+ */
+function cron_updateentry(string $type, $pid, $pc_eid): void
+{
+    $query = "UPDATE openemr_postcalendar_events SET ";
+
+    if ($type === 'SMS' || $type === 'Phone') {
+        $query .= "pc_sendalertsms = 'YES'";
+    } elseif ($type === 'Email') {
+        $query .= "pc_sendalertemail = 'YES'";
+    }
+
+    $query .= " WHERE pc_pid = ? AND pc_eid = ?";
+    sqlStatement($query, [$pid, $pc_eid]);
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -721,27 +742,6 @@ function markTaxes($taxrates): void
             $taxes[$value][2] = '1';
         }
     }
-}
-
-/**
- * Update calendar event to mark that an alert was sent to the patient.
- *
- * @param string $type The notification type ('SMS', 'Email', or 'Phone')
- * @param int|string $pid The patient ID
- * @param int|string $pc_eid The calendar event ID
- */
-function cron_updateentry(string $type, $pid, $pc_eid): void
-{
-    $query = "UPDATE openemr_postcalendar_events SET ";
-
-    if ($type === 'SMS' || $type === 'Phone') {
-        $query .= "pc_sendalertsms = 'YES'";
-    } elseif ($type === 'Email') {
-        $query .= "pc_sendalertemail = 'YES'";
-    }
-
-    $query .= " WHERE pc_pid = ? AND pc_eid = ?";
-    sqlStatement($query, [$pid, $pc_eid]);
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -611,14 +611,6 @@ function OpenTag($tag): void
 }
 
 /**
- * Reads $_POST and trims the value. New code should NOT use this function.
- */
-function trimPost(string $key): string
-{
-    return \trim($_POST[$key] ?? '');
-}
-
-/**
  * Parse note content to extract items within {| and |} markers.
  *
  * @param string $note The note content
@@ -628,6 +620,14 @@ function parse_note($note)
 {
     $result = preg_match_all("/\{\|([^\]]*)\|\}/", (string) $note, $matches);
     return json_encode($matches[1]);
+}
+
+/**
+ * Reads $_POST and trims the value. New code should NOT use this function.
+ */
+function trimPost(string $key): string
+{
+    return \trim($_POST[$key] ?? '');
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -229,6 +229,17 @@ function decorateString($fmt, $str)
 }
 
 /**
+ * Remove all non-digits from a string.
+ *
+ * @param mixed $field The input to process
+ * @return string The string with only digits remaining
+ */
+function Digits($field)
+{
+    return preg_replace("/\D/", "", (string) $field);
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -253,17 +264,6 @@ function OpenTag($tag): void
 
     ++$indent;
     $out .= "<$tag>\n";
-}
-
-/**
- * Remove all non-digits from a string.
- *
- * @param mixed $field The input to process
- * @return string The string with only digits remaining
- */
-function Digits($field)
-{
-    return preg_replace("/\D/", "", (string) $field);
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -535,6 +535,26 @@ function hl7Zip($s)
 }
 
 /**
+ * Given an issue type as a string, compute its index.
+ *
+ * @param string $tstr The issue type string
+ * @return int The index of the issue type
+ * @global array $ISSUE_TYPES The array of issue types
+ */
+function issueTypeIndex($tstr)
+{
+    global $ISSUE_TYPES;
+    $i = 0;
+    foreach ($ISSUE_TYPES as $key => $value) {
+        if ($key == $tstr) {
+            break;
+        }
+        ++$i;
+    }
+    return $i;
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -688,26 +708,6 @@ function ucname($string): string
         }
     }
     return $string;
-}
-
-/**
- * Given an issue type as a string, compute its index.
- *
- * @param string $tstr The issue type string
- * @return int The index of the issue type
- * @global array $ISSUE_TYPES The array of issue types
- */
-function issueTypeIndex($tstr)
-{
-    global $ISSUE_TYPES;
-    $i = 0;
-    foreach ($ISSUE_TYPES as $key => $value) {
-        if ($key == $tstr) {
-            break;
-        }
-        ++$i;
-    }
-    return $i;
 }
 
 function rbvalue($rbname): string

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -10,6 +10,8 @@
  * No new code should be authored into this file; use it only for consolidating
  * and refactoring existing functions.
  *
+ * PLEASE KEEP THE FUNCTION DEFINITONS IN THIS FILE SORTED ALPHABETICALLY
+ *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -473,6 +473,23 @@ function hl7Sex($s)
 }
 
 /**
+ * Format an SSN for HL7.
+ *
+ * @param string $s The SSN string
+ * @param bool $withDashes Whether to include dashes (123-45-6789) or just digits
+ * @return string The formatted SSN, or empty string if invalid
+ */
+function hl7SSN($s, bool $withDashes)
+{
+    if (preg_match("/(\d\d\d)\D*(\d\d)\D*(\d\d\d\d)\D*$/", (string) $s, $tmp)) {
+        return $withDashes
+            ? $tmp[1] . '-' . $tmp[2] . '-' . $tmp[3]
+            : $tmp[1] . $tmp[2] . $tmp[3];
+    }
+    return '';
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -691,23 +708,6 @@ function hl7Time($s, bool $withSeconds)
     }
     $format = $withSeconds ? 'YmdHis' : 'YmdHi';
     return date($format, strtotime((string) $s));
-}
-
-/**
- * Format an SSN for HL7.
- *
- * @param string $s The SSN string
- * @param bool $withDashes Whether to include dashes (123-45-6789) or just digits
- * @return string The formatted SSN, or empty string if invalid
- */
-function hl7SSN($s, bool $withDashes)
-{
-    if (preg_match("/(\d\d\d)\D*(\d\d)\D*(\d\d\d\d)\D*$/", (string) $s, $tmp)) {
-        return $withDashes
-            ? $tmp[1] . '-' . $tmp[2] . '-' . $tmp[3]
-            : $tmp[1] . $tmp[2] . $tmp[3];
-    }
-    return '';
 }
 
 function rbvalue($rbname): string

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -127,6 +127,18 @@ function cron_getFacilitiesMap(FacilityService $facilityService)
 }
 
 /**
+ * Get notification settings from the database.
+ *
+ * @return array|false The notification settings row, or false if not found
+ */
+function cron_GetNotificationSettings(): array|false
+{
+    return sqlFetchArray(sqlStatement(
+        "SELECT * FROM notification_settings WHERE type = 'SMS/Email Settings'"
+    ));
+}
+
+/**
  * Reads $_POST and trims the value. New code should NOT use this function.
  */
 function trimPost(string $key): string
@@ -709,18 +721,6 @@ function markTaxes($taxrates): void
             $taxes[$value][2] = '1';
         }
     }
-}
-
-/**
- * Get notification settings from the database.
- *
- * @return array|false The notification settings row, or false if not found
- */
-function cron_GetNotificationSettings(): array|false
-{
-    return sqlFetchArray(sqlStatement(
-        "SELECT * FROM notification_settings WHERE type = 'SMS/Email Settings'"
-    ));
 }
 
 /**


### PR DESCRIPTION
#### Short description of what this changes or resolves:
When moving manually-included functions out into the autoload path, the 'official' place to dump them has gotten quite messy and disorganized. This is a one-time high-local-churn change to keep things sorted and minimize future diffs.

#### Changes proposed in this pull request:
Functions sorted, one per commit. No actual function body changes. Git/Github isn't really good at "function moved" (RIP Phabricator) so it's one commit per function.  Review accordingly.

#### Was an AI assistant used? Yes / No
Yes