### PR TITLE
docs(api): add OpenAPI attributes to BackgroundServiceRestController

### DIFF
--- a/src/RestControllers/BackgroundServiceRestController.php
+++ b/src/RestControllers/BackgroundServiceRestController.php
@@ -50,7 +50,7 @@ class BackgroundServiceRestController
                             new OA\Property(property: 'active', type: 'boolean'),
                             new OA\Property(property: 'running', type: 'boolean'),
                             new OA\Property(property: 'execute_interval', type: 'integer'),
-                            new OA\Property(property: 'next_run', type: 'string', nullable: true),
+                            new OA\Property(property: 'next_run', type: 'string', format: 'date-time'),
                         ]
                     )
                 )
@@ -102,7 +102,7 @@ class BackgroundServiceRestController
                         new OA\Property(property: 'active', type: 'boolean'),
                         new OA\Property(property: 'running', type: 'boolean'),
                         new OA\Property(property: 'execute_interval', type: 'integer'),
-                        new OA\Property(property: 'next_run', type: 'string', nullable: true),
+                        new OA\Property(property: 'next_run', type: 'string', format: 'date-time'),
                     ]
                 )
             ),

--- a/src/RestControllers/BackgroundServiceRestController.php
+++ b/src/RestControllers/BackgroundServiceRestController.php
@@ -37,8 +37,24 @@ class BackgroundServiceRestController
         description: 'Retrieves all registered background services',
         tags: ['standard'],
         responses: [
-            new OA\Response(response: '200', ref: '#/components/responses/standard'),
-            new OA\Response(response: '400', ref: '#/components/responses/badrequest'),
+            new OA\Response(
+                response: '200',
+                description: 'List of registered background services',
+                content: new OA\JsonContent(
+                    type: 'array',
+                    items: new OA\Items(
+                        type: 'object',
+                        properties: [
+                            new OA\Property(property: 'name', type: 'string'),
+                            new OA\Property(property: 'title', type: 'string'),
+                            new OA\Property(property: 'active', type: 'boolean'),
+                            new OA\Property(property: 'running', type: 'boolean'),
+                            new OA\Property(property: 'execute_interval', type: 'integer'),
+                            new OA\Property(property: 'next_run', type: 'string', nullable: true),
+                        ]
+                    )
+                )
+            ),
             new OA\Response(response: '401', ref: '#/components/responses/unauthorized'),
         ],
         security: [['openemr_auth' => []]]
@@ -75,10 +91,32 @@ class BackgroundServiceRestController
             ),
         ],
         responses: [
-            new OA\Response(response: '200', ref: '#/components/responses/standard'),
-            new OA\Response(response: '400', ref: '#/components/responses/badrequest'),
+            new OA\Response(
+                response: '200',
+                description: 'Background service details',
+                content: new OA\JsonContent(
+                    required: ['name', 'title', 'active', 'running', 'execute_interval', 'next_run'],
+                    properties: [
+                        new OA\Property(property: 'name', type: 'string'),
+                        new OA\Property(property: 'title', type: 'string'),
+                        new OA\Property(property: 'active', type: 'boolean'),
+                        new OA\Property(property: 'running', type: 'boolean'),
+                        new OA\Property(property: 'execute_interval', type: 'integer'),
+                        new OA\Property(property: 'next_run', type: 'string', nullable: true),
+                    ]
+                )
+            ),
             new OA\Response(response: '401', ref: '#/components/responses/unauthorized'),
-            new OA\Response(response: '404', ref: '#/components/responses/uuidnotfound'),
+            new OA\Response(
+                response: '404',
+                description: 'Background service not found',
+                content: new OA\JsonContent(
+                    required: ['error'],
+                    properties: [
+                        new OA\Property(property: 'error', type: 'string', example: 'Service not found'),
+                    ]
+                )
+            ),
         ],
         security: [['openemr_auth' => []]]
     )]
