### PR TITLE
feat(cli): Expose installer in symfony/console command

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,65 @@
+name: Integration tests
+
+on:
+  pull_request:
+    # All PRs
+  push:
+    branhes:
+    - master
+    - rel-*
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: $${ matrix.suite }} - ${{ matrix.php }}
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        php:
+          - '8.5'
+        suite:
+          - 'common'
+
+
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: ci
+          MYSQL_PASSWORD: topsecret
+          MYSQL_DATABASE: openemr_test
+        ports:
+          - 3306:3306
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP and Composer
+        uses: ./.github/actions/setup-php-composer
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Run CLI installer
+        run: |
+          php cli install -n \
+            --db-host=127.0.0.1 \
+            --db-port=3306 \
+            --db-root-user=root \
+            --db-root-password=root \
+            --db-user=ci \
+            --db-password=topsecret \
+            --db-name=openemr_test \
+            --oe-admin-username=admin \
+            --oe-admin-password=pass
+
+      - name: Verify installation
+        run: |
+          mysql -h 127.0.0.1 -u ci -ptopsecret openemr_test \
+            -e "SELECT COUNT(*) as user_count FROM users WHERE username='admin';" \
+            | grep -q "1"
+
+      # TODO: actually run the test suite. For now, just verifying installer.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,16 +4,16 @@ on:
   pull_request:
     # All PRs
   push:
-    branhes:
-    - master
-    - rel-*
+    branches:
+      - master
+      - rel-*
 
 permissions:
   contents: read
 
 jobs:
   test:
-    name: $${ matrix.suite }} - ${{ matrix.php }}
+    name: ${ matrix.suite }} - ${{ matrix.php }}
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   test:
-    name: ${ matrix.suite }} - ${{ matrix.php }}
+    name: ${{ matrix.suite }} - ${{ matrix.php }}
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,17 +47,18 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Run CLI installer
-        run: |
-          php cli install -n \
-            --db-host=127.0.0.1 \
-            --db-port=3306 \
-            --db-root-user=root \
-            --db-root-password=root \
-            --db-user=ci \
-            --db-password=topsecret \
-            --db-name=openemr_test \
-            --oe-admin-username=admin \
+        run: ./cli install
+            --db-host=127.0.0.1
+            --db-port=3306
+            --db-root-user=root
+            --db-root-password=root
+            --db-user=ci
+            --db-password=topsecret
+            --db-name=openemr_test
+            --oe-admin-username=admin
             --oe-admin-password=pass
+            --no-interaction
+            -vvv
 
       - name: Verify installation
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,9 @@ on:
       - master
       - rel-*
 
+env:
+  ENVIRONMENT: ci
+
 permissions:
   contents: read
 

--- a/.phpstan/baseline/assign.propertyType.php
+++ b/.phpstan/baseline/assign.propertyType.php
@@ -327,122 +327,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/classes/Document.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$clone_database \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$collate \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property Installer\\:\\:\\$custom_globals \\(array\\) does not accept mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Installer.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$dbname \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$development_translations \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$i2faEnable \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$i2faSecret \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$igroup \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property Installer\\:\\:\\$ippf_specific \\(string\\) does not accept false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$iufname \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$iuname \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$iuser \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$iuserpass \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$login \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$loginhost \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$new_theme \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$no_root_db_access \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$pass \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$port \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$root \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$rootpass \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$server \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$site \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Installer\\:\\:\\$source_site_id \\(string\\) does not accept mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Installer.class.php',
 ];

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -1897,11 +1897,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/classes/Document.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method Installer\\:\\:__construct\\(\\) has parameter \\$cgi_variables with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Installer.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method Installer\\:\\:extractFileName\\(\\) return type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Installer.class.php',

--- a/cli
+++ b/cli
@@ -6,6 +6,9 @@ declare(strict_types=1);
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Tools\Console\ConsoleRunner;
 use Firehed\Container\TypedContainerInterface;
