### PR TITLE
fix(ci): simplify Codecov flags to fix "Multiple flags detected" error

### DIFF
--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -57,7 +57,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit.xml
-        flags: isolated
+        flags: isolated-php${{ matrix.php-version }}
         report_type: test_results
 
     - name: Upload JUnit test results to GitHub
@@ -79,4 +79,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: clover.xml
-        flags: isolated
+        flags: isolated-php${{ matrix.php-version }}

--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -57,16 +57,8 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit.xml
-        flags: isolated,php${{ matrix.php-version }}
+        flags: isolated
         report_type: test_results
-
-    - name: Hide test results from subsequent uploads
-      if: ${{ !cancelled() && hashFiles('junit.xml') != '' }}
-      run: mv junit.xml junit.saved-test-data
-
-    - name: Unhide test results for GitHub upload
-      if: ${{ !cancelled() && hashFiles('junit.saved-test-data') != '' }}
-      run: mv junit.saved-test-data junit.xml
 
     - name: Upload JUnit test results to GitHub
       if: ${{ !cancelled() }}
@@ -87,4 +79,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: clover.xml
-        flags: isolated,php${{ matrix.php-version }}
+        flags: isolated


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes Codecov "Multiple flags detected. Please ensure one flag per upload." error in PR reports.

Related to #9176 / #9179 which introduced flags.

#### Changes proposed in this pull request:

- Use single `isolated` flag instead of comma-separated `isolated,php${{ matrix.php-version }}`
- Codecov interprets commas as multiple flags per upload, which is not recommended
- Remove unnecessary hide/unhide steps for junit.xml (both uploads explicitly specify files)
- All PHP versions now merge coverage under one flag, which is appropriate since code paths are identical

**Note:** This is a partial fix for `isolated-tests.yml` only. If this works correctly, the same pattern will be applied to `test.yml`.

#### Was an AI assistant used? Yes

🤖 Generated with [Claude Code](https://claude.ai/code)