### PR TITLE
refactor(direct-messaging): wrap phiMail socket lifecycle in try/finally

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -68,7 +68,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 9,
+    'count' => 7,
     'path' => __DIR__ . '/../../ccr/transmitCCD.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -2213,7 +2213,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 6,
+    'count' => 4,
     'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
 ];
 $ignoreErrors[] = [

--- a/ccr/transmitCCD.php
+++ b/ccr/transmitCCD.php
@@ -54,57 +54,54 @@ function transmitMessage($message, $recipient, $verifyFinalDelivery = false)
         return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGING_DISABLED);
     }
 
+    $phimail_username = OEGlobalsBag::getInstance()->getString('phimail_username');
+    $cryptoGen = ServiceContainer::getCrypto();
+    $phimail_password = $cryptoGen->decryptStandard(OEGlobalsBag::getInstance()->getString('phimail_password'));
+
     $fp = phimail_connect($err);
     if ($fp === false) {
         return("$config_err $err");
     }
 
-    $phimail_username = OEGlobalsBag::getInstance()->getString('phimail_username');
-    $cryptoGen = ServiceContainer::getCrypto();
-    $phimail_password = $cryptoGen->decryptStandard(OEGlobalsBag::getInstance()->getString('phimail_password'));
-    $ret = phimail_write_expect_OK($fp, "AUTH $phimail_username $phimail_password\n");
-    if ($ret !== true) {
-        return("$config_err " . ErrorConstants::ERROR_CODE_AUTH_FAILED);
-    }
+    try {
+        $ret = phimail_write_expect_OK($fp, "AUTH $phimail_username $phimail_password\n");
+        if ($ret !== true) {
+            return("$config_err " . ErrorConstants::ERROR_CODE_AUTH_FAILED);
+        }
 
-    $ret = phimail_write_expect_OK($fp, "TO $recipient\n");
-    if ($ret !== true) {
-        return( xl(ErrorConstants::RECIPIENT_NOT_ALLOWED) . " " . $ret );
-    }
+        $ret = phimail_write_expect_OK($fp, "TO $recipient\n");
+        if ($ret !== true) {
+            return( xl(ErrorConstants::RECIPIENT_NOT_ALLOWED) . " " . $ret );
+        }
 
-    $ret = fgets($fp); //ignore extra server data
+        $ret = fgets($fp); //ignore extra server data
 
-    $text_out = $message;
+        $text_out = $message;
 
-    $text_len = strlen((string) $text_out);
-    phimail_write($fp, "TEXT $text_len\n");
-    $ret = @fgets($fp);
-    if ($ret != "BEGIN\n") {
+        $text_len = strlen((string) $text_out);
+        phimail_write($fp, "TEXT $text_len\n");
+        $ret = @fgets($fp);
+        if ($ret != "BEGIN\n") {
+            return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGE_BEGIN_FAILED);
+        }
+
+        $ret = phimail_write_expect_OK($fp, $text_out);
+        if ($ret !== true) {
+            return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGE_BEGIN_OK_FAILED);
+        }
+
+        $finalFlag = $verifyFinalDelivery ? '1' : '0';
+        $ret = phimail_write_expect_OK($fp, "SET FINAL $finalFlag\n");
+        if ($ret !== true) {
+            return( xl(ErrorConstants::ERROR_MESSAGE_SET_DISPOSITION_NOTIFICATION_FAILED) . " " . $ret );
+        }
+
+        phimail_write($fp, "SEND\n");
+        $ret = fgets($fp);
+        phimail_write($fp, "OK\n");
+    } finally {
         phimail_close($fp);
-        return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGE_BEGIN_FAILED);
     }
-
-    $ret = phimail_write_expect_OK($fp, $text_out);
-    if ($ret !== true) {
-        return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGE_BEGIN_OK_FAILED);
-    }
-
-    if ($verifyFinalDelivery) {
-        $ret = phimail_write_expect_OK($fp, "SET FINAL 1\n");
-        if ($ret !== true) {
-            return( xl(ErrorConstants::ERROR_MESSAGE_SET_DISPOSITION_NOTIFICATION_FAILED) . " " . $ret );
-        }
-    } else {
-        $ret = phimail_write_expect_OK($fp, "SET FINAL 0\n");
-        if ($ret !== true) {
-            return( xl(ErrorConstants::ERROR_MESSAGE_SET_DISPOSITION_NOTIFICATION_FAILED) . " " . $ret );
-        }
-    }
-
-    phimail_write($fp, "SEND\n");
-    $ret = fgets($fp);
-    phimail_write($fp, "OK\n");
-    phimail_close($fp);
 
 
     if (substr($ret, 5) == "ERROR") {
@@ -186,96 +183,92 @@ function transmitCCD($pid, $ccd_out, $recipient, $requested_by, $xml_type = "CCD
         return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGING_DISABLED);
     }
 
+    $phimail_username = OEGlobalsBag::getInstance()->getString('phimail_username');
+    $cryptoGen = ServiceContainer::getCrypto();
+    $phimail_password = $cryptoGen->decryptStandard(OEGlobalsBag::getInstance()->getString('phimail_password'));
+
     $fp = phimail_connect($err);
     if ($fp === false) {
         return("$config_err $err");
     }
 
