### PR TITLE
fix(insurance): use WHERE instead of AND for InsuranceCompanyService::getAll() predicates

### DIFF
--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -10292,6 +10292,16 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/QuestionnaireResponse/FhirQuestionnaireResponseFormServiceIntegrationTest.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Cannot call method getData\\(\\) on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Services/InsuranceCompanyServiceTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method hasData\\(\\) on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Services/InsuranceCompanyServiceTest.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Cannot call method C14N\\(\\) on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php',

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -1963,7 +1963,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -692,11 +692,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/ModuleManagerListener.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function rc_sms_notification_cron_update_entry\\(\\) should return int but returns ADORecordSet\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\BootstrapService\\:\\:fetchPersistedSetupSettings\\(\\) should return array but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/BootstrapService.php',

--- a/src/Services/InsuranceCompanyService.php
+++ b/src/Services/InsuranceCompanyService.php
@@ -251,7 +251,7 @@ class InsuranceCompanyService extends BaseService
         $sql .= " LEFT JOIN addresses a ON i.id = a.foreign_id";
 
         if ($search !== []) {
-            $sql .= ' AND ';
+            $sql .= ' WHERE ';
             $whereClauses = [];
             foreach ($search as $fieldName => $fieldValue) {
                 array_push($whereClauses, $fieldName . ' = ?');

--- a/tests/Tests/Services/InsuranceCompanyServiceTest.php
+++ b/tests/Tests/Services/InsuranceCompanyServiceTest.php
@@ -227,6 +227,40 @@ class InsuranceCompanyServiceTest extends TestCase
     }
 
     #[Test]
+    public function testGetAllAppliesSearchPredicateAsWhereClause(): void
+    {
+        // Regression for #11558: getAll() previously appended search
+        // predicates with `AND` directly after the LEFT JOIN ON clause,
+        // which made them part of the join condition rather than the
+        // result-set filter. With LEFT JOIN, every insurance_companies
+        // row still came back (with NULL address columns when the
+        // predicate did not match), so callers that asked for a single
+        // record by cms_id received every other company too.
+        $matchedId = $this->insertAndTrack();
+
+        $otherData = $this->getTestData();
+        $otherData['name'] = 'test-fixture-Other Insurance';
+        $otherData['cms_id'] = '99999';
+        /** @var int|string $otherId */
+        $otherId = $this->service->insert($otherData);
+        $this->createdIds[] = $otherId;
+
+        $result = $this->service->getAll(['cms_id' => '88888']);
+
+        $this->assertTrue($result->hasData());
+        /** @var list<array<string, mixed>> $records */
+        $records = $result->getData();
+
+        $matchedRecords = array_values(array_filter(
+            $records,
+            static fn(array $row): bool => ($row['cms_id'] ?? null) === '88888'
+        ));
+        $this->assertCount(1, $records, 'getAll() with a cms_id filter must restrict the result set, not just the join');
+        $this->assertCount(1, $matchedRecords);
+        $this->assertEquals($matchedId, $matchedRecords[0]['id'] ?? null);
+    }
+
+    #[Test]
     public function testInsertWithExplicitId(): void
     {
         $data = $this->getTestData();


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #11558. `InsuranceCompanyService::getAll()` builds `LEFT JOIN addresses a ON i.id = a.foreign_id` and then appends search predicates with `AND`, which extends the JOIN's `ON` expression instead of filtering the result set. The query is syntactically valid but semantically wrong: a `LEFT JOIN` still emits every row from `insurance_companies`, with the search terms only governing whether the address columns are populated, so callers passing a search filter receive unfiltered results.

#### Changes proposed in this pull request:

- `src/Services/InsuranceCompanyService.php`: change the predicate separator from `AND` to `WHERE` so the search conditions actually restrict the joined result set.
- `tests/Tests/Services/InsuranceCompanyServiceTest.php`: add `testGetAllAppliesSearchPredicateAsWhereClause` — inserts two companies with different `cms_id` values, calls `getAll(['cms_id' => '88888'])`, and asserts exactly one matching row is returned. Fails on master because the broken JOIN still returns both rows (with `NULL` address columns on the non-match).

#### Was an AI assistant used? Yes