### PR TITLE
refactor(calendar): replace hardcoded day/month arrays with int-backed enums

### DIFF
--- a/.phpstan/baseline/constant.notFound.php
+++ b/.phpstan/baseline/constant.notFound.php
@@ -2,66 +2,6 @@
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
-    'message' => '#^Constant _CALAPR not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALAUG not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALDEC not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALFEB not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALJAN not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALJUL not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALJUN not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALMAR not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALMAY not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALNOV not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALOCT not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALSEP not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Constant _PC_OL_CLOSE not found\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
@@ -612,62 +552,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuser.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Constant _CALAPR not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALAUG not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALDEC not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALFEB not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALFRIDAY not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Constant _CALFRIDAYSHORT not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALJAN not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALJUL not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALJUN not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALMAR not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALMAY not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALMONDAY not found\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
 ];
@@ -677,32 +562,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Constant _CALNOV not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALOCT not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALSATURDAY not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Constant _CALSATURDAYSHORT not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALSEP not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALSUNDAY not found\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
 ];
@@ -712,27 +572,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Constant _CALTHURSDAY not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Constant _CALTHURSDAYSHORT not found\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Constant _CALTUESDAY not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Constant _CALTUESDAYSHORT not found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Constant _CALWEDNESDAY not found\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -33062,16 +33062,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/custom_template/personalize.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset 0\\|1\\|2\\|3\\|4\\|5\\|6 on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/date_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset 1\\|2\\|3\\|4\\|5\\|6\\|7\\|8\\|9\\|10\\|11\\|12 on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/date_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'PatientID\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/dated_reminder_functions.php',

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -55,6 +55,7 @@ use OpenEMR\BC\ServiceContainer;
 use OpenEMR\BC\Utilities;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Calendar\DayOfWeek;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
@@ -1071,15 +1072,10 @@ $addEditEventConfig = [
             xl('3rd{{nth}}'),
             xl('4th{{nth}}'),
         ],
-        'weekDays' => [
-            xl('Sunday'),
-            xl('Monday'),
-            xl('Tuesday'),
-            xl('Wednesday'),
-            xl('Thursday'),
-            xl('Friday'),
-            xl('Saturday'),
-        ],
+        'weekDays' => array_map(
+            static fn(DayOfWeek $d): string => $d->label(),
+            DayOfWeek::cases(),
+        ),
     ],
 ];
 ?>

--- a/interface/main/calendar/modules/PostCalendar/pnlang/eng/global.php
+++ b/interface/main/calendar/modules/PostCalendar/pnlang/eng/global.php
@@ -26,6 +26,9 @@
  *
  */
 
+use OpenEMR\Common\Calendar\DayOfWeek;
+use OpenEMR\Common\Calendar\Month;
+
 //=========================================================================
 //  The following define is necessary for the date and time functions
 //  set it to the locale for this language
@@ -44,18 +47,18 @@ define('_USER_BUSY_TITLE', xl('Busy'));
 define('_USER_BUSY_MESSAGE', xl('I am busy during this time.'));
 define('_PC_JUMP_MENU_SUBMIT', xl('Save'));
 define('_PC_TPL_VIEW_SUBMIT', xl('change'));
-define('_CALJAN', xl('January'));
-define('_CALFEB', xl('February'));
-define('_CALMAR', xl('March'));
-define('_CALAPR', xl('April'));
-define('_CALMAY', xl('May'));
-define('_CALJUN', xl('June'));
-define('_CALJUL', xl('July'));
-define('_CALAUG', xl('August'));
-define('_CALSEP', xl('September'));
-define('_CALOCT', xl('October'));
-define('_CALNOV', xl('November'));
-define('_CALDEC', xl('December'));
+define('_CALJAN', Month::January->label());
+define('_CALFEB', Month::February->label());
+define('_CALMAR', Month::March->label());
+define('_CALAPR', Month::April->label());
+define('_CALMAY', Month::May->label());
+define('_CALJUN', Month::June->label());
+define('_CALJUL', Month::July->label());
+define('_CALAUG', Month::August->label());
+define('_CALSEP', Month::September->label());
+define('_CALOCT', Month::October->label());
+define('_CALNOV', Month::November->label());
+define('_CALDEC', Month::December->label());
 define('_CALMONDAYSHORT', xl('M{{Monday}}'));
 define('_CALTUESDAYSHORT', xl('T{{Tuesday}}'));
 define('_CALWEDNESDAYSHORT', xl('W{{Wednesday}}'));
