### PR TITLE
refactor(database): migrate sqlBeginTrans call sites to QueryUtils::inTransaction

### DIFF
--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1503,7 +1503,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 8,
+    'count' => 4,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -9517,11 +9517,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/procedure_order/procedure_order_save_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'increment\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/procedure_order/procedure_order_save_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'procedure_order_title\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/procedure_order/procedure_order_save_functions.php',

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -1257,21 +1257,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/procedure_order/delete.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlBeginTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/procedure_order/handle_deletions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlCommitTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/procedure_order/handle_deletions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlRollbackTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/procedure_order/handle_deletions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/procedure_order/handle_deletions.php',
@@ -1287,18 +1272,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/procedure_order/procedure_order_save_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlBeginTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/procedure_order/procedure_order_save_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlCommitTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/procedure_order/procedure_order_save_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/forms/procedure_order/procedure_order_save_functions.php',
 ];
 $ignoreErrors[] = [
@@ -1308,7 +1283,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 12,
+    'count' => 11,
     'path' => __DIR__ . '/../../interface/forms/procedure_order/procedure_order_save_functions.php',
 ];
 $ignoreErrors[] = [
@@ -1927,16 +1902,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-dorn/src/ReceiveHl7Results.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlBeginTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-dorn/src/ReceiveHl7Results.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlCommitTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-dorn/src/ReceiveHl7Results.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
     'count' => 13,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-dorn/src/ReceiveHl7Results.php',
@@ -2432,21 +2397,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlBeginTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlCommitTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlRollbackTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
     'count' => 7,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php',
@@ -2455,21 +2405,6 @@ $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlBeginTrans\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlCommitTrans\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlRollbackTrans\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
@@ -2724,16 +2659,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../interface/orders/receive_hl7_results.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlBeginTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/orders/receive_hl7_results.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlCommitTrans\\(\\)\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/orders/receive_hl7_results.inc.php',
 ];
 $ignoreErrors[] = [
@@ -6392,16 +6317,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Billing/BillingUtilities.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlBeginTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/BillingUtilities.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlCommitTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/BillingUtilities.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
     'count' => 10,
     'path' => __DIR__ . '/../../src/Billing/BillingUtilities.php',
@@ -6828,21 +6743,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Uuid/UuidMapping.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlBeginTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Uuid/UuidMapping.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlCommitTrans\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Uuid/UuidMapping.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlRollbackTrans\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Uuid/UuidMapping.php',
 ];
@@ -7550,16 +7450,6 @@ $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
     'count' => 7,
     'path' => __DIR__ . '/../../src/Services/PatientTrackerService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlBeginTrans\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/PatientTransactionService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:inTransaction\\(\\) instead of sqlCommitTrans\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/PatientTransactionService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlInsert\\(\\) instead of sqlInsert\\(\\)\\.$#',

--- a/interface/forms/procedure_order/handle_deletions.php
+++ b/interface/forms/procedure_order/handle_deletions.php
@@ -18,6 +18,7 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AccessDeniedResponseFormat;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
@@ -70,9 +71,7 @@ function deleteProcedure()
         return ['success' => false, 'error' => 'Missing required parameters'];
     }
 
