### PR TITLE
fix(faxsms): use 24-hour clock for notification window math

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
@@ -120,7 +120,7 @@ if (!empty($runtime['testrun'])) {
 
 $curr_date = date("Y-m-d");
 $curr_time = time();
-$check_date = date("Y-m-d", mktime((date("h") + $SMS_NOTIFICATION_HOUR), 0, 0, date("m"), date("d"), date("Y")));
+$check_date = date("Y-m-d", mktime((date("H") + $SMS_NOTIFICATION_HOUR), 0, 0, date("m"), date("d"), date("Y")));
 
 $db_sms_msg['type'] = $TYPE;
 $db_sms_msg['sms_gateway_type'] = AppDispatch::getModuleVendor();


### PR DESCRIPTION
Change `date("h")` to `date("H")` in rc_sms_notification.php so the notification check date uses 24-hour format instead of 12-hour, preventing PM appointments from being miscalculated.

Fixes #11482