### PR TITLE
fix(calendar): Render restoreSession JS inside of script tag

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1084,8 +1084,8 @@ $addEditEventConfig = [
 ];
 ?>
 window.addEditEventConfig = <?php echo json_encode($addEditEventConfig); ?>;
-</script>
 <?php require(OEGlobalsBag::getInstance()->get('srcdir') . "/restoreSession.php"); ?>
+</script>
 
 <!-- Extracted JS functions (Issue #8057) — loaded before event dispatch
      so that RENDER_JAVASCRIPT listeners can call these functions immediately -->


### PR DESCRIPTION
#### Short description of what this changes or resolves:

JS code is rendering instead of executing. Repro: on master, try to create a new event from the ui

<img width="1868" height="2944" alt="Screenshot 2026-04-03 at 12 23 27 PM" src="https://github.com/user-attachments/assets/770eaa22-d523-4591-9a1a-b2eb8b59041a" />

This appears to be a regression from #11077.

#### Changes proposed in this pull request:

Moved the JS-building PHP file back inside of the `<script>` tag.

#### Was an AI assistant used? Yes / No
No