### PR TITLE
refactor(billing): replace exec(unzip) with ZipArchive for ERA file uploads

### DIFF
--- a/.phpstan/baseline/assignOp.invalid.php
+++ b/.phpstan/baseline/assignOp.invalid.php
@@ -147,11 +147,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/edit_payment.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\.\\=" between \'\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/era_payments.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\.\\=" between 0\\|0\\.0\\|array\\{\\}\\|string\\|false\\|null and non\\-falsy\\-string results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/era_payments.php',
@@ -233,11 +228,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\.\\=" between mixed and \' OR \' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\.\\=" between string and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -1792,11 +1792,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'\\.zip\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'_\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -248,7 +248,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 19,
+    'count' => 18,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -462,11 +462,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$tmp_name \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$encounter_id \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/billing/sl_receipts_report.php',

--- a/interface/billing/era_payments.php
+++ b/interface/billing/era_payments.php
@@ -120,6 +120,7 @@ elseif (!empty($_FILES['form_erafile']['size'])) {
     if (!is_string($tmp_name)) {
         $alertmsg .= xl("Invalid file upload") . " ";
     } else {
+        $shouldParseEra = true;
         // Handle .zip extension if present.
         if (strtolower(substr((string) $_FILES['form_erafile']['name'], -4)) == '.zip') {
             $zip = new ZipArchive();
@@ -128,17 +129,21 @@ elseif (!empty($_FILES['form_erafile']['size'])) {
                 $zip->close();
                 if ($contents === false) {
                     $alertmsg .= xl("Unable to read file from ZIP archive") . " ";
-                    $contents = '';
+                    $shouldParseEra = false;
+                } elseif (file_put_contents($tmp_name, $contents) === false) {
+                    $alertmsg .= xl("Unable to write extracted ZIP contents") . " ";
+                    $shouldParseEra = false;
                 }
-
-                file_put_contents($tmp_name, $contents);
             } else {
                 $alertmsg .= xl("Unable to open ZIP archive") . " ";
+                $shouldParseEra = false;
             }
         }
-        $parseResult = ParseERA::parseERA($tmp_name, 'era_payments_callback');
-        if (is_string($parseResult)) {
-            $alertmsg .= $parseResult;
+        if ($shouldParseEra) {
+            $parseResult = ParseERA::parseERA($tmp_name, 'era_payments_callback');
+            if (is_string($parseResult)) {
+                $alertmsg .= $parseResult;
+            }
         }
 
         // Ensure the ERA directory exists

--- a/interface/billing/era_payments.php
+++ b/interface/billing/era_payments.php
@@ -136,7 +136,10 @@ elseif (!empty($_FILES['form_erafile']['size'])) {
                 $alertmsg .= xl("Unable to open ZIP archive") . " ";
             }
         }
-        $alertmsg .= ParseERA::parseERA($tmp_name, 'era_payments_callback');
+        $parseResult = ParseERA::parseERA($tmp_name, 'era_payments_callback');
+        if (is_string($parseResult)) {
+            $alertmsg .= $parseResult;
+        }
 
         // Ensure the ERA directory exists
         $eraDir = OEGlobalsBag::getInstance()->getString('OE_SITE_DIR') . "/documents/era";

--- a/interface/billing/era_payments.php
+++ b/interface/billing/era_payments.php
@@ -120,11 +120,21 @@ elseif (!empty($_FILES['form_erafile']['size'])) {
     if (!is_string($tmp_name)) {
         $alertmsg .= xl("Invalid file upload") . " ";
     } else {
-        // Handle .zip extension if present.  Probably won't work on Windows.
+        // Handle .zip extension if present.
         if (strtolower(substr((string) $_FILES['form_erafile']['name'], -4)) == '.zip') {
-            rename($tmp_name, "$tmp_name.zip");
-            exec("unzip -p " . escapeshellarg($tmp_name . ".zip") . " > " . escapeshellarg($tmp_name));
-            unlink("$tmp_name.zip");
+            $zip = new ZipArchive();
+            if ($zip->open($tmp_name) === true) {
+                $contents = $zip->getFromIndex(0);
+                $zip->close();
+                if ($contents === false) {
+                    $alertmsg .= xl("Unable to read file from ZIP archive") . " ";
+                    $contents = '';
+                }
+
+                file_put_contents($tmp_name, $contents);
+            } else {
+                $alertmsg .= xl("Unable to open ZIP archive") . " ";
+            }
         }
         $alertmsg .= ParseERA::parseERA($tmp_name, 'era_payments_callback');
 

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -962,11 +962,21 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
                             if ($_FILES['form_erafile']['size']) {
                                 $tmp_name = $_FILES['form_erafile']['tmp_name'];
 
-                                // Handle .zip extension if present.  Probably won't work on Windows.
+                                // Handle .zip extension if present.
                                 if (strtolower(substr((string) $_FILES['form_erafile']['name'], -4)) == '.zip') {
-                                    rename($tmp_name, "$tmp_name.zip");
-                                    exec("unzip -p " . escapeshellarg($tmp_name . ".zip") . " > " . escapeshellarg((string) $tmp_name));
-                                    unlink("$tmp_name.zip");
+                                    $zip = new ZipArchive();
+                                    if ($zip->open($tmp_name) === true) {
+                                        $contents = $zip->getFromIndex(0);
+                                        $zip->close();
+                                        if ($contents === false) {
+                                            $alertmsg .= xl("Unable to read file from ZIP archive") . " ";
+                                            $contents = '';
+                                        }
+
+                                        file_put_contents($tmp_name, $contents);
+                                    } else {
+                                        $alertmsg .= xl("Unable to open ZIP archive") . " ";
+                                    }
                                 }
 
                                 echo "<!-- Notes from ERA upload processing:\n";

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -960,41 +960,47 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
                             // Handle X12 835 file upload.
                             //
                             if ($_FILES['form_erafile']['size']) {
-                                $tmp_name = $_FILES['form_erafile']['tmp_name'];
+                                $tmp_name = $_FILES['form_erafile']['tmp_name'] ?? null;
+                                if (!is_string($tmp_name)) {
+                                    $alertmsg .= xl("Invalid file upload") . " ";
+                                } else {
+                                    // Handle .zip extension if present.
+                                    if (strtolower(substr((string) $_FILES['form_erafile']['name'], -4)) == '.zip') {
+                                        $zip = new ZipArchive();
+                                        if ($zip->open($tmp_name) === true) {
+                                            $contents = $zip->getFromIndex(0);
+                                            $zip->close();
+                                            if ($contents === false) {
+                                                $alertmsg .= xl("Unable to read file from ZIP archive") . " ";
+                                                $contents = '';
+                                            }
 
-                                // Handle .zip extension if present.
-                                if (strtolower(substr((string) $_FILES['form_erafile']['name'], -4)) == '.zip') {
-                                    $zip = new ZipArchive();
-                                    if ($zip->open($tmp_name) === true) {
-                                        $contents = $zip->getFromIndex(0);
-                                        $zip->close();
-                                        if ($contents === false) {
-                                            $alertmsg .= xl("Unable to read file from ZIP archive") . " ";
-                                            $contents = '';
+                                            file_put_contents($tmp_name, $contents);
+                                        } else {
+                                            $alertmsg .= xl("Unable to open ZIP archive") . " ";
                                         }
-
-                                        file_put_contents($tmp_name, $contents);
-                                    } else {
-                                        $alertmsg .= xl("Unable to open ZIP archive") . " ";
                                     }
-                                }
 
-                                echo "<!-- Notes from ERA upload processing:\n";
-                                $alertmsg .= ParseERA::parseERA($tmp_name, 'eob_search_era_callback');
-                                echo "-->\n";
-                                $erafullname = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/era/$eraname.edi";
-                                $edihname = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/edi/history/f835/$eraname.835";
-
-                                if (is_file($erafullname)) {
-                                    $alertmsg .= "Warning: Set $eraname was already uploaded ";
-                                    if (is_file(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/era/$eraname.html")) {
-                                        $alertmsg .= "and processed. ";
-                                    } else {
-                                        $alertmsg .= "but not yet processed. ";
+                                    echo "<!-- Notes from ERA upload processing:\n";
+                                    $parseResult = ParseERA::parseERA($tmp_name, 'eob_search_era_callback');
+                                    if (is_string($parseResult)) {
+                                        $alertmsg .= $parseResult;
                                     }
+                                    echo "-->\n";
+                                    $erafullname = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/era/$eraname.edi";
+                                    $edihname = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/edi/history/f835/$eraname.835";
+
+                                    if (is_file($erafullname)) {
+                                        $alertmsg .= "Warning: Set $eraname was already uploaded ";
+                                        if (is_file(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/era/$eraname.html")) {
+                                            $alertmsg .= "and processed. ";
+                                        } else {
+                                            $alertmsg .= "but not yet processed. ";
+                                        }
+                                    }
+                                    rename($tmp_name, $erafullname);
+                                    copy($erafullname, $edihname);
                                 }
-                                rename($tmp_name, $erafullname);
-                                copy($erafullname, $edihname);
                             } // End 835 upload
 
                             if ($eracount) {

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -964,6 +964,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
                                 if (!is_string($tmp_name)) {
                                     $alertmsg .= xl("Invalid file upload") . " ";
                                 } else {
+                                    $shouldParseEra = true;
                                     // Handle .zip extension if present.
                                     if (strtolower(substr((string) $_FILES['form_erafile']['name'], -4)) == '.zip') {
                                         $zip = new ZipArchive();
@@ -972,19 +973,23 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
                                             $zip->close();
                                             if ($contents === false) {
                                                 $alertmsg .= xl("Unable to read file from ZIP archive") . " ";
-                                                $contents = '';
+                                                $shouldParseEra = false;
+                                            } elseif (file_put_contents($tmp_name, $contents) === false) {
+                                                $alertmsg .= xl("Unable to write extracted ZIP contents") . " ";
+                                                $shouldParseEra = false;
                                             }
-
-                                            file_put_contents($tmp_name, $contents);
                                         } else {
                                             $alertmsg .= xl("Unable to open ZIP archive") . " ";
+                                            $shouldParseEra = false;
                                         }
                                     }
 
                                     echo "<!-- Notes from ERA upload processing:\n";
-                                    $parseResult = ParseERA::parseERA($tmp_name, 'eob_search_era_callback');
-                                    if (is_string($parseResult)) {
-                                        $alertmsg .= $parseResult;
+                                    if ($shouldParseEra) {
+                                        $parseResult = ParseERA::parseERA($tmp_name, 'eob_search_era_callback');
+                                        if (is_string($parseResult)) {
+                                            $alertmsg .= $parseResult;
+                                        }
                                     }
                                     echo "-->\n";
                                     $erafullname = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/era/$eraname.edi";


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Closes #11413.

Replaces two `exec("unzip -p ...")` shell calls used to extract ZIP-compressed ERA file uploads with PHP's native `ZipArchive::getFromIndex(0)`. Both call sites had the comment _"Probably won't work on Windows"_ — this resolves that portability gap without any change in behavior on Linux/macOS.

#### Changes proposed in this pull request:

- `interface/billing/era_payments.php` — replace `exec("unzip -p ...")` + `rename`/`unlink` dance with `ZipArchive::open()` + `getFromIndex(0)` + `file_put_contents()`; add error messages to `$alertmsg` on open/read failure
- `interface/billing/sl_eob_search.php` — same replacement at the equivalent upload handler

`ext-zip` is already a declared required dependency in `composer.json` and `ZipArchive` is used widely throughout the codebase, so no new requirements are introduced.

#### Was an AI assistant used? Yes

<!-- Assisted-by trailer added to the commit -->