### PR TITLE
fix(security): validate unserialize() return values before use

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -15337,11 +15337,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'insert_\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
@@ -15350,11 +15345,6 @@ $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'\\!\\(\\\\\\\\\\{nocache\\\\\\\\\\:\\(\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_compiled_include.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\-" between int\\<1, max\\> and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.read_cache_file.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \',\' results in an error\\.$#',

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -3138,7 +3138,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../src/Services/PatientService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -4217,11 +4217,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method assign\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method _include\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_compiled_include.php',

--- a/.phpstan/baseline/method.notFound.php
+++ b/.phpstan/baseline/method.notFound.php
@@ -772,6 +772,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/Smarty_Legacy.class.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Call to an undefined method object\\:\\:assign\\(\\)\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Call to an undefined method object\\:\\:get\\(\\)\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/plugins/function.config_load.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -1722,16 +1722,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../custom/zutil.cli.doc_import.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'array\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/Cache_Lite/Lite.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'counter\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/Cache_Lite/Lite.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'description\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../gacl/admin/about.php',
@@ -36392,17 +36382,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'assign\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'insert\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'name\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
 ];
@@ -36422,17 +36402,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'script\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset 0 on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset mixed on mixed\\.$#',
+    'message' => '#^Cannot access offset non\\-empty\\-string on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
 ];
@@ -36457,28 +36432,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.read_cache_file.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'config\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.read_cache_file.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'expires\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.read_cache_file.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'results\' on mixed\\.$#',
     'count' => 4,
-    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.read_cache_file.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'template\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.read_cache_file.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'timestamp\' on mixed\\.$#',
-    'count' => 3,
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.read_cache_file.php',
 ];
 $ignoreErrors[] = [
@@ -50928,7 +50883,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'pid\' on mixed\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Services/PatientService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.notFound.php
+++ b/.phpstan/baseline/offsetAccess.notFound.php
@@ -662,7 +662,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/Smarty_Legacy.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'resource_timestamp\' does not exist on array\\{get_source\\: false, quiet\\: true, resource_name\\: int\\|string\\}\\.$#',
+    'message' => '#^Offset \'resource_timestamp\' does not exist on array\\{get_source\\: false, quiet\\: true, resource_name\\: \\(int\\|string\\)\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.read_cache_file.php',
 ];

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -1963,7 +1963,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/property.nonObject.php
+++ b/.phpstan/baseline/property.nonObject.php
@@ -3102,17 +3102,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.load_resource_plugin.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access property \\$_inclusion_depth on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access property \\$_plugins on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access property \\$_smarty_debug_info on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
 ];
@@ -3123,7 +3113,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access property \\$debugging on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/property.notFound.php
+++ b/.phpstan/baseline/property.notFound.php
@@ -437,6 +437,21 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/Smarty_Legacy.class.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Access to an undefined property object\\:\\:\\$_inclusion_depth\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Access to an undefined property object\\:\\:\\$_smarty_debug_info\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Access to an undefined property object\\:\\:\\$debugging\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/smarty_legacy/smarty/internals/core.process_cached_inserts.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Access to an undefined property object\\:\\:\\$booleanize\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/plugins/function.config_load.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -692,11 +692,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/ModuleManagerListener.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function rc_sms_notification_cron_update_entry\\(\\) should return int but returns ADORecordSet\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\BootstrapService\\:\\:fetchPersistedSetupSettings\\(\\) should return array but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/BootstrapService.php',

--- a/gacl/Cache_Lite/Lite.php
+++ b/gacl/Cache_Lite/Lite.php
@@ -446,8 +446,10 @@ class Cache_Lite
         if ($this->_caching) {
             if ($data = $this->get($id, $group, $doNotTestCacheValidity)) {
                 $array = unserialize($data, ['allowed_classes' => false]);
-                $this->_memoryCachingCounter = $array['counter'];
-                $this->_memoryCachingArray = $array['array'];
+                if (is_array($array) && isset($array['counter'], $array['array'])) {
+                    $this->_memoryCachingCounter = $array['counter'];
+                    $this->_memoryCachingArray = $array['array'];
+                }
             }
         }
     }

--- a/library/smarty_legacy/smarty/internals/core.process_cached_inserts.php
+++ b/library/smarty_legacy/smarty/internals/core.process_cached_inserts.php
@@ -49,6 +49,10 @@ function smarty_core_process_cached_inserts($params, &$smarty)
             }
         }
 
+        if (!isset($smarty->_plugins['insert'][$name][0])) {
+            // insert plugin no longer registered, skip
+            continue;
+        }
         $function_name = $smarty->_plugins['insert'][$name][0];
         if (empty($args['assign'])) {
             $replace = $function_name($args, $smarty);

--- a/library/smarty_legacy/smarty/internals/core.process_cached_inserts.php
+++ b/library/smarty_legacy/smarty/internals/core.process_cached_inserts.php
@@ -26,6 +26,10 @@ function smarty_core_process_cached_inserts($params, &$smarty)
         }
 
         $args = unserialize($insert_args[$i], ['allowed_classes' => false]);
+        if (!is_array($args) || !isset($args['name'])) {
+            // corrupt cached insert, skip
+            continue;
+        }
         $name = $args['name'];
 
         if (isset($args['script'])) {

--- a/library/smarty_legacy/smarty/internals/core.process_cached_inserts.php
+++ b/library/smarty_legacy/smarty/internals/core.process_cached_inserts.php
@@ -26,7 +26,7 @@ function smarty_core_process_cached_inserts($params, &$smarty)
         }
 
         $args = unserialize($insert_args[$i], ['allowed_classes' => false]);
