### PR TITLE
chore(utilities): Refactor and add tests for fixDate

### DIFF
--- a/.phpstan/baseline/assignOp.invalid.php
+++ b/.phpstan/baseline/assignOp.invalid.php
@@ -1697,16 +1697,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/encounter_events.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\+\\=" between mixed and 100 results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/global_functions.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\+\\=" between string and 1900 results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/global_functions.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\.\\=" between mixed and "\\\\t" results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../library/global_functions.inc.php',

--- a/.phpstan/baseline/assignOp.invalid.php
+++ b/.phpstan/baseline/assignOp.invalid.php
@@ -1697,6 +1697,16 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/encounter_events.inc.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Binary operation "\\+\\=" between mixed and 100 results in an error\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/global_functions.inc.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Binary operation "\\+\\=" between string and 1900 results in an error\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/global_functions.inc.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Binary operation "\\.\\=" between mixed and "\\\\t" results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../library/global_functions.inc.php',
@@ -1760,16 +1770,6 @@ $ignoreErrors[] = [
     'message' => '#^Binary operation "\\.\\=" between string and mixed results in an error\\.$#',
     'count' => 7,
     'path' => __DIR__ . '/../../library/options.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\+\\=" between mixed and 100 results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/patient.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\+\\=" between string and 1900 results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/patient.inc.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\.\\=" between mixed and non\\-falsy\\-string results in an error\\.$#',

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -6543,7 +6543,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 8,
+    'count' => 6,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
@@ -16167,11 +16167,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/add_edit_event_user.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'\\+1 year \' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/add_edit_event_user.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/add_edit_event_user.php',
@@ -17132,13 +17127,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/report/pat_ledger.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \' 23\\:59\\:59\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/report/pat_ledger.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 6,
+    'count' => 5,
     'path' => __DIR__ . '/../../portal/report/pat_ledger.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -53,7 +53,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 10,
+    'count' => 7,
     'path' => __DIR__ . '/../../custom/export_labworks.php',
 ];
 $ignoreErrors[] = [
@@ -2348,7 +2348,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 21,
+    'count' => 20,
     'path' => __DIR__ . '/../../library/patient.inc.php',
 ];
 $ignoreErrors[] = [
@@ -2703,7 +2703,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 12,
+    'count' => 7,
     'path' => __DIR__ . '/../../portal/add_edit_event_user.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -2928,7 +2928,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 10,
+    'count' => 11,
     'path' => __DIR__ . '/../../library/global_functions.inc.php',
 ];
 $ignoreErrors[] = [
@@ -2978,7 +2978,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 39,
+    'count' => 38,
     'path' => __DIR__ . '/../../library/patient.inc.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -25907,16 +25907,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/patient.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function fixDate\\(\\) has parameter \\$date with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/patient.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function fixDate\\(\\) has parameter \\$default with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/patient.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function genFacilityTitle\\(\\) has parameter \\$facid with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/patient.inc.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -16387,11 +16387,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/patient.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function fixDate\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/patient.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function genFacilityTitle\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/patient.inc.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -35177,6 +35177,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/global_functions.inc.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Cannot access offset 0 on list\\<string\\>\\|false\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/global_functions.inc.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Cannot access offset 2 on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/global_functions.inc.php',
@@ -35658,11 +35663,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'valedictory\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/patient.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset 0 on list\\<string\\>\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/patient.inc.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -35177,11 +35177,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/global_functions.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset 0 on list\\<string\\>\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/global_functions.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset 2 on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/global_functions.inc.php',

--- a/.phpstan/baseline/openemr.noGlobalNsFunctions.php
+++ b/.phpstan/baseline/openemr.noGlobalNsFunctions.php
@@ -5752,11 +5752,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/patient.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function fixDate may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/patient.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function genFacilityTitle may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/patient.inc.php',

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -275,7 +275,7 @@ function fixDate($date, $default = "0000-00-00")
 {
     $fixed_date = $default;
     $date = trim((string) $date);
-    if (preg_match("'^[0-9]{1,4}[/.-][0-9]{1,2}[/.-][0-9]{1,4}$'", $date)) {
+    if (preg_match("'^[0-9]{1,4}[/.-][0-9]{1,2}[/.-][0-9]{1,4}$'", $date) === 1) {
         $dmy = preg_split("'[/.-]'", $date);
         if ($dmy[0] > 99) {
             $fixed_date = sprintf("%04u-%02u-%02u", $dmy[0], $dmy[1], $dmy[2]);

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -273,35 +273,41 @@ function display_desc($desc)
  */
 function fixDate($date, $default = "0000-00-00")
 {
-    $fixed_date = $default;
     $date = trim((string) $date);
-    if (preg_match("'^[0-9]{1,4}[/.-][0-9]{1,2}[/.-][0-9]{1,4}$'", $date) === 1) {
-        $dmy = preg_split("'[/.-]'", $date);
-        if ($dmy[0] > 99) {
-            $fixed_date = sprintf("%04u-%02u-%02u", $dmy[0], $dmy[1], $dmy[2]);
-        } else {
-            if ($dmy[0] != 0 || $dmy[1] != 0 || $dmy[2] != 0) {
-                if ($dmy[2] < 1000) {
-                    $dmy[2] += 1900;
-                }
+    if (preg_match('/^(\d{1,4})[\/.\-](\d{1,2})[\/.\-](\d{1,4})$/', $date, $matches) !== 1) {
+        return $default;
+    }
 
-                if ($dmy[2] < 1910) {
-                    $dmy[2] += 100;
-                }
-            }
-            // Determine if MDY date format is used, preferring Date Display Format from
-            // global settings if it's not YMD, otherwise guessing from country code.
-            $using_mdy = empty(OEGlobalsBag::getInstance()->get('date_display_format')) ?
-                (OEGlobalsBag::getInstance()->getInt('phone_country_code') === 1) : (OEGlobalsBag::getInstance()->get('date_display_format') == 1);
-            if ($using_mdy) {
-                $fixed_date = sprintf("%04u-%02u-%02u", $dmy[2], $dmy[0], $dmy[1]);
-            } else {
-                $fixed_date = sprintf("%04u-%02u-%02u", $dmy[2], $dmy[1], $dmy[0]);
-            }
+    [, $first, $second, $third] = $matches;
+    $first = (int)$first;
+    $second = (int)$second;
+    $third = (int)$third;
+
+    // Year-first format (YYYY/MM/DD)
+    if ($first > 99) {
+        return sprintf('%04u-%02u-%02u', $first, $second, $third);
+    }
+
+    // Adjust two/three-digit years: 00-09 → 2000-2009, 10-99 → 1910-1999
+    $year = $third;
+    if ($first !== 0 || $second !== 0 || $third !== 0) {
+        if ($year < 1000) {
+            $year += 1900;
+        }
+        if ($year < 1910) {
+            $year += 100;
         }
     }
 
-    return $fixed_date;
+    // Determine if MDY date format is used, preferring Date Display Format from
+    // global settings if it's not YMD, otherwise guessing from country code.
+    $using_mdy = empty(OEGlobalsBag::getInstance()->get('date_display_format'))
+        ? (OEGlobalsBag::getInstance()->getInt('phone_country_code') === 1)
+        : (OEGlobalsBag::getInstance()->get('date_display_format') == 1);
+
+    [$month, $day] = $using_mdy ? [$first, $second] : [$second, $first];
+
+    return sprintf('%04u-%02u-%02u', $year, $month, $day);
 }
 
 /**

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -257,6 +257,45 @@ function display_desc($desc)
     return $desc;
 }
 
+// Supported input date formats are:
+//   mm/dd/yyyy
+//   mm/dd/yy   (assumes 20yy for yy < 10, else 19yy)
+//   yyyy/mm/dd
+//   also mm-dd-yyyy, etc. and mm.dd.yyyy, etc.
+//
+function fixDate($date, $default = "0000-00-00")
+{
+    $fixed_date = $default;
+    $date = trim((string) $date);
+    if (preg_match("'^[0-9]{1,4}[/.-][0-9]{1,2}[/.-][0-9]{1,4}$'", $date)) {
+        $dmy = preg_split("'[/.-]'", $date);
+        if ($dmy[0] > 99) {
+            $fixed_date = sprintf("%04u-%02u-%02u", $dmy[0], $dmy[1], $dmy[2]);
+        } else {
+            if ($dmy[0] != 0 || $dmy[1] != 0 || $dmy[2] != 0) {
+                if ($dmy[2] < 1000) {
+                    $dmy[2] += 1900;
+                }
+
+                if ($dmy[2] < 1910) {
+                    $dmy[2] += 100;
+                }
+            }
+            // Determine if MDY date format is used, preferring Date Display Format from
+            // global settings if it's not YMD, otherwise guessing from country code.
+            $using_mdy = empty(OEGlobalsBag::getInstance()->get('date_display_format')) ?
+                (OEGlobalsBag::getInstance()->getInt('phone_country_code') === 1) : (OEGlobalsBag::getInstance()->get('date_display_format') == 1);
+            if ($using_mdy) {
+                $fixed_date = sprintf("%04u-%02u-%02u", $dmy[2], $dmy[0], $dmy[1]);
+            } else {
+                $fixed_date = sprintf("%04u-%02u-%02u", $dmy[2], $dmy[1], $dmy[0]);
+            }
+        }
+    }
+
+    return $fixed_date;
+}
+
 /**
  * Format a money amount with decimals but no other decoration.
  *

--- a/library/global_functions.inc.php
+++ b/library/global_functions.inc.php
@@ -257,12 +257,20 @@ function display_desc($desc)
     return $desc;
 }
 
-// Supported input date formats are:
-//   mm/dd/yyyy
-//   mm/dd/yy   (assumes 20yy for yy < 10, else 19yy)
-//   yyyy/mm/dd
-//   also mm-dd-yyyy, etc. and mm.dd.yyyy, etc.
-//
+/**
+ * Supported input date formats are:
+ *   mm/dd/yyyy
+ *   mm/dd/yy   (assumes 20yy for yy < 10, else 19yy)
+ *   yyyy/mm/dd
+ *   also mm-dd-yyyy, etc. and mm.dd.yyyy, etc.
+ *
+ * Prefer native date formatting utilities over this
+ *
+ * @template TDefault
+ * @param ?string $date
+ * @param TDefault $default
+ * @return string|TDefault
+ */
 function fixDate($date, $default = "0000-00-00")
 {
     $fixed_date = $default;

--- a/library/patient.inc.php
+++ b/library/patient.inc.php
@@ -1115,45 +1115,6 @@ function newPatientData(
     return $foo['pid'];
 }
 
-// Supported input date formats are:
-//   mm/dd/yyyy
-//   mm/dd/yy   (assumes 20yy for yy < 10, else 19yy)
-//   yyyy/mm/dd
-//   also mm-dd-yyyy, etc. and mm.dd.yyyy, etc.
-//
-function fixDate($date, $default = "0000-00-00")
-{
-    $fixed_date = $default;
-    $date = trim((string) $date);
-    if (preg_match("'^[0-9]{1,4}[/.-][0-9]{1,2}[/.-][0-9]{1,4}$'", $date)) {
-        $dmy = preg_split("'[/.-]'", $date);
-        if ($dmy[0] > 99) {
-            $fixed_date = sprintf("%04u-%02u-%02u", $dmy[0], $dmy[1], $dmy[2]);
-        } else {
-            if ($dmy[0] != 0 || $dmy[1] != 0 || $dmy[2] != 0) {
-                if ($dmy[2] < 1000) {
-                    $dmy[2] += 1900;
-                }
-
-                if ($dmy[2] < 1910) {
-                    $dmy[2] += 100;
-                }
-            }
-            // Determine if MDY date format is used, preferring Date Display Format from
-            // global settings if it's not YMD, otherwise guessing from country code.
-            $using_mdy = empty(OEGlobalsBag::getInstance()->get('date_display_format')) ?
-                (OEGlobalsBag::getInstance()->getInt('phone_country_code') === 1) : (OEGlobalsBag::getInstance()->get('date_display_format') == 1);
-            if ($using_mdy) {
-                $fixed_date = sprintf("%04u-%02u-%02u", $dmy[2], $dmy[0], $dmy[1]);
-            } else {
-                $fixed_date = sprintf("%04u-%02u-%02u", $dmy[2], $dmy[1], $dmy[0]);
-            }
-        }
-    }
-
-    return $fixed_date;
-}
-
 function pdValueOrNull($key, $value)
 {
     if (

--- a/tests/Tests/Isolated/library/GlobalFunctionsTest.php
+++ b/tests/Tests/Isolated/library/GlobalFunctionsTest.php
@@ -21,9 +21,40 @@ class GlobalFunctionsTest extends TestCase
             'empty string uses default' => ['', 'default', 'default'],
             'invalid uses default' => ['notadate', 'default', 'default'],
             'default can be null' => ['notadate', null, null],
-            '01/02/2023' => ['01/02/2023', null, '2023-02-01'],
+            // DMY format with various separators (test env uses DMY, not MDY)
+            '01/02/2023 (slash)' => ['01/02/2023', null, '2023-02-01'],
+            '01-02-2023 (dash)' => ['01-02-2023', null, '2023-02-01'],
+            '01.02.2023 (dot)' => ['01.02.2023', null, '2023-02-01'],
+
+            // Two-digit year handling: 00-09 → 2000-2009
+            '1/2/00' => ['1/2/00', null, '2000-02-01'],
+            '1/2/05' => ['1/2/05', null, '2005-02-01'],
+            '1/2/09' => ['1/2/09', null, '2009-02-01'],
+
+            // Two-digit year handling: 10-99 → 1910-1999
+            '1/2/10' => ['1/2/10', null, '1910-02-01'],
             '1/2/87' => ['1/2/87', null, '1987-02-01'],
-            // Plenty more to test here, just coverign a few basics
+            '1/2/99' => ['1/2/99', null, '1999-02-01'],
+
+            // Without leading zeros
+            '1/2/2023' => ['1/2/2023', null, '2023-02-01'],
+            '31/12/2023' => ['31/12/2023', null, '2023-12-31'],
+
+            // YYYY/MM/DD format (first part > 99)
+            '2023/01/15' => ['2023/01/15', null, '2023-01-15'],
+            '2023-06-30' => ['2023-06-30', null, '2023-06-30'],
+            '100/01/01' => ['100/01/01', null, '0100-01-01'],
+
+            // All zeros produces 0000-00-00 (skips year adjustment)
+            '0/0/0' => ['0/0/0', null, '0000-00-00'],
+            '00/00/00' => ['00/00/00', null, '0000-00-00'],
+
+            // Whitespace handling
+            '  01/02/2023  ' => ['  01/02/2023  ', null, '2023-02-01'],
+
+            // Three-digit years (< 1000 → +1900, then < 1910 → +100)
+            '1/2/100' => ['1/2/100', null, '2000-02-01'],
+            '1/2/900' => ['1/2/900', null, '2800-02-01'],
         ];
     }
 

--- a/tests/Tests/Isolated/library/GlobalFunctionsTest.php
+++ b/tests/Tests/Isolated/library/GlobalFunctionsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\library;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+#[Small]
+class GlobalFunctionsTest extends TestCase
+{
+    public static function dateProvider(): array
+    {
+        return [
+            'null uses default' => [null, 'default', 'default'],
+            'empty string uses default' => ['', 'default', 'default'],
+            'invalid uses default' => ['notadate', 'default', 'default'],
+            'default can be null' => ['notadate', null, null],
+            '01/02/2023' => ['01/02/2023', null, '2023-02-01'],
+            '1/2/87' => ['1/2/87', null, '1987-02-01'],
+            // Plenty more to test here, just coverign a few basics
+        ];
+    }
+
+    #[DataProvider('dateProvider')]
+    public function testFixDate(?string $input, mixed $default, mixed $expected): void
+    {
+        $result = fixDate($input, $default);
+        self::assertSame($expected, $result);
+    }
+}

--- a/tests/Tests/Isolated/library/GlobalFunctionsTest.php
+++ b/tests/Tests/Isolated/library/GlobalFunctionsTest.php
@@ -11,6 +11,9 @@ use PHPUnit\Framework\TestCase;
 #[Small]
 class GlobalFunctionsTest extends TestCase
 {
+    /**
+     * @return array{?string, ?string, ?string}[]
+     */
     public static function dateProvider(): array
     {
         return [


### PR DESCRIPTION
#### Short description of what this changes or resolves:
FixDate is used to... well, it says fix dates, but it's more of an odd formatter. The way it works today makes fixing the SQL NO_ZERO_DATE (#11307) quite a bit harder, since it explicitly defaults to the zero date format.

This adds some tests to capture current behavior and validate that it can actually return null, then tidies up some of the internals and fixes _most_ of its PHPStan errors.

To be clear, future code should not use it. Instead, it should use native `DateTime`-based formatting utilities. For input validation/handling, proper date parsing should be used.

Started over in #11245 during review of the changes and extracted from there.

#### Changes proposed in this pull request:
- Moves fixDate to global functions in autoload
- Adds tests
- Test-backed refactor of internals (mostly ai)

Just for clarity: the tests were added before refactoring to ensure current behavior is maintained.

#### Was an AI assistant used? Yes / No
Yes