### PR TITLE
fix(hooks): read commit message content instead of file path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,7 +145,7 @@ repos:
 
   - id: conventional-commits
     name: Conventional Commits
-    entry: composer conventional-commits:check --
+    entry: bash -c 'composer conventional-commits:check -- "$(<"$1")"' --
     language: system
     stages:
     - commit-msg


### PR DESCRIPTION
## Summary

- The `conventional-commits` pre-commit hook receives a commit message **file path** from the `commit-msg` stage, but `ramsey/conventional-commits validate` expects message **content** as its argument
- Wrap the entry in `bash -c` to read the file content via `$(<"$1")` before passing it to the validator

## Test plan

- [ ] Run `git commit` with a valid conventional commit message — hook should pass
- [ ] Run `git commit` with an invalid message — hook should reject it