### PR TITLE
test(phpunit): fail on deprecations in all test suites

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -56,6 +56,7 @@
     "getPatientFullNameAsString",
     "getRegistryEntryByDirectory",
     "getSmokeCodes",
+    "http_get_last_response_headers",
     "getUserSetting",
     "get_db",
     "get_patient_balance",

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -19387,11 +19387,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/Cda/CdaTemplateParse.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'Missed Physical…\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Cda/CdaTemplateParse.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'OID\\:\' and mixed results in an error\\.$#',
     'count' => 8,
     'path' => __DIR__ . '/../../src/Services/Cda/CdaTemplateParse.php',

--- a/.phpstan/baseline/openemr.forbiddenErrorLog.php
+++ b/.phpstan/baseline/openemr.forbiddenErrorLog.php
@@ -443,7 +443,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 9,
+    'count' => 8,
     'path' => __DIR__ . '/../../src/Services/Cda/CdaTemplateParse.php',
 ];
 $ignoreErrors[] = [
@@ -498,7 +498,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Telemetry/GeoTelemetry.php',
 ];
 $ignoreErrors[] = [

--- a/phpunit-isolated.xml
+++ b/phpunit-isolated.xml
@@ -18,12 +18,12 @@ This file configures the kind that does not require initialization.
          stopOnIncomplete="false"
          stopOnRisky="false"
          stopOnSkipped="false"
-         stopOnWarning="false"
          displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnPhpunitDeprecations="true"
+         failOnDeprecation="true"
          failOnPhpunitDeprecation="true"
          failOnPhpunitWarning="true"
          testdox="false">
@@ -39,19 +39,13 @@ This file configures the kind that does not require initialization.
     <server name="DISABLE_DATABASE" value="1"/>
   </php>
 
-  <source>
+  <source ignoreIndirectDeprecations="true">
     <include>
-      <directory>apis</directory>
-      <directory>gacl</directory>
-      <directory>interface</directory>
-      <directory>library</directory>
-      <directory>modules</directory>
-      <directory>oauth2</directory>
-      <directory>portal</directory>
-      <directory>sites</directory>
-      <directory>src</directory>
-      <directory>tests</directory>
+      <directory>.</directory>
     </include>
+    <exclude>
+      <directory>vendor</directory>
+    </exclude>
   </source>
 
   <testsuites>

--- a/phpunit.integration.xml
+++ b/phpunit.integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
     backupGlobals="false"
     colors="false"
     processIsolation="false"
@@ -13,9 +13,11 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
     displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnPhpunitDeprecations="true"
+    failOnDeprecation="true"
+    failOnPhpunitDeprecation="true"
     failOnPhpunitWarning="true"
     testdox="false">
-  <coverage cacheDirectory=".phpunit.cache"> </coverage>
   <extensions>
     <bootstrap class="OpenEMR\PHPUnit\Extension" />
   </extensions>
@@ -35,4 +37,12 @@
 	    <directory>tests/Tests/Integration/RestControllers/Subscriber/</directory>
     </testsuite>
   </testsuites>
+  <source ignoreIndirectDeprecations="true">
+    <include>
+      <directory>.</directory>
+    </include>
+    <exclude>
+      <directory>vendor</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,8 @@ This file configures the kind that requires initialization.
     displayDetailsOnTestsThatTriggerWarnings="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnPhpunitDeprecations="true"
+    failOnDeprecation="true"
+    failOnPhpunitDeprecation="true"
     failOnPhpunitWarning="true"
     testdox="false">
   <coverage> </coverage>
@@ -82,4 +84,12 @@ This file configures the kind that requires initialization.
       <file>tests/Tests/E2e/NotificationCronEmailTest.php</file>
     </testsuite>
   </testsuites>
+  <source ignoreIndirectDeprecations="true">
+    <include>
+      <directory>.</directory>
+    </include>
+    <exclude>
+      <directory>vendor</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/src/Services/Cda/CdaTemplateParse.php
+++ b/src/Services/Cda/CdaTemplateParse.php
@@ -12,6 +12,7 @@
 
 namespace OpenEMR\Services\Cda;
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\CDA\CDAPostParseEvent;
 use OpenEMR\Events\CDA\CDAPreParseEvent;
@@ -1187,7 +1188,7 @@ class CdaTemplateParse
                     $this->templateData['field_name_value_array']['vital_sign'][$i]['bps'] = $vital_sign_data['organizer']['component'][$j]['observation']['entryRelationship'][0]['observation']['value']['value'] ?? null;
                     $this->templateData['field_name_value_array']['vital_sign'][$i]['bpd'] = $vital_sign_data['organizer']['component'][$j]['observation']['entryRelationship'][1]['observation']['value']['value'] ?? null;
                 } else {
-                    if (array_key_exists($code, $vitals_array)) {
+                    if ($code !== null && array_key_exists($code, $vitals_array)) {
                         $this->templateData['field_name_value_array']['vital_sign'][$i][$vitals_array[$code]] = $vital_sign_data['organizer']['component'][$j]['observation']['value']['value'] ?? null;
                     }
                 }
@@ -1238,12 +1239,12 @@ class CdaTemplateParse
             ];
             $is_negated = !empty($entry['observation']['negationInd'] ?? false);
             $code = $entry['observation']['code']['code'] ?? null;
