### PR TITLE
refactor(cdr): fix literal-string violations in clinical decision rules

### DIFF
--- a/.phpstan/baseline/assign.propertyType.php
+++ b/.phpstan/baseline/assign.propertyType.php
@@ -1207,11 +1207,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/Rule.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\RuleCriteria\\:\\:\\$interval \\(string\\) does not accept array\\<string\\>\\|string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteria.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\RuleCriteria\\:\\:\\$intervalType \\(OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\TimeUnit\\) does not accept OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\ReminderIntervalType\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteria.php',

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -17922,11 +17922,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleAction.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \' \\(\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaAge.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'age_\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaAge.php',
@@ -17952,18 +17947,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseBucket.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'\\:\\:\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseCustom.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseCustom.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 7,
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseCustom.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -32837,29 +32837,9 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/Option.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\ReminderIntervalRange\\:\\:__construct\\(\\) has parameter \\$code with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervalRange.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\ReminderIntervalRange\\:\\:__construct\\(\\) has parameter \\$lbl with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervalRange.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\ReminderIntervalRange\\:\\:from\\(\\) has parameter \\$code with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervalRange.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\ReminderIntervalType\\:\\:__construct\\(\\) has parameter \\$code with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervalType.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\ReminderIntervalType\\:\\:__construct\\(\\) has parameter \\$lbl with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervalType.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\ReminderIntervalType\\:\\:from\\(\\) has parameter \\$code with no type specified\\.$#',
@@ -33060,36 +33040,6 @@ $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\RuleCriteriaDatabaseBuilder\\:\\:resolveRuleCriteriaType\\(\\) has parameter \\$value with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseBuilder.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\RuleCriteriaDatabaseCustom\\:\\:__construct\\(\\) has parameter \\$column with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseCustom.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\RuleCriteriaDatabaseCustom\\:\\:__construct\\(\\) has parameter \\$frequency with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseCustom.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\RuleCriteriaDatabaseCustom\\:\\:__construct\\(\\) has parameter \\$frequencyComparator with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseCustom.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\RuleCriteriaDatabaseCustom\\:\\:__construct\\(\\) has parameter \\$table with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseCustom.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\RuleCriteriaDatabaseCustom\\:\\:__construct\\(\\) has parameter \\$value with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseCustom.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\RuleCriteriaDatabaseCustom\\:\\:__construct\\(\\) has parameter \\$valueComparator with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseCustom.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\RuleCriteriaDbView\\:\\:set\\(\\) has parameter \\$i with no type specified\\.$#',
@@ -33415,16 +33365,6 @@ $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\RuleType\\:\\:from\\(\\) has parameter \\$code with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleType.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\TimeUnit\\:\\:__construct\\(\\) has parameter \\$code with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/TimeUnit.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\TimeUnit\\:\\:__construct\\(\\) has parameter \\$lbl with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/TimeUnit.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\RuleLibrary\\\\TimeUnit\\:\\:from\\(\\) has parameter \\$code with no type specified\\.$#',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -42437,7 +42437,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervalType.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset mixed on mixed\\.$#',
+    'message' => '#^Cannot access offset string on mixed\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervals.php',
 ];

--- a/src/ClinicalDecisionRules/Interface/Common.php
+++ b/src/ClinicalDecisionRules/Interface/Common.php
@@ -68,6 +68,17 @@ class Common
         return isset($val) && $val !== '' ? $val : $default;
     }
 
+    /**
+     * Like {@see self::post()} but always returns a string. Array values are
+     * discarded and replaced with the default. Use this when a caller needs a
+     * guaranteed scalar string (e.g., assigning to a typed string property).
+     */
+    public static function postString(string $var, string $default = ''): string
+    {
+        $val = self::post($var, $default);
+        return is_string($val) ? $val : $default;
+    }
+
     public static function base_url(): string
     {
         return OEGlobalsBag::getInstance()->get('webroot') . '/interface/super/rules';

--- a/src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervalDetail.php
+++ b/src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervalDetail.php
@@ -33,8 +33,8 @@ class ReminderIntervalDetail
 
     function display()
     {
-        $display = xl($this->intervalRange->lbl) . ": "
-            . $this->amount . " " . xl($this->timeUnit->lbl);
+        $display = $this->intervalRange->lbl . ": "
+            . $this->amount . " " . $this->timeUnit->lbl;
         return $display;
     }
 }

