### PR TITLE
fix(security): validate require_once paths loaded from database

### DIFF
--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -219,7 +219,10 @@ class BackgroundServiceRunner
     {
         $requireOnce = $service['require_once'];
         if ($requireOnce !== null && $requireOnce !== '') {
-            require_once(OEGlobalsBag::getInstance()->getProjectDir() . $requireOnce);
+            $projectDir = OEGlobalsBag::getInstance()->getProjectDir();
+            $fullPath = $projectDir . $requireOnce;
+            $this->validateIncludePath($fullPath, $projectDir, $service['name']);
+            require_once($fullPath);
         }
 
         $function = $service['function'];
@@ -232,5 +235,44 @@ class BackgroundServiceRunner
         }
 
         $function();
+    }
+
+    /**
+     * Validate that an include path is safe: no traversal, no stream wrappers,
+     * no NUL bytes, and the resolved path stays under the project root.
+     *
+     * @throws \RuntimeException If the path fails validation
+     */
+    protected function validateIncludePath(string $path, string $projectDir, string $serviceName): void
+    {
+        if (str_contains($path, "\0")) {
+            throw new \RuntimeException(sprintf(
+                'Background service "%s" has an invalid require_once path: contains NUL byte.',
+                $serviceName,
+            ));
+        }
+
+        if (str_contains($path, '://')) {
+            throw new \RuntimeException(sprintf(
+                'Background service "%s" has an invalid require_once path: contains stream wrapper.',
+                $serviceName,
+            ));
+        }
+
+        $realPath = realpath($path);
+        if ($realPath === false) {
+            throw new \RuntimeException(sprintf(
+                'Background service "%s" has an invalid require_once path: file does not exist.',
+                $serviceName,
+            ));
+        }
+
+        $realProjectDir = realpath($projectDir);
+        if ($realProjectDir === false || !str_starts_with($realPath, $realProjectDir . DIRECTORY_SEPARATOR)) {
+            throw new \RuntimeException(sprintf(
+                'Background service "%s" has an invalid require_once path: resolves outside project root.',
+                $serviceName,
+            ));
+        }
     }
 }

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -267,7 +267,7 @@ class BackgroundServiceRunner
         $realPath = realpath($path);
         if ($realPath === false) {
             throw new \RuntimeException(sprintf(
-                'Background service "%s" has an invalid require_once path: file does not exist.',
+                'Background service "%s" has an invalid require_once path: path cannot be resolved.',
                 $serviceName,
             ));
         }

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -221,8 +221,8 @@ class BackgroundServiceRunner
         if ($requireOnce !== null && $requireOnce !== '') {
             $projectDir = OEGlobalsBag::getInstance()->getProjectDir();
             $fullPath = $projectDir . $requireOnce;
-            $this->validateIncludePath($fullPath, $projectDir, $service['name']);
-            require_once($fullPath);
+            $resolvedPath = $this->validateIncludePath($fullPath, $projectDir, $service['name']);
+            require_once($resolvedPath);
         }
 
         $function = $service['function'];
@@ -245,9 +245,10 @@ class BackgroundServiceRunner
      * they are resolved to an absolute path, then the prefix check rejects any
      * result that lands outside the project root.
      *
+     * @return string The resolved real path, safe to include
      * @throws \RuntimeException If the path fails validation
      */
-    protected function validateIncludePath(string $path, string $projectDir, string $serviceName): void
+    protected function validateIncludePath(string $path, string $projectDir, string $serviceName): string
     {
         if (str_contains($path, "\0")) {
             throw new \RuntimeException(sprintf(
@@ -285,5 +286,7 @@ class BackgroundServiceRunner
                 $serviceName,
             ));
         }
+
+        return $realPath;
     }
 }

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -238,8 +238,12 @@ class BackgroundServiceRunner
     }
 
     /**
-     * Validate that an include path is safe: no traversal, no stream wrappers,
-     * no NUL bytes, and the resolved path stays under the project root.
+     * Validate that an include path is safe: no stream wrappers, no NUL bytes,
+     * and the resolved path is a regular file under the project root.
+     *
+     * Traversal sequences (e.g. `..`) are handled implicitly by `realpath()`:
+     * they are resolved to an absolute path, then the prefix check rejects any
+     * result that lands outside the project root.
      *
      * @throws \RuntimeException If the path fails validation
      */
