### PR TITLE
fix(faxsms): stop overwriting pc_apptstatus during notification dedup

### DIFF
--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -1963,7 +1963,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -692,11 +692,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/ModuleManagerListener.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function rc_sms_notification_cron_update_entry\\(\\) should return int but returns ADORecordSet\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\BootstrapService\\:\\:fetchPersistedSetupSettings\\(\\) should return array but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/BootstrapService.php',

--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
@@ -206,7 +206,7 @@ $db_sms_msg['message'] = $MESSAGE;
                             }
                         } else {
                             $strMsg .= " | " . xlt("SMS SENT SUCCESSFULLY TO") . "<strong> " . text($prow['phone_cell']) . "</strong>";
-                            rc_sms_notification_cron_update_entry($TYPE, $prow['pid'], $prow['pc_eid'], $prow['pc_recurrtype']);
+                            rc_sms_notification_cron_update_entry(NotificationChannel::SMS, $prow['pid'], $prow['pc_eid'], $prow['pc_recurrtype']);
                         }
                         if ((int)$prow['pc_recurrtype'] > 0) {
                             $row = fetchRecurrences($prow['pid']);
@@ -251,7 +251,7 @@ $db_sms_msg['message'] = $MESSAGE;
                             }
                         } else {
                             $strMsg .= " | " . xlt("EMAILED SUCCESSFULLY TO") . "<strong> " . text($prow['email']) . "</strong>";
-                            rc_sms_notification_cron_update_entry($TYPE, $prow['pid'], $prow['pc_eid'], $prow['pc_recurrtype']);
+                            rc_sms_notification_cron_update_entry(NotificationChannel::EMAIL, $prow['pid'], $prow['pc_eid'], $prow['pc_recurrtype']);
                         }
                         if ((int)$prow['pc_recurrtype'] > 0) {
                             $row = fetchRecurrences($prow['pid']);
@@ -286,7 +286,12 @@ function isValidPhone($phone): array|bool|string|null
 }
 
 /**
- * Mark a non-recurring event as notified on the events table.
+ * Mark a non-recurring appointment as already-notified for a given channel.
+ *
+ * Only the per-channel alert flag (pc_sendalertsms / pc_sendalertemail) is
+ * updated. pc_apptstatus is intentionally left alone — it holds the real
+ * appointment status set by front-desk staff (Pending, Arrived, etc.) and
+ * must not be overwritten with notification metadata. See #11479.
  *
  * Recurring events are intentionally skipped: the pc_sendalertsms /
  * pc_sendalertemail columns live on the base event row which is shared by
@@ -294,34 +299,23 @@ function isValidPhone($phone): array|bool|string|null
  * occurrences. Recurring-event dedup is handled in
  * faxsms_getAlertPatientData() by checking the notification_log keyed on
  * (pc_eid, pc_eventDate, type).
- *
- * @param string $type
- * @param int    $pid
- * @param int    $pc_eid
- * @param string $recur pc_recurrtype value
- * @return int
  */
