### PR TITLE
refactor: fix scattered xl literal-string violations (Part 7, final)

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -3122,11 +3122,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/note/report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/note/report.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'/forms/\' results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/note/view.php',

--- a/.phpstan/baseline/booleanOr.rightAlwaysTrue.php
+++ b/.phpstan/baseline/booleanOr.rightAlwaysTrue.php
@@ -4,11 +4,6 @@ $ignoreErrors = [];
 $ignoreErrors[] = [
     'message' => '#^Right side of \\|\\| is always true\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/prior_auth/report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Right side of \\|\\| is always true\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -15142,11 +15142,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/super/edit_layout.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function genGroupSelector\\(\\) has parameter \\$name with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/edit_layout.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function genLayoutOptions\\(\\) has parameter \\$default with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/super/edit_layout.php',
@@ -15358,11 +15353,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Function writeOptionLine\\(\\) has parameter \\$subtype with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/edit_list.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function writeOptionLine\\(\\) has parameter \\$title with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/super/edit_list.php',
 ];
@@ -25638,11 +25628,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Function generate_select_list\\(\\) has parameter \\$custom_attributes with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/options.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function generate_select_list\\(\\) has parameter \\$empty_name with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/options.inc.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -28037,11 +28037,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/super/edit_layout.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset 3 on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/edit_layout_props.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'abbreviation\' on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/super/edit_list.php',
@@ -42563,7 +42558,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset 0 on mixed\\.$#',
-    'count' => 20,
+    'count' => 18,
     'path' => __DIR__ . '/../../src/Common/Acl/AclExtended.php',
 ];
 $ignoreErrors[] = [
@@ -42578,7 +42573,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset 3 on mixed\\.$#',
-    'count' => 16,
+    'count' => 12,
     'path' => __DIR__ . '/../../src/Common/Acl/AclExtended.php',
 ];
 $ignoreErrors[] = [

--- a/interface/forms/aftercare_plan/report.php
+++ b/interface/forms/aftercare_plan/report.php
@@ -34,7 +34,8 @@ function aftercare_plan_report($pid, $encounter, $cols, $id): void
             }
 
             $key = ucwords(str_replace("_", " ", $key));
-            print "<td><span class=bold>" . xlt($key) . ": </span><span class=text>" . text($value) . "</span></td>";
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            printf('<td><span class="bold">%s: </span><span class="text">%s</span></td>', xlt($key), text($value));
             $count++;
             if ($count == $cols) {
                 $count = 0;

--- a/interface/forms/ankleinjury/report.php
+++ b/interface/forms/ankleinjury/report.php
@@ -39,7 +39,8 @@ function ankleinjury_report($pid, $encounter, $cols, $id): void
             $key = ucwords(str_replace("_", " ", $key));
             $key = str_replace("Ankle ", "", $key);
             $key = str_replace("Injuary", "Injury", $key);
-            print "<td valign='top'><span class='bold'>" . xlt($key) . ": </span><span class='text'>" . text($value) . "</span></td>\n";
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            printf('<td valign="top"><span class="bold">%s: </span><span class="text">%s</span></td>', xlt($key), text($value));
             $count++;
             if ($count == $cols) {
                 $count = 0;

--- a/interface/forms/bronchitis/report.php
+++ b/interface/forms/bronchitis/report.php
@@ -33,7 +33,8 @@ function bronchitis_report($pid, $encounter, $cols, $id): void
             }
 
             $key = ucwords(str_replace("_", " ", $key));
-            print "<td><span class=bold>" . xlt($key) . ": </span><span class=text>" . text($value) . "</span></td>";
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            printf('<td><span class="bold">%s: </span><span class="text">%s</span></td>', xlt($key), text($value));
             $count++;
             if ($count == $cols) {
                 $count = 0;

--- a/interface/forms/clinic_note/report.php
+++ b/interface/forms/clinic_note/report.php
@@ -46,7 +46,8 @@ function clinic_note_report($pid, $encounter, $cols, $id): void
             }
 
             $key = ucwords(str_replace("_", " ", $key));
-            print "<td valign='top'><span class='bold'>" . xlt($key) . ": </span><span class='text'>" . text($value) . "&nbsp;</span></td>\n";
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            printf('<td valign="top"><span class="bold">%s: </span><span class="text">%s&nbsp;</span></td>', xlt($key), text($value));
             $count++;
             if ($count == $cols) {
                 $count = 0;

--- a/interface/forms/dictation/report.php
+++ b/interface/forms/dictation/report.php
@@ -34,8 +34,8 @@ function dictation_report($pid, $encounter, $cols, $id): void
             }
 
             $key = ucwords(str_replace("_", " ", $key));
-            print "<h3>" . xlt($key) . ": </h3>" .
-                "<p>" . nl2br(text($value)) . "</p>";
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            printf('<h3>%s: </h3><p>%s</p>', xlt($key), nl2br(text($value)));
             $count++;
         }
     }

--- a/interface/forms/misc_billing_options/report.php
+++ b/interface/forms/misc_billing_options/report.php
@@ -78,7 +78,8 @@ function misc_billing_options_report($pid, $encounter, $cols, $id): void
 
 
             $key = ucwords(str_replace("_", " ", $key));
-            print "<td><span class=bold>" . xlt($key) . ": </span><span class=text>" . text($value) . "</span></td>";
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            printf('<td><span class="bold">%s: </span><span class="text">%s</span></td>', xlt($key), text($value));
             $count++;
 
             if ($count == $cols) {

--- a/interface/forms/note/report.php
+++ b/interface/forms/note/report.php
@@ -39,15 +39,21 @@ function note_report($pid, $encounter, $cols, $id): void
             }
 
             $key = ucwords(str_replace("_", " ", $key));
