### PR TITLE
chore(logging): Add and initialize basic fallback exception handler

### DIFF
--- a/.phpstan/baseline/class.notFound.php
+++ b/.phpstan/baseline/class.notFound.php
@@ -7,16 +7,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_options_queries.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^PHPDoc tag @var contains unknown class Dotenv\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/globals.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^PHPDoc tag @var contains unknown class Kernel\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/globals.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function pnConfigGetVar\\(\\) has invalid return type value\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnAPI.php',

--- a/.phpstan/baseline/varTag.noVariable.php
+++ b/.phpstan/baseline/varTag.noVariable.php
@@ -3,7 +3,7 @@
 $ignoreErrors = [];
 $ignoreErrors[] = [
     'message' => '#^PHPDoc tag @var does not specify variable name\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/globals.php',
 ];
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 use Dotenv\Dotenv;
 use Firehed\Container\AutoDetect;
+use OpenEMR\Core\ErrorHandler;
 
 chdir(__DIR__);
 
@@ -44,4 +45,10 @@ if (class_exists(Dotenv::class) && file_exists('.env')) {
 }
 
 // Set up and return the PSR-11 DI container
-return AutoDetect::instance('config');
+$container = AutoDetect::instance('config');
+
+$handler = $container->get(ErrorHandler::class);
+$handler->installErrorHandler(E_ALL);
+$handler->installExceptionHandler();
+
+return $container;

--- a/config/services.php
+++ b/config/services.php
@@ -22,8 +22,15 @@ use Monolog\{
     Processor\PsrLogMessageProcessor,
 };
 use OpenEMR\Common\Http\Psr17Factory;
