### PR TITLE
fix(sql-upgrade): drop fgets() length limit and insert line separator

### DIFF
--- a/src/Services/Utils/SQLUpgradeService.php
+++ b/src/Services/Utils/SQLUpgradeService.php
@@ -254,8 +254,7 @@ class SQLUpgradeService implements ISQLUpgradeService
         $special = false;
         $trim = true;
         $progress = 0;
-        while (!feof($fd)) {
-            $line = fgets($fd, 2048);
+        while (($line = fgets($fd)) !== false) {
             $line = rtrim($line);
 
             $progress += strlen($line);
@@ -787,6 +786,14 @@ class SQLUpgradeService implements ISQLUpgradeService
                 continue;
             }
 
+            // Insert a space separator between concatenated lines so a
+            // continuation line starting at column 0 cannot fuse with the
+            // previous token (same bug class as #10935 in Installer). fgets()
+            // is unbounded, so every call returns a complete logical line
+            // and the separator is always safe to insert.
+            if ($query !== "") {
+                $query .= " ";
+            }
             $query .= $line;
 
             if (str_ends_with(trim($query), ';')) {


### PR DESCRIPTION
Closes #11462.

`SQLUpgradeService::upgradeFromSqlFile()` had the same two bugs as the original `Installer::load_file()` before #10935 / #11003 / #11461:

1. **`fgets(\$fd, 2048)`** chunks any SQL line longer than 2047 bytes across multiple reads. `sql/6_0_0-to-6_1_0_upgrade.sql:1315` contains a 7439-byte `INSERT INTO document_templates` with a hex-encoded HTML blob. Chunked reads have been happening on every 6.0 → 6.1 upgrade, and only survived because…
2. …the concatenation ran `\$query .= \$line` with **no separator**, which reassembles chunks losslessly (byte-for-byte). That is also the #10935 bug in a latent form: a continuation line starting at column 0 will fuse with the previous token (`"SET uor = 0"` + `"WHERE ..."` → `"0WHERE"`). No reported incidents in upgrade files, but the bug class is loaded.

## Fix

Do both together, which is what keeps the result correct:

- Drop the `2048` length argument so `fgets()` reads until newline or EOF. Every call returns a complete logical line; chunking is no longer possible.
- Insert a space separator between concatenated lines. Safe now that every line arrives whole, even multi-KB hex literals.

Doing only one of these would regress:

- Dropping just the length would leave the #10935 fusion bug latent.
- Adding the separator without dropping the length would corrupt the hex literals in upgrade files — which is exactly what broke CI for #11003 initially (same fixture, different loader).

## Out of scope

- The directive parsing (`#IfNotTable`, `#IfColumn`, `#SpecialSql`, etc.) is unchanged. A `mysqli_multi_query()` rewrite is not viable here because the conditional logic needs per-line parsing to decide whether to execute each block.
- The comment detection (`preg_match('/^\s*--/', \$line)`) is unchanged. It already handles indented comments correctly, so the #11465 bug class in `Installer::load_file` does not apply here.

## Test plan

No existing PHPUnit coverage for `SQLUpgradeService`. The affected code path runs during OpenEMR version upgrades, not fresh installs, so the CI install matrix does not exercise it.

Manual verification: reviewed `sql/6_0_0-to-6_1_0_upgrade.sql:1313–1317` (the longest lines in any upgrade file, all `document_templates` hex-literal `INSERT`s) and confirmed they are single logical lines that will arrive intact through unbounded `fgets()`.

- [x] `composer phpstan` — clean (one obsolete baseline entry removed)
- [x] `composer phpcs` — clean
- [ ] Manual upgrade from 6.0 → 6.1 on a test database (not part of CI)