### PR TITLE
chore(errors): Improve handling for Symfony HTTP errors

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -24,10 +24,16 @@ use Monolog\{
 use OpenEMR\Common\Http\Psr17Factory;
 use OpenEMR\Core\ErrorHandler;
 use Psr\Log\LoggerInterface;
+use Psr\Http\Message\{
+    ResponseFactoryInterface,
+    StreamFactoryInterface,
+};
 
 return [
     ErrorHandler::class => fn (TC $c) => new ErrorHandler(
         logger: $c->get(LoggerInterface::class),
+        rf: $c->get(ResponseFactoryInterface::class),
+        sf: $c->get(StreamFactoryInterface::class),
         // Once there are more well-defined environments, set this using them
         shouldDisplayErrors: false,
     ),

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -62,6 +62,8 @@ $logger = ServiceContainer::getLogger();
 // guaranteed way of reaching the logs, regardless of other settings.
 $handler = new \OpenEMR\Core\ErrorHandler(
     logger: $logger,
+    rf: ServiceContainer::getResponseFactory(),
+    sf: ServiceContainer::getStreamFactory(),
     shouldDisplayErrors: ($_ENV['OPENEMR__ENVIRONMENT'] ?? null) === 'dev',
 );
 $handler->installExceptionHandler();

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -41,7 +41,7 @@ readonly class ErrorHandler
         private LoggerInterface $logger,
         private ResponseFactoryInterface $rf,
         private StreamFactoryInterface $sf,
-        private bool $shouldDisplayErrors = false,
+        private bool $shouldDisplayErrors,
     ) {
         $this->isCli = (PHP_SAPI === 'cli');
     }
@@ -126,12 +126,12 @@ readonly class ErrorHandler
             return $response;
         }
 
+        // Default: nondescript 500 error.
         $message = 'An error has occurred.';
         if ($this->shouldDisplayErrors) {
             $message .= "\n$e";
         }
 
-        // Default: nondescript 500 error.
         return $this->rf->createResponse(500)
             ->withBody($this->sf->createStream($message));
     }

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -25,7 +25,6 @@ use Throwable;
 use function assert;
 use function defined;
 use function error_reporting;
-use function get_class;
 use function header;
 use function http_response_code;
 use function is_int;
