### PR TITLE
fix(menu): realpath() read-boundary check with fallback for menu role file loading

### DIFF
--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -1963,7 +1963,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -692,11 +692,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/ModuleManagerListener.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function rc_sms_notification_cron_update_entry\\(\\) should return int but returns ADORecordSet\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\BootstrapService\\:\\:fetchPersistedSetupSettings\\(\\) should return array but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/BootstrapService.php',

--- a/src/Menu/MainMenuRole.php
+++ b/src/Menu/MainMenuRole.php
@@ -49,20 +49,26 @@ class MainMenuRole extends MenuRole
         // Collect the selected menu of user
         $mainMenuRole = $this->getMenuRole();
 
-        // Validate that the menu role filename is a basename only (no path traversal)
-        if ($mainMenuRole !== basename($mainMenuRole) || str_contains($mainMenuRole, '..')) {
-            ServiceContainer::getLogger()->error("Invalid menu role filename rejected", ['filename' => $mainMenuRole]);
-            die("\nInvalid menu role filename.");
+        // Resolve and validate the menu file path at the read boundary.
+        // Values that resolve outside the expected directory — including
+        // symlinks, DB rows written through paths that bypass write-boundary
+        // validation (REST API, direct DB writes, SQL injection, bulk
+        // imports), or otherwise missing files — fall back to "standard".
+        $path = $this->resolveMenuPath($mainMenuRole);
+        if ($path === null) {
+            ServiceContainer::getLogger()->warning(
+                "Menu role file failed read-boundary check, falling back to standard",
+                ['filename' => $mainMenuRole]
+            );
+            $mainMenuRole = 'standard';
+            $path = $this->resolveMenuPath($mainMenuRole);
+        }
+        if ($path === null) {
+            ServiceContainer::getLogger()->error("Standard main menu role file is unavailable");
+            die("\nMenu role unavailable.");
         }
 
-        // Load the selected menu
-        if (str_ends_with($mainMenuRole, '.json')) {
-            // load custom menu (includes .json in id)
-            $menu_parsed = json_decode(file_get_contents(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/custom_menus/" . $mainMenuRole));
-        } else {
-            // load a standardized menu (does not include .json in id)
-            $menu_parsed = json_decode(file_get_contents(OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . "/interface/main/tabs/menu/menus/" . $mainMenuRole . ".json"));
-        }
+        $menu_parsed = json_decode(file_get_contents($path));
 
         // if error, then die and report error
         if (!$menu_parsed) {
@@ -130,6 +136,42 @@ class MainMenuRole extends MenuRole
         }
 
         return $mainMenuRole;
+    }
+
+    /**
+     * Resolve a menu role value to a concrete file path after confirming
+     * the resolved path falls within the expected directory.
+     *
+     * Custom menus live under the site's custom_menus directory; standard
+     * menus ship with the installation. A role value is accepted only if
+     * realpath() places it inside the matching directory, which rejects
+     * path traversal, symlinks escaping the tree, and missing files.
+     */
+    private function resolveMenuPath(string $menuRole): ?string
+    {
+        if ($menuRole === '' || $menuRole !== basename($menuRole) || str_contains($menuRole, '..')) {
+            return null;
+        }
+
+        if (str_ends_with($menuRole, '.json')) {
+            $expectedDir = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/custom_menus";
+            $candidate = $expectedDir . "/" . $menuRole;
+        } else {
+            $expectedDir = OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . "/interface/main/tabs/menu/menus";
+            $candidate = $expectedDir . "/" . $menuRole . ".json";
+        }
+
+        $resolvedDir = realpath($expectedDir);
+        $resolvedFile = realpath($candidate);
+        if ($resolvedDir === false || $resolvedFile === false) {
+            return null;
+        }
+
+        if (!str_starts_with($resolvedFile, $resolvedDir . DIRECTORY_SEPARATOR)) {
+            return null;
+        }
+
+        return $resolvedFile;
     }
 
     // This creates menu entries for all encounter forms.

--- a/src/Menu/MainMenuRole.php
+++ b/src/Menu/MainMenuRole.php
@@ -68,7 +68,13 @@ class MainMenuRole extends MenuRole
             die("\nMenu role unavailable.");
         }
 
-        $menu_parsed = json_decode(file_get_contents($path));
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            ServiceContainer::getLogger()->error("Failed to read main menu role file", ['path' => $path]);
+            die("\nMenu role unavailable.");
+        }
+
+        $menu_parsed = json_decode($contents);
 
         // if error, then die and report error
         if (!$menu_parsed) {

--- a/src/Menu/PatientMenuRole.php
+++ b/src/Menu/PatientMenuRole.php
@@ -53,20 +53,26 @@ class PatientMenuRole extends MenuRole
         // Collect the selected menu of user
         $patientMenuRole = $this->getMenuRole();
 
-        // Validate that the menu role filename is a basename only (no path traversal)
-        if ($patientMenuRole !== basename($patientMenuRole) || str_contains($patientMenuRole, '..')) {
-            ServiceContainer::getLogger()->error("Invalid menu role filename rejected", ['filename' => $patientMenuRole]);
-            die("\nInvalid menu role filename.");
+        // Resolve and validate the menu file path at the read boundary.
+        // Values that resolve outside the expected directory — including
+        // symlinks, DB rows written through paths that bypass write-boundary
+        // validation (REST API, direct DB writes, SQL injection, bulk
+        // imports), or otherwise missing files — fall back to "standard".
+        $path = $this->resolveMenuPath($patientMenuRole);
+        if ($path === null) {
+            ServiceContainer::getLogger()->warning(
+                "Patient menu role file failed read-boundary check, falling back to standard",
+                ['filename' => $patientMenuRole]
+            );
+            $patientMenuRole = 'standard';
+            $path = $this->resolveMenuPath($patientMenuRole);
+        }
+        if ($path === null) {
+            ServiceContainer::getLogger()->error("Standard patient menu role file is unavailable");
+            die("\nMenu role unavailable.");
         }
 
-        // Load the selected menu
-        if (str_ends_with($patientMenuRole, '.json')) {
-            // load custom menu (includes .json in id)
-            $menu_parsed = json_decode(file_get_contents(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/custom_menus/patient_menus/" . $patientMenuRole));
-        } else {
-            // load a standardized menu (does not include .json in id)
-            $menu_parsed = json_decode(file_get_contents(OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . "/interface/main/tabs/menu/menus/patient_menus/" . $patientMenuRole . ".json"));
-        }
+        $menu_parsed = json_decode(file_get_contents($path));
         // if error, then die and report error
         if (!$menu_parsed) {
             die("\nJSON ERROR: " . json_last_error());
@@ -137,6 +143,43 @@ class PatientMenuRole extends MenuRole
         }
 
         return $patientMenuRole;
+    }
+
+    /**
+     * Resolve a patient menu role value to a concrete file path after
+     * confirming the resolved path falls within the expected directory.
+     *
+     * Custom patient menus live under the site's custom_menus/patient_menus
+     * directory; standard menus ship with the installation. A role value is
+     * accepted only if realpath() places it inside the matching directory,
+     * which rejects path traversal, symlinks escaping the tree, and missing
+     * files.
+     */
+    private function resolveMenuPath(string $menuRole): ?string
+    {
+        if ($menuRole === '' || $menuRole !== basename($menuRole) || str_contains($menuRole, '..')) {
+            return null;
+        }
+
+        if (str_ends_with($menuRole, '.json')) {
+            $expectedDir = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/custom_menus/patient_menus";
+            $candidate = $expectedDir . "/" . $menuRole;
+        } else {
+            $expectedDir = OEGlobalsBag::getInstance()->getKernel()->getProjectDir() . "/interface/main/tabs/menu/menus/patient_menus";
+            $candidate = $expectedDir . "/" . $menuRole . ".json";
+        }
+
+        $resolvedDir = realpath($expectedDir);
+        $resolvedFile = realpath($candidate);
+        if ($resolvedDir === false || $resolvedFile === false) {
+            return null;
+        }
+
+        if (!str_starts_with($resolvedFile, $resolvedDir . DIRECTORY_SEPARATOR)) {
+            return null;
+        }
+
+        return $resolvedFile;
     }
 
     /**

--- a/src/Menu/PatientMenuRole.php
+++ b/src/Menu/PatientMenuRole.php
@@ -72,7 +72,13 @@ class PatientMenuRole extends MenuRole
             die("\nMenu role unavailable.");
         }
 
-        $menu_parsed = json_decode(file_get_contents($path));
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            ServiceContainer::getLogger()->error("Failed to read patient menu role file", ['path' => $path]);
+            die("\nMenu role unavailable.");
+        }
+
+        $menu_parsed = json_decode($contents);
         // if error, then die and report error
         if (!$menu_parsed) {
             die("\nJSON ERROR: " . json_last_error());


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #11563 (realpath read-boundary check) and incidentally closes #11562 (replace `die()` with fallback) — the testable condition in #11563 ("falls back to standard") requires that fallback behaviour to exist. Follow-up to merged PR #11513 which added a basename/`..` denylist at the read boundary.

#### Changes proposed in this pull request:

- `src/Menu/MainMenuRole.php` and `src/Menu/PatientMenuRole.php`:
  - Replace the inline path validation + `die()` with a `resolveMenuPath()` helper that:
    1. rejects values containing path separators or `..`,
    2. computes the expected directory for custom vs standard menus,
    3. calls `realpath()` on both the directory and the candidate file, and
    4. confirms the resolved file path starts with the resolved directory followed by `DIRECTORY_SEPARATOR`.
  - On validation failure log a PSR-3 warning and fall back to the `"standard"` role; if even that fails to resolve, log an error and `die()`.
  - Read the resolved file via `file_get_contents()` into a variable, log + terminate cleanly on read failure (handles permission flips and TOCTOU races between resolve and read), then `json_decode` the known-string content.

This is a positive assertion ("the file is where it should be") rather than the denylist added in #11513. It defends against values that enter the DB through paths that bypass write-boundary validation (#11561) — direct DB writes, REST API, SQL injection, bulk imports — and against symlinks pointed outside the expected directory.

Reviewed locally with Codex; the original `json_decode(file_get_contents())` blocker is resolved.

#### Was an AI assistant used? Yes