### PR TITLE
fix(cdr): stop translating DB identifiers in render_select

### DIFF
--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -3143,7 +3143,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleTemplateExtension.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -3143,7 +3143,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleTemplateExtension.php',
 ];
 $ignoreErrors[] = [

--- a/src/ClinicalDecisionRules/Interface/RuleTemplateExtension.php
+++ b/src/ClinicalDecisionRules/Interface/RuleTemplateExtension.php
@@ -21,7 +21,7 @@ class RuleTemplateExtension
                 <option id="<?php echo attr($option['id']); ?>"
                         value="<?php echo attr($option['id']); ?>"
                     <?php echo $args['value'] == $option['id'] ? "SELECTED" : "" ?>>
-                    <?php echo text($option['label']); ?>
+                    <?php echo text((string)($option['label'] ?? '')); ?>
                 </option>
             <?php } ?>
 

--- a/src/ClinicalDecisionRules/Interface/RuleTemplateExtension.php
+++ b/src/ClinicalDecisionRules/Interface/RuleTemplateExtension.php
@@ -21,7 +21,7 @@ class RuleTemplateExtension
                 <option id="<?php echo attr($option['id']); ?>"
                         value="<?php echo attr($option['id']); ?>"
                     <?php echo $args['value'] == $option['id'] ? "SELECTED" : "" ?>>
-                    <?php echo xlt($option['label']); ?>
+                    <?php echo text($option['label']); ?>
                 </option>
             <?php } ?>
 

--- a/src/ClinicalDecisionRules/Interface/RuleTemplateExtension.php
+++ b/src/ClinicalDecisionRules/Interface/RuleTemplateExtension.php
@@ -21,7 +21,7 @@ class RuleTemplateExtension
                 <option id="<?php echo attr($option['id']); ?>"
                         value="<?php echo attr($option['id']); ?>"
                     <?php echo $args['value'] == $option['id'] ? "SELECTED" : "" ?>>
-                    <?php echo text((string)($option['label'] ?? '')); ?>
+                    <?php echo text(is_string($option['label'] ?? null) ? $option['label'] : ''); ?>
                 </option>
             <?php } ?>
 


### PR DESCRIPTION
Change `xlt($option['label'])` to `text($option['label'])` in RuleTemplateExtension.php. Database table names passed by `getTableNameOptions()` should be displayed verbatim, not translated. Callers that need translation already pre-translate their labels.

Fixes #11469