-    $phimail_username = OEGlobalsBag::getInstance()->getString('phimail_username');
-    $cryptoGen = ServiceContainer::getCrypto();
-    $phimail_password = $cryptoGen->decryptStandard(OEGlobalsBag::getInstance()->getString('phimail_password'));
-    $ret = phimail_write_expect_OK($fp, "AUTH $phimail_username $phimail_password\n");
-    if ($ret !== true) {
-        return("$config_err " . ErrorConstants::ERROR_CODE_AUTH_FAILED);
-    }
+    try {
+        $ret = phimail_write_expect_OK($fp, "AUTH $phimail_username $phimail_password\n");
+        if ($ret !== true) {
+            return("$config_err " . ErrorConstants::ERROR_CODE_AUTH_FAILED);
+        }
 
-    $ret = phimail_write_expect_OK($fp, "TO $recipient\n");
-    if ($ret !== true) {
-        return( xl(ErrorConstants::RECIPIENT_NOT_ALLOWED) . " " . $ret );
-    }
+        $ret = phimail_write_expect_OK($fp, "TO $recipient\n");
+        if ($ret !== true) {
+            return( xl(ErrorConstants::RECIPIENT_NOT_ALLOWED) . " " . $ret );
+        }
 
-    $ret = fgets($fp); //ignore extra server data
+        $ret = fgets($fp); //ignore extra server data
 
-    // add whatever the clinican added as a message to be sent.
-    $text_out = "";
-    if (is_string($message) && trim($message) != "") {
-        $text_out = $message . "\n";
-    }
+        // add whatever the clinican added as a message to be sent.
+        $text_out = "";
+        if (is_string($message) && trim($message) != "") {
+            $text_out = $message . "\n";
+        }
 
-    if ($requested_by == "patient") {
-        $text_out .= xl("Delivery of the attached clinical document was requested by the patient") .
-            ($patientName2 == "" ? "." : ", " . $patientName2 . ".");
-    } else {
-        $text_out .= xl("A clinical document is attached") .
-            ($patientName2 == "" ? "." : " " . xl("for patient") . " " . $patientName2 . ".");
-    }
+        if ($requested_by == "patient") {
+            $text_out .= xl("Delivery of the attached clinical document was requested by the patient") .
+                ($patientName2 == "" ? "." : ", " . $patientName2 . ".");
+        } else {
+            $text_out .= xl("A clinical document is attached") .
+                ($patientName2 == "" ? "." : " " . xl("for patient") . " " . $patientName2 . ".");
+        }
 
 
-    $text_len = strlen($text_out);
-    phimail_write($fp, "TEXT $text_len\n");
-    $ret = @fgets($fp);
-    if ($ret != "BEGIN\n") {
-        phimail_close($fp);
-        return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGE_BEGIN_FAILED);
-    }
+        $text_len = strlen($text_out);
+        phimail_write($fp, "TEXT $text_len\n");
+        $ret = @fgets($fp);
+        if ($ret != "BEGIN\n") {
+            return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGE_BEGIN_FAILED);
+        }
 
-    $ret = phimail_write_expect_OK($fp, $text_out);
-    if ($ret !== true) {
-        return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGE_BEGIN_OK_FAILED);
-    }
+        $ret = phimail_write_expect_OK($fp, $text_out);
+        if ($ret !== true) {
+            return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGE_BEGIN_OK_FAILED);
+        }
 
-    // MU2 CareCoordination added the need to send CCDAs formatted as html,pdf, or xml
-    if ($format_type == 'html') {
-        $add_type = "TEXT";
-    } elseif ($format_type == 'pdf') {
-        $add_type = "RAW";
-    } elseif ($format_type == 'xml') {
-        $add_type = $xml_type == "CCR" ? "CCR" : "CDA";
-    } else {
-        // unsupported format
-        return ("$config_err " . ErrorConstants::ERROR_CODE_INVALID_FORMAT_TYPE);
-    }
+        // MU2 CareCoordination added the need to send CCDAs formatted as html,pdf, or xml
+        $add_type = match ($format_type) {
+            'html' => "TEXT",
+            'pdf' => "RAW",
+            'xml' => $xml_type == "CCR" ? "CCR" : "CDA",
+            default => null,
+        };
+        if ($add_type === null) {
+            // unsupported format
+            return ("$config_err " . ErrorConstants::ERROR_CODE_INVALID_FORMAT_TYPE);
+        }
 
-    $ccd_len = strlen((string) $ccd_out);
+        $ccd_len = strlen((string) $ccd_out);
 
-    phimail_write($fp, "ADD " . $add_type . " " . $ccd_len . " " . $att_filename . $extension . "\n");
-    $ret = fgets($fp);
-    if ($ret != "BEGIN\n") {
-        phimail_close($fp);
-        return("$config_err " . ErrorConstants::ERROR_CODE_ADD_FILE_FAILED);
-    }
+        phimail_write($fp, "ADD " . $add_type . " " . $ccd_len . " " . $att_filename . $extension . "\n");
+        $ret = fgets($fp);
+        if ($ret != "BEGIN\n") {
+            return("$config_err " . ErrorConstants::ERROR_CODE_ADD_FILE_FAILED);
+        }
 
-    $ret = phimail_write_expect_OK($fp, $ccd_out);
-    if ($ret !== true) {
-        return("$config_err " . ErrorConstants::ERROR_CODE_ADD_FILE_CONFIRM_FAILED);
-    }
+        $ret = phimail_write_expect_OK($fp, $ccd_out);
+        if ($ret !== true) {
+            return("$config_err " . ErrorConstants::ERROR_CODE_ADD_FILE_CONFIRM_FAILED);
+        }
 
