### PR TITLE
fix(config): stop suppressing E_USER_WARNING and E_USER_DEPRECATED

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -789,8 +789,9 @@ $globalsBag->set('groupname', $groupname);
 // Override temporary_files_dir
 $globalsBag->set('temporary_files_dir', rtrim(sys_get_temp_dir(), '/'));
 
-// user debug mode — only controls display_errors; the error reporting
-// level is left to php.ini so administrators can decide what to log.
+// Report all errors so nothing is silently suppressed.
+error_reporting(E_ALL);
+// user debug mode — controls display_errors
 if ($globalsBag->getInt('user_debug', 0) > 1) {
     ini_set('display_errors', 1);
 }

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -789,10 +789,9 @@ $globalsBag->set('groupname', $groupname);
 // Override temporary_files_dir
 $globalsBag->set('temporary_files_dir', rtrim(sys_get_temp_dir(), '/'));
 
-error_reporting(error_reporting() & ~E_USER_DEPRECATED & ~E_USER_WARNING);
-// user debug mode
+// user debug mode — only controls display_errors; the error reporting
+// level is left to php.ini so administrators can decide what to log.
 if ($globalsBag->getInt('user_debug', 0) > 1) {
-    error_reporting(error_reporting() & ~E_WARNING & ~E_NOTICE & ~E_USER_WARNING & ~E_USER_DEPRECATED);
     ini_set('display_errors', 1);
 }
 


### PR DESCRIPTION
## Summary

Remove the unconditional `error_reporting()` mask in `interface/globals.php` that silences `E_USER_WARNING` and `E_USER_DEPRECATED` on every HTTP request, and replace it with an explicit `error_reporting(E_ALL)`.

## Background

Line 792 was introduced in **PR #4459 (June 2021)** with the commit message *"Temporary fix for deprecated warnings turning into exceptions"* as a workaround for PHP 8.0. Five years later, it still silences all application-level warnings.

## What gets silenced today

| Component | Warning | Impact |
|-----------|---------|--------|
| Smarty `{xlt}`, `{xla}`, `{xlj}` | Missing `t` parameter | Silent rendering failures |
| FHIR Response Parser | Unmapped property warnings | Silent data loss |
| LBF Validation | Invalid JSON config | Silent form validation bypass |
| `xl()` translation | Function not defined | Silent missing translations |

In production (`display_errors = Off`), none of these reach the error log.

## Changes

```diff
-error_reporting(error_reporting() & ~E_USER_DEPRECATED & ~E_USER_WARNING);
-// user debug mode
+// Report all errors so nothing is silently suppressed.
+error_reporting(E_ALL);
+// user debug mode — controls display_errors
 if ($globalsBag->getInt('user_debug', 0) > 1) {
-    error_reporting(error_reporting() & ~E_WARNING & ~E_NOTICE & ~E_USER_WARNING & ~E_USER_DEPRECATED);
     ini_set('display_errors', 1);
 }
```

The error reporting level is now explicitly `E_ALL`, so all warnings (including `E_USER_WARNING` and `E_USER_DEPRECATED`) are logged. The `user_debug` block is simplified to only control `display_errors`.

Fixes #11408
