### PR TITLE
refactor(menu): fix literal-string violations in xl/xlt calls

### DIFF
--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -4188,7 +4188,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 6,
+    'count' => 4,
     'path' => __DIR__ . '/../../src/Menu/MainMenuRole.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -44353,7 +44353,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'category\' on mixed\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../src/Menu/MainMenuRole.php',
 ];
 $ignoreErrors[] = [

--- a/src/Menu/MainMenuRole.php
+++ b/src/Menu/MainMenuRole.php
@@ -49,7 +49,7 @@ class MainMenuRole extends MenuRole
         $mainMenuRole = $this->getMenuRole();
 
         // Load the selected menu
-        if (preg_match("/.json$/", $mainMenuRole)) {
+        if (str_ends_with($mainMenuRole, '.json')) {
             // load custom menu (includes .json in id)
             $menu_parsed = json_decode(file_get_contents(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/custom_menus/" . $mainMenuRole));
         } else {
@@ -90,10 +90,12 @@ class MainMenuRole extends MenuRole
             $dHandle = opendir($customMenuDir);
             while (false !== ($menuCustom = readdir($dHandle))) {
                 // Only process files that contain *.json
-                if (preg_match("/.json$/", $menuCustom)) {
+                if (str_ends_with($menuCustom, '.json')) {
                     $selectedTag = ($selected == $menuCustom) ? "selected" : "";
                     $output .= "<option value='" . attr($menuCustom) . "' " . $selectedTag . ">";
-                    // Drop the .json and translate the name
+                    // Drop the .json suffix and translate the name. Custom
+                    // menu filenames are dynamic, hence the @phpstan-ignore.
+                    // @phpstan-ignore argument.type (custom menu filenames are dynamic)
                     $output .= xlt(substr($menuCustom, 0, -5));
                     $output .= "</option>";
                 }
@@ -132,17 +134,18 @@ class MainMenuRole extends MenuRole
         $regrows = getFormsByCategory('1', false);
         foreach ($regrows as $entry) {
             $option_id = $entry['directory'];
-            $title = trim($entry['nickname'] ?? '');
-            if (empty($title)) {
-                $title = $entry['name'];
-            }
-            if ($entry['category'] != $reglastcat) {
+            $nickname = is_string($entry['nickname'] ?? null) ? trim($entry['nickname']) : '';
+            // Preserve the old empty() semantics: '' AND '0' both fall through
+            // to the form's name. (empty('0') returns true.)
+            $title = ($nickname !== '' && $nickname !== '0') ? $nickname : (is_string($entry['name'] ?? null) ? $entry['name'] : '');
+            $category = is_string($entry['category'] ?? null) ? $entry['category'] : '';
+            if ($category != $reglastcat) {
                 // New category. Close out the previous one if it exists.
                 if ($reglastcat) {
                     array_push($menu_list->children, $catEntry);
                 }
                 // Create the new category's object.
-                $reglastcat = $entry['category'];
+                $reglastcat = $category;
                 $catEntry = new \stdClass();
                 $catEntry->label = xl_form_title($reglastcat);
                 $catEntry->icon = 'fa-caret-right';
@@ -183,17 +186,18 @@ class MainMenuRole extends MenuRole
         $regrows = getFormsByCategory('1', true);
         foreach ($regrows as $entry) {
             $option_id = $entry['directory'];
-            $title = trim($entry['nickname'] ?? '');
-            if (empty($title)) {
-                $title = $entry['name'];
-            }
-            if ($entry['category'] != $reglastcat) {
+            $nickname = is_string($entry['nickname'] ?? null) ? trim($entry['nickname']) : '';
+            // Preserve the old empty() semantics: '' AND '0' both fall through
+            // to the form's name. (empty('0') returns true.)
+            $title = ($nickname !== '' && $nickname !== '0') ? $nickname : (is_string($entry['name'] ?? null) ? $entry['name'] : '');
+            $category = is_string($entry['category'] ?? null) ? $entry['category'] : '';
+            if ($category != $reglastcat) {
                 // New category. Close out the previous one if it exists.
                 if ($reglastcat) {
                     array_push($menu_list->children, $catEntry);
                 }
                 // Create the new category's object.
-                $reglastcat = $entry['category'];
+                $reglastcat = $category;
                 $catEntry = new \stdClass();
                 $catEntry->label = xl_form_title($reglastcat);
                 $catEntry->icon = 'fa-caret-right';

--- a/src/Menu/MenuRole.php
+++ b/src/Menu/MenuRole.php
@@ -52,8 +52,13 @@ abstract class MenuRole implements MenuRoleInterface
                 }
             }
 
-            // Translate the labels
-            $entry->label = xlt($entry->label);
+            // Translate the labels with HTML escaping. At least one render
+            // site (twAddTab in src/Tabs/TabsWrapper.php) concatenates the
+            // label directly into an anchor and an id attribute without
+            // escaping, so labels must be HTML-safe at rest.
+            $rawLabel = $entry->label ?? null;
+            // @phpstan-ignore argument.type (menu labels are dynamic content)
+            $entry->label = xlt(is_string($rawLabel) ? $rawLabel : '');
             // Recursive update of children
             if (isset($entry->children)) {
                 $this->menuUpdateEntries($entry->children);

--- a/src/Menu/PatientMenuRole.php
+++ b/src/Menu/PatientMenuRole.php
@@ -53,7 +53,7 @@ class PatientMenuRole extends MenuRole
         $patientMenuRole = $this->getMenuRole();
 
         // Load the selected menu
-        if (preg_match("/.json$/", $patientMenuRole)) {
+        if (str_ends_with($patientMenuRole, '.json')) {
             // load custom menu (includes .json in id)
             $menu_parsed = json_decode(file_get_contents(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/custom_menus/patient_menus/" . $patientMenuRole));
         } else {
@@ -97,10 +97,12 @@ class PatientMenuRole extends MenuRole
             $dHandle = opendir($customMenuDir);
             while (false !== ($menuCustom = readdir($dHandle))) {
                 // Only process files that contain *.json
-                if (preg_match("/.json$/", $menuCustom)) {
+                if (str_ends_with($menuCustom, '.json')) {
                     $selectedTag = ($selected == $menuCustom) ? "selected" : "";
                     $output .= "<option value='" . attr($menuCustom) . "' " . $selectedTag . ">";
-                    // Drop the .json and translate the name
+                    // Drop the .json suffix and translate the name. Custom
+                    // menu filenames are dynamic, hence the @phpstan-ignore.
+                    // @phpstan-ignore argument.type (custom menu filenames are dynamic)
                     $output .= xlt(substr($menuCustom, 0, -5));
                     $output .= "</option>";
                 }
@@ -159,13 +161,22 @@ class PatientMenuRole extends MenuRole
                 }
 
                 $relative_link = "../../modules/" . $modulePath . "/public/" . $hookrow['path'];
-                $mod_nick_name = $hookrow['menu_name'] ?: 'NoName';
+                // Preserve the old `?:` semantics: '' AND '0' both fall through
+                // to 'NoName'. (The previous code used `$hookrow['menu_name'] ?: 'NoName'`,
+                // and `'0' ?: 'NoName'` returns 'NoName'.)
+                $menuName = $hookrow['menu_name'] ?? null;
+                $mod_nick_name = is_string($menuName) && $menuName !== '' && $menuName !== '0'
+                    ? $menuName
+                    : 'NoName';
 
                 $subEntry = new \stdClass();
                 $subEntry->requirement = 0;
                 $subEntry->target = 'main';
                 $subEntry->menu_id = $hookrow['mod_id'];
-                $subEntry->label = xlt($mod_nick_name);
+                // Assign the raw module menu name; MenuRole::menuUpdateEntries()
+                // will translate and HTML-escape it via xlt() during the
+                // recursive pass over children.
+                $subEntry->label = $mod_nick_name;
                 $subEntry->url = $relative_link;
                 $subEntry->on_click = 'top.restoreSession()';
                 $subEntry->pid = 'false';


### PR DESCRIPTION
Part 5 of a series fixing ~225 PHPStan literal-string violations in xl()/xlt()/xla() calls.

## Summary

Narrows mixed values from JSON-decoded menu entries and DB rows to `string` before passing them to translation helpers in `src/Menu/`. Switches unconditional `xlt()` calls on dynamic labels to the appropriate wrappers (`xlt()` with a scoped `@phpstan-ignore` for menu labels, `xl_form_title()` for form/category labels), which accept runtime strings without literal-string violations.

## Escaping policy

Menu labels **remain HTML-escaped at rest** in `MenuRole::menuUpdateEntries()`, via `xlt()` applied to the narrowed label. This is because `twAddTab()` in `src/Tabs/TabsWrapper.php` concatenates the label directly into the tab anchor and a close-button `id` attribute without escaping. The long-term fix (escape at the render site) is tracked in #11478; until then, this PR preserves the pre-PR "labels are HTML-safe at rest" contract.

Custom menu filenames in `MainMenuRole`/`PatientMenuRole` are translated and escaped at output via `xlt(substr(...))` with a scoped `@phpstan-ignore argument.type` (since the substring is dynamic). `xlt()` is the same as `text(xl(...))` by definition.

## Files

- `src/Menu/MenuRole.php` — narrow `$entry->label` before translating in `menuUpdateEntries`; uses `xlt()` (escaped at rest) due to the `twAddTab()` concern above
- `src/Menu/MainMenuRole.php` — narrow `$reglastcat`/`$title`/`$category` in `updateVisitForms` and `updateBlankForms`; custom menu filenames use `xlt(substr(...))` so they're always translated regardless of `translate_lists`. Switched `preg_match("/\.json$/", ...)` to `str_ends_with()` per review.
- `src/Menu/PatientMenuRole.php` — narrow `$mod_nick_name` and assign raw to `$subEntry->label` (`MenuRole::menuUpdateEntries()` will translate + escape during the recursive pass); custom menu filenames use `xlt(substr(...))` same as `MainMenuRole`. Same `str_ends_with()` cleanup.

## Follow-up issues filed during review

- openemr/openemr#11478 — escape at the render site in `TabsWrapper::twAddTab()` so menu labels can be stored unescaped.
- openemr/openemr#11487 — extract a shared helper from `updateVisitForms` and `updateBlankForms`.

## Baseline impact

PHPStan baselines only go down:

- `argument.type.php`: 30 entries removed (covers all literal-string + several `mixed`-passed-to-string violations on these three files)
- `empty.notAllowed.php`: MainMenuRole 6 → 4
- `offsetAccess.nonOffsetAccessible.php`: MainMenuRole 4 → 2

No new baseline entries were introduced.

## Test plan

- [x] `composer phpstan` — clean, no errors
- [x] `composer phpstan-baseline` — only deletions/decreases for menu files
- [x] Pre-commit hooks (phpcs, phpcbf, rector, codespell, require-checker) — all passing