### PR TITLE
refactor(di): Cache service instances in ServiceContainer

### DIFF
--- a/src/BC/ServiceContainer.php
+++ b/src/BC/ServiceContainer.php
@@ -48,14 +48,18 @@ class ServiceContainer
     /** @var array<class-string, object> */
     private static array $overrides = [];
 
+    /** @var array<class-string, object> */
+    private static array $cache = [];
+
     /**
-     * Reset all registered overrides. For testing only.
+     * Reset all registered overrides and cached instances. For testing only.
      *
      * @internal
      */
     public static function reset(): void
     {
         self::$overrides = [];
+        self::$cache = [];
     }
 
     /**
@@ -82,64 +86,99 @@ class ServiceContainer
     }
 
     /**
+     * Resolve a service from cache, overrides, or create via default factory.
+     *
      * @template T of object
      * @param class-string<T> $interface
-     * @return ?T
+     * @param callable(): T $default
+     * @return T
      */
-    private static function resolve(string $interface): ?object
+    private static function resolveOrCreate(string $interface, callable $default): object
     {
-        /** @var ?T */
-        return self::$overrides[$interface] ?? null;
+        if (array_key_exists($interface, self::$cache)) {
+            /** @var T */
+            return self::$cache[$interface];
+        }
+        /** @var T */
+        $instance = self::$overrides[$interface] ?? $default();
+        self::$cache[$interface] = $instance;
+        return $instance;
     }
 
     public static function getClock(): ClockInterface
     {
-        return self::resolve(ClockInterface::class) ?? SystemClock::fromSystemTimezone();
+        return self::resolveOrCreate(
+            ClockInterface::class,
+            static fn() => SystemClock::fromSystemTimezone(),
+        );
     }
 
     public static function getCrypto(): Crypto\CryptoInterface
     {
-        return self::resolve(Crypto\CryptoInterface::class) ?? new Crypto\CryptoGen();
+        return self::resolveOrCreate(
+            Crypto\CryptoInterface::class,
+            static fn() => new Crypto\CryptoGen(),
+        );
     }
 
     public static function getLogger(): LoggerInterface
     {
-        if ($logger = self::resolve(LoggerInterface::class)) {
-            return $logger;
-        }
-        if (defined('PHPUNIT_COMPOSER_INSTALL')) {
-            return new NullLogger();
-        }
-        return new Logging\SystemLogger();
+        return self::resolveOrCreate(
+            LoggerInterface::class,
+            static function () {
+                if (defined('PHPUNIT_COMPOSER_INSTALL')) {
+                    return new NullLogger();
+                }
+                return new Logging\SystemLogger();
+            },
+        );
     }
 
     public static function getRequestFactory(): RequestFactoryInterface
     {
-        return self::resolve(RequestFactoryInterface::class) ?? new Psr17Factory();
+        return self::resolveOrCreate(
+            RequestFactoryInterface::class,
+            static fn() => new Psr17Factory(),
+        );
     }
 
     public static function getResponseFactory(): ResponseFactoryInterface
     {
-        return self::resolve(ResponseFactoryInterface::class) ?? new Psr17Factory();
+        return self::resolveOrCreate(
+            ResponseFactoryInterface::class,
+            static fn() => new Psr17Factory(),
+        );
     }
 
     public static function getServerRequestFactory(): ServerRequestFactoryInterface
     {
-        return self::resolve(ServerRequestFactoryInterface::class) ?? new Psr17Factory();
+        return self::resolveOrCreate(
+            ServerRequestFactoryInterface::class,
+            static fn() => new Psr17Factory(),
+        );
     }
 
     public static function getStreamFactory(): StreamFactoryInterface
     {
-        return self::resolve(StreamFactoryInterface::class) ?? new Psr17Factory();
+        return self::resolveOrCreate(
+            StreamFactoryInterface::class,
+            static fn() => new Psr17Factory(),
+        );
     }
 
     public static function getUploadedFileFactory(): UploadedFileFactoryInterface
     {
-        return self::resolve(UploadedFileFactoryInterface::class) ?? new Psr17Factory();
+        return self::resolveOrCreate(
+            UploadedFileFactoryInterface::class,
+            static fn() => new Psr17Factory(),
+        );
     }
 
     public static function getUriFactory(): UriFactoryInterface
     {
-        return self::resolve(UriFactoryInterface::class) ?? new Psr17Factory();
+        return self::resolveOrCreate(
+            UriFactoryInterface::class,
+            static fn() => new Psr17Factory(),
+        );
     }
 }

--- a/tests/Tests/Isolated/BC/ServiceContainerTest.php
+++ b/tests/Tests/Isolated/BC/ServiceContainerTest.php
@@ -129,4 +129,26 @@ class ServiceContainerTest extends TestCase
 
         ServiceContainer::override(LoggerInterface::class, new \stdClass());
     }
+
+    public function testGetterReturnsSameInstanceOnRepeatedCalls(): void
+    {
+        ServiceContainer::reset();
+
+        $first = ServiceContainer::getClock();
+        $second = ServiceContainer::getClock();
+
+        self::assertSame($first, $second);
+        ServiceContainer::reset();
+    }
+
+    public function testResetClearsCachedInstances(): void
+    {
+        ServiceContainer::reset();
+
+        $before = ServiceContainer::getClock();
+        ServiceContainer::reset();
+        $after = ServiceContainer::getClock();
+
+        self::assertNotSame($before, $after);
+    }
 }


### PR DESCRIPTION
## Summary
- ServiceContainer now caches resolved instances, ensuring repeated calls return the same instance
- Enables stateful services (like storage managers and upcoming crypto stuff) to work correctly/more performantly as singletons. This mirrors the default behavior of the DI container.
- Added tests for caching behavior

## Test plan
- [x] Existing ServiceContainer tests pass
- [x] New caching tests verify same-instance behavior
- [x] PHPStan passes
- [x] phpcs passes

🤖 Generated with [Claude Code](https://claude.ai/code)