@@ -151,7 +150,7 @@ readonly class ErrorHandler
                 default => LogLevel::WARNING,
             };
             $this->logger->log($logLevel, 'Caught {type} with code {code}', [
-                'type' => get_class($e),
+                'type' => $e::class,
                 'code' => $code,
             ]);
             return;

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -118,7 +118,7 @@ readonly class ErrorHandler
         // Future scope: create a body based on request context (e.g. accept
         // headers, etc).
         if ($e instanceof HttpExceptionInterface) {
-            $response = $this->rf->createResponse($e->getCode());
+            $response = $this->rf->createResponse($e->getStatusCode());
             foreach ($e->getHeaders() as $header => $value) {
                 assert(is_string($value) || is_int($value));
                 $response = $response->withAddedHeader($header, (string)$value);

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -22,13 +22,17 @@ use Psr\Log\{LoggerInterface, LogLevel};
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
+use function assert;
 use function defined;
 use function error_reporting;
+use function get_class;
+use function header;
 use function http_response_code;
 use function is_int;
 use function is_string;
 use function set_error_handler;
 use function set_exception_handler;
+use function sprintf;
 
 use const E_DEPRECATED;
 use const E_USER_DEPRECATED;

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -13,13 +13,20 @@ declare(strict_types=1);
 namespace OpenEMR\Core;
 
 use ErrorException;
-use OpenEMR\BC\ServiceContainer;
-use Psr\Log\LoggerInterface;
+use Psr\Http\Message\{
+    ResponseFactoryInterface,
+    ResponseInterface,
+    StreamFactoryInterface,
+};
+use Psr\Log\{LoggerInterface, LogLevel};
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
 use function defined;
 use function error_reporting;
 use function http_response_code;
+use function is_int;
+use function is_string;
 use function set_error_handler;
 use function set_exception_handler;
 
@@ -28,15 +35,15 @@ use const E_USER_DEPRECATED;
 
 readonly class ErrorHandler
 {
-    private LoggerInterface $logger;
     private bool $isCli;
 
     public function __construct(
-        ?LoggerInterface $logger,
+        private LoggerInterface $logger,
+        private ResponseFactoryInterface $rf,
+        private StreamFactoryInterface $sf,
         private bool $shouldDisplayErrors = false,
     ) {
         $this->isCli = (PHP_SAPI === 'cli');
-        $this->logger = $logger ?? ServiceContainer::getLogger();
     }
 
     /**
@@ -84,30 +91,73 @@ readonly class ErrorHandler
      */
     public function handleException(Throwable $e): never
     {
-        $this->logger->critical('Uncaught exception!', [
-            'exception' => $e,
-        ]);
+        $this->logUncaughtException($e);
 
         // CLI scripts simply exit nonzero
         if ($this->isCli) {
             exit(1);
         }
 
-        // For now, just crash out with minimal detail as before.
-        // In the future, this can be smarter about request context (accept
-        // headers), switching on exception type to yield the correct http
-        // code, etc.
-        // Note: under rare circumstances, this could trigger a secondary error
-        // if headers are already sent. The default deployment seems to turn on
-        // output_buffering in php.ini automatically so it's unlikely to occur
-        http_response_code(500);
-        header('Content-type: text/plain');
-        echo 'An error has occurred.';
+        $response = $this->buildResponse($e);
 
-        if ($this->shouldDisplayErrors) {
-            echo $e;
+        if (!headers_sent()) {
+            http_response_code($response->getStatusCode());
+            foreach ($response->getHeaders() as $name => $values) {
+                foreach ($values as $value) {
+                    header(sprintf('%s: %s', $name, $value), false);
+                }
+            }
         }
+
+        echo (string)$response->getBody();
         exit();
+    }
+
+    private function buildResponse(Throwable $e): ResponseInterface
+    {
+        // Future scope: create a body based on request context (e.g. accept
+        // headers, etc).
+        if ($e instanceof HttpExceptionInterface) {
+            $response = $this->rf->createResponse($e->getCode());
+            foreach ($e->getHeaders() as $header => $value) {
+                assert(is_string($value) || is_int($value));
+                $response = $response->withAddedHeader($header, (string)$value);
+            }
+            return $response;
+        }
+
+        $message = 'An error has occurred.';
+        if ($this->shouldDisplayErrors) {
+            $message .= "\n$e";
+        }
+
+        // Default: nondescript 500 error.
+        return $this->rf->createResponse(500)
+            ->withBody($this->sf->createStream($message));
+    }
+
+    private function logUncaughtException(Throwable $e): void
+    {
+        if ($e instanceof HttpExceptionInterface) {
+            $code = $e->getStatusCode();
+            $logLevel = match (true) {
+                $code < 300 => LogLevel::DEBUG,
+                $code < 400 => LogLevel::INFO,
+                $code < 500 => LogLevel::NOTICE,
+                default => LogLevel::WARNING,
+            };
+            $this->logger->log($logLevel, 'Caught {type} with code {code}', [
+                'type' => get_class($e),
+                'code' => $code,
+            ]);
+            return;
+        }
+
+        // Fallback: log everything else at a high severity. This will very
+        // likely get toned down over time.
+        $this->logger->critical('Uncaught exception!', [
+            'exception' => $e,
+        ]);
     }
 
     /**

--- a/tests/Tests/Isolated/Core/ErrorHandlerTest.php
+++ b/tests/Tests/Isolated/Core/ErrorHandlerTest.php
@@ -16,6 +16,8 @@ use ErrorException;
 use OpenEMR\Core\ErrorHandler;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\NullLogger;
 
 use const E_DEPRECATED;
@@ -25,9 +27,19 @@ use const E_USER_WARNING;
 #[Group('core')]
 class ErrorHandlerTest extends TestCase
 {
+    private function createHandler(bool $shouldDisplayErrors = false): ErrorHandler
+    {
+        return new ErrorHandler(
+            new NullLogger(),
+            $this->createStub(ResponseFactoryInterface::class),
+            $this->createStub(StreamFactoryInterface::class),
+            $shouldDisplayErrors,
+        );
+    }
+
     public function testHandleErrorThrowsWhenErrorReportingMatches(): void
     {
-        $handler = new ErrorHandler(new NullLogger());
+        $handler = $this->createHandler();
 
         // Ensure E_USER_WARNING is in error_reporting
         $originalLevel = error_reporting(E_ALL);
@@ -43,7 +55,7 @@ class ErrorHandlerTest extends TestCase
 
     public function testHandleErrorReturnsFalseWhenSuppressed(): void
     {
-        $handler = new ErrorHandler(new NullLogger());
+        $handler = $this->createHandler();
 
         // The @ operator sets error_reporting to 0 for the duration of the expression
         $result = @$handler->handleError(E_USER_WARNING, 'Suppressed error', '/path/to/file.php', 42);
@@ -55,7 +67,7 @@ class ErrorHandlerTest extends TestCase
     {
         // PHPUNIT_COMPOSER_INSTALL is defined during test runs, so deprecations
         // always throw regardless of error_reporting level
-        $handler = new ErrorHandler(new NullLogger());
+        $handler = $this->createHandler();
 
         $this->expectException(ErrorException::class);
         $this->expectExceptionMessage('Deprecated function');
@@ -65,7 +77,7 @@ class ErrorHandlerTest extends TestCase
 
     public function testErrorHandlerInstallation(): void
     {
-        $handler = new ErrorHandler(new NullLogger());
+        $handler = $this->createHandler();
         $handler->installErrorHandler(E_ALL);
         $old = error_reporting(E_ALL);
 


### PR DESCRIPTION
#### Short description of what this changes or resolves:
Symfony's `HttpKernel` defines an `HttpExceptionInterface` with a number of implementations for various network errors. We don't use them _widely_, but they're used in a handful of places. This updates the new global exception handler to detect when that specific type of exception is thrown and adjusts the response rendering to reflect the status code and headers.

#### Changes proposed in this pull request:

- Detects when an exception implements the interface and special-cases it
- Performs some light restructuring of the internals to split the logging from the response generation
- Updates the globals.php wiring
- Updates the DI container wiring
- Updates tests

#### Was an AI assistant used? Yes / No
Research and tests mostly