### PR TITLE
fix(direct-messaging): drop fgets() length limits in phiMail protocol parsers

### DIFF
--- a/ccr/transmitCCD.php
+++ b/ccr/transmitCCD.php
@@ -72,13 +72,13 @@ function transmitMessage($message, $recipient, $verifyFinalDelivery = false)
         return( xl(ErrorConstants::RECIPIENT_NOT_ALLOWED) . " " . $ret );
     }
 
-    $ret = fgets($fp, 1024); //ignore extra server data
+    $ret = fgets($fp); //ignore extra server data
 
     $text_out = $message;
 
     $text_len = strlen((string) $text_out);
     phimail_write($fp, "TEXT $text_len\n");
-    $ret = @fgets($fp, 256);
+    $ret = @fgets($fp);
     if ($ret != "BEGIN\n") {
         phimail_close($fp);
         return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGE_BEGIN_FAILED);
@@ -204,7 +204,7 @@ function transmitCCD($pid, $ccd_out, $recipient, $requested_by, $xml_type = "CCD
         return( xl(ErrorConstants::RECIPIENT_NOT_ALLOWED) . " " . $ret );
     }
 
-    $ret = fgets($fp, 1024); //ignore extra server data
+    $ret = fgets($fp); //ignore extra server data
 
     // add whatever the clinican added as a message to be sent.
     $text_out = "";
