### PR TITLE
chore(encryption): Adjust wrapped values in primitives

### DIFF
--- a/src/Encryption/Cipher/Aes256CbcHmacSha256.php
+++ b/src/Encryption/Cipher/Aes256CbcHmacSha256.php
@@ -31,7 +31,7 @@ readonly class Aes256CbcHmacSha256 implements CipherInterface
 
     public function decrypt(Ciphertext $ciphertext): Plaintext
     {
-        $ciphertext = $ciphertext->wrapped;
+        $ciphertext = $ciphertext->value;
         $hmac = substr($ciphertext, 0, self::HMAC_LENGTH);
         $iv = substr($ciphertext, self::HMAC_LENGTH, self::IV_LENGTH);
         $data = substr($ciphertext, self::HMAC_LENGTH + self::IV_LENGTH);

--- a/src/Encryption/Cipher/Aes256CbcHmacSha384.php
+++ b/src/Encryption/Cipher/Aes256CbcHmacSha384.php
@@ -28,7 +28,7 @@ readonly class Aes256CbcHmacSha384 implements CipherInterface
 
     public function decrypt(Ciphertext $ciphertext): Plaintext
     {
-        $ciphertext = $ciphertext->wrapped;
+        $ciphertext = $ciphertext->value;
         $hmac = substr($ciphertext, 0, self::HMAC_LENGTH);
         $iv = substr($ciphertext, self::HMAC_LENGTH, self::IV_LENGTH);
         $data = substr($ciphertext, self::HMAC_LENGTH + self::IV_LENGTH);
@@ -57,7 +57,7 @@ readonly class Aes256CbcHmacSha384 implements CipherInterface
     {
         $iv = random_bytes(self::IV_LENGTH);
         $encrypted = openssl_encrypt(
-            $plaintext->wrapped,
+            $plaintext->bytes,
             'aes-256-cbc',
             $this->key->key,
             OPENSSL_RAW_DATA,

--- a/src/Encryption/Cipher/Aes256CbcNoHmac.php
+++ b/src/Encryption/Cipher/Aes256CbcNoHmac.php
@@ -28,7 +28,7 @@ readonly class Aes256CbcNoHmac implements CipherInterface
 
     public function decrypt(Ciphertext $ciphertext): Plaintext
     {
-        $ciphertext = $ciphertext->wrapped;
+        $ciphertext = $ciphertext->value;
         $iv = substr($ciphertext, 0, self::IV_LENGTH);
         $data = substr($ciphertext, self::IV_LENGTH);
 

--- a/src/Encryption/Ciphertext.php
+++ b/src/Encryption/Ciphertext.php
@@ -17,7 +17,7 @@ namespace OpenEMR\Encryption;
  */
 final readonly class Ciphertext
 {
-    public function __construct(public string $wrapped)
+    public function __construct(public string $value)
     {
     }
 }

--- a/src/Encryption/Message.php
+++ b/src/Encryption/Message.php
@@ -83,7 +83,7 @@ final readonly class Message
         assert($this->format === MessageFormat::ImplicitKey);
         return sprintf('%s%s',
             $this->keyId->id,
-            base64_encode($this->ciphertext->wrapped),
+            base64_encode($this->ciphertext->value),
         );
     }
 }

--- a/src/Encryption/Plaintext.php
+++ b/src/Encryption/Plaintext.php
@@ -6,17 +6,17 @@ namespace OpenEMR\Encryption;
 
 use SensitiveParameter;
 
-readonly class Plaintext
+final readonly class Plaintext
 {
     public function __construct(
-        #[SensitiveParameter] public string $wrapped,
+        #[SensitiveParameter] public string $bytes,
     ) {
     }
 
     public function __debugInfo(): array
     {
         return [
-            'wrapped' => '****',
+            'bytes' => '****',
         ];
     }
 }

--- a/tests/Tests/Isolated/Encryption/Cipher/Aes256CbcHmacSha256Test.php
+++ b/tests/Tests/Isolated/Encryption/Cipher/Aes256CbcHmacSha256Test.php
@@ -58,7 +58,7 @@ final class Aes256CbcHmacSha256Test extends TestCase
 
         $result = $cipher->decrypt($rawCiphertext);
 
-        self::assertSame(CryptoFixtureManager::PLAINTEXT, $result->wrapped);
+        self::assertSame(CryptoFixtureManager::PLAINTEXT, $result->bytes);
     }
 
     public function testThrowsOnTamperedHmac(): void
@@ -69,7 +69,7 @@ final class Aes256CbcHmacSha256Test extends TestCase
         );
 
         $rawCiphertext = $this->extractRawCiphertext($this->fixtures->getCiphertext(2))
-            ->wrapped;
+            ->value;
 
         // Tamper with HMAC (first 32 bytes for SHA256)
         $tampered = chr(ord($rawCiphertext[0]) ^ 0xFF) . substr($rawCiphertext, 1);
@@ -87,7 +87,7 @@ final class Aes256CbcHmacSha256Test extends TestCase
         );
 
         $rawCiphertext = $this->extractRawCiphertext($this->fixtures->getCiphertext(2))
