### PR TITLE
fix(finder): cast data_type to int in getSearchClass() for match comp…

### DIFF
--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -13597,11 +13597,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Syndromicsurveillance/src/Syndromicsurveillance/Model/SyndromicsurveillanceTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function getSearchClass\\(\\) has parameter \\$data_type with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/new/new_comprehensive.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function default_loadPayerInfo\\(\\) has parameter \\$date with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/orders/gen_hl7_order.inc.php',

--- a/interface/new/new_comprehensive.php
+++ b/interface/new/new_comprehensive.php
@@ -52,9 +52,9 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 // 2 = select list
 // 0 = not searchable
 //
-function getSearchClass($data_type)
+function getSearchClass(int $data_type)
 {
-    return match ((int)$data_type) {
+    return match ($data_type) {
         // facilities
         1, 10, 11, 12, 13, 14, 26, 35 => 2,
         // date
@@ -333,7 +333,7 @@ while ($lrow = sqlFetchArray($lres)) {
         continue;
     }
 
-    $data_type = $lrow['data_type'];
+    $data_type = (int)$lrow['data_type'];
     $fldname = "form_$field_id";
     switch (getSearchClass($data_type)) {
         case 1:
@@ -907,7 +907,7 @@ while ($lrow = sqlFetchArray($lres)) {
         continue;
     }
 
-    switch (getSearchClass($lrow['data_type'])) {
+    switch (getSearchClass((int)$lrow['data_type'])) {
         case 1:
             echo "    \$(" . js_escape("#form_" . $field_id) . ").click(function() { toggleSearch(this); });\n";
             break;

--- a/interface/new/new_comprehensive.php
+++ b/interface/new/new_comprehensive.php
@@ -54,7 +54,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 //
 function getSearchClass($data_type)
 {
-    return match ($data_type) {
+    return match ((int)$data_type) {
         // facilities
         1, 10, 11, 12, 13, 14, 26, 35 => 2,
         // date


### PR DESCRIPTION
…atibility



Fixes [community forum issue](https://community.open-emr.org/t/new-search-issues-on-version-8/26674).

#### Short description of what this changes or resolves:
PHP's match uses strict comparison (===), so string values returned
by sqlFetchArray() would never match integer arms, causing all fields
to be excluded from the search URL and New/Search to return all patients
regardless of criteria entered.



#### Changes proposed in this pull request:
cast data_type to int in getSearchClass() for match compatibility

#### Was an AI assistant used? No

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
