### PR TITLE
refactor(background-services): distinguish lock failure reasons in BackgroundServiceRunner

### DIFF
--- a/src/Common/Command/BackgroundServicesCommand.php
+++ b/src/Common/Command/BackgroundServicesCommand.php
@@ -109,7 +109,8 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
             match ($result['status']) {
                 'executed' => $io->success("Service '{$result['name']}' executed successfully."),
                 'skipped' => $io->warning("Service '{$result['name']}' skipped (inactive, already running, or requires --force for manual mode)."),
-                'locked' => $io->warning("Service '{$result['name']}' is locked (not yet due to run)."),
+                'already_running' => $io->warning("Service '{$result['name']}' is already running (another process holds the lock)."),
+                'not_due' => $io->warning("Service '{$result['name']}' is not yet due to run (interval has not elapsed)."),
                 'not_found' => $io->error("Service '{$result['name']}' not found."),
                 'error' => $io->error("Service '{$result['name']}' encountered an error."),
                 default => $io->note("Service '{$result['name']}': {$result['status']}"),
@@ -119,7 +120,7 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
         $status = $results[0]['status'] ?? 'not_found';
         return match ($status) {
             'executed' => Command::SUCCESS,
-            'skipped', 'locked' => 2,
+            'skipped', 'already_running', 'not_due' => 2,
             default => Command::FAILURE,
         };
     }

--- a/src/RestControllers/BackgroundServiceRestController.php
+++ b/src/RestControllers/BackgroundServiceRestController.php
@@ -80,7 +80,7 @@ class BackgroundServiceRestController
         $result = $results[0];
         $statusCode = match ($result['status']) {
             'error' => Response::HTTP_INTERNAL_SERVER_ERROR,
-            'locked', 'skipped' => Response::HTTP_CONFLICT,
+            'already_running', 'not_due', 'skipped' => Response::HTTP_CONFLICT,
             default => Response::HTTP_OK,
         };
         return new JsonResponse(['service' => $result['name'], 'status' => $result['status']], $statusCode);

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -37,6 +37,13 @@ class BackgroundServiceRunner
      * @param string|null $serviceName Specific service name, or null for all
      * @param bool $force Bypass interval check
      * @return list<array{name: string, status: string}> Results per service
+     *   Possible status values:
+     *   - 'executed'        — service ran successfully
+     *   - 'skipped'         — inactive, already running (in-memory check), or manual-mode without --force
+     *   - 'already_running' — another process holds the DB lock (running = 1)
+     *   - 'not_due'         — interval has not elapsed yet (NOW() <= next_run)
+     *   - 'error'           — exception during lock acquisition or execution
+     *   - 'not_found'       — requested service name does not exist
      */
     public function run(?string $serviceName = null, bool $force = false): array
     {
@@ -69,14 +76,14 @@ class BackgroundServiceRunner
             }
 
             try {
-                $locked = $this->acquireLock($service, $force);
+                $lockFailureReason = $this->acquireLock($service, $force);
             } catch (\Throwable) {
                 $results[] = ['name' => $name, 'status' => 'error'];
                 continue;
             }
 
-            if (!$locked) {
-                $results[] = ['name' => $name, 'status' => 'locked'];
+            if ($lockFailureReason !== null) {
+                $results[] = ['name' => $name, 'status' => $lockFailureReason];
                 continue;
             }
 
@@ -137,16 +144,40 @@ class BackgroundServiceRunner
     }
 
     /**
+     * Attempt to acquire the running lock for a service.
+     *
+     * Returns null on success (lock acquired), or a reason string when the
+     * lock could not be acquired:
+     *   - 'already_running' — another process holds the lock (running = 1)
+     *   - 'not_due'         — the service interval has not elapsed yet
+     *
      * @param BackgroundServicesRow $service
+     * @return string|null Null on success, reason string on failure
      */
-    protected function acquireLock(array $service, bool $force): bool
+    protected function acquireLock(array $service, bool $force): ?string
     {
         $sql = 'UPDATE background_services SET running = 1, next_run = NOW() + INTERVAL ?'
             . ' MINUTE WHERE running < 1 ' . ($force ? '' : 'AND NOW() > next_run ') . 'AND name = ?';
 
         QueryUtils::sqlStatementThrowException($sql, [$service['execute_interval'], $service['name']], true);
 
-        return QueryUtils::affectedRows() >= 1;
+        if (QueryUtils::affectedRows() >= 1) {
+            return null;
+        }
+
+        // Distinguish why the lock was not acquired: is the service already
+        // running (another process holds the lock) or is it simply not yet due?
+        $row = QueryUtils::querySingleRow(
+            'SELECT running FROM background_services WHERE name = ?',
+            [$service['name']],
+            false,
+        );
+
+        if ($row !== false && ($row['running'] ?? '0') == 1) {
+            return 'already_running';
+        }
+
+        return 'not_due';
     }
 
     protected function releaseLock(string $serviceName): void

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -177,7 +177,7 @@ class BackgroundServiceRunner
             return 'error';
         }
 