-            ->wrapped;
+            ->value;
 
         // Tamper with ciphertext (after HMAC + IV = 32 + 16 = 48 bytes)
         $tampered = substr($rawCiphertext, 0, 48)

--- a/tests/Tests/Isolated/Encryption/Cipher/Aes256CbcHmacSha384Test.php
+++ b/tests/Tests/Isolated/Encryption/Cipher/Aes256CbcHmacSha384Test.php
@@ -53,7 +53,7 @@ final class Aes256CbcHmacSha384Test extends TestCase
 
         $result = $cipher->decrypt($rawCiphertext);
 
-        self::assertSame(CryptoFixtureManager::PLAINTEXT, $result->wrapped);
+        self::assertSame(CryptoFixtureManager::PLAINTEXT, $result->bytes);
     }
 
     public function testThrowsOnTamperedHmac(): void
@@ -64,7 +64,7 @@ final class Aes256CbcHmacSha384Test extends TestCase
         );
 
         $rawCiphertext = $this->extractRawCiphertext($this->fixtures->getCiphertext(7))
-            ->wrapped;
+            ->value;
 
         // Tamper with HMAC (first 48 bytes)
         $tampered = chr(ord($rawCiphertext[0]) ^ 0xFF) . substr($rawCiphertext, 1);
@@ -82,7 +82,7 @@ final class Aes256CbcHmacSha384Test extends TestCase
         );
 
         $rawCiphertext = $this->extractRawCiphertext($this->fixtures->getCiphertext(7))
-            ->wrapped;
+            ->value;
 
         // Tamper with ciphertext (after HMAC + IV = 48 + 16 = 64 bytes)
         $tampered = substr($rawCiphertext, 0, 64)
@@ -149,7 +149,7 @@ final class Aes256CbcHmacSha384Test extends TestCase
 
         $decrypted = $cipher->decrypt($ciphertext);
 
-        self::assertSame(CryptoFixtureManager::PLAINTEXT, $decrypted->wrapped);
+        self::assertSame(CryptoFixtureManager::PLAINTEXT, $decrypted->bytes);
     }
 
     #[DataProvider('versionProvider')]
@@ -172,8 +172,8 @@ final class Aes256CbcHmacSha384Test extends TestCase
         $newDecrypted = $cipher->decrypt($newCiphertext);
 
         // Both should produce the same plaintext
-        self::assertSame($fixtureDecrypted->wrapped, $newDecrypted->wrapped);
-        self::assertSame(CryptoFixtureManager::PLAINTEXT, $newDecrypted->wrapped);
+        self::assertSame($fixtureDecrypted->bytes, $newDecrypted->bytes);
+        self::assertSame(CryptoFixtureManager::PLAINTEXT, $newDecrypted->bytes);
     }
 
     public function testEncryptProducesDifferentCiphertextEachCall(): void
@@ -189,11 +189,11 @@ final class Aes256CbcHmacSha384Test extends TestCase
         $ciphertext2 = $cipher->encrypt($plaintext);
 
         // Different IVs should produce different ciphertexts
-        self::assertNotSame($ciphertext1->wrapped, $ciphertext2->wrapped);
+        self::assertNotSame($ciphertext1->value, $ciphertext2->value);
 
         // But both should decrypt to the same plaintext
