### PR TITLE
refactor(phpstan): add LayoutOptionsRow type to TableTypes

### DIFF
--- a/.github/workflows/phpstan-types.yml
+++ b/.github/workflows/phpstan-types.yml
@@ -55,7 +55,7 @@ jobs:
         # Generate types from database.sql
         php bin/generate-phpstan-types.php sql/database.sql \
           patient_data users form_encounter insurance_data billing \
-          background_services forms form_vitals \
+          background_services forms form_vitals layout_options \
           > src/Common/Database/TableTypes.php
 
         # Append CAMOS form types (tables defined in form-specific SQL, not database.sql)

--- a/src/Common/Database/TableTypes.php
+++ b/src/Common/Database/TableTypes.php
@@ -393,6 +393,30 @@ namespace OpenEMR\Common\Database;
  *   last_updated: string
  * }
  *
+ * @phpstan-type LayoutOptionsRow array{
+ *   form_id: string,
+ *   field_id: string,
+ *   group_id: string,
+ *   title: ?string,
+ *   seq: numeric-string,
+ *   data_type: numeric-string,
+ *   uor: numeric-string,
+ *   fld_length: numeric-string,
+ *   max_length: numeric-string,
+ *   list_id: string,
+ *   titlecols: numeric-string,
+ *   datacols: numeric-string,
+ *   default_value: string,
+ *   edit_options: string,
+ *   description: ?string,
+ *   fld_rows: numeric-string,
+ *   list_backup_id: string,
+ *   source: string,
+ *   conditions: ?string,
+ *   validation: ?string,
+ *   codes: string
+ * }
+ *
  * @phpstan-type FormCAMOSRow array{
  *   id: numeric-string,
  *   date: ?string,


### PR DESCRIPTION
## Summary

- Adds a `LayoutOptionsRow` PHPStan type alias to `TableTypes.php` for the `layout_options` table
- Gives callers proper type information (`numeric-string` for `data_type`, `seq`, etc.) instead of `mixed`
- Unblocks #11409 which needs `data_type` typed as `numeric-string` to satisfy PHPStan level 10

## Test plan

- [x] `php -l` passes
- [x] PHPStan passes (no new errors)
- [x] All pre-commit hooks pass