### PR TITLE
ci(deps): use patch-level tags and refine Dependabot ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -132,9 +132,6 @@ updates:
   allow:
   - dependency-name: selenium/standalone-chromium
   - dependency-name: selenium/video
-  ignore:
-  - dependency-name: selenium/standalone-chromium
-    versions: ['>=50']
   groups:
     selenium-updates:
       patterns:
@@ -144,11 +141,10 @@ updates:
   - selenium
   - docker
 
-  # Docker CI images (database + openemr/dev-php-fpm + openemr/openemr + shared services)
-  # Each ci/ directory tests a specific database + PHP version combination.
-  # Image tags encode the version under test (e.g., mysql:8.4, openemr/dev-php-fpm:8.5),
-  # so Dependabot must not change the major or minor version. Patch updates
-  # within the same minor are allowed (e.g., couchdb 3.4.3 → 3.4.4).
+  # Docker CI images (database + PHP + shared services)
+  # Database and PHP image tags encode the version under test (e.g., mysql:8.4.8,
+  # openemr/dev-php-fpm:8.5), so major/minor bumps are blocked for those.
+  # Tooling images (mailpit, dev-nginx, couchdb) are unconstrained.
 - package-ecosystem: docker-compose
   directories:
   - ci/apache_82_118/
@@ -174,15 +170,15 @@ updates:
   schedule:
     interval: daily
   ignore:
-    # Block major/minor bumps — each CI directory intentionally tests a
-    # specific major.minor version. Patch and digest updates are allowed.
+    # Block major/minor bumps for version-pinned images only — each CI
+    # directory intentionally tests a specific database + PHP version.
   - dependency-name: mariadb
     update-types: [version-update:semver-major, version-update:semver-minor]
   - dependency-name: mysql
     update-types: [version-update:semver-major, version-update:semver-minor]
