### PR TITLE
fix(cpt4): skip UPDATE when CPT4 code lookup returns empty

### DIFF
--- a/interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php
+++ b/interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php
@@ -169,6 +169,7 @@ class CodeTypeEventsSubscriber implements EventSubscriberInterface
                     "Failed to find cpt4 code in codes with code_text. Skipping option_id",
                     ['code_text' => $code_text, 'option_id' => $option_id]
                 );
+                continue;
             }
             $sql = "SELECT codes FROM list_options WHERE list_id=? AND option_id=?";
             $codes = QueryUtils::fetchSingleValue($sql, 'codes', [self::LIST_ID_ENCOUNTER_TYPES, $option_id]);
@@ -270,6 +271,7 @@ class CodeTypeEventsSubscriber implements EventSubscriberInterface
                             'Failed to find cpt4 code in codes with code_text. Skipping option_id',
                             ['code_text' => $code_text, 'option_id' => $option_id]
                         );
+                        continue;
                     }
                     $sql = <<<'SQL'
                     UPDATE list_options SET codes = CONCAT('CPT4:', ?) WHERE list_id = ? AND option_id = ?


### PR DESCRIPTION
## Summary

Add missing `continue` after failed CPT4 code lookups in `CodeTypeEventsSubscriber`.

## Bug

Both `shouldUpdateCPT4Mappings()` and `updateCPT4Mappings()` log "Skipping option_id" when a CPT4 code is not found in the `codes` table, but execution falls through:

- **`shouldUpdateCPT4Mappings()`**: Compares against `"CPT4:" . $code_id` where `$code_id` is empty, spuriously reporting that an update is needed
- **`updateCPT4Mappings()`**: Runs `UPDATE list_options SET codes = CONCAT('CPT4:', ?)` with an empty `$code_id`, clobbering valid existing codes with `"CPT4:"`

## Fix

Add `continue;` inside both `if (empty($code_id))` blocks so the iteration is actually skipped as the log message claims.

Fixes #11490