### PR TITLE
fix(db): Change OSCONJ column type on form_eye_antseg table

### DIFF
--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -113,7 +113,7 @@
 --    desc: Add encounter to the form_misc_billing_options table
 --    arguments: none
 
--- #IfNotColumnType form_eye_antseg OSCONJ text
+#IfNotColumnType form_eye_antseg OSCONJ text
 ALTER TABLE `form_eye_antseg`
   MODIFY COLUMN OSCONJ text;
 #EndIf

--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -112,3 +112,8 @@
 --  #IfMBOEncounterNeeded
 --    desc: Add encounter to the form_misc_billing_options table
 --    arguments: none
+
+-- #IfNotColumnType form_eye_antseg OSCONJ text
+ALTER TABLE `form_eye_antseg`
+  MODIFY COLUMN OSCONJ text;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -13870,7 +13870,7 @@ CREATE TABLE `form_eye_antseg` (
   `OSSCHIRMER2`          varchar(25) DEFAULT NULL,
   `ODTBUT`               varchar(25) DEFAULT NULL,
   `OSTBUT`               varchar(25) DEFAULT NULL,
-  `OSCONJ`               varchar(25) DEFAULT NULL,
+  `OSCONJ`               text,
   `ODCONJ`               text,
   `ODCORNEA`             text,
   `OSCORNEA`             text,

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3,7 +3,7 @@
 --
 -- Keep v_database in sync with $v_database in version.php.
 -- CI will fail if they don't match.
--- v_database: 535
+-- v_database: 536
 --
 
 --

--- a/version.php
+++ b/version.php
@@ -31,7 +31,7 @@ $v_realpatch = '0';
 //
 // Keep in sync with the v_database comment in sql/database.sql.
 // CI will fail if they don't match.
-$v_database = 535;
+$v_database = 536;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
OSCONJ column type on form_ant_antseg table = varchar(25) while column type = text for ODCONJ and other related columns on table. 
This was a problem because users would enter >25 characters in the OSCONJ field on Anterior Segment section (form_eye_antseg) of the Eye Form, but only the first 25 characters would save. Related fields in the section (ODCONJ) allowed and saved entry of >25 characters. 

#### Changes proposed in this pull request:
Change OSCONJ column type to text so that it behaves same as related fields in eye form section. 

#### Test Plan
Ran sql upgrade from 8.1.0 after making changes in 8_1_0-to-8_1_1_upgrade.sql without incident and form/field behaved as expected. 

#### Was an AI assistant used? Yes / No
No

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
