### PR TITLE
fix(messages): resolve index mismatch in deleteItem using ID-based matching

### DIFF
--- a/portal/messaging/messages.php
+++ b/portal/messaging/messages.php
@@ -246,13 +246,18 @@ function getAuthPortalUsers()
                     $scope.currentPage = this.n;
                 };
 
-                $scope.deleteItem = function (idx) {
+                $scope.deleteItem = function (item) {
                     if (!confirm($scope.xLate.confirm.one)) return false;
-                    const itemToDelete = $scope.allItems[idx];
-                    const idxInItems = $scope.items.indexOf(itemToDelete);
-                    $scope.deleteMessage(itemToDelete.mail_chain); // Just this user's message
-                    $scope.items.splice(idxInItems, 1);
-                    $scope.search();
+
+                    const itemId = item && item.id ? item.id : item;
+                    const idxInAllItems = $filter('getById')($scope.allItems, itemId);
+                    if (idxInAllItems === null) {
+                        return false;
+                    }
+
+                    const itemToDelete = $scope.allItems[idxInAllItems];
+                    $scope.deleteMessage(itemToDelete.mail_chain || itemToDelete.id);
+                    $scope.selected = null;
                     $scope.init()
                     return false;
                 };
@@ -694,7 +699,7 @@ function getAuthPortalUsers()
                                                 <span class='btn-group float-right m-0'>
                                                     <button ng-show="selected.sender_id != cUserId && selected.id == item.id" class="btn btn-primary btn-small" title="<?php echo xla('Reply to this message'); ?>" data-toggle="modal" data-mode="reply" data-noteid='{{selected.id}}' data-whoto='{{selected.sender_id}}' data-mtitle='{{selected.title}}' data-username='{{selected.sender_name}}' data-mailchain='{{selected.mail_chain}}' data-target="#modalCompose"><i class="fa fa-reply"></i></button>
                                                     <button ng-show="selected.id == item.id && selected.sender_id != cUserId && !isPortal" class="btn btn-primary btn-small" title="<?php echo xla('Forward message to practice.'); ?>" data-toggle="modal" data-mode="forward" data-noteid='{{selected.id}}' data-whoto='{{selected.sender_id}}' data-mtitle='{{selected.title}}' data-username='{{selected.sender_name}}' data-mailchain='{{selected.mail_chain}}' data-target="#modalCompose"><i class="fa fa-share"></i></button>
-                                                    <button ng-show='!isTrash && selected.id == item.id' class="btn btn-small btn-primary" ng-click="deleteItem(items.indexOf(selected))" title="<?php echo xla('Archive this message'); ?>" data-toggle="tooltip"><i class="fa fa-trash fa-1x"></i>
+                                                    <button ng-show='!isTrash && selected.id == item.id' class="btn btn-small btn-primary" ng-click="deleteItem(selected)" title="<?php echo xla('Archive this message'); ?>" data-toggle="tooltip"><i class="fa fa-trash fa-1x"></i>
                                                     </button>
                                                 </span>
                                                 <div class='col jumbotron jumbotron-fluid my-3 p-1 bg-light text-dark rounded border border-info' ng-show="selected.id == item.id">


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
Previously, deletion relied on the index from a filtered view (state.items) to access state.allItems, which could result in removing the wrong message. This change ensures the correct item is deleted regardless of filtering or ordering.In place of that I have implemented filtering on the basis of the Message  ID. Now  This will fix up the issue of deleting wrong messages due to the indexing miss-match  in both the files.

#### Changes proposed in this pull request:
- Switched from index-based to ID-based deletion in `deleteItem()`
- Fixed incorrect deletions caused by mismatch between filtered and full message lists

#### Was an AI assistant used? Yes / No
No
<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