-    if ($verifyFinalDelivery) {
-        $ret = phimail_write_expect_OK($fp, "SET FINAL 1\n");
+        $finalFlag = $verifyFinalDelivery ? '1' : '0';
+        $ret = phimail_write_expect_OK($fp, "SET FINAL $finalFlag\n");
         if ($ret !== true) {
             return( xl(ErrorConstants::ERROR_MESSAGE_SET_DISPOSITION_NOTIFICATION_FAILED) . " " . $ret );
         }
-    } else {
-        $ret = phimail_write_expect_OK($fp, "SET FINAL 0\n");
-        if ($ret !== true) {
-            return( xl(ErrorConstants::ERROR_MESSAGE_SET_DISPOSITION_NOTIFICATION_FAILED) . " " . $ret );
-        }
-    }
 
-    phimail_write($fp, "SEND\n");
-    $ret = fgets($fp);
-    phimail_write($fp, "OK\n");
-    phimail_close($fp);
+        phimail_write($fp, "SEND\n");
+        $ret = fgets($fp);
+        phimail_write($fp, "OK\n");
+    } finally {
+        phimail_close($fp);
+    }
 
     if ($requested_by == "patient") {
         $reqBy = "portal-user";

--- a/library/direct_message_check.inc.php
+++ b/library/direct_message_check.inc.php
@@ -132,6 +132,7 @@ function phimail_connect(&$phimail_error)
         $ret = phimail_write_expect_OK($fp, "INFO VER OEMR " . (new VersionService())->getSoftwareVersion() . " 1.3.2 "
             . \PHP_VERSION . "\n");
         if ($ret !== true) {
+            phimail_close($fp);
             $fp = false;
             $phimail_error = 'C5';
         }
@@ -155,336 +156,328 @@ function phimail_connect(&$phimail_error)
 
 function phimail_check(): void
 {
+    $phimail_username = OEGlobalsBag::getInstance()->getString('phimail_username');
+    $cryptoGen = ServiceContainer::getCrypto();
+    $phimail_password = $cryptoGen->decryptStandard(OEGlobalsBag::getInstance()->getString('phimail_password'));
+
+    if (!($notifyUsername = OEGlobalsBag::getInstance()->getString('phimail_notify'))) {
+        $notifyUsername = 'admin'; //fallback
+    }
+
     $fp = phimail_connect($err);
     if ($fp === false) {
         phimail_logit(0, xl('could not connect to server') . ' ' . $err);
         return;
     }
 
-    $phimail_username = OEGlobalsBag::getInstance()->getString('phimail_username');
-    $cryptoGen = ServiceContainer::getCrypto();
-    $phimail_password = $cryptoGen->decryptStandard(OEGlobalsBag::getInstance()->getString('phimail_password'));
-
-    $ret = phimail_write_expect_OK($fp, "AUTH $phimail_username $phimail_password\n");
-    if ($ret !== true) {
-        phimail_logit(0, "authentication error " . $ret);
-        return;
-    }
-
-    if (!($notifyUsername = OEGlobalsBag::getInstance()->getString('phimail_notify'))) {
-        $notifyUsername = 'admin'; //fallback
-    }
-
-    while (1) {
-        phimail_write($fp, "CHECK\n");
-        $ret = fgets($fp);
-
-        if ($ret == "NONE\n") { //nothing to process
-            phimail_close($fp);
-            phimail_logit(1, "message check completed");
-            return;
-        } elseif (str_starts_with($ret, "STATUS")) {
-            //Format STATUS message-id status-code [additional-information]
-            $val = explode(" ", trim($ret), 4);
-            $sql = 'SELECT * from direct_message_log WHERE msg_id = ?';
-            $res = sqlStatementNoLog($sql, [$val[1]]);
-            if ($res === false) { //database problem
-                phimail_close($fp);
-                phimail_logit(0, "database problem");
-                return;
-            }
-
-            if (($msg = sqlFetchArray($res)) === false) {
-                //no match, so log it and move on (should never happen)
-                phimail_logit(0, "NO MATCH: " . $ret);
-                $ret = phimail_write_expect_OK($fp, "OK\n");
-                if ($ret !== true) {
-                    phimail_logit(0, "M1 status acknowledgment failed: " . $ret);
-                    return;
-                } else {
-                    continue;
-                }
-            }
-
-            //if we get here, $msg contains the matching outgoing message record
-            if ($val[2] == 'failed') {
-                $success = 0;
-                $status = 'F';
-            } elseif ($val[2] == 'dispatched') {
-                $success = 1;
-                $status = 'D';
-            } else {
-                //unrecognized status, log it and move on (should never happen)
-                $ret = "UNKNOWN STATUS: " . $ret;
-                $success = 0;
-                $status = 'U';
-            }
-
-            phimail_logit($success, $ret, $msg['patient_id']);
-
-            if (!isset($val[3])) {
-                $val[3] = "";
-            }
-
-            $sql = "UPDATE direct_message_log SET status=?, status_ts=NOW(), status_info=? WHERE msg_type='S' AND msg_id=?";
-            $res = sqlStatementNoLog($sql, [$status, $val[3], $val[1]]);
-            if ($res === false) { //database problem
-                phimail_close($fp);
-                phimail_logit(0, "database problem updating: " . $val[1]);
-                return;
-            }
-
-            if (!$success) {
-                //notify local user of failure
-                $sql = "SELECT username FROM users WHERE id = ?";
-                $res2 = sqlStatementNoLog($sql, [$msg['user_id']]);
-                $fail_user = ($res2 === false || ($user_row = sqlFetchArray($res2)) === false) ?
-                    xl('unknown (see log)') : $user_row['username'];
-                $fail_notice = xl('Sent by:') . ' ' . $fail_user . '(' . $msg['user_id'] . ') ' . xl('on') . ' ' . $msg['create_ts']
-                    . "\n" . xl('Sent to:') . ' ' . $msg['recipient'] . "\n" . xl('Server message:') . ' ' . $ret;
-                phimail_notify(xl('Direct Messaging Send Failure.'), $fail_notice);
-                $pnote_id = addPnote(
-                    $msg['patient_id'],
-                    xl("FAILURE NOTICE: Direct Message Send Failed.") . "\n\n$fail_notice\n",
-                    0,
-                    1,
-                    "Unassigned",
-                    $notifyUsername,
-                    "",
-                    "New",
-                    "phimail-service"
-                );
-            }
-
-            //done with this status message
-            $ret = phimail_write_expect_OK($fp, "OK\n");
-            if ($ret !== true) {
-                phimail_logit(0, "M2 status acknowledgment failed: " . $ret);
-                phimail_close($fp);
-                return;
-            }
-        } elseif (str_starts_with($ret, "MAIL")) {
-            $val = explode(" ", trim($ret), 5); // MAIL recipient sender #attachments msg-id
-            $recipient = $val[1];
-            $sender = $val[2];
-            $att = (int)$val[3];
-            $msg_id = $val[4];
-
-            //request main message
-            $ret2 = phimail_write_expect_OK($fp, "SHOW 0\n");
-            if ($ret2 !== true) {
-                phimail_logit(0, "M3 SHOW 0 failed: " . $ret2);
-                phimail_close($fp);
-                return;
-            }
-
-            //get message headers
-            $hdrs = "";
-            while (true) {
-                $next_hdr = fgets($fp);
-                if ($next_hdr === false) {
-                    phimail_logit(0, "M4 read headers failed");
-                    phimail_close($fp);
-                    return;
-                }
-                if ($next_hdr == "\n") {
-                    break;
-                }
-                $hdrs .= $next_hdr;
-            }
-
-            $mime_type = fgets($fp);
-            $mime_info = explode(";", $mime_type);
-            $mime_type_main = trim(strtolower($mime_info[0]));
-
-            //get main message body
-            $body_len = fgets($fp);
-            $body = phimail_read_blob($fp, $body_len);
-            if ($body === false) {
-                phimail_logit(0, "M4 read body failed");
-                phimail_close($fp);
-                return;
-            }
-
-            $att2 = fgets($fp);
-            if ($att2 != $att) { //safety for mismatch on attachments
-                phimail_logit(0, "M5 attachment mismatch");
-                phimail_close($fp);
-                return;
-            }
-
-            //get attachment info
-            if ($att > 0) {
-                for ($attnum = 0; $attnum < $att; $attnum++) {
-                    if (
-                        ($attinfo[$attnum]['name'] = fgets($fp)) === false
-                        || ($attinfo[$attnum]['mime'] = fgets($fp)) === false
-                        || ($attinfo[$attnum]['desc'] = fgets($fp)) === false
-                    ) {
-                        phimail_logit(0, "M6 read attachment " . ($attnum + 1) . " metadata failed");
-                        phimail_close($fp);
-                        return;
-                    }
-                }
-            }
-
-            //main part gets stored as document if not plain text content
-            //(if plain text it will be the body of the final pnote)
-            $all_doc_ids = [];
-            $doc_id = 0;
-            $att_detail = "";
-            if ($mime_type_main != "text/plain" && $mime_type_main != "text/html") {
-                if ($body_len == 0) {
-                    $att_detail = $att_detail . "\n" . xl("Zero length attachment") . " ($mime_type_main; " .
-                        "0 bytes - " . xl("empty file received") . ") Main message body";
-                    unlink($body);
-                } else {
-                    $name = uniqid("dm-message-") . phimail_extension($mime_type_main);
-                    $doc_id = phimail_store($name, $mime_type_main, $body);
-                    if (!$doc_id) {
-                        phimail_logit(0, "M7 store non-text body failed");
-                        phimail_close($fp);
-                        return;
-                    }
-
-                    $idnum = $doc_id['doc_id'];
-                    $all_doc_ids[] = $idnum;
-                    $url = $doc_id['url'];
-                    $url = substr((string) $url, strrpos((string) $url, "/") + 1);
-                    $att_detail = "\n" . xl("Document") . " $idnum (\"$url\"; $mime_type_main; " .
-                        filesize($body) . " bytes) Main message body";
-                }
-            }
-
-            //download and store attachments
-            for ($attnum = 0; $attnum < $att; $attnum++) {
-                $ret2 = phimail_write_expect_OK($fp, "SHOW " . ($attnum + 1) . "\n");
-                if ($ret2 !== true) {
-                    phimail_logit(0, "M8 SHOW " . ($attnum + 1) . " failed: " . $ret2);
-                    phimail_close($fp);
-                    return;
-                }
-
-                //we can ignore next two lines (repeat of name and mime-type)
-                if (($a1 = fgets($fp)) === false || ($a2 = fgets($fp)) === false) {
-                    phimail_logit(0, "M9 skip attachment " . ($attnum + 1) . " duplicate header lines failed");
-                    phimail_close($fp);
-                    return;
-                }
-
-                $att_len = fgets($fp); //length of file
-                $attdata = phimail_read_blob($fp, $att_len);
-                if ($attdata === false) {
-                    phimail_logit(0, "M10 read attachment " . ($attnum + 1) . " failed");
-                    phimail_close($fp);
-                    return;
-                }
-
-                $attinfo[$attnum]['file'] = $attdata;
-
-                $req_name = trim($attinfo[$attnum]['name']);
-                $req_name = (empty($req_name) ? $attdata : "dm-") . $req_name;
-                $attinfo[$attnum]['mime'] = explode(";", trim($attinfo[$attnum]['mime']));
-                $attmime = strtolower($attinfo[$attnum]['mime'][0]);
-
-                if ($att_len == 0) {
-                    $att_detail = $att_detail . "\n" . xl("Zero length attachment") . " ($attmime; " .
-                        "0 bytes - " . xl("empty file received") . " " . trim($attinfo[$attnum]['desc']);
-                    unlink($attdata);
-                } else {
-                    $att_doc_id = phimail_store($req_name, $attmime, $attdata);
-                    if (!$att_doc_id) {
-                        phimail_logit(0, "M11 store attachment " . ($attnum + 1) . " failed");
-                        phimail_close($fp);
-                        return;
-                    }
-
-                    $attinfo[$attnum]['doc_id'] = $att_doc_id;
-                    $idnum = $att_doc_id['doc_id'];
-                    $all_doc_ids[] = $idnum;
-                    $url = $att_doc_id['url'];
-                    $url = substr((string) $url, strrpos((string) $url, "/") + 1);
-                    $att_detail = $att_detail . "\n" . xl("Document") . " $idnum (\"$url\"; $attmime; " .
-                        $att_doc_id['filesize'] . " bytes) " . trim($attinfo[$attnum]['desc']);
-                }
-            }
-
-            if ($att_detail != "") {
-                $att_detail = "\n\n" . xl("The following documents were attached to this Direct message:") . $att_detail;
-            }
-
-            $ret2 = phimail_write_expect_OK($fp, "DONE\n"); //we'll check for failure after logging.
-
-            //logging only after successful download, storage, and acknowledgement of message
-            $sql = "INSERT INTO direct_message_log (msg_type,msg_id,sender,recipient,status,status_ts,user_id) " .
-                "VALUES ('R', ?, ?, ?, 'R', NOW(), ?)";
-            $res = sqlStatementNoLog($sql, [$msg_id, $sender, $recipient, phimail_service_userID()]);
-
-            phimail_logit(1, $ret);
-
-            //alert appointed user about new message
-            switch ($mime_type_main) {
-                case "text/plain":
-                    $body_text = @file_get_contents($body); //this was not uploaded as a document
-                    unlink($body);
-                    if (empty($body_text ?? '')) {
-                        $body_text = xl("Please note, this message was received empty and is not an error.");
-                    }
-                    $pnote_id = addPnote(
-                        0,
-                        xl("Direct Message Received.") . "\n$hdrs\n$body_text$att_detail",
-                        0,
-                        1,
-                        "Unassigned",
-                        $notifyUsername,
-                        "",
-                        "New",
-                        "phimail-service"
-                    );
-                    break;
-                case "text/html":
-                    $body_text = @file_get_contents($body);
-                    unlink($body);
-                    if (empty($body_text ?? '')) {
-                        $body_text = xl("Please note, this message was received empty and is not an error.");
-                    } else {
-                        // meager attempt to convert to text. @TODO convert our Messages message body from textarea to div so can display html.
-                        $body_text = trim(html_entity_decode(strip_tags(str_ireplace(["<br />", "<br>", "<br/>"], PHP_EOL, $body_text))));
-                    }
-                    $pnote_id = addPnote(
-                        0,
-                        xl("Direct Message Received.") . "\n$hdrs\n$body_text$att_detail",
-                        0,
-                        1,
-                        "Unassigned",
-                        $notifyUsername,
-                        "",
-                        "New",
-                        "phimail-service"
-                    );
-                    break;
-
-                default:
-                    $note = xl("Direct Message Received.") . "\n$hdrs\n"
-                        . xl("Message content is not plain text so it has been stored as a document.") . $att_detail;
-                    $pnote_id = addPnote(0, $note, 0, 1, "Unassigned", $notifyUsername, "", "New", "phimail-service");
-                    break;
-            }
-
-            foreach ($all_doc_ids as $doc_id) {
-                setGpRelation(1, $doc_id, 6, $pnote_id);
-            }
-
-            if ($ret2 !== true) {
-                phimail_logit(0, "M12 DONE failed: " . $ret2);
-                phimail_close($fp);
-                return;
-            }
-        } else { //unrecognized or FAIL response
-            phimail_logit(0, "M16 unexpected problem checking messages " . $ret);
-            phimail_close($fp);
+    try {
+        $ret = phimail_write_expect_OK($fp, "AUTH $phimail_username $phimail_password\n");
+        if ($ret !== true) {
+            phimail_logit(0, "authentication error " . $ret);
             return;
         }
+
+        while (1) {
+            phimail_write($fp, "CHECK\n");
+            $ret = fgets($fp);
+
+            if ($ret == "NONE\n") { //nothing to process
+                phimail_logit(1, "message check completed");
+                return;
+            } elseif (str_starts_with($ret, "STATUS")) {
+                //Format STATUS message-id status-code [additional-information]
+                $val = explode(" ", trim($ret), 4);
+                $sql = 'SELECT * from direct_message_log WHERE msg_id = ?';
+                $res = sqlStatementNoLog($sql, [$val[1]]);
+                if ($res === false) { //database problem
+                    phimail_logit(0, "database problem");
+                    return;
+                }
+
+                if (($msg = sqlFetchArray($res)) === false) {
+                    //no match, so log it and move on (should never happen)
+                    phimail_logit(0, "NO MATCH: " . $ret);
+                    $ret = phimail_write_expect_OK($fp, "OK\n");
+                    if ($ret !== true) {
+                        phimail_logit(0, "M1 status acknowledgment failed: " . $ret);
+                        return;
+                    } else {
+                        continue;
+                    }
+                }
+
+                //if we get here, $msg contains the matching outgoing message record
+                if ($val[2] == 'failed') {
+                    $success = 0;
+                    $status = 'F';
+                } elseif ($val[2] == 'dispatched') {
+                    $success = 1;
+                    $status = 'D';
+                } else {
+                    //unrecognized status, log it and move on (should never happen)
+                    $ret = "UNKNOWN STATUS: " . $ret;
+                    $success = 0;
+                    $status = 'U';
+                }
+
+                phimail_logit($success, $ret, $msg['patient_id']);
+
+                if (!isset($val[3])) {
+                    $val[3] = "";
+                }
+
+                $sql = "UPDATE direct_message_log SET status=?, status_ts=NOW(), status_info=? WHERE msg_type='S' AND msg_id=?";
+                $res = sqlStatementNoLog($sql, [$status, $val[3], $val[1]]);
+                if ($res === false) { //database problem
+                    phimail_logit(0, "database problem updating: " . $val[1]);
+                    return;
+                }
+
+                if (!$success) {
+                    //notify local user of failure
+                    $sql = "SELECT username FROM users WHERE id = ?";
+                    $res2 = sqlStatementNoLog($sql, [$msg['user_id']]);
+                    $fail_user = ($res2 === false || ($user_row = sqlFetchArray($res2)) === false) ?
+                        xl('unknown (see log)') : $user_row['username'];
+                    $fail_notice = xl('Sent by:') . ' ' . $fail_user . '(' . $msg['user_id'] . ') ' . xl('on') . ' ' . $msg['create_ts']
+                        . "\n" . xl('Sent to:') . ' ' . $msg['recipient'] . "\n" . xl('Server message:') . ' ' . $ret;
+                    phimail_notify(xl('Direct Messaging Send Failure.'), $fail_notice);
+                    $pnote_id = addPnote(
+                        $msg['patient_id'],
+                        xl("FAILURE NOTICE: Direct Message Send Failed.") . "\n\n$fail_notice\n",
+                        0,
+                        1,
+                        "Unassigned",
+                        $notifyUsername,
+                        "",
+                        "New",
+                        "phimail-service"
+                    );
+                }
+
+                //done with this status message
+                $ret = phimail_write_expect_OK($fp, "OK\n");
+                if ($ret !== true) {
+                    phimail_logit(0, "M2 status acknowledgment failed: " . $ret);
+                    return;
+                }
+            } elseif (str_starts_with($ret, "MAIL")) {
+                $val = explode(" ", trim($ret), 5); // MAIL recipient sender #attachments msg-id
+                $recipient = $val[1];
+                $sender = $val[2];
+                $att = (int)$val[3];
+                $msg_id = $val[4];
+
+                //request main message
+                $ret2 = phimail_write_expect_OK($fp, "SHOW 0\n");
+                if ($ret2 !== true) {
+                    phimail_logit(0, "M3 SHOW 0 failed: " . $ret2);
+                    return;
+                }
+
+                //get message headers
+                $hdrs = "";
+                while (true) {
+                    $next_hdr = fgets($fp);
+                    if ($next_hdr === false) {
+                        phimail_logit(0, "M4 read headers failed");
+                        return;
+                    }
+                    if ($next_hdr == "\n") {
+                        break;
+                    }
+                    $hdrs .= $next_hdr;
+                }
+
+                $mime_type = fgets($fp);
+                $mime_info = explode(";", $mime_type);
+                $mime_type_main = trim(strtolower($mime_info[0]));
+
+                //get main message body
+                $body_len = fgets($fp);
+                $body = phimail_read_blob($fp, $body_len);
+                if ($body === false) {
+                    phimail_logit(0, "M4 read body failed");
+                    return;
+                }
+
+                $att2 = fgets($fp);
+                if ($att2 != $att) { //safety for mismatch on attachments
+                    phimail_logit(0, "M5 attachment mismatch");
+                    return;
+                }
+
+                //get attachment info
+                if ($att > 0) {
+                    for ($attnum = 0; $attnum < $att; $attnum++) {
+                        if (
+                            ($attinfo[$attnum]['name'] = fgets($fp)) === false
+                            || ($attinfo[$attnum]['mime'] = fgets($fp)) === false
+                            || ($attinfo[$attnum]['desc'] = fgets($fp)) === false
+                        ) {
+                            phimail_logit(0, "M6 read attachment " . ($attnum + 1) . " metadata failed");
+                            return;
+                        }
+                    }
+                }
+
+                //main part gets stored as document if not plain text content
+                //(if plain text it will be the body of the final pnote)
+                $all_doc_ids = [];
+                $doc_id = 0;
+                $att_detail = "";
+                if ($mime_type_main != "text/plain" && $mime_type_main != "text/html") {
+                    if ($body_len == 0) {
+                        $att_detail = $att_detail . "\n" . xl("Zero length attachment") . " ($mime_type_main; " .
+                            "0 bytes - " . xl("empty file received") . ") Main message body";
+                        unlink($body);
+                    } else {
+                        $name = uniqid("dm-message-") . phimail_extension($mime_type_main);
+                        $doc_id = phimail_store($name, $mime_type_main, $body);
+                        if (!$doc_id) {
+                            phimail_logit(0, "M7 store non-text body failed");
+                            return;
+                        }
+
+                        $idnum = $doc_id['doc_id'];
+                        $all_doc_ids[] = $idnum;
+                        $url = $doc_id['url'];
+                        if (!is_string($url)) {
+                            phimail_logit(0, "M7 store non-text body returned non-string url");
+                            return;
+                        }
+                        $url = substr($url, strrpos($url, "/") + 1);
+                        $att_detail = "\n" . xl("Document") . " $idnum (\"$url\"; $mime_type_main; " .
+                            filesize($body) . " bytes) Main message body";
+                    }
+                }
+
+                //download and store attachments
+                for ($attnum = 0; $attnum < $att; $attnum++) {
+                    $ret2 = phimail_write_expect_OK($fp, "SHOW " . ($attnum + 1) . "\n");
+                    if ($ret2 !== true) {
+                        phimail_logit(0, "M8 SHOW " . ($attnum + 1) . " failed: " . $ret2);
+                        return;
+                    }
+
+                    //we can ignore next two lines (repeat of name and mime-type)
+                    if (($a1 = fgets($fp)) === false || ($a2 = fgets($fp)) === false) {
+                        phimail_logit(0, "M9 skip attachment " . ($attnum + 1) . " duplicate header lines failed");
+                        return;
+                    }
+
+                    $att_len = fgets($fp); //length of file
+                    $attdata = phimail_read_blob($fp, $att_len);
+                    if ($attdata === false) {
+                        phimail_logit(0, "M10 read attachment " . ($attnum + 1) . " failed");
+                        return;
+                    }
+
+                    $attinfo[$attnum]['file'] = $attdata;
+
+                    $req_name = trim($attinfo[$attnum]['name']);
+                    $req_name = (empty($req_name) ? $attdata : "dm-") . $req_name;
+                    $attinfo[$attnum]['mime'] = explode(";", trim($attinfo[$attnum]['mime']));
+                    $attmime = strtolower($attinfo[$attnum]['mime'][0]);
+
+                    if ($att_len == 0) {
+                        $att_detail = $att_detail . "\n" . xl("Zero length attachment") . " ($attmime; " .
+                            "0 bytes - " . xl("empty file received") . " " . trim($attinfo[$attnum]['desc']);
+                        unlink($attdata);
+                    } else {
+                        $att_doc_id = phimail_store($req_name, $attmime, $attdata);
+                        if (!$att_doc_id) {
+                            phimail_logit(0, "M11 store attachment " . ($attnum + 1) . " failed");
+                            return;
+                        }
+
+                        $attinfo[$attnum]['doc_id'] = $att_doc_id;
+                        $idnum = $att_doc_id['doc_id'];
+                        $all_doc_ids[] = $idnum;
+                        $url = $att_doc_id['url'];
+                        $url = substr((string) $url, strrpos((string) $url, "/") + 1);
+                        $att_detail = $att_detail . "\n" . xl("Document") . " $idnum (\"$url\"; $attmime; " .
+                            $att_doc_id['filesize'] . " bytes) " . trim($attinfo[$attnum]['desc']);
+                    }
+                }
+
+                if ($att_detail != "") {
+                    $att_detail = "\n\n" . xl("The following documents were attached to this Direct message:") . $att_detail;
+                }
+
+                $ret2 = phimail_write_expect_OK($fp, "DONE\n"); //we'll check for failure after logging.
+
+                //logging only after successful download, storage, and acknowledgement of message
+                $sql = "INSERT INTO direct_message_log (msg_type,msg_id,sender,recipient,status,status_ts,user_id) " .
+                    "VALUES ('R', ?, ?, ?, 'R', NOW(), ?)";
+                $res = sqlStatementNoLog($sql, [$msg_id, $sender, $recipient, phimail_service_userID()]);
+
+                phimail_logit(1, $ret);
+
+                //alert appointed user about new message
+                switch ($mime_type_main) {
+                    case "text/plain":
+                        $body_text = @file_get_contents($body); //this was not uploaded as a document
+                        unlink($body);
+                        if (empty($body_text ?? '')) {
+                            $body_text = xl("Please note, this message was received empty and is not an error.");
+                        }
+                        $pnote_id = addPnote(
+                            0,
+                            xl("Direct Message Received.") . "\n$hdrs\n$body_text$att_detail",
+                            0,
+                            1,
+                            "Unassigned",
+                            $notifyUsername,
+                            "",
+                            "New",
+                            "phimail-service"
+                        );
+                        break;
+                    case "text/html":
+                        $body_text = @file_get_contents($body);
+                        unlink($body);
+                        if (empty($body_text ?? '')) {
+                            $body_text = xl("Please note, this message was received empty and is not an error.");
+                        } else {
+                            // meager attempt to convert to text. @TODO convert our Messages message body from textarea to div so can display html.
+                            $body_text = trim(html_entity_decode(strip_tags(str_ireplace(["<br />", "<br>", "<br/>"], PHP_EOL, $body_text))));
+                        }
+                        $pnote_id = addPnote(
+                            0,
+                            xl("Direct Message Received.") . "\n$hdrs\n$body_text$att_detail",
+                            0,
+                            1,
+                            "Unassigned",
+                            $notifyUsername,
+                            "",
+                            "New",
+                            "phimail-service"
+                        );
+                        break;
+
+                    default:
+                        $note = xl("Direct Message Received.") . "\n$hdrs\n"
+                            . xl("Message content is not plain text so it has been stored as a document.") . $att_detail;
+                        $pnote_id = addPnote(0, $note, 0, 1, "Unassigned", $notifyUsername, "", "New", "phimail-service");
+                        break;
+                }
+
+                foreach ($all_doc_ids as $doc_id) {
+                    setGpRelation(1, $doc_id, 6, $pnote_id);
+                }
+
+                if ($ret2 !== true) {
+                    phimail_logit(0, "M12 DONE failed: " . $ret2);
+                    return;
+                }
+            } else { //unrecognized or FAIL response
+                phimail_logit(0, "M16 unexpected problem checking messages " . $ret);
+                return;
+            }
+        }
+    } finally {
+        phimail_close($fp);
     }
 }
 
@@ -502,7 +495,6 @@ function phimail_write_expect_OK($fp, $text)
     phimail_write($fp, $text);
     $ret = fgets($fp);
     if ($ret != "OK\n") { //unexpected error
-        phimail_close($fp);
         return $ret;
     }
 


### PR DESCRIPTION
## Summary

Fixes #11471.

The phiMail Direct Messaging protocol clients in `ccr/transmitCCD.php` (`transmitMessage`, `transmitCCD`) and `library/direct_message_check.inc.php` (`phimail_check`) opened a socket via `phimail_connect()` and relied on scattered `phimail_close($fp)` calls along every return path to release it. Many early-return paths skipped the close entirely, so any protocol-level error — AUTH failed, TO failed, SET FINAL failed, SHOW failed, mid-loop SQL failure, header read failure, attachment read/store failure, and more — leaked the socket handle until the request ended.

This PR wraps the body of each function from `phimail_connect()` through the last use of `$fp` in a `try`/`finally`, and moves `phimail_close($fp)` into the `finally` block. Every in-body `phimail_close()` call is deleted. The control flow becomes obvious and the socket is deterministically released on every exit path, including unexpected exceptions from any of the helpers (`phimail_read_blob`, `phimail_store`, SQL helpers, `addPnote`, `setGpRelation`, etc.).

## Narrow try/finally scope

The crypto setup (`$phimail_username` / `$cryptoGen` / `$phimail_password`) and the `$notifyUsername` fallback in `phimail_check()` are hoisted above `phimail_connect()` so the `try` block contains only socket-using code. The principle — anything that can be computed before the resource is acquired does not belong inside the `try` — is now documented as a coding convention in ocemr-docs.

## Related cleanups

While reindenting the affected blocks, this PR also addresses review feedback on the surrounding code quality:

- **SET FINAL duplication.** Collapse the `SET FINAL 0/1` if/else duplication in both `transmitMessage()` and `transmitCCD()` into a single ternary on the flag value — the two branches differed only in `'0'` vs `'1'`.
- **Format dispatch.** Convert `transmitCCD()`'s `$format_type` if/elseif/elseif/else chain to a `match` expression. Full enum conversion for `$format_type` and `$xml_type` is tracked separately in #11483 because it touches every caller.
- **Narrow, don't cast.** Replace `(string) $url` / `strrpos((string) $url, ...)` in `phimail_check()` with an explicit `is_string($url)` narrow plus log + return on the false case. This incidentally drops two pre-existing entries each from the `binaryOp.invalid.php` and `cast.string.php` PHPStan baselines.

## `phimail_write_expect_OK` no longer closes

`phimail_write_expect_OK()` previously called `phimail_close($fp)` internally on the non-OK path. With the lifecycle now managed by `try`/`finally` in the caller, having the helper close as a side effect was both misleading and caused an actual pre-existing double-close bug in several paths (where the caller then explicitly called `phimail_close()` again on top of the helper's internal close). The helper is now pure "write + check OK" — callers own the socket lifecycle.

Correspondingly, `phimail_connect()`'s own INFO VER failure path (the `C5` error branch) now explicitly closes before setting `$fp = false`, since that site used to rely on `phimail_write_expect_OK`'s internal close.

## Scope

Mechanical. No behavior change on the happy path. On every error path the socket is closed exactly once, where previously it was either leaked or double-closed. The diff is dominated by reindentation inside the `try` blocks; the logic itself is unchanged.

## Test plan

- [x] `php -l` clean on both files
- [x] PHPStan level 10, phpcs, rector, composer-require-checker — all pre-commit hooks pass
- [ ] Manual exercise of Direct Messaging requires a phiMail server; relying on review for the protocol logic and CI for the static checks

## Related

- #11463 / #11470 — the `fgets()` length-limit fix in the same files; this issue was bycatch from that audit.
- #11474 — unchecked `fgets()` `false` returns in the same parsers (still open; independent of this PR).
- #11483 — follow-up: convert `$format_type` and `$xml_type` to backed enums (surfaced during review of this PR).