@@ -263,6 +267,13 @@ class BackgroundServiceRunner
         if ($realPath === false) {
             throw new \RuntimeException(sprintf(
                 'Background service "%s" has an invalid require_once path: file does not exist.',
+                $serviceName,
+            ));
+        }
+
+        if (!is_file($realPath)) {
+            throw new \RuntimeException(sprintf(
+                'Background service "%s" has an invalid require_once path: path is not a file.',
                 $serviceName,
             ));
         }

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -251,14 +251,14 @@ class BackgroundServiceRunner
     protected function validateIncludePath(string $path, string $projectDir, string $serviceName): string
     {
         if (str_contains($path, "\0")) {
-            throw new \RuntimeException(sprintf(
+            throw new UnsafeIncludePathException(sprintf(
                 'Background service "%s" has an invalid require_once path: contains NUL byte.',
                 $serviceName,
             ));
         }
 
         if (str_contains($path, '://')) {
-            throw new \RuntimeException(sprintf(
+            throw new UnsafeIncludePathException(sprintf(
                 'Background service "%s" has an invalid require_once path: contains stream wrapper.',
                 $serviceName,
             ));
@@ -266,14 +266,14 @@ class BackgroundServiceRunner
 
         $realPath = realpath($path);
         if ($realPath === false) {
-            throw new \RuntimeException(sprintf(
+            throw new UnsafeIncludePathException(sprintf(
                 'Background service "%s" has an invalid require_once path: path cannot be resolved.',
                 $serviceName,
             ));
         }
 
         if (!is_file($realPath)) {
-            throw new \RuntimeException(sprintf(
+            throw new UnsafeIncludePathException(sprintf(
                 'Background service "%s" has an invalid require_once path: path is not a file.',
                 $serviceName,
             ));
@@ -281,7 +281,7 @@ class BackgroundServiceRunner
 
         $realProjectDir = realpath($projectDir);
         if ($realProjectDir === false || !str_starts_with($realPath, $realProjectDir . DIRECTORY_SEPARATOR)) {
-            throw new \RuntimeException(sprintf(
+            throw new UnsafeIncludePathException(sprintf(
                 'Background service "%s" has an invalid require_once path: resolves outside project root.',
                 $serviceName,
             ));

--- a/src/Services/Background/UnsafeIncludePathException.php
+++ b/src/Services/Background/UnsafeIncludePathException.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Thrown when a background service's require_once path fails validation.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\Background;
+
+final class UnsafeIncludePathException extends \RuntimeException
+{
+}

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -213,15 +213,20 @@ class BackgroundServiceRunnerTest extends TestCase
         $validator->callValidateIncludePath(__DIR__, $projectDir, 'test_svc');
     }
 
-    public function testValidateIncludePathAcceptsValidFile(): void
+    public function testValidateIncludePathAcceptsValidFileAndReturnsResolvedPath(): void
     {
         $validator = new BackgroundServicePathValidator();
 
         // This test file itself is a valid path under the repository/project root
         $projectDir = dirname(__DIR__, 5); // repository/project root
-        $validator->callValidateIncludePath(__FILE__, $projectDir, 'test_svc');
+        $expectedPath = realpath(__FILE__);
+        if ($expectedPath === false) {
+            $this->fail('Failed to resolve the current test file path');
+        }
 
-        $this->addToAssertionCount(1);
+        $resolvedPath = $validator->callValidateIncludePath(__FILE__, $projectDir, 'test_svc');
+
+        $this->assertSame($expectedPath, $resolvedPath);
     }
 
     /**

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -184,15 +184,22 @@ class BackgroundServiceRunnerTest extends TestCase
     public function testValidateIncludePathRejectsFileOutsideRoot(): void
     {
         $validator = new BackgroundServicePathValidator();
+        $projectDir = dirname(__DIR__, 5); // repository/project root
+        $tempFile = tempnam(sys_get_temp_dir(), 'openemr-bg-');
 
-        // Use /etc/hosts (a real file on macOS/Linux) which is outside the project dir
-        if (!is_file('/etc/hosts')) {
-            $this->markTestSkipped('/etc/hosts not available on this platform');
+        if ($tempFile === false) {
+            $this->fail('Failed to create temporary file for outside-root validation test');
         }
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('resolves outside project root');
-        $validator->callValidateIncludePath('/etc/hosts', __DIR__, 'test_svc');
+        try {
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('resolves outside project root');
+            $validator->callValidateIncludePath($tempFile, $projectDir, 'test_svc');
+        } finally {
+            if (is_file($tempFile)) {
+                unlink($tempFile);
+            }
+        }
     }
 
     public function testValidateIncludePathRejectsDirectory(): void

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -297,8 +297,8 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
  */
 class BackgroundServicePathValidator extends BackgroundServiceRunner
 {
-    public function callValidateIncludePath(string $path, string $projectDir, string $serviceName): void
+    public function callValidateIncludePath(string $path, string $projectDir, string $serviceName): string
     {
-        $this->validateIncludePath($path, $projectDir, $serviceName);
+        return $this->validateIncludePath($path, $projectDir, $serviceName);
     }
 }

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -175,10 +175,12 @@ class BackgroundServiceRunnerTest extends TestCase
     public function testValidateIncludePathRejectsNonexistentFile(): void
     {
         $validator = new BackgroundServicePathValidator();
+        $projectDir = dirname(__DIR__, 5); // repository/project root
+        $nonexistentPath = $projectDir . DIRECTORY_SEPARATOR . 'nonexistent_file_' . uniqid('', true) . '.php';
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('file does not exist');
-        $validator->callValidateIncludePath('/var/www/openemr/nonexistent_file.php', '/var/www/openemr', 'test_svc');
+        $this->expectExceptionMessage('path cannot be resolved');
+        $validator->callValidateIncludePath($nonexistentPath, $projectDir, 'test_svc');
     }
 
     public function testValidateIncludePathRejectsFileOutsideRoot(): void

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -154,6 +154,54 @@ class BackgroundServiceRunnerTest extends TestCase
         $this->assertTrue($executed);
     }
 
+    public function testValidateIncludePathRejectsNulByte(): void
+    {
+        $validator = new BackgroundServicePathValidator();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('contains NUL byte');
+        $validator->callValidateIncludePath("/var/www/openemr/library/file\0.php", '/var/www/openemr', 'test_svc');
+    }
+
+    public function testValidateIncludePathRejectsStreamWrapper(): void
+    {
+        $validator = new BackgroundServicePathValidator();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('contains stream wrapper');
+        $validator->callValidateIncludePath('php://filter/resource=/etc/passwd', '/var/www/openemr', 'test_svc');
+    }
+
+    public function testValidateIncludePathRejectsNonexistentFile(): void
+    {
+        $validator = new BackgroundServicePathValidator();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('file does not exist');
+        $validator->callValidateIncludePath('/var/www/openemr/nonexistent_file.php', '/var/www/openemr', 'test_svc');
+    }
+
+    public function testValidateIncludePathRejectsTraversalOutsideRoot(): void
+    {
+        $validator = new BackgroundServicePathValidator();
+
+        // Use /tmp as a real directory to get past the realpath check, but it's outside the project dir
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('resolves outside project root');
+        $validator->callValidateIncludePath('/tmp', __DIR__, 'test_svc');
+    }
+
+    public function testValidateIncludePathAcceptsValidFile(): void
+    {
+        $validator = new BackgroundServicePathValidator();
+
+        // This test file itself is a valid path under its own directory
+        $projectDir = dirname(__DIR__, 5); // tests/ root
+        $validator->callValidateIncludePath(__FILE__, $projectDir, 'test_svc');
+
+        $this->addToAssertionCount(1);
+    }
+
     /**
      * @return BackgroundServicesRow
      */
@@ -226,5 +274,16 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
         if ($this->executeCallback !== null) {
             ($this->executeCallback)($service);
         }
+    }
+}
+
+/**
+ * Exposes validateIncludePath for direct testing.
+ */
+class BackgroundServicePathValidator extends BackgroundServiceRunner
+{
+    public function callValidateIncludePath(string $path, string $projectDir, string $serviceName): void
+    {
+        $this->validateIncludePath($path, $projectDir, $serviceName);
     }
 }

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -181,22 +181,37 @@ class BackgroundServiceRunnerTest extends TestCase
         $validator->callValidateIncludePath('/var/www/openemr/nonexistent_file.php', '/var/www/openemr', 'test_svc');
     }
 
-    public function testValidateIncludePathRejectsTraversalOutsideRoot(): void
+    public function testValidateIncludePathRejectsFileOutsideRoot(): void
     {
         $validator = new BackgroundServicePathValidator();
 
-        // Use /tmp as a real directory to get past the realpath check, but it's outside the project dir
+        // Use /etc/hosts (a real file on macOS/Linux) which is outside the project dir
+        if (!is_file('/etc/hosts')) {
+            $this->markTestSkipped('/etc/hosts not available on this platform');
+        }
+
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('resolves outside project root');
-        $validator->callValidateIncludePath('/tmp', __DIR__, 'test_svc');
+        $validator->callValidateIncludePath('/etc/hosts', __DIR__, 'test_svc');
+    }
+
+    public function testValidateIncludePathRejectsDirectory(): void
+    {
+        $validator = new BackgroundServicePathValidator();
+
+        // __DIR__ is a real directory under the project root — should be rejected as not a file
+        $projectDir = dirname(__DIR__, 5); // repository/project root
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('path is not a file');
+        $validator->callValidateIncludePath(__DIR__, $projectDir, 'test_svc');
     }
 
     public function testValidateIncludePathAcceptsValidFile(): void
     {
         $validator = new BackgroundServicePathValidator();
 
-        // This test file itself is a valid path under its own directory
-        $projectDir = dirname(__DIR__, 5); // tests/ root
+        // This test file itself is a valid path under the repository/project root
+        $projectDir = dirname(__DIR__, 5); // repository/project root
         $validator->callValidateIncludePath(__FILE__, $projectDir, 'test_svc');
 
         $this->addToAssertionCount(1);

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -15,6 +15,7 @@ namespace OpenEMR\Tests\Isolated\Services\Background;
 
 use OpenEMR\Common\Database\TableTypes;
 use OpenEMR\Services\Background\BackgroundServiceRunner;
+use OpenEMR\Services\Background\UnsafeIncludePathException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
@@ -158,7 +159,7 @@ class BackgroundServiceRunnerTest extends TestCase
     {
         $validator = new BackgroundServicePathValidator();
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(UnsafeIncludePathException::class);
         $this->expectExceptionMessage('contains NUL byte');
         $validator->callValidateIncludePath("/var/www/openemr/library/file\0.php", '/var/www/openemr', 'test_svc');
     }
@@ -167,7 +168,7 @@ class BackgroundServiceRunnerTest extends TestCase
     {
         $validator = new BackgroundServicePathValidator();
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(UnsafeIncludePathException::class);
         $this->expectExceptionMessage('contains stream wrapper');
         $validator->callValidateIncludePath('php://filter/resource=/etc/passwd', '/var/www/openemr', 'test_svc');
     }
@@ -178,7 +179,7 @@ class BackgroundServiceRunnerTest extends TestCase
         $projectDir = dirname(__DIR__, 5); // repository/project root
         $nonexistentPath = $projectDir . DIRECTORY_SEPARATOR . 'nonexistent_file_' . uniqid('', true) . '.php';
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(UnsafeIncludePathException::class);
         $this->expectExceptionMessage('path cannot be resolved');
         $validator->callValidateIncludePath($nonexistentPath, $projectDir, 'test_svc');
     }
@@ -194,7 +195,7 @@ class BackgroundServiceRunnerTest extends TestCase
         }
 
         try {
-            $this->expectException(\RuntimeException::class);
+            $this->expectException(UnsafeIncludePathException::class);
             $this->expectExceptionMessage('resolves outside project root');
             $validator->callValidateIncludePath($tempFile, $projectDir, 'test_svc');
         } finally {
@@ -210,7 +211,7 @@ class BackgroundServiceRunnerTest extends TestCase
 
         // __DIR__ is a real directory under the project root — should be rejected as not a file
         $projectDir = dirname(__DIR__, 5); // repository/project root
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(UnsafeIncludePathException::class);
         $this->expectExceptionMessage('path is not a file');
         $validator->callValidateIncludePath(__DIR__, $projectDir, 'test_svc');
     }


### PR DESCRIPTION
## Summary

- Add `validateIncludePath()` to `BackgroundServiceRunner` that rejects NUL bytes, stream wrappers (`://`), directories, and paths that resolve outside the project root via `realpath()`
- Return the resolved `realpath` and use it for `require_once`, eliminating a TOCTOU symlink-swap window between validation and inclusion
- Introduce `UnsafeIncludePathException` so callers can distinguish path validation failures from other errors
- Add 6 isolated tests covering each rejection vector, directory rejection, and the resolved-path return contract

Defense-in-depth hardening — exploitation requires existing write access to the `background_services` table.

**Note:** A similar pattern exists in `library/report.inc.php:319` (`formdir` from the `forms` table used in `include_once`). That should be addressed separately.

## Test plan

- [x] `composer phpunit-isolated -- --filter BackgroundServiceRunner` — 16 tests pass
- [ ] CI passes
- [ ] Manual: verify background services still execute normally in Docker

Closes #11358