### PR TITLE
feat(ui): display software version in fixed footer

### DIFF
--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -34,6 +34,7 @@ use OpenEMR\Events\Main\Tabs\RenderEvent;
 use OpenEMR\Menu\MainMenuRole;
 use OpenEMR\Services\LogoService;
 use OpenEMR\Services\ProductRegistrationService;
+use OpenEMR\Services\VersionService;
 use OpenEMR\Telemetry\TelemetryService;
 use Symfony\Component\Filesystem\Path;
 
@@ -43,6 +44,8 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 $logoService = new LogoService();
 $menuLogo = $logoService->getLogo('core/menu/primary/');
+$versionService = new VersionService();
+$softwareVersion = text($versionService->asString());
 // Registration status and options.
 $productRegistration = new ProductRegistrationService();
 $product_row = $productRegistration->getProductDialogStatus();
@@ -510,6 +513,9 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
             'webroot' => $webroot,
             'allowEmail' => $allowEmail ?? false,
             'allowTelemetry' => $allowTelemetry ?? false]); ?>
+    </div>
+    <div id="versionFooter" class="text-muted" style="position:fixed; bottom:4px; inset-inline-end:8px; font-size:11px; pointer-events:none; z-index:4;">
+        <?php echo $softwareVersion; ?>
     </div>
     <script>
         ko.applyBindings(app_view_model);


### PR DESCRIPTION
## Summary

- Add a fixed-position version string to the bottom-right corner of the main application frame
- Visible to all authenticated users on every page (the main tabs frame wraps all content)
- Uses `VersionService::asString()` to render the version from the outer `main.php` chrome, so it persists across all tab navigation

<img width="1111" height="1365" alt="image" src="https://github.com/user-attachments/assets/ebb75d96-1d21-4cc8-a9b9-3ef83f4dceb4" />

## Test plan

- [ ] Log in to OpenEMR — verify version appears in bottom-right corner
- [ ] Navigate between tabs — verify footer persists
- [ ] Resize browser — verify footer stays fixed and doesn't overlap important UI
- [ ] Open modals/dropdowns — verify footer doesn't interfere (low z-index)