### PR TITLE
feat(encryption): New core API - `CipherSuiteInterface`

### DIFF
--- a/src/Encryption/CipherSuite.php
+++ b/src/Encryption/CipherSuite.php
@@ -1,10 +1,20 @@
 <?php
 
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 declare(strict_types=1);
 
 namespace OpenEMR\Encryption;
 
 use SensitiveParameter;
+
+use function is_string;
 
 final readonly class CipherSuite implements CipherSuiteInterface
 {
@@ -20,13 +30,15 @@ final readonly class CipherSuite implements CipherSuiteInterface
         return $cipher->decrypt($parsed->ciphertext)->bytes;
     }
 
-    public function encrypt(#[SensitiveParameter] string $plaintext): string
+    public function encrypt(#[SensitiveParameter] Plaintext|string $plaintext): string
     {
         $currentKeyId = $this->keychain->getCurrentKeyId();
         $cipher = $this->keychain->getCipher($currentKeyId);
 
-        $wrapped = new Plaintext($plaintext);
-        $ciphertext = $cipher->encrypt($wrapped);
+        if (is_string($plaintext)) {
+            $plaintext = new Plaintext($plaintext);
+        }
+        $ciphertext = $cipher->encrypt($plaintext);
         $message = new Message(keyId: $currentKeyId, ciphertext: $ciphertext);
         return $message->encode();
     }

--- a/src/Encryption/CipherSuite.php
+++ b/src/Encryption/CipherSuite.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\Encryption;
+
+use SensitiveParameter;
+
+final readonly class CipherSuite implements CipherSuiteInterface
+{
+    public function __construct(
+        private Keys\KeychainInterface $keychain,
+    ) {
+    }
+
+    public function decrypt(string $encodedMessage): string
+    {
+        $parsed = Message::parse($encodedMessage);
+        $cipher = $this->keychain->getCipher($parsed->keyId);
+        return $cipher->decrypt($parsed->ciphertext)->bytes;
+    }
+
+    public function encrypt(#[SensitiveParameter] string $plaintext): string
+    {
+        $currentKeyId = $this->keychain->getCurrentKeyId();
+        $cipher = $this->keychain->getCipher($currentKeyId);
+
+        $wrapped = new Plaintext($plaintext);
+        $ciphertext = $cipher->encrypt($wrapped);
+        $message = new Message(keyId: $currentKeyId, ciphertext: $ciphertext);
+        return $message->encode();
+    }
+}

--- a/src/Encryption/CipherSuiteInterface.php
+++ b/src/Encryption/CipherSuiteInterface.php
@@ -34,9 +34,11 @@ interface CipherSuiteInterface
 
 
     /**
-     * Takes a sensitive value as a string and encrypts it, wrapping the
-     * encrypted data in a format that includes enough metadata to later
-     * decrypt it using the `decrypt()` method.
+     * Takes a secret value (as a raw string or a pre-wrapped `Plaintext`
+     * object), encrypts it, and returns an opaque string holding the encrypted
+     * data and a key identifier that can be used to decrypt it later. The
+     * return value of this method is guaranteed compatible with `decrypt()` so
+     * long as the key used to encrypt it is in the keychain.
      */
     public function encrypt(#[SensitiveParameter] Plaintext|string $plaintext): string;
 }

--- a/src/Encryption/CipherSuiteInterface.php
+++ b/src/Encryption/CipherSuiteInterface.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 declare(strict_types=1);
 
 namespace OpenEMR\Encryption;
@@ -10,7 +18,8 @@ use SensitiveParameter;
  * Cryptography implementations.
  *
  * Unlike the lower-level cryptographic tools, this does not require wrapping
- * and unwrapping `Plaintext` structures.
+ * and unwrapping `Plaintext` structures (though you _may_ pass a `Plaintext`
+ * to the `encrypt()` method).
  *
  * Note: This is the replacement for `CryptoInterface` (and `CryptoGen`), and
  * should be preferred whenever possible.
@@ -29,5 +38,5 @@ interface CipherSuiteInterface
      * encrypted data in a format that includes enough metadata to later
      * decrypt it using the `decrypt()` method.
      */
-    public function encrypt(#[SensitiveParameter] string $plaintext): string;
+    public function encrypt(#[SensitiveParameter] Plaintext|string $plaintext): string;
 }

--- a/src/Encryption/CipherSuiteInterface.php
+++ b/src/Encryption/CipherSuiteInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\Encryption;
+
+use SensitiveParameter;
+
+/**
+ * Cryptography implementations.
+ *
+ * Unlike the lower-level cryptographic tools, this does not require wrapping
+ * and unwrapping `Plaintext` structures.
+ *
+ * Note: This is the replacement for `CryptoInterface` (and `CryptoGen`), and
+ * should be preferred whenever possible.
+ */
+interface CipherSuiteInterface
+{
+    /**
+     * Takes an encrypted and encoded message (the result of `encrypt()`) and
+     * decrypts it, returning the originally-encrypted data as a string.
+     */
+    public function decrypt(string $encodedMessage): string;
+
+
+    /**
+     * Takes a sensitive value as a string and encrypts it, wrapping the
+     * encrypted data in a format that includes enough metadata to later
+     * decrypt it using the `decrypt()` method.
+     */
+    public function encrypt(#[SensitiveParameter] string $plaintext): string;
+}

--- a/src/Encryption/Keys/Keychain.php
+++ b/src/Encryption/Keys/Keychain.php
@@ -20,9 +20,15 @@ use function array_key_exists;
 
 /**
  * An eager-loaded keychain, which holds all of the keys/ciphers for active use.
+ *
+ * This will use the most-recently-registered KeyId as the current one.
  */
 class Keychain implements KeychainInterface
 {
+    // This is intentionally not initialized in a constructor; trying to get
+    // the current key id before anything is registered is an error.
+    private KeyId $currentKeyId;
+
     /**
      * @var array<string, CipherInterface>
      */
@@ -38,6 +44,7 @@ class Keychain implements KeychainInterface
 
     public function getCurrentKeyId(): KeyId
     {
+        return $this->currentKeyId;
     }
 
     public function hasKey(KeyId $keyId): bool
@@ -50,5 +57,6 @@ class Keychain implements KeychainInterface
         CipherInterface $cipher,
     ): void {
         $this->mappings[$id->id] = $cipher;
+        $this->currentKeyId = $id;
     }
 }

--- a/src/Encryption/Keys/Keychain.php
+++ b/src/Encryption/Keys/Keychain.php
@@ -36,6 +36,10 @@ class Keychain implements KeychainInterface
         throw new OutOfBoundsException('Key id not registered');
     }
 
+    public function getCurrentKeyId(): KeyId
+    {
+    }
+
     public function hasKey(KeyId $keyId): bool
     {
         return array_key_exists($keyId->id, $this->mappings);

--- a/src/Encryption/Keys/KeychainInterface.php
+++ b/src/Encryption/Keys/KeychainInterface.php
@@ -25,5 +25,7 @@ interface KeychainInterface
 {
     public function getCipher(KeyId $keyId): CipherInterface;
 
+    public function getCurrentKeyId(): KeyId;
+
     public function hasKey(KeyId $keyId): bool;
 }

--- a/tests/Tests/Isolated/Encryption/CipherSuiteTest.php
+++ b/tests/Tests/Isolated/Encryption/CipherSuiteTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Encryption;
+
+use OpenEMR\Encryption\Cipher\CipherInterface;
+use OpenEMR\Encryption\Ciphertext;
+use OpenEMR\Encryption\CipherSuite;
+use OpenEMR\Encryption\KeyId;
+use OpenEMR\Encryption\Keys\KeychainInterface;
+use OpenEMR\Encryption\Plaintext;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[Small]
+class CipherSuiteTest extends TestCase
+{
+    private KeychainInterface&MockObject $keychain;
+    private CipherInterface&MockObject $cipher;
+
+    private CipherSuite $suite;
+    private KeyId $keyId;
+
+    protected function setUp(): void
+    {
+        $this->cipher = $this->createMock(CipherInterface::class);
+
+        $this->keyId = new KeyId('005');
+
+        $this->keychain = $this->createMock(KeychainInterface::class);
+        $this->keychain->method('getCurrentKeyId')->willReturn($this->keyId);
+        $this->keychain->method('getCipher')->with($this->keyId)->willReturn($this->cipher);
+
+        $this->suite = new CipherSuite($this->keychain);
+    }
+
+    public function testRoundtripWithStringInput(): void
+    {
+        $plaintext = 'sensitive data';
+
+        $ciphertext = new Ciphertext('encrypted bytes');
+
+        $this->cipher->method('encrypt')
+            ->with(self::callback(fn (Plaintext $pt) => $pt->bytes === $plaintext))
+            ->willReturn($ciphertext);
+
+        $encrypted = $this->suite->encrypt($plaintext);
+
+        self::assertStringNotContainsString($plaintext, $encrypted);
+
+        $this->cipher->expects(self::once())
+            ->method('decrypt')
+            ->with(self::callback(fn (Ciphertext $c) => $c->value === $ciphertext->value))
+            ->willReturn(new Plaintext($plaintext));
+
+        $decrypted = $this->suite->decrypt($encrypted);
+        self::assertSame($plaintext, $decrypted);
+    }
+
+    public function testEncryptWithPlaintextInput(): void
+    {
+        $plaintext = new Plaintext('sensitive data');
+
+        $ciphertext = new Ciphertext('encrypted bytes');
+
+        $this->cipher->method('encrypt')
+            ->with(self::callback(fn (Plaintext $pt) => $pt->bytes === $plaintext->bytes))
+            ->willReturn($ciphertext);
+
+        $encrypted = $this->suite->encrypt($plaintext);
+
+        self::assertStringNotContainsString($plaintext->bytes, $encrypted);
+
+        $this->cipher->expects(self::once())
+            ->method('decrypt')
+            ->with(self::callback(fn (Ciphertext $c) => $c->value === $ciphertext->value))
+            ->willReturn($plaintext);
+
+        $decrypted = $this->suite->decrypt($encrypted);
+        self::assertSame($plaintext->bytes, $decrypted);
+    }
+}

--- a/tests/Tests/Isolated/Encryption/CipherSuiteTest.php
+++ b/tests/Tests/Isolated/Encryption/CipherSuiteTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Isolated\Encryption;
 
 use OpenEMR\Encryption\Cipher\CipherInterface;
-use OpenEMR\Encryption\Ciphertext;
 use OpenEMR\Encryption\CipherSuite;
+use OpenEMR\Encryption\Ciphertext;
 use OpenEMR\Encryption\KeyId;
 use OpenEMR\Encryption\Keys\KeychainInterface;
 use OpenEMR\Encryption\Plaintext;
 use PHPUnit\Framework\Attributes\Small;
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 #[Small]
 class CipherSuiteTest extends TestCase

--- a/tests/Tests/Isolated/Encryption/Keys/KeychainTest.php
+++ b/tests/Tests/Isolated/Encryption/Keys/KeychainTest.php
@@ -62,4 +62,23 @@ class KeychainTest extends TestCase
         self::expectException(OutOfBoundsException::class);
         $keychain->getCipher(new KeyId('not registered'));
     }
+
+    public function testCurrentKeyIsMostRecent(): void
+    {
+        $keychain = new Keychain();
+        try {
+            $keychain->getCurrentKeyId();
+            $this->fail('getCurrentKeyId before registring ciphers should be an error');
+        } catch (\Error $e) {
+            $this->addToAssertionCount(1);
+        }
+
+        $id1 = new KeyId('key one');
+        $keychain->registerCipher($id1, self::createStub(CipherInterface::class));
+        self::assertSame($id1, $keychain->getCurrentKeyId());
+
+        $id2 = new KeyId('key two');
+        $keychain->registerCipher($id2, self::createStub(CipherInterface::class));
+        self::assertSame($id2, $keychain->getCurrentKeyId());
+    }
 }

--- a/tests/Tests/Isolated/Encryption/Keys/KeychainTest.php
+++ b/tests/Tests/Isolated/Encryption/Keys/KeychainTest.php
@@ -67,9 +67,9 @@ class KeychainTest extends TestCase
     {
         $keychain = new Keychain();
         try {
-            $keychain->getCurrentKeyId();
+            $_ = $keychain->getCurrentKeyId();
             $this->fail('getCurrentKeyId before registring ciphers should be an error');
-        } catch (\Error $e) {
+        } catch (\Error) {
             $this->addToAssertionCount(1);
         }
 

--- a/tests/Tests/Isolated/Encryption/Keys/KeychainTest.php
+++ b/tests/Tests/Isolated/Encryption/Keys/KeychainTest.php
@@ -68,7 +68,7 @@ class KeychainTest extends TestCase
         $keychain = new Keychain();
         try {
             $_ = $keychain->getCurrentKeyId();
-            $this->fail('getCurrentKeyId before registring ciphers should be an error');
+            $this->fail('getCurrentKeyId before registering ciphers should be an error');
         } catch (\Error) {
             $this->addToAssertionCount(1);
         }


### PR DESCRIPTION
#### Short description of what this changes or resolves:
This is the successor to `CryptoInterface`/`CryptoGen`. It's a simplified, easier-to-use interface that's difficult to use incorrectly.

How this differs from the previous encryption tooling:

- Key versioning/sourcing/rotation/etc is all managed internally, not at call sites
- `#[SensitiveParameter]` attribute to reduce risk of secrets appearing in stack traces
- Type safety throughout
- Failure mode is now throwing an exception; no silent failures
- Linear data-flow in internals; various cryptographic operations delegated to well-tested, narrowly-scoped implementations
- Heavily unit-tested, including backwards-compatibility tests

Future scope in later PRs:
- Add this to DI config (make it easy to use in new code)
- Canonicalize it as a module-stable interface (maybe)
- Migrate sites using CryptoGen to this
- Additional "needs re-encrypting" method(s) on the interface and implementation (TBD; probably an instance method here to check a specific opaque blob, and an instance method on the keychain to get a prefix that matches up-to-date data)

#### Changes proposed in this pull request:
- Add CipherSuiteInterface
- Add CipherSuite implementation
- Supporting adjustments to other tools in the namespace (mostly the `Keychain->getCurrentKeyId()`)
- Tests

#### Was an AI assistant used? Yes / No
Just for some boilerplate