### PR TITLE
refactor(finder): replace getSearchClass with SearchClass enum

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -7102,11 +7102,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/new/new_comprehensive.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'\\#form_\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/new/new_comprehensive.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'label_\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/new/new_comprehensive.php',

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -7103,7 +7103,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'\\#form_\' and mixed results in an error\\.$#',
-    'count' => 3,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/new/new_comprehensive.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -2347,11 +2347,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/new/new_comprehensive.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$field_id \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/new/new_comprehensive.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$srcdir \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 5,
     'path' => __DIR__ . '/../../interface/new/new_comprehensive.php',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -13537,11 +13537,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Syndromicsurveillance/src/Syndromicsurveillance/Model/SyndromicsurveillanceTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function getSearchClass\\(\\) has parameter \\$data_type with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/new/new_comprehensive.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function default_loadPayerInfo\\(\\) has parameter \\$date with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/orders/gen_hl7_order.inc.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -7427,11 +7427,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Syndromicsurveillance/src/Syndromicsurveillance/Model/SyndromicsurveillanceTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function getSearchClass\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/new/new_comprehensive.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function oresRawData\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/orders/orders_results.php',

--- a/.phpstan/baseline/openemr.noGlobalNsFunctions.php
+++ b/.phpstan/baseline/openemr.noGlobalNsFunctions.php
@@ -2512,11 +2512,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/new/new_comprehensive.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function getSearchClass may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/new/new_comprehensive.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function default_gen_hl7_order may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/orders/gen_hl7_order.inc.php',

--- a/interface/new/new_comprehensive.php
+++ b/interface/new/new_comprehensive.php
@@ -23,6 +23,7 @@ require_once("$srcdir/patientvalidation.inc.php");
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Layouts\SearchClass;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -46,22 +47,6 @@ getLayoutProperties('DEM', $grparr, '*');
 $TOPCPR = empty($grparr['']['grp_columns']) ? 4 : $grparr['']['grp_columns'];
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
-
-// Determine layout field search treatment from its data type:
-// 1 = text field
-// 2 = select list
-// 0 = not searchable
-//
-function getSearchClass($data_type)
-{
-    return match ($data_type) {
-        // facilities
-        1, 10, 11, 12, 13, 14, 26, 35 => 2,
-        // date
-        2, 3, 4 => 1,
-        default => 0,
-    };
-}
 
 $fres = getLayoutRes($SHORT_FORM);
 ?>
@@ -333,21 +318,21 @@ while ($lrow = sqlFetchArray($lres)) {
         continue;
     }
 
-    $data_type = $lrow['data_type'];
-    $fldname = "form_$field_id";
-    switch (getSearchClass($data_type)) {
-        case 1:
-            echo
-            " if (f." . attr($fldname) . ".style.backgroundColor != '' && trimlen(f." . attr($fldname) . ".value) > 0) {\n" .
-            "  url += '&" . attr($field_id) . "=' + encodeURIComponent(f." . attr($fldname) . ".value);\n" .
-            " }\n";
-            break;
-        case 2:
-            echo
-            " if (f." . attr($fldname) . ".style.backgroundColor != '' && f." . attr($fldname) . ".selectedIndex > 0) {\n" .
-            "  url += '&" . attr($field_id) . "=' + encodeURIComponent(f." . attr($fldname) . ".options[f." . attr($fldname) . ".selectedIndex].value);\n" .
-            " }\n";
-            break;
+    $fldname = "form_{$field_id}";
+    $af = attr($fldname);
+    $ai = attr($field_id);
+    [$hasValue, $getValue] = match (SearchClass::fromLayoutRow($lrow)) {
+        SearchClass::NotSearchable => [null, null],
+        SearchClass::TextField => ["trimlen(f.{$af}.value) > 0", "f.{$af}.value"],
+        SearchClass::SelectList => ["f.{$af}.selectedIndex > 0", "f.{$af}.options[f.{$af}.selectedIndex].value"],
+    };
+    if ($hasValue !== null) {
+        printf(<<<'FMT'
+ if (f.%s.style.backgroundColor != '' && %s) {
+  url += '&%s=' + encodeURIComponent(%s);
+ }
+
+FMT, $af, $hasValue, $ai, $getValue);
     }
 }
 ?>
@@ -907,14 +892,14 @@ while ($lrow = sqlFetchArray($lres)) {
         continue;
     }
 