+use OpenEMR\Common\Command\{
+    InstallCommand,
+};
 use Symfony\Component\Console\Application;
 
 $container = require_once __DIR__ . '/bootstrap.php';
@@ -22,6 +25,7 @@ file_put_contents(
 );
 
 $application = new Application();
+$application->addCommand($container->get(InstallCommand::class));
 
 // Doctrine Migrations integration
 ConsoleRunner::addCommands($application, $container->get(DependencyFactory::class));

--- a/config/cli.php
+++ b/config/cli.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Command;
+
+return [
+    InstallCommand::class,
+];

--- a/config/cli.php
+++ b/config/cli.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Console command configuration
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 declare(strict_types=1);
 
 namespace OpenEMR\Common\Command;

--- a/config/services.php
+++ b/config/services.php
@@ -13,6 +13,7 @@
 declare(strict_types=1);
 
 use Firehed\Container\TypedContainerInterface as TC;
+use Installer;
 use Lcobucci\Clock\SystemClock;
 use Monolog\{
     Formatter\LineFormatter,
@@ -23,6 +24,7 @@ use Monolog\{
 };
 use OpenEMR\BC\FallbackRouter;
 use OpenEMR\Common\Http\Psr17Factory;
+use OpenEMR\Common\Installer\InstallerInterface;
 use OpenEMR\Core\ErrorHandler;
 use Psr\Log\LoggerInterface;
 use Psr\Http\Message\{
@@ -43,6 +45,9 @@ return [
         installRoot: $c->getString('installRoot'),
         logger: $c->get(LoggerInterface::class),
     ),
+
+    InstallerInterface::class => Installer::class,
+    Installer::class => fn (TC $c) => new Installer([], $c->get(LoggerInterface::class)),
 
     Level::class => fn (TC $c) => Level::fromName($c->get('LOG_LEVEL')),
     Logger::class => function (TC $c) {

--- a/config/services.php
+++ b/config/services.php
@@ -6,14 +6,13 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Eric Stern <erics@opencoreemr.com>
- * @copyright Copyright (c) 2026 Eric Stern
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 declare(strict_types=1);
 
 use Firehed\Container\TypedContainerInterface as TC;
-use Installer;
 use Lcobucci\Clock\SystemClock;
 use Monolog\{
     Formatter\LineFormatter,

--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -1412,6 +1412,7 @@ $config = 1; /////////////
         // Validation of OpenEMR user settings
         //   (applicable if not cloning from another database)
         if (empty($this->clone_database)) {
+            $this->logger->debug('Validating installation parameters');
             if (! $this->login_is_valid()) {
                 return false;
             }
@@ -1432,6 +1433,7 @@ $config = 1; /////////////
 
         if (! $this->no_root_db_access) {
             // Connect to mysql via root user
+            $this->logger->debug('Connecting to database as root');
             if (! $this->root_database_connection()) {
                 return false;
             }
@@ -1439,6 +1441,7 @@ $config = 1; /////////////
             // Create the dumpfile
             //   (applicable if cloning from another database)
             if (! empty($this->clone_database)) {
+                $this->logger->debug('Creating database dumpfiles for cloning');
                 if (! $this->create_dumpfiles()) {
                     return false;
                 }
@@ -1447,6 +1450,7 @@ $config = 1; /////////////
             // Create the site directory
             //   (applicable if mirroring another local site)
             if (! empty($this->source_site_id)) {
+                $this->logger->debug('Creating site directory from {source}', ['source' => $this->source_site_id]);
                 if (! $this->create_site_directory()) {
                     return false;
                 }
@@ -1470,16 +1474,19 @@ $config = 1; /////////////
                 }
 
                 // Create the mysql database
+                $this->logger->debug('Creating database {dbname}', ['dbname' => $this->dbname]);
                 if (! $this->create_database()) {
                     return false;
                 }
 
                 // Create the mysql user
+                $this->logger->debug('Creating database user {login}', ['login' => $this->login]);
                 if (! $this->create_database_user()) {
                     return false;
                 }
 
                 // Grant user privileges to the mysql database
+                $this->logger->debug('Granting database privileges');
                 if (! $this->grant_privileges()) {
                     return false;
                 }
@@ -1489,16 +1496,19 @@ $config = 1; /////////////
         }
 
         // Connect to mysql via created user
+        $this->logger->debug('Connecting to database as {login}', ['login' => $this->login]);
         if (! $this->user_database_connection()) {
             return false;
         }
 
         // Build the database
+        $this->logger->debug('Loading database schema (this may take a while)');
         if (! $this->load_dumpfiles()) {
             return false;
         }
 
         // Write the sql configuration file
+        $this->logger->debug('Writing configuration file');
         if (! $this->write_configuration_file()) {
             return false;
         }
@@ -1507,10 +1517,12 @@ $config = 1; /////////////
         // initial user, and set up gacl access controls.
         // (applicable if not cloning from another database)
         if (empty($this->clone_database)) {
+            $this->logger->debug('Adding version info');
             if (! $this->add_version_info()) {
                 return false;
             }
 
+            $this->logger->debug('Inserting global settings');
             if (! $this->insert_globals()) {
                 return false;
             }
@@ -1519,18 +1531,22 @@ $config = 1; /////////////
                 return false;
             }
 
+            $this->logger->debug('Creating initial user {iuser}', ['iuser' => $this->iuser]);
             if (! $this->add_initial_user()) {
                 return false;
             }
 
+            $this->logger->debug('Installing access controls');
             if (! $this->install_gacl()) {
                 return false;
             }
 
+            $this->logger->debug('Installing additional users');
             if (! $this->install_additional_users()) {
                 return false;
             }
 
+            $this->logger->debug('Configuring care coordination');
             if (! $this->on_care_coordination()) {
                 return false;
             }

--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -20,10 +20,14 @@ use OpenEMR\BC\DatabaseConnectionFactory;
 use OpenEMR\BC\DatabaseConnectionOptions;
 use OpenEMR\Common\Crypto\KeyVersion;
 use OpenEMR\Common\Crypto\PasswordBasedCrypto;
+use OpenEMR\Common\Installer\InstallerInterface;
 use OpenEMR\Gacl\GaclApi;
 use Psr\Log\LoggerInterface;
 
-class Installer
+/**
+ * @phpstan-import-type InstallParams from InstallerInterface
+ */
+class Installer implements InstallerInterface
 {
     public array $custom_globals;
     public array $dumpfiles;
@@ -64,10 +68,17 @@ class Installer
     /**
      * Initialize the Installer with configuration variables.
      *
-     * @param array $cgi_variables Configuration array containing installation parameters
-     * @param LoggerInterface $logger Logger instance for error reporting
+     * @param InstallParams $cgi_variables Configuration array containing installation parameters
      */
-    public function __construct(array $cgi_variables, private readonly LoggerInterface $logger)
+    public function __construct(array $cgi_variables, private LoggerInterface $logger)
+    {
+        $this->initializeParams($cgi_variables);
+    }
+
+    /**
+     * @param InstallParams $cgi_variables
+     */
+    protected function initializeParams(array $cgi_variables): void
     {
         // Installation variables
         // For a good explanation of these variables, see documentation in
@@ -81,7 +92,7 @@ class Installer
         $this->i2faSecret               = $cgi_variables['i2fasecret'] ?? '';
         $this->server                   = $cgi_variables['server'] ?? ''; // mysql server (usually localhost)
         $this->loginhost                = $cgi_variables['loginhost'] ?? ''; // php/apache server (usually localhost)
-        $this->port                     = $cgi_variables['port'] ?? '';
+        $this->port                     = (string) ($cgi_variables['port'] ?? '');
         $this->root                     = $cgi_variables['root'] ?? '';
         $this->rootpass                 = $cgi_variables['rootpass'] ?? '';
         $this->login                    = $cgi_variables['login'] ?? '';
@@ -2336,5 +2347,23 @@ SETHLP;
     protected function writeToFile($stream, string $data, ?int $length = null): int|false
     {
         return $length !== null ? fwrite($stream, $data, $length) : fwrite($stream, $data);
+    }
+
+    // InstallerInterface implementation
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    public function install(array $params): bool
+    {
+        $this->initializeParams($params);
+        return $this->quick_install();
+    }
+
+    public function getErrorMessage(): string
+    {
+        return $this->error_message;
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,6 +16,7 @@ parameters:
   - apis
   - ccdaservice
   - ccr
+  - cli
   - config
   - contrib
   - controller.php

--- a/src/Common/Command/InstallCommand.php
+++ b/src/Common/Command/InstallCommand.php
@@ -16,7 +16,7 @@ class InstallCommand extends Command
 {
     public function __invoke(
         OutputInterface $output,
-        #[Option] string $dbServer = '127.0.0.1',
+        #[Option] string $dbHost = '127.0.0.1',
         #[Option] int $dbPort = 3306,
         #[Option] string $dbUser = '',
         #[Option] string $dbPassword = '',
@@ -24,12 +24,40 @@ class InstallCommand extends Command
         #[Option] string $dbRootUser = 'root',
         #[Option] string $dbRootPassword = '',
     ): int {
-        $logger = new ConsoleLogger($output);
 
         // login -> dbuser
         // pass -> dbPassowrd
         // dbname => dbName
         // collate = 'utf8mb4_general_ci'
-        return -2;
+        // pre-validate things are nonempty??
+        $params = [
+            // DB root
+            'root' => $dbRootUser,
+            'rootpass' => $dbRootPassword,
+
+            'server' => $dbHost,
+            'port' => $dbPort,
+            'login' => $dbUser,
+            'pass' => $dbPassword,
+            'dbname' => $dbName, // NEEDS VALIDATION
+            'loginhost' => '%', // FIXME: webserver for db user
+
+            'iuserpass' => 'changeme',
+            'site' => 'FAKESITE', // FIXME: remove this.
+        ];
+        $logger = new ConsoleLogger($output);
+        $installer = new Installer(
+            $params,
+            $logger,
+        );
+        /* return 2; */
+        $success = $installer->quick_install();
+        if (!$success) {
+            $output->writeln('Installation failed:');
+            $output->writeln($installer->error_message);
+            return Command::FAILURE;
+        }
+        $output->writeln('OpenEMR has been installed!');
+        return Command::SUCCESS;
     }
 }

--- a/src/Common/Command/InstallCommand.php
+++ b/src/Common/Command/InstallCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Command;
+
+use Installer;
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+
+#[AsCommand(name: 'install')]
+class InstallCommand extends Command
+{
+    public function __invoke(
+        #[Option] string $dbServer = '127.0.0.1',
+        #[Option] int $dbPort = 3306,
+        #[Option] string $dbUser = '',
+        #[Option] string $dbPassword = '',
+        #[Option] string $dbName = 'openemr',
+        #[Option] string $dbRootUser = 'root',
+        #[Option] string $dbRootPassword = '',
+    ): int {
+        // login -> dbuser
+        // pass -> dbPassowrd
+        // dbname => dbName
+        // collate = 'utf8mb4_general_ci'
+        return -2;
+    }
+}

--- a/src/Common/Command/InstallCommand.php
+++ b/src/Common/Command/InstallCommand.php
@@ -8,13 +8,16 @@ use Installer;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(name: 'install')]
 class InstallCommand extends Command
 {
     public function __invoke(
+        InputInterface $input,
         OutputInterface $output,
         #[Option] string $dbHost = '127.0.0.1',
         #[Option] int $dbPort = 3306,
@@ -24,6 +27,11 @@ class InstallCommand extends Command
         #[Option] string $dbRootUser = 'root',
         #[Option] string $dbRootPassword = '',
     ): int {
+        $io = new SymfonyStyle($input, $output);
+
+        if ($input->isInteractive() && !$io->confirm('This command is experimental. Continue? (--no-interaction will auto-apply "yes")', default: false)) {
+            return Command::FAILURE;
+        }
 
         // login -> dbuser
         // pass -> dbPassowrd

--- a/src/Common/Command/InstallCommand.php
+++ b/src/Common/Command/InstallCommand.php
@@ -8,11 +8,14 @@ use Installer;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'install')]
 class InstallCommand extends Command
 {
     public function __invoke(
+        OutputInterface $output,
         #[Option] string $dbServer = '127.0.0.1',
         #[Option] int $dbPort = 3306,
         #[Option] string $dbUser = '',
@@ -21,6 +24,8 @@ class InstallCommand extends Command
         #[Option] string $dbRootUser = 'root',
         #[Option] string $dbRootPassword = '',
     ): int {
+        $logger = new ConsoleLogger($output);
+
         // login -> dbuser
         // pass -> dbPassowrd
         // dbname => dbName

--- a/src/Common/Command/InstallCommand.php
+++ b/src/Common/Command/InstallCommand.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Common\Command;
 
-use Installer;
+use OpenEMR\Common\Installer\InstallerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
@@ -26,6 +26,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand(name: 'install', description: 'Install OpenEMR (experimental)')]
 class InstallCommand extends Command
 {
+    public function __construct(private readonly InstallerInterface $installer)
+    {
+        parent::__construct();
+    }
+
     public function __invoke(
         InputInterface $input,
         OutputInterface $output,
@@ -71,14 +76,10 @@ class InstallCommand extends Command
             // == Not user configurable ==
             'site' => 'default', // Only default site supported.
         ];
-        $logger = new ConsoleLogger($output);
-        $installer = new Installer(
-            $params,
-            $logger,
-        );
-        $success = $installer->quick_install();
+        $this->installer->setLogger(new ConsoleLogger($output));
+        $success = $this->installer->install($params);
         if (!$success) {
-            $io->error(['Installation failed:', $installer->error_message]);
+            $io->error(['Installation failed:', $this->installer->getErrorMessage()]);
             return Command::FAILURE;
         }
         $io->success('OpenEMR has been installed!');

--- a/src/Common/Command/InstallCommand.php
+++ b/src/Common/Command/InstallCommand.php
@@ -1,38 +1,48 @@
 <?php
 
+/**
+ * CLI installer command for OpenEMR.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <eric@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 declare(strict_types=1);
 
 namespace OpenEMR\Common\Command;
 
 use Installer;
-use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand(name: 'install')]
+#[AsCommand(name: 'install', description: 'Install OpenEMR (experimental)')]
 class InstallCommand extends Command
 {
     public function __invoke(
         InputInterface $input,
         OutputInterface $output,
-        #[Option] string $dbHost = '127.0.0.1',
-        #[Option] int $dbPort = 3306,
-        #[Option] string $dbUser = '',
-        #[Option] string $dbPassword = '',
-        #[Option] string $dbName = 'openemr',
-        #[Option] string $dbRootUser = 'root',
-        #[Option] string $dbRootPassword = '',
+        #[Option(description: 'Database server hostname')] string $dbHost = '127.0.0.1',
+        #[Option(description: 'Database server port')] int $dbPort = 3306,
+        #[Option(description: 'Database username for OpenEMR')] string $dbUser = '',
+        #[Option(description: 'Database password for OpenEMR')] string $dbPassword = '',
+        #[Option(description: 'Database name')] string $dbName = 'openemr',
+        #[Option(description: 'Database root username')] string $dbRootUser = 'root',
+        #[Option(description: 'Database root password')] string $dbRootPassword = '',
         #[Option(description: 'OpenEMR admin display name')] string $oeAdminName = 'Administrator',
         #[Option(description: 'OpenEMR admin username')] string $oeAdminUsername = 'admin',
         #[Option(description: 'OpenEMR admin password')] string $oeAdminPassword = '',
     ): int {
         $io = new SymfonyStyle($input, $output);
 
-        if ($input->isInteractive() && !$io->confirm('This command is experimental. Continue? (--no-interaction will auto-apply "yes")', default: false)) {
+        if ($input->isInteractive() && !$io->confirm('This command is experimental. Continue?', default: false)) {
             return Command::FAILURE;
         }
 
@@ -68,11 +78,10 @@ class InstallCommand extends Command
         );
         $success = $installer->quick_install();
         if (!$success) {
-            $output->writeln('Installation failed:');
-            $output->writeln($installer->error_message);
+            $io->error(['Installation failed:', $installer->error_message]);
             return Command::FAILURE;
         }
-        $output->writeln('OpenEMR has been installed!');
+        $io->success('OpenEMR has been installed!');
         return Command::SUCCESS;
     }
 }

--- a/src/Common/Command/InstallCommand.php
+++ b/src/Common/Command/InstallCommand.php
@@ -26,6 +26,9 @@ class InstallCommand extends Command
         #[Option] string $dbName = 'openemr',
         #[Option] string $dbRootUser = 'root',
         #[Option] string $dbRootPassword = '',
+        #[Option(description: 'OpenEMR admin display name')] string $oeAdminName = 'Administrator',
+        #[Option(description: 'OpenEMR admin username')] string $oeAdminUsername = 'admin',
+        #[Option(description: 'OpenEMR admin password')] string $oeAdminPassword = '',
     ): int {
         $io = new SymfonyStyle($input, $output);
 
@@ -33,32 +36,36 @@ class InstallCommand extends Command
             return Command::FAILURE;
         }
 
-        // login -> dbuser
-        // pass -> dbPassowrd
-        // dbname => dbName
-        // collate = 'utf8mb4_general_ci'
-        // pre-validate things are nonempty??
         $params = [
             // DB root
             'root' => $dbRootUser,
             'rootpass' => $dbRootPassword,
 
+            // Runtime DB info
             'server' => $dbHost,
             'port' => $dbPort,
             'login' => $dbUser,
             'pass' => $dbPassword,
             'dbname' => $dbName, // NEEDS VALIDATION
+            // Future:
+            // - sockets instead of host/port
+            // - SSL
+
             'loginhost' => '%', // FIXME: webserver for db user
 
-            'iuserpass' => 'changeme',
-            'site' => 'FAKESITE', // FIXME: remove this.
+            // Initial admin user seed
+            'iuser' => $oeAdminUsername,
+            'iuname' => $oeAdminName,
+            'iuserpass' => $oeAdminPassword,
+
+            // == Not user configurable ==
+            'site' => 'default', // Only default site supported.
         ];
         $logger = new ConsoleLogger($output);
         $installer = new Installer(
             $params,
             $logger,
         );
-        /* return 2; */
         $success = $installer->quick_install();
         if (!$success) {
             $output->writeln('Installation failed:');

--- a/src/Common/Installer/InstallerInterface.php
+++ b/src/Common/Installer/InstallerInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Interface for the OpenEMR installer.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Installer;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * @phpstan-type InstallParams array{
+ *   iuser?: string,
+ *   iuserpass?: string,
+ *   iuname?: string,
+ *   iufname?: string,
+ *   igroup?: string,
+ *   i2faenable?: string,
+ *   i2fasecret?: string,
+ *   server?: string,
+ *   loginhost?: string,
+ *   port?: int|string,
+ *   root?: string,
+ *   rootpass?: string,
+ *   login?: string,
+ *   pass?: string,
+ *   dbname?: string,
+ *   collate?: string,
+ *   site?: string,
+ *   source_site_id?: string,
+ *   clone_database?: string,
+ *   no_root_db_access?: string,
+ *   development_translations?: string,
+ *   new_theme?: string,
+ *   custom_globals?: string,
+ * }
+ */
+interface InstallerInterface
+{
+    public function setLogger(LoggerInterface $logger): void;
+
+    /**
+     * @param InstallParams $params
+     */
+    public function install(array $params): bool;
+
+    public function getErrorMessage(): string;
+}

--- a/tests/Tests/Isolated/Common/Command/InstallCommandTest.php
+++ b/tests/Tests/Isolated/Common/Command/InstallCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Command;
+
+use OpenEMR\Common\Command\InstallCommand;
+use OpenEMR\Common\Installer\InstallerInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[Group('isolated')]
+class InstallCommandTest extends TestCase
+{
+    public function testOptionToParamMapping(): void
+    {
+        $capturedParams = null;
+
+        $installer = $this->createMock(InstallerInterface::class);
+        $installer->expects($this->once())
+            ->method('setLogger')
+            ->with($this->isInstanceOf(LoggerInterface::class));
+        $installer->expects($this->once())
+            ->method('install')
+            ->with($this->callback(function (array $params) use (&$capturedParams): bool {
+                $capturedParams = $params;
+                return true;
+            }))
+            ->willReturn(true);
+
+        $command = new InstallCommand($installer);
+        $tester = $this->createTester($command);
+
+        $tester->execute([
+            '--db-host' => 'mydbhost',
+            '--db-port' => '3307',
+            '--db-user' => 'myuser',
+            '--db-password' => 'mypass',
+            '--db-name' => 'mydb',
+            '--db-root-user' => 'myroot',
+            '--db-root-password' => 'myrootpass',
+            '--oe-admin-name' => 'Test Admin',
+            '--oe-admin-username' => 'testadmin',
+            '--oe-admin-password' => 'adminpass',
+        ], ['interactive' => false]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertNotNull($capturedParams);
+
+        // Verify CLI options are mapped to correct param keys
+        $this->assertSame('mydbhost', $capturedParams['server']);
+        $this->assertSame(3307, $capturedParams['port']);
+        $this->assertSame('myuser', $capturedParams['login']);
+        $this->assertSame('mypass', $capturedParams['pass']);
+        $this->assertSame('mydb', $capturedParams['dbname']);
+        $this->assertSame('myroot', $capturedParams['root']);
+        $this->assertSame('myrootpass', $capturedParams['rootpass']);
+        $this->assertSame('Test Admin', $capturedParams['iuname']);
+        $this->assertSame('testadmin', $capturedParams['iuser']);
+        $this->assertSame('adminpass', $capturedParams['iuserpass']);
+
+        // Verify hardcoded values
+        $this->assertSame('%', $capturedParams['loginhost']);
+        $this->assertSame('default', $capturedParams['site']);
+    }
+
+    public function testInstallFailureReturnsError(): void
+    {
+        $installer = $this->createMock(InstallerInterface::class);
+        $installer->method('install')->willReturn(false);
+        $installer->method('getErrorMessage')->willReturn('Database connection failed');
+
+        $command = new InstallCommand($installer);
+        $tester = $this->createTester($command);
+
+        $tester->execute([], ['interactive' => false]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('Database connection failed', $tester->getDisplay());
+    }
+
+    private function createTester(InstallCommand $command): CommandTester
+    {
+        $app = new Application();
+        $app->addCommand($command);
+        return new CommandTester($app->find('install'));
+    }
+}

--- a/tests/Tests/Isolated/Common/Command/InstallCommandTest.php
+++ b/tests/Tests/Isolated/Common/Command/InstallCommandTest.php
@@ -31,10 +31,10 @@ class InstallCommandTest extends TestCase
         $installer = $this->createMock(InstallerInterface::class);
         $installer->expects($this->once())
             ->method('setLogger')
-            ->with($this->isInstanceOf(LoggerInterface::class));
+            ->with(self::isInstanceOf(LoggerInterface::class));
         $installer->expects($this->once())
             ->method('install')
-            ->with($this->callback(function (array $params) use (&$capturedParams): bool {
+            ->with(self::callback(function (array $params) use (&$capturedParams): bool {
                 $capturedParams = $params;
                 return true;
             }))
@@ -56,24 +56,24 @@ class InstallCommandTest extends TestCase
             '--oe-admin-password' => 'adminpass',
         ], ['interactive' => false]);
 
-        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
-        $this->assertNotNull($capturedParams);
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertNotNull($capturedParams);
 
         // Verify CLI options are mapped to correct param keys
-        $this->assertSame('mydbhost', $capturedParams['server']);
-        $this->assertSame(3307, $capturedParams['port']);
-        $this->assertSame('myuser', $capturedParams['login']);
-        $this->assertSame('mypass', $capturedParams['pass']);
-        $this->assertSame('mydb', $capturedParams['dbname']);
-        $this->assertSame('myroot', $capturedParams['root']);
-        $this->assertSame('myrootpass', $capturedParams['rootpass']);
-        $this->assertSame('Test Admin', $capturedParams['iuname']);
-        $this->assertSame('testadmin', $capturedParams['iuser']);
-        $this->assertSame('adminpass', $capturedParams['iuserpass']);
+        self::assertSame('mydbhost', $capturedParams['server']);
+        self::assertSame(3307, $capturedParams['port']);
+        self::assertSame('myuser', $capturedParams['login']);
+        self::assertSame('mypass', $capturedParams['pass']);
+        self::assertSame('mydb', $capturedParams['dbname']);
+        self::assertSame('myroot', $capturedParams['root']);
+        self::assertSame('myrootpass', $capturedParams['rootpass']);
+        self::assertSame('Test Admin', $capturedParams['iuname']);
+        self::assertSame('testadmin', $capturedParams['iuser']);
+        self::assertSame('adminpass', $capturedParams['iuserpass']);
 
         // Verify hardcoded values
-        $this->assertSame('%', $capturedParams['loginhost']);
-        $this->assertSame('default', $capturedParams['site']);
+        self::assertSame('%', $capturedParams['loginhost']);
+        self::assertSame('default', $capturedParams['site']);
     }
 
     public function testInstallFailureReturnsError(): void
@@ -87,8 +87,8 @@ class InstallCommandTest extends TestCase
 
         $tester->execute([], ['interactive' => false]);
 
-        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
-        $this->assertStringContainsString('Database connection failed', $tester->getDisplay());
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString('Database connection failed', $tester->getDisplay());
     }
 
     private function createTester(InstallCommand $command): CommandTester


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Adds an experimental CLI command to install OpenEMR, as a lighter-weight alternative to the web-based installer or `InstallerAuto.php` script. It's not deeply different than running the InstallerAuto file, but provides improved ergonomics and data validation over the baseline. In time I'd like it to replace InstallerAuto, but for now I want something that's easy to integrate into CI.

#### Changes proposed in this pull request:

**New CLI command: `./cli install`**

Capabilities:
- Configure database connection (host, port, user, password, database name)
- Configure database root credentials for setup
- Configure initial OpenEMR admin user (username, display name, password)
- Debug logging with `-vvv` to show installation progress
- Interactive confirmation prompt (skippable with `-n`)

Limitations (experimental):
- Only supports `default` site
- No validation of required parameters before calling Installer (relies on Installer's error messages)
- `--oe-admin-password` defaults to empty string, which will fail validation
- No `--db-login-host` option (hardcoded to `%`)
- No admin first name option (`iufname`)
- Does not check if already installed (see #11630)

**Installer improvements:**
- Added debug logging throughout `quick_install()` for better visibility

**Related issues:**
- #11629 - Installer recursive directory bug (discovered during development)
- #11630 - Installer should check if already installed

#### Was an AI assistant used? Yes

Assisted-by trailers were added to commits.
