### PR TITLE
refactor(fhir): fix literal-string violations in xl/xlt calls

### DIFF
--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -4558,7 +4558,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 16,
+    'count' => 15,
     'path' => __DIR__ . '/../../src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -36952,11 +36952,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/FHIR/SMART/SmartLaunchController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\FHIR\\\\SMART\\\\SmartLaunchController\\:\\:renderLaunchButton\\(\\) has parameter \\$launchText with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/FHIR/SMART/SmartLaunchController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Forms\\\\FeeSheet\\\\Review\\\\CodeInfo\\:\\:__construct\\(\\) has parameter \\$code with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Forms/FeeSheet/Review/CodeInfo.php',
@@ -44123,11 +44118,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\FHIR\\\\Observation\\\\FhirObservationVitalsService\\:\\:populateComponentColumn\\(\\) has parameter \\$dataRecord with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationVitalsService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\FHIR\\\\Observation\\\\FhirObservationVitalsService\\:\\:populateComponentColumn\\(\\) has parameter \\$description with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationVitalsService.php',
 ];

--- a/src/FHIR/SMART/SmartLaunchController.php
+++ b/src/FHIR/SMART/SmartLaunchController.php
@@ -95,7 +95,10 @@ class SmartLaunchController
             $this->renderLaunchScript();
     }
 
