### PR TITLE
fix(security): use DOM construction for iframe in twAddFrameTab

### DIFF
--- a/src/Tabs/TabsWrapper.php
+++ b/src/Tabs/TabsWrapper.php
@@ -203,29 +203,18 @@ function twAddFrameTab(tabsid, label, url) {
   var panelId = nextPanelId(tabsid);
   top.restoreSession();
   if (label === "Fee Sheet") {
-    if (!execute) {
-      twAddTab(
-        tabsid,
-        label,
-        "<iframe name='" + panelId + "' class='w-100' style='height:94.5vh;border: 0;' src='" + url + "'>Oops</iframe>"
-      );
-      execute = true;
-      temp = panelId;
-      return panelId;
-    } else {
+    if (execute) {
       asyncAlertMsg($message, 3000, 'warning','') ;
       return false;
     }
-  } else {
-    twAddTab(
-      tabsid,
-      label,
-      "<iframe name='" + panelId + "' class='w-100' style='height:94.5vh;border: 0;' src='" + url + "'>Oops</iframe>"
-    );
-    return panelId;
+    execute = true;
+    temp = panelId;
   }
-
-
+  var iframe = $("<iframe class='w-100' style='height:94.5vh;border:0;'>Oops</iframe>")
+    .attr('name', panelId)
+    .attr('src', url);
+  twAddTab(tabsid, label, iframe.prop('outerHTML'));
+  return panelId;
 }
 
 // Remove the specified tab from the specified tab set.


### PR DESCRIPTION
## Summary

`twAddFrameTab()` in `TabsWrapper.php` concatenated `url` directly into an iframe's `src` attribute using string interpolation, which could allow attribute breakout if a URL contained a single quote. This is the same class of issue fixed in #11512 for tab labels.

- Replace string-concatenated iframe markup with jQuery DOM construction and `.attr()` for safe attribute escaping
- Deduplicate the two identical iframe-building branches (Fee Sheet vs other) into a single code path

Follow-up to #11512.

## Test plan

- [ ] Open an encounter and add forms via the tab UI — verify iframes load correctly
- [ ] Verify Fee Sheet duplicate-tab prevention still works (should show warning on second open)