### PR TITLE
chore(db): Baseline tooling for doctrine/migrations conversion

### DIFF
--- a/db/Migrations/README.md
+++ b/db/Migrations/README.md
@@ -1,0 +1,37 @@
+# Doctrine Migrations
+
+## CreateTableTrait
+
+Use `CreateTableTrait` for migrations that create tables. It sets appropriate charset/collation and generates platform-specific SQL.
+
+```php
+final class Version20260000000001 extends AbstractMigration
+{
+    use CreateTableTrait;
+
+    public function up(Schema $schema): void
+    {
+        $table = new Table('foos');
+        $table->addColumn('id', Types::INTEGER, ['default' => 0]);
+        // ...
+        $this->addPrimaryKey($table, 'id');
+
+        $this->createTable($table);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE foos');
+    }
+}
+```
+
+### Why not use `$schema->createTable()`?
+
+The standard Doctrine approach requires schema introspection to diff current vs desired state.
+This adds overhead and complexity, and will cause migrations to get steadily slower (minutes vs milliseconds) as more exist.
+
+### Methods
+
+- `createTable(Table $table)` - Sets charset/collation options and adds the CREATE TABLE SQL
+- `addPrimaryKey(Table $table, string $column, string ...$otherColumns)` - Adds a primary key constraint

--- a/db/migration-template.php.tpl
+++ b/db/migration-template.php.tpl
@@ -14,9 +14,12 @@ namespace <namespace>;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Migrations\AbstractMigration;
+use OpenEMR\Core\Migrations;
 
 final class <className> extends AbstractMigration
 {
+    use CreateTableTrait;
+
     public function getDescription(): string
     {
         return '';

--- a/src/Core/Migrations/CreateTableTrait.php
+++ b/src/Core/Migrations/CreateTableTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @package   OpeENR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Core\Migrations;
+
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
+
+/**
+ * Trait for migrations that create tables.
+ *
+ * Generates platform-specific SQL without schema introspection overhead.
+ */
+trait CreateTableTrait
+{
+    private function createTable(Table $table): void
+    {
+        $table->addOption('charset', 'utf8mb4');
+        $table->addOption('collation', 'utf8mb4_general_ci');
+        $platform = $this->connection->getDatabasePlatform();
+        foreach ($platform->getCreateTableSQL($table) as $sql) {
+            $this->addSql($sql);
+        }
+    }
+
+    /**
+     * @param non-empty-string $column
+     * @param non-empty-string ...$otherColumns
+     */
+    private function addPrimaryKey(Table $table, string $column, string ...$otherColumns): void
+    {
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setUnquotedColumnNames($column, ...$otherColumns)
+                ->create()
+        );
+    }
+
+}

--- a/tests/Tests/Isolated/Core/Migrations/CreateTableTraitTest.php
+++ b/tests/Tests/Isolated/Core/Migrations/CreateTableTraitTest.php
@@ -15,10 +15,29 @@ namespace OpenEMR\Tests\Isolated\Core\Migrations;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\Migrations\AbstractMigration;
 use OpenEMR\Core\Migrations\CreateTableTrait;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+interface TestableCreateTableMigration
+{
+    public function runCreateTable(Table $table): void;
+
+    /**
+     * @param non-empty-string $column
+     * @param non-empty-string ...$otherColumns
+     */
+    public function runAddPrimaryKey(Table $table, string $column, string ...$otherColumns): void;
+
+    /**
+     * @return list<\Doctrine\Migrations\Query\Query>
+     */
+    public function getSql(): array;
+}
 
 #[Group('isolated')]
 #[Group('core')]
@@ -45,13 +64,16 @@ class CreateTableTraitTest extends TestCase
             }))
             ->willReturn($expectedSql);
 
-        $connection = $this->createStub(Connection::class);
+        $connection = self::createStub(Connection::class);
         $connection->method('getDatabasePlatform')->willReturn($platform);
 
