### PR TITLE
fix(security): validate menu role filenames to prevent path traversal

### DIFF
--- a/src/Menu/MainMenuRole.php
+++ b/src/Menu/MainMenuRole.php
@@ -12,7 +12,7 @@
 
 namespace OpenEMR\Menu;
 
-use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\UserService;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -51,7 +51,7 @@ class MainMenuRole extends MenuRole
 
         // Validate that the menu role filename is a basename only (no path traversal)
         if ($mainMenuRole !== basename($mainMenuRole) || str_contains($mainMenuRole, '..')) {
-            (new SystemLogger())->error("Invalid menu role filename rejected", ['filename' => $mainMenuRole]);
+            ServiceContainer::getLogger()->error("Invalid menu role filename rejected", ['filename' => $mainMenuRole]);
             die("\nInvalid menu role filename.");
         }
 

--- a/src/Menu/MainMenuRole.php
+++ b/src/Menu/MainMenuRole.php
@@ -12,6 +12,7 @@
 
 namespace OpenEMR\Menu;
 
+use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\UserService;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -50,7 +51,7 @@ class MainMenuRole extends MenuRole
 
         // Validate that the menu role filename is a basename only (no path traversal)
         if ($mainMenuRole !== basename($mainMenuRole) || str_contains($mainMenuRole, '..')) {
-            error_log("OpenEMR: invalid main menu role filename rejected: " . $mainMenuRole);
+            (new SystemLogger())->error("Invalid menu role filename rejected", ['filename' => $mainMenuRole]);
             die("\nInvalid menu role filename.");
         }
 

--- a/src/Menu/MainMenuRole.php
+++ b/src/Menu/MainMenuRole.php
@@ -48,6 +48,12 @@ class MainMenuRole extends MenuRole
         // Collect the selected menu of user
         $mainMenuRole = $this->getMenuRole();
 
+        // Validate that the menu role filename is a basename only (no path traversal)
+        if ($mainMenuRole !== basename($mainMenuRole) || str_contains($mainMenuRole, '..')) {
+            error_log("OpenEMR: invalid main menu role filename rejected: " . $mainMenuRole);
+            die("\nInvalid menu role filename.");
+        }
+
         // Load the selected menu
         if (str_ends_with($mainMenuRole, '.json')) {
             // load custom menu (includes .json in id)

--- a/src/Menu/PatientMenuRole.php
+++ b/src/Menu/PatientMenuRole.php
@@ -15,6 +15,7 @@
 namespace OpenEMR\Menu;
 
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Menu\PatientMenuEvent;
@@ -54,7 +55,7 @@ class PatientMenuRole extends MenuRole
 
         // Validate that the menu role filename is a basename only (no path traversal)
         if ($patientMenuRole !== basename($patientMenuRole) || str_contains($patientMenuRole, '..')) {
-            error_log("OpenEMR: invalid patient menu role filename rejected: " . $patientMenuRole);
+            (new SystemLogger())->error("Invalid menu role filename rejected", ['filename' => $patientMenuRole]);
             die("\nInvalid menu role filename.");
         }
 

--- a/src/Menu/PatientMenuRole.php
+++ b/src/Menu/PatientMenuRole.php
@@ -52,6 +52,12 @@ class PatientMenuRole extends MenuRole
         // Collect the selected menu of user
         $patientMenuRole = $this->getMenuRole();
 
+        // Validate that the menu role filename is a basename only (no path traversal)
+        if ($patientMenuRole !== basename($patientMenuRole) || str_contains($patientMenuRole, '..')) {
+            error_log("OpenEMR: invalid patient menu role filename rejected: " . $patientMenuRole);
+            die("\nInvalid menu role filename.");
+        }
+
         // Load the selected menu
         if (str_ends_with($patientMenuRole, '.json')) {
             // load custom menu (includes .json in id)

--- a/src/Menu/PatientMenuRole.php
+++ b/src/Menu/PatientMenuRole.php
@@ -14,8 +14,8 @@
 
 namespace OpenEMR\Menu;
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AclMain;
-use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Menu\PatientMenuEvent;
@@ -55,7 +55,7 @@ class PatientMenuRole extends MenuRole
 
         // Validate that the menu role filename is a basename only (no path traversal)
         if ($patientMenuRole !== basename($patientMenuRole) || str_contains($patientMenuRole, '..')) {
-            (new SystemLogger())->error("Invalid menu role filename rejected", ['filename' => $patientMenuRole]);
+            ServiceContainer::getLogger()->error("Invalid menu role filename rejected", ['filename' => $patientMenuRole]);
             die("\nInvalid menu role filename.");
         }
 


### PR DESCRIPTION
Reject menu role filenames containing `/`, `\`, or `..` before passing to `file_get_contents()` in MainMenuRole and PatientMenuRole. Prevents admin-supplied filenames from reading arbitrary JSON files outside the custom_menus directory.

Fixes #11489