-    switch (getSearchClass($lrow['data_type'])) {
-        case 1:
-            echo "    \$(" . js_escape("#form_" . $field_id) . ").click(function() { toggleSearch(this); });\n";
-            break;
-        case 2:
-            echo "    \$(" . js_escape("#form_" . $field_id) . ").click(function() { selClick(this); });\n";
-            echo "    \$(" . js_escape("#form_" . $field_id) . ").blur(function() { selBlur(this); });\n";
-            break;
+    $bindings = match (SearchClass::fromLayoutRow($lrow)) {
+        SearchClass::NotSearchable => [],
+        SearchClass::TextField => [['click', 'toggleSearch']],
+        SearchClass::SelectList => [['click', 'selClick'], ['blur', 'selBlur']],
+    };
+    $sel = js_escape("#form_" . $field_id);
+    foreach ($bindings as [$event, $handler]) {
+        printf('    $(%s).%s(function() { %s(this); });' . "\n", $sel, $event, $handler);
     }
 }
 ?>

--- a/interface/new/new_comprehensive.php
+++ b/interface/new/new_comprehensive.php
@@ -313,8 +313,8 @@ function searchme() {
 $lres = getLayoutRes($SHORT_FORM);
 
 while ($lrow = sqlFetchArray($lres)) {
-    $field_id  = $lrow['field_id'];
-    if (str_starts_with((string) $field_id, 'em_')) {
+    $field_id = (string) $lrow['field_id'];
+    if (str_starts_with($field_id, 'em_')) {
         continue;
     }
 
@@ -887,8 +887,8 @@ $(function () {
 <?php
 $lres = getLayoutRes($SHORT_FORM);
 while ($lrow = sqlFetchArray($lres)) {
-    $field_id  = $lrow['field_id'];
-    if (str_starts_with((string) $field_id, 'em_')) {
+    $field_id = (string) $lrow['field_id'];
+    if (str_starts_with($field_id, 'em_')) {
         continue;
     }
 

--- a/src/Common/Layouts/SearchClass.php
+++ b/src/Common/Layouts/SearchClass.php
@@ -14,16 +14,12 @@ declare(strict_types=1);
 
 namespace OpenEMR\Common\Layouts;
 
-use OpenEMR\Common\Database\TableTypes;
-
 /**
  * Categorize layout field data types by their search UI treatment.
  *
  * Each layout field has a numeric data_type that determines how it renders.
  * For search purposes, those data types fall into three classes: not searchable,
  * text input, or select list.
- *
- * @phpstan-import-type LayoutOptionsRow from TableTypes
  */
 enum SearchClass
 {

--- a/src/Common/Layouts/SearchClass.php
+++ b/src/Common/Layouts/SearchClass.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Search class for layout field data types.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Layouts;
+
+use OpenEMR\Common\Database\TableTypes;
+
+/**
+ * Categorize layout field data types by their search UI treatment.
+ *
+ * Each layout field has a numeric data_type that determines how it renders.
+ * For search purposes, those data types fall into three classes: not searchable,
+ * text input, or select list.
+ *
+ * @phpstan-import-type LayoutOptionsRow from TableTypes
+ */
+enum SearchClass
+{
+    case NotSearchable;
+    case TextField;
+    case SelectList;
+
+    /**
+     * Determine the search class for a given layout field data type.
+     */
+    public static function fromDataType(int $dataType): self
+    {
+        return match ($dataType) {
+            1, 10, 11, 12, 13, 14, 26, 35 => self::SelectList,
+            2, 3, 4 => self::TextField,
+            default => self::NotSearchable,
+        };
+    }
+
+    /**
+     * Determine the search class from a layout_options row.
+     *
+     * Accepts the raw sqlFetchArray result and narrows data_type internally,
+     * so callers don't need to cast.
+     *
+     * @param non-empty-array<mixed> $row
+     */
+    public static function fromLayoutRow(array $row): self
+    {
+        $dataType = $row['data_type'] ?? 0;
+        return self::fromDataType(is_numeric($dataType) ? (int) $dataType : 0);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce `SearchClass` enum in `src/Common/Layouts/` to categorize layout field data types by their search UI treatment (not searchable, text field, select list)
- Move the `getSearchClass()` logic into `SearchClass::fromDataType()` on the enum
- Add `fromLayoutRow()` that accepts raw `sqlFetchArray` results and narrows `data_type` internally, using the `LayoutOptionsRow` type from #11556
- Replace `switch` statements with exhaustive `match` expressions on the enum, using data-driven patterns instead of repeated string construction
- Use `printf` with heredoc format strings for cleaner JS output (no backslash escapes)
- Remove several PHPStan baseline entries (`missingType.parameter`, `missingType.return`, `noGlobalNsFunctions`, `cast.int`)

Related to #11409 — this PR supersedes the type-narrowing approach with a proper enum that gives PHPStan exhaustiveness checking.

## Test plan

- [ ] Verify patient search in New Patient form (search by text fields like name)
- [ ] Verify patient search by select fields (sex, status, etc.)
- [ ] Verify non-searchable fields are correctly skipped
- [ ] Verify onclick/onfocus toggle handlers still apply to search fields