### PR TITLE
fix(calendar): route freq_type 5 to REPEAT_ON branch to prevent infin…

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -381,7 +381,7 @@ if (!empty($_POST['form_action']) && ($_POST['form_action'] == "duplicate" || $_
         $event_date = setEventDate($_POST['form_date'], $my_repeat_freq);
     } elseif (!empty($_POST['form_repeat'])) {
         $my_recurrtype = 1;
-        if ($my_repeat_type > 6 || $my_repeat_type == 5) { // Changed from 4 to 6 to accommodate new options.
+        if ($my_repeat_type > 6 || $my_repeat_type == 5) { // 5 is nth weekday (REPEAT_ON); >6 handles 7th, 8th, 9th occurrences
             $my_recurrtype = 2;
             $time = strtotime((string) $event_date);
             $my_repeat_on_day = 0 + date('w', $time);

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -381,7 +381,7 @@ if (!empty($_POST['form_action']) && ($_POST['form_action'] == "duplicate" || $_
         $event_date = setEventDate($_POST['form_date'], $my_repeat_freq);
     } elseif (!empty($_POST['form_repeat'])) {
         $my_recurrtype = 1;
-        if ($my_repeat_type > 6) { // Changed from 4 to 6 to accommodate new options.
+        if ($my_repeat_type > 6 || $my_repeat_type == 5) { // Changed from 4 to 6 to accommodate new options.
             $my_recurrtype = 2;
             $time = strtotime((string) $event_date);
             $my_repeat_on_day = 0 + date('w', $time);

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -381,7 +381,7 @@ if (!empty($_POST['form_action']) && ($_POST['form_action'] == "duplicate" || $_
         $event_date = setEventDate($_POST['form_date'], $my_repeat_freq);
     } elseif (!empty($_POST['form_repeat'])) {
         $my_recurrtype = 1;
-        if ($my_repeat_type > 6 || $my_repeat_type == 5) { // 5 is nth weekday (REPEAT_ON); >6 handles 7th, 8th, 9th occurrences
+        if ($my_repeat_type > 6 || in_array($my_repeat_type, [5, 6])) { // 5 is nth weekday (REPEAT_ON); >6 handles 7th, 8th, 9th occurrences
             $my_recurrtype = 2;
             $time = strtotime((string) $event_date);
             $my_repeat_on_day = 0 + date('w', $time);

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -381,7 +381,7 @@ if (!empty($_POST['form_action']) && ($_POST['form_action'] == "duplicate" || $_
         $event_date = setEventDate($_POST['form_date'], $my_repeat_freq);
     } elseif (!empty($_POST['form_repeat'])) {
         $my_recurrtype = 1;
-        if ($my_repeat_type > 6 || in_array($my_repeat_type, [5, 6])) { // 5 is nth weekday (REPEAT_ON); >6 handles 7th, 8th, 9th occurrences
+        if ($my_repeat_type > 4) { // Types 5+ use REPEAT_ON: 5=nth weekday, 6=last weekday, 7-9=nth occurrences
             $my_recurrtype = 2;
             $time = strtotime((string) $event_date);
             $my_repeat_on_day = 0 + date('w', $time);


### PR DESCRIPTION
…ite loop

<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
Fixes infinite loop when saving recurring events with freq_type 5 (nth weekday of month). The REPEAT_ON threshold check in add_edit_event.php was changed from > 4 to > 6 to accommodate new repeat options, but this inadvertently excluded freq_type 5 from the REPEAT_ON branch, causing it to be stored as a REPEAT event with an unhandled freq_type, resulting in an infinite loop in the __increment() fast-forward loop.

#### Changes proposed in this pull request:
Changed threshold condition from $my_repeat_type > 6 to $my_repeat_type > 6 || $my_repeat_type == 5 in add_edit_event.php to correctly route freq_type 5 events into the REPEAT_ON branch.

#### Was an AI assistant used? Yes Assisted-by: Claude.ai

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