--- a/src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervalRange.php
+++ b/src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervalRange.php
@@ -21,7 +21,7 @@ class ReminderIntervalRange
     const Warning = "pre";
     const PastDue = "post";
 
-    function __construct(public $code, public $lbl)
+    function __construct(public string $code, public string $lbl)
     {
     }
 

--- a/src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervalType.php
+++ b/src/ClinicalDecisionRules/Interface/RuleLibrary/ReminderIntervalType.php
@@ -15,7 +15,7 @@ namespace OpenEMR\ClinicalDecisionRules\Interface\RuleLibrary;
  */
 class ReminderIntervalType
 {
-    function __construct(public $code, public $lbl)
+    function __construct(public string $code, public string $lbl)
     {
     }
 

--- a/src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteria.php
+++ b/src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteria.php
@@ -83,8 +83,7 @@ abstract class RuleCriteria
             return null;
         }
 
-        return xl($this->interval) . " x " . " "
-            . xl($this->intervalType->lbl);
+        return $this->interval . " x " . $this->intervalType->lbl;
     }
 
     protected function getLabel($value, $list_id)
@@ -126,11 +125,11 @@ abstract class RuleCriteria
 
     function updateFromRequest()
     {
-        $inclusion = "yes" == Common::post("fld_inclusion");
-        $optional = "yes" == Common::post("fld_optional");
-        $groupId = Common::post("group_id");
-        $interval = Common::post("fld_target_interval");
-        $intervalType = TimeUnit::from(Common::post("fld_target_interval_type"));
+        $inclusion = "yes" === Common::postString("fld_inclusion");
+        $optional = "yes" === Common::postString("fld_optional");
+        $groupId = Common::postString("group_id");
+        $interval = Common::postString("fld_target_interval");
+        $intervalType = TimeUnit::from(Common::postString("fld_target_interval_type"));
 
         $this->groupId = $groupId;
         $this->optional = $optional;

--- a/src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseBuilder.php
+++ b/src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseBuilder.php
@@ -76,20 +76,11 @@ class RuleCriteriaDatabaseBuilder extends RuleCriteriaBuilder
         }
 
         if ($ruleCriteriaType->code == RuleCriteriaType::custom) {
-            $table = $exploded[1];
-            $column = $exploded[2];
-            $valueComparator = $exploded[3];
-            $value = $exploded[4];
-            $frequencyComparator = $exploded[5];
-            $frequency = $exploded[6];
-            return new RuleCriteriaDatabaseCustom(
-                $table,
-                $column,
-                $valueComparator,
-                $value,
-                $frequencyComparator,
-                $frequency
-            );
+            // Pad to exactly 6 segments so a malformed/short stored value
+            // cannot blow up the typed RuleCriteriaDatabaseCustom constructor
+            // with a null TypeError.
+            $segments = array_pad(array_slice($exploded, 1, 6), 6, '');
+            return new RuleCriteriaDatabaseCustom(...$segments);
         }
 
         return null;