@@ -63,13 +66,13 @@ define('_CALTHURSDAYSHORT', xl('T{{Thursday}}'));
 define('_CALFRIDAYSHORT', xl('F{{Friday}}'));
 define('_CALSATURDAYSHORT', xl('S{{Saturday}}'));
 define('_CALSUNDAYSHORT', xl('S{{Sunday}}'));
-define('_CALSUNDAY', xl('Sunday'));
-define('_CALMONDAY', xl('Monday'));
-define('_CALTUESDAY', xl('Tuesday'));
-define('_CALWEDNESDAY', xl('Wednesday'));
-define('_CALTHURSDAY', xl('Thursday'));
-define('_CALFRIDAY', xl('Friday'));
-define('_CALSATURDAY', xl('Saturday'));
+define('_CALSUNDAY', DayOfWeek::Sunday->label());
+define('_CALMONDAY', DayOfWeek::Monday->label());
+define('_CALTUESDAY', DayOfWeek::Tuesday->label());
+define('_CALWEDNESDAY', DayOfWeek::Wednesday->label());
+define('_CALTHURSDAY', DayOfWeek::Thursday->label());
+define('_CALFRIDAY', DayOfWeek::Friday->label());
+define('_CALSATURDAY', DayOfWeek::Saturday->label());
 define('_CAL_DAYVIEW', xl('Day'));
 define('_CAL_WEEKVIEW', xl('Week'));
 define('_CAL_MONTHVIEW', xl('Month'));

--- a/library/appointments.inc.php
+++ b/library/appointments.inc.php
@@ -18,6 +18,7 @@
 require_once(__DIR__ . "/encounter_events.inc.php");
 require_once(__DIR__ . "/../interface/main/calendar/modules/PostCalendar/pnincludes/Date/Calc.php");
 
+use OpenEMR\Common\Calendar\DayOfWeek;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Appointments\AppointmentsFilterEvent;
 use OpenEMR\Events\BoundFilter;
@@ -74,15 +75,10 @@ $REPEAT_ON_NUM = [
     '5' => xl('Last')
 ];
 