-  - dependency-name: openemr/*
+  - dependency-name: openemr/openemr
     update-types: [version-update:semver-major, version-update:semver-minor]
-  - dependency-name: couchdb
+  - dependency-name: openemr/dev-php-fpm
     update-types: [version-update:semver-major, version-update:semver-minor]
   groups:
     mariadb:

--- a/ci/apache_82_118/docker-compose.yml
+++ b/ci/apache_82_118/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
+    image: mariadb:11.8.6@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
     image: openemr/openemr:flex-3.22-php-8.2@sha256:186433921a8da60a18f152d3baaeb5fad9ebe0649e2c503f896ed41584e2329a

--- a/ci/apache_83_118/docker-compose.yml
+++ b/ci/apache_83_118/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
+    image: mariadb:11.8.6@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
     image: openemr/openemr:flex-3.23-php-8.3@sha256:821c735f9cbe605872dff47e47a30454e5c041c5b21ca54d1a1dcab181e2d14d

--- a/ci/apache_84_118/docker-compose.yml
+++ b/ci/apache_84_118/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
+    image: mariadb:11.8.6@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
     image: openemr/openemr:flex-3.23-php-8.4@sha256:fe55756b3d611d7cf789585acda5e20fb391e1912f600dc4b5b5833bd3475c07

--- a/ci/apache_85_1011/docker-compose.yml
+++ b/ci/apache_85_1011/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:10.11@sha256:2f2b6bbcdbaf88afe53b76cb8d73927b623559180c5ab15db2049736f32ec590
+    image: mariadb:10.11.16@sha256:2f2b6bbcdbaf88afe53b76cb8d73927b623559180c5ab15db2049736f32ec590
   openemr:
     image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_106/docker-compose.yml
+++ b/ci/apache_85_106/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:10.6@sha256:62e7c42cb0fd5b2bdf7684e0c7af1e7eb1e840b367ba728f3511d841268058a6
+    image: mariadb:10.6.25@sha256:62e7c42cb0fd5b2bdf7684e0c7af1e7eb1e840b367ba728f3511d841268058a6
   openemr:
     image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_114/docker-compose.yml
+++ b/ci/apache_85_114/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:11.4@sha256:bdd77d2a639e5e123025e4c5f7e0a2373b06f733631c57d53034709b23dae807
+    image: mariadb:11.4.10@sha256:bdd77d2a639e5e123025e4c5f7e0a2373b06f733631c57d53034709b23dae807
   openemr:
     image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_118/docker-compose.yml
+++ b/ci/apache_85_118/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
+    image: mariadb:11.8.6@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
     image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_120/docker-compose.yml
+++ b/ci/apache_85_120/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:12.0@sha256:607835cd628b78e2876f6a586d0ec37b296c47683b31ef750002d3d17d3d8f7a
+    image: mariadb:12.0.2@sha256:607835cd628b78e2876f6a586d0ec37b296c47683b31ef750002d3d17d3d8f7a
   openemr:
     image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_57/docker-compose.yml
+++ b/ci/apache_85_57/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mysql:5.7@sha256:4bc6bc963e6d8443453676cae56536f4b8156d78bae03c0145cbe47c2aad73bb
+    image: mysql:5.7.44@sha256:4bc6bc963e6d8443453676cae56536f4b8156d78bae03c0145cbe47c2aad73bb
   openemr:
     image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_80/docker-compose.yml
+++ b/ci/apache_85_80/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mysql:8.0@sha256:64756cc92f707eb504496d774353990bcb0f6999ddf598b6ad188f2da66bd000
+    image: mysql:8.0.45@sha256:64756cc92f707eb504496d774353990bcb0f6999ddf598b6ad188f2da66bd000
   openemr:
     image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_84/docker-compose.yml
+++ b/ci/apache_85_84/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mysql:8.4@sha256:da906917ca4ace3ba55538b7c2ee97a9bc865ef14a4b6920b021f0249d603f3d
+    image: mysql:8.4.8@sha256:da906917ca4ace3ba55538b7c2ee97a9bc865ef14a4b6920b021f0249d603f3d
   openemr:
     image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/apache_85_93/docker-compose.yml
+++ b/ci/apache_85_93/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mysql:9.3@sha256:b9d8b7ec6e6aced08b1cfe50776f8e323c0a625adf4e10e69f90fc686ea10807
+    image: mysql:9.3.0@sha256:b9d8b7ec6e6aced08b1cfe50776f8e323c0a625adf4e10e69f90fc686ea10807
   openemr:
     image: openemr/openemr:flex-3.23-php-8.5@sha256:e4562b0c7d3f222ec8f72122ce00d10ffa93f559c38c00ab12c1355394c35d1c

--- a/ci/compose-shared-mailpit/compose.yml
+++ b/ci/compose-shared-mailpit/compose.yml
@@ -1,6 +1,6 @@
 services:
   mailpit:
-    image: axllent/mailpit:v1.29@sha256:0b5c5f7ffd3c93474baa7fd3869c1462e5a3d03256ed0933dfc0e7d81d794036
+    image: axllent/mailpit:v1.29.6@sha256:0b5c5f7ffd3c93474baa7fd3869c1462e5a3d03256ed0933dfc0e7d81d794036
     environment:
       MP_SMTP_AUTH_ACCEPT_ANY: 1
       MP_SMTP_AUTH_ALLOW_INSECURE: 1

--- a/ci/inferno/compose.yml
+++ b/ci/inferno/compose.yml
@@ -1,7 +1,7 @@
 services:
   mysql:
     restart: always
-    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
+    image: mariadb:11.8.6@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
     command:
     - mariadbd
     - --character-set-server=utf8mb4

--- a/ci/nginx_82/docker-compose.yml
+++ b/ci/nginx_82/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
+    image: mariadb:11.8.6@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
     image: openemr/dev-php-fpm:8.2@sha256:4dece20bb2da29bbb145cb19a470562b103cd9fe21225ddebf444a5d96705b7f

--- a/ci/nginx_83/docker-compose.yml
+++ b/ci/nginx_83/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
+    image: mariadb:11.8.6@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
     image: openemr/dev-php-fpm:8.3@sha256:b7304018c9504bb0c9a2b28e358c66a4ec15a9ff8f914dc1f6d11c0e8dedb8f5

--- a/ci/nginx_84/docker-compose.yml
+++ b/ci/nginx_84/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
+    image: mariadb:11.8.6@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
     image: openemr/dev-php-fpm:8.4@sha256:8a788de05698fa634a703444893fdee7c1bffd0155aeb5a049b3f85804c1ce12

--- a/ci/nginx_85/docker-compose.yml
+++ b/ci/nginx_85/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
+    image: mariadb:11.8.6@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
     image: openemr/dev-php-fpm:8.5@sha256:f1fb7924f7359c08bb72233e12a3361dae91e88541560c4085b85931462c802c

--- a/ci/nginx_86/docker-compose.yml
+++ b/ci/nginx_86/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:11.8@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
+    image: mariadb:11.8.6@sha256:f5644a292224cdf4b6514aca38b3b4436f0b0443d54170a472cd14261f31402d
   openemr:
     image: openemr/dev-php-fpm:8.6@sha256:3c63bdade469a0c4a3537dc9185f3820dc6001381820e026311740e9da44b369


### PR DESCRIPTION
## Summary

Follow-up to #11535.

- Use patch-level tags (e.g., `mariadb:11.8.6` instead of `mariadb:11.8`) for all MariaDB and MySQL images, and mailpit (`v1.29.6` instead of `v1.29`). Digests are unchanged — the minor and patch tags currently point to the same manifest. This makes it immediately clear which patch version CI is running.
- Allow patch updates for version-pinned images (remove `semver-patch` from ignore rules). A patch bump within the same minor (e.g., `11.8.6` → `11.8.7`) is safe — it doesn't change which database version is being tested.
- Narrow the `openemr/*` ignore rule to only `openemr/openemr` and `openemr/dev-php-fpm`. The wildcard was accidentally blocking `openemr/dev-nginx`, which is tooling and should be unconstrained.
- Remove `couchdb` from ignore rules — it's inferno infrastructure, not a version under test.
- Remove the obsolete `selenium/standalone-chromium` version cap (`>=50`). This was added in #8774 to prevent Dependabot from jumping to unexpected tag schemes, but current selenium versions (145.x) are well past this threshold, making it a no-op.

## Test plan

- [ ] All CI workflows pass (no image changes, only tag names)
- [ ] Dependabot proposes couchdb minor/major updates when available
- [ ] Dependabot proposes patch updates for database images when available