### PR TITLE
ci(deps): ignore version bumps for CI images pinned to specific versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -145,6 +145,10 @@ updates:
   - docker
 
   # Docker CI images (database + openemr/dev-php-fpm + openemr/openemr + shared services)
+  # Each ci/ directory tests a specific database + PHP version combination.
+  # Image tags encode the version under test (e.g., mysql:8.4, openemr/dev-php-fpm:8.5),
+  # so Dependabot must only update digests, not change tags. Changing a tag would
+  # silently alter which version is being tested.
 - package-ecosystem: docker-compose
   directories:
   - ci/apache_82_118/
@@ -169,6 +173,17 @@ updates:
   - ci/nginx_86/
   schedule:
     interval: daily
+  ignore:
+    # Only allow digest updates for version-pinned images — changing the tag
+    # would switch which database or PHP version the CI directory tests.
+  - dependency-name: mariadb
+    update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
+  - dependency-name: mysql
+    update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
+  - dependency-name: openemr/*
+    update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
+  - dependency-name: couchdb
+    update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
   groups:
     mariadb:
       patterns:


### PR DESCRIPTION
## Summary

- Add `ignore` rules to the CI images Dependabot entry to block semver updates for `mariadb`, `mysql`, `openemr/*`, and `couchdb`
- Only digest updates will be proposed for these images — tag changes are blocked because each CI directory intentionally tests a specific database and PHP version
- Add comments explaining the rationale

Without these rules, Dependabot proposes PRs like mysql 5.7→9.6 (#11528) and openemr/openemr flex-3.22-php-8.2→flex-3.22-php-8.4 (#11532), which would silently change which versions CI tests against.

## Test plan

- [ ] Verify that #11528, #11525, #11532, and #11533 are closed/superseded after merge
- [ ] Confirm Dependabot still proposes digest-only updates for CI images