-            if (array_key_exists($code, $vitals_array)) {
+            if ($code !== null && array_key_exists($code, $vitals_array)) {
                 $this->templateData['field_name_value_array']['vital_sign'][$i][$vitals_array[$code]] = $entry['observation']['value']['value'] ?? null;
                 $this->templateData['field_name_value_array']['vital_sign'][$i]['vital_column'] = $vitals_array[$code] ?? '';
             } else {
                 // log missed exam
-                error_log('Missed Physical Exam code (likely vital): ' . $code);
+                ServiceContainer::getLogger()->warning('Missed Physical Exam code (likely vital)', ['code' => $code]);
             }
 
             if (!empty($entry['observation']['entryRelationship']['observation']['value']['code'] ?? null)) {

--- a/src/Telemetry/GeoTelemetry.php
+++ b/src/Telemetry/GeoTelemetry.php
@@ -24,6 +24,7 @@
 
 namespace OpenEMR\Telemetry;
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Utils\ValidationUtils;
 
 class GeoTelemetry implements GeoTelemetryInterface
@@ -233,20 +234,48 @@ class GeoTelemetry implements GeoTelemetryInterface
 
         $result = @$this->fileGetContents($url, false, $ctx);
 
-        // Check if we got an HTTP error
-        /** @phpstan-ignore-next-line */
-        if ($result === false && isset($http_response_header)) {
-            // Parse status code from headers
-            /** @phpstan-ignore-next-line */
-            if (preg_match('/HTTP\/\d\.\d\s+(\d+)/', (string)$http_response_header[0], $matches)) {
-                $statusCode = (int)$matches[1];
-                if ($statusCode >= 400) {
-                    error_log("GeoTelemetry: HTTP {$statusCode} error fetching {$url}");
-                }
-            }
-        }
+        // With ignore_errors enabled, file_get_contents() returns the
+        // response body even for HTTP 4xx/5xx, so check headers on every
+        // request rather than only when $result === false.
+        $this->logHttpError($url);
 
         return $result ?: '';
+    }
+
+    /**
+     * Log an HTTP error from the most recent file_get_contents() call.
+     *
+     * Uses http_get_last_response_headers() (PHP 8.5+). The previous
+     * implementation used $http_response_header, but that magic variable
+     * is scoped to the function that calls file_get_contents() directly,
+     * so it was never available here (file_get_contents is called inside
+     * the fileGetContents() wrapper method).
+     */
+    private function logHttpError(string $url): void
+    {
+        if (!function_exists('http_get_last_response_headers')) {
+            return;
+        }
+
+        $responseHeaders = http_get_last_response_headers();
+        if (!is_array($responseHeaders) || $responseHeaders === []) {
+            return;
+        }
+
+        $statusLine = $responseHeaders[0];
+        if (!is_string($statusLine)) {
+            return;
+        }
+
+        if (preg_match('/HTTP\/\d\.\d\s+(\d+)/', $statusLine, $matches)) {
+            $statusCode = (int)$matches[1];
+            if ($statusCode >= 400) {
+                ServiceContainer::getLogger()->warning('GeoTelemetry: HTTP error', [
+                    'statusCode' => $statusCode,
+                    'url' => $url,
+                ]);
+            }
+        }
     }
 
     /**

--- a/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
@@ -21,6 +21,7 @@ use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Logging\AuditConfig;
 use OpenEMR\Common\Logging\BreakglassCheckerInterface;
 use OpenEMR\Common\Logging\EventAuditLogger;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
@@ -2309,8 +2310,8 @@ final class EventAuditLoggerTest extends TestCase
     /**
      * Test logHttpRequest method with various HTTP request methods
      *
-     * @dataProvider httpRequestDataProvider
      */
+    #[DataProvider('httpRequestDataProvider')]
     public function testLogHttpRequestParameterized(
         string $method,
         string $script,

--- a/tests/Tests/Unit/Common/Session/SessionWrapperFactoryTest.php
+++ b/tests/Tests/Unit/Common/Session/SessionWrapperFactoryTest.php
@@ -20,6 +20,7 @@ namespace OpenEMR\Tests\Unit\Common\Session;
 
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -346,8 +347,8 @@ class SessionWrapperFactoryTest extends TestCase
     /**
      * Test that all non-portal session types route to core session
      *
-     * @dataProvider nonPortalSessionTypeProvider
      */
+    #[DataProvider('nonPortalSessionTypeProvider')]
     public function testAllNonPortalSessionTypesRouteToCore(string $sessionType): void
     {
         $_COOKIE[SessionUtil::APP_COOKIE_NAME] = $sessionType;
@@ -873,8 +874,8 @@ class SessionWrapperFactoryTest extends TestCase
     /**
      * Test: Injected session takes priority regardless of any App cookie value
      *
-     * @dataProvider appCookieProvider
      */
+    #[DataProvider('appCookieProvider')]
     public function testInjectedSessionTakesPriorityOverAnyCookie(string $cookieValue): void
     {
         $_COOKIE[SessionUtil::APP_COOKIE_NAME] = $cookieValue;

--- a/tests/Tests/Unit/FHIR/SMART/ClientAdminControllerTest.php
+++ b/tests/Tests/Unit/FHIR/SMART/ClientAdminControllerTest.php
@@ -18,6 +18,7 @@ use OpenEMR\Core\Kernel;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\FHIR\SMART\ClientAdminController;
 use OpenEMR\FHIR\SMART\ExternalClinicalDecisionSupport\RouteController;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -350,9 +351,7 @@ class ClientAdminControllerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider actionDataProvider
-     */
+    #[DataProvider('actionDataProvider')]
     public function testDispatchWithVariousActions(string $action, int $expectedStatusCode): void
     {
         // Arrange

--- a/tests/Tests/Unit/NumberToTextTest.php
+++ b/tests/Tests/Unit/NumberToTextTest.php
@@ -5,13 +5,12 @@
 namespace OpenEMR\Tests\Unit;
 
 use NumberToText;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class NumberToTextTest extends TestCase
 {
-  /**
-   * @dataProvider cases
-   */
+    #[DataProvider('cases')]
     public function testConvert($numeral, $text): void
     {
         $ntt = new NumberToText($numeral);

--- a/tests/Tests/Unit/Portal/PatientControllerSecurityTest.php
+++ b/tests/Tests/Unit/Portal/PatientControllerSecurityTest.php
@@ -64,7 +64,6 @@ class PatientControllerSecurityTest extends TestCase
      * 2. User attempts to modify patient ID 2's profile by manipulating the pid parameter
      * 3. The system should reject this unauthorized access attempt
      *
-     * @test
      */
     public function testUserCannotUpdateOtherUsersProfile(): void
     {
@@ -101,7 +100,6 @@ class PatientControllerSecurityTest extends TestCase
      * Even if authorization checks pass, users should never be able to
      * modify their own pid or pubpid as these are internal system identifiers
      *
-     * @test
      */
     public function testPidAndPubpidCannotBeModifiedByUser(): void
     {
@@ -127,7 +125,6 @@ class PatientControllerSecurityTest extends TestCase
     /**
      * Test that authorization check properly validates session pid
      *
-     * @test
      */
     public function testAuthorizationCheckValidatesSessionPid(): void
     {
@@ -155,7 +152,6 @@ class PatientControllerSecurityTest extends TestCase
     /**
      * Test that authorization prevents IDOR (Insecure Direct Object Reference)
      *
-     * @test
      */
     public function testIDORAttackPrevention(): void
     {
@@ -217,7 +213,6 @@ class PatientControllerSecurityTest extends TestCase
      * 2. User A modifies request to target User B's profile
      * 3. System should reject the cross-account modification
      *
-     * @test
      */
     public function testCompleteAttackScenarioFromAdvisory(): void
     {


### PR DESCRIPTION
## Summary

Enforce deprecation-free test suites by making PHP and PHPUnit deprecations fail the build.

- Add `failOnDeprecation` and `failOnPhpunitDeprecation` to all three PHPUnit configs (`phpunit.xml`, `phpunit-isolated.xml`, `phpunit.integration.xml`)
- Add `<source ignoreIndirectDeprecations="true">` with include-all / exclude-vendor so vendor/third-party deprecations are displayed but don't break the build — only first-party code deprecations are enforced
- Fix two first-party PHP deprecations:
  - **CdaTemplateParse**: guard `array_key_exists()` against `null` key (deprecated in PHP 8.5)
  - **GeoTelemetry**: replace broken `$http_response_header` usage with `http_get_last_response_headers()` (PHP 8.5+). The previous code never actually worked because `$http_response_header` is scoped to the function that calls `file_get_contents()` directly, and the call goes through a wrapper method. Also call `logHttpError()` unconditionally since `ignore_errors => true` means `$result` is rarely `false` on HTTP errors.
- Convert 10 PHPUnit doc-comment annotations to PHP 8 attributes:
  - `@dataProvider` → `#[DataProvider(...)]` in EventAuditLoggerTest, SessionWrapperFactoryTest, ClientAdminControllerTest, NumberToTextTest
  - Remove redundant `@test` annotations from PatientControllerSecurityTest (methods already start with `test`)
- Upgrade `phpunit.integration.xml` schema from 10.3 to 11.5
- Remove deprecated `stopOnWarning` attribute from `phpunit-isolated.xml`
- Remove obsolete `<coverage cacheDirectory>` from `phpunit.integration.xml`
- Whitelist `http_get_last_response_headers` in composer-require-checker (PHP 8.5 built-in not yet in checker's stubs)

## Test plan

- [x] Isolated tests pass locally (PHP 8.2–8.6) with zero deprecations
- [x] CI: all test suites pass
