### PR TITLE
fix(faxsms): stop resending appointment reminder emails every hour

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -5657,16 +5657,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/phone-services/voice_webhook.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\+" between \'01\'\\|\'02\'\\|\'03\'\\|\'04\'\\|\'05\'\\|\'06\'\\|\'07\'\\|\'08\'\\|\'09\'\\|\'10\'\\|\'11\'\\|\'12\' and mixed results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\-" between float and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
     'count' => 5,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',

--- a/.phpstan/baseline/function.nameCase.php
+++ b/.phpstan/baseline/function.nameCase.php
@@ -122,11 +122,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/classes/smtp/smtp.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to function cron_GetAlertPatientData\\(\\) with incorrect case\\: cron_getAlertpatientData$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_email_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to function cron_GetNotificationData\\(\\) with incorrect case\\: cron_getNotificationData$#',
     'count' => 2,
     'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_email_notification.php',
@@ -135,11 +130,6 @@ $ignoreErrors[] = [
     'message' => '#^Call to function cron_SetMessage\\(\\) with incorrect case\\: cron_setmessage$#',
     'count' => 1,
     'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_email_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to function cron_GetAlertPatientData\\(\\) with incorrect case\\: cron_getAlertpatientData$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_sms_notification.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to function cron_GetNotificationData\\(\\) with incorrect case\\: cron_getNotificationData$#',

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -907,11 +907,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-ehi-exporter/src/TableDefinitions/ExportTableDefinition.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function cron_GetAlertPatientData\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function cron_GetNotificationData\\(\\) return type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -17307,11 +17307,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function cron_getAlertpatientData\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function cron_getNotificationData\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_functions.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -15372,11 +15372,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/phone-services/voice_webhook.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'email\' on mixed\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'email_message\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
@@ -15389,16 +15384,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'email_subject\' on mixed\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'fname\' on mixed\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'lname\' on mixed\\.$#',
-    'count' => 4,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
 ];
 $ignoreErrors[] = [
@@ -15417,38 +15402,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pc_eid\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pc_eventDate\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'pc_recurrspec\' on mixed\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pc_recurrtype\' on mixed\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pc_startTime\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'phone_cell\' on mixed\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pid\' on mixed\\.$#',
-    'count' => 4,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
 ];
 $ignoreErrors[] = [
@@ -15468,21 +15423,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'type\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ufname\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ulname\' on mixed\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'utitle\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
 ];
@@ -38037,32 +37977,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_email_notification.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'email\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_email_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'message\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_email_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pc_eid\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_email_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pc_eventDate\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_email_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pc_startTime\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_email_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pid\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_email_notification.php',
 ];
@@ -38178,31 +38093,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'message\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pc_eid\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pc_eventDate\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pc_startTime\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'phone_cell\' on mixed\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pid\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../modules/sms_email_reminder/cron_sms_notification.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
@@ -742,11 +742,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-dorn/src/ReceiveHl7Results.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use of the "global" keyword is forbidden \\(\\$SMS_NOTIFICATION_HOUR, \\$TYPE\\)\\. Use dependency injection instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use of the "global" keyword is forbidden \\(\\$bTestRun\\)\\. Use dependency injection instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',