-    public function renderLaunchButton(ClientEntity $client, string $issuer, SMARTLaunchToken $launchToken, $launchText = "Launch")
+    /**
+     * @param literal-string $launchText
+     */
+    public function renderLaunchButton(ClientEntity $client, string $issuer, SMARTLaunchToken $launchToken, string $launchText = "Launch")
     {
         $launchCode = $launchToken->serialize();
         $launchParams = "?launch=" . urlencode((string) $launchCode) . "&iss=" . urlencode($issuer) . "&aud=" . urlencode($issuer);

--- a/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php
+++ b/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php
@@ -141,8 +141,9 @@ class FhirDiagnosticReportLaboratoryService extends FhirServiceBase implements I
         if (!empty($dataRecordReport['results'])) {
             foreach ($dataRecordReport['results'] as $result) {
                 $obsReference = UtilsService::createRelativeReference("Observation", $result['uuid']);
-                if (!empty($result['text'])) {
-                    $obsReference->setDisplay(xlt($result['text']));
+                $resultText = is_string($result['text'] ?? null) ? $result['text'] : '';
+                if ($resultText !== '') {
+                    $obsReference->setDisplay(xl_list_label($resultText));
                 }
                 $report->addResult($obsReference);
             }

--- a/src/Services/FHIR/FhirCareTeamService.php
+++ b/src/Services/FHIR/FhirCareTeamService.php
@@ -214,10 +214,11 @@ class FhirCareTeamService extends FhirServiceBase implements IResourceUSCIGProfi
         if (!empty($dataRecordProvider['role'])) {
             $role = strtolower((string)$dataRecordProvider['role']);
             if (isset($roleMapping[$role])) {
+                $roleLabel = is_string($dataRecordProvider['role']) ? $dataRecordProvider['role'] : '';
                 $codes = [
                     'code' => $roleMapping[$role],
                     'system' => self::CARE_TEAM_MEMBER_FUNCTION_SYSTEM,
-                    'description' => $dataRecordProvider['role_title'] ?? xlt($dataRecordProvider['role'])
+                    'description' => $dataRecordProvider['role_title'] ?? xl_list_label($roleLabel)
                 ];
                 return UtilsService::createCodeableConcept([$codes['code'] => $codes]);
             }
@@ -413,10 +414,11 @@ class FhirCareTeamService extends FhirServiceBase implements IResourceUSCIGProfi
                 if (!empty($person['role'])) {
                     $role = strtolower((string)$person['role']);
                     if (isset($roleMapping[$role])) {
+                        $roleLabel = is_string($person['role']) ? $person['role'] : '';
                         $codes = [
                             'code' => $roleMapping[$role],
                             'system' => self::CARE_TEAM_MEMBER_FUNCTION_SYSTEM,
-                            'description' => $person['role_title'] ?? xlt($person['role'])
+                            'description' => $person['role_title'] ?? xl_list_label($roleLabel)
                         ];
                         $participant->addRole(UtilsService::createCodeableConcept([$codes['code'] => $codes]));
                     }

--- a/src/Services/FHIR/FhirGoalService.php
+++ b/src/Services/FHIR/FhirGoalService.php
@@ -182,7 +182,7 @@ class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileSe
                     $coding->setCode($cleanCode);
                     if (!empty($codeText)) {
                         // FIXED: Fix apostrophes in display text
-                        $cleanDisplay = str_replace('`', "'", xlt($codeText));
+                        $cleanDisplay = str_replace('`', "'", xl_list_label($codeText));
                         $coding->setDisplay($cleanDisplay);
                     }
                     $coding->setSystem($codeSystem);
@@ -236,7 +236,7 @@ class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileSe
                             $coding->setDisplay(UtilsService::createDataMissingExtension());
                         } else {
                             // FIXED: Fix apostrophes in target display text
-                            $cleanCodeText = str_replace('`', "'", xlt($codeText));
+                            $cleanCodeText = str_replace('`', "'", xl_list_label($codeText));
                             $coding->setDisplay($cleanCodeText);
                         }
                         $coding->setSystem($codeSystem);

--- a/src/Services/FHIR/FhirLocationService.php
+++ b/src/Services/FHIR/FhirLocationService.php
@@ -25,6 +25,7 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRContactPoint;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRIdentifier;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRString;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRDomainResource;
 use OpenEMR\Services\FHIR\Traits\BulkExportSupportAllOperationsTrait;
 use OpenEMR\Services\FHIR\Traits\FhirBulkExportDomainResourceTrait;
@@ -169,11 +170,11 @@ class FhirLocationService extends FhirServiceBase implements IFhirExportableReso
         $locationResource->setStatus("active");
 
         if (!empty($dataRecord['name'])) {
-            $name = $dataRecord['name'];
+            $name = is_string($dataRecord['name']) ? $dataRecord['name'] : '';
             if ($dataRecord['type'] != 'facility') {
-                $name = xlt($name);
+                $name = xl_list_label($name);
             }
-            $locationResource->setName($name);
+            $locationResource->setName(new FHIRString($name));
         } else {
             $locationResource->setName(UtilsService::createDataMissingExtension());
         }

--- a/src/Services/FHIR/FhirMedicationRequestService.php
+++ b/src/Services/FHIR/FhirMedicationRequestService.php
@@ -470,10 +470,11 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
     public function populateCategory(FHIRMedicationRequest $medRequestResource, array $dataRecord)
     {
         if (isset($dataRecord['category'])) {
+            $categoryTitle = is_string($dataRecord['category_title'] ?? null) ? $dataRecord['category_title'] : '';
             $medRequestResource->addCategory(UtilsService::createCodeableConcept(
                 [
                     $dataRecord['category'] =>
-                        ['code' => $dataRecord['category'], 'description' => xlt($dataRecord['category_title'])
+                        ['code' => $dataRecord['category'], 'description' => xl_list_label($categoryTitle)
                             ,'system' => FhirCodeSystemConstants::HL7_MEDICATION_REQUEST_CATEGORY]
                 ]
             ));

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -419,7 +419,7 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
     private function parseOpenEMRRaceRecord(FHIRPatient $patientResource, $race)
     {
         $code = 'UNK';
-        $display = xlt("Unknown");
+        $display = xl("Unknown");
         $system = FhirCodeSystemConstants::HL7_NULL_FLAVOR;
         // race is defined as containing 2 required extensions, text & ombCategory
         $raceExtension = new FHIRExtension();
@@ -434,16 +434,17 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
             if ($race === 'decline_to_specify' || $race === 'declne_to_specfy') {
                 // @see https://www.hl7.org/fhir/us/core/ValueSet-omb-race-category.html
                 $code = "ASKU";
-                $display = xlt("Asked but no answer");
+                $display = xl("Asked but no answer");
             } elseif (!empty($record)) {
                 $code = $record['notes'];
-                $display = $record['title'];
+                $title = is_string($record['title']) ? $record['title'] : '';
+                $display = xl_list_label($title);
                 $system = FhirCodeSystemConstants::OID_RACE_AND_ETHNICITY;
             }
         }
         $ombCategoryCoding->setSystem(new FHIRUri($system));
         $ombCategoryCoding->setCode($code);
-        $ombCategoryCoding->setDisplay(xlt($display));
+        $ombCategoryCoding->setDisplay($display);
         $ombCategory->setValueCoding($ombCategoryCoding);
         $raceExtension->addExtension($ombCategory);
 
@@ -572,9 +573,11 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
             $language = new FHIRCoding();
             $language->setSystem(new FHIRUri(FhirCodeSystemConstants::LANGUAGE_BCP_47));
             $language->setCode(new FHIRCode($record['notes']));
-            $language->setDisplay(xlt($record['title']));
+            $languageTitle = is_string($record['title']) ? $record['title'] : '';
+            $translatedTitle = xl_list_label($languageTitle);
+            $language->setDisplay($translatedTitle);
             $languageConcept->addCoding($language);
-            $languageConcept->setText(xlt($record['title']));
+            $languageConcept->setText($translatedTitle);
             $communication->setLanguage($languageConcept);
             $patientResource->addCommunication($communication);
         }

--- a/src/Services/FHIR/Observation/FhirObservationVitalsService.php
+++ b/src/Services/FHIR/Observation/FhirObservationVitalsService.php
@@ -895,6 +895,9 @@ class FhirObservationVitalsService extends FhirServiceBase implements IPatientCo
             );
     }
 
+    /**
+     * @param literal-string $description
+     */
     private function populateComponentColumn(FHIRObservation $observation, $dataRecord, $column, $code, $description): void
     {
         $component = new FHIRObservationComponent();


### PR DESCRIPTION
## Summary

- Replace `xlt()` with `xl_list_label()` for dynamic values from database queries in FHIR service files (role titles, list labels, code descriptions)
- Fix double-translation in `FhirPatientService` race/language parsing where `xlt()` was called on already-translated values
- Remove unnecessary HTML escaping (`xlt`) in FHIR resource setters where the output is not rendered as HTML
- Add `@param literal-string` annotations and native `string` types to methods that only receive literal strings from callers (`populateComponentColumn`, `renderLaunchButton`)
- Narrow `mixed` DB values to `string` with `is_string()` guards

Part 1 of a series fixing ~225 PHPStan `literal-string` violations in `xl()`/`xlt()`/`xla()` calls. The `mixed` type from `sqlQuery`/`sqlFetchArray` return values triggers these violations. The `xl_list_label()` wrapper accepts `string` (not `literal-string`) while preserving translation behavior.

## Test plan

- [ ] Verify FHIR Patient, CareTeam, Goal, Location, MedicationRequest, DiagnosticReport, and Observation resources render correctly
- [ ] Check that race, ethnicity, and language display values are still translated
- [ ] Run `composer phpstan` — passes clean
- [ ] Spot-check SMART launch button text