### PR TITLE
fix(cda): register-conditional list XPath in CdaTextParser

### DIFF
--- a/src/Services/Cda/CdaTextParser.php
+++ b/src/Services/Cda/CdaTextParser.php
@@ -55,7 +55,12 @@ class CdaTextParser
             if (!$section instanceof DOMElement) {
                 continue;
             }
-            $listResult = $xpath->query(".//ns:list | .//list", $section);
+            // Match the section query's pattern: only reference the 'ns'
+            // prefix when it has actually been registered, otherwise the
+            // namespaced branch of the query fails silently and list
+            // elements are dropped.
+            $listQuery = $namespaces !== null ? ".//ns:list" : ".//list";
+            $listResult = $xpath->query($listQuery, $section);
             $list = $listResult !== false ? $listResult->item(0) : null;
             if ($list instanceof DOMElement) {
                 foreach ($list->getElementsByTagName("item") as $item) {

--- a/tests/Tests/Isolated/Services/Cda/CdaTextParserTest.php
+++ b/tests/Tests/Isolated/Services/Cda/CdaTextParserTest.php
@@ -46,6 +46,27 @@ class CdaTextParserTest extends TestCase
 </ClinicalDocument>
 XML;
 
+    private const XML_WITHOUT_NAMESPACE = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <code code="18776-5" codeSystem="2.16.840.1.113883.6.1"/>
+          <list>
+            <item ID="goal1">
+              <caption>Goal A</caption>
+              Some text content
+            </item>
+          </list>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>
+XML;
+
     private const XML_NESTED_LISTS = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <ClinicalDocument xmlns="urn:hl7-org:v3">
@@ -100,6 +121,22 @@ XML;
         $this->assertStringContainsString('Top level text', $notes[0]['content']);
         $this->assertSame('child1', $notes[1]['id']);
         $this->assertStringContainsString('Nested text', $notes[1]['content']);
+    }
+
+    public function testParseSectionByCodeWithoutNamespaceExtractsItems(): void
+    {
+        // Regression: previously the list XPath unconditionally contained
+        // `ns:list`, so a document without a default namespace referenced an
+        // unregistered prefix and DOMXPath::query() returned false for the
+        // entire branch, dropping list items silently.
+        $parser = new CdaTextParser(self::XML_WITHOUT_NAMESPACE);
+        /** @var list<array{id: string, caption: string, content: string}> $notes */
+        $notes = $parser->parseSectionByCode(self::SECTION_CODE);
+
+        $this->assertCount(1, $notes);
+        $this->assertSame('goal1', $notes[0]['id']);
+        $this->assertSame('Goal A', $notes[0]['caption']);
+        $this->assertStringContainsString('Some text content', $notes[0]['content']);
     }
 
     public function testParseSectionByCodeWithUnknownCodeReturnsEmpty(): void


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #11568. `CdaTextParser::parseSectionByCode()` only registers the `ns` namespace prefix when the document has a default namespace, and correctly switches its section query between `ns:section[...]` and `section[...]` based on that condition. The list lookup on the next block, however, always contained `ns:list`, so when the document had no default namespace the `ns` prefix was unregistered: `DOMXPath::query()` emits a warning and returns `false`, dropping the entire list branch silently.

#### Changes proposed in this pull request:

- `src/Services/Cda/CdaTextParser.php`: build the list query with the same register-conditional pattern as the section query — `.//ns:list` when a namespace is registered, `.//list` otherwise — so list items are extracted in both namespaced and non-namespaced CDA documents.
- `tests/Tests/Isolated/Services/Cda/CdaTextParserTest.php`: add `testParseSectionByCodeWithoutNamespaceExtractsItems` and an `XML_WITHOUT_NAMESPACE` fixture that exercise the previously-broken path. Fails on master without the fix.

`composer phpunit-isolated --filter CdaTextParserTest` → 7 pass / 0 fail.

#### Was an AI assistant used? Yes