### PR TITLE
ci: pin Docker images by digest and add Dependabot for CI images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -128,19 +128,65 @@ updates:
   - docker/development-easy-redis/
   - docker/development-insane/
   schedule:
-    interval: weekly
+    interval: daily
   allow:
   - dependency-name: selenium/standalone-chromium
+  - dependency-name: selenium/video
   ignore:
   - dependency-name: selenium/standalone-chromium
     versions: ['>=50']
   groups:
     selenium-updates:
       patterns:
-      - selenium/standalone-chromium
+      - selenium/*
   labels:
   - dependencies
   - selenium
+  - docker
+
+  # Docker CI images (database + openemr/dev-php-fpm + openemr/openemr + shared services)
+- package-ecosystem: docker-compose
+  directories:
+  - ci/apache_82_118/
+  - ci/apache_83_118/
+  - ci/apache_84_118/
+  - ci/apache_85_1011/
+  - ci/apache_85_106/
+  - ci/apache_85_114/
+  - ci/apache_85_118/
+  - ci/apache_85_120/
+  - ci/apache_85_57/
+  - ci/apache_85_80/
+  - ci/apache_85_84/
+  - ci/apache_85_93/
+  - ci/compose-shared-mailpit/
+  - ci/compose-shared-nginx/
+  - ci/inferno/
+  - ci/nginx_82/
+  - ci/nginx_83/
+  - ci/nginx_84/
+  - ci/nginx_85/
+  - ci/nginx_86/
+  schedule:
+    interval: daily
+  groups:
+    mariadb:
+      patterns:
+      - mariadb
+    mysql:
+      patterns:
+      - mysql
+    openemr-images:
+      patterns:
+      - openemr/*
+    couchdb:
+      patterns:
+      - couchdb
+    mailpit:
+      patterns:
+      - axllent/mailpit
+  labels:
+  - dependencies
   - docker
 
   # JavaScript dependencies (ccdaservice)

--- a/ci/README.md
+++ b/ci/README.md
@@ -79,9 +79,10 @@ The CI system uses Docker Compose's multi-file composition (otherwise known as c
 1. **Shared Configuration Files**:
    - `compose-shared-selenium/docker-compose.yml`: Contains the Selenium Grid configuration for running E2E tests. It is always included.
    - `compose-shared-apache.yml`: Contains the base configuration for Apache-based setups with database specific items not included.
-   - `compose-shared-nginx.yml`: Contains the base configuration for Nginx-based setups with database specific items not included.
+   - `compose-shared-nginx/compose.yml`: Contains the base configuration for Nginx-based setups with database specific items not included.
    - `compose-shared-mariadb.yml`: Contains MariaDB specific items.
    - `compose-shared-mysql.yml`: Contains MySQL specific items.
+   - `compose-shared-mailpit/compose.yml`: Contains the Mailpit configuration for email testing.
 
 2. **Individual Test Environment Setup**:
    Each test directory (e.g., `apache_83_116`) has its own `docker-compose.yml` that:
@@ -110,7 +111,7 @@ To add a new test configuration:
 
 1. Decide if your new environment needs Apache or Nginx:
    - For Apache-based environments, will use `compose-shared-apache.yml`
-   - For Nginx-based environments, will use `compose-shared-nginx.yml`
+   - For Nginx-based environments, will use `compose-shared-nginx/compose.yml`
 
 2. Decide if your new environment needs MariaDB or MySQL:
    - For MariaDB, will use `compose-shared-mariadb.yml`
@@ -161,7 +162,7 @@ To add a new test configuration:
    #  multi-file composition command line commands.
    x-includes:
      selenium-template: "compose-shared-selenium/docker-compose.yml"  # Show the Selenium Grid template
-     webserver-template: "compose-shared-nginx.yml"   # Show the Nginx web server template
+     webserver-template: "compose-shared-nginx/compose.yml"   # Show the Nginx web server template
      database-template: "compose-shared-mariadb.yml"  # Show the MariaDB database template
 
    services:
@@ -177,7 +178,7 @@ To add a new test configuration:
    #  multi-file composition command line commands.
    x-includes:
      selenium-template: "compose-shared-selenium/docker-compose.yml"  # Show the Selenium Grid template
-     webserver-template: "compose-shared-nginx.yml"   # Show the Nginx web server template
+     webserver-template: "compose-shared-nginx/compose.yml"   # Show the Nginx web server template
      database-template: "compose-shared-mysql.yml"    # Show the MySQL database template
 
    services:
@@ -192,7 +193,7 @@ To add a new test configuration:
 #### Modifying Shared Configurations
 
 When updating the shared configuration files:
-- Changes to `compose-shared-selenium/docker-compose.yml`, ```compose-shared-apache.yml`, `compose-shared-nginx.yml`, `compose-shared-mariadb.yml`, and  `compose-shared-mysql.yml` will affect all test environments that use them
+- Changes to `compose-shared-selenium/docker-compose.yml`, `compose-shared-apache.yml`, `compose-shared-nginx/compose.yml`, `compose-shared-mariadb.yml`, and `compose-shared-mysql.yml` will affect all test environments that use them
 - Make sure your changes are backward compatible or update the individual environment files as needed
 - Test the changes across multiple environments to ensure they work correctly
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -193,7 +193,7 @@ To add a new test configuration:
 #### Modifying Shared Configurations
 
 When updating the shared configuration files:
-- Changes to `compose-shared-selenium/docker-compose.yml`, `compose-shared-apache.yml`, `compose-shared-nginx/compose.yml`, `compose-shared-mariadb.yml`, and `compose-shared-mysql.yml` will affect all test environments that use them
+- Changes to `compose-shared-selenium/docker-compose.yml`, `compose-shared-apache.yml`, `compose-shared-nginx/compose.yml`, `compose-shared-mariadb.yml`, `compose-shared-mysql.yml`, and `compose-shared-mailpit/compose.yml` will affect all test environments that use them
 - Make sure your changes are backward compatible or update the individual environment files as needed
 - Test the changes across multiple environments to ensure they work correctly
 
@@ -208,7 +208,7 @@ If tests are failing in CI but passing locally, check:
 
 ### Debugging Configurations
 
--For below commands:
+- For below commands:
   - Replace `apache_84_114` with the configuration directory you want to test.
   - Replace `compose-shared-mariadb.yml` and `compose-shared-apache.yml` with the database and webserver `x-includes` values from the configuration's docker-compose.yml file.
   - Run the below commands from the base openemr directory.

--- a/ci/README.md
+++ b/ci/README.md
@@ -68,7 +68,7 @@ The CI process uses several important environment variables:
 - `DOCKER_DIR`: The directory containing the Docker Compose configuration
 - `ENABLE_COVERAGE`: Whether to enable code coverage reporting (true/false)
 - `OPENEMR_DIR`: The directory containing OpenEMR inside the Docker container
-- `COMPOSE_FILE`: The Docker Compose COMPOSE_FILE environment variable is set to store the templates for the multi-file composition. The first file is the template for the web server configuration (Apache or Nginx). The second file is the template for the database configuration (MariaDB or MySQL). The third file is the template for the PHP version and MariaDB/MySQL version.
+- `COMPOSE_FILE`: The Docker Compose COMPOSE_FILE environment variable is set to store the templates for the multi-file composition. The first file is the template for the database configuration (MariaDB or MySQL) — it must be directly in `ci/` (not a subdirectory) because Docker Compose resolves all relative paths from the first file's directory. The remaining files are the webserver template, Selenium Grid template, Mailpit template, and the per-configuration `docker-compose.yml`.
 
 ### Docker Compose Extension System
 
@@ -210,26 +210,26 @@ If tests are failing in CI but passing locally, check:
 
 -For below commands:
   - Replace `apache_84_114` with the configuration directory you want to test.
-  - Replace `compose-shared-apache.yml` and `compose-shared-mariadb.yml` with the `x-includes` values that are included in the main docker-compose.yml file.
+  - Replace `compose-shared-mariadb.yml` and `compose-shared-apache.yml` with the database and webserver `x-includes` values from the configuration's docker-compose.yml file.
   - Run the below commands from the base openemr directory.
   - Note that for future: the first entry (-f) in the command needs to be in ci/ (if it has a subdirectory then it breaks things)
 
 You can view the fully merged configuration file with the following `config` command:
 ```bash
-docker compose -f "ci/compose-shared-apache.yml" -f "ci/compose-shared-mariadb.yml" -f "ci/compose-shared-selenium/docker-compose.yml" -f "ci/apache_84_114/docker-compose.yml" config
+docker compose -f "ci/compose-shared-mariadb.yml" -f "ci/compose-shared-apache.yml" -f "ci/compose-shared-selenium/docker-compose.yml" -f "ci/compose-shared-mailpit/compose.yml" -f "ci/apache_84_114/docker-compose.yml" config
 ```
 
 You can also run the same Docker Compose setup locally:
 ```bash
-docker compose -f "ci/compose-shared-apache.yml" -f "ci/compose-shared-mariadb.yml" -f "ci/compose-shared-selenium/docker-compose.yml" -f "ci/apache_84_114/docker-compose.yml" up -d
+docker compose -f "ci/compose-shared-mariadb.yml" -f "ci/compose-shared-apache.yml" -f "ci/compose-shared-selenium/docker-compose.yml" -f "ci/compose-shared-mailpit/compose.yml" -f "ci/apache_84_114/docker-compose.yml" up -d
 ```
 
 You can go directly into the OpenEMR testing container:
 ```bash
-docker compose -f "ci/compose-shared-apache.yml" -f "ci/compose-shared-mariadb.yml" -f "ci/compose-shared-selenium/docker-compose.yml" -f "ci/apache_84_114/docker-compose.yml" exec -it openemr sh
+docker compose -f "ci/compose-shared-mariadb.yml" -f "ci/compose-shared-apache.yml" -f "ci/compose-shared-selenium/docker-compose.yml" -f "ci/compose-shared-mailpit/compose.yml" -f "ci/apache_84_114/docker-compose.yml" exec -it openemr sh
 ```
 
 You can shut down the Docker Compose setup:
 ```bash
-docker compose -f "ci/compose-shared-apache.yml" -f "ci/compose-shared-mariadb.yml" -f "ci/compose-shared-selenium/docker-compose.yml" -f "ci/apache_84_114/docker-compose.yml" down -v
+docker compose -f "ci/compose-shared-mariadb.yml" -f "ci/compose-shared-apache.yml" -f "ci/compose-shared-selenium/docker-compose.yml" -f "ci/compose-shared-mailpit/compose.yml" -f "ci/apache_84_114/docker-compose.yml" down -v
 ```

--- a/ci/apache_82_118/docker-compose.yml
+++ b/ci/apache_82_118/docker-compose.yml
@@ -3,10 +3,10 @@ x-includes:
   selenium-template: "compose-shared-selenium/docker-compose.yml"
   webserver-template: "compose-shared-apache.yml"
   database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mariadb:11.8
+    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
-    image: openemr/openemr:flex-3.22-php-8.2
+    image: openemr/openemr:flex-3.22-php-8.2@sha256:186433921a8da60a18f152d3baaeb5fad9ebe0649e2c503f896ed41584e2329a

--- a/ci/apache_83_118/docker-compose.yml
+++ b/ci/apache_83_118/docker-compose.yml
@@ -3,10 +3,10 @@ x-includes:
   selenium-template: "compose-shared-selenium/docker-compose.yml"
   webserver-template: "compose-shared-apache.yml"
   database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mariadb:11.8
+    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
-    image: openemr/openemr:flex-3.23-php-8.3
+    image: openemr/openemr:flex-3.23-php-8.3@sha256:821c735f9cbe605872dff47e47a30454e5c041c5b21ca54d1a1dcab181e2d14d

--- a/ci/apache_84_118/docker-compose.yml
+++ b/ci/apache_84_118/docker-compose.yml
@@ -3,10 +3,10 @@ x-includes:
   selenium-template: "compose-shared-selenium/docker-compose.yml"
   webserver-template: "compose-shared-apache.yml"
   database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mariadb:11.8
+    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
-    image: openemr/openemr:flex-3.23-php-8.4
+    image: openemr/openemr:flex-3.23-php-8.4@sha256:fe55756b3d611d7cf789585acda5e20fb391e1912f600dc4b5b5833bd3475c07

--- a/ci/apache_85_1011/docker-compose.yml
+++ b/ci/apache_85_1011/docker-compose.yml
@@ -3,10 +3,10 @@ x-includes:
   selenium-template: "compose-shared-selenium/docker-compose.yml"
   webserver-template: "compose-shared-apache.yml"
   database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mariadb:10.11
+    image: mariadb:10.11@sha256:2f2b6bbcdbaf88afe53b76cb8d73927b623559180c5ab15db2049736f32ec590
   openemr:
-    image: openemr/openemr:flex-3.23-php-8.5
+    image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_106/docker-compose.yml
+++ b/ci/apache_85_106/docker-compose.yml
@@ -3,10 +3,10 @@ x-includes:
   selenium-template: "compose-shared-selenium/docker-compose.yml"
   webserver-template: "compose-shared-apache.yml"
   database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mariadb:10.6
+    image: mariadb:10.6@sha256:62e7c42cb0fd5b2bdf7684e0c7af1e7eb1e840b367ba728f3511d841268058a6
   openemr:
-    image: openemr/openemr:flex-3.23-php-8.5
+    image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_114/docker-compose.yml
+++ b/ci/apache_85_114/docker-compose.yml
@@ -3,10 +3,10 @@ x-includes:
   selenium-template: compose-shared-selenium/docker-compose.yml
   webserver-template: compose-shared-apache.yml
   database-template: compose-shared-mariadb.yml
-  mailpit-template: compose-shared-mailpit.yml
+  mailpit-template: compose-shared-mailpit/compose.yml
 
 services:
   mysql:
-    image: mariadb:11.4
+    image: mariadb:11.4@sha256:bdd77d2a639e5e123025e4c5f7e0a2373b06f733631c57d53034709b23dae807
   openemr:
-    image: openemr/openemr:flex-3.23-php-8.5
+    image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_118/docker-compose.yml
+++ b/ci/apache_85_118/docker-compose.yml
@@ -3,10 +3,10 @@ x-includes:
   selenium-template: "compose-shared-selenium/docker-compose.yml"
   webserver-template: "compose-shared-apache.yml"
   database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mariadb:11.8
+    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
-    image: openemr/openemr:flex-3.23-php-8.5
+    image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_120/docker-compose.yml
+++ b/ci/apache_85_120/docker-compose.yml
@@ -3,10 +3,10 @@ x-includes:
   selenium-template: "compose-shared-selenium/docker-compose.yml"
   webserver-template: "compose-shared-apache.yml"
   database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mariadb:12.0
+    image: mariadb:12.0@sha256:607835cd628b78e2876f6a586d0ec37b296c47683b31ef750002d3d17d3d8f7a
   openemr:
-    image: openemr/openemr:flex-3.23-php-8.5
+    image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_57/docker-compose.yml
+++ b/ci/apache_85_57/docker-compose.yml
@@ -3,10 +3,10 @@ x-includes:
   selenium-template: "compose-shared-selenium/docker-compose.yml"
   webserver-template: "compose-shared-apache.yml"
   database-template: "compose-shared-mysql.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mysql:5.7
+    image: mysql:5.7@sha256:4bc6bc963e6d8443453676cae56536f4b8156d78bae03c0145cbe47c2aad73bb
   openemr:
-    image: openemr/openemr:flex-3.23-php-8.5
+    image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_80/docker-compose.yml
+++ b/ci/apache_85_80/docker-compose.yml
@@ -3,10 +3,10 @@ x-includes:
   selenium-template: "compose-shared-selenium/docker-compose.yml"
   webserver-template: "compose-shared-apache.yml"
   database-template: "compose-shared-mysql.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mysql:8.0
+    image: mysql:8.0@sha256:64756cc92f707eb504496d774353990bcb0f6999ddf598b6ad188f2da66bd000
   openemr:
-    image: openemr/openemr:flex-3.23-php-8.5
+    image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_84/docker-compose.yml
+++ b/ci/apache_85_84/docker-compose.yml
@@ -3,10 +3,10 @@ x-includes:
   selenium-template: "compose-shared-selenium/docker-compose.yml"
   webserver-template: "compose-shared-apache.yml"
   database-template: "compose-shared-mysql.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mysql:8.4
+    image: mysql:8.4@sha256:da906917ca4ace3ba55538b7c2ee97a9bc865ef14a4b6920b021f0249d603f3d
   openemr:
-    image: openemr/openemr:flex-3.23-php-8.5
+    image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_93/docker-compose.yml
+++ b/ci/apache_85_93/docker-compose.yml
@@ -3,10 +3,10 @@ x-includes:
   selenium-template: "compose-shared-selenium/docker-compose.yml"
   webserver-template: "compose-shared-apache.yml"
   database-template: "compose-shared-mysql.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mysql:9.3
+    image: mysql:9.3@sha256:b9d8b7ec6e6aced08b1cfe50776f8e323c0a625adf4e10e69f90fc686ea10807
   openemr:
-    image: openemr/openemr:flex-3.23-php-8.5
+    image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/compose-shared-mailpit/compose.yml
+++ b/ci/compose-shared-mailpit/compose.yml
@@ -1,6 +1,6 @@
 services:
   mailpit:
-    image: axllent/mailpit:latest
+    image: axllent/mailpit:v1.29@sha256:0b5c5f7ffd3c93474baa7fd3869c1462e5a3d03256ed0933dfc0e7d81d794036
     environment:
       MP_SMTP_AUTH_ACCEPT_ANY: 1
       MP_SMTP_AUTH_ALLOW_INSECURE: 1

--- a/ci/compose-shared-nginx/compose.yml
+++ b/ci/compose-shared-nginx/compose.yml
@@ -9,7 +9,7 @@ services:
     - ../:/usr/share/nginx/html/openemr
     - ./nginx/php.ini:/usr/local/etc/php/php.ini:ro
   nginx:
-    image: openemr/dev-nginx
+    image: openemr/dev-nginx:latest@sha256:cd70ec94ddce2956b6acbc5f873c6bbfffda5129cc5fbf6f3f76979ae7afdb80
     ports:
     - 80:80
     - 443:443

--- a/ci/compose-shared-selenium/docker-compose.yml
+++ b/ci/compose-shared-selenium/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   selenium:
-    image: selenium/standalone-chromium:4.41.0
+    image: selenium/standalone-chromium:4.41.0@sha256:36474a4c56765ec3d04dc4cbac57a021e0d88e89fdb5dca297a50f1100279c1a
     # Services with profiles don't start by default.
     profiles:
     - selenium
@@ -25,7 +25,7 @@ services:
       timeout: 5s
       retries: 3
   video:
-    image: selenium/video:ffmpeg-7.1-20250707
+    image: selenium/video:ffmpeg-7.1-20250707@sha256:0fdf34adbb2eae696ee08bad7c118c7d90b58fb33a86bbb5034c9198d43e6b55
     # Services with profiles don't start by default.
     profiles:
     - video-recording

--- a/ci/inferno/compose.yml
+++ b/ci/inferno/compose.yml
@@ -1,7 +1,7 @@
 services:
   mysql:
     restart: always
-    image: mariadb:11.8
+    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
     command:
     - mariadbd
     - --character-set-server=utf8mb4
@@ -21,7 +21,7 @@ services:
       retries: 3
   openemr:
     restart: always
-    image: openemr/openemr:flex-3.23-php-8.5
+    image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c
     ports:
     - 8080:80
     - 8523:443
@@ -98,7 +98,7 @@ services:
       dockerfile: Dockerfile.terminology
   couchdb:
     restart: always
-    image: couchdb
+    image: couchdb:3.4.3@sha256:625be8e930f8fce9f7be31e353aae789462590d62b87577322d8ea2be79911c0
     ports:
     - 5984:5984
     - 6984:6984

--- a/ci/nginx_82/docker-compose.yml
+++ b/ci/nginx_82/docker-compose.yml
@@ -1,12 +1,12 @@
 x-includes:
   node-version: "24"
   selenium-template: "compose-shared-selenium/docker-compose.yml"
-  webserver-template: "compose-shared-nginx.yml"
+  webserver-template: "compose-shared-nginx/compose.yml"
   database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mariadb:11.8
+    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
-    image: openemr/dev-php-fpm:8.2
+    image: openemr/dev-php-fpm:8.2@sha256:4dece20bb2da29bbb145cb19a470562b103cd9fe21225ddebf444a5d96705b7f

--- a/ci/nginx_83/docker-compose.yml
+++ b/ci/nginx_83/docker-compose.yml
@@ -1,12 +1,12 @@
 x-includes:
   node-version: "24"
   selenium-template: "compose-shared-selenium/docker-compose.yml"
-  webserver-template: "compose-shared-nginx.yml"
+  webserver-template: "compose-shared-nginx/compose.yml"
   database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mariadb:11.8
+    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
-    image: openemr/dev-php-fpm:8.3
+    image: openemr/dev-php-fpm:8.3@sha256:b7304018c9504bb0c9a2b28e358c66a4ec15a9ff8f914dc1f6d11c0e8dedb8f5

--- a/ci/nginx_84/docker-compose.yml
+++ b/ci/nginx_84/docker-compose.yml
@@ -1,12 +1,12 @@
 x-includes:
   node-version: "24"
   selenium-template: "compose-shared-selenium/docker-compose.yml"
-  webserver-template: "compose-shared-nginx.yml"
+  webserver-template: "compose-shared-nginx/compose.yml"
   database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mariadb:11.8
+    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
-    image: openemr/dev-php-fpm:8.4
+    image: openemr/dev-php-fpm:8.4@sha256:8a788de05698fa634a703444893fdee7c1bffd0155aeb5a049b3f85804c1ce12

--- a/ci/nginx_85/docker-compose.yml
+++ b/ci/nginx_85/docker-compose.yml
@@ -1,12 +1,12 @@
 x-includes:
   node-version: "24"
   selenium-template: "compose-shared-selenium/docker-compose.yml"
-  webserver-template: "compose-shared-nginx.yml"
+  webserver-template: "compose-shared-nginx/compose.yml"
   database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mariadb:11.8
+    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
-    image: openemr/dev-php-fpm:8.5
+    image: openemr/dev-php-fpm:8.5@sha256:f1fb7924f7359c08bb72233e12a3361dae91e88541560c4085b85931462c802c

--- a/ci/nginx_86/docker-compose.yml
+++ b/ci/nginx_86/docker-compose.yml
@@ -1,12 +1,12 @@
 x-includes:
   node-version: "24"
   selenium-template: "compose-shared-selenium/docker-compose.yml"
-  webserver-template: "compose-shared-nginx.yml"
+  webserver-template: "compose-shared-nginx/compose.yml"
   database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  mailpit-template: "compose-shared-mailpit/compose.yml"
 
 services:
   mysql:
-    image: mariadb:11.8
+    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
-    image: openemr/dev-php-fpm:8.6
+    image: openemr/dev-php-fpm:8.6@sha256:3c63bdade469a0c4a3537dc9185f3820dc6001381820e026311740e9da44b369

--- a/ci/parse_docker_dir.sh
+++ b/ci/parse_docker_dir.sh
@@ -21,9 +21,12 @@ parse() {
   local webserver_template
   local database_template
   local mailpit_template
+  local mysql_image
 
   # Parse docker directory name
   mysql_image=$(yq '.services.mysql.image' "ci/${docker_dir}/docker-compose.yml")
+  # Strip any @sha256:... digest suffix before splitting on ':'
+  mysql_image="${mysql_image%%@*}"
   IFS=: read -r database db <<< "${mysql_image}"
   IFS=_ read -r webserver php _ <<< "${docker_dir}"
 
@@ -74,8 +77,9 @@ parse() {
     save_node_cache=false
   fi
 
-  # Compose file path (first entry needs to be in ci/ if it has a subdirectory then it breaks things)
-  compose_file="ci/${webserver_template}:ci/${database_template}:ci/${selenium_template}:ci/${mailpit_template}:ci/${docker_dir}/docker-compose.yml"
+  # Compose file path (first entry must be directly in ci/, not a subdirectory,
+  # because Docker Compose resolves all relative paths from the first file's directory)
+  compose_file="ci/${database_template}:ci/${webserver_template}:ci/${selenium_template}:ci/${mailpit_template}:ci/${docker_dir}/docker-compose.yml"
 
   jq -cn \
     --arg compose_file "${compose_file}" \


### PR DESCRIPTION
## Summary

- Pin all CI docker-compose images to their current `@sha256:` digests, including shared compose files (mailpit, dev-nginx, selenium) and inferno
- Move `compose-shared-mailpit.yml` and `compose-shared-nginx.yml` into their own directories so Dependabot can discover them
- Fix `parse_docker_dir.sh` to strip `@sha256:` suffixes before splitting image references (prevents noisy matrix names)
- Reorder `COMPOSE_FILE` so the first entry is always directly in `ci/` (required for correct relative path resolution)
- Add Dependabot `docker-compose` entries covering all CI directories

This prevents silent CI breakage when an upstream image is rebuilt under the same tag. The recent Alpine 3.22→3.23 bump in `dev-php-fpm:8.5` (openemr/openemr-devops#628) changed Node.js from 22 to 24, causing an ABI mismatch in `libxmljs2` that broke `CcdaServiceDocumentRequestorTest::testSocket_get`. With digest pinning, that image change would have arrived as a Dependabot PR where CI would have caught the failure before merge.

## Test plan

- [x] All CI workflows pass with pinned digests
- [ ] Dependabot creates PRs when images are rebuilt (observable after merge)