### PR TITLE
fix(ci): match runner Node version to nginx container

### DIFF
--- a/ci/nginx_82/docker-compose.yml
+++ b/ci/nginx_82/docker-compose.yml
@@ -1,8 +1,9 @@
 x-includes:
-  selenium-template: "compose-shared-selenium/docker-compose.yml"
-  webserver-template: "compose-shared-nginx.yml"
-  database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  node-version: '24'
+  selenium-template: compose-shared-selenium/docker-compose.yml
+  webserver-template: compose-shared-nginx.yml
+  database-template: compose-shared-mariadb.yml
+  mailpit-template: compose-shared-mailpit.yml
 
 services:
   mysql:

--- a/ci/nginx_83/docker-compose.yml
+++ b/ci/nginx_83/docker-compose.yml
@@ -1,8 +1,9 @@
 x-includes:
-  selenium-template: "compose-shared-selenium/docker-compose.yml"
-  webserver-template: "compose-shared-nginx.yml"
-  database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  node-version: '24'
+  selenium-template: compose-shared-selenium/docker-compose.yml
+  webserver-template: compose-shared-nginx.yml
+  database-template: compose-shared-mariadb.yml
+  mailpit-template: compose-shared-mailpit.yml
 
 services:
   mysql:

--- a/ci/nginx_84/docker-compose.yml
+++ b/ci/nginx_84/docker-compose.yml
@@ -1,8 +1,9 @@
 x-includes:
-  selenium-template: "compose-shared-selenium/docker-compose.yml"
-  webserver-template: "compose-shared-nginx.yml"
-  database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  node-version: '24'
+  selenium-template: compose-shared-selenium/docker-compose.yml
+  webserver-template: compose-shared-nginx.yml
+  database-template: compose-shared-mariadb.yml
+  mailpit-template: compose-shared-mailpit.yml
 
 services:
   mysql:

--- a/ci/nginx_85/docker-compose.yml
+++ b/ci/nginx_85/docker-compose.yml
@@ -1,8 +1,9 @@
 x-includes:
-  selenium-template: "compose-shared-selenium/docker-compose.yml"
-  webserver-template: "compose-shared-nginx.yml"
-  database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  node-version: '24'
+  selenium-template: compose-shared-selenium/docker-compose.yml
+  webserver-template: compose-shared-nginx.yml
+  database-template: compose-shared-mariadb.yml
+  mailpit-template: compose-shared-mailpit.yml
 
 services:
   mysql:

--- a/ci/nginx_86/docker-compose.yml
+++ b/ci/nginx_86/docker-compose.yml
@@ -1,8 +1,9 @@
 x-includes:
-  selenium-template: "compose-shared-selenium/docker-compose.yml"
-  webserver-template: "compose-shared-nginx.yml"
-  database-template: "compose-shared-mariadb.yml"
-  mailpit-template: "compose-shared-mailpit.yml"
+  node-version: '24'
+  selenium-template: compose-shared-selenium/docker-compose.yml
+  webserver-template: compose-shared-nginx.yml
+  database-template: compose-shared-mariadb.yml
+  mailpit-template: compose-shared-mailpit.yml
 
 services:
   mysql:

--- a/ci/parse_docker_dir.sh
+++ b/ci/parse_docker_dir.sh
@@ -12,7 +12,7 @@ readonly -A WEBSERVER_OPENEMR_DIRS=(
 # to build configurations for tests in GitHub Actions
 parse() {
   local docker_dir="${1}"
-  local node_version=22
+  local node_version
   local database
   local db
   local webserver
@@ -29,6 +29,9 @@ parse() {
 
   # Format PHP version
   printf -v php '%d.%d' "${php::1}" "${php:1}"
+
+  # Read node version from compose file, default to 22
+  node_version=$(yq '.x-includes."node-version" // "22"' "ci/${docker_dir}/docker-compose.yml")
 
   # Collect docker-compose.yml templates
   selenium_template=$(yq '.x-includes.selenium-template' "ci/${docker_dir}/docker-compose.yml")


### PR DESCRIPTION
## Summary

- The `dev-php-fpm` Docker images now ship Node 24, but `parse_docker_dir.sh` hardcoded `node_version=22`. The runner built native modules (`libxmljs2`) for Node 22 and cached them; when mounted into the Node 24 container the ABI mismatch crashed the CCDA service, failing `CcdaServiceDocumentRequestorTest` on every nginx job.
- Read `node-version` from each compose file's `x-includes` (defaulting to `22` for apache configs that don't declare it) so the runner and container agree on the Node ABI.

## Test plan

- [ ] All nginx CI jobs pass (the `CcdaServiceDocumentRequestorTest::testSocketGet` error should be gone)
- [ ] Apache CI jobs continue to pass (they default to Node 22 since they don't declare `node-version`)