### PR TITLE
fix(security): escape tab label in TabsWrapper to prevent XSS

### DIFF
--- a/src/Tabs/TabsWrapper.php
+++ b/src/Tabs/TabsWrapper.php
@@ -150,7 +150,7 @@ function twSetup(tabsid) {
         closeTab();
     }
 
-    if (panelId === 'SOAP' && top.isSoapEdit === true) {
+    if (self.data('tab-label') === 'SOAP' && top.isSoapEdit === true) {
         dlgopen('', '', 450, 125, '', '<div class="text-danger">$modalTitle</div>', {
             type: 'Alert',
             html: '<p>$modalContent</p>',
@@ -186,7 +186,7 @@ function twAddTab(tabsid, label, content) {
   var li = $("<li class='tabs-tabs'></li>");
   var anchor = $("<a data-toggle='tab' class='tabs-anchor'></a>").attr('href', '#' + panelId);
   anchor.append(document.createTextNode(label));
-  anchor.append($("<span aria-label='close' class='icon-close' role='close'>&times;</span>").attr('id', closeId));
+  anchor.append($("<span aria-label='close' class='icon-close' role='close'>&times;</span>").attr('id', closeId).attr('data-tab-label', label));
   li.append(anchor);
   twObject[tabsid].nav.append(li);
   top.restoreSession();

--- a/src/Tabs/TabsWrapper.php
+++ b/src/Tabs/TabsWrapper.php
@@ -139,8 +139,8 @@ function twSetup(tabsid) {
   // Close icon: removing the tab on click
   nav.on("click", "span.icon-close", function() {
     const self = $(this);
+    const panelId = self.parent().attr("href").substring(1);
     const closeTab = function() {
-        const panelId = self.parent().attr("href").substring(1);
         top.restoreSession();
         twCloseTab(tabsid, panelId);
     }
@@ -150,7 +150,7 @@ function twSetup(tabsid) {
         closeTab();
     }
 
-    if (self[0].id === 'SOAP' && top.isSoapEdit === true) {
+    if (panelId === 'SOAP' && top.isSoapEdit === true) {
         dlgopen('', '', 450, 125, '', '<div class="text-danger">$modalTitle</div>', {
             type: 'Alert',
             html: '<p>$modalContent</p>',

--- a/src/Tabs/TabsWrapper.php
+++ b/src/Tabs/TabsWrapper.php
@@ -182,7 +182,12 @@ function nextPanelId(tabsid){
 function twAddTab(tabsid, label, content) {
   var oldcount = twObject[tabsid].nav.find(".nav-tabs li").length;
   var panelId = nextPanelId(tabsid);
-  var li = "<li class='tabs-tabs'><a data-toggle='tab' class='tabs-anchor' href='#" + panelId + "'>" + label + "<span aria-label='close' class='icon-close' id='" + label + "' role='close'>&times;</span></a> </li>";
+  var closeId = panelId + '-close';
+  var li = $("<li class='tabs-tabs'></li>");
+  var anchor = $("<a data-toggle='tab' class='tabs-anchor'></a>").attr('href', '#' + panelId);
+  anchor.append(document.createTextNode(label));
+  anchor.append($("<span aria-label='close' class='icon-close' role='close'>&times;</span>").attr('id', closeId));
+  li.append(anchor);
   twObject[tabsid].nav.append(li);
   top.restoreSession();
   twObject[tabsid].content.append("<div class='tab-pane tabs-panel' id='" + panelId + "'>" + content + "</div>");


### PR DESCRIPTION
Replace string-concatenated HTML with jQuery DOM construction using `document.createTextNode(label)` to prevent XSS from tab labels. Use `panelId + '-close'` as close button ID instead of raw label. Store the original label in `data-tab-label` attribute for SOAP dirty-check compatibility.

Fixes #11478