### PR TITLE
fix(deps): resolve Dependabot overlapping directory error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,13 +120,12 @@ updates:
     include: scope
   open-pull-requests-limit: 5
 
-  # Docker selenium docker updates in 4 places in the repo as a group
+  # Docker selenium updates for CI (shared compose file)
+  # Docker dev directories are covered by their own entries below,
+  # which handle selenium alongside all other images.
 - package-ecosystem: docker-compose
   directories:
   - ci/compose-shared-selenium/
-  - docker/development-easy/
-  - docker/development-easy-redis/
-  - docker/development-insane/
   schedule:
     interval: daily
   allow:
@@ -228,6 +227,9 @@ updates:
     redis:
       patterns:
       - redis
+    selenium:
+      patterns:
+      - selenium/*
     mailpit:
       patterns:
       - axllent/mailpit
@@ -271,6 +273,9 @@ updates:
     redis:
       patterns:
       - redis
+    selenium:
+      patterns:
+      - selenium/*
     mailpit:
       patterns:
       - axllent/mailpit


### PR DESCRIPTION
## Summary

- Remove `docker/development-easy/`, `docker/development-easy-redis/`, and `docker/development-insane/` from the selenium Dependabot entry (now CI-only)
- Add `selenium/*` group patterns to both docker/* Dependabot entries so selenium updates are still grouped

The selenium entry and the new docker/* entries from #11541 both listed the same directories, which Dependabot rejects as overlapping for the same `docker-compose` ecosystem. The docker/* entries already handle all images (no `allow:` filter), so they naturally cover selenium updates too.

## Test plan

- [ ] Dependabot config validation passes (the check that's currently failing on master)