-    sqlBeginTrans();
-
-    try {
+    return QueryUtils::inTransaction(function () use ($orderId, $orderSeq) {
         // Delete procedure answers (QOE)
         sqlStatement(
             "DELETE FROM procedure_answers
@@ -110,16 +109,11 @@ function deleteProcedure()
             );
         }
 
-        sqlCommitTrans();
-
         return [
             'success' => true,
             'orderEmpty' => ($remaining['cnt'] == 0)
         ];
-    } catch (\Throwable $e) {
-        sqlRollbackTrans();
-        throw $e;
-    }
+    });
 }
 
 /**

--- a/interface/forms/procedure_order/procedure_order_save_functions.php
+++ b/interface/forms/procedure_order/procedure_order_save_functions.php
@@ -10,6 +10,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Uuid\UuidRegistry;
 
@@ -634,27 +635,32 @@ function saveProcedureAnswers($formid, $poseq, $ptid, $postData, $index): void
         }
 
         foreach ($data as $datum) {
-            sqlBeginTrans();
-            $answer_seq = sqlQuery(
-                "SELECT IFNULL(MAX(answer_seq), 0) + 1 AS increment
-                 FROM procedure_answers
-                 WHERE procedure_order_id = ?
-                   AND procedure_order_seq = ?
-                   AND question_code = ?",
-                [$formid, $poseq, $qcode]
-            );
+            QueryUtils::inTransaction(function () use ($formid, $poseq, $qcode, $datum, $pcode): void {
+                $answerSeq = QueryUtils::fetchSingleValue(
+                    <<<'SQL'
+                    SELECT IFNULL(MAX(answer_seq), 0) + 1 AS increment
+                    FROM procedure_answers
+                    WHERE procedure_order_id = ?
+                      AND procedure_order_seq = ?
+                      AND question_code = ?
+                    SQL,
+                    'increment',
+                    [$formid, $poseq, $qcode]
+                );
 
-            sqlStatement(
-                "INSERT INTO procedure_answers SET
-                 procedure_order_id = ?,
-                 procedure_order_seq = ?,
-                 question_code = ?,
-                 answer_seq = ?,
-                 answer = ?,
-                 procedure_code = ?",
-                [$formid, $poseq, $qcode, $answer_seq['increment'], trim((string) $datum), $pcode]
-            );
-            sqlCommitTrans();
+                QueryUtils::sqlStatementThrowException(
+                    <<<'SQL'
+                    INSERT INTO procedure_answers SET
+                        procedure_order_id = ?,
+                        procedure_order_seq = ?,
+                        question_code = ?,
+                        answer_seq = ?,
+                        answer = ?,
+                        procedure_code = ?
+                    SQL,
+                    [$formid, $poseq, $qcode, $answerSeq, trim((string) $datum), $pcode]
+                );
+            });
         }
     }
 }

--- a/interface/modules/custom_modules/oe-module-dorn/src/ReceiveHl7Results.php
+++ b/interface/modules/custom_modules/oe-module-dorn/src/ReceiveHl7Results.php
@@ -687,32 +687,37 @@ class ReceiveHl7Results
                         $lkup = $this->lookupTestCode($lab_id, $in_procedure_code);
                         $code_type = ($lkup['procedure_type'] ?? '') ? trim($lkup['procedure_type']) : '';
                         $code_transport = ($lkup['transport'] ?? '') ? trim($lkup['transport']) : '';
-                        sqlBeginTrans();
-                        $procedure_order_seq = sqlQuery(
-                            "SELECT IFNULL(MAX(procedure_order_seq),0) + 1 AS increment FROM procedure_order_code " .
-                            "WHERE procedure_order_id = ? ",
-                            [$in_orderid]
-                        );
-                        sqlInsert(
-                            "INSERT INTO procedure_order_code SET " .
-                            "procedure_order_id = ?, " .
-                            "procedure_order_seq = ?, " .
-                            "procedure_code = ?, " .
-                            "procedure_name = ?, " .
-                            "procedure_type = ?, " .
-                            "transport = ?, " .
-                            "procedure_source = '2'",
-                            [
-                                $in_orderid,
-                                $procedure_order_seq['increment'],
-                                $in_procedure_code,
-                                $in_procedure_name,
-                                $code_type,
-                                $code_transport
-                            ]
-                        );
-                        $pcrow = sqlQuery($pcquery, $pcqueryargs);
-                        sqlCommitTrans();
+                        $pcrow = QueryUtils::inTransaction(function () use ($in_orderid, $in_procedure_code, $in_procedure_name, $code_type, $code_transport, $pcquery, $pcqueryargs) {
+                            $procedure_order_seq = sqlQuery(
+                                <<<'SQL'
+                                SELECT IFNULL(MAX(procedure_order_seq), 0) + 1 AS increment
+                                FROM procedure_order_code
+                                WHERE procedure_order_id = ?
+                                SQL,
+                                [$in_orderid]
+                            );
+                            sqlInsert(
+                                <<<'SQL'
+                                INSERT INTO procedure_order_code SET
+                                    procedure_order_id = ?,
+                                    procedure_order_seq = ?,
+                                    procedure_code = ?,
+                                    procedure_name = ?,
+                                    procedure_type = ?,
+                                    transport = ?,
+                                    procedure_source = '2'
+                                SQL,
+                                [
+                                    $in_orderid,
+                                    $procedure_order_seq['increment'],
+                                    $in_procedure_code,
+                                    $in_procedure_name,
+                                    $code_type,
+                                    $code_transport,
+                                ]
+                            );
+                            return sqlQuery($pcquery, $pcqueryargs);
+                        });
                     } else {
                         // Dry run, make a dummy procedure_order_code row.
                         $pcrow = [

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
@@ -3930,9 +3930,8 @@ class EncounterccdadispatchTable
 
         $mimeType = "text/xml";
 
-        try {
-            \sqlBeginTrans();
-
+        // TODO: @adunsulag do we need to clean up the file if we fail to commit the transaction here?
+        $moduleInsertId = QueryUtils::inTransaction(function () use ($document, $pid, $categoryId, $file_name, $mimeType, $content, $binaryUuid, $encounter, $time, $status, $user_id, $view, $transfer, $emr_transfer) {
             // set the foreign key so we can track documents connected to a specific export
             $result = $document->createDocument(
                 $pid,
@@ -3969,12 +3968,9 @@ class EncounterccdadispatchTable
                 $document->set_encounter_id($encounter);
             }
             $document->persist(); // save the updated references here.
-            \sqlCommitTrans();
-        } catch (\Throwable $exception) {
-            \sqlRollbackTrans();
-            // TODO: @adunsulag do we need to clean up the file if we fail to commit the transaction here?
-            throw $exception;
-        }
+
+            return $moduleInsertId;
+        });
         return new GeneratedCcdaResult($moduleInsertId, UuidRegistry::uuidToString($binaryUuid), $file_name, $content);
     }
 

--- a/interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php
+++ b/interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php
@@ -227,23 +227,26 @@ class CodeTypeEventsSubscriber implements EventSubscriberInterface
     private function updateSNOMEDCTMappingsForList($mappings, $list_id, $logger = null)
     {
         // update our list options
+        $sql = null;
+        $values = null;
         try {
-            \sqlBeginTrans();
-            foreach ($mappings as $option_id => $code_id) {
-                $sql = "UPDATE list_options SET codes=CONCAT('SNOMED-CT:', ?) WHERE list_id=? AND option_id=?";
-                $values = [$code_id, $list_id, $option_id];
-                QueryUtils::sqlStatementThrowException($sql, $values);
-                if (!empty($logger) && is_callable($logger)) {
-                    $logger(xl('Success') . ' - (sql=`"' . $sql . '`, values=`' . var_export($values, true) . "`)");
+            QueryUtils::inTransaction(function () use ($mappings, $list_id, $logger, &$sql, &$values): void {
+                foreach ($mappings as $option_id => $code_id) {
+                    $sql = <<<'SQL'
+                    UPDATE list_options SET codes = CONCAT('SNOMED-CT:', ?) WHERE list_id = ? AND option_id = ?
+                    SQL;
+                    $values = [$code_id, $list_id, $option_id];
+                    QueryUtils::sqlStatementThrowException($sql, $values);
+                    if (is_callable($logger)) {
+                        $logger(xl('Success') . ' - (sql=`' . $sql . '`, values=`' . var_export($values, true) . '`)');
+                    }
                 }
-            }
-            \sqlCommitTrans();
+            });
         } catch (\Throwable $exception) {
             ServiceContainer::getLogger()->error($exception->getMessage(), ['exception' => $exception]);
-            if (!empty($logger) && is_callable($logger)) {
-                $logger(xl('Failed') . ' - (sql=`"' . ($sql ?? 'N/A') . '`, values=`' . var_export($values ?? [], true) . "`)");
+            if (is_callable($logger)) {
+                $logger(xl('Failed') . ' - (sql=`' . ($sql ?? 'N/A') . '`, values=`' . var_export($values ?? [], true) . '`)');
             }
-            \sqlRollbackTrans();
         }
     }
 
@@ -251,27 +254,35 @@ class CodeTypeEventsSubscriber implements EventSubscriberInterface
     {
         // update our list options
         try {
-            \sqlBeginTrans();
-            foreach (self::CPT4_ENCOUNTER_TYPE_MAPPINGS as $option_id => $code_text) {
-                $code_id = QueryUtils::fetchSingleValue("SELECT `code` FROM codes WHERE code_text =? "
-                    . " AND code_type IN (SELECT ct_id FROM code_types WHERE ct_key = 'CPT4')", 'code', [$code_text]);
-                if (empty($code_id)) {
-                    ServiceContainer::getLogger()->debug(
-                        "Failed to find cpt4 code in codes with code_text. Skipping option_id",
-                        ['code_text' => $code_text, 'option_id' => $option_id]
+            QueryUtils::inTransaction(function () use ($logger): void {
+                foreach (self::CPT4_ENCOUNTER_TYPE_MAPPINGS as $option_id => $code_text) {
+                    $code_id = QueryUtils::fetchSingleValue(
+                        <<<'SQL'
+                        SELECT `code` FROM codes
+                        WHERE code_text = ?
+                          AND code_type IN (SELECT ct_id FROM code_types WHERE ct_key = 'CPT4')
+                        SQL,
+                        'code',
+                        [$code_text]
                     );
+                    if ($code_id === null || $code_id === '') {
+                        ServiceContainer::getLogger()->debug(
+                            'Failed to find cpt4 code in codes with code_text. Skipping option_id',
+                            ['code_text' => $code_text, 'option_id' => $option_id]
+                        );
+                    }
+                    $sql = <<<'SQL'
+                    UPDATE list_options SET codes = CONCAT('CPT4:', ?) WHERE list_id = ? AND option_id = ?
+                    SQL;
+                    $values = [$code_id, self::LIST_ID_ENCOUNTER_TYPES, $option_id];
+                    if (is_callable($logger)) {
+                        $logger('(sql=`' . $sql . '`, values=`' . var_export($values, true) . '`)');
+                    }
+                    QueryUtils::sqlStatementThrowException($sql, $values);
                 }
-                $sql = "UPDATE list_options SET codes=CONCAT('CPT4:', ?) WHERE list_id=? AND option_id=?";
-                $values = [$code_id, self::LIST_ID_ENCOUNTER_TYPES, $option_id];
-                if (!empty($logger) && is_callable($logger)) {
-                    $logger('(sql=`"' . $sql . '`, values=`' . var_export($values, true) . "`)");
-                }
-                QueryUtils::sqlStatementThrowException($sql, $values);
-            }
-            \sqlCommitTrans();
+            });
         } catch (\Throwable $exception) {
             ServiceContainer::getLogger()->error($exception->getMessage(), ['exception' => $exception]);
-            \sqlRollbackTrans();
         }
     }
 }

--- a/interface/orders/receive_hl7_results.inc.php
+++ b/interface/orders/receive_hl7_results.inc.php
@@ -1202,32 +1202,37 @@ function receive_hl7_results(&$hl7, &$matchreq, $lab_id = 0, $direction = 'B', $
                     $lkup = lookupTestCode($lab_id, $in_procedure_code);
                     $code_type = ($lkup['procedure_type'] ?? '') ? trim($lkup['procedure_type']) : '';
                     $code_transport = ($lkup['transport'] ?? '') ? trim($lkup['transport']) : '';
-                    sqlBeginTrans();
-                    $procedure_order_seq = sqlQuery(
-                        "SELECT IFNULL(MAX(procedure_order_seq),0) + 1 AS increment FROM procedure_order_code " .
-                        "WHERE procedure_order_id = ? ",
-                        [$in_orderid]
-                    );
-                    sqlInsert(
-                        "INSERT INTO procedure_order_code SET " .
-                        "procedure_order_id = ?, " .
-                        "procedure_order_seq = ?, " .
-                        "procedure_code = ?, " .
-                        "procedure_name = ?, " .
-                        "procedure_type = ?, " .
-                        "transport = ?, " .
-                        "procedure_source = '2'",
-                        [
-                            $in_orderid,
-                            $procedure_order_seq['increment'],
-                            $in_procedure_code,
-                            $in_procedure_name,
-                            $code_type,
-                            $code_transport
-                        ]
-                    );
-                    $pcrow = sqlQuery($pcquery, $pcqueryargs);
-                    sqlCommitTrans();
+                    $pcrow = QueryUtils::inTransaction(function () use ($in_orderid, $in_procedure_code, $in_procedure_name, $code_type, $code_transport, $pcquery, $pcqueryargs) {
+                        $procedure_order_seq = sqlQuery(
+                            <<<'SQL'
+                            SELECT IFNULL(MAX(procedure_order_seq), 0) + 1 AS increment
+                            FROM procedure_order_code
+                            WHERE procedure_order_id = ?
+                            SQL,
+                            [$in_orderid]
+                        );
+                        sqlInsert(
+                            <<<'SQL'
+                            INSERT INTO procedure_order_code SET
+                                procedure_order_id = ?,
+                                procedure_order_seq = ?,
+                                procedure_code = ?,
+                                procedure_name = ?,
+                                procedure_type = ?,
+                                transport = ?,
+                                procedure_source = '2'
+                            SQL,
+                            [
+                                $in_orderid,
+                                $procedure_order_seq['increment'],
+                                $in_procedure_code,
+                                $in_procedure_name,
+                                $code_type,
+                                $code_transport,
+                            ]
+                        );
+                        return sqlQuery($pcquery, $pcqueryargs);
+                    });
                 } else {
                     // Dry run, make a dummy procedure_order_code row.
                     $pcrow = [

--- a/src/Billing/BillingUtilities.php
+++ b/src/Billing/BillingUtilities.php
@@ -14,6 +14,7 @@
 
 namespace OpenEMR\Billing;
 
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 
 class BillingUtilities
@@ -1673,30 +1674,38 @@ class BillingUtilities
              * "target = '$target', " .
              * "x12_partner_id = '$partner_id'";
              ****/