@@ -223,7 +223,7 @@ function transmitCCD($pid, $ccd_out, $recipient, $requested_by, $xml_type = "CCD
 
     $text_len = strlen($text_out);
     phimail_write($fp, "TEXT $text_len\n");
-    $ret = @fgets($fp, 256);
+    $ret = @fgets($fp);
     if ($ret != "BEGIN\n") {
         phimail_close($fp);
         return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGE_BEGIN_FAILED);
@@ -249,7 +249,7 @@ function transmitCCD($pid, $ccd_out, $recipient, $requested_by, $xml_type = "CCD
     $ccd_len = strlen((string) $ccd_out);
 
     phimail_write($fp, "ADD " . $add_type . " " . $ccd_len . " " . $att_filename . $extension . "\n");
-    $ret = fgets($fp, 256);
+    $ret = fgets($fp);
     if ($ret != "BEGIN\n") {
         phimail_close($fp);
         return("$config_err " . ErrorConstants::ERROR_CODE_ADD_FILE_FAILED);

--- a/library/direct_message_check.inc.php
+++ b/library/direct_message_check.inc.php
@@ -177,7 +177,7 @@ function phimail_check(): void
 
     while (1) {
         phimail_write($fp, "CHECK\n");
-        $ret = fgets($fp, 512);
+        $ret = fgets($fp);
 
         if ($ret == "NONE\n") { //nothing to process
             phimail_close($fp);
@@ -280,16 +280,25 @@ function phimail_check(): void
 
             //get message headers
             $hdrs = "";
-            while (($next_hdr = fgets($fp, 1024)) != "\n") {
+            while (true) {
+                $next_hdr = fgets($fp);
+                if ($next_hdr === false) {
+                    phimail_logit(0, "M4 read headers failed");
+                    phimail_close($fp);
+                    return;
+                }
+                if ($next_hdr == "\n") {
+                    break;
+                }
                 $hdrs .= $next_hdr;
             }
 
-            $mime_type = fgets($fp, 512);
+            $mime_type = fgets($fp);
             $mime_info = explode(";", $mime_type);
             $mime_type_main = trim(strtolower($mime_info[0]));
 
             //get main message body
-            $body_len = fgets($fp, 256);
+            $body_len = fgets($fp);
             $body = phimail_read_blob($fp, $body_len);
             if ($body === false) {
                 phimail_logit(0, "M4 read body failed");
@@ -297,7 +306,7 @@ function phimail_check(): void
                 return;
             }
 
-            $att2 = fgets($fp, 256);
+            $att2 = fgets($fp);
             if ($att2 != $att) { //safety for mismatch on attachments
                 phimail_logit(0, "M5 attachment mismatch");
                 phimail_close($fp);
@@ -308,9 +317,9 @@ function phimail_check(): void
             if ($att > 0) {
                 for ($attnum = 0; $attnum < $att; $attnum++) {
                     if (
-                        ($attinfo[$attnum]['name'] = fgets($fp, 1024)) === false
-                        || ($attinfo[$attnum]['mime'] = fgets($fp, 1024)) === false
-                        || ($attinfo[$attnum]['desc'] = fgets($fp, 1024)) === false
+                        ($attinfo[$attnum]['name'] = fgets($fp)) === false
+                        || ($attinfo[$attnum]['mime'] = fgets($fp)) === false
+                        || ($attinfo[$attnum]['desc'] = fgets($fp)) === false
                     ) {
                         phimail_logit(0, "M6 read attachment " . ($attnum + 1) . " metadata failed");
                         phimail_close($fp);
@@ -357,13 +366,13 @@ function phimail_check(): void
                 }
 
                 //we can ignore next two lines (repeat of name and mime-type)
-                if (($a1 = fgets($fp, 512)) === false || ($a2 = fgets($fp, 512)) === false) {
+                if (($a1 = fgets($fp)) === false || ($a2 = fgets($fp)) === false) {
                     phimail_logit(0, "M9 skip attachment " . ($attnum + 1) . " duplicate header lines failed");
                     phimail_close($fp);
                     return;
                 }
 
-                $att_len = fgets($fp, 256); //length of file
+                $att_len = fgets($fp); //length of file
                 $attdata = phimail_read_blob($fp, $att_len);
                 if ($attdata === false) {
                     phimail_logit(0, "M10 read attachment " . ($attnum + 1) . " failed");
@@ -491,7 +500,7 @@ function phimail_write($fp, $text): void
 function phimail_write_expect_OK($fp, $text)
 {
     phimail_write($fp, $text);
-    $ret = fgets($fp, 256);
+    $ret = fgets($fp);
     if ($ret != "OK\n") { //unexpected error
         phimail_close($fp);
         return $ret;


### PR DESCRIPTION
## Summary

Fixes #11463.

The phiMail Direct Messaging protocol parsers in `library/direct_message_check.inc.php` and `ccr/transmitCCD.php` read line-oriented responses with fixed-length `fgets()` buffers (256/512/1024 bytes) and then compare against exact strings like `"BEGIN\n"` or `"NONE\n"`. When the server sends a line longer than the buffer, `fgets()` returns a mid-line chunk and the equality checks fail, sending the protocol state machine off the rails.

The MIME header-reading loop in `phimail_check()` is the most fragile spot — long `Received:`, `DKIM-Signature:`, or `Message-ID` headers routinely exceed 1 KB in real-world mail and would be treated as multiple shorter headers, corrupting MIME parsing.

This drops the length argument from every `fgets()` call in both files. Without a length, `fgets()` reads until newline or EOF, so each call returns a complete logical line and the existing exact-string comparisons work as written.

## Also fixed

While touching the header-read loop, this PR also fixes a latent infinite-loop bug: the loop was written as `while (($next_hdr = fgets($fp)) != "\n")`, which spins forever if the connection drops and `fgets()` returns `false` (`false != "\n"` is true, and the empty string keeps getting appended). Restructured as a clean `while (true)` with an explicit `false` check (log + close + return) before the blank-line terminator. Caught during review by `copilot-pull-request-reviewer`.

## Notes

- All buffer sizes (256/512/1024) in the originals were arbitrary cargo from the same parser pattern copy-pasted into both files; none were intentional caps.
- Mechanical change, no behavior change in the happy path. The only way this could regress is if surrounding code relied on `fgets()` bailing out early on oversized responses, and nothing in the logic suggests that.
- No test coverage exists for these protocol paths. Per the issue, not blocking on adding tests for a latent-behavior bugfix.
- Same root cause as #10935 / #11003 / #11459, found by the bycatch audit during #11461.

## Follow-ups

Surfaced during review, tracked separately:

- #11471 — phiMail socket cleanup via try/finally (scattered `phimail_close()` calls leak on early-return paths).
- #11474 — unchecked `fgets()` `false` returns elsewhere in the same files (pre-existing `str_starts_with` / `explode` / `phimail_read_blob` TypeError risks on EOF).

## Test plan

- [x] `php -l` clean on both files
- [x] PHPStan / phpcs / rector / require-checker pre-commit hooks pass
- [ ] Manual exercise of Direct Messaging would require a phiMail server; relying on review for the protocol logic