### PR TITLE
refactor(globals): add typed path accessors to Kernel and migrate src/

### DIFF
--- a/.phpstan/baseline/array.invalidKey.php
+++ b/.phpstan/baseline/array.invalidKey.php
@@ -143,7 +143,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/LogoService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/assign.propertyType.php
+++ b/.phpstan/baseline/assign.propertyType.php
@@ -1387,11 +1387,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Forms/BaseForm.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\Common\\\\Forms\\\\FormLocator\\:\\:\\$fileRoot \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Forms/FormLocator.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Common\\\\Forms\\\\FormQuestionnaireAssessment\\:\\:\\$activity \\(int\\) does not accept mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Forms/FormQuestionnaireAssessment.php',
@@ -1712,16 +1707,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/FHIR/Config/ServerConfig.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\Config\\\\ServerConfig\\:\\:\\$webRoot \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/FHIR/Config/ServerConfig.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\Config\\\\ServerConfig\\:\\:\\$webServerRoot \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/FHIR/Config/ServerConfig.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\FHIR\\\\Export\\\\ExportJob\\:\\:\\$apiBaseUrl \\(string\\) does not accept mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/FHIR/Export/ExportJob.php',
@@ -1803,11 +1788,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\RestControllers\\\\AuthorizationController\\:\\:\\$userId \\(int\\|string\\|null\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\RestControllers\\\\AuthorizationController\\:\\:\\$webroot \\(string\\) does not accept mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
 ];

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -18878,12 +18878,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and string results in an error\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -17257,11 +17257,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Billing/BillingProcessor/BillingProcessor.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/billing…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/BillingProcessor/Tasks/AbstractGenerator.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../src/Billing/BillingProcessor/Tasks/GeneratorHCFA.php',
@@ -17298,11 +17293,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\-" between mixed and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/BillingProcessor/Tasks/GeneratorHCFA_PDF_IMG.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/cms1500\\.png\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Billing/BillingProcessor/Tasks/GeneratorHCFA_PDF_IMG.php',
 ];
@@ -17358,11 +17348,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'batch\\-p\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/BillingProcessor/Tasks/GeneratorX12Direct.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/billing…\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Billing/BillingProcessor/Tasks/GeneratorX12Direct.php',
 ];
@@ -17498,7 +17483,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 14,
+    'count' => 13,
     'path' => __DIR__ . '/../../src/Billing/EDI270.php',
 ];
 $ignoreErrors[] = [
@@ -17837,21 +17822,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/ActionRouter.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/super…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/Common.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/super/rules/\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/Common.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'super\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/Common.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/Common.php',
@@ -17865,11 +17835,6 @@ $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/Controller/ControllerEdit.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/library/clinical…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/CdrAlertManager.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'\\:\' results in an error\\.$#',
@@ -17997,11 +17962,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleLibrary/RuleManager.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/options\\.inc\\.php\' results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/RuleTemplateExtension.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Common/Acl/AclExtended.php',
@@ -18112,7 +18072,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/FhirUserClaim.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and mixed results in an error\\.$#',
+    'message' => '#^Binary operation "\\." between mixed and string results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/IdTokenSMARTResponse.php',
 ];
@@ -18145,11 +18105,6 @@ $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Common/Command/AclModify.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/\'\\|\'\\\\\\\\\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Command/CreateClientCredentialsAssertionSymfonyCommand.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'  \\- \' and mixed results in an error\\.$#',
@@ -18229,11 +18184,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'\\{EncounterForm\\:\' and mixed results in an error\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Forms/CoreFormToPortalUtility.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/\\.\\./interface/forms/\' results in an error\\.$#',
-    'count' => 3,
     'path' => __DIR__ . '/../../src/Common/Forms/CoreFormToPortalUtility.php',
 ];
 $ignoreErrors[] = [
@@ -18462,26 +18412,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Session/SessionTracker.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/templates\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Twig/TwigContainer.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/display_help_icon…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Twig/TwigExtension.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/formatting…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Twig/TwigExtension.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/js/xl/jquery…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Twig/TwigExtension.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'\\?\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Utils/CacheUtils.php',
@@ -18542,42 +18472,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Uuid/UuidRegistry.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/forms…\' results in an error\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../src/Controllers/Interface/Forms/Observation/ObservationController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \' \' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Core/Header.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'/\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Core/Header.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/config/config\\.yaml\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Core/Header.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/custom/assets…\' results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Core/Header.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Core/ModulesApplication.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/\'\\|\'\\\\\\\\\' results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Core/ModulesApplication.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and string\\|false\\|null results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Core/ModulesApplication.php',
 ];
@@ -18647,16 +18547,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Easipro/Easipro.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/forms/\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Events/Encounter/LoadEncounterFormFilterEvent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/modules/\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Events/Encounter/LoadEncounterFormFilterEvent.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'/\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Events/RestApiExtend/RestApiScopeEvent.php',
@@ -18718,11 +18608,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\-" between mixed and 1 results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Gacl/GaclAdminApi.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'Location\\: \' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Gacl/GaclAdminApi.php',
 ];
@@ -18902,28 +18787,13 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Menu/MainMenuRole.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/main…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Menu/MainMenuRole.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'\\.\\./\\.\\./modules/\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Menu/PatientMenuRole.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Menu/PatientMenuRole.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'/documents/custom…\' results in an error\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../src/Menu/PatientMenuRole.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/main…\' results in an error\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../src/Menu/PatientMenuRole.php',
 ];
 $ignoreErrors[] = [
@@ -18938,11 +18808,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \\- \' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/OeUI/OemrUI.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and non\\-falsy\\-string results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/OeUI/OemrUI.php',
 ];
@@ -18967,11 +18832,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Patient/Cards/CareTeamViewCard.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/patient…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Patient/Cards/PortalCard.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \\- \' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/PaymentProcessing/PaymentProcessing.php',
@@ -18987,22 +18847,17 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/PaymentProcessing/PaymentProcessing.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and mixed results in an error\\.$#',
+    'message' => '#^Binary operation "\\." between mixed and string results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/PaymentProcessing/Sphere/SpherePayment.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and mixed results in an error\\.$#',
+    'message' => '#^Binary operation "\\." between mixed and string results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/PaymentProcessing/Sphere/SphereRevert.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'/documents/temp\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Pdf/PdfCreator.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/openemr…\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Pdf/PdfCreator.php',
 ];
@@ -19017,18 +18872,13 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/Authorization/BearerTokenAuthorizationStrategy.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/oauth2/\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and mixed results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and non\\-falsy\\-string results in an error\\.$#',
     'count' => 1,
+    'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Binary operation "\\." between mixed and string results in an error\\.$#',
+    'count' => 2,
     'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
 ];
 $ignoreErrors[] = [
@@ -19442,7 +19292,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/RestControllerHelper.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and mixed results in an error\\.$#',
+    'message' => '#^Binary operation "\\." between mixed and string results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/SMART/SMARTAuthorizationController.php',
 ];
@@ -19490,11 +19340,6 @@ $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 5,
     'path' => __DIR__ . '/../../src/Services/BaseService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/modules…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/CDADocumentService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'Invalid care plan…\' and mixed results in an error\\.$#',
@@ -19622,11 +19467,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/Cda/CdaTemplateParse.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/ccdaservice/node…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Cda/CdaValidateDocuments.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'\\#\' and mixed results in an error\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../src/Services/Cda/ClinicalNoteParser.php',
@@ -19667,11 +19507,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/DocumentService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/controller\\.php\\?\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/DocumentService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\+" between mixed and int results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/DocumentTemplates/DocumentTemplateRender.php',
@@ -19683,16 +19518,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \' \\(\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/DocumentTemplates/DocumentTemplateRender.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/appointments\\.inc…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/DocumentTemplates/DocumentTemplateRender.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/options\\.inc\\.php\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/DocumentTemplates/DocumentTemplateRender.php',
 ];
@@ -20572,11 +20397,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/LogoService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/logos/\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/LogoService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'INSERT INTO lists…\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/MedicationPatientIssueService.php',
@@ -20847,11 +20667,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/ProcedureService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/product…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/ProductRegistrationService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'/\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/Qdm/MeasureService.php',
@@ -20862,7 +20677,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/Qdm/MeasureService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and mixed results in an error\\.$#',
+    'message' => '#^Binary operation "\\." between string and mixed results in an error\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../src/Services/Qdm/MeasureService.php',
 ];