-        self::assertSame(CryptoFixtureManager::PLAINTEXT, $cipher->decrypt($ciphertext1)->wrapped);
-        self::assertSame(CryptoFixtureManager::PLAINTEXT, $cipher->decrypt($ciphertext2)->wrapped);
+        self::assertSame(CryptoFixtureManager::PLAINTEXT, $cipher->decrypt($ciphertext1)->bytes);
+        self::assertSame(CryptoFixtureManager::PLAINTEXT, $cipher->decrypt($ciphertext2)->bytes);
     }
 
     public function testEncryptedDataCannotBeDecryptedWithWrongKey(): void

--- a/tests/Tests/Isolated/Encryption/Cipher/Aes256CbcNoHmacTest.php
+++ b/tests/Tests/Isolated/Encryption/Cipher/Aes256CbcNoHmacTest.php
@@ -43,7 +43,7 @@ final class Aes256CbcNoHmacTest extends TestCase
 
         $result = $cipher->decrypt($rawCiphertext);
 
-        self::assertSame(CryptoFixtureManager::PLAINTEXT, $result->wrapped);
+        self::assertSame(CryptoFixtureManager::PLAINTEXT, $result->bytes);
     }
 
     public function testThrowsOnWrongKey(): void
@@ -83,7 +83,7 @@ final class Aes256CbcNoHmacTest extends TestCase
         );
 
         $rawCiphertext = $this->extractRawCiphertext($this->fixtures->getCiphertext(1))
-            ->wrapped;
+            ->value;
 
         // Corrupt the ciphertext (after IV = 16 bytes)
         // Without HMAC, this just produces garbage output
@@ -94,7 +94,7 @@ final class Aes256CbcNoHmacTest extends TestCase
         $result = $cipher->decrypt(new Ciphertext($corrupted));
 
         // It decrypts to something, just not the right thing
-        self::assertNotSame(CryptoFixtureManager::PLAINTEXT, $result->wrapped);
+        self::assertNotSame(CryptoFixtureManager::PLAINTEXT, $result->bytes);
     }
 
     public function testEncryptThrowsBadMethodCallException(): void

--- a/tests/Tests/Isolated/Encryption/MessageTest.php
+++ b/tests/Tests/Isolated/Encryption/MessageTest.php
@@ -107,7 +107,7 @@ class MessageTest extends TestCase
         $encoded = $message->encode();
         $parsed = Message::parse($encoded);
         self::assertSame($keyId->id, $parsed->keyId->id, 'Key mismatch');
-        self::assertSame($ciphertext->wrapped, $parsed->ciphertext->wrapped, 'Ciphertext mismatch');
+        self::assertSame($ciphertext->value, $parsed->ciphertext->value, 'Ciphertext mismatch');
     }
 
     public function testParseThrowsOnTooShortMessage(): void

--- a/tests/Tests/Isolated/Encryption/PlaintextTest.php
+++ b/tests/Tests/Isolated/Encryption/PlaintextTest.php
@@ -35,8 +35,8 @@ final class PlaintextTest extends TestCase
         $plaintext = new Plaintext($data);
         $debugInfo = $plaintext->__debugInfo();
 
-        self::assertArrayHasKey('wrapped', $debugInfo);
-        self::assertSame('****', $debugInfo['wrapped']);
+        self::assertArrayHasKey('bytes', $debugInfo);
+        self::assertSame('****', $debugInfo['bytes']);
         self::assertStringNotContainsString('secret', print_r($debugInfo, true));
     }
 

--- a/tests/Tests/Isolated/Encryption/PlaintextTest.php
+++ b/tests/Tests/Isolated/Encryption/PlaintextTest.php
@@ -25,7 +25,7 @@ final class PlaintextTest extends TestCase
 
         $plaintext = new Plaintext($data);
 
-        self::assertSame($data, $plaintext->wrapped);
+        self::assertSame($data, $plaintext->bytes);
     }
 
     public function testDebugInfoRedactsContent(): void


### PR DESCRIPTION
#### Short description of what this changes or resolves:
The "wrapped" name was somewhat ambiguous and confusing, and negated some of the value of having the primitive wrappers.

#### Changes proposed in this pull request:

- Plaintext: wrapped -> bytes
- Ciphertext: wrapped -> value
- Update calls/references

#### Was an AI assistant used? Yes / No
No