### PR TITLE
refactor(install): drop 1024-byte fgets() buffer in Installer::getLine()

### DIFF
--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -471,38 +471,26 @@ class Installer
             return false;
         }
 
-        // Track whether the previous fgets() chunk reached an actual line
-        // boundary (ended in "\n") or was a partial chunk of a long line that
-        // exceeded the 1024-byte buffer. We can only insert a separator at
-        // real line boundaries — inserting one mid-line would break tokens
-        // like hex literals (0x...) that are split across chunks.
-        $prevReachedEol = true;
         while (!$this->atEndOfFile($fd)) {
-            $rawLine = $this->getLine($fd, 1024);
+            $rawLine = $this->getLine($fd);
             if ($rawLine === false) {
                 continue;
             }
-            $reachedEol = str_ends_with($rawLine, "\n");
             $line = rtrim($rawLine);
             if ($line === "" || str_starts_with($line, "--") || str_starts_with($line, "#")) {
-                // A skipped line still counts as a line boundary if it
-                // actually ended in a newline.
-                if ($reachedEol) {
-                    $prevReachedEol = true;
-                }
                 continue;
             }
 
-            // Insert a single space separator only when we are starting a
-            // new logical line (previous chunk ended in newline) and there
-            // is already buffered query text. This fixes #10935 — without
-            // a separator, a continuation line at column 0 would fuse with
-            // the previous token (e.g. "= 0" + "WHERE" → "0WHERE").
-            if ($prevReachedEol && $query !== "") {
+            // Insert a single space separator between concatenated lines.
+            // Without it, a continuation line starting at column 0 would
+            // fuse with the previous token (e.g. "= 0" + "WHERE" → "0WHERE",
+            // see #10935). getLine() is unbounded, so every call returns a
+            // complete logical line and the separator is always safe to
+            // insert.
+            if ($query !== "") {
                 $query .= " ";
             }
             $query .= $line;
-            $prevReachedEol = $reachedEol;
             $chr = substr($query, strlen($query) - 1, 1);
             if ($chr == ";") { // valid query, execute
                 $query = rtrim($query, ";");
@@ -2140,12 +2128,11 @@ SETHLP;
      * @codeCoverageIgnore
      *
      * @param resource $stream
-     * @param int $length
      * @return string|false
      */
-    protected function getLine($stream, int $length): string|false
+    protected function getLine($stream): string|false
     {
-        return fgets($stream, $length);
+        return fgets($stream);
     }
 
     /**

--- a/tests/Tests/Isolated/library/classes/InstallerTest.php
+++ b/tests/Tests/Isolated/library/classes/InstallerTest.php
@@ -807,7 +807,7 @@ class InstallerTest extends TestCase
 
         $mockInstaller->expects($this->exactly(2))
             ->method('getLine')
-            ->with($mockResource, 1024)
+            ->with($mockResource)
             ->willReturnOnConsecutiveCalls(
                 "CREATE TABLE users;",
                 "INSERT INTO users VALUES (1, 'admin');"
@@ -882,7 +882,7 @@ class InstallerTest extends TestCase
 
         $mockInstaller->expects($this->once())
             ->method('getLine')
-            ->with($mockResource, 1024)
+            ->with($mockResource)
             ->willReturn("CREATE TABLE users;");
 
         $mockInstaller->expects($this->exactly(3))
@@ -3409,8 +3409,8 @@ class InstallerTest extends TestCase
      *
      *   UPDATE layout_options SET uor = 0WHERE form_id = 'DEM'
      *
-     * The fix inserts a single space between concatenated lines at real
-     * line boundaries, restoring valid token separation.
+     * The fix inserts a single space between concatenated lines, restoring
+     * valid token separation.
      */
     public function testLoadFileInsertsSpaceSeparatorBetweenSqlLines(): void
     {
@@ -3430,12 +3430,9 @@ class InstallerTest extends TestCase
                 return $eofCallCount > 3;
             });
 
-        // Each fgets() result includes the trailing newline that signals a
-        // complete line; load_file() relies on this to know it can safely
-        // insert a separator.
         $mockInstaller->expects($this->exactly(3))
             ->method('getLine')
-            ->with($mockResource, 1024)
+            ->with($mockResource)
             ->willReturnOnConsecutiveCalls(
                 "UPDATE layout_options SET uor = 0\n",
                 "WHERE form_id = 'DEM' AND seq > 10\n",
@@ -3474,59 +3471,6 @@ class InstallerTest extends TestCase
         // Must contain "10 AND" (with space), not "10AND" (fused)
         $this->assertStringContainsString('10 AND', $completeUpdateStatement);
         $this->assertStringNotContainsString('10AND', $completeUpdateStatement);
-    }
-
-    /**
-     * Regression test: a single SQL line longer than the 1024-byte fgets()
-     * buffer is read as multiple chunks. load_file() must NOT insert a
-     * separator between those chunks — doing so would corrupt tokens that
-     * span chunk boundaries (e.g. hex literals like 0x3c68746d6c...).
-     */
-    public function testLoadFileDoesNotInsertSeparatorBetweenChunksOfSameLine(): void
-    {
-        $mockInstaller = $this->buildLoadFileMock();
-        $mockResource = fopen('php://memory', 'w+');
-
-        $mockInstaller->expects($this->once())
-            ->method('openFile')
-            ->willReturn($mockResource);
-
-        $eofCallCount = 0;
-        $mockInstaller->expects($this->exactly(4))
-            ->method('atEndOfFile')
-            ->willReturnCallback(function ($resource) use (&$eofCallCount) {
-                $eofCallCount++;
-                return $eofCallCount > 3;
-            });
-
-        // Three chunks of one logical line — only the final chunk ends in
-        // "\n". The first two simulate fgets() returning a partial chunk
-        // because the buffer filled up before the newline.
-        $mockInstaller->expects($this->exactly(3))
-            ->method('getLine')
-            ->willReturnOnConsecutiveCalls(
-                "INSERT INTO t VALUES (0x3c68746d6c",
-                "3e0d0a3c2f68746d6c3e",
-                ");\n"
-            );
-
-        $executedSql = [];
-        $mockInstaller->expects($this->exactly(5))
-            ->method('execute_sql')
-            ->willReturnCallback(function ($sql) use (&$executedSql) {
-                $executedSql[] = $sql;
-                return true;
-            });
-
-        $mockInstaller->expects($this->once())->method('closeFile')->willReturn(true);
-
-        $mockInstaller->load_file('/path/to/test.sql', 'Test SQL');
-
-        // The assembled INSERT must contain the unbroken hex literal.
-        $this->assertSame(
-            'INSERT INTO t VALUES (0x3c68746d6c3e0d0a3c2f68746d6c3e)',
-            $executedSql[2]
-        );
     }
 
     /**


### PR DESCRIPTION
Closes #11459.

The `1024` length argument on `fgets()` in `Installer::getLine()` was introduced in August 2010 and cargo-culted from pre-PHP-4.3 code, when the argument was mandatory and `1024` was the textbook example. PHP 4.3 made it optional in December 2002 and PHP 4 went out of security support in August 2008 — two years before this line was committed. It has served no purpose for fifteen years, and it was the root cause of two bugs:

1. **#10935 / #11003.** Lines longer than 1023 bytes (notably the multi-KB hex literals in the `document_templates` fixture) were split across multiple `fgets()` calls. The minimal fix for #10935 inserted a space between concatenated lines and ended up inserting one into the middle of a hex literal, breaking install in CI. #11003 worked around this by tracking whether each chunk ended in a newline and only inserting the separator at real line boundaries.
2. **Latent.** A `--` or `#` comment longer than 1023 bytes got chunked the same way. Only the first chunk was recognized as a comment and skipped; subsequent chunks got injected into whatever statement was accumulating. Never reported in the wild because nobody wrote a long enough comment, but the footgun was loaded.

## Change

Drop the length argument. `fgets($fd)` reads until newline or EOF, so every call returns a complete logical line. This:

- deletes the `\$prevReachedEol` tracking that #11003 added,
- lets `load_file()` unconditionally insert the space separator,
- removes the companion regression test for the chunked-line case (the scenario is no longer possible),
- and fixes the latent long-comment bug as a side effect.

Net: **-74 lines**, and the bug class is gone at the root.

## Not in scope

Replacing the whole line-by-line parser with `mysqli_multi_query()`. That is the larger cleanup tracked in #11458 and subsumes this change if it lands first.

## Test plan

- [x] `composer phpunit-isolated` — full isolated suite passes (113 → 112 tests; the chunked-line regression test was removed as obsolete)
- [x] `composer phpstan` — clean (one now-obsolete baseline entry removed)
- [ ] CI install + "Test All Configurations" matrix — confirms the `document_templates` hex literal still loads correctly without the EOL scaffolding