### PR TITLE
test(security): expand isolated tests for unserialize allowed_classes

### DIFF
--- a/tests/Tests/Isolated/Security/UnserializeAllowedClassesTest.php
+++ b/tests/Tests/Isolated/Security/UnserializeAllowedClassesTest.php
@@ -36,6 +36,16 @@ require_once SMARTY_CORE_DIR . 'core.read_cache_file.php';
 #[CoversClass(\ConnectionSetting::class)]
 #[CoversFunction('smarty_core_process_cached_inserts')]
 #[CoversFunction('smarty_core_read_cache_file')]
+/**
+ * Cache_Lite subclass that declares the undeclared dynamic property
+ * _memoryCachingState, avoiding PHP 8.2+ deprecation warnings in tests.
+ */
+class TestCacheLite extends \Cache_Lite
+{
+    /** @var array<string, mixed> */
+    public array $_memoryCachingState = [];
+}
+
 class UnserializeAllowedClassesTest extends TestCase
 {
     // ---- Cache_Lite: memory-cached automatic deserialization (line 256) ----
@@ -85,7 +95,7 @@ class UnserializeAllowedClassesTest extends TestCase
 
     public function testCacheLiteGetMemoryCachingStateRoundTrip(): void
     {
-        $cache = new \Cache_Lite([
+        $cache = new TestCacheLite([
             'caching' => true,
             'memoryCaching' => true,
             'onlyMemoryCaching' => true,
@@ -97,7 +107,7 @@ class UnserializeAllowedClassesTest extends TestCase
         // saveMemoryCachingState serializes _memoryCachingCounter and
         // _memoryCachingState into a cache entry.
         $cache->_memoryCachingCounter = 5;
-        @$cache->_memoryCachingState = ['key1' => 'data1', 'key2' => 'data2']; // @phpstan-ignore property.notFound (legacy undeclared dynamic property)
+        $cache->_memoryCachingState = ['key1' => 'data1', 'key2' => 'data2'];
 
         $cache->saveMemoryCachingState('state-id', 'state-group');
 
@@ -112,7 +122,7 @@ class UnserializeAllowedClassesTest extends TestCase
 
     public function testCacheLiteGetMemoryCachingStateBlocksObjectInjection(): void
     {
-        $cache = new \Cache_Lite([
+        $cache = new TestCacheLite([
             'caching' => true,
             'memoryCaching' => true,
             'onlyMemoryCaching' => true,
@@ -125,7 +135,7 @@ class UnserializeAllowedClassesTest extends TestCase
         $obj->evil = true;
 
         $cache->_memoryCachingCounter = 1;
-        @$cache->_memoryCachingState = ['entry' => $obj]; // @phpstan-ignore property.notFound (legacy undeclared dynamic property)
+        $cache->_memoryCachingState = ['entry' => $obj];
 
         $cache->saveMemoryCachingState('inject-state', 'state-group');
 
@@ -186,7 +196,7 @@ class UnserializeAllowedClassesTest extends TestCase
         $smarty->_plugins = [
             'insert' => [
                 'testfunc' => [
-                    static fn(array $args): string => 'REPLACED',
+                    static fn(array $args, object $smarty): string => 'REPLACED',
                 ],
             ],
         ];
@@ -216,7 +226,7 @@ class UnserializeAllowedClassesTest extends TestCase
         $smarty->_plugins = [
             'insert' => [
                 'testfunc' => [
-                    static fn(array $args): string => ($args['extra'] instanceof \__PHP_Incomplete_Class)
+                    static fn(array $args, object $smarty): string => ($args['extra'] instanceof \__PHP_Incomplete_Class)
                         ? 'BLOCKED'
                         : 'INJECTED',
                 ],

--- a/tests/Tests/Isolated/Security/UnserializeAllowedClassesTest.php
+++ b/tests/Tests/Isolated/Security/UnserializeAllowedClassesTest.php
@@ -32,10 +32,6 @@ if (!defined('SMARTY_CORE_DIR')) {
 require_once SMARTY_CORE_DIR . 'core.process_cached_inserts.php';
 require_once SMARTY_CORE_DIR . 'core.read_cache_file.php';
 
-#[CoversClass(\Cache_Lite::class)]
-#[CoversClass(\ConnectionSetting::class)]
-#[CoversFunction('smarty_core_process_cached_inserts')]
-#[CoversFunction('smarty_core_read_cache_file')]
 /**
  * Cache_Lite subclass that declares the undeclared dynamic property
  * _memoryCachingState, avoiding PHP 8.2+ deprecation warnings in tests.
@@ -46,6 +42,10 @@ class TestCacheLite extends \Cache_Lite
     public array $_memoryCachingState = [];
 }
 
+#[CoversClass(\Cache_Lite::class)]
+#[CoversClass(\ConnectionSetting::class)]
+#[CoversFunction('smarty_core_process_cached_inserts')]
+#[CoversFunction('smarty_core_read_cache_file')]
 class UnserializeAllowedClassesTest extends TestCase
 {
     // ---- Cache_Lite: memory-cached automatic deserialization (line 256) ----
@@ -265,6 +265,7 @@ class UnserializeAllowedClassesTest extends TestCase
             string $action,
             object $smarty,
             ?string &$results,
+            mixed ...$unused,
         ) use ($content): void {
             $results = $content;
         };
@@ -303,6 +304,7 @@ class UnserializeAllowedClassesTest extends TestCase
             string $action,
             object $smarty,
             ?string &$results,
+            mixed ...$unused,
         ) use ($content): void {
             $results = $content;
         };

--- a/tests/Tests/Isolated/Security/UnserializeAllowedClassesTest.php
+++ b/tests/Tests/Isolated/Security/UnserializeAllowedClassesTest.php
@@ -15,16 +15,30 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Isolated\Security;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../../../gacl/Cache_Lite/Lite.php';
 require_once __DIR__ . '/../../../../portal/patient/fwk/libs/verysimple/Phreeze/ConnectionSetting.php';
 
+if (!defined('SMARTY_DIR')) {
+    define('SMARTY_DIR', __DIR__ . '/../../../../library/smarty_legacy/smarty/');
+}
+
+if (!defined('SMARTY_CORE_DIR')) {
+    define('SMARTY_CORE_DIR', SMARTY_DIR . 'internals/');
+}
+
+require_once SMARTY_CORE_DIR . 'core.process_cached_inserts.php';
+require_once SMARTY_CORE_DIR . 'core.read_cache_file.php';
+
 #[CoversClass(\Cache_Lite::class)]
 #[CoversClass(\ConnectionSetting::class)]
+#[CoversFunction('smarty_core_process_cached_inserts')]
+#[CoversFunction('smarty_core_read_cache_file')]
 class UnserializeAllowedClassesTest extends TestCase
 {
-    // ---- Cache_Lite: memory-cached automatic deserialization ----
+    // ---- Cache_Lite: memory-cached automatic deserialization (line 256) ----
 
     public function testCacheLiteMemoryCacheReturnsArrayNotObject(): void
     {
@@ -67,7 +81,61 @@ class UnserializeAllowedClassesTest extends TestCase
         $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $result); // @phpstan-ignore method.impossibleType
     }
 
-    // ---- ConnectionSetting: round-trip serialize/unserialize ----
+    // ---- Cache_Lite: getMemoryCachingState (line 448) ----
+
+    public function testCacheLiteGetMemoryCachingStateRoundTrip(): void
+    {
+        $cache = new \Cache_Lite([
+            'caching' => true,
+            'memoryCaching' => true,
+            'onlyMemoryCaching' => true,
+            'automaticSerialization' => false,
+            'fileNameProtection' => true,
+            'cacheDir' => sys_get_temp_dir() . '/',
+        ]);
+
+        // saveMemoryCachingState serializes _memoryCachingCounter and
+        // _memoryCachingState into a cache entry.
+        $cache->_memoryCachingCounter = 5;
+        @$cache->_memoryCachingState = ['key1' => 'data1', 'key2' => 'data2']; // @phpstan-ignore property.notFound (legacy undeclared dynamic property)
+
+        $cache->saveMemoryCachingState('state-id', 'state-group');
+
+        // getMemoryCachingState restores the counter and array from the
+        // serialized entry. The counter was 5 when serialized (before
+        // _memoryCacheAdd incremented it during save).
+        $cache->getMemoryCachingState('state-id', 'state-group');
+
+        $this->assertSame(5, $cache->_memoryCachingCounter);
+        $this->assertSame(['key1' => 'data1', 'key2' => 'data2'], $cache->_memoryCachingArray);
+    }
+
+    public function testCacheLiteGetMemoryCachingStateBlocksObjectInjection(): void
+    {
+        $cache = new \Cache_Lite([
+            'caching' => true,
+            'memoryCaching' => true,
+            'onlyMemoryCaching' => true,
+            'automaticSerialization' => false,
+            'fileNameProtection' => true,
+            'cacheDir' => sys_get_temp_dir() . '/',
+        ]);
+
+        $obj = new \stdClass();
+        $obj->evil = true;
+
+        $cache->_memoryCachingCounter = 1;
+        @$cache->_memoryCachingState = ['entry' => $obj]; // @phpstan-ignore property.notFound (legacy undeclared dynamic property)
+
+        $cache->saveMemoryCachingState('inject-state', 'state-group');
+
+        $cache->getMemoryCachingState('inject-state', 'state-group');
+
+        $restored = $cache->_memoryCachingArray;
+        $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $restored['entry']);
+    }
+
+    // ---- ConnectionSetting: round-trip serialize/unserialize (line 99) ----
 
     public function testConnectionSettingRoundTrip(): void
     {
@@ -106,5 +174,142 @@ class UnserializeAllowedClassesTest extends TestCase
         $setting->Unserialize($payload);
 
         $this->assertSame('mysql', $setting->Type);
+    }
+
+    // ---- Smarty: core.process_cached_inserts (line 28) ----
+
+    public function testSmartyProcessCachedInsertsDeserializesArgs(): void
+    {
+        $smarty = new \stdClass();
+        $smarty->_smarty_md5 = 'f8d698aea36fcbead2b9d5359ffca76f';
+        $smarty->debugging = false;
+        $smarty->_plugins = [
+            'insert' => [
+                'testfunc' => [
+                    static fn(array $args): string => 'REPLACED',
+                ],
+            ],
+        ];
+
+        $args = ['name' => 'testfunc'];
+        $serialized = serialize($args);
+        $results = $smarty->_smarty_md5
+            . '{insert_cache ' . $serialized . '}'
+            . $smarty->_smarty_md5;
+
+        $output = smarty_core_process_cached_inserts(
+            ['results' => $results],
+            $smarty
+        );
+
+        $this->assertSame('REPLACED', $output);
+    }
+
+    public function testSmartyProcessCachedInsertsBlocksObjectInjection(): void
+    {
+        $smarty = new \stdClass();
+        $smarty->_smarty_md5 = 'f8d698aea36fcbead2b9d5359ffca76f';
+        $smarty->debugging = false;
+
+        // The insert function checks whether the 'extra' key survived as an
+        // object or was converted to __PHP_Incomplete_Class.
+        $smarty->_plugins = [
+            'insert' => [
+                'testfunc' => [
+                    static fn(array $args): string => ($args['extra'] instanceof \__PHP_Incomplete_Class)
+                        ? 'BLOCKED'
+                        : 'INJECTED',
+                ],
+            ],
+        ];
+
+        $args = ['name' => 'testfunc', 'extra' => new \stdClass()];
+        $serialized = serialize($args);
+        $results = $smarty->_smarty_md5
+            . '{insert_cache ' . $serialized . '}'
+            . $smarty->_smarty_md5;
+
+        $output = smarty_core_process_cached_inserts(
+            ['results' => $results],
+            $smarty
+        );
+
+        $this->assertSame('BLOCKED', $output);
+    }
+
+    // ---- Smarty: core.read_cache_file (line 55) ----
+
+    public function testSmartyReadCacheFileDeserializesCacheInfo(): void
+    {
+        $cacheInfo = [
+            'expires' => -1,
+            'timestamp' => time(),
+            'template' => [],
+        ];
+        $serializedInfo = serialize($cacheInfo);
+        $content = strlen($serializedInfo) . "\n" . $serializedInfo . '<html>cached</html>';
+
+        $smarty = new \stdClass();
+        $smarty->force_compile = false;
+        $smarty->cache_handler_func = static function (
+            string $action,
+            object $smarty,
+            ?string &$results,
+        ) use ($content): void {
+            $results = $content;
+        };
+        $smarty->caching = 2;
+        $smarty->compile_check = false;
+        $smarty->_cache_info = [];
+
+        $params = [
+            'tpl_file' => 'read-cache-test.tpl',
+            'cache_id' => 'c1',
+            'compile_id' => 'co1',
+            'results' => '',
+        ];
+
+        $result = smarty_core_read_cache_file($params, $smarty);
+
+        $this->assertTrue($result);
+        $this->assertSame($cacheInfo, $smarty->_cache_info); // @phpstan-ignore property.nonObject (by-reference parameter loses type)
+        $this->assertSame('<html>cached</html>', $params['results']); // @phpstan-ignore offsetAccess.nonOffsetAccessible
+    }
+
+    public function testSmartyReadCacheFileBlocksObjectInjection(): void
+    {
+        $cacheInfo = [
+            'expires' => -1,
+            'timestamp' => time(),
+            'template' => [],
+            'evil' => new \stdClass(),
+        ];
+        $serializedInfo = serialize($cacheInfo);
+        $content = strlen($serializedInfo) . "\n" . $serializedInfo . '<html>cached</html>';
+
+        $smarty = new \stdClass();
+        $smarty->force_compile = false;
+        $smarty->cache_handler_func = static function (
+            string $action,
+            object $smarty,
+            ?string &$results,
+        ) use ($content): void {
+            $results = $content;
+        };
+        $smarty->caching = 2;
+        $smarty->compile_check = false;
+        $smarty->_cache_info = [];
+
+        $params = [
+            'tpl_file' => 'read-cache-inject.tpl',
+            'cache_id' => 'c2',
+            'compile_id' => 'co2',
+            'results' => '',
+        ];
+
+        $result = smarty_core_read_cache_file($params, $smarty);
+
+        $this->assertTrue($result);
+        $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $smarty->_cache_info['evil']); // @phpstan-ignore property.nonObject, offsetAccess.nonOffsetAccessible
     }
 }

--- a/tests/Tests/Isolated/Security/UnserializeAllowedClassesTest.php
+++ b/tests/Tests/Isolated/Security/UnserializeAllowedClassesTest.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Security;
 
-use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../../../gacl/Cache_Lite/Lite.php';
@@ -42,10 +40,6 @@ class TestCacheLite extends \Cache_Lite
     public array $_memoryCachingState = [];
 }
 
-#[CoversClass(\Cache_Lite::class)]
-#[CoversClass(\ConnectionSetting::class)]
-#[CoversFunction('smarty_core_process_cached_inserts')]
-#[CoversFunction('smarty_core_read_cache_file')]
 class UnserializeAllowedClassesTest extends TestCase
 {
     // ---- Cache_Lite: memory-cached automatic deserialization (line 256) ----


### PR DESCRIPTION
## Summary

- Adds 6 new isolated tests covering additional `unserialize()` + `allowed_classes` code paths from #10896
- Tests cover `Cache_Lite::getMemoryCachingState()` (line 448), `smarty_core_process_cached_inserts()` (line 28), and `smarty_core_read_cache_file()` (line 55)
- Each path has a round-trip test and an object-injection-blocking test
- Total: 10 tests (4 existing + 6 new), 22 assertions

## Not testable in isolation

These changed files require database, sessions, or removed PHP functions and cannot be covered by isolated tests:

| File | Reason |
|------|--------|
| `src/Services/PatientService.php` | Uses `sqlQuery()`/`sqlStatement()` |
| `src/Gacl/Gacl.php` | Constructor requires database |
| `portal/.../Authenticator.php` | Uses `session_start()` and `SessionWrapperFactory` |
| `portal/.../HTTP/Context.php` | Uses `session_start()` and `SessionWrapperFactory` |
| `gacl/Cache_Lite/Lite.php` line 279 | `_read()` calls `get_magic_quotes_runtime()` removed in PHP 8 |

## Test plan

- [ ] `composer phpunit-isolated` passes
- [ ] All 10 tests in `UnserializeAllowedClassesTest` pass
- [ ] PHPStan clean
- [ ] Codecov patch coverage improves over #10896