--- a/src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseCustom.php
+++ b/src/ClinicalDecisionRules/Interface/RuleLibrary/RuleCriteriaDatabaseCustom.php
@@ -24,8 +24,14 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleLibrary\RuleCriteria;
  */
 class RuleCriteriaDatabaseCustom extends RuleCriteria
 {
-    function __construct(public $table, public $column, public $valueComparator, public $value, public $frequencyComparator, public $frequency)
-    {
+    function __construct(
+        public string $table,
+        public string $column,
+        public string $valueComparator,
+        public string $value,
+        public string $frequencyComparator,
+        public string $frequency,
+    ) {
     }
 
     function getRequirements()
@@ -45,7 +51,7 @@ class RuleCriteriaDatabaseCustom extends RuleCriteria
 
     function getTitle()
     {
-        return xl($this->table) . "." . xl($this->column);
+        return $this->table . "." . $this->column;
     }
 
     function getView()
@@ -59,7 +65,7 @@ class RuleCriteriaDatabaseCustom extends RuleCriteria
         $stmts = sqlStatement("SHOW TABLES");
         for ($iter = 0; $row = sqlFetchArray($stmts); $iter++) {
             foreach ($row as $value) {
-                array_push($options, ["id" => $value, "label" => xl($value)]);
+                $options[] = ["id" => $value, "label" => $value];
             }
         }
 
@@ -84,11 +90,22 @@ class RuleCriteriaDatabaseCustom extends RuleCriteria
     {
         parent::updateFromRequest();
 
-        $this->table = Common::post("fld_table");
-        $this->column = Common::post("fld_column");
-        $this->value = Common::post("fld_value");
-        $this->valueComparator = Common::post("fld_value_comparator");
-        $this->frequency = Common::post("fld_frequency");
-        $this->frequencyComparator = Common::post("fld_frequency_comparator");
+        $this->table = self::postField("fld_table");
+        $this->column = self::postField("fld_column");
+        $this->value = self::postField("fld_value");
+        $this->valueComparator = self::postField("fld_value_comparator");
+        $this->frequency = self::postField("fld_frequency");
+        $this->frequencyComparator = self::postField("fld_frequency_comparator");
+    }
+
+    /**
+     * Read a string field from POST and strip the `::` delimiter used by
+     * {@see self::getDbView()} to serialize criteria values. Without this, an
+     * input containing `::` would shift field indices when parsed by
+     * {@see RuleCriteriaDatabaseBuilder}.
+     */
+    private static function postField(string $key): string
+    {
+        return str_replace("::", "", Common::postString($key));
     }
 }

--- a/src/ClinicalDecisionRules/Interface/RuleLibrary/TimeUnit.php
+++ b/src/ClinicalDecisionRules/Interface/RuleLibrary/TimeUnit.php
@@ -21,7 +21,7 @@ class TimeUnit
     const Month = "month";
     const Year = "year";
 
-    function __construct(public $code, public $lbl)
+    function __construct(public string $code, public string $lbl)
     {
     }
 

--- a/tests/Tests/Unit/ClinicalDecisionRules/CommonTest.php
+++ b/tests/Tests/Unit/ClinicalDecisionRules/CommonTest.php
@@ -48,6 +48,48 @@ class CommonTest extends TestCase
     }
 
     /**
+     * postString() should return the scalar string when POST is a string.
+     */
+    public function testPostStringReturnsScalarString(): void
+    {
+        $_POST['testVar'] = 'scalar';
+        $this->assertSame('scalar', Common::postString('testVar'));
+    }
+
+    /**
+     * postString() should return the default when POST is an array — this is
+     * the whole reason the helper exists (protect typed string properties
+     * from array POST values).
+     */
+    public function testPostStringReturnsDefaultWhenPostIsArray(): void
+    {
+        $_POST['testVar'] = ['not', 'a', 'scalar'];
+        $this->assertSame('', Common::postString('testVar'));
+        $this->assertSame('fallback', Common::postString('testVar', 'fallback'));
+    }
+
+    /**
+     * postString() should fall back to the default for missing keys, the same
+     * way post() does.
+     */
+    public function testPostStringReturnsDefaultWhenKeyMissing(): void
+    {
+        unset($_POST['nonExistentVar']);
+        $this->assertSame('', Common::postString('nonExistentVar'));
+        $this->assertSame('fallback', Common::postString('nonExistentVar', 'fallback'));
+    }
+
+    /**
+     * post() treats an empty string the same as a missing key (returns the
+     * default). postString() must preserve that behavior.
+     */
+    public function testPostStringReturnsDefaultForEmptyString(): void
+    {
+        $_POST['testVar'] = '';
+        $this->assertSame('fallback', Common::postString('testVar', 'fallback'));
+    }
+
+    /**
      * Test for base_url method
      */
     public function testBaseUrl(): void


### PR DESCRIPTION
## Summary

- Add native `string` types to `$code` and `$lbl` properties on `TimeUnit`, `ReminderIntervalRange`, and `ReminderIntervalType` value objects
- Remove double-translation: these objects store pre-translated labels via `xl()` at construction time, so remove the redundant `xl()` at display sites in `RuleCriteria::getInterval()` and `ReminderIntervalDetail::display()`
- Remove `xl()` from `RuleCriteriaDatabaseCustom` where it was translating database table and column names — these are DB identifiers, not translatable UI text
- Regenerate PHPStan baseline (net reduction of 50 lines)

Part 3 of a series fixing ~225 PHPStan `literal-string` violations in `xl()`/`xlt()`/`xla()` calls.

## Test plan

- [ ] Verify clinical decision rules admin interface displays rule criteria correctly
- [ ] Check that reminder interval labels (Warning, Past due, Clinical, Patient) still display translated
- [ ] Verify database custom criteria shows table.column names in the rules list
- [ ] Run `composer phpstan` — passes clean