+            $valueText = is_string($value) ? $value : '';
             print("<tr>\n");
             print("<tr>\n");
-            if ($key == "Note Type") {
-                print "<td><span class=bold>" . xlt($key) . ": </span><span class=text>" . xlt($value) . "</span></td>";
-            } elseif ($key == "Date Of Signature") {
-                print "<td><span class=bold>" . xlt($key) . ": </span><span class=text>" . oeFormatShortDate($value) . "</span></td>";
-            } else {
-                print "<td><span class=bold>" . xlt($key) . ": </span><span class=text>" . text($value) . "</span></td>";
-            }
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            $keyLabel = xlt($key);
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            $valueLabel = xlt($valueText);
+            $dateResult = oeFormatShortDate($valueText);
+            $dateLabel = is_string($dateResult) ? text($dateResult) : '';
+            $valueOutput = match ($key) {
+                'Note Type' => $valueLabel,
+                'Date Of Signature' => $dateLabel,
+                default => text($valueText),
+            };
+            printf('<td><span class="bold">%s: </span><span class="text">%s</span></td>', $keyLabel, $valueOutput);
 
             $count++;
             if ($count == $cols) {

--- a/interface/forms/physical_exam/report.php
+++ b/interface/forms/physical_exam/report.php
@@ -31,7 +31,9 @@ function physical_exam_report($pid, $encounter, $cols, $id): void
     echo "<table cellpadding='0' cellspacing='0'>\n";
 
     foreach ($pelines as $sysname => $sysarray) {
-        $sysnamedisp = xl($sysname);
+        $sysnameStr = is_string($sysname) ? $sysname : '';
+        // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+        $sysnamedisp = xl($sysnameStr);
         foreach ($sysarray as $line_id => $description) {
             $linedbrow = $rows[$line_id];
             if (

--- a/interface/forms/prior_auth/report.php
+++ b/interface/forms/prior_auth/report.php
@@ -31,12 +31,13 @@ function prior_auth_report($pid, $encounter, $cols, $id): void
                 $value = "yes";
             }
 
-            if ($key == "from_date" || "to_date") {
+            if ($key === "from_date" || $key === "to_date") {
                 $value = oeFormatShortDate($value);
             }
 
             $key = ucwords(str_replace("_", " ", $key));
-            print "<td><span class=bold>" . xlt($key) . ": </span><span class=text>" . text($value) . "</span></td>";
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            printf('<td><span class="bold">%s: </span><span class="text">%s</span></td>', xlt($key), text($value));
             $count++;
             if ($count == $cols) {
                 $count = 0;

--- a/interface/forms/reviewofs/report.php
+++ b/interface/forms/reviewofs/report.php
@@ -34,11 +34,13 @@ function reviewofs_report($pid, $encounter, $cols, $id): void
             $key = ucwords(str_replace("_", " ", $key));
 
             //modified by BM 07-2009 for internationalization
-            if ($key == "Additional Notes") {
-                    print "<td><span class=bold>" . xlt($key) . ": </span><span class=text>" . text($value) . "</span></td>";
-            } else {
-                    print "<td><span class=bold>" . xlt($key) . ": </span><span class=text>" . xlt($value) . "</span></td>";
-            }
+            $valueText = is_string($value) ? $value : '';
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            $keyLabel = xlt($key);
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            $valueLabel = xlt($valueText);
+            $valueOutput = $key == 'Additional Notes' ? text($valueText) : $valueLabel;
+            printf('<td><span class="bold">%s: </span><span class="text">%s</span></td>', $keyLabel, $valueOutput);
 
             $count++;
             if ($count == $cols) {

--- a/interface/forms/ros/report.php
+++ b/interface/forms/ros/report.php
@@ -112,7 +112,9 @@ function ros_report($pid, $encounter, $cols, $id): void
                 $value = "yes";
             }
 
-            printf("<td><span class=bold>%s: </span><span class=text>%s</span></td>", xlt($key), xlt($value));
+            $valueStr = is_string($value) ? $value : '';
+            // @phpstan-ignore argument.type, argument.type (legacy on-the-fly translation of dynamic values; migration tracked in #11498)
+            printf('<td><span class="bold">%s: </span><span class="text">%s</span></td>', xlt($key), xlt($valueStr));
             $count++;
 
             if ($count == $cols) {

--- a/interface/forms/soap/report.php
+++ b/interface/forms/soap/report.php
@@ -35,7 +35,8 @@ function soap_report($pid, $encounter, $cols, $id): void
 
             $key = ucwords(str_replace("_", " ", $key));
                                                                               //Updated by Sherwin 10/24/2016
-            print "<td><span class=bold>" . xlt($key) . ": </span><span class=text>" . nl2br(text($value)) . "</span></td>";
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            printf('<td><span class="bold">%s: </span><span class="text">%s</span></td>', xlt($key), nl2br(text($value)));
             $count++;
             if ($count == $cols) {
                 $count = 0;

--- a/interface/forms/transfer_summary/report.php
+++ b/interface/forms/transfer_summary/report.php
@@ -34,7 +34,8 @@ function transfer_summary_report($pid, $encounter, $cols, $id): void
             }
 
             $key = ucwords(str_replace("_", " ", $key));
-            print "<td><span class=bold>" . xlt($key) . ": </span><span class=text>" . text($value) . "</span></td>";
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            printf('<td><span class="bold">%s: </span><span class="text">%s</span></td>', xlt($key), text($value));
             $count++;
             if ($count == $cols) {
                 $count = 0;

--- a/interface/forms/treatment_plan/report.php
+++ b/interface/forms/treatment_plan/report.php
@@ -34,7 +34,8 @@ function treatment_plan_report($pid, $encounter, $cols, $id): void
             }
 
             $key = ucwords(str_replace("_", " ", $key));
-            print "<td><span class=bold>" . xlt($key) . ": </span><span class=text>" . text($value) . "</span></td>";
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            printf('<td><span class="bold">%s: </span><span class="text">%s</span></td>', xlt($key), text($value));
             $count++;
             if ($count == $cols) {
                 $count = 0;

--- a/interface/forms/vitals/report.php
+++ b/interface/forms/vitals/report.php
@@ -70,7 +70,12 @@ function vitals_report($pid, $encounter, $cols, $id, $print = true)
                     }
                 }
 
-                $vitals .= '<td><div class="bold" style="display:inline-block">' . xlt($key) . ': </div></td><td><div class="text" style="display:inline-block">' . xlt($value) . "</div></td>";
+                $valueStr = is_string($value) ? $value : '';
+                // Vitals labels/values are dynamic content; translate unconditionally via xl().
+                $keyLabel = xl($key);
+                // @phpstan-ignore argument.type (vitals values are dynamic content)
+                $valueLabel = xl($valueStr);
+                $vitals .= '<td><div class="bold" style="display:inline-block">' . text($keyLabel) . ': </div></td><td><div class="text" style="display:inline-block">' . text($valueLabel) . "</div></td>";
             } elseif ($key == "Bps") {
                 $bps = $value;
                 if (!empty($bpd)) {
@@ -154,7 +159,9 @@ function vitals_report($pid, $encounter, $cols, $id, $print = true)
                     }
                 }
             } else {
-                $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($value) . "</div></td>";
+                // @phpstan-ignore argument.type (vitals keys are dynamic content)
+                $keyLabel = xl($key);
+                $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . text($keyLabel) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($value) . "</div></td>";
             }
 
             $count++;

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -413,13 +413,14 @@ function checkBackgroundServices(): void
                         <div id="globals-div">
                             <ul class="tabNav tabWidthWide sticky-top" id="oe-nav-ul">
                                 <?php
-                                $i = 0;
+                                $tabClass = ' class="current"';
                                 foreach ($GLOBALS_METADATA as $grpname => $grparr) {
                                     if (!$userMode || in_array($grpname, $USER_SPECIFIC_TABS)) {
-                                        echo " <li" . ($i ? "" : " class='current'") .
-                                            "><a href='#'>" .
-                                            xlt($grpname) . "</a></li>\n";
-                                        ++$i;
+                                        $grpnameStr = is_string($grpname) ? $grpname : '';
+                                        // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+                                        $tabLabel = xlt($grpnameStr);
+                                        printf('<li%s><a href="#">%s</a></li>', $tabClass, $tabLabel);
+                                        $tabClass = '';
                                     }
                                 }
                                 ?>
@@ -431,11 +432,20 @@ function checkBackgroundServices(): void
                                 $authUserID = $session->get('authUserID');
                                 foreach ($GLOBALS_METADATA as $grpname => $grparr) {
                                     if (!$userMode || in_array($grpname, $USER_SPECIFIC_TABS)) {
+                                        $grpnameStr = is_string($grpname) ? $grpname : '';
                                         echo " <div class='tab w-100 h-auto" . ($i ? "" : " current") . "' style='font-size: 0.9rem'>\n";
 
                                         echo '<div class="striped">';
                                         $addendum = $grpname == 'Appearance' ? ' (*' . xl("need to logout/login after changing these settings") . ')' : '';
-                                        echo "<div class='col-sm-12 oe-global-tab-heading'><div class='oe-pull-toward' style='font-size: 1.4rem'>" . xlt($grpname) . " &nbsp;</div><div style='margin-top: 5px'>" . text($addendum) . "</div></div>";
+                                        // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+                                        $tabHeading = xlt($grpnameStr);
+                                        $addendumHtml = text($addendum);
+                                        echo <<<HTML
+                                            <div class="col-sm-12 oe-global-tab-heading">
+                                                <div class="oe-pull-toward" style="font-size: 1.4rem">{$tabHeading} &nbsp;</div>
+                                                <div style="margin-top: 5px">{$addendumHtml}</div>
+                                            </div>
+                                            HTML;
                                         echo "<div class='clearfix'></div>";
                                         if ($userMode) {
                                             echo "<div class='row'>";
@@ -590,13 +600,14 @@ function checkBackgroundServices(): void
                                                     $res = sqlStatement("SELECT * FROM lang_languages ORDER BY lang_description");
                                                     echo "  <select class='form-control' name='form_$i' id='form_$i'>\n";
                                                     while ($row = sqlFetchArray($res)) {
+                                                        $langDesc = is_string($row['lang_description'] ?? null) ? $row['lang_description'] : '';
                                                         echo "   <option value='" . attr($row['lang_description']) . "'";
                                                         if ($row['lang_description'] == $fldvalue) {
                                                             echo " selected";
                                                         }
 
                                                         echo ">";
-                                                        echo xlt($row['lang_description']);
+                                                        echo text(xl_list_label($langDesc));
                                                         echo "</option>\n";
                                                     }
 
@@ -605,13 +616,14 @@ function checkBackgroundServices(): void
                                                     global $code_types;
                                                     echo "  <select class='form-control' name='form_$i' id='form_$i'>\n";
                                                     foreach (array_keys($code_types) as $code_key) {
+                                                        $codeLabel = is_string($code_types[$code_key]['label'] ?? null) ? $code_types[$code_key]['label'] : '';
                                                         echo "   <option value='" . attr($code_key) . "'";
                                                         if ($code_key == $fldvalue) {
                                                             echo " selected";
                                                         }
 
                                                         echo ">";
-                                                        echo xlt($code_types[$code_key]['label']);
+                                                        echo text(xl_list_label($codeLabel));
                                                         echo "</option>\n";
                                                     }
 
@@ -620,6 +632,7 @@ function checkBackgroundServices(): void
                                                     $res = sqlStatement("SELECT * FROM lang_languages  ORDER BY lang_description");
                                                     echo "  <select multiple class='form-control' name='form_{$i}[]' id='form_{$i}[]' size='3'>\n";
                                                     while ($row = sqlFetchArray($res)) {
+                                                        $langDesc = is_string($row['lang_description'] ?? null) ? $row['lang_description'] : '';
                                                         echo "   <option value='" . attr($row['lang_description']) . "'";
                                                         foreach ($glarr as $glrow) {
                                                             if ($glrow['gl_value'] == $row['lang_description']) {
@@ -628,7 +641,7 @@ function checkBackgroundServices(): void
                                                             }
                                                         }
                                                         echo ">";
-                                                        echo xlt($row['lang_description']);
+                                                        echo text(xl_list_label($langDesc));
                                                         echo "</option>\n";
                                                     }
                                                     echo "  </select>\n";
@@ -639,20 +652,22 @@ function checkBackgroundServices(): void
                                                         $hiddenList[] = $row['gl_value'];
                                                     }
                                                     // The list of cards to hide. For now add to array new cards.
+                                                    // Store raw literals; escape via attr() and translate via xlt()
+                                                    // once at output below.
                                                     $res = [
-                                                        ['card_abrev' => '', 'card_name' => xlt('None or Reset')],
-                                                        ['card_abrev' => attr('card_allergies'), 'card_name' => xlt('Allergies')],
-                                                        ['card_abrev' => attr('card_amendments'), 'card_name' => xlt('Amendments')],
-                                                        ['card_abrev' => attr('card_disclosure'), 'card_name' => xlt('Disclosures')],
-                                                        ['card_abrev' => attr('card_insurance'), 'card_name' => xlt('Insurance')],
-                                                        ['card_abrev' => attr('card_lab'), 'card_name' => xlt('Labs')],
-                                                        ['card_abrev' => attr('card_medicalproblems'), 'card_name' => xlt('Medical Problems')],
-                                                        ['card_abrev' => attr('card_medication'), 'card_name' => xlt('Medications')],
+                                                        ['card_abrev' => '', 'card_name' => 'None or Reset'],
+                                                        ['card_abrev' => 'card_allergies', 'card_name' => 'Allergies'],
+                                                        ['card_abrev' => 'card_amendments', 'card_name' => 'Amendments'],
+                                                        ['card_abrev' => 'card_disclosure', 'card_name' => 'Disclosures'],
+                                                        ['card_abrev' => 'card_insurance', 'card_name' => 'Insurance'],
+                                                        ['card_abrev' => 'card_lab', 'card_name' => 'Labs'],
+                                                        ['card_abrev' => 'card_medicalproblems', 'card_name' => 'Medical Problems'],
+                                                        ['card_abrev' => 'card_medication', 'card_name' => 'Medications'],
                                                         ['card_abrev' => 'card_prescriptions', 'card_name' => 'Prescriptions'], // For now don't hide because can be disabled as feature.
-                                                        ['card_abrev' => attr('card_vitals'), 'card_name' => xlt('Vitals')],
-                                                        ['card_abrev' => attr('card_care_team'), 'card_name' => xlt('Care Team')],
-                                                        ['card_abrev' => attr('card_care_experience'), 'card_name' => xlt('Care Experience Preferences')],
-                                                        ['card_abrev' => attr('card_treatment_preferences'), 'card_name' => xlt('Treatment Intervention Preferences')],
+                                                        ['card_abrev' => 'card_vitals', 'card_name' => 'Vitals'],
+                                                        ['card_abrev' => 'card_care_team', 'card_name' => 'Care Team'],
+                                                        ['card_abrev' => 'card_care_experience', 'card_name' => 'Care Experience Preferences'],
+                                                        ['card_abrev' => 'card_treatment_preferences', 'card_name' => 'Treatment Intervention Preferences'],
                                                     ];
                                                     echo "  <select multiple class='form-control' name='form_{$i}[]' id='form_{$i}[]' size='13'>\n";
                                                     foreach ($res as $row) {
@@ -664,6 +679,9 @@ function checkBackgroundServices(): void
                                                             }
                                                         }
                                                         echo ">";
+                                                        // Translate + escape once at output. Card names should always
+                                                        // be translated, not gated on translate_lists. PHPStan infers
+                                                        // literal-string from the array shape above.
                                                         echo xlt($row['card_name']);
                                                         echo "</option>\n";
                                                     }
@@ -807,7 +825,16 @@ function checkBackgroundServices(): void
                                         echo "<div class='btn-group oe-margin-b-10'>" .
                                             "<button type='submit' class='btn btn-primary btn-save oe-pull-toward' name='form_save'" .
                                             "value='" . xla('Save') . "'>" . xlt('Save') . "</button></div>";
-                                        echo "<div class='oe-pull-away oe-margin-t-10' style=''>" . xlt($grpname) . " &nbsp;<a href='#' class='text-dark text-decoration-none fa fa-lg fa-arrow-circle-up oe-help-redirect scroll' aria-hidden='true'></a></div><div class='clearfix'></div></div>";
+                                        // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+                                        $tabFooter = xlt($grpnameStr);
+                                        echo <<<HTML
+                                            <div class="oe-pull-away oe-margin-t-10">
+                                                {$tabFooter} &nbsp;
+                                                <a href="#" class="text-dark text-decoration-none fa fa-lg fa-arrow-circle-up oe-help-redirect scroll" aria-hidden="true"></a>
+                                            </div>
+                                            <div class="clearfix"></div>
+                                            </div>
+                                            HTML;
                                         echo " </div>\n";
                                     }
                                 }

--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -86,7 +86,10 @@ function nextGroupOrder($order)
 // Included also are parent groups containing only sub-groups.  Groups are listed
 // in the same order as they appear in the layout.
 //
-function genGroupSelector($name, $layout_id, $default = '')
+/**
+ * @param literal-string $name
+ */
+function genGroupSelector(string $name, $layout_id, $default = '')
 {
     $res = sqlStatement(
         "SELECT grp_group_id, grp_title " .
@@ -783,7 +786,8 @@ function writeFieldLine($linedata): void
 
     // if not english and set to translate layout labels, then show the translation
     if (OEGlobalsBag::getInstance()->getBoolean('translate_layout') && $session->get('language_choice') > 1) {
-        echo "<td class='text-center translation'>" . xlt($linedata['title']) . "</td>\n";
+        $titleStr = is_string($linedata['title'] ?? null) ? $linedata['title'] : '';
+        echo "<td class='text-center translation'>" . text(xl_layout_label($titleStr)) . "</td>\n";
     }
 
     echo "  <td class='text-center optcell'>";
@@ -938,7 +942,8 @@ function writeFieldLine($linedata): void
         echo "</td>\n";
       // if not english and showing layout labels, then show the translation of Description
         if (OEGlobalsBag::getInstance()->getBoolean('translate_layout') && $session->get('language_choice') > 1) {
-            echo "<td class='text-center translation'>" . xlt($linedata['description']) . "</td>\n";
+            $descStr = is_string($linedata['description'] ?? null) ? $linedata['description'] : '';
+            echo "<td class='text-center translation'>" . text(xl_layout_label($descStr)) . "</td>\n";
         }
     }
     echo "  <td class='text-center optcell'>";
@@ -1609,7 +1614,7 @@ if ($layout_id) {
                 "xla_move_down" => xla("Move Down"),
                 "xla_group_props" => xla("Group Properties"),
                 'text_group_name' => text($gdispname),
-                'translate_layout' => (OEGlobalsBag::getInstance()->getBoolean('translate_layout') && $language_choice > 1) ? xlt($gdispname) : "",
+                'translate_layout' => (OEGlobalsBag::getInstance()->getBoolean('translate_layout') && $language_choice > 1) ? text(xl_layout_label($gdispname)) : "",
                 'attr_gmyname' => attr($gmyname),
             ];
             echo <<<HTML

--- a/interface/super/edit_layout_props.php
+++ b/interface/super/edit_layout_props.php
@@ -394,11 +394,12 @@ for ($cols = 2; $cols <= 12; ++$cols) {
         [OEGlobalsBag::getInstance()->get('ippf_specific') ? 'ippf_specific' : 'default']
     );
     while ($itrow = sqlFetchArray($itres)) {
+        $singularStr = is_string($itrow['singular'] ?? null) ? $itrow['singular'] : '';
         echo "<option value='" . attr($itrow['type']) . "'";
         if ($itrow['type'] == $row['grp_issue_type']) {
             echo " selected";
         }
-        echo ">" . xlt($itrow['singular']) . "</option>\n";
+        echo ">" . text(xl_list_label($singularStr)) . "</option>\n";
     }
     ?>
    </select>
@@ -422,17 +423,28 @@ for ($cols = 2; $cols <= 12; ++$cols) {
             continue;
         }
         asort($list_aco_objects[$seckey]);
+        // get_section_data() and get_object_data() in src/Gacl/GaclApi.php
+        // are docblocked as returning array but can actually return false
+        // on a missing row. The is_array() guard below keeps the offset
+        // access safe at runtime; PHPStan marks it "always true" because
+        // it trusts the (wrong) docblock, so we ignore that specific rule.
         $aco_section_data = $gacl->get_section_data($seckey, 'ACO');
-        $aco_section_title = $aco_section_data[3];
+        $aco_section_title = is_array($aco_section_data) && is_string($aco_section_data[3] ?? null) /* @phpstan-ignore function.alreadyNarrowedType */
+            ? $aco_section_data[3]
+            : '';
+        // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
         echo " <optgroup label='" . xla($aco_section_title) . "'>\n";
         foreach ($list_aco_objects[$seckey] as $acokey) {
             $aco_id = $gacl->get_object_id($seckey, $acokey, 'ACO');
             $aco_data = $gacl->get_object_data($aco_id, 'ACO');
-            $aco_title = $aco_data[0][3];
+            $aco_title = is_array($aco_data) && is_array($aco_data[0] ?? null) && is_string($aco_data[0][3] ?? null) /* @phpstan-ignore function.alreadyNarrowedType */
+                ? $aco_data[0][3]
+                : '';
             echo "  <option value='" . attr("$seckey|$acokey") . "'";
             if ("$seckey|$acokey" == $row['grp_aco_spec']) {
                 echo " selected";
             }
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
             echo ">" . xlt($aco_title) . "</option>\n";
         }
         echo " </optgroup>\n";

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -383,7 +383,7 @@ function getCodeDescriptions($codes)
 
 // Write one option line to the form.
 //
-function writeOptionLine($option_id, $title, $seq, $default, $value, $mapping = '', $notes = '', $codes = '', $tog1 = '', $tog2 = '', $active = '1', $subtype = ''): void
+function writeOptionLine($option_id, string $title, $seq, $default, $value, $mapping = '', $notes = '', $codes = '', $tog1 = '', $tog2 = '', $active = '1', $subtype = ''): void
 {
     global $opt_line_no, $list_id;
     ++$opt_line_no;
@@ -410,7 +410,7 @@ function writeOptionLine($option_id, $title, $seq, $default, $value, $mapping = 
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
     // if not english and translating lists then show the translation
     if (OEGlobalsBag::getInstance()->getBoolean('translate_lists') && $session->get('language_choice') > 1) {
-        echo "  <td align='center' class='translation'>" . xlt($title) . "</td>\n";
+        echo "  <td align='center' class='translation'>" . text(xl_list_label($title)) . "</td>\n";
     }
     echo "  <td>";
     echo "<input type='text' name='opt[" . attr($opt_line_no) . "][seq]' value='" .
@@ -519,7 +519,7 @@ function writeOptionLine($option_id, $title, $seq, $default, $value, $mapping = 
         echo "</td>\n";
     } elseif ($list_id == 'ptlistcols') {
         echo "  <td>";
-        echo generate_select_list("opt[$opt_line_no][toggle_setting_1]", 'Sort_Direction', $tog1, 'Sort Direction', null, 'option');
+        echo generate_select_list("opt[$opt_line_no][toggle_setting_1]", 'Sort_Direction', $tog1, 'Sort Direction', '', 'option');
         echo "</td>\n";
     }
 
@@ -716,7 +716,8 @@ function writeCTLine($ct_array): void
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
     // if not english and translating lists then show the translation
     if (OEGlobalsBag::getInstance()->getBoolean('translate_lists') && $session->get('language_choice') > 1) {
-        echo "  <td align='center' class='translation'>" . xlt($ct_array['ct_label']) . "</td>\n";
+        $ctLabelStr = is_string($ct_array['ct_label'] ?? null) ? $ct_array['ct_label'] : '';
+        echo "  <td align='center' class='translation'>" . text(xl_list_label($ctLabelStr)) . "</td>\n";
     }
     echo ctGenCell(
         $opt_line_no,
@@ -833,17 +834,20 @@ function writeITLine($it_array): void
     $language_choice = $session->get('language_choice');
     // if not english and translating lists then show the translation
     if (OEGlobalsBag::getInstance()->getBoolean('translate_lists') && $language_choice > 1) {
-        echo "  <td align='center' class='translation'>" . xlt($it_array['plural']) . "</td>\n";
+        $pluralStr = is_string($it_array['plural'] ?? null) ? $it_array['plural'] : '';
+        echo "  <td align='center' class='translation'>" . text(xl_list_label($pluralStr)) . "</td>\n";
     }
     echo ctGenCell($opt_line_no, $it_array, 'singular', 15, 75, xl('Singular'));
     // if not english and translating lists then show the translation
     if (OEGlobalsBag::getInstance()->getBoolean('translate_lists') && $language_choice > 1) {
-        echo "  <td align='center' class='translation'>" . xlt($it_array['singular']) . "</td>\n";
+        $singularStr = is_string($it_array['singular'] ?? null) ? $it_array['singular'] : '';
+        echo "  <td align='center' class='translation'>" . text(xl_list_label($singularStr)) . "</td>\n";
     }
     echo ctGenCell($opt_line_no, $it_array, 'abbreviation', 5, 10, xl('Abbreviation'));
     // if not english and translating lists then show the translation
     if (OEGlobalsBag::getInstance()->getBoolean('translate_lists') && $language_choice > 1) {
-        echo "  <td align='center' class='translation'>" . xlt($it_array['abbreviation']) . "</td>\n";
+        $abbrStr = is_string($it_array['abbreviation'] ?? null) ? $it_array['abbreviation'] : '';
+        echo "  <td align='center' class='translation'>" . text(xl_list_label($abbrStr)) . "</td>\n";
     }
     echo ctSelector($opt_line_no, $it_array, 'style', $ISSUE_TYPE_STYLES, xl('Standard; Simplified: only title, start date, comments and an Active checkbox;no diagnosis, occurrence, end date, referred-by or sports fields. ; Football Injury'));
     echo ctGenCBox($opt_line_no, $it_array, 'force_show', xl('Show this category on the patient summary screen even if no issues have been entered for this category.'));
@@ -1450,7 +1454,7 @@ function writeITLine($it_array): void
                     while ($row = sqlFetchArray($res)) {
                         writeOptionLine(
                             $row['option_id'],
-                            $row['title'],
+                            is_string($row['title'] ?? null) ? $row['title'] : '',
                             $row['seq'],
                             $row['is_default'],
                             $row['option_value'],

--- a/library/lists.inc.php
+++ b/library/lists.inc.php
@@ -85,10 +85,13 @@ $res = sqlStatement(
     [collect_issue_type_category()]
 );
 while ($row = sqlFetchArray($res)) {
+    $pluralStr = is_string($row['plural'] ?? null) ? $row['plural'] : '';
+    $singularStr = is_string($row['singular'] ?? null) ? $row['singular'] : '';
+    $abbrStr = is_string($row['abbreviation'] ?? null) ? $row['abbreviation'] : '';
     $ISSUE_TYPES[$row['type']] = [
-    xl($row['plural']),
-    xl($row['singular']),
-    xl($row['abbreviation']),
+    xl_list_label($pluralStr),
+    xl_list_label($singularStr),
+    xl_list_label($abbrStr),
     $row['style'],
     $row['force_show'],
     $row['aco_spec']];

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -140,7 +140,7 @@ function generate_select_list(
     $list_id,
     $currvalue,
     $title,
-    $empty_name = ' ',
+    string $empty_name = ' ',
     $class = '',
     $onchange = '',
     $tag_id = '',
@@ -185,6 +185,10 @@ function generate_select_list(
 
     $attributes['title'] = attr($title);
 
+    // generate_select_list() previously translated $empty_name unconditionally
+    // via xlt(), so keep that behavior with xlt() rather than xl_list_label()
+    // which is gated on the translate_lists setting.
+    // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
     $selectEmptyName = xlt($empty_name);
     if ($empty_name) {
         preg_match_all('/select2/m', ($class ?? ''), $matches, PREG_SET_ORDER, 0);
@@ -644,7 +648,7 @@ function generate_form_field($frow, $currvalue): void
             $showEmpty = false;
             $empty_title = "Unassigned";
         } else {
-            $empty_title = $frow['empty_title'];
+            $empty_title = is_string($frow['empty_title']) ? $frow['empty_title'] : '';
         }
     } else {
         $empty_title = "Unassigned";
@@ -810,6 +814,7 @@ function generate_form_field($frow, $currvalue): void
         "AND authorized = 1 " .
         "ORDER BY lname, fname");
         echo "<select name='form_$field_id_esc' id='form_$field_id_esc' title='$description' $lbfonchange $disabled class='form-control$smallform'>";
+        // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
         echo "<option value=''>" . xlt($empty_title) . "</option>";
         $got_selected = false;
         while ($urow = sqlFetchArray($ures)) {
@@ -1011,6 +1016,7 @@ function generate_form_field($frow, $currvalue): void
         $cres = sqlStatement("SELECT pc_catid, pc_catname " .
         "FROM openemr_postcalendar_categories ORDER BY pc_catname");
         echo "<select name='form_$field_id_esc' id='form_$field_id_esc' class='form-control$smallform' title='$description'" . " $lbfonchange $disabled>";
+        // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
         echo "<option value=''>" . xlt($empty_title) . "</option>";
         $got_selected = false;
         while ($crow = sqlFetchArray($cres)) {
@@ -1709,7 +1715,7 @@ function generate_print_field($frow, $currvalue, $value_allowed = true): void
             $showEmpty = false;
             $empty_title = "Unassigned";
         } else {
-            $empty_title = $frow['empty_title'];
+            $empty_title = is_string($frow['empty_title']) ? $frow['empty_title'] : '';
         }
     } else {
         $empty_title = "Unassigned";

--- a/src/Common/Acl/AclExtended.php
+++ b/src/Common/Acl/AclExtended.php
@@ -527,13 +527,15 @@ class AclExtended
         $acoArray = self::genAcoArray();
         $s = '';
         foreach ($acoArray as $section => $acos_array) {
-            $s .= "<optgroup label='" . xla($section) . "'>\n";
+            $sectionLabel = is_string($section) ? $section : '';
+            $s .= "<optgroup label='" . xla($sectionLabel) . "'>\n";
             foreach ($acos_array as $aco_array) {
                 $s .= "<option value='" . attr($aco_array['value']) . "'";
                 if ($aco_array['value'] == $default) {
                     $s .= ' selected';
                 }
-                $s .= ">" . xlt($aco_array['name']) . "</option>";
+                $acoName = is_string($aco_array['name'] ?? null) ? $aco_array['name'] : '';
+                $s .= ">" . xlt($acoName) . "</option>";
             }
             $s .= "</optgroup>";
         }
@@ -595,12 +597,14 @@ class AclExtended
                 // Modified 6-2009 by BM - Translate gacl group name if applicable
                 //                         Translate return value
                 //                         Translate description
+                $retLabel = is_string($ret) ? $ret : '';
+                $noteLabel = is_string($note) ? $note : '';
                 $message .= "\t<acl>\n" .
                     "\t\t<value>" . xmlEscape($value) . "</value>\n" .
                     "\t\t<title>" . xmlEscape(xl_gacl_group($value)) . "</title>\n" .
                     "\t\t<returnid>" . xmlEscape($ret)  . "</returnid>\n" .
-                    "\t\t<returntitle>" . xlx($ret)  . "</returntitle>\n" .
-                    "\t\t<note>" . xlx($note)  . "</note>\n" .
+                    "\t\t<returntitle>" . xlx($retLabel)  . "</returntitle>\n" .
+                    "\t\t<note>" . xlx($noteLabel)  . "</note>\n" .
                     "\t</acl>\n";
             }
         }
@@ -647,7 +651,10 @@ class AclExtended
                     if ($counter == 0) {
                         $counter += 1;
                         $aco_section_data = $gacl->get_section_data($key, 'ACO');
-                        $aco_section_title = $aco_section_data[3];
+                        $aco_section_title = '';
+                        if (is_array($aco_section_data) && isset($aco_section_data[3]) && is_string($aco_section_data[3])) {
+                            $aco_section_title = $aco_section_data[3];
+                        }
 
                         // Modified 6-2009 by BM - Translate gacl aco section name
                         $message .= "\t\t<section>\n" .
@@ -656,7 +663,10 @@ class AclExtended
 
                     $aco_id = $gacl->get_object_id($key, $value2, 'ACO');
                     $aco_data = $gacl->get_object_data($aco_id, 'ACO');
-                    $aco_title = $aco_data[0][3];
+                    $aco_title = '';
+                    if (is_array($aco_data) && isset($aco_data[0]) && is_array($aco_data[0]) && isset($aco_data[0][3]) && is_string($aco_data[0][3])) {
+                        $aco_title = $aco_data[0][3];
+                    }
                     $message .= "\t\t\t<aco>\n";
 
                     // Modified 6-2009 by BM - Translate gacl aco name
@@ -676,7 +686,10 @@ class AclExtended
             "\t<active>\n";
         foreach ($active_aco_objects as $key => $value) {
             $aco_section_data = $gacl->get_section_data($key, 'ACO');
-            $aco_section_title = $aco_section_data[3];
+            $aco_section_title = '';
+            if (is_array($aco_section_data) && isset($aco_section_data[3]) && is_string($aco_section_data[3])) {
+                $aco_section_title = $aco_section_data[3];
+            }
 
             // Modified 6-2009 by BM - Translate gacl aco section name
             $message .= "\t\t<section>\n" .
@@ -685,7 +698,10 @@ class AclExtended
             foreach ($active_aco_objects[$key] as $value2) {
                 $aco_id = $gacl->get_object_id($key, $value2, 'ACO');
                 $aco_data = $gacl->get_object_data($aco_id, 'ACO');
-                $aco_title = $aco_data[0][3];
+                $aco_title = '';
+                if (is_array($aco_data) && isset($aco_data[0]) && is_array($aco_data[0]) && isset($aco_data[0][3]) && is_string($aco_data[0][3])) {
+                    $aco_title = $aco_data[0][3];
+                }
                 $message .= "\t\t\t<aco>\n";
 
                 // Modified 6-2009 by BM - Translate gacl aco name
@@ -727,9 +743,10 @@ class AclExtended
                 $ret = $acl["return_value"];
                 if (!in_array($ret, $returns)) {
                     // Modified 6-2009 by BM - Translate return value
+                    $retLabel = is_string($ret) ? $ret : '';
                     $message .= "\t<return>\n";
                     $message .= "\t\t<returnid>" . xmlEscape($ret)  . "</returnid>\n";
-                    $message .= "\t\t<returntitle>" . xlx($ret)  . "</returntitle>\n";
+                    $message .= "\t\t<returntitle>" . xlx($retLabel)  . "</returntitle>\n";
                     $message .= "\t</return>\n";
 
                     array_push($returns, $ret);

--- a/src/Common/Forms/Types/SmokingStatusType.php
+++ b/src/Common/Forms/Types/SmokingStatusType.php
@@ -237,7 +237,7 @@ class SmokingStatusType implements IOptionFormType {
                 $showEmpty = false;
                 $empty_title = "Unassigned";
             } else {
-                $empty_title = $frow['empty_title'];
+                $empty_title = is_string($frow['empty_title']) ? $frow['empty_title'] : '';
             }
         } else {
             $empty_title = "Unassigned";

--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -110,6 +110,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                 'selectList',
                 function ($name, $list, $value, $title, $opts = []) {
                     $empty_name = array_key_exists('empty_name', $opts) ? $opts['empty_name'] : '';
+                    $empty_name = is_string($empty_name) ? $empty_name : '';
                     $class = array_key_exists('class', $opts) ? $opts['class'] : '';
                     $onchange = array_key_exists('onchange', $opts) ? $opts['onchange'] : '';
                     $tag_id = array_key_exists('tag_id', $opts) ? $opts['tag_id'] : '';


### PR DESCRIPTION
## Summary

Part 7 (final) of a series fixing PHPStan literal-string violations in `xl()`/`xlt()`/`xla()` calls. This PR addresses the remaining scattered violations across form report templates, the super admin pages, lists/options helpers, and a few `/src` classes.

## Approach

- **Narrow, don't cast.** Use `is_string()` narrowing to convert `mixed` values from `sqlFetchArray()` and array offsets into `string` before passing to xl wrappers.
- **Unconditional translation + scoped `@phpstan-ignore`.** Where the dynamic string must be passed to `xl()`/`xlt()`/`xla()` at runtime, add a single `@phpstan-ignore argument.type` comment on the line with a reference to #11498 (where the long-term fix — an explicit `xl_admin*()` helper — is tracked). Do **not** route through `xl_list_label()` just to satisfy PHPStan; that helper is gated on the `translate_lists` global and is meant for list_options labels, so using it for form field names, ACO metadata, GACL sections, or empty-option placeholders would stop those strings from translating when `translate_lists` is off.
- **Add native parameter types** where a function received an untyped parameter that was being passed through to `xlt()`.

## Also fixed

- Pre-existing always-truthy bug in `interface/forms/prior_auth/report.php`: `if ($key == "from_date" || "to_date")` → `if ($key === 'from_date' || $key === 'to_date')`.
- `interface/super/edit_globals.php` multi-dashboard-cards list: stored raw `card_abrev` literals in the `$res` array and escaped once at output (previously the entries were `attr()`-wrapped at build time **and** at output, which would have double-escaped any future entry containing special characters — `card_prescriptions` was already the correct pattern).
- Legibility cleanup per [`ocemr-docs/reference/php-conventions.md`](https://github.com/opencoreemr/ocemr-docs):
  - Single-line HTML fragments use `printf` with single-quoted format strings.
  - Multi-line HTML fragments use heredoc interpolation, not concatenation-for-wrapping.
  - `note/report.php`: `if`/`elseif`/`else` → `match` expression.
  - `reviewofs/report.php`: `if`/`else` → ternary.
  - `edit_globals.php` tab nav: dropped the `$i` integer-used-as-boolean pattern in favor of a `$tabClass` string that resets after the first iteration.

## Files touched

- `interface/forms/{aftercare_plan,ankleinjury,bronchitis,clinic_note,dictation,misc_billing_options,note,physical_exam,prior_auth,reviewofs,ros,soap,transfer_summary,treatment_plan,vitals}/report.php`
- `interface/super/{edit_globals,edit_layout,edit_layout_props,edit_list}.php`
- `library/{lists,options}.inc.php`
- `src/Common/Acl/AclExtended.php`
- `src/Common/Forms/Types/SmokingStatusType.php`
- `src/Common/Twig/TwigExtension.php`

## PHPStan baseline

Net reduction. A handful of stale `argument.type` and `binaryOp.invalid` entries were removed (including the `prior_auth` always-truthy baseline that was papering over the bug fixed here). No new entries added.

## Follow-ups

- #11498 — Migrate remaining dynamic translation callers to explicit `xl_admin*()` helpers once #11496/#11497 land.
- #11506 — Extract a shared helper for the 13+ near-identical form `report.php` files.

## Test plan

- [x] `composer phpstan` reports no errors
- [x] `composer phpcs`, rector, codespell, syntax check pass via pre-commit hooks
- [ ] CI green