### PR TITLE
refactor(faxsms): remove dead variables from notification script

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
@@ -14,6 +14,7 @@
  * @copyright Copyright (c) 2008 Larry Lart
  * @copyright Copyright (c) 2018-2024 Jerry Padgett
  * @copyright Copyright (c) 2021 Robert Down <robertdown@live.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  */
 
 //hack add for command line version
@@ -117,10 +118,6 @@ $bTestRun = isset($_REQUEST['dryrun']) ? 1 : 0;
 if (!empty($runtime['testrun'])) {
     $bTestRun = 1;
 }
-
-$curr_date = date("Y-m-d");
-$curr_time = time();
-$check_date = date("Y-m-d", mktime((date("H") + $SMS_NOTIFICATION_HOUR), 0, 0, date("m"), date("d"), date("Y")));
 
 $db_sms_msg['type'] = $TYPE;
 $db_sms_msg['sms_gateway_type'] = AppDispatch::getModuleVendor();


### PR DESCRIPTION
## Summary

- Remove `$curr_date`, `$curr_time`, and the top-level `$check_date` assignment from `rc_sms_notification.php` — all three are set but never referenced. The actual notification window is computed inside `faxsms_getAlertPatientData()`.
- Regenerate PHPStan baseline to drop the now-unmatched entries for the removed line.

Follow-up to #11509, addressing [Copilot's review comment](https://github.com/openemr/openemr/pull/11509#pullrequestreview-2910523437).

## Test plan

- [ ] CI passes (PHPStan baseline no longer has stale entries for this file)
- [ ] SMS/fax notification cron behavior is unchanged (removed variables were dead code)