-        $migration = new TestMigration($connection);
-        $migration->doCreateTable($table);
+        $migration = $this->createMigration($connection);
+        $migration->runCreateTable($table);
 
-        self::assertSame($expectedSql, $migration->getAddedSql());
+        self::assertSame($expectedSql, array_map(
+            static fn($q) => $q->getStatement(),
+            $migration->getSql(),
+        ));
     }
 
     public function testAddPrimaryKeyAddsSingleColumnPrimaryKey(): void
@@ -59,8 +81,8 @@ class CreateTableTraitTest extends TestCase
         $table = new Table('test_table');
         $table->addColumn('id', 'integer');
 
-        $migration = new TestMigration($this->createStub(Connection::class));
-        $migration->doAddPrimaryKey($table, 'id');
+        $migration = $this->createMigration(self::createStub(Connection::class));
+        $migration->runAddPrimaryKey($table, 'id');
 
         $pk = $table->getPrimaryKeyConstraint();
         self::assertNotNull($pk);
@@ -73,12 +95,37 @@ class CreateTableTraitTest extends TestCase
         $table->addColumn('user_id', 'integer');
         $table->addColumn('group_id', 'integer');
 
-        $migration = new TestMigration($this->createStub(Connection::class));
-        $migration->doAddPrimaryKey($table, 'user_id', 'group_id');
+        $migration = $this->createMigration(self::createStub(Connection::class));
+        $migration->runAddPrimaryKey($table, 'user_id', 'group_id');
 
         $pk = $table->getPrimaryKeyConstraint();
         self::assertNotNull($pk);
         self::assertSame(['user_id', 'group_id'], $this->extractColumnNames($pk->getColumnNames()));
+    }
+
+    private function createMigration(Connection $connection): TestableCreateTableMigration
+    {
+        return new class ($connection, new NullLogger()) extends AbstractMigration implements TestableCreateTableMigration {
+            use CreateTableTrait;
+
+            public function up(Schema $schema): void
+            {
+            }
+
+            public function runCreateTable(Table $table): void
+            {
+                $this->createTable($table);
+            }
+
+            /**
+             * @param non-empty-string $column
+             * @param non-empty-string ...$otherColumns
+             */
+            public function runAddPrimaryKey(Table $table, string $column, string ...$otherColumns): void
+            {
+                $this->addPrimaryKey($table, $column, ...$otherColumns);
+            }
+        };
     }
 
     /**
@@ -91,50 +138,5 @@ class CreateTableTraitTest extends TestCase
             static fn(UnqualifiedName $name): string => $name->toString(),
             $columnNames,
         );
-    }
-}
-
-/**
- * Test double that exposes the trait's methods for testing.
- */
-class TestMigration
-{
-    use CreateTableTrait;
-
-    /** @var list<string> */
-    private array $addedSql = [];
-
-    public function __construct(
-        /** @phpstan-ignore property.onlyWritten (Used by CreateTableTrait) */
-        private readonly Connection $connection,
-    ) {
-    }
-
-    public function doCreateTable(Table $table): void
-    {
-        $this->createTable($table);
-    }
-
-    /**
-     * @param non-empty-string $column
-     * @param non-empty-string ...$otherColumns
-     */
-    public function doAddPrimaryKey(Table $table, string $column, string ...$otherColumns): void
-    {
-        $this->addPrimaryKey($table, $column, ...$otherColumns);
-    }
-
-    /** @phpstan-ignore method.unused (Used by CreateTableTrait) */
-    private function addSql(string $sql): void
-    {
-        $this->addedSql[] = $sql;
-    }
-
-    /**
-     * @return list<string>
-     */
-    public function getAddedSql(): array
-    {
-        return $this->addedSql;
     }
 }