@@ -21290,11 +21105,6 @@ $ignoreErrors[] = [
     'message' => '#^Binary operation "\\-" between int\\<1, max\\> and mixed results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Telemetry/GeoTelemetry.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'\\#\\^\\(\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Telemetry/TelemetryService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'unsupported context…\' and mixed results in an error\\.$#',

--- a/.phpstan/baseline/cast.int.php
+++ b/.phpstan/baseline/cast.int.php
@@ -703,7 +703,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to int\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../src/Controllers/Interface/Forms/Observation/ObservationController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -3908,7 +3908,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 1,
+    'count' => 3,
     'path' => __DIR__ . '/../../tests/Tests/Api/AuthorizationGrantFlowTest.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -3328,11 +3328,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Core/ModulesApplication.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Cqm/Generator.php',
 ];

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -3308,7 +3308,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Controllers/Interface/Forms/Observation/ObservationController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -3908,7 +3908,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 3,
+    'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Api/AuthorizationGrantFlowTest.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -5228,7 +5228,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 8,
+    'count' => 7,
     'path' => __DIR__ . '/../../src/Telemetry/TelemetryService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -5402,11 +5402,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Gacl/GaclApi.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$web_root \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/OeUI/OemrUI.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$relationship \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Patient/Cards/CareTeamViewCard.php',

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -15292,12 +15292,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Certification/HIT1/US_Core_311/InfernoSinglePatientAPITest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method League\\\\OAuth2\\\\Server\\\\Entities\\\\UserEntityInterface@anonymous/tests/Tests/Common/Auth/OpenIDConnect/SMARTSessionTokenContextIntegrationTest\\.php\\:404\\:\\:getClaims\\(\\) return type has no value type specified in iterable type array\\.$#',
+    'message' => '#^Method League\\\\OAuth2\\\\Server\\\\Entities\\\\UserEntityInterface@anonymous/tests/Tests/Common/Auth/OpenIDConnect/SMARTSessionTokenContextIntegrationTest\\.php\\:415\\:\\:getClaims\\(\\) return type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Common/Auth/OpenIDConnect/SMARTSessionTokenContextIntegrationTest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method League\\\\OAuth2\\\\Server\\\\Entities\\\\UserEntityInterface@anonymous/tests/Tests/Common/Auth/OpenIDConnect/SMARTSessionTokenContextIntegrationTest\\.php\\:470\\:\\:getClaims\\(\\) return type has no value type specified in iterable type array\\.$#',
+    'message' => '#^Method League\\\\OAuth2\\\\Server\\\\Entities\\\\UserEntityInterface@anonymous/tests/Tests/Common/Auth/OpenIDConnect/SMARTSessionTokenContextIntegrationTest\\.php\\:481\\:\\:getClaims\\(\\) return type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Common/Auth/OpenIDConnect/SMARTSessionTokenContextIntegrationTest.php',
 ];

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -3042,11 +3042,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/Common.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\Common\\:\\:src_dir\\(\\) should return string but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/Common.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\ClinicalDecisionRules\\\\Interface\\\\ControllerRouter\\:\\:route\\(\\) should return Symfony\\\\Component\\\\HttpFoundation\\\\Response but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/ClinicalDecisionRules/Interface/ControllerRouter.php',

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -380,7 +380,7 @@ try {
     // we inject the eventDispatcher if we have one setup already
     // TODO: @adunsulag is there a better way to do this?
     /** @var Kernel */
-    $globalsBag->set("kernel", new Kernel($globalsBag->get('eventDispatcher')));
+    $globalsBag->set("kernel", new Kernel($webserver_root, $web_root, $globalsBag->get('eventDispatcher')));
 } catch (\Throwable $e) {
     $logger->error($e->getMessage(), ['exception' => $e]);
     http_response_code(500);

--- a/src/Billing/BillingProcessor/Tasks/AbstractGenerator.php
+++ b/src/Billing/BillingProcessor/Tasks/AbstractGenerator.php
@@ -105,7 +105,7 @@ abstract class AbstractGenerator extends AbstractProcessingTask implements Gener
     public function printDownloadClaimFileJS($filename, $location = '', $delete = false)
     {
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
-        $url = OEGlobalsBag::getInstance()->get('webroot') . '/interface/billing/get_claim_file.php?' .
+        $url = OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . '/interface/billing/get_claim_file.php?' .
             'key=' . urlencode((string) $filename) .
             '&location=' . urlencode((string) $location) .
             '&delete=' . urlencode($delete) .

--- a/src/Billing/BillingProcessor/Tasks/GeneratorHCFA_PDF_IMG.php
+++ b/src/Billing/BillingProcessor/Tasks/GeneratorHCFA_PDF_IMG.php
@@ -47,7 +47,7 @@ class GeneratorHCFA_PDF_IMG extends GeneratorHCFA_PDF implements
         $log = '';
         $hcfa = new Hcfa1500();
         $lines = $hcfa->genHcfa1500($claim->getPid(), $claim->getEncounter(), $log);
-        $hcfa_image = OEGlobalsBag::getInstance()->get('images_static_absolute') . "/cms1500.png";
+        $hcfa_image = OEGlobalsBag::getInstance()->getKernel()->getImagesAbsolute() . "/cms1500.png";
         $this->appendToLog($log);
         $alines = explode("\014", (string) $lines); // form feeds may separate pages
         foreach ($alines as $tmplines) {

--- a/src/Billing/BillingProcessor/Tasks/GeneratorX12Direct.php
+++ b/src/Billing/BillingProcessor/Tasks/GeneratorX12Direct.php
@@ -295,7 +295,7 @@ class GeneratorX12Direct extends AbstractGenerator implements GeneratorInterface
                 $x12_partner_name = text($this->x12_partners[$x12_partner_id]['name']);
                 // For the modal, build a list of downloads
                 $file = $created_batch->getBatFilename();
-                $url = OEGlobalsBag::getInstance()->get('webroot') . '/interface/billing/get_claim_file.php?' .
+                $url = OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . '/interface/billing/get_claim_file.php?' .
                     'key=' . urlencode($file) .
                     '&partner=' . urlencode($x12_partner_id) .
                     '&csrf_token_form=' . urlencode(CsrfUtils::collectCsrfToken(session: $session));

--- a/src/Billing/EDI270.php
+++ b/src/Billing/EDI270.php
@@ -572,7 +572,7 @@ class EDI270
 				<td class ='detail'>" . text($row['subscriber_sex']) . "</td>
 				<td class ='detail'>" . text($row['subscriber_ss']) . "</td>
 				<td class ='detail'>
-				<img src=\"" . OEGlobalsBag::getInstance()->get('images_static_relative') . "/deleteBtn.png\" title=" . text(xl('Delete Row')) . " style='cursor:pointer;cursor:hand;' onclick='deletetherow(\"" . $i . "_" . text($row['policy_number']) . "\")'>
+				<img src=\"" . OEGlobalsBag::getInstance()->getKernel()->getImagesRelative() . "/deleteBtn.png\" title=" . text(xl('Delete Row')) . " style='cursor:pointer;cursor:hand;' onclick='deletetherow(\"" . $i . "_" . text($row['policy_number']) . "\")'>
 				</td>
 			</tr>
 		";

--- a/src/ClinicalDecisionRules/Interface/ActionRouter.php
+++ b/src/ClinicalDecisionRules/Interface/ActionRouter.php
@@ -32,7 +32,7 @@ class ActionRouter
     public function __construct(protected $controller, protected $action)
     {
         $this->appRoot = Common::base_dir();
-        $this->webRoot = OEGlobalsBag::getInstance()->get('webroot');
+        $this->webRoot = OEGlobalsBag::getInstance()->getKernel()->getWebRoot();
         $this->templateRoot = Common::template_dir();
     }
 

--- a/src/ClinicalDecisionRules/Interface/Common.php
+++ b/src/ClinicalDecisionRules/Interface/Common.php
@@ -81,22 +81,22 @@ class Common
 
     public static function base_url(): string
     {
-        return OEGlobalsBag::getInstance()->get('webroot') . '/interface/super/rules';
+        return OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . '/interface/super/rules';
     }
 
     public static function src_dir(): string
     {
-        return OEGlobalsBag::getInstance()->get('srcdir');
+        return OEGlobalsBag::getInstance()->getKernel()->getSrcDir();
     }
 
     public static function template_dir(): string
     {
-        return OEGlobalsBag::getInstance()->get('template_dir') . 'super' . DIRECTORY_SEPARATOR . 'rules' . DIRECTORY_SEPARATOR;
+        return OEGlobalsBag::getInstance()->getKernel()->getTemplateDir() . 'super' . DIRECTORY_SEPARATOR . 'rules' . DIRECTORY_SEPARATOR;
     }
 
     public static function base_dir(): string
     {
-        return OEGlobalsBag::getInstance()->get('incdir') . '/super/rules/';
+        return OEGlobalsBag::getInstance()->getKernel()->getIncludeRoot() . '/super/rules/';
     }
 
     public static function library_dir(): string

--- a/src/ClinicalDecisionRules/Interface/RuleLibrary/CdrAlertManager.php
+++ b/src/ClinicalDecisionRules/Interface/RuleLibrary/CdrAlertManager.php
@@ -23,7 +23,7 @@ namespace OpenEMR\ClinicalDecisionRules\Interface\RuleLibrary;
 use OpenEMR\ClinicalDecisionRules\Interface\RuleLibrary\CdrResults;
 use OpenEMR\Core\OEGlobalsBag;
 
-require_once(OEGlobalsBag::getInstance()->get('fileroot') . "/library/clinical_rules.php");
+require_once(OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . "/library/clinical_rules.php");
 
 /**
  * class OpenEMR\ClinicalDecisionRules\Interface\RuleLibrary\CdrAlertManager

--- a/src/ClinicalDecisionRules/Interface/RuleTemplateExtension.php
+++ b/src/ClinicalDecisionRules/Interface/RuleTemplateExtension.php
@@ -78,7 +78,7 @@ class RuleTemplateExtension
 
     public static function timeunit_select($args)
     {
-        require_once(OEGlobalsBag::getInstance()->get("srcdir") . "/options.inc.php");
+        require_once(OEGlobalsBag::getInstance()->getKernel()->getSrcDir() . "/options.inc.php");
 
         return generate_select_list(
             $args['name'],
@@ -95,7 +95,7 @@ class RuleTemplateExtension
 
     public static function getLabel($value, $list_id)
     {
-        require_once(OEGlobalsBag::getInstance()->get("srcdir") . "/options.inc.php");
+        require_once(OEGlobalsBag::getInstance()->getKernel()->getSrcDir() . "/options.inc.php");
 
         // get from list_options
         $result = generate_display_field(['data_type' => '1','list_id' => $list_id], $value);

--- a/src/Common/Auth/OpenIDConnect/IdTokenSMARTResponse.php
+++ b/src/Common/Auth/OpenIDConnect/IdTokenSMARTResponse.php
@@ -165,7 +165,7 @@ class IdTokenSMARTResponse extends IdTokenResponse
         // Add required id_token claims
         $builder = $builder
             ->permittedFor($accessToken->getClient()->getIdentifier())
-            ->issuedBy($this->globalsBag->get('site_addr_oath') . $this->globalsBag->get('webroot') . "/oauth2/" . $this->session->get('site_id'))
+            ->issuedBy($this->globalsBag->get('site_addr_oath') . $this->globalsBag->getKernel()->getWebRoot() . "/oauth2/" . $this->session->get('site_id'))
             ->issuedAt(new \DateTimeImmutable('@' . time()))
             ->expiresAt(new \DateTimeImmutable('@' . $accessToken->getExpiryDateTime()->getTimestamp()))
             ->relatedTo($userEntity->getIdentifier());

--- a/src/Common/Command/BackgroundServicesCommand.php
+++ b/src/Common/Command/BackgroundServicesCommand.php
@@ -131,7 +131,8 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
         if (!is_string($php)) {
             $php = PHP_BINARY;
         }
-        $fileroot = $this->getGlobalsBag()->getString('fileroot');
+        $globalsBag = $this->getGlobalsBag();
+        $fileroot = $globalsBag->getProjectDir();
         if ($fileroot === '') {
             $io->error('Global "fileroot" is not configured.');
             return Command::FAILURE;

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -41,11 +41,7 @@ class CreateAPIDocumentationCommand extends Command
     }
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        // Use $GLOBALS directly instead of OEGlobalsBag because bin/console
-        // sets up $GLOBALS['fileroot'] before the command runs, but OEGlobalsBag
-        // may not be fully initialized when --skip-globals is used.
-        /** @var string $fileroot */
-        $fileroot = OEGlobalsBag::getInstance()->get('fileroot');
+        $fileroot = OEGlobalsBag::getInstance()->getProjectDir();
         $fileDestinationFolder = $fileroot . DIRECTORY_SEPARATOR . "swagger" . DIRECTORY_SEPARATOR;
         $fileDestinationYaml =  $fileDestinationFolder . "openemr-api.yaml";
 

--- a/src/Common/Command/CreateClientCredentialsAssertionSymfonyCommand.php
+++ b/src/Common/Command/CreateClientCredentialsAssertionSymfonyCommand.php
@@ -51,7 +51,7 @@ class CreateClientCredentialsAssertionSymfonyCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $rootPath = OEGlobalsBag::getInstance()->get('fileroot');
+        $rootPath = OEGlobalsBag::getInstance()->getProjectDir();
 
         $keyLocation = $rootPath . DIRECTORY_SEPARATOR . "tests" . DIRECTORY_SEPARATOR . "Tests" . DIRECTORY_SEPARATOR
             . "data" . DIRECTORY_SEPARATOR . "Unit" . DIRECTORY_SEPARATOR . "Common" . DIRECTORY_SEPARATOR . "Auth"

--- a/src/Common/Forms/CoreFormToPortalUtility.php
+++ b/src/Common/Forms/CoreFormToPortalUtility.php
@@ -146,7 +146,7 @@ class CoreFormToPortalUtility
     public static function insertPatientPortalTemplate(int $id): void
     {
         $infoNewRegisteredForm = sqlQuery("SELECT `name`, `directory` FROM `registry` WHERE `id` = ?", [$id]);
-        $patientPortalCompliant = file_exists(OEGlobalsBag::getInstance()->get('srcdir') . "/../interface/forms/" . $infoNewRegisteredForm['directory'] . "/patient_portal.php");
+        $patientPortalCompliant = file_exists(OEGlobalsBag::getInstance()->getKernel()->getSrcDir() . "/../interface/forms/" . $infoNewRegisteredForm['directory'] . "/patient_portal.php");
         if ($patientPortalCompliant) {
             $checkDocumentTemplate = sqlQuery("SELECT `id` FROM `document_templates` WHERE `template_name` = ?", [$infoNewRegisteredForm['name']]);
             if (empty($checkDocumentTemplate)) {
@@ -163,11 +163,11 @@ class CoreFormToPortalUtility
     {
         // first get list of form directory names that are patient portal compliant
         $dirFormNames = [];
-        $formDirs = scandir(OEGlobalsBag::getInstance()->get('srcdir') . "/../interface/forms/");
+        $formDirs = scandir(OEGlobalsBag::getInstance()->getKernel()->getSrcDir() . "/../interface/forms/");
         foreach ($formDirs as $formDir) {
             if (
                 !in_array($formDir, [".", "..", "LBF"]) &&
-                file_exists(OEGlobalsBag::getInstance()->get('srcdir') . "/../interface/forms/" . $formDir . "/patient_portal.php")
+                file_exists(OEGlobalsBag::getInstance()->getKernel()->getSrcDir() . "/../interface/forms/" . $formDir . "/patient_portal.php")
             ) {
                 $dirFormNames[] = $formDir;
             }

--- a/src/Common/Forms/FormLocator.php
+++ b/src/Common/Forms/FormLocator.php
@@ -33,7 +33,7 @@ class FormLocator
         }
         $this->logger = $logger;
     // AI GENERATED CODE: HEADER START
-        $this->fileRoot = OEGlobalsBag::getInstance()->get('fileroot');
+        $this->fileRoot = OEGlobalsBag::getInstance()->getProjectDir();
     }
 
     public function findFile(string $formDir, string $fileName, string $page): string

--- a/src/Common/Twig/TwigContainer.php
+++ b/src/Common/Twig/TwigContainer.php
@@ -41,14 +41,18 @@ class TwigContainer
      */
     public function __construct(?string $path = null, ?Kernel $kernel = null)
     {
-        $this->paths[] = OEGlobalsBag::getInstance()->get('fileroot') . '/templates';
+        if (null !== $kernel) {
+            $this->kernel = $kernel;
+        }
+
+        $globalsBag = OEGlobalsBag::getInstance();
+        $templateRoot = $this->kernel !== null
+            ? $this->kernel->getProjectDir()
+            : $globalsBag->getProjectDir();
+        $this->paths[] = $templateRoot . '/templates';
 
         if (!empty($path)) {
             $this->addPath($path);
-        }
-
-        if (null !== $kernel) {
-            $this->kernel = $kernel;
         }
     }
 

--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -55,9 +55,32 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     ) {
     }
 
+    protected function getKernel(): ?Kernel
+    {
+        if ($this->kernel !== null) {
+            return $this->kernel;
+        }
+        if ($this->globals->hasKernel()) {
+            return $this->globals->getKernel();
+        }
+        return null;
+    }
+
     public function getGlobals(): array
     {
+        $kernel = $this->getKernel();
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
+        if ($kernel !== null) {
+            return [
+                'assets_dir' => $kernel->getAssetsRelative(),
+                'srcdir' => $kernel->getSrcDir(),
+                'rootdir' => $kernel->getRootDir(),
+                'webroot' => $kernel->getWebRoot(),
+                'assetVersion' => $this->globals->get('v_js_includes'),
+                'session' => $session->all(),
+            ];
+        }
+        // Fallback for contexts where the Kernel is not available (e.g. tests)
         return [
             'assets_dir' => $this->globals->get('assets_static_relative'),
             'srcdir' => $this->globals->get('srcdir'),
@@ -196,7 +219,8 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                     // In the event we need to pass the this objecto to the datetimepicker, we cannot use quotations because `this` would not be a string
                     $selector = ($domSelector == "this") ? $domSelector : "\"$domSelector\"";
                     echo "$($selector).datetimepicker({";
-                    require(OEGlobalsBag::getInstance()->get('srcdir') . '/js/xl/jquery-datetimepicker-2-5-4.js.php');
+                    $srcDir = $this->getKernel()?->getSrcDir() ?? $this->globals->getString('srcdir');
+                    require($srcDir . '/js/xl/jquery-datetimepicker-2-5-4.js.php');
                     echo "})";
                     return ob_get_clean();
                 }
@@ -205,7 +229,8 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                 'DateToYYYYMMDD_js',
                 function () {
                     ob_start();
-                    require OEGlobalsBag::getInstance()->get('srcdir') . "/formatting_DateToYYYYMMDD_js.js.php";
+                    $srcDir = $this->getKernel()?->getSrcDir() ?? $this->globals->getString('srcdir');
+                    require $srcDir . "/formatting_DateToYYYYMMDD_js.js.php";
                     return ob_get_clean();
                 }
             ),
@@ -235,7 +260,8 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                 'oemHelpIcon',
                 function () {
                     // this setups a variable called $help_icon... strange
-                    require OEGlobalsBag::getInstance()->get('srcdir') . "/display_help_icon_inc.php";
+                    $srcDir = $this->getKernel()?->getSrcDir() ?? $this->globals->getString('srcdir');
+                    require $srcDir . "/display_help_icon_inc.php";
                     return $help_icon ?? '';
                 }
             ),

--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -61,7 +61,8 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             return $this->kernel;
         }
         if ($this->globals->hasKernel()) {
-            return $this->globals->getKernel();
+            $this->kernel = $this->globals->getKernel();
+            return $this->kernel;
         }
         return null;
     }

--- a/src/Controllers/Interface/Forms/Observation/ObservationController.php
+++ b/src/Controllers/Interface/Forms/Observation/ObservationController.php
@@ -262,9 +262,7 @@ class ObservationController
 
             // we have to keep id as the formId due to backwards compatibility
             return $this->createRedirectResponse(
-                OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . "/interface/forms/observation/new.php?id="
-                . urlencode((string) $observation['form_id'])
-                . "&status=saved"
+                $this->buildObservationFormUrl((int) $observation['form_id'], 'saved')
             );
         } catch (\Throwable $e) {
             $this->getSystemLogger()->error("Error saving observation", [
@@ -492,8 +490,7 @@ class ObservationController
             if (!$observation) {
                 // observation may have already been deleted, just redirect to list with success to avoid error loops
                 return $this->createRedirectResponse(
-                    OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . "/interface/forms/observation/new.php?id=" . urlencode($formId)
-                    . "&status=delete_success" // still redirect to list with success to avoid error loops
+                    $this->buildObservationFormUrl($formId, 'delete_success')
                 );
             }
             if ($observation['form_id'] != $formId) {
@@ -509,8 +506,7 @@ class ObservationController
             QueryUtils::commitTransaction();
             $committed = true;
             return $this->createRedirectResponse(
-                OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . "/interface/forms/observation/new.php?id=" . urlencode($formId)
-                . "&status=delete_success" // still redirect to list with success to avoid error loops
+                $this->buildObservationFormUrl($formId, 'delete_success')
             );
         } catch (\Throwable $e) {
             $this->getSystemLogger()->error("Error deleting observation", [
@@ -518,8 +514,7 @@ class ObservationController
                 'formId' => $formId
             ]);
             return $this->createRedirectResponse(
-                OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . "/interface/forms/observation/new.php?id=" . urlencode($formId)
-                . "&status=delete_failed" // let them know that the delete failed
+                $this->buildObservationFormUrl($formId, 'delete_failed')
             );
         } finally {
             if (!$committed) {
@@ -574,6 +569,13 @@ class ObservationController
     private function createRedirectResponse(string $url, int $status = Response::HTTP_SEE_OTHER): Response
     {
         return new RedirectResponse($url, $status);
+    }
+
+    private function buildObservationFormUrl(int|string $formId, string $status): string
+    {
+        return OEGlobalsBag::getInstance()->getWebRoot()
+            . "/interface/forms/observation/new.php?id=" . urlencode((string) $formId)
+            . "&status=" . urlencode($status);
     }
 
     /**

--- a/src/Controllers/Interface/Forms/Observation/ObservationController.php
+++ b/src/Controllers/Interface/Forms/Observation/ObservationController.php
@@ -262,7 +262,7 @@ class ObservationController
 
             // we have to keep id as the formId due to backwards compatibility
             return $this->createRedirectResponse(
-                OEGlobalsBag::getInstance()->get('webroot') . "/interface/forms/observation/new.php?id="
+                OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . "/interface/forms/observation/new.php?id="
                 . urlencode((string) $observation['form_id'])
                 . "&status=saved"
             );
@@ -492,7 +492,7 @@ class ObservationController
             if (!$observation) {
                 // observation may have already been deleted, just redirect to list with success to avoid error loops
                 return $this->createRedirectResponse(
-                    OEGlobalsBag::getInstance()->get('webroot') . "/interface/forms/observation/new.php?id=" . urlencode($formId)
+                    OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . "/interface/forms/observation/new.php?id=" . urlencode($formId)
                     . "&status=delete_success" // still redirect to list with success to avoid error loops
                 );
             }
@@ -509,7 +509,7 @@ class ObservationController
             QueryUtils::commitTransaction();
             $committed = true;
             return $this->createRedirectResponse(
-                OEGlobalsBag::getInstance()->get('webroot') . "/interface/forms/observation/new.php?id=" . urlencode($formId)
+                OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . "/interface/forms/observation/new.php?id=" . urlencode($formId)
                 . "&status=delete_success" // still redirect to list with success to avoid error loops
             );
         } catch (\Throwable $e) {
@@ -518,7 +518,7 @@ class ObservationController
                 'formId' => $formId
             ]);
             return $this->createRedirectResponse(
-                OEGlobalsBag::getInstance()->get('webroot') . "/interface/forms/observation/new.php?id=" . urlencode($formId)
+                OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . "/interface/forms/observation/new.php?id=" . urlencode($formId)
                 . "&status=delete_failed" // let them know that the delete failed
             );
         } finally {

--- a/src/Core/Header.php
+++ b/src/Core/Header.php
@@ -188,15 +188,16 @@ class Header
         $assets = array_filter($assets, static fn ($asset): bool => is_string($asset) && trim($asset) !== '');
 
         // @TODO Hard coded the path to the config file, not good RD 2017-05-27
-        $map = self::readConfigFile(OEGlobalsBag::getInstance()->get('fileroot') . "/config/config.yaml");
+        $projectDir = OEGlobalsBag::getInstance()->getKernel()->getProjectDir();
+        $map = self::readConfigFile($projectDir . "/config/config.yaml");
         self::$scripts = [];
         self::$links = [];
 
         self::parseConfigFile($map, $assets);
 
         /* adding custom assets in addition */
-        if (is_file(OEGlobalsBag::getInstance()->get('fileroot') . "/custom/assets/custom.yaml")) {
-            $customMap = self::readConfigFile(OEGlobalsBag::getInstance()->get('fileroot') . "/custom/assets/custom.yaml");
+        if (is_file($projectDir . "/custom/assets/custom.yaml")) {
+            $customMap = self::readConfigFile($projectDir . "/custom/assets/custom.yaml");
             self::parseConfigFile($customMap, $assets);
         }
 
@@ -437,6 +438,11 @@ class Header
     private static function getCurrentFile()
     {
         //remove web root and query string
-        return str_replace(OEGlobalsBag::getInstance()->get('webroot') . '/', '', strtok($_SERVER["REQUEST_URI"], '?'));
+        $uriPath = strtok($_SERVER["REQUEST_URI"], '?') ?: '';
+        $webRoot = OEGlobalsBag::getInstance()->getKernel()->getWebRoot();
+        if ($webRoot !== '') {
+            return str_replace($webRoot . '/', '', $uriPath);
+        }
+        return ltrim($uriPath, '/');
     }
 }

--- a/src/Core/Header.php
+++ b/src/Core/Header.php
@@ -440,9 +440,8 @@ class Header
         //remove web root and query string
         $uriPath = strtok($_SERVER["REQUEST_URI"], '?') ?: '';
         $webRoot = OEGlobalsBag::getInstance()->getKernel()->getWebRoot();
-        if ($webRoot !== '') {
-            return str_replace($webRoot . '/', '', $uriPath);
-        }
-        return ltrim($uriPath, '/');
+        return $webRoot !== ''
+            ? str_replace($webRoot . '/', '', $uriPath)
+            : ltrim($uriPath, '/');
     }
 }

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -18,23 +18,36 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
- * Class Kernel.
+ * Core OpenEMR kernel.
  *
- * This is the core of OpenEMR. It is a thin class enabling service containers,
- * event dispatching for now.
+ * Holds the service container, event dispatcher, and infrastructure paths.
+ * Path accessors follow Symfony's convention (getProjectDir(), etc.).
  *
- * @package OpenEMR
+ * @package   OpenEMR
  * @subpackage Core
- * @author Robert Down <robertdown@live.com>
+ * @author    Robert Down <robertdown@live.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2017-2022 Robert Down
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
  */
 class Kernel
 {
     /** @var ContainerBuilder */
     private $container;
 
-    public function __construct(private readonly ?EventDispatcherInterface $dispatcher = null)
-    {
+    /**
+     * @param ?string $projectDir Absolute filesystem root (e.g. "/var/www/openemr").
+     *                            Optional for backward compat with modules that construct
+     *                            a Kernel without paths; path getters throw if null.
+     * @param ?string $webRoot    URL path prefix (e.g. "/openemr" or "").
+     *                            Optional for the same reason as $projectDir.
+     * @param ?EventDispatcherInterface $dispatcher Pre-built event dispatcher to inject.
+     */
+    public function __construct(
+        private readonly ?string $projectDir = null,
+        private readonly ?string $webRoot = null,
+        private readonly ?EventDispatcherInterface $dispatcher = null,
+    ) {
         $this->prepareContainer();
     }
 
@@ -59,6 +72,126 @@ class Kernel
             }
         }
     }
+
+    // ---- Path accessors (web-relative) ------------------------------------
+
+    /**
+     * URL path prefix, e.g. "/openemr" or ""
+     */
+    public function getWebRoot(): string
+    {
+        return $this->requireWebRoot();
+    }
+
+    /**
+     * Web root + "/interface"
+     */
+    public function getRootDir(): string
+    {
+        return $this->requireWebRoot() . '/interface';
+    }
+
+    /**
+     * Web root + "/public/assets"
+     */
+    public function getAssetsRelative(): string
+    {
+        return $this->requireWebRoot() . '/public/assets';
+    }
+
+    /**
+     * Web root + "/public/themes"
+     */
+    public function getThemesRelative(): string
+    {
+        return $this->requireWebRoot() . '/public/themes';
+    }
+
+    /**
+     * Web root + "/public/images"
+     */
+    public function getImagesRelative(): string
+    {
+        return $this->requireWebRoot() . '/public/images';
+    }
+
+    // ---- Path accessors (filesystem-absolute) -----------------------------
+
+    /**
+     * Absolute filesystem root, e.g. "/var/www/openemr"
+     */
+    public function getProjectDir(): string
+    {
+        return $this->requireProjectDir();
+    }
+
+    /**
+     * Project dir + "/library"
+     */
+    public function getSrcDir(): string
+    {
+        return $this->requireProjectDir() . '/library';
+    }
+
+    /**
+     * Project dir + "/interface"
+     */
+    public function getIncludeRoot(): string
+    {
+        return $this->requireProjectDir() . '/interface';
+    }
+
+    /**
+     * Project dir + "/vendor"
+     */
+    public function getVendorDir(): string
+    {
+        return $this->requireProjectDir() . '/vendor';
+    }
+
+    /**
+     * Project dir + "/templates/"
+     */
+    public function getTemplateDir(): string
+    {
+        return $this->requireProjectDir() . '/templates/';
+    }
+
+    /**
+     * Project dir + "/public/images"
+     */
+    public function getImagesAbsolute(): string
+    {
+        return $this->requireProjectDir() . '/public/images';
+    }
+
+    /**
+     * Project dir + "/sites"
+     */
+    public function getSitesBase(): string
+    {
+        return $this->requireProjectDir() . '/sites';
+    }
+
+    // ---- Site-specific path accessors -------------------------------------
+
+    /**
+     * Absolute path to a site directory: sitesBase + "/$siteId"
+     */
+    public function getSiteDir(string $siteId): string
+    {
+        return $this->getSitesBase() . '/' . $siteId;
+    }
+
+    /**
+     * Web path to a site directory: webRoot + "/sites/$siteId"
+     */
+    public function getSiteWebRoot(string $siteId): string
+    {
+        return $this->requireWebRoot() . '/sites/' . $siteId;
+    }
+
+    // ---- Existing API -----------------------------------------------------
 
     /**
      * Return true if the environment variable OPENEMR__ENVIRONMENT is set to dev.
@@ -98,5 +231,29 @@ class Kernel
         } else {
             throw new \Exception('Container does not exist');
         }
+    }
+
+    // ---- Internal helpers -------------------------------------------------
+
+    private function requireProjectDir(): string
+    {
+        if ($this->projectDir === null) {
+            throw new \RuntimeException(
+                'Kernel was constructed without a projectDir. '
+                . 'Pass $projectDir to the Kernel constructor.'
+            );
+        }
+        return $this->projectDir;
+    }
+
+    private function requireWebRoot(): string
+    {
+        if ($this->webRoot === null) {
+            throw new \RuntimeException(
+                'Kernel was constructed without a webRoot. '
+                . 'Pass $webRoot to the Kernel constructor.'
+            );
+        }
+        return $this->webRoot;
     }
 }

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -28,7 +28,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * @author    Robert Down <robertdown@live.com>
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2017-2022 Robert Down
- * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  */
 class Kernel
 {
@@ -238,10 +238,7 @@ class Kernel
     private function requireProjectDir(): string
     {
         if ($this->projectDir === null) {
-            throw new \RuntimeException(
-                'Kernel was constructed without a projectDir. '
-                . 'Pass $projectDir to the Kernel constructor.'
-            );
+            throw new \RuntimeException('Kernel was constructed without a projectDir. Pass $projectDir to the Kernel constructor.');
         }
         return $this->projectDir;
     }
@@ -249,10 +246,7 @@ class Kernel
     private function requireWebRoot(): string
     {
         if ($this->webRoot === null) {
-            throw new \RuntimeException(
-                'Kernel was constructed without a webRoot. '
-                . 'Pass $webRoot to the Kernel constructor.'
-            );
+            throw new \RuntimeException('Kernel was constructed without a webRoot. Pass $webRoot to the Kernel constructor.');
         }
         return $this->webRoot;
     }

--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -202,6 +202,14 @@ class ModulesApplication
     }
 
     /**
+     * @return string|false The resolved module root path, or false if it cannot be resolved
+     */
+    private static function getModuleRootRealpath(): string|false
+    {
+        return realpath(OEGlobalsBag::getInstance()->getProjectDir() . DIRECTORY_SEPARATOR . 'interface' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR);
+    }
+
+    /**
      * Checks to make sure the file originates in a module directory and is safe to include.
      *
      * @param string $file
@@ -210,7 +218,7 @@ class ModulesApplication
     public static function isSafeModuleFileForInclude($file)
     {
         $realpath = realpath($file);
-        $moduleRootLocation = realpath(OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . DIRECTORY_SEPARATOR . 'interface' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR);
+        $moduleRootLocation = self::getModuleRootRealpath();
 
         // make sure we haven't left our root path ie interface folder
         if (str_starts_with($realpath, $moduleRootLocation) && file_exists($realpath) && str_contains($realpath, ".php")) {
@@ -232,21 +240,22 @@ class ModulesApplication
     {
         if (is_array($files) && !empty($files)) {
             // for safety we only allow the scripts to be from the local filesystem for now
-            $kernel = OEGlobalsBag::getInstance()->getKernel();
-            $filteredFiles = array_filter(array_map(function ($scriptSrc) use ($kernel) {
+            $globalsBag = OEGlobalsBag::getInstance();
+            $projectDir = $globalsBag->getProjectDir();
+            $webRoot = $globalsBag->getWebRoot();
+            $moduleRootLocation = self::getModuleRootRealpath();
+            $filteredFiles = array_filter(array_map(function ($scriptSrc) use ($projectDir, $webRoot, $moduleRootLocation) {
                 // scripts that have any kind of parameters in them such as a cache buster mess up finding the real path
                 // we need to strip that out and then check against the real path
                 $scriptSrcPath = parse_url($scriptSrc, PHP_URL_PATH);
                 // need to remove the web root as that is included in the $scriptSrc and also in the fileroot
-                $webRoot = $kernel->getWebRoot();
                 $pos = stripos($scriptSrcPath, $webRoot);
                 if ($pos !== false) {
                     $scriptSrcPathWithoutWebroot = substr_replace($scriptSrcPath, '', $pos, strlen($webRoot));
                 } else {
                     $scriptSrcPathWithoutWebroot = $scriptSrcPath;
                 }
-                $realPath = realpath($kernel->getProjectDir() . $scriptSrcPathWithoutWebroot);
-                $moduleRootLocation = realpath($kernel->getProjectDir() . DIRECTORY_SEPARATOR . 'interface' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR);
+                $realPath = realpath($projectDir . $scriptSrcPathWithoutWebroot);
 
                 // make sure we haven't left our root path ie interface folder
                 if (str_starts_with($realPath, $moduleRootLocation) && file_exists($realPath)) {

--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -210,7 +210,7 @@ class ModulesApplication
     public static function isSafeModuleFileForInclude($file)
     {
         $realpath = realpath($file);
-        $moduleRootLocation = realpath(OEGlobalsBag::getInstance()->get('fileroot') . DIRECTORY_SEPARATOR . 'interface' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR);
+        $moduleRootLocation = realpath(OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . DIRECTORY_SEPARATOR . 'interface' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR);
 
         // make sure we haven't left our root path ie interface folder
         if (str_starts_with($realpath, $moduleRootLocation) && file_exists($realpath) && str_contains($realpath, ".php")) {
@@ -232,19 +232,21 @@ class ModulesApplication
     {
         if (is_array($files) && !empty($files)) {
             // for safety we only allow the scripts to be from the local filesystem for now
-            $filteredFiles = array_filter(array_map(function ($scriptSrc) {
+            $kernel = OEGlobalsBag::getInstance()->getKernel();
+            $filteredFiles = array_filter(array_map(function ($scriptSrc) use ($kernel) {
                 // scripts that have any kind of parameters in them such as a cache buster mess up finding the real path
                 // we need to strip that out and then check against the real path
                 $scriptSrcPath = parse_url($scriptSrc, PHP_URL_PATH);
                 // need to remove the web root as that is included in the $scriptSrc and also in the fileroot
-                $pos = stripos($scriptSrcPath, (string) OEGlobalsBag::getInstance()->get('web_root'));
+                $webRoot = $kernel->getWebRoot();
+                $pos = stripos($scriptSrcPath, $webRoot);
                 if ($pos !== false) {
-                    $scriptSrcPathWithoutWebroot = substr_replace($scriptSrcPath, '', $pos, strlen((string) OEGlobalsBag::getInstance()->get('web_root')));
+                    $scriptSrcPathWithoutWebroot = substr_replace($scriptSrcPath, '', $pos, strlen($webRoot));
                 } else {
                     $scriptSrcPathWithoutWebroot = $scriptSrcPath;
                 }
-                $realPath = realpath(OEGlobalsBag::getInstance()->get('fileroot') . $scriptSrcPathWithoutWebroot);
-                $moduleRootLocation = realpath(OEGlobalsBag::getInstance()->get('fileroot') . DIRECTORY_SEPARATOR . 'interface' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR);
+                $realPath = realpath($kernel->getProjectDir() . $scriptSrcPathWithoutWebroot);
+                $moduleRootLocation = realpath($kernel->getProjectDir() . DIRECTORY_SEPARATOR . 'interface' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR);
 
                 // make sure we haven't left our root path ie interface folder
                 if (str_starts_with($realPath, $moduleRootLocation) && file_exists($realPath)) {

--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -206,7 +206,8 @@ class ModulesApplication
      */
     private static function getModuleRootRealpath(): string|false
     {
-        return realpath(OEGlobalsBag::getInstance()->getProjectDir() . DIRECTORY_SEPARATOR . 'interface' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR);
+        // realpath() normalizes directory separators, so forward slashes are platform-agnostic.
+        return realpath(OEGlobalsBag::getInstance()->getProjectDir() . '/interface/modules');
     }
 
     /**

--- a/src/Core/OEGlobalsBag.php
+++ b/src/Core/OEGlobalsBag.php
@@ -97,4 +97,37 @@ class OEGlobalsBag extends ParameterBag
         }
         return $kernel;
     }
+
+    /**
+     * Get the project directory, falling back to the 'fileroot' global
+     * when the Kernel is not initialized (e.g. CLI --skip-globals).
+     */
+    public function getProjectDir(): string
+    {
+        return $this->hasKernel()
+            ? $this->getKernel()->getProjectDir()
+            : $this->getString('fileroot');
+    }
+
+    /**
+     * Get the web root path, falling back to the 'webroot' global
+     * when the Kernel is not initialized.
+     */
+    public function getWebRoot(): string
+    {
+        return $this->hasKernel()
+            ? $this->getKernel()->getWebRoot()
+            : $this->getString('webroot');
+    }
+
+    /**
+     * Get the src (library) directory, falling back to the 'srcdir' global
+     * when the Kernel is not initialized.
+     */
+    public function getSrcDir(): string
+    {
+        return $this->hasKernel()
+            ? $this->getKernel()->getSrcDir()
+            : $this->getString('srcdir');
+    }
 }

--- a/src/Cqm/CqmServiceManager.php
+++ b/src/Cqm/CqmServiceManager.php
@@ -9,7 +9,7 @@ class CqmServiceManager
 {
     public static function makeCqmClient(): CqmClient
     {
-        $servicePath = OEGlobalsBag::getInstance()->getString('fileroot') . DIRECTORY_SEPARATOR .
+        $servicePath = OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . DIRECTORY_SEPARATOR .
             'ccdaservice/node_modules' . DIRECTORY_SEPARATOR .
             'oe-cqm-service' . DIRECTORY_SEPARATOR .
             'server.js';

--- a/src/Cqm/CqmServiceManager.php
+++ b/src/Cqm/CqmServiceManager.php
@@ -9,10 +9,8 @@ class CqmServiceManager
 {
     public static function makeCqmClient(): CqmClient
     {
-        $servicePath = OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . DIRECTORY_SEPARATOR .
-            'ccdaservice/node_modules' . DIRECTORY_SEPARATOR .
-            'oe-cqm-service' . DIRECTORY_SEPARATOR .
-            'server.js';
+        $servicePath = OEGlobalsBag::getInstance()->getProjectDir()
+            . '/ccdaservice/node_modules/oe-cqm-service/server.js';
         $client = new CqmClient(
             new System(),
             $servicePath,

--- a/src/Events/Encounter/LoadEncounterFormFilterEvent.php
+++ b/src/Events/Encounter/LoadEncounterFormFilterEvent.php
@@ -110,7 +110,7 @@ class LoadEncounterFormFilterEvent extends Event
     }
 
     /**
-     * @param string $dir  The directory as a string (note the path will be concatenated to $GLOBALS['fileroot']
+     * @param string $dir  The directory as a string (note the path will be concatenated to \OpenEMR\Core\OEGlobalsBag::getInstance()->getKernel()->getProjectDir()
      * @throws \InvalidArgumentException if the path is invalid or does not exist.  Paths must currently be within the /interface/forms/ directory or the /interface/modules/ directory
      */
     public function setDir(string $dir): void
@@ -127,10 +127,14 @@ class LoadEncounterFormFilterEvent extends Event
     private function validatePath($path)
     {
         $path = realpath($path);
+        if ($path === false) {
+            throw new \InvalidArgumentException('Invalid path');
+        }
         // for now we will lock this down to just the forms directory or to the modules directory
-        $inModules = str_starts_with($path, OEGlobalsBag::getInstance()->get('fileroot') . '/interface/modules/');
-        $inForms = str_starts_with($path, OEGlobalsBag::getInstance()->get('fileroot') . '/interface/forms/');
-        if (!(($inModules || $inForms) && file_exists($path))) {
+        $projectDir = OEGlobalsBag::getInstance()->getKernel()->getProjectDir();
+        $inModules = str_starts_with($path, $projectDir . '/interface/modules/');
+        $inForms = str_starts_with($path, $projectDir . '/interface/forms/');
+        if (!($inModules || $inForms)) {
             throw new \InvalidArgumentException('Invalid path');
         }
     }

--- a/src/FHIR/Config/ServerConfig.php
+++ b/src/FHIR/Config/ServerConfig.php
@@ -40,9 +40,10 @@ class ServerConfig
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
         // we may let these be injected at another point in time but for now we set this up as globals
         $this->siteId = $session->get('site_id') ?? '';
-        $this->oauthAddress = OEGlobalsBag::getInstance()->get('site_addr_oath') ?? $_SERVER['HTTP_HOST'];
-        $this->webServerRoot = OEGlobalsBag::getInstance()->get('fileroot') ?? '';
-        $this->webRoot = OEGlobalsBag::getInstance()->get('web_root') ?? '';
+        $globalsBag = OEGlobalsBag::getInstance();
+        $this->oauthAddress = $globalsBag->get('site_addr_oath') ?? $_SERVER['HTTP_HOST'];
+        $this->webServerRoot = $globalsBag->getProjectDir();
+        $this->webRoot = $globalsBag->getWebRoot();
     }
 
     /**
@@ -148,7 +149,7 @@ class ServerConfig
     {
         // TODO: @adunsulag we have redundancy here in OAuth2KeyConfig and ServerConfig.  We should probably merge these.
         $site = $this->getSiteId() ?? "default";
-        $webServerRoot = $this->getWebServerRoot() ?? OEGlobalsBag::getInstance()->get('fileroot') ?? "";
+        $webServerRoot = $this->getWebServerRoot() ?? OEGlobalsBag::getInstance()->getProjectDir();
         // if we can't get the web server root then we can't get the public key
         if (empty($webServerRoot)) {
             throw new \RuntimeException("Unable to determine web server root");

--- a/src/FHIR/SMART/ClientAdminController.php
+++ b/src/FHIR/SMART/ClientAdminController.php
@@ -78,7 +78,7 @@ class ClientAdminController
         $this->kernel = $this->globalsBag->getKernel();
         $this->actionUrlBuilder = new ActionUrlBuilder($this->session, $this->actionURL, self::CSRF_TOKEN_NAME);
         $this->twig = (new TwigContainer(null, $this->kernel))->getTwig();
-        $this->webroot = $this->globalsBag->getString('web_root');
+        $this->webroot = $this->globalsBag->getKernel()->getWebRoot();
     }
 
     public function setTwig(Environment $twig): void

--- a/src/Gacl/GaclAdminApi.php
+++ b/src/Gacl/GaclAdminApi.php
@@ -49,7 +49,7 @@ class GaclAdminApi extends GaclApi {
      */
     function return_page($url=""): never {
         $return_page = basename((string) $url);
-        header('Location: ' . OEGlobalsBag::getInstance()->get('web_root') . "/gacl/admin/" . $return_page);
+        header('Location: ' . OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . "/gacl/admin/" . $return_page);
         exit;
     }
 

--- a/src/Menu/MainMenuRole.php
+++ b/src/Menu/MainMenuRole.php
@@ -61,7 +61,7 @@ class MainMenuRole extends MenuRole
             $menu_parsed = json_decode(file_get_contents(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/custom_menus/" . $mainMenuRole));
         } else {
             // load a standardized menu (does not include .json in id)
-            $menu_parsed = json_decode(file_get_contents(OEGlobalsBag::getInstance()->get('fileroot') . "/interface/main/tabs/menu/menus/" . $mainMenuRole . ".json"));
+            $menu_parsed = json_decode(file_get_contents(OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . "/interface/main/tabs/menu/menus/" . $mainMenuRole . ".json"));
         }
 
         // if error, then die and report error

--- a/src/Menu/PatientMenuRole.php
+++ b/src/Menu/PatientMenuRole.php
@@ -65,7 +65,7 @@ class PatientMenuRole extends MenuRole
             $menu_parsed = json_decode(file_get_contents(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/custom_menus/patient_menus/" . $patientMenuRole));
         } else {
             // load a standardized menu (does not include .json in id)
-            $menu_parsed = json_decode(file_get_contents(OEGlobalsBag::getInstance()->get('fileroot') . "/interface/main/tabs/menu/menus/patient_menus/" . $patientMenuRole . ".json"));
+            $menu_parsed = json_decode(file_get_contents(OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . "/interface/main/tabs/menu/menus/patient_menus/" . $patientMenuRole . ".json"));
         }
         // if error, then die and report error
         if (!$menu_parsed) {
@@ -258,7 +258,7 @@ class PatientMenuRole extends MenuRole
             if (str_starts_with((string) $rel_url, '/') || str_starts_with((string) $rel_url, '\\')) {
                 $rel_url = ltrim((string) $rel_url, '/\\');
             }
-            return OEGlobalsBag::getInstance()->get('webroot') . "/" . $rel_url;
+            return OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . "/" . $rel_url;
         }
         return $rel_url;
     }

--- a/src/OeUI/OemrUI.php
+++ b/src/OeUI/OemrUI.php
@@ -354,7 +354,7 @@ class OemrUI
         $print = xla("Print");
         if ($help_file) {
             $help_file = attr($help_file);
-            $help_file = OEGlobalsBag::getInstance()->get('webroot') . "/Documentation/help_files/$help_file";
+            $help_file = OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . "/Documentation/help_files/$help_file";
             $modal_body = "<iframe src=\"$help_file\" id='targetiframe' class='w-100 h-100 border-0' style='overflow-x: hidden;'
                                 allowtransparency='true'></iframe>";
         } else {
@@ -416,7 +416,7 @@ class OemrUI
         $expandTitle = xlj("Click to Contract and set to henceforth open in Centered mode");
         $contractTitle = xlj("Click to Expand and set to henceforth open in Expanded mode");
         $arrFiles = json_encode($this->arrFiles);
-        $web_root = OEGlobalsBag::getInstance()->get('webroot');
+        $web_root = OEGlobalsBag::getInstance()->getKernel()->getWebRoot();
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
         $collectToken = js_escape(CsrfUtils::collectCsrfToken(session: $session));
         $header_expand_js = <<<EXP

--- a/src/Patient/Cards/CareExperiencePreferenceViewCard.php
+++ b/src/Patient/Cards/CareExperiencePreferenceViewCard.php
@@ -134,7 +134,7 @@ class CareExperiencePreferenceViewCard extends CardModel
             'pid'              => $this->pid,
             'auth'             => true,  // TODO ACL
             'can_write'        => true,  // TODO ACL
-            'webroot'          => OEGlobalsBag::getInstance()->get('webroot') ?? '',
+            'webroot'          => OEGlobalsBag::getInstance()->getKernel()->getWebRoot(),
             'csrf_token'       => CsrfUtils::collectCsrfToken(session: $session),
             'preferences'      => $preferences,
             'loinc_codes'      => $loincCodes,

--- a/src/Patient/Cards/PortalCard.php
+++ b/src/Patient/Cards/PortalCard.php
@@ -85,7 +85,7 @@ class PortalCard extends CardModel
                 'isPortalEnabled' => isPortalEnabled(),
                 'isPortalSiteAddressValid' => isPortalSiteAddressValid(),
                 'isPortalAllowed' => isPortalAllowed($pid),
-                'portalLoginHref' => OEGlobalsBag::getInstance()->get('webroot') . "/interface/patient_file/summary/create_portallogin.php",
+                'portalLoginHref' => OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . "/interface/patient_file/summary/create_portallogin.php",
                 'isApiAllowed' => isApiAllowed($pid),
                 'areCredentialsCreated' => areCredentialsCreated($pid),
                 'isContactEmail' => isContactEmail($pid),

--- a/src/Patient/Cards/TreatmentPreferenceViewCard.php
+++ b/src/Patient/Cards/TreatmentPreferenceViewCard.php
@@ -133,7 +133,7 @@ class TreatmentPreferenceViewCard extends CardModel
             'pid'              => $this->pid,
             'auth'             => true,  // TODO ACL
             'can_write'        => true,  // TODO ACL
-            'webroot'          => OEGlobalsBag::getInstance()->get('webroot') ?? '',
+            'webroot'          => OEGlobalsBag::getInstance()->getKernel()->getWebRoot(),
             'csrf_token'       => CsrfUtils::collectCsrfToken(session: $session),
             'preferences'      => $preferences,
             'loinc_codes'      => $loincCodes,

--- a/src/PaymentProcessing/Sphere/SpherePayment.php
+++ b/src/PaymentProcessing/Sphere/SpherePayment.php
@@ -70,7 +70,7 @@ class SpherePayment
         }
 
         // Calculate the OpenEMR server
-        $this->serverSite = OEGlobalsBag::getInstance()->get('site_addr_oath') . OEGlobalsBag::getInstance()->get('web_root');
+        $this->serverSite = OEGlobalsBag::getInstance()->get('site_addr_oath') . OEGlobalsBag::getInstance()->getKernel()->getWebRoot();
 
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
         // Calculate the $mainUrl

--- a/src/PaymentProcessing/Sphere/SphereRevert.php
+++ b/src/PaymentProcessing/Sphere/SphereRevert.php
@@ -86,7 +86,7 @@ class SphereRevert
         $this->client = new Client(['base_uri' => Sphere::TRUSTEE_API_URL]);
 
         // Calculate the OpenEMR server returnUrl
-        $this->returnUrl = OEGlobalsBag::getInstance()->get('site_addr_oath') . OEGlobalsBag::getInstance()->get('web_root') . '/sphere/initial_response.php';
+        $this->returnUrl = OEGlobalsBag::getInstance()->get('site_addr_oath') . OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . '/sphere/initial_response.php';
     }
 
     /**
@@ -264,7 +264,7 @@ class SphereRevert
             function processSphereRevert(token, front, action, transId, uuidTx) {
                 // Note that the returnUrl needs to match the returnurl that is created in getToken() function, so
                 //  if modify this, also need to modify there
-                let returnUrl = ' . js_escape(OEGlobalsBag::getInstance()->get("site_addr_oath") . OEGlobalsBag::getInstance()->get("web_root")) . ' + "/sphere/initial_response.php?action=" + encodeURIComponent(action) + "&front=" + encodeURIComponent(front) + "&uuid_tx=" + encodeURIComponent(uuidTx) + "&revert=1&csrf_token=" + ' . js_url(CsrfUtils::collectCsrfToken($session, 'sphere_revert')) . ';
+                let returnUrl = ' . js_escape(OEGlobalsBag::getInstance()->get("site_addr_oath") . OEGlobalsBag::getInstance()->getKernel()->getWebRoot()) . ' + "/sphere/initial_response.php?action=" + encodeURIComponent(action) + "&front=" + encodeURIComponent(front) + "&uuid_tx=" + encodeURIComponent(uuidTx) + "&revert=1&csrf_token=" + ' . js_url(CsrfUtils::collectCsrfToken($session, 'sphere_revert')) . ';
                 let mainUrl = ' . js_escape(Sphere::TRUSTEE_API_URL) . ' + "payment.php?aggregators=1&aggregator1=" + ' . js_escape(Sphere::AGGREGATOR_ID) . ' + "&transid=" + encodeURIComponent(transId) + "&token=" + encodeURIComponent(token) + "&action=" + encodeURIComponent(action) + "&returnurl=" + encodeURIComponent(returnUrl);
                 dlgopen(mainUrl, "_blank", 950, 650, "", "Sphere " + action, {allowExternal: true});
             }

--- a/src/Pdf/PdfCreator.php
+++ b/src/Pdf/PdfCreator.php
@@ -35,7 +35,7 @@ class PdfCreator
      */
     private function getBinaryPath(): string
     {
-        $binroot = OEGlobalsBag::getInstance()->get('vendor_dir') . "/openemr/wkhtmltopdf-openemr/bin";
+        $binroot = OEGlobalsBag::getInstance()->getKernel()->getVendorDir() . "/openemr/wkhtmltopdf-openemr/bin";
 
         // This will not necessarily reflect actual machine bus width but php bus size.
         $bit = str_contains(php_uname("m"), '64') ? "64" : "32";

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -166,7 +166,7 @@ class AuthorizationController
         private bool $providerForm = true
     ) {
         $globalsBag = $this->kernel->getGlobalsBag();
-        $this->webroot = $globalsBag->getKernel()->getWebRoot();
+        $this->webroot = $globalsBag->getWebRoot();
         $this->globalsBag = $globalsBag;
         if (empty($this->session->get('site_id'))) {
             // should never reach this but just in case
@@ -688,13 +688,13 @@ class AuthorizationController
         if ($this->grantType === 'authorization_code') {
             $this->getSystemLogger()->debug(
                 "logging global params",
-                ['site_addr_oath' => $this->globalsBag->get('site_addr_oath'), 'web_root' => $this->globalsBag->getKernel()->getWebRoot(), 'site_id' => $this->session->get('site_id')]
+                ['site_addr_oath' => $this->globalsBag->get('site_addr_oath'), 'web_root' => $this->webroot, 'site_id' => $this->session->get('site_id')]
             );
             $fhirServiceConfig = new ServerConfig();
             $expectedAudience = [
                 $fhirServiceConfig->getFhirUrl(),
-                $this->globalsBag->get('site_addr_oath') . $this->globalsBag->getKernel()->getWebRoot() . '/apis/' . $this->session->get('site_id', 'default') . "/api",
-                $this->globalsBag->get('site_addr_oath') . $this->globalsBag->getKernel()->getWebRoot() . '/apis/' . $this->session->get('site_id', 'default') . "/portal",
+                $this->globalsBag->get('site_addr_oath') . $this->webroot . '/apis/' . $this->session->get('site_id', 'default') . "/api",
+                $this->globalsBag->get('site_addr_oath') . $this->webroot . '/apis/' . $this->session->get('site_id', 'default') . "/portal",
             ];
             $grant = new CustomAuthCodeGrant(
                 new AuthCodeRepository(),
@@ -1593,7 +1593,7 @@ class AuthorizationController
      */
     public static function getAuthBaseFullURL(OEGlobalsBag $globalsBag, SessionInterface $session): string
     {
-        $baseUrl = $globalsBag->getKernel()->getWebRoot() . '/oauth2/' . $session->get('site_id', 'default');
+        $baseUrl = $globalsBag->getWebRoot() . '/oauth2/' . $session->get('site_id', 'default');
         // collect full url and issuing url by using 'site_addr_oath' global
         return $globalsBag->get('site_addr_oath', '') . $baseUrl;
     }

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -166,7 +166,7 @@ class AuthorizationController
         private bool $providerForm = true
     ) {
         $globalsBag = $this->kernel->getGlobalsBag();
-        $this->webroot = $globalsBag->get('webroot', '');
+        $this->webroot = $globalsBag->getKernel()->getWebRoot();
         $this->globalsBag = $globalsBag;
         if (empty($this->session->get('site_id'))) {
             // should never reach this but just in case
@@ -688,13 +688,13 @@ class AuthorizationController
         if ($this->grantType === 'authorization_code') {
             $this->getSystemLogger()->debug(
                 "logging global params",
-                ['site_addr_oath' => $this->globalsBag->get('site_addr_oath'), 'web_root' => $this->globalsBag->get('web_root'), 'site_id' => $this->session->get('site_id')]
+                ['site_addr_oath' => $this->globalsBag->get('site_addr_oath'), 'web_root' => $this->globalsBag->getKernel()->getWebRoot(), 'site_id' => $this->session->get('site_id')]
             );
             $fhirServiceConfig = new ServerConfig();
             $expectedAudience = [
                 $fhirServiceConfig->getFhirUrl(),
-                $this->globalsBag->get('site_addr_oath') . $this->globalsBag->get('web_root') . '/apis/' . $this->session->get('site_id', 'default') . "/api",
-                $this->globalsBag->get('site_addr_oath') . $this->globalsBag->get('web_root') . '/apis/' . $this->session->get('site_id', 'default') . "/portal",
+                $this->globalsBag->get('site_addr_oath') . $this->globalsBag->getKernel()->getWebRoot() . '/apis/' . $this->session->get('site_id', 'default') . "/api",
+                $this->globalsBag->get('site_addr_oath') . $this->globalsBag->getKernel()->getWebRoot() . '/apis/' . $this->session->get('site_id', 'default') . "/portal",
             ];
             $grant = new CustomAuthCodeGrant(
                 new AuthCodeRepository(),
@@ -1593,7 +1593,7 @@ class AuthorizationController
      */
     public static function getAuthBaseFullURL(OEGlobalsBag $globalsBag, SessionInterface $session): string
     {
-        $baseUrl = $globalsBag->get('webroot', '') . '/oauth2/' . $session->get('site_id', 'default');
+        $baseUrl = $globalsBag->getKernel()->getWebRoot() . '/oauth2/' . $session->get('site_id', 'default');
         // collect full url and issuing url by using 'site_addr_oath' global
         return $globalsBag->get('site_addr_oath', '') . $baseUrl;
     }

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -691,10 +691,11 @@ class AuthorizationController
                 ['site_addr_oath' => $this->globalsBag->get('site_addr_oath'), 'web_root' => $this->webroot, 'site_id' => $this->session->get('site_id')]
             );
             $fhirServiceConfig = new ServerConfig();
+            $apiBase = $this->globalsBag->get('site_addr_oath') . $this->webroot . '/apis/' . $this->session->get('site_id', 'default');
             $expectedAudience = [
                 $fhirServiceConfig->getFhirUrl(),
-                $this->globalsBag->get('site_addr_oath') . $this->webroot . '/apis/' . $this->session->get('site_id', 'default') . "/api",
-                $this->globalsBag->get('site_addr_oath') . $this->webroot . '/apis/' . $this->session->get('site_id', 'default') . "/portal",
+                $apiBase . "/api",
+                $apiBase . "/portal",
             ];
             $grant = new CustomAuthCodeGrant(
                 new AuthCodeRepository(),

--- a/src/RestControllers/SMART/SMARTAuthorizationController.php
+++ b/src/RestControllers/SMART/SMARTAuthorizationController.php
@@ -416,7 +416,7 @@ class SMARTAuthorizationController
         $coreTheme = !empty($parts[0]) ? $parts[0] : "style_light";
         $logoService = $this->getLogoService();
         // do we want to expose each of the logos?  These really need to be cached instead of hitting FS each time...
-        $primaryLogo = $this->globalsBag->get('site_addr_oath') . $this->globalsBag->get('web_root') . $logoService->getLogo("core/login/primary");
+        $primaryLogo = $this->globalsBag->get('site_addr_oath') . $this->globalsBag->getKernel()->getWebRoot() . $logoService->getLogo("core/login/primary");
         $context = [
             'logo' => [
                 'primary' => $primaryLogo

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -219,7 +219,7 @@ class BackgroundServiceRunner
     {
         $requireOnce = $service['require_once'];
         if ($requireOnce !== null && $requireOnce !== '') {
-            require_once(OEGlobalsBag::getInstance()->getString('fileroot') . $requireOnce);
+            require_once(OEGlobalsBag::getInstance()->getProjectDir() . $requireOnce);
         }
 
         $function = $service['function'];

--- a/src/Services/CDADocumentService.php
+++ b/src/Services/CDADocumentService.php
@@ -46,7 +46,7 @@ class CDADocumentService extends BaseService
      */
     private function getXslPath(): string
     {
-        return OEGlobalsBag::getInstance()->get('fileroot') . self::XSL_PATH;
+        return OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . self::XSL_PATH;
     }
 
     /**
@@ -129,8 +129,7 @@ class CDADocumentService extends BaseService
             null,
             []
         );
-        $content = $result->getContent();
-        unset($result);
+        $content = $result->getContent() ?: '';
 
         if (str_starts_with($content, 'ERROR:')) {
             ServiceContainer::getLogger()->error("Error generating CCDA: {message}", ['message' => $content]);

--- a/src/Services/Cda/CdaValidateDocuments.php
+++ b/src/Services/Cda/CdaValidateDocuments.php
@@ -113,7 +113,7 @@ class CdaValidateDocuments
         $serverActive = @socket_connect($socket, "localhost", $port);
 
         if ($serverActive === false) {
-            $path = OEGlobalsBag::getInstance()->get('fileroot') . "/ccdaservice/node_modules/oe-schematron-service";
+            $path = OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . "/ccdaservice/node_modules/oe-schematron-service";
             if (IS_WINDOWS) {
                 $redirect_errors = " > ";
                 $redirect_errors .= $system->escapeshellcmd(OEGlobalsBag::getInstance()->getString('temporary_files_dir') . "/schematron_server.log") . " 2>&1";

--- a/src/Services/DocumentService.php
+++ b/src/Services/DocumentService.php
@@ -46,7 +46,7 @@ class DocumentService extends BaseService
             $queryParams['patient_id'] = $pid;
         }
         $query = http_build_query($queryParams);
-        return OEGlobalsBag::getInstance()->get('web_root') . '/controller.php?' . $query;
+        return OEGlobalsBag::getInstance()->getKernel()->getWebRoot() . '/controller.php?' . $query;
     }
 
     public function isValidPath($path)

--- a/src/Services/DocumentTemplates/DocumentTemplateRender.php
+++ b/src/Services/DocumentTemplates/DocumentTemplateRender.php
@@ -29,8 +29,9 @@ use OpenEMR\Services\VersionService;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
-require_once(OEGlobalsBag::getInstance()->get('srcdir') . '/appointments.inc.php');
-require_once(OEGlobalsBag::getInstance()->get('srcdir') . '/options.inc.php');
+$srcDir = OEGlobalsBag::getInstance()->getSrcDir();
+require_once($srcDir . '/appointments.inc.php');
+require_once($srcDir . '/options.inc.php');
 
 class DocumentTemplateRender
 {

--- a/src/Services/LogoService.php
+++ b/src/Services/LogoService.php
@@ -75,7 +75,7 @@ class LogoService
     public function getLogo(string $type, string $filename = "logo.*"): string
     {
         $siteDir = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/images/logos/" . $type . "/";
-        $publicDir = OEGlobalsBag::getInstance()->get('images_static_absolute') . "/logos/" . $type . "/";
+        $publicDir = OEGlobalsBag::getInstance()->getKernel()->getImagesAbsolute() . "/logos/" . $type . "/";
         $paths = [];
 
         if ($this->fs->exists($publicDir)) {
@@ -116,9 +116,10 @@ class LogoService
      */
     private function convertToWebPath(string $path): string
     {
+        $kernel = OEGlobalsBag::getInstance()->getKernel();
         $paths = [
             OEGlobalsBag::getInstance()->get('OE_SITE_DIR') => OEGlobalsBag::getInstance()->get('OE_SITE_WEBROOT'),
-            OEGlobalsBag::getInstance()->get('images_static_absolute') => OEGlobalsBag::getInstance()->get('images_static_relative'),
+            $kernel->getImagesAbsolute() => $kernel->getImagesRelative(),
         ];
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
             $path = str_replace('\\', '/', $path);

--- a/src/Services/ProductRegistrationService.php
+++ b/src/Services/ProductRegistrationService.php
@@ -18,7 +18,7 @@ namespace OpenEMR\Services;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\VersionService;
 
-require_once(OEGlobalsBag::getInstance()->get('fileroot') . "/interface/product_registration/exceptions/generic_product_registration_exception.php");
+require_once(__DIR__ . '/../../interface/product_registration/exceptions/generic_product_registration_exception.php');
 
 class ProductRegistrationService
 {

--- a/src/Services/Qdm/MeasureService.php
+++ b/src/Services/Qdm/MeasureService.php
@@ -29,7 +29,7 @@ class MeasureService
     {
         $measureSources = self::fetchMeasureSourceOptions();
         $measureSourcePath = $measureSources['openemr/oe-cqm-parsers'];
-        $measurePath = OEGlobalsBag::getInstance()->get('fileroot') . $measureSourcePath;
+        $measurePath = OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . $measureSourcePath;
         $options = [];
 
         foreach (glob("$measurePath/*", GLOB_ONLYDIR) as $measureDirectory) {
@@ -43,7 +43,7 @@ class MeasureService
     {
         $measureSources = self::fetchMeasureSourceOptions();
         $measureSourcePath = $measureSources['openemr/oe-cqm-parsers'];
-        return OEGlobalsBag::getInstance()->get('fileroot') . $measureSourcePath;
+        return OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . $measureSourcePath;
     }
 
     /**
@@ -106,7 +106,7 @@ class MeasureService
         OEGlobalsBag::getInstance()->set('cqm_performance_period', $year);
 
         $measureSources = self::fetchMeasureSourceOptions();
-        $measurePath = OEGlobalsBag::getInstance()->get('fileroot') . $measureSources['openemr/oe-cqm-parsers'];
+        $measurePath = OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . $measureSources['openemr/oe-cqm-parsers'];
 
         // Restore original global
         OEGlobalsBag::getInstance()->set('cqm_performance_period', $tempGlobal);

--- a/src/Services/Qdm/MeasureService.php
+++ b/src/Services/Qdm/MeasureService.php
@@ -29,7 +29,7 @@ class MeasureService
     {
         $measureSources = self::fetchMeasureSourceOptions();
         $measureSourcePath = $measureSources['openemr/oe-cqm-parsers'];
-        $measurePath = OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . $measureSourcePath;
+        $measurePath = OEGlobalsBag::getInstance()->getProjectDir() . $measureSourcePath;
         $options = [];
 
         foreach (glob("$measurePath/*", GLOB_ONLYDIR) as $measureDirectory) {
@@ -43,7 +43,7 @@ class MeasureService
     {
         $measureSources = self::fetchMeasureSourceOptions();
         $measureSourcePath = $measureSources['openemr/oe-cqm-parsers'];
-        return OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . $measureSourcePath;
+        return OEGlobalsBag::getInstance()->getProjectDir() . $measureSourcePath;
     }
 
     /**
@@ -106,7 +106,7 @@ class MeasureService
         OEGlobalsBag::getInstance()->set('cqm_performance_period', $year);
 
         $measureSources = self::fetchMeasureSourceOptions();
-        $measurePath = OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . $measureSources['openemr/oe-cqm-parsers'];
+        $measurePath = OEGlobalsBag::getInstance()->getProjectDir() . $measureSources['openemr/oe-cqm-parsers'];
 
         // Restore original global
         OEGlobalsBag::getInstance()->set('cqm_performance_period', $tempGlobal);

--- a/src/Telemetry/TelemetryService.php
+++ b/src/Telemetry/TelemetryService.php
@@ -245,7 +245,8 @@ class TelemetryService
         $parsed = parse_url($url);
         $path = $parsed['path'] ?? '';
         $fragment = isset($parsed['fragment']) ? '#' . $parsed['fragment'] : '';
-        $normalized = !empty(OEGlobalsBag::getInstance()->get('webroot')) ? preg_replace('#^(' . OEGlobalsBag::getInstance()->get('webroot') . ')?#', '', $path) : $path;
+        $webRoot = OEGlobalsBag::getInstance()->getWebRoot();
+        $normalized = ($webRoot !== '') ? preg_replace('#^(' . preg_quote($webRoot, '#') . ')?#', '', $path) : $path;
         return ($normalized . $fragment);
     }
 

--- a/tests/Tests/Api/AuthorizationGrantFlowTest.php
+++ b/tests/Tests/Api/AuthorizationGrantFlowTest.php
@@ -71,9 +71,14 @@ class AuthorizationGrantFlowTest extends TestCase
         // set the globals.php kernel which doesn't do much... need to reconicle these two
         // set our site_addr_oath so we use it properly
         $kernel->getGlobalsBag()->set('site_addr_oath', $this->getBaseUrlApi());
+        $projectDir = $GLOBALS['webserver_root'] ?? dirname(__DIR__, 3);
+        $webRoot = $GLOBALS['webroot'] ?? '';
+        if (!is_string($projectDir) || !is_string($webRoot)) {
+            $this->fail('Expected $GLOBALS[webserver_root] and $GLOBALS[webroot] to be strings');
+        }
         $kernel->getGlobalsBag()->set('kernel', new Kernel(
-            (string) ($GLOBALS['webserver_root'] ?? dirname(__DIR__, 3)),
-            (string) ($GLOBALS['webroot'] ?? ''),
+            $projectDir,
+            $webRoot,
             $dispatcher,
         ));
         [$clientIdentifier, $clientSecret] = $this->requestTestRegistrationEndpoint($kernel, $redirectUri, $scopesString);

--- a/tests/Tests/Api/AuthorizationGrantFlowTest.php
+++ b/tests/Tests/Api/AuthorizationGrantFlowTest.php
@@ -71,7 +71,11 @@ class AuthorizationGrantFlowTest extends TestCase
         // set the globals.php kernel which doesn't do much... need to reconicle these two
         // set our site_addr_oath so we use it properly
         $kernel->getGlobalsBag()->set('site_addr_oath', $this->getBaseUrlApi());
-        $kernel->getGlobalsBag()->set('kernel', new Kernel($dispatcher));
+        $kernel->getGlobalsBag()->set('kernel', new Kernel(
+            $GLOBALS['webserver_root'] ?? dirname(__DIR__, 3),
+            $GLOBALS['webroot'] ?? '',
+            $dispatcher,
+        ));
         [$clientIdentifier, $clientSecret] = $this->requestTestRegistrationEndpoint($kernel, $redirectUri, $scopesString);
 
         // now test the authorization flow

--- a/tests/Tests/Api/AuthorizationGrantFlowTest.php
+++ b/tests/Tests/Api/AuthorizationGrantFlowTest.php
@@ -72,8 +72,8 @@ class AuthorizationGrantFlowTest extends TestCase
         // set our site_addr_oath so we use it properly
         $kernel->getGlobalsBag()->set('site_addr_oath', $this->getBaseUrlApi());
         $kernel->getGlobalsBag()->set('kernel', new Kernel(
-            $GLOBALS['webserver_root'] ?? dirname(__DIR__, 3),
-            $GLOBALS['webroot'] ?? '',
+            (string) ($GLOBALS['webserver_root'] ?? dirname(__DIR__, 3)),
+            (string) ($GLOBALS['webroot'] ?? ''),
             $dispatcher,
         ));
         [$clientIdentifier, $clientSecret] = $this->requestTestRegistrationEndpoint($kernel, $redirectUri, $scopesString);

--- a/tests/Tests/Common/Auth/OpenIDConnect/SMARTSessionTokenContextIntegrationTest.php
+++ b/tests/Tests/Common/Auth/OpenIDConnect/SMARTSessionTokenContextIntegrationTest.php
@@ -39,6 +39,7 @@ use OpenEMR\Common\Auth\OpenIDConnect\IdTokenSMARTResponse;
 use OpenEMR\Common\Auth\OpenIDConnect\SMARTSessionTokenContextBuilder;
 use OpenEMR\Common\Http\Psr17Factory;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Core\Kernel;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\FHIR\Config\ServerConfig;
 use OpenEMR\FHIR\SMART\SmartLaunchController;
@@ -64,6 +65,7 @@ class SMARTSessionTokenContextIntegrationTest extends TestCase
 
     const KEY_PATH_PRIVATE = __DIR__ . '/../../../data/Unit/Common/Auth/Grant/openemr-rsa384-private.key';
     private OEGlobalsBag $oldGlobals;
+    private mixed $oldKernel = null;
 
     private ServerConfig $serverConfig;
 
@@ -83,6 +85,10 @@ class SMARTSessionTokenContextIntegrationTest extends TestCase
         foreach ($this->globalsBag->all() as $key => $value) {
             $GLOBALS[$key] = $value;
         }
+        // ServerConfig reads webRoot from the Kernel, so provide one with the test value
+        $this->oldKernel = $GLOBALS['kernel'] ?? null;
+        $webserverRoot = OEGlobalsBag::getInstance()->getProjectDir() ?: '/var/www/openemr';
+        $GLOBALS['kernel'] = new Kernel($webserverRoot, '/openemr');
         $this->serverConfig = new ServerConfig();
         // Use a real session with mock storage for integration testing
         $this->session = new Session(new MockArraySessionStorage());
@@ -129,6 +135,11 @@ class SMARTSessionTokenContextIntegrationTest extends TestCase
             } else {
                 $GLOBALS[$key] = $value;
             }
+        }
+        if ($this->oldKernel !== null) {
+            $GLOBALS['kernel'] = $this->oldKernel;
+        } else {
+            unset($GLOBALS['kernel']);
         }
     }
 

--- a/tests/Tests/Isolated/Common/Twig/TwigExtensionIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Twig/TwigExtensionIsolatedTest.php
@@ -13,6 +13,7 @@
 namespace OpenEMR\Tests\Isolated\Common\Twig;
 
 use OpenEMR\Common\Twig\TwigExtension;
+use OpenEMR\Core\Kernel;
 use OpenEMR\Core\OEGlobalsBag;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -23,19 +24,15 @@ class TwigExtensionIsolatedTest extends TestCase
 {
     public function testGetGlobals(): void
     {
-        $bag = new OEGlobalsBag([
-            'assets_static_relative' => 'some-asset-dir',
-            'srcdir' => 'some-src-dir',
-            'rootdir' => 'some-root-dir',
-            'webroot' => 'some-webroot-dir',
-        ]);
-        $extension = new TwigExtension($bag);
+        $kernel = new Kernel('/var/www/openemr', '/openemr');
+        $bag = new OEGlobalsBag([]);
+        $extension = new TwigExtension($bag, $kernel);
 
         $expectedTwigGlobals = [
-            'assets_dir' => 'some-asset-dir',
-            'srcdir' => 'some-src-dir',
-            'rootdir' => 'some-root-dir',
-            'webroot' => 'some-webroot-dir',
+            'assets_dir' => '/openemr/public/assets',
+            'srcdir' => '/var/www/openemr/library',
+            'rootdir' => '/openemr/interface',
+            'webroot' => '/openemr',
             'assetVersion' => null,
             'session' => [],
         ];

--- a/tests/Tests/Isolated/Core/KernelPathsTest.php
+++ b/tests/Tests/Isolated/Core/KernelPathsTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ *
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Core;
+
+use OpenEMR\Core\Kernel;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+#[Group('core')]
+class KernelPathsTest extends TestCase
+{
+    private Kernel $kernel;
+
+    protected function setUp(): void
+    {
+        $this->kernel = new Kernel('/var/www/openemr', '/openemr');
+    }
+
+    // ---- Web paths --------------------------------------------------------
+
+    public function testGetWebRoot(): void
+    {
+        $this->assertSame('/openemr', $this->kernel->getWebRoot());
+    }
+
+    public function testGetWebRootEmpty(): void
+    {
+        $kernel = new Kernel('/var/www/openemr', '');
+        $this->assertSame('', $kernel->getWebRoot());
+    }
+
+    public function testGetRootDir(): void
+    {
+        $this->assertSame('/openemr/interface', $this->kernel->getRootDir());
+    }
+
+    public function testGetAssetsRelative(): void
+    {
+        $this->assertSame('/openemr/public/assets', $this->kernel->getAssetsRelative());
+    }
+
+    public function testGetThemesRelative(): void
+    {
+        $this->assertSame('/openemr/public/themes', $this->kernel->getThemesRelative());
+    }
+
+    public function testGetImagesRelative(): void
+    {
+        $this->assertSame('/openemr/public/images', $this->kernel->getImagesRelative());
+    }
+
+    // ---- Filesystem paths -------------------------------------------------
+
+    public function testGetProjectDir(): void
+    {
+        $this->assertSame('/var/www/openemr', $this->kernel->getProjectDir());
+    }
+
+    public function testGetSrcDir(): void
+    {
+        $this->assertSame('/var/www/openemr/library', $this->kernel->getSrcDir());
+    }
+
+    public function testGetIncludeRoot(): void
+    {
+        $this->assertSame('/var/www/openemr/interface', $this->kernel->getIncludeRoot());
+    }
+
+    public function testGetVendorDir(): void
+    {
+        $this->assertSame('/var/www/openemr/vendor', $this->kernel->getVendorDir());
+    }
+
+    public function testGetTemplateDir(): void
+    {
+        $this->assertSame('/var/www/openemr/templates/', $this->kernel->getTemplateDir());
+    }
+
+    public function testGetImagesAbsolute(): void
+    {
+        $this->assertSame('/var/www/openemr/public/images', $this->kernel->getImagesAbsolute());
+    }
+
+    public function testGetSitesBase(): void
+    {
+        $this->assertSame('/var/www/openemr/sites', $this->kernel->getSitesBase());
+    }
+
+    // ---- Site-specific paths ----------------------------------------------
+
+    public function testGetSiteDir(): void
+    {
+        $this->assertSame('/var/www/openemr/sites/default', $this->kernel->getSiteDir('default'));
+    }
+
+    public function testGetSiteWebRoot(): void
+    {
+        $this->assertSame('/openemr/sites/default', $this->kernel->getSiteWebRoot('default'));
+    }
+
+    // ---- RuntimeException when paths not provided -------------------------
+
+    public function testGetProjectDirThrowsWhenNull(): void
+    {
+        $kernel = new Kernel();
+        $this->expectException(\RuntimeException::class);
+        $kernel->getProjectDir();
+    }
+
+    public function testGetWebRootThrowsWhenNull(): void
+    {
+        $kernel = new Kernel();
+        $this->expectException(\RuntimeException::class);
+        $kernel->getWebRoot();
+    }
+
+    // ---- Backward compat: dispatcher-only construction --------------------
+
+    public function testConstructWithDispatcherOnly(): void
+    {
+        $dispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+        $kernel = new Kernel(dispatcher: $dispatcher);
+        $this->assertSame($dispatcher, $kernel->getEventDispatcher());
+    }
+}

--- a/tests/Tests/Isolated/Telemetry/TelemetryServiceTest.php
+++ b/tests/Tests/Isolated/Telemetry/TelemetryServiceTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Telemetry;
 
-use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Core\Kernel;
 use OpenEMR\Services\SoftwareVersion;
 use OpenEMR\Services\VersionServiceInterface;
 use OpenEMR\Telemetry\GeoTelemetryInterface;
@@ -26,6 +26,24 @@ use Psr\Log\LoggerInterface;
 
 class TelemetryServiceTest extends TestCase
 {
+    private bool $hadKernel;
+    private mixed $originalKernel;
+
+    protected function setUp(): void
+    {
+        $this->hadKernel = array_key_exists('kernel', $GLOBALS);
+        $this->originalKernel = $GLOBALS['kernel'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->hadKernel) {
+            $GLOBALS['kernel'] = $this->originalKernel;
+        } else {
+            unset($GLOBALS['kernel']);
+        }
+    }
+
     public function testIsTelemetryEnabledReturnsTrueWhenTelemetryDisabledIsZero(): void
     {
         $mockRepository = $this->createMock(TelemetryRepository::class);
@@ -255,10 +273,8 @@ class TelemetryServiceTest extends TestCase
 
         $telemetryService = new TelemetryService($mockRepository, $mockVersionService, $mockLogger);
 
-        // Set up webroot to test the normalization behavior
-        $globalsBag = OEGlobalsBag::getInstance();
-        $originalWebroot = $globalsBag->get('webroot');
-        $globalsBag->set('webroot', '/openemr');
+        // Set up a Kernel with webroot to test URL normalization
+        $GLOBALS['kernel'] = new Kernel('/var/www/openemr', '/openemr');
 
         $data = [
             'eventType' => 'click',
@@ -282,9 +298,6 @@ class TelemetryServiceTest extends TestCase
         $decodedResult = json_decode($result, true);
 
         $this->assertEquals(["success" => true], $decodedResult);
-
-        // Restore original webroot
-        $globalsBag->set('webroot', $originalWebroot);
     }
 
     public function testReportClickEventHandlesMissingOptionalFields(): void
@@ -673,10 +686,8 @@ class TelemetryServiceTest extends TestCase
 
         $telemetryService = new TelemetryService($mockRepository, $mockVersionService, $mockLogger);
 
-        // Set up empty webroot to test the fallback behavior
-        $globalsBag = OEGlobalsBag::getInstance();
-        $originalWebroot = $globalsBag->get('webroot');
-        $globalsBag->set('webroot', '');
+        // Set up a Kernel with empty webroot to test the fallback behavior
+        $GLOBALS['kernel'] = new Kernel('/var/www/openemr', '');
 
         $data = [
             'eventType' => 'click',
@@ -700,13 +711,12 @@ class TelemetryServiceTest extends TestCase
         $decodedResult = json_decode($result, true);
 
         $this->assertEquals(["success" => true], $decodedResult);
-
-        // Restore original webroot
-        $globalsBag->set('webroot', $originalWebroot);
     }
 
     public function testReportClickEventNormalizesUrlWithFragmentOnly(): void
     {
+        $GLOBALS['kernel'] = new Kernel('/var/www/openemr', '/openemr');
+
         $mockRepository = $this->createMock(TelemetryRepository::class);
         $mockVersionService = $this->createMock(VersionServiceInterface::class);
         $mockLogger = $this->createMock(LoggerInterface::class);

--- a/tests/Tests/RestControllers/Authorization/AuthorizationControllerTest.php
+++ b/tests/Tests/RestControllers/Authorization/AuthorizationControllerTest.php
@@ -48,6 +48,8 @@ class AuthorizationControllerTest extends TestCase
         $coreKernel = $this->createMock(Kernel::class);
         $coreKernel->method('getEventDispatcher')
             ->willReturn(new EventDispatcher());
+        $coreKernel->method('getProjectDir')->willReturn(dirname(__DIR__, 4));
+        $coreKernel->method('getWebRoot')->willReturn('');
         /** @var array<string, mixed> $globalParams */
         $globalParams = array_merge([
             'kernel' => $coreKernel,

--- a/tests/Tests/Unit/Controllers/Interface/Forms/Observation/ObservationControllerTest.php
+++ b/tests/Tests/Unit/Controllers/Interface/Forms/Observation/ObservationControllerTest.php
@@ -77,8 +77,14 @@ class ObservationControllerTest extends TestCase
         $this->globalKernelBackup = $globalsBag->getKernel();
         $this->globalDateFormat = $GLOBALS['date_display_format'] ?? null;
         $GLOBALS['webroot'] = '/openemr';
-        $globalsBag->set('kernel', null);
         $GLOBALS['date_display_format'] = 0; // YYYY-MM-DD
+
+        // Provide a mock Kernel with path stubs instead of nulling
+        $mockKernel = $this->createMock(Kernel::class);
+        $mockKernel->method('getProjectDir')->willReturn(dirname(__DIR__, 7));
+        $mockKernel->method('getWebRoot')->willReturn('/openemr');
+        $mockKernel->method('getEventDispatcher')->willReturn(new \Symfony\Component\EventDispatcher\EventDispatcher());
+        $globalsBag->set('kernel', $mockKernel);
 
         // Create mock dependencies
         $this->mockObservationService = $this->createMock(ObservationService::class);

--- a/tests/Tests/Unit/FHIR/SMART/ClientAdminControllerTest.php
+++ b/tests/Tests/Unit/FHIR/SMART/ClientAdminControllerTest.php
@@ -56,9 +56,11 @@ class ClientAdminControllerTest extends TestCase
         $mockTwig = $this->createMock(Environment::class);
         $mockTwig->method('render')->willReturn('<html>Mock Template</html>');
 
-        // Mock event dispatcher
+        // Mock event dispatcher and path accessors
         $mockEventDispatcher = new EventDispatcher();
         $this->mockKernel->method('getEventDispatcher')->willReturn($mockEventDispatcher);
+        $this->mockKernel->method('getProjectDir')->willReturn(dirname(__DIR__, 5));
+        $this->mockKernel->method('getWebRoot')->willReturn('');
 
         // Create controller instance
         $this->controller = new ClientAdminController(

--- a/tests/api/InternalApiTest.php
+++ b/tests/api/InternalApiTest.php
@@ -104,7 +104,7 @@ $getParams = [];
 try {
     $restRequest = HttpRestRequest::create('/api/facility', 'GET');
     $restRequest->setRequestUserRole("users");
-    $sessionFactory = new HttpSessionFactory($restRequest, $globalsBag->getString('webroot'), HttpSessionFactory::SESSION_TYPE_CORE);
+    $sessionFactory = new HttpSessionFactory($restRequest, $globalsBag->getKernel()->getWebRoot(), HttpSessionFactory::SESSION_TYPE_CORE);
     $restRequest->setSession($sessionFactory->createSession());
     $getParams = $restRequest->getQueryParams();
     $kernel = new OEHttpKernel($globalsBag->getKernel()->getEventDispatcher(), new ControllerResolver());

--- a/tests/api/InternalApiTest.php
+++ b/tests/api/InternalApiTest.php
@@ -100,14 +100,15 @@ echo "<br /><br />";
 //  This allows same notation as the calls in the api (ie. '/api/facility'), but
 //  is limited to get requests at this time.
 $globalsBag = OEGlobalsBag::getInstance();
+$oeKernel = $globalsBag->getKernel();
 $getParams = [];
 try {
     $restRequest = HttpRestRequest::create('/api/facility', 'GET');
     $restRequest->setRequestUserRole("users");
-    $sessionFactory = new HttpSessionFactory($restRequest, $globalsBag->getKernel()->getWebRoot(), HttpSessionFactory::SESSION_TYPE_CORE);
+    $sessionFactory = new HttpSessionFactory($restRequest, $oeKernel->getWebRoot(), HttpSessionFactory::SESSION_TYPE_CORE);
     $restRequest->setSession($sessionFactory->createSession());
     $getParams = $restRequest->getQueryParams();
-    $kernel = new OEHttpKernel($globalsBag->getKernel()->getEventDispatcher(), new ControllerResolver());
+    $kernel = new OEHttpKernel($oeKernel->getEventDispatcher(), new ControllerResolver());
     $kernel->setSystemLogger(ServiceContainer::getLogger());
     $dispatchHandler = new HttpRestRouteHandler($kernel);
     $routeFinder = new StandardRouteFinder($kernel);

--- a/tests/api/InternalFhirTest.php
+++ b/tests/api/InternalFhirTest.php
@@ -108,7 +108,7 @@ $getParams = [];
 try {
     $restRequest = HttpRestRequest::create('/fhir/Organization', 'GET');
     $restRequest->setRequestUserRole("users");
-    $sessionFactory = new HttpSessionFactory($restRequest, $globalsBag->getString('webroot'), HttpSessionFactory::SESSION_TYPE_CORE);
+    $sessionFactory = new HttpSessionFactory($restRequest, $globalsBag->getKernel()->getWebRoot(), HttpSessionFactory::SESSION_TYPE_CORE);
     $restRequest->setSession($sessionFactory->createSession());
     $getParams = $restRequest->getQueryParams();
     $kernel = new OEHttpKernel($globalsBag->getKernel()->getEventDispatcher(), new ControllerResolver());

--- a/tests/api/InternalFhirTest.php
+++ b/tests/api/InternalFhirTest.php
@@ -104,14 +104,15 @@ echo "<br /><br />";
 //  This allows same notation as the calls in the api (ie. '/api/facility'), but
 //  is limited to get requests at this time.
 $globalsBag = OEGlobalsBag::getInstance();
+$oeKernel = $globalsBag->getKernel();
 $getParams = [];
 try {
     $restRequest = HttpRestRequest::create('/fhir/Organization', 'GET');
     $restRequest->setRequestUserRole("users");
-    $sessionFactory = new HttpSessionFactory($restRequest, $globalsBag->getKernel()->getWebRoot(), HttpSessionFactory::SESSION_TYPE_CORE);
+    $sessionFactory = new HttpSessionFactory($restRequest, $oeKernel->getWebRoot(), HttpSessionFactory::SESSION_TYPE_CORE);
     $restRequest->setSession($sessionFactory->createSession());
     $getParams = $restRequest->getQueryParams();
-    $kernel = new OEHttpKernel($globalsBag->getKernel()->getEventDispatcher(), new ControllerResolver());
+    $kernel = new OEHttpKernel($oeKernel->getEventDispatcher(), new ControllerResolver());
     $kernel->setSystemLogger(ServiceContainer::getLogger());
     $dispatchHandler = new HttpRestRouteHandler($kernel);
     $routeFinder = new FhirRouteFinder($kernel);


### PR DESCRIPTION
## Summary

- Add `projectDir` and `webRoot` constructor params to `Kernel` with 14 derived path accessors (`getProjectDir()`, `getWebRoot()`, `getVendorDir()`, `getSrcDir()`, etc.), following Symfony's convention
- Params are optional for backward compat with modules that construct bare `Kernel()` instances — path getters throw `RuntimeException` if called without paths
- Migrate all `src/` call sites from `OEGlobalsBag->get('webroot')` / `getString('srcdir')` / etc. to typed `->getKernel()->getWebRoot()` / `->getKernel()->getSrcDir()`
- Eliminates stringly-typed path lookups in the modern codebase; legacy `interface/` and `library/` files will be migrated in follow-up PRs

Supersedes #11263 — this is the first in a series of smaller PRs splitting that work.

## Test plan

- [ ] Existing isolated tests pass (KernelPathsTest, TwigExtensionIsolatedTest, TelemetryServiceTest, BackgroundServicesCommandTest, AuthorizationControllerTest)
- [ ] PHPStan level 10 passes with regenerated baselines
- [ ] Docker e2e tests pass — globals bootstrap provides paths to Kernel