--- a/.phpstan/baseline/openemr.noGlobalNsFunctions.php
+++ b/.phpstan/baseline/openemr.noGlobalNsFunctions.php
@@ -2332,11 +2332,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/phone-services/voice_webhook.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function cron_GetAlertPatientData may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function cron_GetNotificationData may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
@@ -2353,6 +2348,11 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Function displayHelp may not be defined in the global namespace\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Function faxsms_getAlertPatientData may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
 ];

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -692,11 +692,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/ModuleManagerListener.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function cron_GetAlertPatientData\\(\\) should return array but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function rc_sms_notification_cron_update_entry\\(\\) should return int but returns ADORecordSet\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,34 @@ Isolated tests run on the host without a database or Docker:
 composer phpunit-isolated        # Run all isolated tests
 ```
 
+### Data providers: mark as `@codeCoverageIgnore`
+
+PHPUnit data provider methods execute *before* coverage instrumentation
+starts, so their lines never register as "hit" even though they run on every
+test. Without an explicit ignore they show up as uncovered in Codecov
+patch-coverage reports and drag the number down for no real reason (a
+10-case data provider = 10 spurious "missing" lines on every new test).
+
+Annotate every data provider with the standard comment used elsewhere in
+this repo (see `tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php`):
+
+```php
+/**
+ * @return array<string, array{string, int}>
+ *
+ * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+ */
+public static function exampleProvider(): array
+{
+    return [
+        'case one' => ['input-1', 1],
+        'case two' => ['input-2', 2],
+    ];
+}
+```
+
+Use this exact wording so a repo-wide grep finds every provider in one pass.
+
 ### Twig template tests
 
 Twig templates have two layers of testing (both isolated):

--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
@@ -21,6 +21,7 @@ use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Controller\AppDispatch;
+use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
 use OpenEMR\Modules\FaxSMS\Exception\EmailSendFailedException;
 use OpenEMR\Modules\FaxSMS\Exception\InvalidEmailAddressException;
 use OpenEMR\Modules\FaxSMS\Exception\SmtpNotConfiguredException;
@@ -107,7 +108,8 @@ if ($TYPE === "EMAIL") {
 session_write_close();
 set_time_limit(0);
 
-$SMS_NOTIFICATION_HOUR = $cred['smsHours'] ?? $cred['notification_hours'] ?? 24;
+$smsNotificationHourRaw = $cred['smsHours'] ?? $cred['notification_hours'] ?? 24;
+$SMS_NOTIFICATION_HOUR = is_numeric($smsNotificationHourRaw) ? (int) $smsNotificationHourRaw : 24;
 $MESSAGE = $cred['smsMessage'] ?? $cred['email_message'];
 
 // check command line for quite option
@@ -145,8 +147,8 @@ $db_sms_msg['message'] = $MESSAGE;
             if ($bTestRun) {
                 echo xlt("We are in Test Mode and no reminders will be sent. This test will check what reminders will be sent in when running Live Mode.");
             }
-            $db_patient = cron_GetAlertPatientData();
-            echo "\n<br>" . xlt('Total of') . ": " . count($db_patient ?? []) . " " . xlt('Reminders Found') . " " . ($bTestRun ? xlt("and will be sending for reminders") . " " : xlt("and Sending for reminders ")) . ' ' . text($SMS_NOTIFICATION_HOUR) . ' ' . xlt("hrs from now.");
+            $db_patient = faxsms_getAlertPatientData(NotificationChannel::fromLegacyType($TYPE), $SMS_NOTIFICATION_HOUR);
+            echo "\n<br>" . xlt('Total of') . ": " . count($db_patient ?? []) . " " . xlt('Reminders Found') . " " . ($bTestRun ? xlt("and will be sending for reminders") . " " : xlt("and Sending for reminders ")) . ' ' . $SMS_NOTIFICATION_HOUR . ' ' . xlt("hrs from now.");
             ob_flush();
             flush();
             // for every event found
@@ -171,7 +173,7 @@ $db_sms_msg['message'] = $MESSAGE;
                     echo "<h4>" . xlt("For Provider") . ": " . text($prow['utitle']) . ' ' . text($prow['ufname']) . ' ' . text($prow['ulname']) . "</h4>";
                     $plast = $prow['ulname'];
                 }
-                $strMsg = "<strong>* " . xlt("SEND NOTIFICATION BEFORE:") . text($SMS_NOTIFICATION_HOUR) . " | " . xlt("CRONJOB RUNS EVERY:") . text($CRON_TIME) . " | " . xlt("APPOINTMENT DATE TIME") . ': ' . $app_date . " | " . xlt("APPOINTMENT REMAINING HOURS") . ": " . text($remaining_app_hour) . " | " . xlt("SEND ALERT AFTER") . ': ' . text($remain_hour) . "</strong>";
+                $strMsg = "<strong>* " . xlt("SEND NOTIFICATION BEFORE:") . $SMS_NOTIFICATION_HOUR . " | " . xlt("CRONJOB RUNS EVERY:") . $CRON_TIME . " | " . xlt("APPOINTMENT DATE TIME") . ': ' . $app_date . " | " . xlt("APPOINTMENT REMAINING HOURS") . ": " . text($remaining_app_hour) . " | " . xlt("SEND ALERT AFTER") . ': ' . text($remain_hour) . "</strong>";
 
                 // check in the interval
                 if ($remain_hour >= -($CRON_TIME) && $remain_hour <= $CRON_TIME) {
@@ -320,23 +322,40 @@ function rc_sms_notification_cron_update_entry($type, $pid, $pc_eid, $recur = ''
 
 /**
  * Cron Get Alert Patient Data
- * *
  *
- * @param $type
- * @return array
+ * Pass the notification channel and hours-ahead explicitly rather than reading
+ * them from globals. The Background Services entry path loads this file via
+ * require_once from inside a function, which traps the file's top-level
+ * variables as function locals — `global $TYPE` then sees null and the wrong
+ * WHERE clause runs, causing duplicate email reminders. See issue #11477.
+ *
+ * Renamed from `cron_GetAlertPatientData()` to a module-prefixed name to avoid
+ * a PHP case-insensitive collision with the legacy `cron_getAlertpatientData()`
+ * in `modules/sms_email_reminder/cron_functions.php`.
+ *
+ * @return list<array<mixed>>
  */
-function cron_GetAlertPatientData()
+function faxsms_getAlertPatientData(NotificationChannel $channel, int $notificationHour): array
 {
-    global $SMS_NOTIFICATION_HOUR, $TYPE;
-    $where = " AND (p.hipaa_allowsms='YES' AND p.phone_cell<>'' AND (e.pc_sendalertsms != 'YES' || e.pc_apptstatus != 'SMS') AND e.pc_apptstatus != 'x')";
-    if ($TYPE == 'EMAIL') {
-        $where = " AND (p.hipaa_allowemail='YES' AND p.email<>'' AND (e.pc_sendalertemail != 'YES' || e.pc_apptstatus != 'EMAIL') AND e.pc_apptstatus != 'x')";
-    }
-    $adj_date = date("h") + $SMS_NOTIFICATION_HOUR;
-    $check_date = date("Y-m-d", mktime($adj_date, 0, 0, date("m"), date("d"), date("Y")));
-    $patient_array = fetchEvents($check_date, $check_date, $where, 'u.lname,pc_startTime,p.lname');
+    $where = match ($channel) {
+        NotificationChannel::EMAIL => " AND (p.hipaa_allowemail='YES' AND p.email<>'' AND (e.pc_sendalertemail != 'YES' || e.pc_apptstatus != 'EMAIL') AND e.pc_apptstatus != 'x')",
+        NotificationChannel::SMS   => " AND (p.hipaa_allowsms='YES' AND p.phone_cell<>'' AND (e.pc_sendalertsms != 'YES' || e.pc_apptstatus != 'SMS') AND e.pc_apptstatus != 'x')",
+    };
+    $adj_date = (int)date("H") + $notificationHour;
+    $check_date = date("Y-m-d", mktime($adj_date, 0, 0, (int)date("m"), (int)date("d"), (int)date("Y")));
 
-    return $patient_array;
+    $events = fetchEvents($check_date, $check_date, $where, 'u.lname,pc_startTime,p.lname');
+    if (!is_array($events)) {
+        return [];
+    }
+
+    $normalized = [];
+    foreach ($events as $event) {
+        if (is_array($event)) {
+            $normalized[] = $event;
+        }
+    }
+    return $normalized;
 }
 
 /**

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Enums/NotificationChannel.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Enums/NotificationChannel.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Notification Channel Enum
+ *
+ * Identifies the channel used for an appointment-reminder notification
+ * (currently SMS or email). Used to replace stringly-typed `$TYPE` parameters
+ * in the legacy faxsms reminder helpers (e.g. faxsms_getAlertPatientData()).
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\FaxSMS\Enums;
+
+enum NotificationChannel: string
+{
+    case SMS = 'SMS';
+    case EMAIL = 'EMAIL';
+
+    /**
+     * Parse a legacy `$TYPE` string (case-insensitive) into a channel,
+     * defaulting to SMS for unrecognized values to match the historical
+     * fall-through behavior of `cron_GetAlertPatientData()`.
+     */
+    public static function fromLegacyType(?string $type): self
+    {
+        return self::tryFrom(strtoupper((string) $type)) ?? self::SMS;
+    }
+}

--- a/modules/sms_email_reminder/cron_email_notification.php
+++ b/modules/sms_email_reminder/cron_email_notification.php
@@ -41,7 +41,7 @@ $db_email_msg = cron_getNotificationData($TYPE);
 //my_print_r($db_email_msg);
 
 // get patient data for send alert
-$db_patient = cron_getAlertpatientData();
+$db_patient = cron_getAlertpatientData($TYPE);
 echo "<br />Total " . count($db_patient) . " Records Found\n";
 for ($p = 0; $p < count($db_patient); $p++) {
     $prow = $db_patient[$p];

--- a/modules/sms_email_reminder/cron_functions.php
+++ b/modules/sms_email_reminder/cron_functions.php
@@ -215,7 +215,10 @@ function cron_SendSMS(sms_interface $mysms, $to, $subject, $vBody, $from)
 // Function:    cron_getAlertpatientData
 // Purpose: get patient data for send to alert
 ////////////////////////////////////////////////////////////////////
-function cron_getAlertpatientData($type)
+/**
+ * @return list<array<mixed>>
+ */
+function cron_getAlertpatientData($type): array
 {
     // larry :: move this at the top - not in the function body
     global $SMS_NOTIFICATION_HOUR,$EMAIL_NOTIFICATION_HOUR;
@@ -256,10 +259,8 @@ function cron_getAlertpatientData($type)
 
     $db_patient = (sqlStatement($query));
     $patient_array = [];
-    $cnt = 0;
     while ($prow = sqlFetchArray($db_patient)) {
-        $patient_array[$cnt] = $prow;
-        $cnt++;
+        $patient_array[] = $prow;
     }
 
     return $patient_array;

--- a/modules/sms_email_reminder/cron_sms_notification.php
+++ b/modules/sms_email_reminder/cron_sms_notification.php
@@ -61,7 +61,7 @@ $mysms = match ($db_email_msg['sms_gateway_type']) {
 };
 
 
-$db_patient = cron_getAlertpatientData();
+$db_patient = cron_getAlertpatientData($TYPE);
 echo "\n<br />Total " . text(count($db_patient)) . " Records Found";
 
 // for every event found

--- a/tests/Tests/Api/ApiTestClient.php
+++ b/tests/Tests/Api/ApiTestClient.php
@@ -22,7 +22,7 @@ use Psr\Log\NullLogger;
  * @author    Dixon Whitmire <dixonwh@gmail.com>
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2020 Dixon Whitmire <dixonwh@gmail.com>
- * @copyright Copyright (c) 2026 Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */

--- a/tests/Tests/Api/BulkAPITestClient.php
+++ b/tests/Tests/Api/BulkAPITestClient.php
@@ -20,7 +20,7 @@ use Psr\Log\NullLogger;
  * @author    Stephen Nielson <snielson@discoverandchange.com>
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 Discover and Change, Inc. <snielson@discoverandchange.com>
- * @copyright Copyright (c) 2026 Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */

--- a/tests/Tests/Isolated/Modules/FaxSMS/Enums/NotificationChannelTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Enums/NotificationChannelTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Isolated NotificationChannel Test
+ *
+ * Tests the NotificationChannel enum's fromLegacyType() factory, which
+ * normalizes the legacy stringly-typed $TYPE global into the typed enum.
+ * The factory's behavior gates which WHERE clause runs in
+ * cron_GetAlertPatientData(), so its mapping must be exhaustively covered.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Modules\FaxSMS\Enums;
+
+use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+// The faxsms module's classes are not registered in the root composer
+// autoloader (the module is loaded by OpenEMR's runtime module system).
+// Pull the enum file in directly so this isolated test can run without
+// bootstrapping the full module loader.
+require_once __DIR__ . '/../../../../../../interface/modules/custom_modules/oe-module-faxsms/src/Enums/NotificationChannel.php';
+
+class NotificationChannelTest extends TestCase
+{
+    #[DataProvider('legacyTypeProvider')]
+    public function testFromLegacyType(?string $input, NotificationChannel $expected): void
+    {
+        $this->assertSame($expected, NotificationChannel::fromLegacyType($input));
+    }
+
+    /**
+     * @return array<string, array{?string, NotificationChannel}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function legacyTypeProvider(): array
+    {
+        return [
+            'uppercase EMAIL'         => ['EMAIL', NotificationChannel::EMAIL],
+            'lowercase email'         => ['email', NotificationChannel::EMAIL],
+            'mixed-case Email'        => ['Email', NotificationChannel::EMAIL],
+            'uppercase SMS'           => ['SMS', NotificationChannel::SMS],
+            'lowercase sms'           => ['sms', NotificationChannel::SMS],
+            'mixed-case Sms'          => ['Sms', NotificationChannel::SMS],
+            'null defaults to SMS'    => [null, NotificationChannel::SMS],
+            'empty string defaults'   => ['', NotificationChannel::SMS],
+            'unknown defaults to SMS' => ['fax', NotificationChannel::SMS],
+            'whitespace defaults'     => ['  ', NotificationChannel::SMS],
+        ];
+    }
+}

--- a/tests/Tests/Isolated/RestControllers/Authorization/EhrLaunchPatientContextTest.php
+++ b/tests/Tests/Isolated/RestControllers/Authorization/EhrLaunchPatientContextTest.php
@@ -13,7 +13,7 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>
- * @copyright Copyright (c) 2026 Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/Isolated/RestControllers/EncounterRestControllerTest.php
+++ b/tests/Tests/Isolated/RestControllers/EncounterRestControllerTest.php
@@ -6,7 +6,7 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>
- * @copyright Copyright (c) 2026 Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/Isolated/RestControllers/Subscriber/SessionCleanupListenerTest.php
+++ b/tests/Tests/Isolated/RestControllers/Subscriber/SessionCleanupListenerTest.php
@@ -10,7 +10,7 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>
- * @copyright Copyright (c) 2026 Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/Isolated/RestControllers/Subscriber/SiteSetupListenerTest.php
+++ b/tests/Tests/Isolated/RestControllers/Subscriber/SiteSetupListenerTest.php
@@ -10,7 +10,7 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>
- * @copyright Copyright (c) 2026 Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 


### PR DESCRIPTION
Fixes #11477.

## Problem

When the `Notification_Email_Task` background service is enabled, any patient with both `hipaa_allowemail='YES'` and `hipaa_allowsms='YES'` (and a non-empty `phone_cell`) receives an appointment reminder email **every hour** for as long as the appointment date is \"today,\" instead of exactly one reminder per appointment.

## Root cause

`cron_GetAlertPatientData()` in `interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php` reads `$TYPE` and `$SMS_NOTIFICATION_HOUR` via `global`. The CLI entry point works because those variables land in real global scope. The Background Services entry point does not: `doEmailNotificationTask()` loads `rc_sms_notification.php` via `require_once` *from inside the function*, which traps the file's top-level variables as locals of `doEmailNotificationTask()`. `global \$TYPE` then sees `null`, the SMS WHERE clause runs instead of the EMAIL one, and dedup checks the wrong columns (`pc_sendalertsms` / `pc_apptstatus != 'SMS'`). The surrounding send loop is in the same function scope, so it still sees the correct `\$TYPE === 'EMAIL'`, sends the email, and updates the email dedup columns — which the next iteration's SELECT never looks at. The row matches again and the loop never terminates.

See #11477 for the full write-up, origin analysis, and reproduction steps.

## Fix

- `cron_GetAlertPatientData()` now takes the notification channel and hours-ahead as explicit parameters. No more `global`.
- The channel parameter is a new `NotificationChannel` backed enum (`SMS` / `EMAIL`) with a `fromLegacyType()` factory that normalizes the legacy stringly-typed `\$TYPE` global. The WHERE-clause selection is now an exhaustive `match` on the enum.
- `\$SMS_NOTIFICATION_HOUR` is narrowed to `int` at its initialization so the call site does not need a cast.
- Drive-by: `date(\"h\")` → `date(\"H\")` inside the function (the 12-hour wall-clock hour was mentioned in #11477 as a second latent bug in the same `mktime()` call).

The CLI entry path and the Background Services entry path now behave identically with respect to which WHERE clause runs.

## Not addressed here (tracked separately)

The four \"other latent issues\" called out in the #11477 write-up are filed as follow-ups so they can ship independently:

- #11479 — `pc_apptstatus` is clobbered by the dedup UPDATE with the literal strings `'EMAIL'` / `'SMS'`, destroying the real appointment status column.
- #11480 — `rc_sms_notification_cron_update_entry()` short-circuits on `pc_recurrtype > 0`, so once this PR lands recurring events will still re-send hourly.
- #11481 — `\$CRON_TIME = 150` makes the time-window guard a no-op.
- #11482 — the second `date(\"h\")` at line 121 (outside the function this PR fixes) is still on the 12-hour clock.

## Test plan

- [ ] Unit-style check: `NotificationChannel::fromLegacyType()` returns EMAIL/SMS for the expected inputs and defaults to SMS for unknown input.
- [ ] Manual: enable `Notification_Email_Task`, create a patient with both HIPAA flags YES and an appointment today, let the background service run at least twice, verify only one row is added to `notification_log` for that `pc_eid` and only one email is sent.
- [ ] Manual: CLI path (`php rc_sms_notification.php type=email site=...`) continues to work unchanged.
- [ ] PHPStan and full composer code-quality suite pass.