-        if (($row['running'] ?? '0') == 1) {
+        if (($row['running'] ?? '0') === '1') {
             return 'already_running';
         }
 

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -173,11 +173,15 @@ class BackgroundServiceRunner
             false,
         );
 
-        if ($row !== false && ($row['running'] ?? '0') == 1) {
+        if ($row === false) {
+            return 'error';
+        }
+
+        if (($row['running'] ?? '0') == 1) {
             return 'already_running';
         }
 
-        return 'not_due';
+        return $force ? 'already_running' : 'not_due';
     }
 
     protected function releaseLock(string $serviceName): void

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -55,15 +55,26 @@ class BackgroundServiceRunnerTest extends TestCase
         $this->assertSame('skipped', $results[0]['status']);
     }
 
-    public function testRunReturnsLockedWhenLockFails(): void
+    public function testRunReturnsAlreadyRunningWhenLockFailsDueToRunningProcess(): void
     {
         $runner = new BackgroundServiceRunnerStub(
             services: [self::makeService('svc1')],
-            lockResult: false,
+            lockFailureReason: 'already_running',
         );
         $results = $runner->run('svc1');
 
-        $this->assertSame('locked', $results[0]['status']);
+        $this->assertSame('already_running', $results[0]['status']);
+    }
+
+    public function testRunReturnsNotDueWhenLockFailsDueToInterval(): void
+    {
+        $runner = new BackgroundServiceRunnerStub(
+            services: [self::makeService('svc1')],
+            lockFailureReason: 'not_due',
+        );
+        $results = $runner->run('svc1');
+
+        $this->assertSame('not_due', $results[0]['status']);
     }
 
     public function testRunExecutesServiceSuccessfully(): void
@@ -179,11 +190,12 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
 
     /**
      * @param list<BackgroundServicesRow> $services
+     * @param string|null $lockFailureReason Null means lock acquired; a string is the failure reason returned to run()
      * @param (\Closure(BackgroundServicesRow): void)|null $executeCallback
      */
     public function __construct(
         private readonly array $services = [],
-        private readonly bool $lockResult = true,
+        private readonly ?string $lockFailureReason = null,
         private readonly ?\Closure $executeCallback = null,
     ) {
     }
@@ -199,9 +211,9 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
         return $this->services;
     }
 
-    protected function acquireLock(array $service, bool $force): bool
+    protected function acquireLock(array $service, bool $force): ?string
     {
-        return $this->lockResult;
+        return $this->lockFailureReason;
     }
 
     protected function releaseLock(string $serviceName): void


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Closes #11350.

`BackgroundServiceRunner::run()` previously emitted a single `'locked'` status when `acquireLock()` returned false, regardless of whether the cause was another process holding the DB lock or the service interval not yet having elapsed. This change distinguishes the two cases so CLI and API callers get actionable diagnostic output.

#### Changes proposed in this pull request:

**`BackgroundServiceRunner`**
- Change `acquireLock()` signature from `bool` to `?string` — returns `null` on success (lock acquired), or a reason string on failure
- When the `UPDATE` affects 0 rows, a follow-up `SELECT` on `running` determines which condition blocked the lock:
  - `'already_running'` — `running = 1`, another process holds the lock
  - `'not_due'` — interval has not elapsed (`NOW() <= next_run`)
- Update `run()` docblock to document all possible status values

**`BackgroundServicesCommand`**
- Replace the single `'locked'` match arm with distinct messages for `'already_running'` and `'not_due'`
- Both map to exit code `2` (unchanged behaviour)

**`BackgroundServiceRestController`**
- Replace `'locked'` in the HTTP status match with `'already_running'` and `'not_due'`
- Both continue to return `HTTP 409 Conflict` (unchanged behaviour)

**`BackgroundServiceRunnerTest`**
- Update the stub's `acquireLock()` from `bool` to `?string`
- Replace the single `testRunReturnsLockedWhenLockFails` test with two separate tests: `testRunReturnsAlreadyRunningWhenLockFailsDueToRunningProcess` and `testRunReturnsNotDueWhenLockFailsDueToInterval`

#### Was an AI assistant used? Yes

<!-- Assisted-by trailer added to the commit -->