--- a/tests/Tests/Isolated/Core/Migrations/CreateTableTraitTest.php
+++ b/tests/Tests/Isolated/Core/Migrations/CreateTableTraitTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Core\Migrations;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\Table;
+use OpenEMR\Core\Migrations\CreateTableTrait;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+#[Group('core')]
+#[Group('migrations')]
+class CreateTableTraitTest extends TestCase
+{
+    public function testCreateTableSetsCharsetAndCollationAndAddsSql(): void
+    {
+        $table = new Table('test_table');
+        $table->addColumn('id', 'integer');
+
+        $expectedSql = [
+            'CREATE TABLE test_table (id INT NOT NULL)',
+            'ALTER TABLE test_table ADD PRIMARY KEY (id)',
+        ];
+
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
+            ->method('getCreateTableSQL')
+            ->with(self::callback(function (Table $t) {
+                self::assertSame('utf8mb4', $t->getOption('charset'));
+                self::assertSame('utf8mb4_general_ci', $t->getOption('collation'));
+                return true;
+            }))
+            ->willReturn($expectedSql);
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn($platform);
+
+        $migration = new TestMigration($connection);
+        $migration->doCreateTable($table);
+
+        self::assertSame($expectedSql, $migration->getAddedSql());
+    }
+
+    public function testAddPrimaryKeyAddsSingleColumnPrimaryKey(): void
+    {
+        $table = new Table('test_table');
+        $table->addColumn('id', 'integer');
+
+        $migration = new TestMigration($this->createStub(Connection::class));
+        $migration->doAddPrimaryKey($table, 'id');
+
+        $pk = $table->getPrimaryKeyConstraint();
+        self::assertNotNull($pk);
+        self::assertSame(['id'], $this->extractColumnNames($pk->getColumnNames()));
+    }
+
+    public function testAddPrimaryKeyAddsCompositeKey(): void
+    {
+        $table = new Table('test_table');
+        $table->addColumn('user_id', 'integer');
+        $table->addColumn('group_id', 'integer');
+
+        $migration = new TestMigration($this->createStub(Connection::class));
+        $migration->doAddPrimaryKey($table, 'user_id', 'group_id');
+
+        $pk = $table->getPrimaryKeyConstraint();
+        self::assertNotNull($pk);
+        self::assertSame(['user_id', 'group_id'], $this->extractColumnNames($pk->getColumnNames()));
+    }
+
+    /**
+     * @param list<UnqualifiedName> $columnNames
+     * @return list<string>
+     */
+    private function extractColumnNames(array $columnNames): array
+    {
+        return array_map(
+            static fn(UnqualifiedName $name): string => $name->toString(),
+            $columnNames,
+        );
+    }
+}
+
+/**
+ * Test double that exposes the trait's methods for testing.
+ */
+class TestMigration
+{
+    use CreateTableTrait;
+
+    /** @var list<string> */
+    private array $addedSql = [];
+
+    public function __construct(
+        /** @phpstan-ignore property.onlyWritten (Used by CreateTableTrait) */
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function doCreateTable(Table $table): void
+    {
+        $this->createTable($table);
+    }
+
+    /**
+     * @param non-empty-string $column
+     * @param non-empty-string ...$otherColumns
+     */
+    public function doAddPrimaryKey(Table $table, string $column, string ...$otherColumns): void
+    {
+        $this->addPrimaryKey($table, $column, ...$otherColumns);
+    }
+
+    /** @phpstan-ignore method.unused (Used by CreateTableTrait) */
+    private function addSql(string $sql): void
+    {
+        $this->addedSql[] = $sql;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getAddedSql(): array
+    {
+        return $this->addedSql;
+    }
+}


### PR DESCRIPTION
#### Short description of what this changes or resolves:
In projects using a lot of migration scripts (as OpenEMR inevitably will), there's an annoying behavior where the tooling will inspect the DB's schema (table by table, IIIRC) and get progressively slower as you have more tables and migration. We're talking minutes, not a few seconds.

This adds a trait that works around the issue, and at the same time sets up some default configuration for all tables. It also adds a convenience wrapper for creating PKs, since the default syntax is quite verbose for the common-case.

#### Changes proposed in this pull request:
Adds new migrations tooling trait and tests

#### Was an AI assistant used? Yes / No
Tests were AI