-            sqlBeginTrans();
-            $version = sqlQuery("SELECT IFNULL(MAX(version),0) + 1 AS increment FROM claims WHERE patient_id = ? AND encounter_id = ?", [$patient_id, $encounter_id]);
+            QueryUtils::inTransaction(function () use ($patient_id, $encounter_id, $crossover, $claimset, $sqlBindClaimset, $status): void {
+                $version = sqlQuery(
+                    'SELECT IFNULL(MAX(version), 0) + 1 AS increment FROM claims WHERE patient_id = ? AND encounter_id = ?',
+                    [$patient_id, $encounter_id]
+                );
 
-            $sqlBindArray = [];
-            array_push($sqlBindArray, $patient_id, $encounter_id);
-            if ($crossover <> 1) {
-                $sql = "INSERT INTO claims SET " .
-                    "patient_id = ?, " .
-                    "encounter_id = ?, " .
-                    "bill_time = NOW() $claimset ," .
-                    "version = ?";
-                $sqlBindArray = array_merge($sqlBindArray, $sqlBindClaimset);
-                array_push($sqlBindArray, $version['increment']);
-            } else {//Claim automatic forward case.startTra
-                $sql = "INSERT INTO claims SET " .
-                    "patient_id = ?, " .
-                    "encounter_id = ?, " .
-                    "bill_time = NOW(), status=? ," .
-                    "version = ?";
-                array_push($sqlBindArray, $status, $version['increment']);
-            }
+                $sqlBindArray = [];
+                array_push($sqlBindArray, $patient_id, $encounter_id);
+                if ($crossover <> 1) {
+                    // heredoc (not nowdoc) because $claimset is a dynamic SQL fragment
+                    $sql = <<<SQL
+                    INSERT INTO claims SET
+                        patient_id = ?,
+                        encounter_id = ?,
+                        bill_time = NOW() $claimset ,
+                        version = ?
+                    SQL;
+                    $sqlBindArray = array_merge($sqlBindArray, $sqlBindClaimset);
+                    array_push($sqlBindArray, $version['increment']);
+                } else {//Claim automatic forward case.startTra
+                    $sql = <<<'SQL'
+                    INSERT INTO claims SET
+                        patient_id = ?,
+                        encounter_id = ?,
+                        bill_time = NOW(), status = ? ,
+                        version = ?
+                    SQL;
+                    array_push($sqlBindArray, $status, $version['increment']);
+                }
 
-            sqlStatement($sql, $sqlBindArray);
-            sqlCommitTrans();
+                sqlStatement($sql, $sqlBindArray);
+            });
         } elseif ($claimset) { // Otherwise update the existing claim row.
             $sqlBindArray = $sqlBindClaimset;
             array_push($sqlBindArray, $patient_id, $encounter_id, $row['version']);

--- a/src/Common/Uuid/UuidMapping.php
+++ b/src/Common/Uuid/UuidMapping.php
@@ -110,19 +110,14 @@ class UuidMapping
     //   when presented with that use case (this is why the uuid column in uuid_mapping is not unique btw).
     public static function createMissingResourceUuids($resource, $table, $resourcePath = null)
     {
-        try {
-            sqlBeginTrans();
+        return QueryUtils::inTransaction(function () use ($resource, $table, $resourcePath) {
             $counter = 0;
             do {
                 $count = self::createMissingResourceUuidsStep($resource, $table, $resourcePath);
                 $counter += $count;
             } while ($count > 0);
-            sqlCommitTrans();
             return $counter;
-        } catch (\Throwable $exception) {
-            sqlRollbackTrans();
-            throw $exception;
-        }
+        });
     }
 
     private static function createMissingResourceUuidsStep($resource, $table, $resourcePath = null)

--- a/src/Services/PatientTransactionInsertFailedException.php
+++ b/src/Services/PatientTransactionInsertFailedException.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Sentinel exception for PatientTransactionService::insert().
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services;
+
+/**
+ * Internal sentinel exception used to roll back an in-progress transaction
+ * inside PatientTransactionService::insert() when an underlying insert helper
+ * returns false. Caught immediately by insert() and translated back into the
+ * legacy false-return contract.
+ *
+ * @internal Not part of the public API; do not throw or catch outside
+ * PatientTransactionService.
+ */
+final class PatientTransactionInsertFailedException extends \RuntimeException
+{
+}

--- a/src/Services/PatientTransactionService.php
+++ b/src/Services/PatientTransactionService.php
@@ -133,19 +133,23 @@ class PatientTransactionService extends BaseService
 
     public function insert($pid, $data)
     {
-        sqlBeginTrans();
-        $transactionId = $this->insertTransaction($pid, $data);
-        if ($transactionId == false) {
+        try {
+            return QueryUtils::inTransaction(function () use ($pid, $data) {
+                $transactionId = $this->insertTransaction($pid, $data);
+                if ($transactionId == false) {
+                    throw new PatientTransactionInsertFailedException('Failed to insert patient transaction');
+                }
+
+                $lbtDataId = $this->insertTransactionForm($transactionId, $data);
+                if ($lbtDataId == false) {
+                    throw new PatientTransactionInsertFailedException('Failed to insert patient transaction form');
+                }
+
+                return ["id" => $transactionId, "form_id" => $lbtDataId];
+            });
+        } catch (PatientTransactionInsertFailedException) {
             return false;
         }
-
-
-        $lbtDataId = $this->insertTransactionForm($transactionId, $data);
-        if ($lbtDataId == false) {
-            return false;
-        }
-        sqlCommitTrans();
-        return ["id" => $transactionId, "form_id" => $lbtDataId];
     }
 
     public function insertTransaction($pid, $data)
@@ -243,19 +247,19 @@ class PatientTransactionService extends BaseService
         $validFrom = $data["validFrom"];
         $validThrough = $data["validThrough"];
 
-        sqlBeginTrans();
-        $this->updateTransactionForm($tid, 'refer_from', $referById);
-        $this->updateTransactionForm($tid, 'refer_to', $referToId);
-        $this->updateTransactionForm($tid, 'body', $body);
-        $this->updateTransactionForm($tid, 'refer_date', $referralDate);
-        $this->updateTransactionForm($tid, 'refer_diag', $referralDiagnosis);
-        $this->updateTransactionForm($tid, 'refer_risk_level', $riskLevel);
-        $this->updateTransactionForm($tid, 'refer_vitals', $includeVitals);
-        $this->updateTransactionForm($tid, 'refer_authorization', $authorization);
-        $this->updateTransactionForm($tid, 'refer_visits', $visits);
-        $this->updateTransactionForm($tid, 'refer_validFrom', $validFrom);
-        $this->updateTransactionForm($tid, 'refer_validThrough', $validThrough);
-        sqlCommitTrans();
+        QueryUtils::inTransaction(function () use ($tid, $referById, $referToId, $body, $referralDate, $referralDiagnosis, $riskLevel, $includeVitals, $authorization, $visits, $validFrom, $validThrough): void {
+            $this->updateTransactionForm($tid, 'refer_from', $referById);
+            $this->updateTransactionForm($tid, 'refer_to', $referToId);
+            $this->updateTransactionForm($tid, 'body', $body);
+            $this->updateTransactionForm($tid, 'refer_date', $referralDate);
+            $this->updateTransactionForm($tid, 'refer_diag', $referralDiagnosis);
+            $this->updateTransactionForm($tid, 'refer_risk_level', $riskLevel);
+            $this->updateTransactionForm($tid, 'refer_vitals', $includeVitals);
+            $this->updateTransactionForm($tid, 'refer_authorization', $authorization);
+            $this->updateTransactionForm($tid, 'refer_visits', $visits);
+            $this->updateTransactionForm($tid, 'refer_validFrom', $validFrom);
+            $this->updateTransactionForm($tid, 'refer_validThrough', $validThrough);
+        });
 
         return $this->getOneFromDb($tid);
     }


### PR DESCRIPTION
## Summary

Fixes #11472.

Several call sites opened a database transaction with `sqlBeginTrans()` and committed with `sqlCommitTrans()` without `try`/`catch` protecting the range in between. If any statement between the two threw, the transaction was never committed or rolled back — it sat open on the connection until the request ended. Other sites had a manual `try`/`catch` around the same pattern, correct but verbose and inconsistent with the project's official `QueryUtils::inTransaction()` helper. The existing `openemr.deprecatedSqlFunction` PHPStan rule has been flagging every bare call via the baseline.

This PR migrates **every** bare `sqlBeginTrans` / `sqlCommitTrans` / `sqlRollbackTrans` call site to `QueryUtils::inTransaction(callable)`. The helper already does the right thing: start, run the closure, commit on success, rollback and rethrow on `\Throwable`.

## Sites migrated

| File | Was | Becomes |
|---|---|---|
| `src/Billing/BillingUtilities.php` | unprotected | wrapped |
| `src/Common/Uuid/UuidMapping.php` | manual try/catch/rethrow | collapsed |
| `src/Services/PatientTransactionService.php::insert` | unprotected + 2× `return false` leak paths | wrapped, false contract preserved via private sentinel exception (see below) |
| `src/Services/PatientTransactionService.php::update` | unprotected | wrapped |
| `interface/orders/receive_hl7_results.inc.php` | unprotected | wrapped |
| `interface/forms/procedure_order/procedure_order_save_functions.php` | unprotected | wrapped |
| `interface/forms/procedure_order/handle_deletions.php` | manual try/catch/rethrow | collapsed |
| `interface/modules/zend_modules/.../CodeTypeEventsSubscriber.php` (×2) | manual try/catch with catch-log-continue | inTransaction inside the existing catch-log-continue |
| `interface/modules/zend_modules/.../EncounterccdadispatchTable.php` | manual try/catch/rethrow | collapsed |
| `interface/modules/custom_modules/oe-module-dorn/src/ReceiveHl7Results.php` | unprotected | wrapped |

## `PatientTransactionService::insert` false-return contract

The current method has two `return false` early-exit paths *inside* the transaction body, which leak the transaction. Migrating to `inTransaction()` requires a decision on those paths because returning normally from the closure causes a commit.

Chosen behavior: throw a private sentinel exception (`PatientTransactionInsertFailedException`, `@internal` in `src/Services/`) from inside the closure to trigger rollback, then catch it immediately in `insert()` and return `false` — preserving the existing contract. Cleaner than sentinel magic codes on a generic `RuntimeException` because the class name documents intent and the catch can't accidentally swallow an unrelated exception.

## String-literal cleanup in touched code

Per review feedback, while the diff is already reindenting the SQL inside each closure, also bring the touched strings up to the project's string-literal conventions:

- **Multi-line concatenated SQL → nowdocs.** Every `"SELECT ..." . "FROM ..."`-style concatenation in the diff becomes a `<<<'SQL'` nowdoc (or a `<<<SQL` heredoc in the one place where a dynamic `$claimset` SQL fragment is interpolated — `BillingUtilities` claims INSERT).
- **Single-line double-quoted SQL → single-quoted.** `BillingUtilities`' version-lookup SELECT was double-quoted for no reason; now single-quoted.
- **Bare `sqlQuery`/`sqlStatement` → `QueryUtils::*`.** In `procedure_order_save_functions.php` and `CodeTypeEventsSubscriber.php`, replace with `QueryUtils::fetchSingleValue` and `QueryUtils::sqlStatementThrowException`.
- **`empty($code_id)` → `$code_id === null || $code_id === ''`.** Per the project's avoid-empty() rule.
- **`!empty($logger) && is_callable($logger)` → `is_callable($logger)`.** An empty value can never be callable, so the first half is redundant. All three occurrences in `CodeTypeEventsSubscriber` simplified.

## Baseline impact

- **21 entries dropped** from `.phpstan/baseline/openemr.deprecatedSqlFunction.php` (110 lines) — the rule was already telling us to migrate.
- **4 entries dropped** from `.phpstan/baseline/openemr.emptyIsNotAllowed.php` — from the explicit null/empty checks.
- **Additional drops** from `offsetAccess.nonOffsetAccessible.php` and related baselines as incidental side effects of the narrower types and the nowdoc conversions.

No new baseline entries. Tracked PHPStan rules are strictly reduced.

## Scope

Mechanical refactor with no behavior change on the happy path. On every error path the transaction is now deterministically rolled back instead of leaked. Uses the existing `QueryUtils::inTransaction()` helper rather than introducing a new abstraction.

## Test plan

- [x] `php -l` clean on all 12 changed files
- [x] PHPStan level 10, phpcs, rector, composer-require-checker — all pre-commit hooks pass
- [x] `composer phpstan-baseline` regenerated with only expected drops

## Related

- #11471 / #11476 — phiMail socket cleanup (parallel resource-cleanup work in the same audit)
- #11490 — CPT4 mapping "Skipping option_id" log + missing `continue` (pre-existing bug copilot surfaced during review of this PR; intentionally out of scope)
- opencoreemr/ocemr-docs#67 — "Narrow try/finally Scope" convention, motivated by this audit
- opencoreemr/ocemr-docs#69 — heredoc/nowdoc for embedded languages, motivated by this audit
- opencoreemr/ocemr-docs#70 — string quoting discipline, motivated by review of this PR