### PR TITLE
chore: drop unnecessary fgets() length limits

### DIFF
--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -746,7 +746,7 @@ class C_Prescription extends Controller
                 if (file_exists($addenumFile)) {
                     $pdf->ezText('');
                     $f = fopen($addenumFile, "r");
-                    while ($line = fgets($f, 1000)) {
+                    while ($line = fgets($f)) {
                         $pdf->ezText(rtrim($line));
                     }
                 }

--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -746,8 +746,14 @@ class C_Prescription extends Controller
                 if (file_exists($addenumFile)) {
                     $pdf->ezText('');
                     $f = fopen($addenumFile, "r");
-                    while ($line = fgets($f)) {
-                        $pdf->ezText(rtrim($line));
+                    if ($f !== false) {
+                        try {
+                            while (($line = fgets($f)) !== false) {
+                                $pdf->ezText(rtrim($line));
+                            }
+                        } finally {
+                            fclose($f);
+                        }
                     }
                 }
 

--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -746,14 +746,8 @@ class C_Prescription extends Controller
                 if (file_exists($addenumFile)) {
                     $pdf->ezText('');
                     $f = fopen($addenumFile, "r");
-                    if ($f !== false) {
-                        try {
-                            while (($line = fgets($f)) !== false) {
-                                $pdf->ezText(rtrim($line));
-                            }
-                        } finally {
-                            fclose($f);
-                        }
+                    while (($line = fgets($f)) !== false) {
+                        $pdf->ezText(rtrim($line));
                     }
                 }
 

--- a/library/smarty_legacy/smarty/plugins/function.fetch.php
+++ b/library/smarty_legacy/smarty/plugins/function.fetch.php
@@ -39,8 +39,8 @@ function smarty_function_fetch($params, &$smarty)
 
         // fetch the file
         if($fp = @fopen($params['file'],'r')) {
-            while(!feof($fp)) {
-                $content .= fgets($fp);
+            while(($line = fgets($fp)) !== false) {
+                $content .= $line;
             }
             fclose($fp);
         } else {
@@ -174,8 +174,8 @@ function smarty_function_fetch($params, &$smarty)
                     }
 
                     fwrite($fp, "\r\n");
-                    while(!feof($fp)) {
-                        $content .= fgets($fp);
+                    while(($line = fgets($fp)) !== false) {
+                        $content .= $line;
                     }
                     fclose($fp);
                     $csplit = preg_split("!\r\n\r\n!",$content,2);
@@ -193,8 +193,8 @@ function smarty_function_fetch($params, &$smarty)
         } else {
             // ftp fetch
             if($fp = @fopen($params['file'],'r')) {
-                while(!feof($fp)) {
-                    $content .= fgets($fp);
+                while(($line = fgets($fp)) !== false) {
+                    $content .= $line;
                 }
                 fclose($fp);
             } else {

--- a/library/smarty_legacy/smarty/plugins/function.fetch.php
+++ b/library/smarty_legacy/smarty/plugins/function.fetch.php
@@ -40,7 +40,7 @@ function smarty_function_fetch($params, &$smarty)
         // fetch the file
         if($fp = @fopen($params['file'],'r')) {
             while(!feof($fp)) {
-                $content .= fgets ($fp,4096);
+                $content .= fgets($fp);
             }
             fclose($fp);
         } else {
@@ -175,7 +175,7 @@ function smarty_function_fetch($params, &$smarty)
 
                     fwrite($fp, "\r\n");
                     while(!feof($fp)) {
-                        $content .= fgets($fp,4096);
+                        $content .= fgets($fp);
                     }
                     fclose($fp);
                     $csplit = preg_split("!\r\n\r\n!",$content,2);
@@ -194,7 +194,7 @@ function smarty_function_fetch($params, &$smarty)
             // ftp fetch
             if($fp = @fopen($params['file'],'r')) {
                 while(!feof($fp)) {
-                    $content .= fgets ($fp,4096);
+                    $content .= fgets($fp);
                 }
                 fclose($fp);
             } else {

--- a/modules/sms_email_reminder/sms_clickatell.php
+++ b/modules/sms_email_reminder/sms_clickatell.php
@@ -351,7 +351,7 @@ class sms_clickatell implements sms_interface
         $result = '';
         $handler = @fopen($command, 'r');
         if ($handler) {
-            while ($line = @fgets($handler, 1024)) {
+            while ($line = @fgets($handler)) {
                 $result .= $line;
             }
 

--- a/modules/sms_email_reminder/sms_clickatell.php
+++ b/modules/sms_email_reminder/sms_clickatell.php
@@ -351,7 +351,7 @@ class sms_clickatell implements sms_interface
         $result = '';
         $handler = @fopen($command, 'r');
         if ($handler) {
-            while ($line = @fgets($handler)) {
+            while (($line = @fgets($handler)) !== false) {
                 $result .= $line;
             }
 


### PR DESCRIPTION
Remove the second argument from 5 `fgets()` calls across 3 files. The length parameter has been optional since PHP 4.3 and these fixed limits (1000-4096 bytes) silently truncate long lines.

Fixes #11464