-        if (!is_array($args) || !isset($args['name'])) {
+        if (!is_array($args) || !isset($args['name']) || !is_string($args['name']) || $args['name'] === '') {
             // corrupt cached insert, skip
             continue;
         }

--- a/library/smarty_legacy/smarty/internals/core.read_cache_file.php
+++ b/library/smarty_legacy/smarty/internals/core.read_cache_file.php
@@ -53,6 +53,10 @@ function smarty_core_read_cache_file(&$params, &$smarty)
     $_info_start = strpos((string) $_contents, "\n") + 1;
     $_info_len = (int)substr((string) $_contents, 0, $_info_start - 1);
     $_cache_info = unserialize(substr((string) $_contents, $_info_start, $_info_len), ['allowed_classes' => false]);
+    if (!is_array($_cache_info)) {
+        // corrupt cache header, regenerate
+        return false;
+    }
     $params['results'] = substr((string) $_contents, $_info_start + $_info_len);
 
     if ($smarty->caching == 2 && isset ($_cache_info['expires'])){

--- a/library/smarty_legacy/smarty/internals/core.read_cache_file.php
+++ b/library/smarty_legacy/smarty/internals/core.read_cache_file.php
@@ -56,6 +56,7 @@ function smarty_core_read_cache_file(&$params, &$smarty)
     if (
         !is_array($_cache_info)
         || !isset($_cache_info['timestamp'], $_cache_info['template'])
+        || !is_numeric($_cache_info['timestamp'])
         || !is_array($_cache_info['template'])
     ) {
         // corrupt cache header, regenerate

--- a/library/smarty_legacy/smarty/internals/core.read_cache_file.php
+++ b/library/smarty_legacy/smarty/internals/core.read_cache_file.php
@@ -53,7 +53,11 @@ function smarty_core_read_cache_file(&$params, &$smarty)
     $_info_start = strpos((string) $_contents, "\n") + 1;
     $_info_len = (int)substr((string) $_contents, 0, $_info_start - 1);
     $_cache_info = unserialize(substr((string) $_contents, $_info_start, $_info_len), ['allowed_classes' => false]);
-    if (!is_array($_cache_info)) {
+    if (
+        !is_array($_cache_info)
+        || !isset($_cache_info['timestamp'], $_cache_info['template'])
+        || !is_array($_cache_info['template'])
+    ) {
         // corrupt cache header, regenerate
         return false;
     }

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -999,7 +999,11 @@ class PatientService extends BaseService
         // We only want the pid value so we can fetch the data from patient_data...
         //
         $pids = [];
-        foreach (($res) ? unserialize($res['patients'], ['allowed_classes' => false]) : [] as $v) {
+        $patients = $res ? unserialize($res['patients'], ['allowed_classes' => false]) : [];
+        if (!is_array($patients)) {
+            return $pids;
+        }
+        foreach ($patients as $v) {
             $pids[]['pid'] = $v['pid'];
         }
         return($pids);

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -999,11 +999,17 @@ class PatientService extends BaseService
         // We only want the pid value so we can fetch the data from patient_data...
         //
         $pids = [];
-        $patients = $res ? unserialize($res['patients'], ['allowed_classes' => false]) : [];
+        if (!is_array($res) || !is_string($res['patients'] ?? null)) {
+            return $pids;
+        }
+        $patients = unserialize($res['patients'], ['allowed_classes' => false]);
         if (!is_array($patients)) {
             return $pids;
         }
         foreach ($patients as $v) {
+            if (!is_array($v) || !isset($v['pid'])) {
+                continue;
+            }
             $pids[]['pid'] = $v['pid'];
         }
         return($pids);


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #11580. Follow-up to merged PR #10896 — that PR added `allowed_classes => false` restrictions but the four call sites still consumed the `unserialize()` result without checking for `false` (returned on malformed/corrupted payloads), producing warnings and incorrect behaviour when data was bad.

#### Changes proposed in this pull request:

- `src/Services/PatientService.php` (`getRecentPatientList`): require the SQL row and the serialized blob to be present and string-typed before unserialize, then skip loop entries that are not arrays carrying a `pid` key. Returns an empty list rather than dereferencing a scalar's `pid` offset.
- `gacl/Cache_Lite/Lite.php` (`getMemoryCachingState`): require the unserialized payload to be an array carrying both `counter` and `array` keys before updating in-memory cache state.
- `library/smarty_legacy/smarty/internals/core.read_cache_file.php`: treat any header whose unserialize result is missing/non-array, missing the `timestamp`/`template` keys, has a non-numeric `timestamp`, or has a non-array `template`, as a corrupt cache → return false (regenerate).
- `library/smarty_legacy/smarty/internals/core.process_cached_inserts.php`: skip the cached insert when `unserialize` produced a payload without a non-empty string `name`, and additionally skip when the named insert plugin is no longer registered (otherwise `$smarty->_plugins['insert'][$name][0]` warns + TypeErrors).

Each new guard also narrows the type for PHPStan so the downstream array access no longer feeds `mixed`/`false` into array indexing. The Smarty changes stay minimal because the files are vendored legacy.

Reviewed locally with Codex (multiple iterations) until no remaining findings.

#### Was an AI assistant used? Yes