@@ -131,11 +169,58 @@ class BackgroundServiceRestController
             )
         ),
         responses: [
-            new OA\Response(response: '200', ref: '#/components/responses/standard'),
-            new OA\Response(response: '400', ref: '#/components/responses/badrequest'),
+            new OA\Response(
+                response: '200',
+                description: 'Service executed successfully',
+                content: new OA\JsonContent(
+                    required: ['service', 'status'],
+                    properties: [
+                        new OA\Property(property: 'service', type: 'string'),
+                        new OA\Property(property: 'status', type: 'string'),
+                    ],
+                    example: ['service' => 'patient-reminder', 'status' => 'completed']
+                )
+            ),
             new OA\Response(response: '401', ref: '#/components/responses/unauthorized'),
-            new OA\Response(response: '404', ref: '#/components/responses/uuidnotfound'),
-            new OA\Response(response: '409', description: 'Service is already running, not due, or skipped'),
+            new OA\Response(
+                response: '404',
+                description: 'Background service not found',
+                content: new OA\JsonContent(
+                    required: ['error'],
+                    properties: [
+                        new OA\Property(property: 'error', type: 'string'),
+                    ],
+                    example: ['error' => 'Service not found']
+                )
+            ),
+            new OA\Response(
+                response: '409',
+                description: 'Service is already running, not due, or skipped',
+                content: new OA\JsonContent(
+                    required: ['service', 'status'],
+                    properties: [
+                        new OA\Property(property: 'service', type: 'string'),
+                        new OA\Property(
+                            property: 'status',
+                            type: 'string',
+                            enum: ['already_running', 'not_due', 'skipped']
+                        ),
+                    ],
+                    example: ['service' => 'patient-reminder', 'status' => 'already_running']
+                )
+            ),
+            new OA\Response(
+                response: '500',
+                description: 'Service execution failed',
+                content: new OA\JsonContent(
+                    required: ['service', 'status'],
+                    properties: [
+                        new OA\Property(property: 'service', type: 'string'),
+                        new OA\Property(property: 'status', type: 'string', enum: ['error']),
+                    ],
+                    example: ['service' => 'patient-reminder', 'status' => 'error']
+                )
+            ),
         ],
         security: [['openemr_auth' => []]]
     )]

--- a/src/RestControllers/BackgroundServiceRestController.php
+++ b/src/RestControllers/BackgroundServiceRestController.php
@@ -181,6 +181,17 @@ class BackgroundServiceRestController
                     example: ['service' => 'patient-reminder', 'status' => 'completed']
                 )
             ),
+            new OA\Response(
+                response: '400',
+                description: 'Invalid JSON payload',
+                content: new OA\JsonContent(
+                    required: ['error'],
+                    properties: [
+                        new OA\Property(property: 'error', type: 'string'),
+                    ],
+                    example: ['error' => 'Invalid JSON payload']
+                )
+            ),
             new OA\Response(response: '401', ref: '#/components/responses/unauthorized'),
             new OA\Response(
                 response: '404',

--- a/src/RestControllers/BackgroundServiceRestController.php
+++ b/src/RestControllers/BackgroundServiceRestController.php
@@ -178,7 +178,7 @@ class BackgroundServiceRestController
                         new OA\Property(property: 'service', type: 'string'),
                         new OA\Property(property: 'status', type: 'string'),
                     ],
-                    example: ['service' => 'patient-reminder', 'status' => 'completed']
+                    example: ['service' => 'patient-reminder', 'status' => 'executed']
                 )
             ),
             new OA\Response(

--- a/src/RestControllers/BackgroundServiceRestController.php
+++ b/src/RestControllers/BackgroundServiceRestController.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\RestControllers;
 
+use OpenApi\Attributes as OA;
 use OpenEMR\Services\Background\BackgroundServiceRegistry;
 use OpenEMR\Services\Background\BackgroundServiceRunner;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -31,6 +32,17 @@ class BackgroundServiceRestController
         $this->runner = new BackgroundServiceRunner();
     }
 
