### PR TITLE
refactor(reports): fix literal-string violations in xl/xlt calls

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -1412,11 +1412,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \' onchange\\=\\\\\'\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -198,11 +198,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/billing/payment_pat_sel.inc.php',
 ];

--- a/.phpstan/baseline/echo.nonString.php
+++ b/.phpstan/baseline/echo.nonString.php
@@ -83,7 +83,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 6,
+    'count' => 5,
     'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -2153,7 +2153,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 34,
+    'count' => 33,
     'path' => __DIR__ . '/../../interface/reports/ippf_statistics.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -1287,51 +1287,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/edi_270.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function generate_list_payment_category\\(\\) has parameter \\$PaymentType with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function generate_list_payment_category\\(\\) has parameter \\$class with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function generate_list_payment_category\\(\\) has parameter \\$currvalue with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function generate_list_payment_category\\(\\) has parameter \\$empty_name with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function generate_list_payment_category\\(\\) has parameter \\$list_id with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function generate_list_payment_category\\(\\) has parameter \\$onchange with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function generate_list_payment_category\\(\\) has parameter \\$screen with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function generate_list_payment_category\\(\\) has parameter \\$tag_name with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function generate_list_payment_category\\(\\) has parameter \\$title with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function SavePatientAudit\\(\\) has parameter \\$invs with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -732,11 +732,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/edi_270.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function generate_list_payment_category\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/billing/payment_master.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function SavePatientAudit\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',

--- a/interface/billing/payment_master.inc.php
+++ b/interface/billing/payment_master.inc.php
@@ -15,25 +15,25 @@
 
 use OpenEMR\BC\Utilities;
 
