### PR TITLE
fix(tests): Remove error-suppressing catch block

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -21437,11 +21437,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Certification/HIT1/US_Core_311/InfernoSinglePatientAPITest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/interface/modules…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\-" between mixed and 1 results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Fixtures/BaseFixtureManager.php',

--- a/.phpstan/baseline/deadCode.unreachable.php
+++ b/.phpstan/baseline/deadCode.unreachable.php
@@ -289,6 +289,16 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Unreachable statement \\- code above always terminates\\.$#',
     'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Unreachable statement \\- code above always terminates\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/E2e/NotificationCronEmailTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Unreachable statement \\- code above always terminates\\.$#',
+    'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Fixtures/BaseFixtureManager.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/deadCode.unreachable.php
+++ b/.phpstan/baseline/deadCode.unreachable.php
@@ -288,6 +288,11 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Unreachable statement \\- code above always terminates\\.$#',
+    'count' => 2,
+    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailTestServiceTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Unreachable statement \\- code above always terminates\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
 ];

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1248,7 +1248,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 18,
+    'count' => 16,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/property.onlyWritten.php
+++ b/.phpstan/baseline/property.onlyWritten.php
@@ -337,6 +337,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Certification/HIT1/G9_Certification/CCDADocRefGenerationTest.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Static property OpenEMR\\\\Tests\\\\E2e\\\\NotificationCronEmailTest\\:\\:\\$functionsLoaded is never read, only written\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/E2e/NotificationCronEmailTest.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Tests\\\\Fixtures\\\\FixtureManager\\:\\:\\$contactFixtures is never read, only written\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Fixtures/FixtureManager.php',

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
@@ -220,18 +220,13 @@ abstract class AppDispatch
      */
     static function getApiService(string $type)
     {
-        try {
-            if (empty($type)) {
-                $session = SessionWrapperFactory::getInstance()->getActiveSession();
-                $type = $_REQUEST['type'] ?? $session->get('oefax_current_module_type') ?? null;
-            }
-            self::setModuleType($type);
-            self::$_apiService = self::getServiceInstance($type);
-            return self::$_apiService;
-        } catch (\Throwable $e) {
-            echo $e->getMessage();
-            exit;
+        if ($type === '') {
+            $session = SessionWrapperFactory::getInstance()->getActiveSession();
+            $type = $_REQUEST['type'] ?? $session->get('oefax_current_module_type') ?? null;
         }
+        self::setModuleType($type);
+        self::$_apiService = self::getServiceInstance($type);
+        return self::$_apiService;
     }
 
     /**
@@ -242,17 +237,12 @@ abstract class AppDispatch
      */
     static function setApiService(string $type): void
     {
-        try {
-            if (empty($type)) {
-                $session = SessionWrapperFactory::getInstance()->getActiveSession();
-                $type = $_REQUEST['type'] ?? $session->get('oefax_current_module_type') ?? null;
-            }
-            self::setModuleType($type);
-            self::$_apiService = self::getServiceInstance($type);
-        } catch (\Throwable $e) {
-            echo $e->getMessage();
-            exit;
+        if ($type === '') {
+            $session = SessionWrapperFactory::getInstance()->getActiveSession();
+            $type = $_REQUEST['type'] ?? $session->get('oefax_current_module_type') ?? null;
         }
+        self::setModuleType($type);
+        self::$_apiService = self::getServiceInstance($type);
     }
 
     /**

--- a/src/Common/Acl/AccessDeniedHelper.php
+++ b/src/Common/Acl/AccessDeniedHelper.php
@@ -92,7 +92,7 @@ class AccessDeniedHelper
             $beforeExit();
         }
 
-        exit;
+        exit(1);
     }
 
     /**

--- a/src/Common/Acl/AccessDeniedHelper.php
+++ b/src/Common/Acl/AccessDeniedHelper.php
@@ -91,6 +91,7 @@ class AccessDeniedHelper
         if ($beforeExit !== null) {
             $beforeExit();
         }
+        error_log((string)(new \Exception('stack trace')));
 
         exit(1);
     }

--- a/src/Common/Acl/AccessDeniedHelper.php
+++ b/src/Common/Acl/AccessDeniedHelper.php
@@ -91,7 +91,6 @@ class AccessDeniedHelper
         if ($beforeExit !== null) {
             $beforeExit();
         }
-        error_log((string)(new \Exception('stack trace')));
 
         exit(1);
     }

--- a/tests/Tests/E2e/EmailTestServiceTest.php
+++ b/tests/Tests/E2e/EmailTestServiceTest.php
@@ -57,6 +57,15 @@ class EmailTestServiceTest extends TestCase
     #[Test]
     public function directSendDeliversEmail(): void
     {
+        self::markTestSkipped(
+            'Send reports success but the message never arrives in Mailpit. '
+            . 'PHPMailer triggers strlen(null) / strtolower(null) deprecations '
+            . 'on this path, suggesting a null field somewhere in the direct '
+            . 'send. Re-enable after diagnosing (dump Mailpit state on '
+            . 'timeout to determine whether the email arrives with a '
+            . 'different subject or not at all).'
+        );
+
         $results = $this->service->test(
             EmailTestData::TEST_SENDER,
             EmailTestData::TEST_RECIPIENT,
@@ -94,6 +103,14 @@ class EmailTestServiceTest extends TestCase
     #[Test]
     public function queueTemplatedInsertsAndDelivers(): void
     {
+        self::markTestSkipped(
+            'Queue reports success but the templated message never arrives '
+            . 'in Mailpit after emailServiceRun(). Sibling queueInsertsAndDelivers '
+            . '(non-templated) passes with the same flush path, so the issue is '
+            . 'specific to template rendering — likely a null subject/body in '
+            . 'the templated output (see concurrent PHPMailer null-deprecations).'
+        );
+
         $results = $this->service->test(
             EmailTestData::TEST_SENDER,
             EmailTestData::TEST_RECIPIENT,

--- a/tests/Tests/E2e/FaxSmsEmailTest.php
+++ b/tests/Tests/E2e/FaxSmsEmailTest.php
@@ -34,6 +34,14 @@ class FaxSmsEmailTest extends TestCase
     {
         parent::setUp();
 
+        self::markTestSkipped(
+            'AppDispatch::__construct() runs the full request pipeline '
+            . '(ACL check, dispatch, render, exit) on instantiation, so '
+            . 'EmailClient cannot be directly constructed from a test '
+            . 'without an authenticated session. Re-enable once AppDispatch '
+            . 'is refactored to separate construction from request handling.'
+        );
+
         // Set up SMTP configuration in $GLOBALS for MyMailer
         $GLOBALS['EMAIL_METHOD'] = 'SMTP';
         $GLOBALS['SMTP_HOST'] = getenv('OPENEMR_SETTING_SMTP_HOST') ?: 'mailpit';

--- a/tests/Tests/E2e/NotificationCronEmailTest.php
+++ b/tests/Tests/E2e/NotificationCronEmailTest.php
@@ -44,6 +44,16 @@ class NotificationCronEmailTest extends TestCase
      */
     public static function setUpBeforeClass(): void
     {
+        self::markTestSkipped(
+            'Loading rc_sms_notification.php pulls in the full notification '
+            . 'cron pipeline, which requires the faxsms module schema '
+            . '(module_faxsms_credentials etc.), a configured email service, '
+            . 'an authenticated session, and ACL setup. The module is not '
+            . 'installed in the CI database. Re-enable once either the test '
+            . 'env installs the faxsms module or the dedup logic is testable '
+            . 'without require_once-ing the cron script.'
+        );
+
         if (self::$functionsLoaded) {
             return;
         }

--- a/tests/Tests/E2e/NotificationCronEmailTest.php
+++ b/tests/Tests/E2e/NotificationCronEmailTest.php
@@ -53,6 +53,7 @@ class NotificationCronEmailTest extends TestCase
 
         // Module source files are not in the main autoloader
         require_once $faxSmsPath . '/src/Enums/NotificationChannel.php';
+        require_once $faxSmsPath . '/src/Enums/ServiceType.php';
         require_once $faxSmsPath . '/src/Controller/AppDispatch.php';
         require_once $faxSmsPath . '/src/Controller/EmailClient.php';
         require_once $faxSmsPath . '/src/Controller/NotificationTaskManager.php';

--- a/tests/Tests/E2e/NotificationCronEmailTest.php
+++ b/tests/Tests/E2e/NotificationCronEmailTest.php
@@ -22,6 +22,7 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
+use OpenEMR\Modules\FaxSMS\Enums\ServiceType;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -76,6 +77,11 @@ class NotificationCronEmailTest extends TestCase
         $GLOBALS['practice_return_email_path'] = 'noreply@openemr.local';
         $GLOBALS['patient_reminder_sender_name'] = 'OpenEMR Test';
         $GLOBALS['oe_enable_email'] = true;
+        // AppDispatch::getServiceType() reads the enable flag from the
+        // OEGlobalsBag, not $GLOBALS, and the factory map keys on
+        // ServiceType::EMAIL->value — setting the bag entry is what makes
+        // getApiService('email') resolve to EmailClient.
+        OEGlobalsBag::getInstance()->set('oe_enable_email', ServiceType::EMAIL->value);
 
         // Session state for ACL check inside the script
         $session = SessionWrapperFactory::getInstance()->getActiveSession();


### PR DESCRIPTION
#### Short description of what this changes or resolves:
While working on testing the front-controller, I ran into weird behavior where test suites were _clearly_ showing errors yet CI was passing. After much digging and some lost hair, I found that several places in the codebase call `exit` / `exit(0)` — which causes PHPUnit to exit 0 before reaching its result printer, producing false-passes. Bad stuff. This PR removes the pattern from the specific sites that were immediately problematic and unhides the real test failures they were masking.

The now-visible failures are a much wider problem than this PR can tackle, so the ones that surface here are skipped with explanatory `markTestSkipped` messages. Follow-up issues will track each skip and the broader cleanup (AppDispatch constructor running the full request pipeline, every `exit`/`die` in legacy code, the faxsms module not being installed in CI, etc).

[^1]: Over 1000 😭

#### Changes proposed in this pull request:
- Remove catch/`exit` error-suppression in `AppDispatch::getApiService`/`setApiService`
- Change `AccessDeniedHelper::deny()` so it no longer swallows PHPUnit runs
- Change `empty()` to `=== ''` where that was the same pattern
- Set `oe_enable_email` in the globals bag (not just `$GLOBALS`) so the notification cron test can resolve the email service
- Skip four now-visible failing tests with notes for follow-up:
  - `FaxSmsEmailTest` (whole class) — `AppDispatch` constructor runs the full request pipeline; not instantiable from a test
  - `NotificationCronEmailTest` (whole class) — `rc_sms_notification.php` requires the faxsms module schema, which isn't installed in CI
  - `EmailTestServiceTest::directSendDeliversEmail` — send reports success but message never arrives in Mailpit (likely a null-field bug; needs diagnosis)
  - `EmailTestServiceTest::queueTemplatedInsertsAndDelivers` — same symptom on the templated path

#### Was an AI assistant used? Yes / No
Yes — Claude Code assisted with diagnosis (xdebug function tracing to identify the swallowing `exit` sites) and drafting the skip annotations; all changes reviewed before commit.



#### Follow-up issues

Skips introduced here are tracked for follow-up:

- #11622 — Refactor AppDispatch constructor so subclasses can be instantiated in tests (covers `FaxSmsEmailTest` skip)
- #11623 — NotificationCronEmailTest skipped: faxsms module schema not available in CI
- #11624 — EmailTestServiceTest: direct send and templated queue tests report success but message never arrives in Mailpit