+    #[OA\Get(
+        path: '/api/background_service',
+        description: 'Retrieves all registered background services',
+        tags: ['standard'],
+        responses: [
+            new OA\Response(response: '200', ref: '#/components/responses/standard'),
+            new OA\Response(response: '400', ref: '#/components/responses/badrequest'),
+            new OA\Response(response: '401', ref: '#/components/responses/unauthorized'),
+        ],
+        security: [['openemr_auth' => []]]
+    )]
     public function listAll(): Response
     {
         $definitions = $this->registry->list();
@@ -49,6 +61,27 @@ class BackgroundServiceRestController
         return new JsonResponse($data);
     }
 
+    #[OA\Get(
+        path: '/api/background_service/{name}',
+        description: 'Retrieves a single background service by name',
+        tags: ['standard'],
+        parameters: [
+            new OA\Parameter(
+                name: 'name',
+                in: 'path',
+                description: 'The registered name of the background service.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(response: '200', ref: '#/components/responses/standard'),
+            new OA\Response(response: '400', ref: '#/components/responses/badrequest'),
+            new OA\Response(response: '401', ref: '#/components/responses/unauthorized'),
+            new OA\Response(response: '404', ref: '#/components/responses/uuidnotfound'),
+        ],
+        security: [['openemr_auth' => []]]
+    )]
     public function getOne(string $name): Response
     {
         $definition = $this->registry->get($name);
@@ -68,6 +101,44 @@ class BackgroundServiceRestController
     /**
      * @param array<mixed> $data
      */
+    #[OA\Post(
+        path: '/api/background_service/{name}/run',
+        description: 'Triggers execution of a background service',
+        tags: ['standard'],
+        parameters: [
+            new OA\Parameter(
+                name: 'name',
+                in: 'path',
+                description: 'The registered name of the background service.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            required: false,
+            content: new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(
+                    properties: [
+                        new OA\Property(
+                            property: 'force',
+                            description: 'Force execution even if the service is not due to run.',
+                            type: 'boolean',
+                        ),
+                    ],
+                    example: ['force' => true]
+                )
+            )
+        ),
+        responses: [
+            new OA\Response(response: '200', ref: '#/components/responses/standard'),
+            new OA\Response(response: '400', ref: '#/components/responses/badrequest'),
+            new OA\Response(response: '401', ref: '#/components/responses/unauthorized'),
+            new OA\Response(response: '404', ref: '#/components/responses/uuidnotfound'),
+            new OA\Response(response: '409', description: 'Service is already running, not due, or skipped'),
+        ],
+        security: [['openemr_auth' => []]]
+    )]
     public function runService(string $name, array $data = []): Response
     {
         $force = isset($data['force']) && $data['force'] === true;

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -258,7 +258,7 @@ paths:
                 type: object
               example:
                 service: patient-reminder
-                status: completed
+                status: executed
         400:
           description: 'Invalid JSON payload'
           content:

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -151,7 +151,7 @@ paths:
                       type: integer
                     next_run:
                       type: string
-                      nullable: true
+                      format: date-time
                   type: object
         401:
           $ref: '#/components/responses/unauthorized'
@@ -197,7 +197,7 @@ paths:
                     type: integer
                   next_run:
                     type: string
-                    nullable: true
+                    format: date-time
                 type: object
         401:
           $ref: '#/components/responses/unauthorized'

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -125,6 +125,211 @@ paths:
       security:
         -
           openemr_auth: {  }
+  /api/background_service:
+    get:
+      tags:
+        - standard
+      description: 'Retrieves all registered background services'
+      responses:
+        200:
+          description: 'List of registered background services'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties:
+                    name:
+                      type: string
+                    title:
+                      type: string
+                    active:
+                      type: boolean
+                    running:
+                      type: boolean
+                    execute_interval:
+                      type: integer
+                    next_run:
+                      type: string
+                      nullable: true
+                  type: object
+        401:
+          $ref: '#/components/responses/unauthorized'
+      security:
+        -
+          openemr_auth: {  }
+  '/api/background_service/{name}':
+    get:
+      tags:
+        - standard
+      description: 'Retrieves a single background service by name'
+      parameters:
+        -
+          name: name
+          in: path
+          description: 'The registered name of the background service.'
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'Background service details'
+          content:
+            application/json:
+              schema:
+                required:
+                  - name
+                  - title
+                  - active
+                  - running
+                  - execute_interval
+                  - next_run
+                properties:
+                  name:
+                    type: string
+                  title:
+                    type: string
+                  active:
+                    type: boolean
+                  running:
+                    type: boolean
+                  execute_interval:
+                    type: integer
+                  next_run:
+                    type: string
+                    nullable: true
+                type: object
+        401:
+          $ref: '#/components/responses/unauthorized'
+        404:
+          description: 'Background service not found'
+          content:
+            application/json:
+              schema:
+                required:
+                  - error
+                properties:
+                  error:
+                    type: string
+                    example: 'Service not found'
+                type: object
+      security:
+        -
+          openemr_auth: {  }
+  '/api/background_service/{name}/run':
+    post:
+      tags:
+        - standard
+      description: 'Triggers execution of a background service'
+      parameters:
+        -
+          name: name
+          in: path
+          description: 'The registered name of the background service.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              properties:
+                force:
+                  description: 'Force execution even if the service is not due to run.'
+                  type: boolean
+              type: object
+              example:
+                force: true
+      responses:
+        200:
+          description: 'Service executed successfully'
+          content:
+            application/json:
+              schema:
+                required:
+                  - service
+                  - status
+                properties:
+                  service:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              example:
+                service: patient-reminder
+                status: completed
+        400:
+          description: 'Invalid JSON payload'
+          content:
+            application/json:
+              schema:
+                required:
+                  - error
+                properties:
+                  error:
+                    type: string
+                type: object
+              example:
+                error: 'Invalid JSON payload'
+        401:
+          $ref: '#/components/responses/unauthorized'
+        404:
+          description: 'Background service not found'
+          content:
+            application/json:
+              schema:
+                required:
+                  - error
+                properties:
+                  error:
+                    type: string
+                type: object
+              example:
+                error: 'Service not found'
+        409:
+          description: 'Service is already running, not due, or skipped'
+          content:
+            application/json:
+              schema:
+                required:
+                  - service
+                  - status
+                properties:
+                  service:
+                    type: string
+                  status:
+                    type: string
+                    enum:
+                      - already_running
+                      - not_due
+                      - skipped
+                type: object
+              example:
+                service: patient-reminder
+                status: already_running
+        500:
+          description: 'Service execution failed'
+          content:
+            application/json:
+              schema:
+                required:
+                  - service
+                  - status
+                properties:
+                  service:
+                    type: string
+                  status:
+                    type: string
+                    enum:
+                      - error
+                type: object
+              example:
+                service: patient-reminder
+                status: error
+      security:
+        -
+          openemr_auth: {  }
   /api/drug:
     get:
       tags:

--- a/tests/Tests/Services/Background/BackgroundServiceRegistryTest.php
+++ b/tests/Tests/Services/Background/BackgroundServiceRegistryTest.php
@@ -32,7 +32,7 @@ class BackgroundServiceRegistryTest extends TestCase
     private BackgroundServiceRegistry $registry;
 
     /** @var list<string> names of services created during the test — read in tearDown() */
-    private array $createdServices = []; // @phpstan-ignore property.onlyWritten (read by tearDown)
+    private array $createdServices = [];
 
     protected function setUp(): void
     {


### PR DESCRIPTION
## Summary

- Add `OpenApi\Attributes` annotations to all three `BackgroundServiceRestController` endpoints: `GET /api/background_service` (list), `GET /api/background_service/{name}` (get one), and `POST /api/background_service/{name}/run` (trigger execution)
- Use inline response schemas matching actual controller output rather than generic component refs — documents the real JSON payload shapes for 200, 400, 404, 409, and 500 responses
- Regenerate `swagger/openemr-api.yaml` so the spec stays in sync
- Remove a stale `@phpstan-ignore property.onlyWritten` comment from `BackgroundServiceRegistryTest`

## Test plan

- [x] Pre-commit hooks pass (phpstan, phpcs, rector, require-checker)
- [ ] Verify the OpenAPI spec generation includes the new background service endpoints
- [ ] Confirm API Docs Freshness CI check passes

Closes #11365