-function generate_list_payment_category($tag_name, $list_id, $currvalue, $title, $empty_name = ' ', $class = '', $onchange = '', $PaymentType = 'insurance', $screen = 'new_payment')
+function generate_list_payment_category(string $tag_name, string $list_id, string $currvalue, string $title, string $empty_name = ' ', string $class = '', string $onchange = '', string $PaymentType = 'insurance', string $screen = 'new_payment'): string
 {
     $s = '';
     $s .= "<select name='" . attr($tag_name) . "' id='" . attr($tag_name) . "'";
-    if ($class) {
+    if ($class !== '') {
         $s .= " class='" . attr($class) . "'";
     }
-    if ($onchange) {
+    if ($onchange !== '') {
         $s .= " onchange='" . $onchange . "'"; //Need to html escape $onchange prior to the generate_list_payment_category function call
     }
     $s .= " title='" . attr($title) . "'>";
-    if ($empty_name) {
-        $s .= "<option value=''>" . xlt($empty_name) . "</option>";
+    if ($empty_name !== '') {
+        $s .= "<option value=''>" . text(xl_list_label($empty_name)) . "</option>";
     }
     $lres = sqlStatement("SELECT * FROM list_options WHERE list_id = ? AND activity = 1 ORDER BY seq, title", [$list_id]);
     $got_selected = false;
     while ($lrow = sqlFetchArray($lres)) {
         $s .= "<option   id='option_" . attr($lrow['option_id']) . "'" . " value='" . attr($lrow['option_id']) . "'";
-        if ((strlen((string) $currvalue) == 0 && $lrow['is_default']) || (strlen((string) $currvalue) > 0 && $lrow['option_id'] == $currvalue) || ($lrow['option_id'] == 'insurance_payment' && $screen == 'new_payment')) {
+        if ((strlen($currvalue) == 0 && $lrow['is_default']) || (strlen($currvalue) > 0 && $lrow['option_id'] == $currvalue) || ($lrow['option_id'] == 'insurance_payment' && $screen == 'new_payment')) {
             $s .= " selected";
             $got_selected = true;
         }
@@ -43,10 +43,10 @@ function generate_list_payment_category($tag_name, $list_id, $currvalue, $title,
         if ($PaymentType == 'patient' && $lrow['option_id'] == 'insurance_payment') {
             $s .= " style='background-color: var(--light)' ";
         }
-        $s .= ">" . text(xl_list_label($lrow['title'])) . "</option>\n";
+        $title_value = is_string($lrow['title'] ?? null) ? $lrow['title'] : '';
+        $s .= ">" . text(xl_list_label($title_value)) . "</option>\n";
     }
-    if (!$got_selected && strlen((string) $currvalue) > 0) {
-        $currescaped = text($currvalue);
+    if (!$got_selected && strlen($currvalue) > 0) {
         $s .= "<option value='" . attr($currvalue) . "' selected>* " . text($currvalue) . " *</option>";
         $s .= "</select>";
         $fontTitle = xl('Please choose a valid selection from the list.');

--- a/interface/reports/ippf_statistics.php
+++ b/interface/reports/ippf_statistics.php
@@ -787,8 +787,8 @@ function process_ma_code($row): void
   // One row for each service category.
   //
     if ($form_by === '101') {
-        if (!empty($row['lo_title'])) {
-            $key = xl($row['lo_title']);
+        if (is_string($row['lo_title'] ?? null) && $row['lo_title'] !== '') {
+            $key = xl_list_label($row['lo_title']);
         }
     } elseif ($form_by === '102') { // Specific Services. One row for each MA code.
         $key = $row['code'];

--- a/interface/reports/message_list.php
+++ b/interface/reports/message_list.php
@@ -242,8 +242,8 @@ if (!empty($_POST['form_refresh']) || !empty($_POST['form_csvexport'])) {
         $patient_name    = $row['lname'] . ', ' . $row['fname'] . ' ' . $row['mname'];
         $patient_id      = $row['pubpid'];
         $patient_dob     = $row['dob'];
-        $msg_type        = $row['title'];
-        $msg_status      = $row['message_status'];
+        $msg_type        = is_string($row['title'] ?? null) ? $row['title'] : '';
+        $msg_status      = is_string($row['message_status'] ?? null) ? $row['message_status'] : '';
         $updateById      = $row['update_by'];
         if ($updateById) {
             $userRecord = $userService->getUser($updateById);
@@ -262,8 +262,8 @@ if (!empty($_POST['form_refresh']) || !empty($_POST['form_csvexport'])) {
             echo csvEscape($row['fname']) . ',';
             echo csvEscape($patient_id) . ',';
             echo csvEscape($patient_dob) . ',';
-            echo csvEscape(xl($msg_type)) . ',';
-            echo csvEscape(xl($msg_status)) . ',';
+            echo csvEscape(xl_list_label($msg_type)) . ',';
+            echo csvEscape(xl_list_label($msg_status)) . ',';
             echo csvEscape($update_by) . ',';
             echo csvEscape(oeFormatShortDate(substr((string) $update_date, 0, 10))) . "\n";
         } else {

--- a/interface/reports/patient_list.php
+++ b/interface/reports/patient_list.php
@@ -280,15 +280,19 @@ if (!empty($_POST['form_refresh']) || !empty($_POST['form_csvexport'])) {
             $age = intval($ageInMonths / 12);
         }
 
+        $street = is_string($row['street'] ?? null) ? $row['street'] : '';
+        $city = is_string($row['city'] ?? null) ? $row['city'] : '';
+        $state = is_string($row['state'] ?? null) ? $row['state'] : '';
+
         if ($_POST['form_csvexport']) {
             echo csvEscape(oeFormatShortDate(substr((string) $row['edate'], 0, 10))) . ',';
             echo csvEscape($row['lname']) . ',';
             echo csvEscape($row['fname']) . ',';
             echo csvEscape($row['mname']) . ',';
             echo csvEscape($row['pubpid']) . ',';
-            echo csvEscape(xl($row['street'])) . ',';
-            echo csvEscape(xl($row['city'])) . ',';
-            echo csvEscape(xl($row['state'])) . ',';
+            echo csvEscape($street) . ',';
+            echo csvEscape($city) . ',';
+            echo csvEscape($state) . ',';
             echo csvEscape($row['postal_code']) . ',';
             echo csvEscape($row['phone_home']) . ',';
             echo csvEscape($row['phone_biz']) . "\n";
@@ -305,13 +309,13 @@ if (!empty($_POST['form_refresh']) || !empty($_POST['form_csvexport'])) {
             <?php echo text($row['pubpid']); ?>
    </td>
    <td>
-            <?php echo xlt($row['street']); ?>
+            <?php echo text($street); ?>
    </td>
    <td>
-            <?php echo xlt($row['city']); ?>
+            <?php echo text($city); ?>
    </td>
    <td>
-            <?php echo xlt($row['state']); ?>
+            <?php echo text($state); ?>
    </td>
    <td>
             <?php echo text($row['postal_code']); ?>

--- a/interface/reports/receipts_by_method_report.php
+++ b/interface/reports/receipts_by_method_report.php
@@ -667,8 +667,19 @@ if (!empty($_POST['form_refresh'])) {
                         $rowmethod = xl('Unnamed insurance company');
                     }
                     if (!empty($insurance_id['provider'])) {
-                        $insurance_company = (new InsuranceCompanyService())->getOneById($insurance_id['provider']) ?? '';
-                        $rowmethod = xl($insurance_company['name']);
+                        // getOneById delegates to sqlQuery which can return
+                        // array|false|null. Normalize to [] so the ['name']
+                        // lookup below can't trip on a non-array value.
+                        $insurance_company = (new InsuranceCompanyService())->getOneById($insurance_id['provider']) ?: [];
+                        $insurance_company_name = $insurance_company['name'] ?? null;
+                        if (is_string($insurance_company_name) && trim($insurance_company_name) !== '') {
+                            $rowmethod = $insurance_company_name;
+                        } else {
+                            // Fall back to the same label the missing-provider
+                            // branch below uses, so empty payer keys don't get
+                            // bucketed as "Patient"/"Unknown" downstream.
+                            $rowmethod = xl('Unnamed insurance company');
+                        }
                     } elseif (!($row['payer_type'] == '0')) {
                         $rowmethod = xl('Unnamed insurance company');
                     }

--- a/library/FeeSheet.class.php
+++ b/library/FeeSheet.class.php
@@ -574,7 +574,7 @@ class FeeSheet
         }
 
         if ($codetype == 'COPAY') {
-            $li['codetype'] = xl($codetype);
+            $li['codetype'] = xl('COPAY');
             if ($ndc_info) {
                 $li['codetype'] .= " ($ndc_info)";
             }

--- a/library/ajax/billing_tracker_ajax.php
+++ b/library/ajax/billing_tracker_ajax.php
@@ -39,7 +39,7 @@ foreach ($claim_files as $claim_file) {
     $element->x12_partner_id = text($claim_file['x12_partner_id']);
     $element->x12_partner_name = text($claim_file['name']);
     $element->x12_filename = text($claim_file['x12_filename']);
-    $element->status = xl($claim_file['status']);
+    $element->status = xl_list_label(is_string($claim_file['status'] ?? null) ? $claim_file['status'] : '');
     $element->created_at = $claim_file['created_at'];
     $element->updated_at = $claim_file['updated_at'];
     $element->claims = json_decode((string) $claim_file['claims']);


### PR DESCRIPTION
## Summary

Part 6 of a series fixing ~225 PHPStan literal-string violations in `xl()`/`xlt()`/`xla()` calls.

Fix PHPStan literal-string violations in reports and billing files:

- **patient_list.php**: drop spurious `xl`/`xlt` on street/city/state (addresses are not translatable); narrow with `is_string()` before echoing.
- **message_list.php**: switch `xl()` on DB labels to `xl_list_label()` and narrow `$msg_type`/`$msg_status` with `is_string()`.
- **ippf_statistics.php**: switch `xl()` on `lo_title` to `xl_list_label()` with `is_string()` narrowing.
- **receipts_by_method_report.php**: drop spurious `xl()` on insurance company name (not translatable); narrow with `is_string()`.
- **billing_tracker_ajax.php**: switch `xl()` on claim status to `xl_list_label()` with `is_string()` narrowing.
- **FeeSheet.class.php**: inline `'COPAY'` literal since `$codetype` is always `'COPAY'` inside the `if` block.
- **payment_master.inc.php**: add native `string` types to `generate_list_payment_category()`; switch `xlt($empty_name)` to `text(xl_list_label($empty_name))`; narrow `$lrow['title']` with `is_string()`.

PHPStan baseline counts only decrease — no new entries added.

## Test plan

- [x] `composer phpstan` reports no errors
- [x] `composer phpstan-baseline` shows only decreases for touched files
- [x] Pre-commit hooks pass (phpcs, phpstan, rector, etc.)