### PR TITLE
fix(php85): resolve deprecations in services test suite

### DIFF
--- a/.phpstan/baseline/openemr.forbiddenCurlFunction.php
+++ b/.phpstan/baseline/openemr.forbiddenCurlFunction.php
@@ -267,11 +267,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../modules/sms_email_reminder/sms_tmb4.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Raw curl_\\* function curl_close\\(\\) is forbidden\\. Use GuzzleHttp\\\\Client or OpenEMR\\\\Common\\\\Http\\\\oeHttp instead\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/Cda/CdaValidateDocuments.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Raw curl_\\* function curl_error\\(\\) is forbidden\\. Use GuzzleHttp\\\\Client or OpenEMR\\\\Common\\\\Http\\\\oeHttp instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/Cda/CdaValidateDocuments.php',

--- a/src/Services/Cda/CdaValidateDocuments.php
+++ b/src/Services/Cda/CdaValidateDocuments.php
@@ -175,8 +175,6 @@ class CdaValidateDocuments
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
         $response = curl_exec($ch);
-        curl_close($ch);
-
         $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
         if ($status == '200') {
             $reply = json_decode($response, true);
@@ -237,7 +235,6 @@ class CdaValidateDocuments
                     xlt('Request Status') . ':' . $status
             ];
         }
-        curl_close($ch);
         if ($status == '200') {
             $reply = json_decode($response, true);
         }

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -533,6 +533,9 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
     }
     protected function getCachedListOption($list_id, $option_id): ?array
     {
+        if ($option_id === null) {
+            return null;
+        }
         if (!isset($this->cachedListOptions[$list_id])) {
             $this->cachedListOptions[$list_id] = [];
         }


### PR DESCRIPTION
## Summary

Fix PHP 8.5 deprecations caught by the new `failOnDeprecation=true` setting in the services test suite (#11638).

- **CdaValidateDocuments**: remove both deprecated `curl_close()` calls (no-op since PHP 8.0, deprecated in 8.5). Also fixes a pre-existing bug where `curl_getinfo()` was called *after* `curl_close()`, which would return incorrect results.
- **FhirPatientService**: guard `getCachedListOption()` against null `$option_id` to prevent "using null as an array offset" deprecation in PHP 8.5.

## Test plan

- [x] CI: full test matrix passes (via `Test-Mode: full` trailer)
