### PR TITLE
fix(faxsms): read cron interval from background_services instead of hardcoding 150

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
@@ -174,7 +174,7 @@ $db_sms_msg['message'] = $MESSAGE;
                 $strMsg = "<strong>* " . xlt("SEND NOTIFICATION BEFORE:") . $SMS_NOTIFICATION_HOUR . " | " . xlt("CRONJOB RUNS EVERY:") . $CRON_TIME . " | " . xlt("APPOINTMENT DATE TIME") . ': ' . $app_date . " | " . xlt("APPOINTMENT REMAINING HOURS") . ": " . text($remaining_app_hour) . " | " . xlt("SEND ALERT AFTER") . ': ' . text($remain_hour) . "</strong>";
 
                 // check in the interval
-                if ($remain_hour >= -($CRON_TIME) && $remain_hour <= $CRON_TIME) {
+                if (\OpenEMR\Modules\FaxSMS\Controller\NotificationTaskManager::isWithinCronWindow((int) $remain_hour, $CRON_TIME)) {
                     //set message
                     $db_sms_msg['message'] = cron_SetMessage($prow, $db_sms_msg);
                     // send sms to patient - if not in test mode

--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
@@ -85,7 +85,8 @@ if (!empty($runtime['type'])) {
     $TYPE = $runtime['type'] = "SMS"; // default
 }
 
-$CRON_TIME = 150;
+$taskManager = new \OpenEMR\Modules\FaxSMS\Controller\NotificationTaskManager();
+$CRON_TIME = $taskManager->getTaskHours(strtolower($TYPE));
 // use service if needed
 if ($TYPE === "SMS") {
     $session->set('authUser', $runtime['user'] ?? $session->get('authUser'));

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
@@ -42,6 +42,10 @@ class NotificationTaskManager
      */
     public static function isWithinCronWindow(int $remainHour, int $cronIntervalHours): bool
     {
+        // Enforce a minimum 1-hour window. getTaskHours() returns int, so
+        // sub-hour intervals (e.g. 30 minutes) truncate to 0 — which would
+        // make the window zero-width and silently suppress all sends.
+        $cronIntervalHours = max(1, $cronIntervalHours);
         return $remainHour >= -$cronIntervalHours && $remainHour <= $cronIntervalHours;
     }
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
@@ -32,6 +32,20 @@ class NotificationTaskManager
     }
 
     /**
+     * Check whether a reminder falls within the cron send window.
+     *
+     * $remainHour is the difference between hours-until-appointment and the
+     * configured notification lead time. A value of 0 means "exactly time to
+     * send"; negative means the ideal send time has passed. The cron window
+     * is the background-service execution interval — if the remainder falls
+     * within ±interval, we should send.
+     */
+    public static function isWithinCronWindow(int $remainHour, int $cronIntervalHours): bool
+    {
+        return $remainHour >= -$cronIntervalHours && $remainHour <= $cronIntervalHours;
+    }
+
+    /**
      * Creates or updates the background Notification task
      */
     public function manageService($type, $hours = 0): bool

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
@@ -34,11 +34,14 @@ class NotificationTaskManager
     /**
      * Check whether a reminder falls within the cron send window.
      *
-     * $remainHour is the difference between hours-until-appointment and the
-     * configured notification lead time. A value of 0 means "exactly time to
-     * send"; negative means the ideal send time has passed. The cron window
-     * is the background-service execution interval — if the remainder falls
-     * within ±interval, we should send.
+     * Both parameters use whole-hour granularity. $remainHour is the
+     * difference between hours-until-appointment and the configured
+     * notification lead time. A value of 0 means "exactly time to send";
+     * negative means the ideal send time has passed.
+     *
+     * $cronIntervalHours is the background-service execution interval
+     * converted to hours (via getTaskHours()). Values below 1 are clamped
+     * to 1 so the window is never zero-width.
      */
     public static function isWithinCronWindow(int $remainHour, int $cronIntervalHours): bool
     {

--- a/tests/Tests/Isolated/Modules/FaxSMS/Controller/NotificationTaskManagerTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Controller/NotificationTaskManagerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Isolated NotificationTaskManager Test
+ *
+ * Tests the pure static methods on NotificationTaskManager that do not
+ * require a database connection.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Modules\FaxSMS\Controller;
+
+use OpenEMR\Modules\FaxSMS\Controller\NotificationTaskManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../../../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php';
+
+class NotificationTaskManagerTest extends TestCase
+{
+    #[DataProvider('cronWindowProvider')]
+    public function testIsWithinCronWindow(int $remainHour, int $cronInterval, bool $expected): void
+    {
+        $this->assertSame($expected, NotificationTaskManager::isWithinCronWindow($remainHour, $cronInterval));
+    }
+
+    /**
+     * @return array<string, array{int, int, bool}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function cronWindowProvider(): array
+    {
+        return [
+            'exactly on time'                    => [0, 1, true],
+            'one hour early with 1h interval'    => [1, 1, true],
+            'one hour late with 1h interval'     => [-1, 1, true],
+            'two hours early with 1h interval'   => [2, 1, false],
+            'two hours late with 1h interval'    => [-2, 1, false],
+            'within 24h window (positive)'       => [12, 24, true],
+            'within 24h window (negative)'       => [-12, 24, true],
+            'at boundary of 24h window'          => [24, 24, true],
+            'at negative boundary of 24h window' => [-24, 24, true],
+            'outside 24h window'                 => [25, 24, false],
+            'far outside window'                 => [100, 24, false],
+            'old 150h window was a no-op'        => [100, 150, true],
+        ];
+    }
+}

--- a/tests/Tests/Isolated/Modules/FaxSMS/Controller/NotificationTaskManagerTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Controller/NotificationTaskManagerTest.php
@@ -51,6 +51,9 @@ class NotificationTaskManagerTest extends TestCase
             'outside 24h window'                 => [25, 24, false],
             'far outside window'                 => [100, 24, false],
             'old 150h window was a no-op'        => [100, 150, true],
+            'zero interval clamps to 1h'         => [1, 0, true],
+            'zero interval rejects 2h early'     => [2, 0, false],
+            'negative interval clamps to 1h'     => [0, -5, true],
         ];
     }
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded `$CRON_TIME = 150` with a read from `NotificationTaskManager::getTaskHours()`, which queries the actual `execute_interval` from the `background_services` table
- The old value of 150 (hours) made the time-window guard at line 176 a no-op — ±6 days never excluded anything
- Now the guard window matches the configured background service interval, so reminders only fire for appointments within a meaningful window of the notification time

Closes #11481

## Test plan

- [ ] Verify `$CRON_TIME` reflects the configured `execute_interval` for SMS and email background tasks
- [ ] With default 24-hour interval, confirm reminders are sent only for appointments within ±24 hours of the configured notification lead time
- [ ] Run in test mode (`testrun=1`) and confirm the displayed "CRONJOB RUNS EVERY" value matches the background service configuration