+use OpenEMR\Core\ErrorHandler;
+use Psr\Log\LoggerInterface;
 
 return [
+    ErrorHandler::class => fn (TC $c) => new ErrorHandler(
+        logger: $c->get(LoggerInterface::class),
+        // Once there are more well-defined environments, set this using them
+        shouldDisplayErrors: false,
+    ),
     Level::class => fn (TC $c) => Level::fromName($c->get('LOG_LEVEL')),
     Logger::class => function (TC $c) {
         // Duplicated from setup in SystemLogger (for now)

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -13,16 +13,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-// Set up autoloader as early as possible
-require_once dirname(__DIR__) . '/vendor/autoload.php';
-
-// Checks if the server's PHP version is compatible with OpenEMR:
-$response = OpenEMR\Common\Compatibility\Checker::checkPhpVersion();
-if ($response !== true) {
-    http_response_code(500);
-    die(htmlspecialchars($response));
-}
-
 use Dotenv\Dotenv;
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Database\QueryUtils;
@@ -34,7 +24,50 @@ use OpenEMR\Core\Kernel;
 use OpenEMR\Core\ModulesApplication;
 use OpenEMR\Core\OEGlobalsBag;
 
+// Set up autoloader as early as possible
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+// Checks if the server's PHP version is compatible with OpenEMR:
+$response = OpenEMR\Common\Compatibility\Checker::checkPhpVersion();
+if ($response !== true) {
+    http_response_code(500);
+    die(htmlspecialchars($response));
+}
+// Is this windows or non-windows? Create a boolean definition.
+if (!defined('IS_WINDOWS')) {
+    define('IS_WINDOWS', (stripos(PHP_OS, 'WIN') === 0));
+}
+
+// The webserver_root and web_root are now automatically collected.
+// If not working, can set manually below.
+// Auto collect the full absolute directory path for openemr.
+$webserver_root = dirname(__FILE__, 2);
+if (IS_WINDOWS) {
+ //convert windows path separators
+    $webserver_root = str_replace("\\", "/", $webserver_root);
+}
+
+/**
+ * Allow a `.env` file to be read in and applied as $_SERVER variables.
+ *
+ * This allows to define a "development" environment which can then load up
+ * different variables and reporting/debugging functionality. Should be used in
+ * development only, not for production
+ *
+ * @link https://www.open-emr.org/wiki/index.php/Dotenv_Usage
+ */
+if (file_exists("{$webserver_root}/.env")) {
+    Dotenv::createImmutable($webserver_root)->load();
+}
+
 $logger = ServiceContainer::getLogger();
+$handler = new \OpenEMR\Core\ErrorHandler(
+    logger: $logger,
+    shouldDisplayErrors: ($_ENV['OPENEMR__ENVIRONMENT'] ?? null) === 'dev',
+);
+$handler->installExceptionHandler();
+
+throw new \Exception('crashy');
 
 // Throw error if the php openssl module is not installed.
 if (!(extension_loaded('openssl'))) {
@@ -122,20 +155,6 @@ if (!isset($ignoreAuth)) {
 // Same for onsite
 if (!isset($ignoreAuth_onsite_portal)) {
     $ignoreAuth_onsite_portal = false;
-}
-
-// Is this windows or non-windows? Create a boolean definition.
-if (!defined('IS_WINDOWS')) {
-    define('IS_WINDOWS', (stripos(PHP_OS, 'WIN') === 0));
-}
-
-// The webserver_root and web_root are now automatically collected.
-// If not working, can set manually below.
-// Auto collect the full absolute directory path for openemr.
-$webserver_root = dirname(__FILE__, 2);
-if (IS_WINDOWS) {
- //convert windows path separators
-    $webserver_root = str_replace("\\", "/", $webserver_root);
 }
 
 // Collect the apache server document root (and convert to windows slashes, if needed)
@@ -351,20 +370,6 @@ if (! is_dir($GLOBALS['MPDF_WRITE_DIR'])) {
     if (!mkdir($concurrentDirectory = $GLOBALS['MPDF_WRITE_DIR'], 0755, true) && !is_dir($concurrentDirectory)) {
         throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
     }
-}
-
-/**
- * @var Dotenv Allow a `.env` file to be read in and applied as $_SERVER variables.
- *
- * This allows to define a "development" environment which can then load up
- * different variables and reporting/debugging functionality. Should be used in
- * development only, not for production
- *
- * @link https://www.open-emr.org/wiki/index.php/Dotenv_Usage
- */
-if (file_exists("{$webserver_root}/.env")) {
-    $dotenv = Dotenv::createImmutable($webserver_root);
-    $dotenv->load();
 }
 
 // The logging level for common/logging/logger.php

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -42,10 +42,6 @@ if (!defined('IS_WINDOWS')) {
 // If not working, can set manually below.
 // Auto collect the full absolute directory path for openemr.
 $webserver_root = dirname(__FILE__, 2);
-if (IS_WINDOWS) {
- //convert windows path separators
-    $webserver_root = str_replace("\\", "/", $webserver_root);
-}
 
 /**
  * Allow a `.env` file to be read in and applied as $_SERVER variables.

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -61,13 +61,18 @@ if (file_exists("{$webserver_root}/.env")) {
 }
 
 $logger = ServiceContainer::getLogger();
+
+// Set up exception handling: ensure that any uncaught exceptions have some
+// guaranteed way of reaching the logs, regardless of other settings.
 $handler = new \OpenEMR\Core\ErrorHandler(
     logger: $logger,
     shouldDisplayErrors: ($_ENV['OPENEMR__ENVIRONMENT'] ?? null) === 'dev',
 );
 $handler->installExceptionHandler();
+// Note: installErrorHandler() is intentionally NOT called, too much would
+// break today. As we gain confidence in error handling, we can call it with
+// a high-severity level and incrementally move it to cover more.
 
-throw new \Exception('crashy');
 
 // Throw error if the php openssl module is not installed.
 if (!(extension_loaded('openssl'))) {

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -75,6 +75,13 @@ readonly class ErrorHandler
         return false;
     }
 
+    /**
+     * Handler for uncaught exceptions. This will do a few things:
+     * - Log information about the exception and stack trace
+     * - Set HTTP status codes for web requests
+     * - Render some basic information that an error occurred
+     * - Abort the request
+     */
     public function handleException(Throwable $e): never
     {
         $this->logger->critical('Uncaught exception!', [
@@ -103,11 +110,20 @@ readonly class ErrorHandler
         exit();
     }
 
+    /**
+     * Configures the runtime with this class's `handleError` as the system
+     * error handler.
+     */
     public function installErrorHandler(int $level = E_ALL): void
     {
         set_error_handler($this->handleError(...), $level);
     }
 
+    /**
+     * Configures the runtime with this class's `handleException` as the system
+     * fallback exception handler. Only exceptions that are uncaught will reach
+     * it; locally-handled exceptions are not changed.
+     */
     public function installExceptionHandler(): void
     {
         set_exception_handler($this->handleException(...));

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -57,7 +57,8 @@ readonly class ErrorHandler
         if ((error_reporting() & $errno) !== 0) {
             throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
         }
-        // Always log deprecation warnings even if they're turned off at runtime.
+        // If the current error_reporting DOES NOT capture the error level,
+        // still log deprecation warnings even if they're turned off at runtime.
         // If running inside unit tests, throw anyway.
         if ($errno === E_USER_DEPRECATED || $errno === E_DEPRECATED) {
             if (defined('PHPUNIT_COMPOSER_INSTALL')) {

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -83,6 +83,7 @@ readonly class ErrorHandler
         // headers), switching on exception type to yield the correct http
         // code, etc.
         http_response_code(500);
+        header('Content-type: text/plain');
         echo 'An error has occurred.';
 
         if ($this->shouldDisplayErrors) {

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\Core;
+
+use ErrorException;
+use OpenEMR\BC\ServiceContainer;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+use function defined;
+use function error_reporting;
+use function http_response_code;
+use function set_error_handler;
+use function set_exception_handler;
+
+use const E_DEPRECATED;
+use const E_USER_DEPRECATED;
+
+readonly class ErrorHandler
+{
+    private LoggerInterface $logger;
+    private bool $isCli;
+
+    public function __construct(
+        ?LoggerInterface $logger,
+        private bool $shouldDisplayErrors = false,
+    ) {
+        $this->isCli = (PHP_SAPI === 'cli');
+        $this->logger = $logger ?? ServiceContainer::getLogger();
+    }
+
+    /**
+     * Promotes errors to ErrorExceptions, respecting the current
+     * error_reporting level (including @)
+     *
+     * @link https://www.php.net/manual/en/function.set-error-handler.php
+     */
+    public function handleError(
+        int $errno,
+        string $errstr,
+        string $errfile,
+        int $errline,
+    ): bool {
+        // If the current error_reporting error level matches the specified
+        // severity, convert it to an error exception. With this check, `@` error
+        // suppression (or changes to `error_reporting`) are respected.
+        if ((error_reporting() & $errno) !== 0) {
+            throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+        }
+        // Always log deprecation warnings even if they're turned off at runtime.
+        // If running inside unit tests, throw anyway.
+        if ($errno === E_USER_DEPRECATED || $errno === E_DEPRECATED) {
+            if (defined('PHPUNIT_COMPOSER_INSTALL')) {
+                throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+            } else {
+                $this->logger->warning('Deprecated: {message} ({file}:{line})', [
+                    'message' => $errstr,
+                    'file' => $errfile,
+                    'line' => $errline,
+                ]);
+            }
+        }
+        // "If the function returns false then the normal error handler
+        // continues."
+        return false;
+    }
+
+    public function handleException(Throwable $e): never
+    {
+        $this->logger->critical('Uncaught exception!', [
+            'exception' => $e,
+        ]);
+
+        // CLI scripts simply exit nonzero
+        if ($this->isCli) {
+            exit(1);
+        }
+
+        // For now, just crash out with minimal detail as before.
+        // In the future, this can be smarter about request context (accept
+        // headers), switching on exception type to yield the correct http
+        // code, etc.
+        http_response_code(500);
+        echo 'An error has occurred.';
+
+        if ($this->shouldDisplayErrors) {
+            echo $e;
+        }
+        exit();
+    }
+
+    public function installErrorHandler(int $level = E_ALL): void
+    {
+        set_error_handler($this->handleError(...), $level);
+    }
+
+    public function installExceptionHandler(): void
+    {
+        set_exception_handler($this->handleException(...));
+    }
+}

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * @package   openemr
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 declare(strict_types=1);
 
 namespace OpenEMR\Core;

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -90,6 +90,9 @@ readonly class ErrorHandler
         // In the future, this can be smarter about request context (accept
         // headers), switching on exception type to yield the correct http
         // code, etc.
+        // Note: under rare circumstances, this could trigger a secondary error
+        // if headers are already sent. The default deployment seems to turn on
+        // output_buffering in php.ini automatically so it's unlikely to occur
         http_response_code(500);
         header('Content-type: text/plain');
         echo 'An error has occurred.';

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -62,13 +62,12 @@ readonly class ErrorHandler
         if ($errno === E_USER_DEPRECATED || $errno === E_DEPRECATED) {
             if (defined('PHPUNIT_COMPOSER_INSTALL')) {
                 throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
-            } else {
-                $this->logger->warning('Deprecated: {message} ({file}:{line})', [
-                    'message' => $errstr,
-                    'file' => $errfile,
-                    'line' => $errline,
-                ]);
             }
+            $this->logger->warning('Deprecated: {message} ({file}:{line})', [
+                'message' => $errstr,
+                'file' => $errfile,
+                'line' => $errline,
+            ]);
         }
         // "If the function returns false then the normal error handler
         // continues."

--- a/tests/Tests/Isolated/Core/ErrorHandlerTest.php
+++ b/tests/Tests/Isolated/Core/ErrorHandlerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ *
+ * @author    Eric Stern <eric@lwt.io>
+ * @copyright Copyright (c) 2026 Eric Stern
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Core;
+
+use ErrorException;
+use OpenEMR\Core\ErrorHandler;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+use const E_DEPRECATED;
+use const E_USER_WARNING;
+
+#[Group('isolated')]
+#[Group('core')]
+class ErrorHandlerTest extends TestCase
+{
+    public function testHandleErrorThrowsWhenErrorReportingMatches(): void
+    {
+        $handler = new ErrorHandler(new NullLogger());
+
+        // Ensure E_USER_WARNING is in error_reporting
+        $originalLevel = error_reporting(E_ALL);
+        try {
+            $this->expectException(ErrorException::class);
+            $this->expectExceptionMessage('Test error');
+
+            $handler->handleError(E_USER_WARNING, 'Test error', '/path/to/file.php', 42);
+        } finally {
+            error_reporting($originalLevel);
+        }
+    }
+
+    public function testHandleErrorReturnsFalseWhenSuppressed(): void
+    {
+        $handler = new ErrorHandler(new NullLogger());
+
+        // The @ operator sets error_reporting to 0 for the duration of the expression
+        $result = @$handler->handleError(E_USER_WARNING, 'Suppressed error', '/path/to/file.php', 42);
+
+        self::assertFalse($result);
+    }
+
+    public function testDeprecationThrowsEvenWhenSuppressed(): void
+    {
+        // PHPUNIT_COMPOSER_INSTALL is defined during test runs, so deprecations
+        // always throw regardless of error_reporting level
+        $handler = new ErrorHandler(new NullLogger());
+
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Deprecated function');
+
+        @$handler->handleError(E_DEPRECATED, 'Deprecated function', '/path/to/file.php', 50);
+    }
+
+    public function testErrorHandlerInstallation(): void
+    {
+        $handler = new ErrorHandler(new NullLogger());
+        $handler->installErrorHandler(E_ALL);
+        $old = error_reporting(E_ALL);
+
+        try {
+            trigger_error('test error', E_USER_WARNING);
+            self::fail('Error handler did not trigger');
+        } catch (ErrorException $e) {
+            self::assertSame('test error', $e->getMessage());
+            self::assertSame(E_USER_WARNING, $e->getSeverity());
+        } finally {
+            restore_error_handler();
+            error_reporting($old);
+        }
+    }
+
+    // handleException() cannot be unit tested because it calls exit() which
+    // terminates the process. Tests run in CLI mode which hits exit(1)
+    // immediately after logging.
+}

--- a/tests/Tests/Isolated/Core/ErrorHandlerTest.php
+++ b/tests/Tests/Isolated/Core/ErrorHandlerTest.php
@@ -1,14 +1,14 @@
 <?php
 
 /**
- * @package   OpenEMR
- *
+ * @package   openemr
  * @link      https://www.open-emr.org
- *
- * @author    Eric Stern <eric@lwt.io>
- * @copyright Copyright (c) 2026 Eric Stern
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Core;
 


### PR DESCRIPTION
Ref #8756, #9701, #8964, probably others.

#### Short description of what this changes or resolves:
When OpenEMR throws an exception and it's not caught, we tend to get the (in)famous "white screen of death". Depending on `php.ini` settings you may get slightly different output, but the end result is the same - absolutely no useful information at all.

This makes an error handler class, and initializes it in `interface/globals.php` which serves as a bootstrap for many paths. With this, in the event of an uncaught exception, it'll be logged and _something_ will be displayed on the page. If you have `OPENEMR__ENVIRONMENT` set to `dev` (used in version and kernel), it'll render the stack trace in addition to logging it.

_This is a very basic start._ Future enhancements (vaguely noted in the code) include things like:
- Better awareness of log levels and runtime environment
- Customizing the failure information based on exception type (e.g. a `RuntimeException` may send a 4xx class; a request indicating it wants `json` back might format the output as such)
- Pluggable and chainable error handlers (remote logging, telemetry, etc)

There's a lot more we can do to enhance this, but we've gotta start somewhere, and this should be a non-disruptive enhancement that more or less guarantees uncaught exceptions never go to the void.

Practical runtime changes:
- What was a "white screen of death" will now serve a 500 response type, where previously it may not have
- It will now send a nondescript message in `Content-type: text/plain`
- If an envvar indicates dev mode, it'll render the stack trace. This is not a default anywhere.

#### Changes proposed in this pull request:
- Adds `ErrorHandler` class
- Adds basic smoke tests
- Changes the loading order slightly within `interface/globals.php` to make the handler install as early as possible
- Configures the exception handling path (only) in `interface/globals.php`
- Sets up strict mode in `bootstrap.php`, which is only used by some next-generation prototypes for now.

#### Was an AI assistant used? Yes / No
Tests were AI generated.