-function rc_sms_notification_cron_update_entry($type, $pid, $pc_eid, $recur = '')
+function rc_sms_notification_cron_update_entry(NotificationChannel $channel, int $pid, int $pc_eid, string $recur = ''): void
 {
     global $bTestRun;
 
     if ($bTestRun || (int)trim($recur) > 0) {
-        return 1;
+        return;
     }
 
-    $query = "UPDATE openemr_postcalendar_events SET";
+    $column = match ($channel) {
+        NotificationChannel::SMS   => 'pc_sendalertsms',
+        NotificationChannel::EMAIL => 'pc_sendalertemail',
+    };
 
-    if ($type == 'SMS') {
-        $query .= " pc_sendalertsms='YES', pc_apptstatus='SMS' ";
-    } elseif ($type == 'EMAIL') {
-        $query .= " pc_sendalertemail='YES', pc_apptstatus='EMAIL' ";
-    } else {
-        $query .= " pc_sendalertsms='NO' ";
-    }
+    $query = "UPDATE openemr_postcalendar_events SET {$column} = 'YES' WHERE pc_pid = ? AND pc_eid = ?";
 
-    $query .= " where pc_pid=? and pc_eid=? ";
-
-    return sqlStatement($query, [$pid, $pc_eid]);
+    QueryUtils::sqlStatementThrowException($query, [$pid, $pc_eid]);
 }
 
 /**
@@ -342,8 +336,8 @@ function rc_sms_notification_cron_update_entry($type, $pid, $pc_eid, $recur = ''
 function faxsms_getAlertPatientData(NotificationChannel $channel, int $notificationHour): array
 {
     $where = match ($channel) {
-        NotificationChannel::EMAIL => " AND (p.hipaa_allowemail='YES' AND p.email<>'' AND (e.pc_sendalertemail != 'YES' || e.pc_apptstatus != 'EMAIL') AND e.pc_apptstatus != 'x')",
-        NotificationChannel::SMS   => " AND (p.hipaa_allowsms='YES' AND p.phone_cell<>'' AND (e.pc_sendalertsms != 'YES' || e.pc_apptstatus != 'SMS') AND e.pc_apptstatus != 'x')",
+        NotificationChannel::EMAIL => " AND (p.hipaa_allowemail='YES' AND p.email<>'' AND e.pc_sendalertemail != 'YES' AND e.pc_apptstatus != 'x')",
+        NotificationChannel::SMS   => " AND (p.hipaa_allowsms='YES' AND p.phone_cell<>'' AND e.pc_sendalertsms != 'YES' AND e.pc_apptstatus != 'x')",
     };
     $adj_date = (int)date("H") + $notificationHour;
     $check_date = date("Y-m-d", mktime($adj_date, 0, 0, (int)date("m"), (int)date("d"), (int)date("Y")));

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -56,6 +56,7 @@ This file configures the kind that requires initialization.
       <file>tests/Tests/E2e/EmailSendTest.php</file>
       <file>tests/Tests/E2e/EmailTestServiceTest.php</file>
       <file>tests/Tests/E2e/FaxSmsEmailTest.php</file>
+      <file>tests/Tests/E2e/NotificationCronEmailTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/Tests/E2e/NotificationCronEmailTest.php
+++ b/tests/Tests/E2e/NotificationCronEmailTest.php
@@ -1,0 +1,327 @@
+<?php
+
+/**
+ * E2E test for the faxsms notification cron's dedup behavior.
+ *
+ * Verifies that marking an appointment as notified (email or SMS) sets the
+ * per-channel alert flag without clobbering pc_apptstatus, and that the
+ * dedup query correctly excludes already-notified appointments.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\E2e;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class NotificationCronEmailTest extends TestCase
+{
+    private const TEST_EMAIL = 'test-notification-cron@example.com';
+    private const NOTIFICATION_HOURS = 24;
+
+    private static bool $functionsLoaded = false;
+
+    private int $testPatientPid = 0;
+    private int $testEventEid = 0;
+
+    /**
+     * Load the cron script once to define its global functions.
+     *
+     * The script outputs HTML and initializes SMTP services as a side
+     * effect, so we run it in dryrun mode with output buffering.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        if (self::$functionsLoaded) {
+            return;
+        }
+
+        $globals = OEGlobalsBag::getInstance();
+        $faxSmsPath = $globals->getString('fileroot')
+            . '/interface/modules/custom_modules/oe-module-faxsms';
+
+        // Module source files are not in the main autoloader
+        require_once $faxSmsPath . '/src/Enums/NotificationChannel.php';
+        require_once $faxSmsPath . '/src/Controller/AppDispatch.php';
+        require_once $faxSmsPath . '/src/Controller/EmailClient.php';
+        require_once $faxSmsPath . '/src/BootstrapService.php';
+        require_once $faxSmsPath . '/src/Exception/EmailException.php';
+        require_once $faxSmsPath . '/src/Exception/SmtpNotConfiguredException.php';
+        require_once $faxSmsPath . '/src/Exception/InvalidEmailAddressException.php';
+        require_once $faxSmsPath . '/src/Exception/EmailSendFailedException.php';
+
+        require_once $globals->getString('srcdir') . '/appointments.inc.php';
+
+        // SMTP globals — point at Mailpit so the script initializes
+        $GLOBALS['EMAIL_METHOD'] = 'SMTP';
+        $GLOBALS['SMTP_HOST'] = getenv('OPENEMR_SETTING_SMTP_HOST') ?: 'mailpit';
+        $GLOBALS['SMTP_PORT'] = getenv('OPENEMR_SETTING_SMTP_PORT') ?: '1025';
+        $GLOBALS['SMTP_USER'] = getenv('OPENEMR_SETTING_SMTP_USER') ?: 'openemr';
+        $GLOBALS['SMTP_PASS'] = getenv('OPENEMR_SETTING_SMTP_PASS') ?: 'openemr';
+        $GLOBALS['SMTP_SECURE'] = getenv('OPENEMR_SETTING_SMTP_SECURE') ?: 'none';
+        $GLOBALS['SMTP_Auth'] = getenv('OPENEMR_SETTING_SMTP_Auth') ?: 'TRUE';
+        $GLOBALS['practice_return_email_path'] = 'noreply@openemr.local';
+        $GLOBALS['patient_reminder_sender_name'] = 'OpenEMR Test';
+        $GLOBALS['oe_enable_email'] = true;
+
+        // Session state for ACL check inside the script
+        $session = SessionWrapperFactory::getInstance()->getActiveSession();
+        $session->set('authUser', 'admin');
+        $session->set('authUserID', 1);
+        $session->set('site_id', 'default');
+
+        // Dryrun prevents the main loop from sending or updating
+        $_REQUEST['dryrun'] = '1';
+        $_GET['type'] = 'email';
+        $_GET['site'] = 'default';
+
+        ob_start();
+        require_once $faxSmsPath . '/library/rc_sms_notification.php';
+        ob_end_clean();
+
+        self::$functionsLoaded = true;
+    }
+
+    protected function setUp(): void
+    {
+        // The update function reads global $bTestRun — ensure it's off
+        $GLOBALS['bTestRun'] = 0;
+
+        $this->insertTestPatient();
+        $this->insertTestAppointment();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->testEventEid > 0) {
+            QueryUtils::sqlStatementThrowException(
+                'DELETE FROM openemr_postcalendar_events WHERE pc_eid = ?',
+                [$this->testEventEid],
+            );
+        }
+        if ($this->testPatientPid > 0) {
+            QueryUtils::sqlStatementThrowException(
+                'DELETE FROM notification_log WHERE pid = ? AND pc_eid = ?',
+                [$this->testPatientPid, $this->testEventEid],
+            );
+            QueryUtils::sqlStatementThrowException(
+                'DELETE FROM patient_data WHERE pid = ?',
+                [$this->testPatientPid],
+            );
+        }
+    }
+
+    #[Test]
+    public function emailDedupDoesNotClobberAppointmentStatus(): void
+    {
+        $this->assertInitialState();
+
+        $this->assertAppointmentFoundBy(NotificationChannel::EMAIL);
+
+        rc_sms_notification_cron_update_entry(
+            NotificationChannel::EMAIL,
+            $this->testPatientPid,
+            $this->testEventEid,
+        );
+
+        $row = $this->fetchEvent();
+        $this->assertSame('-', $row['pc_apptstatus'], 'pc_apptstatus must not be overwritten');
+        $this->assertSame('YES', $row['pc_sendalertemail'], 'pc_sendalertemail should be YES');
+        $this->assertSame('NO', $row['pc_sendalertsms'], 'pc_sendalertsms should remain NO');
+
+        $this->assertAppointmentNotFoundBy(
+            NotificationChannel::EMAIL,
+            'Already-notified appointment must be excluded by dedup',
+        );
+    }
+
+    #[Test]
+    public function smsDedupDoesNotClobberAppointmentStatus(): void
+    {
+        $this->assertInitialState();
+
+        $this->assertAppointmentFoundBy(NotificationChannel::SMS);
+
+        rc_sms_notification_cron_update_entry(
+            NotificationChannel::SMS,
+            $this->testPatientPid,
+            $this->testEventEid,
+        );
+
+        $row = $this->fetchEvent();
+        $this->assertSame('-', $row['pc_apptstatus'], 'pc_apptstatus must not be overwritten');
+        $this->assertSame('YES', $row['pc_sendalertsms'], 'pc_sendalertsms should be YES');
+        $this->assertSame('NO', $row['pc_sendalertemail'], 'pc_sendalertemail should remain NO');
+
+        $this->assertAppointmentNotFoundBy(
+            NotificationChannel::SMS,
+            'Already-notified appointment must be excluded by dedup',
+        );
+    }
+
+    #[Test]
+    public function cancelledAppointmentIsExcludedFromNotification(): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            "UPDATE openemr_postcalendar_events SET pc_apptstatus = 'x' WHERE pc_eid = ?",
+            [$this->testEventEid],
+        );
+
+        $this->assertAppointmentNotFoundBy(
+            NotificationChannel::EMAIL,
+            'Cancelled appointment must be excluded',
+        );
+        $this->assertAppointmentNotFoundBy(
+            NotificationChannel::SMS,
+            'Cancelled appointment must be excluded',
+        );
+    }
+
+    #[Test]
+    public function emailDedupDoesNotAffectSmsDedupAndViceVersa(): void
+    {
+        // Mark as email-notified
+        rc_sms_notification_cron_update_entry(
+            NotificationChannel::EMAIL,
+            $this->testPatientPid,
+            $this->testEventEid,
+        );
+
+        // SMS query should still find the appointment (only email flag is set)
+        $this->assertAppointmentFoundBy(NotificationChannel::SMS);
+        $this->assertAppointmentNotFoundBy(NotificationChannel::EMAIL);
+
+        // Now mark as SMS-notified too
+        rc_sms_notification_cron_update_entry(
+            NotificationChannel::SMS,
+            $this->testPatientPid,
+            $this->testEventEid,
+        );
+
+        // Both channels should now exclude it
+        $this->assertAppointmentNotFoundBy(NotificationChannel::EMAIL);
+        $this->assertAppointmentNotFoundBy(NotificationChannel::SMS);
+
+        // Appointment status still untouched
+        $row = $this->fetchEvent();
+        $this->assertSame('-', $row['pc_apptstatus']);
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private function insertTestPatient(): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            "INSERT INTO patient_data"
+            . " (fname, lname, email, hipaa_allowemail, hipaa_allowsms, phone_cell, title)"
+            . " VALUES ('TestCron', 'Patient', ?, 'YES', 'YES', '5551234567', 'Mr.')",
+            [self::TEST_EMAIL],
+        );
+        $pid = QueryUtils::fetchSingleValue(
+            'SELECT MAX(pid) AS v FROM patient_data WHERE email = ?',
+            'v',
+            [self::TEST_EMAIL],
+        );
+        $this->assertIsNumeric($pid);
+        $this->testPatientPid = (int) $pid;
+        $this->assertGreaterThan(0, $this->testPatientPid);
+    }
+
+    private function insertTestAppointment(): void
+    {
+        // Compute the date faxsms_getAlertPatientData() will query for
+        $adjHour = (int) date('H') + self::NOTIFICATION_HOURS;
+        $timestamp = mktime($adjHour, 0, 0, (int) date('m'), (int) date('d'), (int) date('Y'));
+        $this->assertIsInt($timestamp);
+        $eventDate = date('Y-m-d', $timestamp);
+
+        QueryUtils::sqlStatementThrowException(
+            "INSERT INTO openemr_postcalendar_events"
+            . " (pc_pid, pc_aid, pc_eventDate, pc_endDate,"
+            . "  pc_startTime, pc_endTime, pc_duration, pc_catid,"
+            . "  pc_apptstatus, pc_sendalertemail, pc_sendalertsms,"
+            . "  pc_recurrtype, pc_facility, pc_title)"
+            . " VALUES (?, 1, ?, ?, '12:00:00', '12:30:00', 1800, 5,"
+            . "         '-', 'NO', 'NO', 0, 3, 'Test Notification Cron')",
+            [$this->testPatientPid, $eventDate, $eventDate],
+        );
+        $eid = QueryUtils::fetchSingleValue(
+            'SELECT MAX(pc_eid) AS v FROM openemr_postcalendar_events WHERE pc_pid = ?',
+            'v',
+            [$this->testPatientPid],
+        );
+        $this->assertIsNumeric($eid);
+        $this->testEventEid = (int) $eid;
+        $this->assertGreaterThan(0, $this->testEventEid);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchEvent(): array
+    {
+        $row = QueryUtils::querySingleRow(
+            'SELECT pc_apptstatus, pc_sendalertemail, pc_sendalertsms'
+            . ' FROM openemr_postcalendar_events WHERE pc_eid = ?',
+            [$this->testEventEid],
+        );
+        $this->assertIsArray($row);
+        /** @var array{pc_apptstatus: string, pc_sendalertemail: string, pc_sendalertsms: string} $row */
+        return $row;
+    }
+
+    private function assertInitialState(): void
+    {
+        $row = $this->fetchEvent();
+        $this->assertSame('-', $row['pc_apptstatus']);
+        $this->assertSame('NO', $row['pc_sendalertemail']);
+        $this->assertSame('NO', $row['pc_sendalertsms']);
+    }
+
+    private function assertAppointmentFoundBy(NotificationChannel $channel): void
+    {
+        $appointments = faxsms_getAlertPatientData($channel, self::NOTIFICATION_HOURS);
+        $this->assertTrue(
+            $this->eventInResults($appointments),
+            "Appointment should be found by {$channel->value} query",
+        );
+    }
+
+    private function assertAppointmentNotFoundBy(
+        NotificationChannel $channel,
+        string $message = '',
+    ): void {
+        $appointments = faxsms_getAlertPatientData($channel, self::NOTIFICATION_HOURS);
+        $this->assertFalse(
+            $this->eventInResults($appointments),
+            $message ?: "Appointment should NOT be found by {$channel->value} query",
+        );
+    }
+
+    /**
+     * @param list<array<mixed>> $appointments
+     */
+    private function eventInResults(array $appointments): bool
+    {
+        foreach ($appointments as $appt) {
+            $eid = $appt['pc_eid'] ?? 0;
+            if (is_numeric($eid) && (int) $eid === $this->testEventEid) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tests/Tests/E2e/NotificationCronEmailTest.php
+++ b/tests/Tests/E2e/NotificationCronEmailTest.php
@@ -55,6 +55,7 @@ class NotificationCronEmailTest extends TestCase
         require_once $faxSmsPath . '/src/Enums/NotificationChannel.php';
         require_once $faxSmsPath . '/src/Controller/AppDispatch.php';
         require_once $faxSmsPath . '/src/Controller/EmailClient.php';
+        require_once $faxSmsPath . '/src/Controller/NotificationTaskManager.php';
         require_once $faxSmsPath . '/src/BootstrapService.php';
         require_once $faxSmsPath . '/src/Exception/EmailException.php';
         require_once $faxSmsPath . '/src/Exception/SmtpNotConfiguredException.php';

--- a/tests/Tests/Services/Background/BackgroundServiceRegistryTest.php
+++ b/tests/Tests/Services/Background/BackgroundServiceRegistryTest.php
@@ -32,7 +32,7 @@ class BackgroundServiceRegistryTest extends TestCase
     private BackgroundServiceRegistry $registry;
 
     /** @var list<string> names of services created during the test — read in tearDown() */
-    private array $createdServices = []; // @phpstan-ignore property.onlyWritten (read by tearDown)
+    private array $createdServices = [];
 
     protected function setUp(): void
     {


### PR DESCRIPTION
## Summary

- `rc_sms_notification_cron_update_entry()` was setting `pc_apptstatus` to `'SMS'` or `'EMAIL'` when marking appointments as notified, destroying the real appointment status (Pending, Arrived, No Show, etc.) set by front-desk staff.
- Dedup now relies solely on the existing `pc_sendalertsms` / `pc_sendalertemail` flags, which already exist for exactly this purpose.
- The dedup WHERE clause in `faxsms_getAlertPatientData()` is simplified to check only the alert flag, dropping the redundant `pc_apptstatus` check.
- Refactors the function to accept the `NotificationChannel` enum and use a `match` expression instead of string-typed `if`/`elseif`.
- Adds e2e test (`NotificationCronEmailTest`) covering all dedup scenarios.

Closes #11479

## Test plan

All scenarios are covered by the new `NotificationCronEmailTest` (runs in the `email` test suite with MailPit):

- [x] Email notification sets `pc_sendalertemail='YES'` without changing `pc_apptstatus`
- [x] SMS notification sets `pc_sendalertsms='YES'` without changing `pc_apptstatus`
- [x] Already email-notified appointments are excluded from subsequent email runs
- [x] Already SMS-notified appointments are excluded from subsequent SMS runs
- [x] Email dedup and SMS dedup are independent (marking one channel doesn't affect the other)
- [x] Cancelled appointments (`pc_apptstatus='x'`) are excluded from both channels
