### PR TITLE
fix(translation): use unconditional xl() for dynamic strings, not xl_list_label

### DIFF
--- a/interface/billing/billing_tracker.php
+++ b/interface/billing/billing_tracker.php
@@ -73,18 +73,16 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
                     {
                         "data": "status",
                         "render": function(data, type, row, meta) {
-                            // Format the status with a nice looking badge
-                            if (type === 'display') {
-                                if (data == 'success') {
-                                    data = '<span class="badge badge-success">' + jsText(data) + '</span>';
-                                } else if (data == 'waiting') {
-                                    data = '<span class="badge badge-info">' + jsText(data) + '</span>';
-                                } else {
-                                    data = '<span class="badge badge-warning">' + jsText(data) + '</span>';
-                                }
+                            // Format the status with a nice looking badge.
+                            // Compare against the raw enum (`row.status`) but
+                            // display the translated label (`row.status_label`).
+                            if (type !== 'display') {
+                                return data;
                             }
-
-                            return data;
+                            const variants = { success: 'success', waiting: 'info' };
+                            const variant = variants[data] || 'warning';
+                            const label = row.status_label || data;
+                            return `<span class="badge badge-${variant}">${jsText(label)}</span>`;
                         }
                     },
                     { "data": "x12_partner_name" },

--- a/interface/billing/payment_master.inc.php
+++ b/interface/billing/payment_master.inc.php
@@ -27,7 +27,8 @@ function generate_list_payment_category(string $tag_name, string $list_id, strin
     }
     $s .= " title='" . attr($title) . "'>";
     if ($empty_name !== '') {
-        $s .= "<option value=''>" . text(xl_list_label($empty_name)) . "</option>";
+        // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+        $s .= "<option value=''>" . xlt($empty_name) . "</option>";
     }
     $lres = sqlStatement("SELECT * FROM list_options WHERE list_id = ? AND activity = 1 ORDER BY seq, title", [$list_id]);
     $got_selected = false;

--- a/interface/reports/ippf_statistics.php
+++ b/interface/reports/ippf_statistics.php
@@ -788,7 +788,8 @@ function process_ma_code($row): void
   //
     if ($form_by === '101') {
         if (is_string($row['lo_title'] ?? null) && $row['lo_title'] !== '') {
-            $key = xl_list_label($row['lo_title']);
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            $key = xl($row['lo_title']);
         }
     } elseif ($form_by === '102') { // Specific Services. One row for each MA code.
         $key = $row['code'];

--- a/interface/reports/message_list.php
+++ b/interface/reports/message_list.php
@@ -262,8 +262,10 @@ if (!empty($_POST['form_refresh']) || !empty($_POST['form_csvexport'])) {
             echo csvEscape($row['fname']) . ',';
             echo csvEscape($patient_id) . ',';
             echo csvEscape($patient_dob) . ',';
-            echo csvEscape(xl_list_label($msg_type)) . ',';
-            echo csvEscape(xl_list_label($msg_status)) . ',';
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            echo csvEscape(xl($msg_type)) . ',';
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            echo csvEscape(xl($msg_status)) . ',';
             echo csvEscape($update_by) . ',';
             echo csvEscape(oeFormatShortDate(substr((string) $update_date, 0, 10))) . "\n";
         } else {

--- a/library/ajax/billing_tracker_ajax.php
+++ b/library/ajax/billing_tracker_ajax.php
@@ -39,7 +39,11 @@ foreach ($claim_files as $claim_file) {
     $element->x12_partner_id = text($claim_file['x12_partner_id']);
     $element->x12_partner_name = text($claim_file['name']);
     $element->x12_filename = text($claim_file['x12_filename']);
-    $element->status = xl_list_label(is_string($claim_file['status'] ?? null) ? $claim_file['status'] : '');
+    $claimStatus = is_string($claim_file['status'] ?? null) ? $claim_file['status'] : '';
+    // Keep `status` as the raw enum so JS can compare against 'success'/'waiting'.
+    $element->status = $claimStatus;
+    // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+    $element->status_label = xl($claimStatus);
     $element->created_at = $claim_file['created_at'];
     $element->updated_at = $claim_file['updated_at'];
     $element->claims = json_decode((string) $claim_file['claims']);

--- a/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php
+++ b/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php
@@ -143,7 +143,8 @@ class FhirDiagnosticReportLaboratoryService extends FhirServiceBase implements I
                 $obsReference = UtilsService::createRelativeReference("Observation", $result['uuid']);
                 $resultText = is_string($result['text'] ?? null) ? $result['text'] : '';
                 if ($resultText !== '') {
-                    $obsReference->setDisplay(xl_list_label($resultText));
+                    // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+                    $obsReference->setDisplay(xl($resultText));
                 }
                 $report->addResult($obsReference);
             }

--- a/src/Services/FHIR/FhirCareTeamService.php
+++ b/src/Services/FHIR/FhirCareTeamService.php
@@ -214,11 +214,10 @@ class FhirCareTeamService extends FhirServiceBase implements IResourceUSCIGProfi
         if (!empty($dataRecordProvider['role'])) {
             $role = strtolower((string)$dataRecordProvider['role']);
             if (isset($roleMapping[$role])) {
-                $roleLabel = is_string($dataRecordProvider['role']) ? $dataRecordProvider['role'] : '';
                 $codes = [
                     'code' => $roleMapping[$role],
                     'system' => self::CARE_TEAM_MEMBER_FUNCTION_SYSTEM,
-                    'description' => $dataRecordProvider['role_title'] ?? xl_list_label($roleLabel)
+                    'description' => $dataRecordProvider['role_title'] ?? '',
                 ];
                 return UtilsService::createCodeableConcept([$codes['code'] => $codes]);
             }
@@ -414,11 +413,10 @@ class FhirCareTeamService extends FhirServiceBase implements IResourceUSCIGProfi
                 if (!empty($person['role'])) {
                     $role = strtolower((string)$person['role']);
                     if (isset($roleMapping[$role])) {
-                        $roleLabel = is_string($person['role']) ? $person['role'] : '';
                         $codes = [
                             'code' => $roleMapping[$role],
                             'system' => self::CARE_TEAM_MEMBER_FUNCTION_SYSTEM,
-                            'description' => $person['role_title'] ?? xl_list_label($roleLabel)
+                            'description' => $person['role_title'] ?? '',
                         ];
                         $participant->addRole(UtilsService::createCodeableConcept([$codes['code'] => $codes]));
                     }

--- a/src/Services/FHIR/FhirGoalService.php
+++ b/src/Services/FHIR/FhirGoalService.php
@@ -182,7 +182,8 @@ class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileSe
                     $coding->setCode($cleanCode);
                     if (!empty($codeText)) {
                         // FIXED: Fix apostrophes in display text
-                        $cleanDisplay = str_replace('`', "'", xl_list_label($codeText));
+                        // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+                        $cleanDisplay = str_replace('`', "'", xl($codeText));
                         $coding->setDisplay($cleanDisplay);
                     }
                     $coding->setSystem($codeSystem);
@@ -236,7 +237,8 @@ class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileSe
                             $coding->setDisplay(UtilsService::createDataMissingExtension());
                         } else {
                             // FIXED: Fix apostrophes in target display text
-                            $cleanCodeText = str_replace('`', "'", xl_list_label($codeText));
+                            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+                            $cleanCodeText = str_replace('`', "'", xl($codeText));
                             $coding->setDisplay($cleanCodeText);
                         }
                         $coding->setSystem($codeSystem);

--- a/src/Services/FHIR/FhirLocationService.php
+++ b/src/Services/FHIR/FhirLocationService.php
@@ -172,7 +172,9 @@ class FhirLocationService extends FhirServiceBase implements IFhirExportableReso
         if (!empty($dataRecord['name'])) {
             $name = is_string($dataRecord['name']) ? $dataRecord['name'] : '';
             if ($dataRecord['type'] != 'facility') {
-                $name = xl_list_label($name);
+                // LocationService hard-codes patient/user `name` to the literal
+                // "Home Address" — translate the known literal directly.
+                $name = xl('Home Address');
             }
             $locationResource->setName(new FHIRString($name));
         } else {

--- a/src/Services/FHIR/FhirMedicationRequestService.php
+++ b/src/Services/FHIR/FhirMedicationRequestService.php
@@ -474,7 +474,8 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
             $medRequestResource->addCategory(UtilsService::createCodeableConcept(
                 [
                     $dataRecord['category'] =>
-                        ['code' => $dataRecord['category'], 'description' => xl_list_label($categoryTitle)
+                        // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+                        ['code' => $dataRecord['category'], 'description' => xl($categoryTitle)
                             ,'system' => FhirCodeSystemConstants::HL7_MEDICATION_REQUEST_CATEGORY]
                 ]
             ));

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -438,7 +438,8 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
             } elseif (!empty($record)) {
                 $code = $record['notes'];
                 $title = is_string($record['title']) ? $record['title'] : '';
-                $display = xl_list_label($title);
+                // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+                $display = xl($title);
                 $system = FhirCodeSystemConstants::OID_RACE_AND_ETHNICITY;
             }
         }
@@ -574,7 +575,8 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
             $language->setSystem(new FHIRUri(FhirCodeSystemConstants::LANGUAGE_BCP_47));
             $language->setCode(new FHIRCode($record['notes']));
             $languageTitle = is_string($record['title']) ? $record['title'] : '';
-            $translatedTitle = xl_list_label($languageTitle);
+            // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+            $translatedTitle = xl($languageTitle);
             $language->setDisplay($translatedTitle);
             $languageConcept->addCoding($language);
             $languageConcept->setText($translatedTitle);


### PR DESCRIPTION
## Summary

PRs #11429 (FHIR) and #11457 (reports) introduced calls to `xl_list_label()` on dynamic strings as a way to satisfy PHPStan's literal-string constraint. That was wrong: `xl_list_label()` is **not** a more permissive variant of `xl()` — it gates translation on the `translate_lists` global. Strings that aren't list_options labels (FHIR resource displays, message types, claim statuses, generic option labels) should not be conditionally translated based on a global meant for the list_options table.

This PR reverts all 14 misuses to unconditional `xl()` with scoped `@phpstan-ignore argument.type` comments (or, where the source turned out to be a known literal, drops the dynamic call entirely).

### Sites changed

**FHIR (9 sites, from #11429):**
- `src/Services/FHIR/FhirGoalService.php` (×2)
- `src/Services/FHIR/FhirLocationService.php` — `LocationService` hard-codes patient/user `name` to the literal `"Home Address"`, so this site translates the literal directly with no `@phpstan-ignore`.
- `src/Services/FHIR/FhirPatientService.php` (×2 — race/ethnicity, language)
- `src/Services/FHIR/FhirCareTeamService.php` (×2) — `role_title` is always populated by `CareTeamService::*` (`$row['role_title'] ?? $row['role']`), so the dead `?? xl($roleLabel)` fallback was dropped.
- `src/Services/FHIR/FhirMedicationRequestService.php`
- `src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php`

**Reports / billing (5 sites, from #11457):**
- `interface/billing/payment_master.inc.php` (the `$empty_name` call only — `$title_value` is a correct pre-existing list_options call and is left alone)
- `interface/reports/message_list.php` (×2 — msg_type, msg_status)
- `interface/reports/ippf_statistics.php`
- `library/ajax/billing_tracker_ajax.php` — `status` is now exposed as the raw enum (so JS comparisons against `'success'`/`'waiting'` keep working) and the translated form is exposed as a new `status_label` field.

**Billing tracker UI (follow-on for the `status_label` change):**
- `interface/billing/billing_tracker.php` — DataTables renderer updated to display `row.status_label` for the badge text while still comparing on `row.status` for the badge color.

### Why @phpstan-ignore is acceptable here

The dynamic strings come from the database (list_options titles, claim statuses, FHIR resource text, etc.). Translating them at runtime is the legacy "administrative translation" pattern. The follow-up issues track making this less hacky:

- #11496 — Tighten `xl_*` helpers to require literal-string
- #11497 — Introduce explicit `xl_admin*()` helper for administrative translation
- #11498 — Migrate dynamic callers to the new helper

Until those land, scoped `@phpstan-ignore argument.type` is the correct local fix.

## Test plan

- [x] `composer phpstan` reports no errors
- [x] `composer phpstan-baseline` produces no diff (no new baseline entries)
- [x] Pre-commit hooks pass