-$REPEAT_ON_DAY = [
-    '0' => xl('Sunday'),
-    '1' => xl('Monday'),
-    '2' => xl('Tuesday'),
-    '3' => xl('Wednesday'),
-    '4' => xl('Thursday'),
-    '5' => xl('Friday'),
-    '6' => xl('Saturday')
-];
+$REPEAT_ON_DAY = array_map(
+    static fn(DayOfWeek $d): string => $d->label(),
+    DayOfWeek::cases(),
+);
 
 function checkEvent($recurrtype, $recurrspec)
 {

--- a/library/date_functions.php
+++ b/library/date_functions.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenEMR\Common\Calendar\DayOfWeek;
+use OpenEMR\Common\Calendar\Month;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 
 /**
@@ -26,28 +28,11 @@ function dateformat(string|int $strtime = '', bool $with_dow = false): string
 
     // name the day of the week for different languages
     $day = (int) date("w", $strtime); // 0 sunday -> 6 saturday
-
-    static $days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-    $dow = xl($days[$day]);
+    $dow = DayOfWeek::from($day)->label();
 
     // name of the month in different languages
     $month = (int) date('m', $strtime);
-
-    static $months = [
-        1 => 'January',
-        2 => 'February',
-        3 => 'March',
-        4 => 'April',
-        5 => 'May',
-        6 => 'June',
-        7 => 'July',
-        8 => 'August',
-        9 => 'September',
-        10 => 'October',
-        11 => 'November',
-        12 => 'December',
-    ];
-    $nom = xl($months[$month]);
+    $nom = Month::from($month)->label();
 
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
     // Date string format

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -76,6 +76,7 @@
 //   Uzbek                          // xl('Uzbek')
 //   Vietnamese                     // xl('Vietnamese')
 
+use OpenEMR\Common\Calendar\DayOfWeek;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Globals\GlobalsInitializedEvent;
@@ -837,11 +838,11 @@ $GLOBALS_METADATA = [
         'weekend_days' => [
             xl('Your weekend days'),
             [
-                '6,0' => xl('Saturday') . ' - ' . xl('Sunday'),
-                '0' => xl('Sunday'),
-                '5' => xl('Friday'),
-                '6' => xl('Saturday'),
-                '5,6' => xl('Friday') . ' - ' . xl('Saturday'),
+                '6,0' => DayOfWeek::Saturday->label() . ' - ' . DayOfWeek::Sunday->label(),
+                '0' => DayOfWeek::Sunday->label(),
+                '5' => DayOfWeek::Friday->label(),
+                '6' => DayOfWeek::Saturday->label(),
+                '5,6' => DayOfWeek::Friday->label() . ' - ' . DayOfWeek::Saturday->label(),
             ],
             '6,0'
             , xl('which days are your weekend days?')
@@ -1784,9 +1785,9 @@ $GLOBALS_METADATA = [
         'first_day_week' => [
             xl('First day in the week'),
             [
-                '1' => xl('Monday'),
-                '0' => xl('Sunday'),
-                '6' => xl('Saturday')
+                '1' => DayOfWeek::Monday->label(),
+                '0' => DayOfWeek::Sunday->label(),
+                '6' => DayOfWeek::Saturday->label()
             ],
             '1',
             xl('Your first day of the week.')

--- a/src/Common/Calendar/DayOfWeek.php
+++ b/src/Common/Calendar/DayOfWeek.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Day-of-week enum with translatable labels.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Calendar;
+
+enum DayOfWeek: int
+{
+    case Sunday = 0;
+    case Monday = 1;
+    case Tuesday = 2;
+    case Wednesday = 3;
+    case Thursday = 4;
+    case Friday = 5;
+    case Saturday = 6;
+
+    /**
+     * Return the translated day name.
+     *
+     * Call xl() on each literal arm so translation-key extraction tools
+     * (e.g. xgettext, grep) can find every key statically.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Sunday => xl('Sunday'),
+            self::Monday => xl('Monday'),
+            self::Tuesday => xl('Tuesday'),
+            self::Wednesday => xl('Wednesday'),
+            self::Thursday => xl('Thursday'),
+            self::Friday => xl('Friday'),
+            self::Saturday => xl('Saturday'),
+        };
+    }
+}

--- a/src/Common/Calendar/Month.php
+++ b/src/Common/Calendar/Month.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Month enum with translatable labels.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Calendar;
+
+enum Month: int
+{
+    case January = 1;
+    case February = 2;
+    case March = 3;
+    case April = 4;
+    case May = 5;
+    case June = 6;
+    case July = 7;
+    case August = 8;
+    case September = 9;
+    case October = 10;
+    case November = 11;
+    case December = 12;
+
+    /**
+     * Return the translated month name.
+     *
+     * Call xl() on each literal arm so translation-key extraction tools
+     * (e.g. xgettext, grep) can find every key statically.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::January => xl('January'),
+            self::February => xl('February'),
+            self::March => xl('March'),
+            self::April => xl('April'),
+            self::May => xl('May'),
+            self::June => xl('June'),
+            self::July => xl('July'),
+            self::August => xl('August'),
+            self::September => xl('September'),
+            self::October => xl('October'),
+            self::November => xl('November'),
+            self::December => xl('December'),
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce `DayOfWeek` and `Month` int-backed enums in `src/Common/Calendar/` with `label()` methods using exhaustive `match` expressions calling `xl()` on literal strings
- Replace all hardcoded day-of-week and month name arrays across `date_functions.php`, `appointments.inc.php`, `globals.inc.php`, `add_edit_event.php`, and the PostCalendar language file with enum usage
- PHPStan sees each `match` arm as `literal-string`, eliminating the `mixed`-type violations from array-indexed `xl()` calls
- Removes 155 stale `constant.notFound` baseline entries for the old `_CAL*` defines

Closes #10074 (partially — adds literal-string enforcement for day/month translations)

## Test plan

- [ ] Verify date formatting displays correctly in English and at least one non-English language
- [ ] Check calendar event creation/editing shows translated day names
- [ ] Verify appointment repeat-on-day selector shows translated labels
- [ ] Run `composer phpstan` — should pass clean