### PR TITLE
chore(encryption): Move KeyId primitive up to top namespace

### DIFF
--- a/src/Encryption/KeyId.php
+++ b/src/Encryption/KeyId.php
@@ -10,9 +10,9 @@
 
 declare(strict_types=1);
 
-namespace OpenEMR\Encryption\Keys;
+namespace OpenEMR\Encryption;
 
-final readonly class Id
+final readonly class KeyId
 {
     public function __construct(public string $id)
     {

--- a/src/Encryption/Keys/Keychain.php
+++ b/src/Encryption/Keys/Keychain.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace OpenEMR\Encryption\Keys;
 
 use OpenEMR\Encryption\Cipher\CipherInterface;
+use OpenEMR\Encryption\KeyId;
 use OutOfBoundsException;
 
 use function array_key_exists;
@@ -27,14 +28,7 @@ class Keychain implements KeychainInterface
      */
     private array $mappings = [];
 
-    public function addCipher(
-        Id $id,
-        CipherInterface $cipher,
-    ): void {
-        $this->mappings[$id->id] = $cipher;
-    }
-
-    public function getCipher(Id $keyId): CipherInterface
+    public function getCipher(KeyId $keyId): CipherInterface
     {
         if ($this->hasKey($keyId)) {
             return $this->mappings[$keyId->id];
@@ -42,8 +36,15 @@ class Keychain implements KeychainInterface
         throw new OutOfBoundsException('Key id not registered');
     }
 
-    public function hasKey(Id $keyId): bool
+    public function hasKey(KeyId $keyId): bool
     {
         return array_key_exists($keyId->id, $this->mappings);
+    }
+
+    public function registerCipher(
+        KeyId $id,
+        CipherInterface $cipher,
+    ): void {
+        $this->mappings[$id->id] = $cipher;
     }
 }

--- a/src/Encryption/Keys/KeychainInterface.php
+++ b/src/Encryption/Keys/KeychainInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace OpenEMR\Encryption\Keys;
 
 use OpenEMR\Encryption\Cipher\CipherInterface;
+use OpenEMR\Encryption\KeyId;
 
 /**
  * Implementations of KeychainInterface are responsible for key management and
@@ -22,7 +23,7 @@ use OpenEMR\Encryption\Cipher\CipherInterface;
  */
 interface KeychainInterface
 {
-    public function getCipher(Id $keyId): CipherInterface;
+    public function getCipher(KeyId $keyId): CipherInterface;
 
-    public function hasKey(Id $keyId): bool;
+    public function hasKey(KeyId $keyId): bool;
 }

--- a/src/Encryption/Message.php
+++ b/src/Encryption/Message.php
@@ -18,7 +18,7 @@ use UnexpectedValueException;
 final readonly class Message
 {
     public function __construct(
-        public Keys\Id $keyId,
+        public KeyId $keyId,
         public Ciphertext $ciphertext,
         public MessageFormat $format = MessageFormat::LATEST,
     ) {
@@ -63,7 +63,7 @@ final readonly class Message
 
         return new Message(
             format: MessageFormat::ImplicitKey,
-            keyId: new Keys\Id($numericKeyId),
+            keyId: new KeyId($numericKeyId),
             ciphertext: new Ciphertext($ciphertext),
         );
     }

--- a/tests/Tests/Isolated/Encryption/KeyIdTest.php
+++ b/tests/Tests/Isolated/Encryption/KeyIdTest.php
@@ -10,19 +10,19 @@
 
 declare(strict_types=1);
 
-namespace OpenEMR\Tests\Isolated\Encryption\Keys;
+namespace OpenEMR\Tests\Isolated\Encryption;
 
-use OpenEMR\Encryption\Keys\Id;
+use OpenEMR\Encryption\KeyId;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
 
 #[Small]
-class IdTest extends TestCase
+class KeyIdTest extends TestCase
 {
     public function testWrapping(): void
     {
         $raw = 'some-key-123';
-        $id = new Id($raw);
+        $id = new KeyId($raw);
         self::assertSame($raw, $id->id);
     }
 }

--- a/tests/Tests/Isolated/Encryption/Keys/KeychainTest.php
+++ b/tests/Tests/Isolated/Encryption/Keys/KeychainTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Isolated\Encryption\Keys;
 
 use OpenEMR\Encryption\Cipher\CipherInterface;
+use OpenEMR\Encryption\KeyId;
 use OpenEMR\Encryption\Keys\{
-    Id,
     Keychain,
 };
 use OutOfBoundsException;
@@ -27,11 +27,11 @@ class KeychainTest extends TestCase
     public function testHasKey(): void
     {
         $keychain = new Keychain();
-        $id = new Id('abc');
+        $id = new KeyId('abc');
         self::assertFalse($keychain->hasKey($id), 'Initial state should have no keys');
 
         $cipher = self::createStub(CipherInterface::class);
-        $keychain->addCipher($id, $cipher);
+        $keychain->registerCipher($id, $cipher);
         self::assertTrue($keychain->hasKey($id), 'Key should exist after adding');
     }
 
@@ -39,13 +39,13 @@ class KeychainTest extends TestCase
     {
         $keychain = new Keychain();
 
-        $id1 = new Id('one');
+        $id1 = new KeyId('one');
         $cipher1 = self::createStub(CipherInterface::class);
-        $keychain->addCipher($id1, $cipher1);
+        $keychain->registerCipher($id1, $cipher1);
 
-        $id2 = new Id('two');
+        $id2 = new KeyId('two');
         $cipher2 = self::createStub(CipherInterface::class);
-        $keychain->addCipher($id2, $cipher2);
+        $keychain->registerCipher($id2, $cipher2);
 
 
         assert($cipher1 !== $cipher2);
@@ -60,6 +60,6 @@ class KeychainTest extends TestCase
     {
         $keychain = new Keychain();
         self::expectException(OutOfBoundsException::class);
-        $keychain->getCipher(new Id('not registered'));
+        $keychain->getCipher(new KeyId('not registered'));
     }
 }

--- a/tests/Tests/Isolated/Encryption/MessageTest.php
+++ b/tests/Tests/Isolated/Encryption/MessageTest.php
@@ -15,7 +15,7 @@ namespace OpenEMR\Tests\Isolated\Encryption;
 use BadMethodCallException;
 use OpenEMR\Encryption\{
     Ciphertext,
-    Keys\Id,
+    KeyId,
     Message,
     MessageFormat,
 };
@@ -82,7 +82,7 @@ class MessageTest extends TestCase
 
     public function testConstructWithImplicitKeyFormat(): void
     {
-        $keyId = new Id('005');
+        $keyId = new KeyId('005');
         $ciphertext = new Ciphertext('test data');
         $message = new Message($keyId, $ciphertext, MessageFormat::ImplicitKey);
 
@@ -92,7 +92,7 @@ class MessageTest extends TestCase
 
     public function testConstructWithInvalidImplicitKey(): void
     {
-        $keyId = new Id('not-a-number');
+        $keyId = new KeyId('not-a-number');
         $ciphertext = new Ciphertext('test data');
         $this->expectException(BadMethodCallException::class);
         $message = new Message($keyId, $ciphertext, MessageFormat::ImplicitKey);
@@ -101,7 +101,7 @@ class MessageTest extends TestCase
 
     public function testConstructParseRoundtripImplicitKey(): void
     {
-        $keyId = new Id('007');
+        $keyId = new KeyId('007');
         $ciphertext = new Ciphertext('some encrypted data');
         $message = new Message($keyId, $ciphertext, MessageFormat::ImplicitKey);
         $encoded = $message->encode();


### PR DESCRIPTION
#### Short description of what this changes or resolves:
While iterating on #11267, I'm getting a better grasp of what should be a top-level concept and what should not. Key identifiers need to be, since they'll be part of the runtime configuration.

#### Changes proposed in this pull request:
Rename `Keys/Id` to `KeyId` within the `OpenEMR\Encryption` namespace. Update various references.

Rename `addCipher`  to `registerCipher` in `Keychain` for a little added clarity.

#### Was an AI assistant used? Yes / No
No