### PR TITLE
ci: include composer.json in vendor cache key

### DIFF
--- a/.github/workflows/inferno-test.yml
+++ b/.github/workflows/inferno-test.yml
@@ -88,8 +88,8 @@ jobs:
       id: cache-keys
       run: |
         {
-          echo 'vendor=${{ runner.os }}-vendor-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}'
-          echo 'composer=${{ runner.os }}-composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}'
+          echo 'vendor=${{ runner.os }}-vendor-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock', 'composer.json') }}'
+          echo 'composer=${{ runner.os }}-composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock', 'composer.json') }}'
         } >> "$GITHUB_OUTPUT"
 
     ##

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,8 +157,8 @@ jobs:
       id: cache-keys
       run: |
         {
-          echo 'vendor=${{ runner.os }}-vendor-${{ steps.parse.outputs.php }}-${{ hashFiles('**/composer.lock') }}'
-          echo 'composer=${{ runner.os }}-composer-${{ steps.parse.outputs.php }}-${{ hashFiles('**/composer.lock') }}'
+          echo 'vendor=${{ runner.os }}-vendor-${{ steps.parse.outputs.php }}-${{ hashFiles('**/composer.lock', 'composer.json') }}'
+          echo 'composer=${{ runner.os }}-composer-${{ steps.parse.outputs.php }}-${{ hashFiles('**/composer.lock', 'composer.json') }}'
           echo 'npm-build=${{ runner.os }}-npm-build-${{ steps.parse.outputs.node_version }}-${{ hashFiles('**/package-lock.json') }}'
           echo 'ccda-build=${{ runner.os }}-ccda-build-${{ steps.parse.outputs.node_version }}-${{ hashFiles('**/ccdaservice/package-lock.json') }}'
           echo 'npm=${{ runner.os }}-node-${{ steps.parse.outputs.node_version }}-${{ hashFiles('**/package-lock.json') }}'


### PR DESCRIPTION
#### Short description of what this changes or resolves:

The `test` and `inferno-test` workflows cache `vendor/` and gate `composer install` on a cache hit. The cache key only hashes `composer.lock`, so changes to `composer.json` that don't touch the lock — most commonly PSR-4 `autoload` / `autoload-dev` edits — are silently ignored: CI restores a stale `vendor/`, skips install, and the generated `vendor/composer/autoload_psr4.php` doesn't reflect the current `composer.json`. Classes that should be autoloadable aren't.

Including `composer.json` in the cache key forces a miss when autoload config changes, which in turn runs `composer install` and regenerates the autoloader.

#### Changes proposed in this pull request:

- `.github/workflows/test.yml`: add `composer.json` to the `vendor` and `composer` cache keys.
- `.github/workflows/inferno-test.yml`: same.

Audited the other workflows for the same pattern:
- `phpstan.yml`, `rector.yml`, `isolated-tests.yml` use the `setup-php-composer` composite action, which runs `composer install` unconditionally — stale downloads cache is harmless because install regenerates the autoloader.
- `rector.yml`'s `tmp-rector` result cache is a performance cache with per-file hashing internally; staleness is safe.
- `styling.yml` / `js-test.yml` cache npm only; `package-lock.json` fully determines `node_modules`.
- `composer-require-checker.yml` already hashes both `composer.json` and `composer.lock`.

#### Was an AI assistant used? Yes

Body and commits drafted with Claude Code, reviewed by a human.