### PR TITLE
refactor(billing): use symfony/process for print command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
         "symfony/http-client": "~6.4.26",
         "symfony/http-foundation": "~6.4.26",
         "symfony/http-kernel": "~6.4.27",
-        "symfony/process": "^7.4",
+        "symfony/process": "^6.4",
         "symfony/psr-http-message-bridge": "~6.4.24",
         "symfony/yaml": "~6.4.26",
         "twig/twig": "^3.22.2",

--- a/composer.json
+++ b/composer.json
@@ -120,6 +120,7 @@
         "symfony/http-client": "~6.4.26",
         "symfony/http-foundation": "~6.4.26",
         "symfony/http-kernel": "~6.4.27",
+        "symfony/process": "^7.4",
         "symfony/psr-http-message-bridge": "~6.4.24",
         "symfony/yaml": "~6.4.26",
         "twig/twig": "^3.22.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "519b8e617b0d215e899fe49641cef906",
+    "content-hash": "824a35d301ec46e7e0346f7111205b73",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -10962,16 +10962,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.5",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97"
+                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/608476f4604102976d687c483ac63a79ba18cc97",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97",
+                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
+                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
                 "shasum": ""
             },
             "require": {
@@ -11003,7 +11003,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.5"
+                "source": "https://github.com/symfony/process/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -11023,7 +11023,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:07:59+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/property-access",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "824a35d301ec46e7e0346f7111205b73",
+    "content-hash": "16444996fbc07e497e95352a950bf81f",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -10962,20 +10962,20 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.8",
+            "version": "v6.4.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c46e854e79b52d07666e43924a20cb6dc546644e",
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "autoload": {
@@ -11003,7 +11003,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
+                "source": "https://github.com/symfony/process/tree/v6.4.33"
             },
             "funding": [
                 {
@@ -11023,7 +11023,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-01-23T16:02:12+00:00"
         },
         {
             "name": "symfony/property-access",

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -44,6 +44,7 @@ use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\OeUI\OemrUI;
 use OpenEMR\Pdf\Config_Mpdf;
+use Symfony\Component\Process\Process;
 
 require_once("../globals.php");
 
@@ -628,7 +629,7 @@ if (
         if ($DEBUG) {
             $alertmsg = xl("Printing skipped; see test output in") . ' ' . $STMT_TEMP_FILE;
         } else {
-            exec(escapeshellcmd(OPENEMR_PRINT_COMMAND) . " " . escapeshellarg((string) $STMT_TEMP_FILE));
+            (new Process([OPENEMR_PRINT_COMMAND, (string) $STMT_TEMP_FILE]))->run();
             if ($_REQUEST['form_without']) {
                 $alertmsg = xl('Now printing') . ' ' . $stmt_count . ' ' . xl('statements; invoices will not be updated.');
             } else {


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Part of #11405 - migrating shell exec calls to use symfony/process.

This is also partially to get symfony/process as an explicit dependency ahead of some other work that needs it.

#### Changes proposed in this pull request:

- Replace `exec()` with Symfony Process using array arguments for the print command in `sl_eob_search.php`
- This is safer (no shell injection possible) and more maintainable
- Uses array arguments instead of shell string, so no manual escaping needed

#### Was an AI assistant used? Yes

Assisted-by trailer included in commit.

---

Generated with [Claude Code](https://claude.ai/claude-code)