### PR TITLE
fix(encounter): fix saving in collection on auto create encounter

### DIFF
--- a/interface/forms/newpatient/C_EncounterVisitForm.class.php
+++ b/interface/forms/newpatient/C_EncounterVisitForm.class.php
@@ -345,13 +345,13 @@ class C_EncounterVisitForm
             ['value' => '0', 'title' => xl('No')],
             ['value' => '1', 'title' => xl('Yes')],
         ];
-
-        // Mark selected option for existing encounters
+        // For new encounters default to No, for existing use stored value
+        $current = ($encounter && isset($encounter['in_collection']))
+            ? $encounter['in_collection']
+            : '0';
         foreach ($options as &$option) {
-            $option['selected'] = ($encounter && isset($encounter['in_collection'])
-                && $encounter['in_collection'] == $option['value']);
+            $option['selected'] = ($option['value'] === $current);
         }
-
         return $options;
     }
 

--- a/interface/forms/newpatient/C_EncounterVisitForm.class.php
+++ b/interface/forms/newpatient/C_EncounterVisitForm.class.php
@@ -342,8 +342,8 @@ class C_EncounterVisitForm
     function getInCollectionOptionsForTemplate($encounter = null)
     {
         $options = [
+            ['value' => '0', 'title' => xl('No')],
             ['value' => '1', 'title' => xl('Yes')],
-            ['value' => '0', 'title' => xl('No')]
         ];
 
         // Mark selected option for existing encounters


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
fixes the order of the options in the encounter template, the auto create encounter would default to in collection in error

#### Changes proposed in this pull request:


#### Was an AI assistant used? Yes / No

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
