### PR TITLE
fix(background-services): recover stuck leases from crashed workers

### DIFF
--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -3669,16 +3669,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/background_services.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/background_services.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/chart_location_activity.php',
 ];
 $ignoreErrors[] = [

--- a/interface/reports/background_services.php
+++ b/interface/reports/background_services.php
@@ -122,8 +122,15 @@ if (!AclMain::aclCheckCore('admin', 'super')) {
  <tbody>  <!-- added for better print-ability -->
 <?php
 
-$res = sqlStatement("SELECT *, (`next_run` - INTERVAL `execute_interval` MINUTE) as `last_run_start`" .
-  " FROM `background_services` ORDER BY `sort_order`");
+// `is_busy` reflects the live lease rather than the legacy `running` flag
+// so stuck locks from crashed workers render as not-busy (see GH #11661).
+$res = sqlStatement(
+    "SELECT *,"
+    . " (`next_run` - INTERVAL `execute_interval` MINUTE) AS `last_run_start`,"
+    . " (`lock_expires_at` IS NOT NULL AND `lock_expires_at` > NOW()) AS `is_busy`"
+    . " FROM `background_services`"
+    . " ORDER BY `sort_order`"
+);
 while ($row = sqlFetchArray($res)) {
     ?>
   <tr>
@@ -143,7 +150,7 @@ while ($row = sqlFetchArray($res)) {
           <td align='center'><?php echo xlt('Not Applicable'); ?></td>
         <?php } ?>
 
-          <td align='center'><?php echo ($row['running'] > 0) ? xlt("Yes") : xlt("No"); ?></td>
+          <td align='center'><?php echo ($row['is_busy']) ? xlt("Yes") : xlt("No"); ?></td>
 
         <?php if ($row['running'] > -1) { ?>
           <td align='center'><?php echo text(DateFormatterUtils::oeFormatDateTime($row['last_run_start'], "global", true)); ?></td>

--- a/interface/reports/background_services.php
+++ b/interface/reports/background_services.php
@@ -14,6 +14,7 @@ require_once("../globals.php");
 
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Core\Header;
 use OpenEMR\Services\Utils\DateFormatterUtils;
 
@@ -124,14 +125,14 @@ if (!AclMain::aclCheckCore('admin', 'super')) {
 
 // `is_busy` reflects the live lease rather than the legacy `running` flag
 // so stuck locks from crashed workers render as not-busy (see GH #11661).
-$res = sqlStatement(
-    "SELECT *,"
-    . " (`next_run` - INTERVAL `execute_interval` MINUTE) AS `last_run_start`,"
-    . " (`lock_expires_at` IS NOT NULL AND `lock_expires_at` > NOW()) AS `is_busy`"
-    . " FROM `background_services`"
-    . " ORDER BY `sort_order`"
-);
-while ($row = sqlFetchArray($res)) {
+$rows = QueryUtils::fetchRecordsNoLog(<<<'SQL'
+    SELECT *,
+           (`next_run` - INTERVAL `execute_interval` MINUTE) AS `last_run_start`,
+           (`lock_expires_at` IS NOT NULL AND `lock_expires_at` > NOW()) AS `is_busy`
+      FROM `background_services`
+     ORDER BY `sort_order`
+    SQL, []);
+foreach ($rows as $row) {
     ?>
   <tr>
       <td align='center'><?php echo xlt($row['title']); ?></td>
@@ -172,7 +173,7 @@ while ($row = sqlFetchArray($res)) {
 
   </tr>
     <?php
-} // $row = sqlFetchArray($res) while
+} // foreach $rows
 ?>
 </tbody>
 </table>

--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -120,5 +120,5 @@ ALTER TABLE `form_eye_antseg`
 
 #IfMissingColumn background_services lock_expires_at
 ALTER TABLE `background_services`
-  ADD COLUMN `lock_expires_at` datetime DEFAULT NULL COMMENT 'Lease expiration (UTC). Set on acquire, cleared on release. Expired leases are automatically stolen by the next worker.';
+  ADD COLUMN `lock_expires_at` datetime DEFAULT NULL COMMENT 'Lease expiration. Compared with NOW() on acquire, so the stored value uses whatever session timezone is in effect (OpenEMR syncs it to gbl_time_zone). Set on acquire, cleared on release. Expired leases are automatically stolen by the next worker.';
 #EndIf

--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -117,3 +117,8 @@
 ALTER TABLE `form_eye_antseg`
   MODIFY COLUMN OSCONJ text;
 #EndIf
+
+#IfMissingColumn background_services lock_expires_at
+ALTER TABLE `background_services`
+  ADD COLUMN `lock_expires_at` datetime DEFAULT NULL COMMENT 'Lease expiration (UTC). Set on acquire, cleared on release. Expired leases are automatically stolen by the next worker.';
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -196,7 +196,7 @@ CREATE TABLE `background_services` (
   `function` varchar(127) NOT NULL COMMENT 'name of background service function',
   `require_once` varchar(255) default NULL COMMENT 'include file (if necessary)',
   `sort_order` int(11) NOT NULL default '100' COMMENT 'lower numbers will be run first',
-  `lock_expires_at` datetime DEFAULT NULL COMMENT 'Lease expiration (UTC). Set on acquire, cleared on release. Expired leases are automatically stolen by the next worker.',
+  `lock_expires_at` datetime DEFAULT NULL COMMENT 'Lease expiration. Compared with NOW() on acquire, so the stored value uses whatever session timezone is in effect (OpenEMR syncs it to gbl_time_zone). Set on acquire, cleared on release. Expired leases are automatically stolen by the next worker.',
   PRIMARY KEY  (`name`)
 ) ENGINE=InnoDB;
 

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -196,6 +196,7 @@ CREATE TABLE `background_services` (
   `function` varchar(127) NOT NULL COMMENT 'name of background service function',
   `require_once` varchar(255) default NULL COMMENT 'include file (if necessary)',
   `sort_order` int(11) NOT NULL default '100' COMMENT 'lower numbers will be run first',
+  `lock_expires_at` datetime DEFAULT NULL COMMENT 'Lease expiration (UTC). Set on acquire, cleared on release. Expired leases are automatically stolen by the next worker.',
   PRIMARY KEY  (`name`)
 ) ENGINE=InnoDB;
 

--- a/src/Common/Command/BackgroundServicesCommand.php
+++ b/src/Common/Command/BackgroundServicesCommand.php
@@ -40,11 +40,11 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
     {
         $this
             ->setName('background:services')
-            ->setDescription('List, run, or generate crontab entries for background services')
+            ->setDescription('List, run, unlock, or generate crontab entries for background services')
             ->setDefinition(
                 new InputDefinition([
-                    new InputArgument('action', InputArgument::REQUIRED, 'Action to perform: list, run, or crontab'),
-                    new InputOption('name', null, InputOption::VALUE_REQUIRED, 'Service name (required for "run")'),
+                    new InputArgument('action', InputArgument::REQUIRED, 'Action to perform: list, run, unlock, or crontab'),
+                    new InputOption('name', null, InputOption::VALUE_REQUIRED, 'Service name (required for "run" and "unlock")'),
                     new InputOption('force', 'f', InputOption::VALUE_NONE, 'Bypass interval check (for "run")'),
                     new InputOption('php', null, InputOption::VALUE_REQUIRED, 'PHP binary path (for "crontab")', PHP_BINARY),
                 ])
@@ -64,6 +64,7 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
         return match ($action) {
             'list' => $this->handleList($io),
             'run' => $this->handleRun($input, $io),
+            'unlock' => $this->handleUnlock($input, $io),
             'crontab' => $this->handleCrontab($input, $io),
             default => $this->handleUnknownAction($action, $io),
         };
@@ -170,10 +171,60 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
         return Command::SUCCESS;
     }
 
+    /**
+     * Clear a service's lease unconditionally.
+     *
+     * Normally not needed — crashed workers' leases expire and are stolen
+     * automatically on the next tick. Use this when a service is genuinely
+     * hung mid-run and an operator has verified it is not making progress
+     * but doesn't want to wait out the lease (see GH #11661).
+     */
+    private function handleUnlock(InputInterface $input, SymfonyStyle $io): int
+    {
+        $name = $input->getOption('name');
+        if (!is_string($name) || $name === '') {
+            $io->error('The --name option is required for the "unlock" action.');
+            return Command::FAILURE;
+        }
+
+        $affected = $this->clearLease($name);
+
+        if ($affected === 0) {
+            $io->error("Service '{$name}' not found.");
+            return Command::FAILURE;
+        }
+
+        $io->success("Lease cleared for service '{$name}'.");
+        return Command::SUCCESS;
+    }
+
     private function handleUnknownAction(string $action, SymfonyStyle $io): int
     {
-        $io->error("Unknown action '{$action}'. Valid actions: list, run, crontab");
+        $io->error("Unknown action '{$action}'. Valid actions: list, run, unlock, crontab");
         return Command::FAILURE;
+    }
+
+    /**
+     * Clear the lease (and legacy running flag) for a service.
+     *
+     * Returns the number of rows affected (0 when the service does not
+     * exist, 1 when the lease was cleared).
+     */
+    protected function clearLease(string $name): int
+    {
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE `background_services` SET `running` = 0, `lock_expires_at` = NULL WHERE `name` = ?',
+            [$name],
+            true,
+        );
+        // affectedRows() on a no-op UPDATE (e.g. already null/0) returns 0,
+        // which we want: it distinguishes a missing service from a live clear.
+        // Use a separate existence check so "already clear" still reports success.
+        $exists = QueryUtils::fetchRecordsNoLog(
+            'SELECT 1 FROM `background_services` WHERE `name` = ? LIMIT 1',
+            [$name],
+        );
+        return $exists === [] ? 0 : 1;
     }
 
     /**

--- a/src/Common/Command/BackgroundServicesCommand.php
+++ b/src/Common/Command/BackgroundServicesCommand.php
@@ -205,10 +205,12 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
     }
 
     /**
-     * Clear the lease (and legacy running flag) for a service.
+     * Clear the lease (and legacy running flag) for a service. The UPDATE
+     * is executed unconditionally; callers that need to distinguish "already
+     * clear" from "actively cleared" should check lock state beforehand.
      *
-     * Returns the number of rows affected (0 when the service does not
-     * exist, 1 when the lease was cleared).
+     * Returns 1 when the service exists (lease is now clear either way) or
+     * 0 when no service with that name exists.
      */
     protected function clearLease(string $name): int
     {

--- a/src/Common/Command/BackgroundServicesCommand.php
+++ b/src/Common/Command/BackgroundServicesCommand.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace OpenEMR\Common\Command;
 
 use OpenEMR\Common\Database\QueryUtils;
-use OpenEMR\Common\Database\TableTypes;
+use OpenEMR\Services\Background\BackgroundServiceDefinition;
 use OpenEMR\Services\Background\BackgroundServiceRunner;
 use OpenEMR\Services\IGlobalsAware;
 use OpenEMR\Services\Trait\GlobalInterfaceTrait;
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * @phpstan-import-type BackgroundServicesRow from TableTypes
+ * @phpstan-import-type BackgroundServicesQueryRow from BackgroundServiceDefinition
  */
 class BackgroundServicesCommand extends Command implements IGlobalsAware
 {
@@ -85,7 +85,10 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
                 $s['name'],
                 $s['title'],
                 (int) $s['active'] !== 0 ? 'yes' : 'no',
-                (int) $s['running'] === 1 ? 'yes' : 'no',
+                // Prefer the SQL-computed liveness flag over the legacy
+                // `running` column so stuck locks from crashed workers
+                // don't display as "yes" indefinitely.
+                (int) ($s['lease_is_live'] ?? $s['running']) === 1 ? 'yes' : 'no',
                 $this->formatInterval((int) $s['execute_interval']),
                 $s['next_run'],
             ], $services),
@@ -230,25 +233,34 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
     }
 
     /**
-     * @return list<BackgroundServicesRow>
+     * SQL-computed liveness flag (`lease_is_live`) is selected alongside
+     * the row so display/listing uses the same clock as acquireLock().
+     */
+    private const SELECT_WITH_LEASE_LIVE =
+        'SELECT background_services.*,'
+        . ' (lock_expires_at IS NOT NULL AND lock_expires_at > NOW()) AS lease_is_live'
+        . ' FROM background_services';
+
+    /**
+     * @return list<BackgroundServicesQueryRow>
      */
     protected function fetchServices(): array
     {
-        /** @var list<BackgroundServicesRow> */
+        /** @var list<BackgroundServicesQueryRow> */
         return QueryUtils::fetchRecordsNoLog(
-            'SELECT * FROM background_services ORDER BY sort_order',
+            self::SELECT_WITH_LEASE_LIVE . ' ORDER BY sort_order',
             [],
         );
     }
 
     /**
-     * @return list<BackgroundServicesRow>
+     * @return list<BackgroundServicesQueryRow>
      */
     protected function fetchActiveServices(): array
     {
-        /** @var list<BackgroundServicesRow> */
+        /** @var list<BackgroundServicesQueryRow> */
         return QueryUtils::fetchRecordsNoLog(
-            'SELECT * FROM background_services WHERE active = 1 AND execute_interval > 0 ORDER BY sort_order',
+            self::SELECT_WITH_LEASE_LIVE . ' WHERE active = 1 AND execute_interval > 0 ORDER BY sort_order',
             [],
         );
     }

--- a/src/Common/Command/BackgroundServicesCommand.php
+++ b/src/Common/Command/BackgroundServicesCommand.php
@@ -222,9 +222,11 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
             [$name],
             true,
         );
-        // affectedRows() on a no-op UPDATE (e.g. already null/0) returns 0,
-        // which we want: it distinguishes a missing service from a live clear.
-        // Use a separate existence check so "already clear" still reports success.
+        // The UPDATE runs unconditionally; its affected-row count would
+        // report 0 for "already clear" and 1 for "actively cleared",
+        // which is a distinction the caller doesn't care about. A
+        // dedicated existence check lets us report "not found" vs
+        // "service exists (lease is clear either way)".
         $exists = QueryUtils::fetchRecordsNoLog(
             'SELECT 1 FROM `background_services` WHERE `name` = ? LIMIT 1',
             [$name],

--- a/src/Common/Command/BackgroundServicesCommand.php
+++ b/src/Common/Command/BackgroundServicesCommand.php
@@ -18,6 +18,7 @@ namespace OpenEMR\Common\Command;
 
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Services\Background\BackgroundServiceDefinition;
+use OpenEMR\Services\Background\BackgroundServiceRegistry;
 use OpenEMR\Services\Background\BackgroundServiceRunner;
 use OpenEMR\Services\IGlobalsAware;
 use OpenEMR\Services\Trait\GlobalInterfaceTrait;
@@ -190,9 +191,7 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
             return Command::FAILURE;
         }
 
-        $affected = $this->clearLease($name);
-
-        if ($affected === 0) {
+        if (!$this->clearLease($name)) {
             $io->error("Service '{$name}' not found.");
             return Command::FAILURE;
         }
@@ -212,10 +211,10 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
      * is executed unconditionally; callers that need to distinguish "already
      * clear" from "actively cleared" should check lock state beforehand.
      *
-     * Returns 1 when the service exists (lease is now clear either way) or
-     * 0 when no service with that name exists.
+     * Returns true when the service exists (its lease is now clear either
+     * way), or false when no service with that name exists.
      */
-    protected function clearLease(string $name): int
+    protected function clearLease(string $name): bool
     {
         QueryUtils::sqlStatementThrowException(
             'UPDATE `background_services` SET `running` = 0, `lock_expires_at` = NULL WHERE `name` = ?',
@@ -231,17 +230,8 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
             'SELECT 1 FROM `background_services` WHERE `name` = ? LIMIT 1',
             [$name],
         );
-        return $exists === [] ? 0 : 1;
+        return $exists !== [];
     }
-
-    /**
-     * SQL-computed liveness flag (`lease_is_live`) is selected alongside
-     * the row so display/listing uses the same clock as acquireLock().
-     */
-    private const SELECT_WITH_LEASE_LIVE =
-        'SELECT background_services.*,'
-        . ' (lock_expires_at IS NOT NULL AND lock_expires_at > NOW()) AS lease_is_live'
-        . ' FROM background_services';
 
     /**
      * @return list<BackgroundServicesQueryRow>
@@ -250,7 +240,7 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
     {
         /** @var list<BackgroundServicesQueryRow> */
         return QueryUtils::fetchRecordsNoLog(
-            self::SELECT_WITH_LEASE_LIVE . ' ORDER BY sort_order',
+            BackgroundServiceRegistry::SELECT_WITH_LEASE_LIVE . ' ORDER BY sort_order',
             [],
         );
     }
@@ -262,7 +252,7 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
     {
         /** @var list<BackgroundServicesQueryRow> */
         return QueryUtils::fetchRecordsNoLog(
-            self::SELECT_WITH_LEASE_LIVE . ' WHERE active = 1 AND execute_interval > 0 ORDER BY sort_order',
+            BackgroundServiceRegistry::SELECT_WITH_LEASE_LIVE . ' WHERE `active` = 1 AND `execute_interval` > 0 ORDER BY `sort_order`',
             [],
         );
     }

--- a/src/Common/Database/TableTypes.php
+++ b/src/Common/Database/TableTypes.php
@@ -341,7 +341,8 @@ namespace OpenEMR\Common\Database;
  *   execute_interval: numeric-string,
  *   function: string,
  *   require_once: ?string,
- *   sort_order: numeric-string
+ *   sort_order: numeric-string,
+ *   lock_expires_at: ?string
  * }
  *
  * @phpstan-type FormsRow array{

--- a/src/Common/Database/TableTypes.php
+++ b/src/Common/Database/TableTypes.php
@@ -342,8 +342,7 @@ namespace OpenEMR\Common\Database;
  *   function: string,
  *   require_once: ?string,
  *   sort_order: numeric-string,
- *   lock_expires_at: ?string,
- *   lease_is_live?: ?numeric-string
+ *   lock_expires_at: ?string
  * }
  *
  * @phpstan-type FormsRow array{

--- a/src/Common/Database/TableTypes.php
+++ b/src/Common/Database/TableTypes.php
@@ -342,7 +342,8 @@ namespace OpenEMR\Common\Database;
  *   function: string,
  *   require_once: ?string,
  *   sort_order: numeric-string,
- *   lock_expires_at: ?string
+ *   lock_expires_at: ?string,
+ *   lease_is_live?: ?numeric-string
  * }
  *
  * @phpstan-type FormsRow array{

--- a/src/Services/Background/BackgroundServiceDefinition.php
+++ b/src/Services/Background/BackgroundServiceDefinition.php
@@ -18,7 +18,24 @@ namespace OpenEMR\Services\Background;
 use OpenEMR\Common\Database\TableTypes;
 
 /**
+ * The `lease_is_live` field is computed at query time by BackgroundServiceRegistry
+ * (e.g. `lock_expires_at > NOW() AS lease_is_live`) and is intentionally NOT part
+ * of the generated `BackgroundServicesRow` schema because it is not a table column.
+ *
  * @phpstan-import-type BackgroundServicesRow from TableTypes
+ * @phpstan-type BackgroundServicesQueryRow BackgroundServicesRow|array{
+ *   name: string,
+ *   title: string,
+ *   active: numeric-string,
+ *   running: numeric-string,
+ *   next_run: string,
+ *   execute_interval: numeric-string,
+ *   function: string,
+ *   require_once: ?string,
+ *   sort_order: numeric-string,
+ *   lock_expires_at: ?string,
+ *   lease_is_live: ?numeric-string
+ * }
  */
 final readonly class BackgroundServiceDefinition
 {
@@ -37,7 +54,7 @@ final readonly class BackgroundServiceDefinition
     }
 
     /**
-     * @param BackgroundServicesRow $row
+     * @param BackgroundServicesQueryRow $row
      */
     public static function fromDatabaseRow(array $row): self
     {
@@ -88,7 +105,7 @@ final readonly class BackgroundServiceDefinition
      * as acquireLock(). When absent — e.g. for test fixtures built by hand —
      * fall back to PHP-clock comparison.
      *
-     * @param BackgroundServicesRow $row
+     * @param BackgroundServicesQueryRow $row
      */
     private static function resolveRunning(array $row): bool
     {

--- a/src/Services/Background/BackgroundServiceDefinition.php
+++ b/src/Services/Background/BackgroundServiceDefinition.php
@@ -52,8 +52,11 @@ final readonly class BackgroundServiceDefinition
             // `running` is derived from the lease: a service is only
             // actually running if the lease exists and has not expired.
             // This means stuck locks from crashed workers report as
-            // not-running, matching reality.
-            running: self::leaseIsLive($row['lock_expires_at']),
+            // not-running, matching reality. Prefer the SQL-computed
+            // `lease_is_live` when present (same clock as acquireLock),
+            // falling back to PHP-clock comparison for callers that
+            // didn't select it.
+            running: self::resolveRunning($row),
             nextRun: $row['next_run'],
             lockExpiresAt: $row['lock_expires_at'],
         );
@@ -79,12 +82,33 @@ final readonly class BackgroundServiceDefinition
     }
 
     /**
-     * A lease is "live" when it has a future expiration timestamp.
-     * Treats malformed timestamps as not-live (fail safe — better to
-     * let the next tick attempt to re-acquire than to report a lock
-     * we can't interpret as held).
+     * Resolve whether a service is currently running from a DB row. Prefer
+     * the SQL-computed `lease_is_live` column when present, because it uses
+     * the same clock (MySQL NOW() under whatever session timezone applies)
+     * as acquireLock(). When absent — e.g. for test fixtures built by hand —
+     * fall back to PHP-clock comparison.
+     *
+     * @param BackgroundServicesRow $row
      */
-    private static function leaseIsLive(?string $lockExpiresAt): bool
+    private static function resolveRunning(array $row): bool
+    {
+        $liveFlag = $row['lease_is_live'] ?? null;
+        if ($liveFlag !== null) {
+            return (int) $liveFlag === 1;
+        }
+        return self::leaseIsLiveByPhpClock($row['lock_expires_at']);
+    }
+
+    /**
+     * Fallback for rows without an SQL-computed liveness flag. A lease is
+     * "live" when it has a future expiration timestamp. Treats malformed
+     * timestamps as not-live (fail safe — better to let the next tick
+     * attempt to re-acquire than to report a lock we can't interpret).
+     *
+     * Prefer the SQL-computed column (see `resolveRunning`) to avoid PHP
+     * and DB clock/timezone drift.
+     */
+    private static function leaseIsLiveByPhpClock(?string $lockExpiresAt): bool
     {
         if ($lockExpiresAt === null || $lockExpiresAt === '') {
             return false;

--- a/src/Services/Background/BackgroundServiceDefinition.php
+++ b/src/Services/Background/BackgroundServiceDefinition.php
@@ -15,15 +15,15 @@ declare(strict_types=1);
 
 namespace OpenEMR\Services\Background;
 
-use OpenEMR\Common\Database\TableTypes;
-
 /**
- * The `lease_is_live` field is computed at query time by BackgroundServiceRegistry
- * (e.g. `lock_expires_at > NOW() AS lease_is_live`) and is intentionally NOT part
- * of the generated `BackgroundServicesRow` schema because it is not a table column.
+ * The `lease_is_live` field is computed at query time (e.g.
+ * `lock_expires_at > NOW() AS lease_is_live`) and is intentionally NOT part
+ * of the generated `BackgroundServicesRow` schema because it is not a table
+ * column. All callers of `fromDatabaseRow()` MUST include it so liveness is
+ * always derived from the DB clock — never from PHP's `time()`, which can
+ * drift from the MySQL session timezone.
  *
- * @phpstan-import-type BackgroundServicesRow from TableTypes
- * @phpstan-type BackgroundServicesQueryRow BackgroundServicesRow|array{
+ * @phpstan-type BackgroundServicesQueryRow array{
  *   name: string,
  *   title: string,
  *   active: numeric-string,
@@ -66,21 +66,19 @@ final readonly class BackgroundServiceDefinition
             executeInterval: (int) $row['execute_interval'],
             sortOrder: (int) $row['sort_order'],
             active: (int) $row['active'] !== 0,
-            // `running` is derived from the lease: a service is only
-            // actually running if the lease exists and has not expired.
-            // This means stuck locks from crashed workers report as
-            // not-running, matching reality. Prefer the SQL-computed
-            // `lease_is_live` when present (same clock as acquireLock),
-            // falling back to PHP-clock comparison for callers that
-            // didn't select it.
-            running: self::resolveRunning($row),
+            // `running` reflects the live lease — not the legacy `running`
+            // column, which can be stale (e.g. set to 1 by a worker that
+            // crashed before release). `lease_is_live` is computed in SQL
+            // using the DB's own clock, so reporting matches what
+            // acquireLock() will enforce.
+            running: (int) ($row['lease_is_live'] ?? 0) === 1,
             nextRun: $row['next_run'],
             lockExpiresAt: $row['lock_expires_at'],
         );
     }
 
     /**
-     * @return BackgroundServicesRow
+     * @return BackgroundServicesQueryRow
      */
     public function toArray(): array
     {
@@ -95,42 +93,9 @@ final readonly class BackgroundServiceDefinition
             'require_once' => $this->requireOnce,
             'sort_order' => (string) $this->sortOrder,
             'lock_expires_at' => $this->lockExpiresAt,
+            // Emit the SQL-computed flag so a round-tripped row reports the
+            // same liveness after fromDatabaseRow() re-constructs it.
+            'lease_is_live' => $this->running ? '1' : '0',
         ];
-    }
-
-    /**
-     * Resolve whether a service is currently running from a DB row. Prefer
-     * the SQL-computed `lease_is_live` column when present, because it uses
-     * the same clock (MySQL NOW() under whatever session timezone applies)
-     * as acquireLock(). When absent — e.g. for test fixtures built by hand —
-     * fall back to PHP-clock comparison.
-     *
-     * @param BackgroundServicesQueryRow $row
-     */
-    private static function resolveRunning(array $row): bool
-    {
-        $liveFlag = $row['lease_is_live'] ?? null;
-        if ($liveFlag !== null) {
-            return (int) $liveFlag === 1;
-        }
-        return self::leaseIsLiveByPhpClock($row['lock_expires_at']);
-    }
-
-    /**
-     * Fallback for rows without an SQL-computed liveness flag. A lease is
-     * "live" when it has a future expiration timestamp. Treats malformed
-     * timestamps as not-live (fail safe — better to let the next tick
-     * attempt to re-acquire than to report a lock we can't interpret).
-     *
-     * Prefer the SQL-computed column (see `resolveRunning`) to avoid PHP
-     * and DB clock/timezone drift.
-     */
-    private static function leaseIsLiveByPhpClock(?string $lockExpiresAt): bool
-    {
-        if ($lockExpiresAt === null || $lockExpiresAt === '') {
-            return false;
-        }
-        $expiry = strtotime($lockExpiresAt);
-        return $expiry !== false && $expiry > time();
     }
 }

--- a/src/Services/Background/BackgroundServiceDefinition.php
+++ b/src/Services/Background/BackgroundServiceDefinition.php
@@ -32,6 +32,7 @@ final readonly class BackgroundServiceDefinition
         public readonly bool $active = false,
         public readonly bool $running = false,
         public readonly ?string $nextRun = null,
+        public readonly ?string $lockExpiresAt = null,
     ) {
     }
 
@@ -48,8 +49,13 @@ final readonly class BackgroundServiceDefinition
             executeInterval: (int) $row['execute_interval'],
             sortOrder: (int) $row['sort_order'],
             active: (int) $row['active'] !== 0,
-            running: (int) $row['running'] > 0,
+            // `running` is derived from the lease: a service is only
+            // actually running if the lease exists and has not expired.
+            // This means stuck locks from crashed workers report as
+            // not-running, matching reality.
+            running: self::leaseIsLive($row['lock_expires_at']),
             nextRun: $row['next_run'],
+            lockExpiresAt: $row['lock_expires_at'],
         );
     }
 
@@ -68,6 +74,22 @@ final readonly class BackgroundServiceDefinition
             'function' => $this->function,
             'require_once' => $this->requireOnce,
             'sort_order' => (string) $this->sortOrder,
+            'lock_expires_at' => $this->lockExpiresAt,
         ];
+    }
+
+    /**
+     * A lease is "live" when it has a future expiration timestamp.
+     * Treats malformed timestamps as not-live (fail safe — better to
+     * let the next tick attempt to re-acquire than to report a lock
+     * we can't interpret as held).
+     */
+    private static function leaseIsLive(?string $lockExpiresAt): bool
+    {
+        if ($lockExpiresAt === null || $lockExpiresAt === '') {
+            return false;
+        }
+        $expiry = strtotime($lockExpiresAt);
+        return $expiry !== false && $expiry > time();
     }
 }

--- a/src/Services/Background/BackgroundServiceRegistry.php
+++ b/src/Services/Background/BackgroundServiceRegistry.php
@@ -71,13 +71,23 @@ class BackgroundServiceRegistry
     }
 
     /**
+     * Projection that derives lease liveness in SQL so the "running"
+     * signal uses the same clock (and time_zone) as acquireLock(), rather
+     * than PHP's clock via `time()` + `strtotime()`.
+     */
+    private const SELECT_WITH_LEASE_LIVE =
+        'SELECT `background_services`.*,'
+        . ' (`lock_expires_at` IS NOT NULL AND `lock_expires_at` > NOW()) AS `lease_is_live`'
+        . ' FROM `background_services`';
+
+    /**
      * Get a single service by name, or null if not found.
      */
     public function get(string $name): ?BackgroundServiceDefinition
     {
         /** @var list<BackgroundServicesRow> $rows */
         $rows = QueryUtils::fetchRecordsNoLog(
-            'SELECT * FROM `background_services` WHERE `name` = ?',
+            self::SELECT_WITH_LEASE_LIVE . ' WHERE `name` = ?',
             [$name],
         );
 
@@ -95,7 +105,7 @@ class BackgroundServiceRegistry
      */
     public function list(?bool $activeFilter = null): array
     {
-        $sql = 'SELECT * FROM `background_services`';
+        $sql = self::SELECT_WITH_LEASE_LIVE;
         $binds = [];
 
         if ($activeFilter !== null) {

--- a/src/Services/Background/BackgroundServiceRegistry.php
+++ b/src/Services/Background/BackgroundServiceRegistry.php
@@ -19,10 +19,9 @@ declare(strict_types=1);
 namespace OpenEMR\Services\Background;
 
 use OpenEMR\Common\Database\QueryUtils;
-use OpenEMR\Common\Database\TableTypes;
 
 /**
- * @phpstan-import-type BackgroundServicesRow from TableTypes
+ * @phpstan-import-type BackgroundServicesQueryRow from BackgroundServiceDefinition
  */
 class BackgroundServiceRegistry
 {
@@ -73,19 +72,22 @@ class BackgroundServiceRegistry
     /**
      * Projection that derives lease liveness in SQL so the "running"
      * signal uses the same clock (and time_zone) as acquireLock(), rather
-     * than PHP's clock via `time()` + `strtotime()`.
+     * than PHP's clock via `time()` + `strtotime()`. Public so callers
+     * outside the registry (e.g. the CLI command) can reuse the same
+     * projection without duplicating the expression.
      */
-    private const SELECT_WITH_LEASE_LIVE =
-        'SELECT `background_services`.*,'
-        . ' (`lock_expires_at` IS NOT NULL AND `lock_expires_at` > NOW()) AS `lease_is_live`'
-        . ' FROM `background_services`';
+    public const SELECT_WITH_LEASE_LIVE = <<<'SQL'
+        SELECT `background_services`.*,
+               (`lock_expires_at` IS NOT NULL AND `lock_expires_at` > NOW()) AS `lease_is_live`
+          FROM `background_services`
+        SQL;
 
     /**
      * Get a single service by name, or null if not found.
      */
     public function get(string $name): ?BackgroundServiceDefinition
     {
-        /** @var list<BackgroundServicesRow> $rows */
+        /** @var list<BackgroundServicesQueryRow> $rows */
         $rows = QueryUtils::fetchRecordsNoLog(
             self::SELECT_WITH_LEASE_LIVE . ' WHERE `name` = ?',
             [$name],
@@ -115,7 +117,7 @@ class BackgroundServiceRegistry
 
         $sql .= ' ORDER BY `sort_order`';
 
-        /** @var list<BackgroundServicesRow> $rows */
+        /** @var list<BackgroundServicesQueryRow> $rows */
         $rows = QueryUtils::fetchRecordsNoLog($sql, $binds);
 
         return array_map(

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -219,7 +219,7 @@ class BackgroundServiceRunner
                AND (lock_expires_at IS NULL OR lock_expires_at < NOW())
             SQL;
         if (!$force) {
-            $sql .= "\n   AND NOW() > next_run";
+            $sql .= ' AND NOW() > next_run';
         }
 
         QueryUtils::sqlStatementThrowException(

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -234,12 +234,18 @@ class BackgroundServiceRunner
             return null;
         }
 
-        // Distinguish why we failed: lease still live, or just not yet due?
-        $currentExpiry = $this->readLeaseExpiry($service['name']);
-        if ($currentExpiry === false) {
-            return 'error';
-        }
-        if ($currentExpiry !== null) {
+        // Distinguish why the UPDATE failed: is a LIVE lease held, or
+        // is the lease expired/null and the service simply not yet due?
+        // Checking `lock_expires_at > NOW()` in SQL ensures an expired
+        // lease does not get misreported as 'already_running' when the
+        // true reason is 'not_due'.
+        $liveLease = QueryUtils::querySingleRow(
+            'SELECT 1 AS live FROM background_services'
+            . ' WHERE name = ? AND lock_expires_at > NOW()',
+            [$service['name']],
+            false,
+        );
+        if (is_array($liveLease)) {
             return 'already_running';
         }
         return $force ? 'already_running' : 'not_due';
@@ -255,15 +261,12 @@ class BackgroundServiceRunner
     }
 
     /**
-     * Read the current lease expiration for a service.
-     *
-     * Returns the stored timestamp string when a lease exists, null when
-     * no lease is held, and false when the row is missing entirely (which
-     * callers treat as an error).
-     *
-     * @return string|false|null
+     * Read the current lease expiration for a service, used to detect
+     * the prior state before attempting an acquire. Returns the stored
+     * timestamp string when a lease exists (expired or live) or null
+     * when no lease is held or the row is missing.
      */
-    private function readLeaseExpiry(string $serviceName): string|false|null
+    private function readLeaseExpiry(string $serviceName): ?string
     {
         $row = QueryUtils::querySingleRow(
             'SELECT lock_expires_at FROM background_services WHERE name = ?',
@@ -271,8 +274,8 @@ class BackgroundServiceRunner
             false,
         );
 
-        if ($row === false) {
-            return false;
+        if (!is_array($row)) {
+            return null;
         }
 
         $value = $row['lock_expires_at'] ?? null;

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -198,7 +198,13 @@ class BackgroundServiceRunner
     protected function acquireLock(array $service, bool $force): ?string
     {
         $leaseMinutes = $this->computeLeaseMinutes($service);
-        $priorExpiry = $this->readLeaseExpiry($service['name']);
+        // Best-effort "prior lease" signal reused from the row we already
+        // have. If the value turns out to be stale (another worker cleared
+        // or acquired between our fetch and the UPDATE below), the only
+        // cost is a missed or extra warning log — the atomic UPDATE still
+        // arbitrates who wins. A dedicated pre-read would not be fully
+        // race-free either, and it costs an extra round-trip per tick.
+        $priorExpiry = $service['lock_expires_at'];
 
         // Atomic acquire-or-steal. The UPDATE matches only when:
         //   - no lease is held (lock_expires_at IS NULL), or
@@ -258,28 +264,6 @@ class BackgroundServiceRunner
             [$serviceName],
             true,
         );
-    }
-
-    /**
-     * Read the current lease expiration for a service, used to detect
-     * the prior state before attempting an acquire. Returns the stored
-     * timestamp string when a lease exists (expired or live) or null
-     * when no lease is held or the row is missing.
-     */
-    private function readLeaseExpiry(string $serviceName): ?string
-    {
-        $row = QueryUtils::querySingleRow(
-            'SELECT lock_expires_at FROM background_services WHERE name = ?',
-            [$serviceName],
-            false,
-        );
-
-        if (!is_array($row)) {
-            return null;
-        }
-
-        $value = $row['lock_expires_at'] ?? null;
-        return is_string($value) ? $value : null;
     }
 
     /**

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -6,6 +6,12 @@
  * Extracted from library/ajax/execute_background_services.php to enable
  * reuse from CLI tooling and REST API endpoints.
  *
+ * Locking is lease-based: each acquire sets `lock_expires_at` to a future
+ * timestamp and clears it on release. If a worker crashes before releasing
+ * (SIGKILL, OOM, container restart, DB disconnect), the next tick atomically
+ * steals the expired lease, so background services self-recover without
+ * operator intervention. See GH issue #11661.
+ *
  * @package   OpenEMR
  *
  * @link      https://www.open-emr.org
@@ -18,19 +24,42 @@ declare(strict_types=1);
 
 namespace OpenEMR\Services\Background;
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Database\TableTypes;
 use OpenEMR\Common\Filesystem\SafeIncludeResolver;
 use OpenEMR\Core\OEGlobalsBag;
+use Psr\Log\LoggerInterface;
 
 /**
  * @phpstan-import-type BackgroundServicesRow from TableTypes
  */
 class BackgroundServiceRunner
 {
+    /**
+     * Default lease duration floor. Every acquired lease is at least this
+     * long, giving a reasonable recovery window even for short-interval
+     * services (e.g. interval = 1 min should not expire after 2 min).
+     */
+    private const MIN_LEASE_MINUTES = 60;
+
+    /**
+     * Lease duration ceiling. Caps a pathological configuration (e.g.
+     * interval = 1 week) from making a stuck lock unrecoverable for an
+     * unreasonable amount of time.
+     */
+    private const MAX_LEASE_MINUTES = 1440;
+
     private ?string $currentServiceName = null;
 
     private bool $shutdownRegistered = false;
+
+    private readonly LoggerInterface $logger;
+
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->logger = $logger ?? ServiceContainer::getLogger();
+    }
 
     /**
      * Run one or all background services.
@@ -40,8 +69,8 @@ class BackgroundServiceRunner
      * @return list<array{name: string, status: string}> Results per service
      *   Possible status values:
      *   - 'executed'        — service ran successfully
-     *   - 'skipped'         — inactive, already running (in-memory check), or manual-mode without --force
-     *   - 'already_running' — another process holds the DB lock (running = 1)
+     *   - 'skipped'         — inactive, or manual-mode without --force
+     *   - 'already_running' — another process holds an unexpired lease
      *   - 'not_due'         — interval has not elapsed yet (NOW() <= next_run)
      *   - 'error'           — exception during lock acquisition or execution
      *   - 'not_found'       — requested service name does not exist
@@ -64,8 +93,10 @@ class BackgroundServiceRunner
         foreach ($services as $service) {
             $name = $service['name'];
 
-            // ADOdb returns string values; use loose comparison for DB row checks
-            if ($service['active'] == 0 || $service['running'] == 1) {
+            // ADOdb returns string values; use loose comparison for DB row checks.
+            // Note: the `running` column is not consulted here — acquireLock()
+            // is authoritative and can steal a lease left by a crashed worker.
+            if ($service['active'] == 0) {
                 $results[] = ['name' => $name, 'status' => 'skipped'];
                 continue;
             }
@@ -107,6 +138,10 @@ class BackgroundServiceRunner
     /**
      * Register a shutdown handler that releases the lock if the process exits
      * abnormally during service execution. Called automatically by run().
+     *
+     * Shutdown handlers do NOT fire on SIGKILL, OOM kill, container restart,
+     * host crash, or fatal DB connection loss. For those cases, the lease
+     * expires naturally and acquireLock() steals it on the next tick.
      */
     public function registerShutdownHandler(): void
     {
@@ -145,11 +180,16 @@ class BackgroundServiceRunner
     }
 
     /**
-     * Attempt to acquire the running lock for a service.
+     * Attempt to acquire a lease on the service.
+     *
+     * The acquire is atomic: the UPDATE matches only when no lease is held,
+     * or the existing lease has expired. An expired lease is stolen (a
+     * previous worker crashed before releasing) and a warning is logged so
+     * operators get a signal instead of silent self-healing.
      *
      * Returns null on success (lock acquired), or a reason string when the
      * lock could not be acquired:
-     *   - 'already_running' — another process holds the lock (running = 1)
+     *   - 'already_running' — another process holds an unexpired lease
      *   - 'not_due'         — the service interval has not elapsed yet
      *
      * @param BackgroundServicesRow $service
@@ -157,59 +197,116 @@ class BackgroundServiceRunner
      */
     protected function acquireLock(array $service, bool $force): ?string
     {
-        $sql = 'UPDATE background_services SET running = 1, next_run = NOW() + INTERVAL ?'
-            . ' MINUTE WHERE running < 1 ' . ($force ? '' : 'AND NOW() > next_run ') . 'AND name = ?';
+        $leaseMinutes = $this->computeLeaseMinutes($service);
+        $priorExpiry = $this->readLeaseExpiry($service['name']);
 
-        QueryUtils::sqlStatementThrowException($sql, [$service['execute_interval'], $service['name']], true);
+        // Atomic acquire-or-steal. The UPDATE matches only when:
+        //   - no lease is held (lock_expires_at IS NULL), or
+        //   - the existing lease has expired (prior worker crashed)
+        // and, unless --force, the service is due (NOW() > next_run).
+        $sql = 'UPDATE background_services'
+            . ' SET running = 1,'
+            . '     lock_expires_at = NOW() + INTERVAL ? MINUTE,'
+            . '     next_run = NOW() + INTERVAL ? MINUTE'
+            . ' WHERE name = ?'
+            . '   AND (lock_expires_at IS NULL OR lock_expires_at < NOW())'
+            . ($force ? '' : ' AND NOW() > next_run');
+
+        QueryUtils::sqlStatementThrowException(
+            $sql,
+            [$leaseMinutes, (int) $service['execute_interval'], $service['name']],
+            true,
+        );
 
         if (QueryUtils::affectedRows() >= 1) {
+            if ($priorExpiry !== null) {
+                // We stole a lease from a crashed worker. Operators should
+                // see a signal, not silent self-healing — almost always this
+                // indicates an OOM kill, SIGKILL, or container restart.
+                $this->logger->warning(
+                    'Background service lease recovered from crashed worker.',
+                    [
+                        'service' => $service['name'],
+                        'prior_lease_expired_at' => $priorExpiry,
+                    ],
+                );
+            }
             return null;
         }
 
-        // Distinguish why the lock was not acquired: is the service already
-        // running (another process holds the lock) or is it simply not yet due?
-        $row = QueryUtils::querySingleRow(
-            'SELECT running FROM background_services WHERE name = ?',
-            [$service['name']],
-            false,
-        );
-
-        if ($row === false) {
+        // Distinguish why we failed: lease still live, or just not yet due?
+        $currentExpiry = $this->readLeaseExpiry($service['name']);
+        if ($currentExpiry === false) {
             return 'error';
         }
-
-        if (($row['running'] ?? '0') === '1') {
+        if ($currentExpiry !== null) {
             return 'already_running';
         }
-
         return $force ? 'already_running' : 'not_due';
     }
 
     protected function releaseLock(string $serviceName): void
     {
         QueryUtils::sqlStatementThrowException(
-            'UPDATE background_services SET running = 0 WHERE name = ?',
+            'UPDATE background_services SET running = 0, lock_expires_at = NULL WHERE name = ?',
             [$serviceName],
             true,
         );
     }
 
     /**
+     * Read the current lease expiration for a service.
+     *
+     * Returns the stored timestamp string when a lease exists, null when
+     * no lease is held, and false when the row is missing entirely (which
+     * callers treat as an error).
+     *
+     * @return string|false|null
+     */
+    private function readLeaseExpiry(string $serviceName): string|false|null
+    {
+        $row = QueryUtils::querySingleRow(
+            'SELECT lock_expires_at FROM background_services WHERE name = ?',
+            [$serviceName],
+            false,
+        );
+
+        if ($row === false) {
+            return false;
+        }
+
+        $value = $row['lock_expires_at'] ?? null;
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Compute the lease duration for a service. At least MIN_LEASE_MINUTES,
+     * at most MAX_LEASE_MINUTES, otherwise 2x the execution interval so that
+     * a normal run comfortably fits inside its lease.
+     *
+     * @param BackgroundServicesRow $service
+     */
+    private function computeLeaseMinutes(array $service): int
+    {
+        $proposed = max(self::MIN_LEASE_MINUTES, ((int) $service['execute_interval']) * 2);
+        return min($proposed, self::MAX_LEASE_MINUTES);
+    }
+
+    /**
      * Release a lock, swallowing exceptions so cleanup failures don't break
      * orchestration or crash shutdown handlers.
      *
-     * Note: If the underlying DB update to clear the `running` flag fails,
-     * the lock will remain set and this runner will continue to skip the
-     * service on subsequent runs. In that case, the stuck lock must be
-     * cleared manually or by a separate lock-recovery mechanism.
+     * If the underlying DB update fails, the lease remains set; the next
+     * tick will see it expire naturally and recover — no manual operator
+     * intervention required.
      */
     private function safeReleaseLock(string $serviceName): void
     {
         try {
             $this->releaseLock($serviceName);
         } catch (\Throwable) {
-            // Best-effort only: on failure the `running` flag remains set and
-            // must be cleared manually or by a separate recovery mechanism.
+            // Best-effort only: the lease expires naturally and is stolen
+            // on the next tick, so no operator intervention is required.
         }
     }
 

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -210,13 +210,17 @@ class BackgroundServiceRunner
         //   - no lease is held (lock_expires_at IS NULL), or
         //   - the existing lease has expired (prior worker crashed)
         // and, unless --force, the service is due (NOW() > next_run).
-        $sql = 'UPDATE background_services'
-            . ' SET running = 1,'
-            . '     lock_expires_at = NOW() + INTERVAL ? MINUTE,'
-            . '     next_run = NOW() + INTERVAL ? MINUTE'
-            . ' WHERE name = ?'
-            . '   AND (lock_expires_at IS NULL OR lock_expires_at < NOW())'
-            . ($force ? '' : ' AND NOW() > next_run');
+        $sql = <<<'SQL'
+            UPDATE background_services
+               SET running = 1,
+                   lock_expires_at = NOW() + INTERVAL ? MINUTE,
+                   next_run = NOW() + INTERVAL ? MINUTE
+             WHERE name = ?
+               AND (lock_expires_at IS NULL OR lock_expires_at < NOW())
+            SQL;
+        if (!$force) {
+            $sql .= "\n   AND NOW() > next_run";
+        }
 
         QueryUtils::sqlStatementThrowException(
             $sql,
@@ -246,8 +250,11 @@ class BackgroundServiceRunner
         // lease does not get misreported as 'already_running' when the
         // true reason is 'not_due'.
         $liveLease = QueryUtils::querySingleRow(
-            'SELECT 1 AS live FROM background_services'
-            . ' WHERE name = ? AND lock_expires_at > NOW()',
+            <<<'SQL'
+            SELECT 1 AS live
+              FROM background_services
+             WHERE name = ? AND lock_expires_at > NOW()
+            SQL,
             [$service['name']],
             false,
         );
@@ -257,6 +264,16 @@ class BackgroundServiceRunner
         return $force ? 'already_running' : 'not_due';
     }
 
+    /**
+     * Release the lease for a service by clearing `lock_expires_at` (and
+     * the legacy `running` flag).
+     *
+     * @throws \OpenEMR\Common\Database\SqlQueryException when the UPDATE
+     *         cannot be executed — e.g. the DB connection is dead, the
+     *         table/column is missing, or a deadlock aborted the statement.
+     *         Orchestration callers that must survive cleanup failures
+     *         should call safeReleaseLock() instead.
+     */
     protected function releaseLock(string $serviceName): void
     {
         QueryUtils::sqlStatementThrowException(
@@ -280,12 +297,20 @@ class BackgroundServiceRunner
     }
 
     /**
-     * Release a lock, swallowing exceptions so cleanup failures don't break
-     * orchestration or crash shutdown handlers.
+     * Release a lock, swallowing the expected cleanup-path failures from
+     * `releaseLock()` so they don't break orchestration or crash shutdown
+     * handlers. Specifically, this absorbs:
      *
-     * If the underlying DB update fails, the lease remains set; the next
-     * tick will see it expire naturally and recover — no manual operator
-     * intervention required.
+     *   - `SqlQueryException` — transient DB errors (dropped connection,
+     *     deadlock, lock-wait timeout) that happen mid-cleanup.
+     *   - `\Error` subclasses from QueryUtils initialization during a
+     *     fatal shutdown (PDO gone, container half-torn-down, etc.)
+     *     where the runtime is already unwinding.
+     *
+     * The catch is `\Throwable` intentionally — shutdown handlers run in
+     * contexts where even a TypeError must not propagate, and losing the
+     * release is not a correctness problem: the lease expires on its own
+     * and the next tick recovers it.
      */
     private function safeReleaseLock(string $serviceName): void
     {

--- a/tests/Tests/Isolated/Common/Command/BackgroundServicesCommandTest.php
+++ b/tests/Tests/Isolated/Common/Command/BackgroundServicesCommandTest.php
@@ -47,8 +47,14 @@ class BackgroundServicesCommandTest extends TestCase
         int $executeInterval = 5,
         string $nextRun = '2026-03-28 10:00:00',
         ?string $lockExpiresAt = null,
+        bool $leaseIsLive = false,
     ): array {
-        // Use string values to match ADOdb runtime behavior (numeric-string)
+        // `leaseIsLive` is intentionally independent of `running` and
+        // `lockExpiresAt` — production SQL derives it from
+        // `lock_expires_at > NOW()`, but tests need to exercise
+        // inconsistent-state rows too (e.g. stuck `running = 1` with an
+        // expired/NULL lease, which is the whole point of GH #11661).
+        // Use string values to match ADOdb runtime behavior (numeric-string).
         return [
             'name' => $name,
             'title' => $title,
@@ -60,7 +66,7 @@ class BackgroundServicesCommandTest extends TestCase
             'require_once' => null,
             'sort_order' => '100',
             'lock_expires_at' => $lockExpiresAt,
-            'lease_is_live' => $lockExpiresAt !== null && $running === 1 ? '1' : '0',
+            'lease_is_live' => $leaseIsLive ? '1' : '0',
         ];
     }
 
@@ -141,19 +147,43 @@ class BackgroundServicesCommandTest extends TestCase
         $this->assertStringContainsString('4h', $tester->getDisplay());
     }
 
-    public function testRunningColumnShowsNoForNegativeOne(): void
+    public function testRunningColumnShowsNoWhenLeaseNotLive(): void
     {
-        // The default value for running in the DB schema is -1
+        // The "Running" column in `list` renders from `lease_is_live`, not
+        // from the legacy `running` column. A row with `running = -1` (the
+        // DB default) and no live lease should show "no".
         $command = new BackgroundServicesCommandStub([
-            self::makeService('svc', 'Service', running: -1),
+            self::makeService('svc', 'Service', running: -1, leaseIsLive: false),
         ]);
         $tester = $this->createTester($command);
 
         $tester->execute(['action' => 'list']);
 
         $output = $tester->getDisplay();
-        // Active is "yes" (default), running should be "no" for -1
+        // Active is "yes" (default), running should be "no" when lease is not live
         $this->assertMatchesRegularExpression('/svc.*yes\s+no/s', $output);
+    }
+
+    public function testRunningColumnShowsNoForStuckLegacyFlagWithoutLiveLease(): void
+    {
+        // Regression guard for GH #11661: a row with the legacy `running`
+        // column stuck at 1 but no live lease (crashed worker) must render
+        // as "no" — the whole point of the fix is that stuck locks don't
+        // display as running forever.
+        $command = new BackgroundServicesCommandStub([
+            self::makeService(
+                'svc',
+                'Service',
+                running: 1,
+                lockExpiresAt: '2020-01-01 00:00:00',
+                leaseIsLive: false,
+            ),
+        ]);
+        $tester = $this->createTester($command);
+
+        $tester->execute(['action' => 'list']);
+
+        $this->assertMatchesRegularExpression('/svc.*yes\s+no/s', $tester->getDisplay());
     }
 
     public function testMinutesToCronSubHour(): void

--- a/tests/Tests/Isolated/Common/Command/BackgroundServicesCommandTest.php
+++ b/tests/Tests/Isolated/Common/Command/BackgroundServicesCommandTest.php
@@ -46,6 +46,7 @@ class BackgroundServicesCommandTest extends TestCase
         int $running = 0,
         int $executeInterval = 5,
         string $nextRun = '2026-03-28 10:00:00',
+        ?string $lockExpiresAt = null,
     ): array {
         // Use string values to match ADOdb runtime behavior (numeric-string)
         return [
@@ -58,6 +59,7 @@ class BackgroundServicesCommandTest extends TestCase
             'function' => 'test_fn',
             'require_once' => null,
             'sort_order' => '100',
+            'lock_expires_at' => $lockExpiresAt,
         ];
     }
 
@@ -212,6 +214,42 @@ class BackgroundServicesCommandTest extends TestCase
 
         $this->assertStringContainsString('0 0 * * *', $tester->getDisplay());
     }
+
+    public function testUnlockRequiresName(): void
+    {
+        $command = new BackgroundServicesCommandStub([]);
+        $tester = $this->createTester($command);
+
+        $tester->execute(['action' => 'unlock']);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('--name', $tester->getDisplay());
+    }
+
+    public function testUnlockReportsNotFound(): void
+    {
+        $command = new BackgroundServicesCommandStub([]);
+        $tester = $this->createTester($command);
+
+        $tester->execute(['action' => 'unlock', '--name' => 'ghost']);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('not found', $tester->getDisplay());
+    }
+
+    public function testUnlockClearsExistingService(): void
+    {
+        $command = new BackgroundServicesCommandStub([
+            self::makeService('svc', 'Service', running: 1, lockExpiresAt: '2026-03-28 11:00:00'),
+        ]);
+        $tester = $this->createTester($command);
+
+        $tester->execute(['action' => 'unlock', '--name' => 'svc']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString("Lease cleared for service 'svc'", $tester->getDisplay());
+        $this->assertContains('svc', $command->unlockedServices);
+    }
 }
 
 /**
@@ -221,6 +259,9 @@ class BackgroundServicesCommandTest extends TestCase
  */
 class BackgroundServicesCommandStub extends BackgroundServicesCommand
 {
+    /** @var list<string> */
+    public array $unlockedServices = [];
+
     /**
      * @param list<BackgroundServicesRow> $services
      */
@@ -241,5 +282,15 @@ class BackgroundServicesCommandStub extends BackgroundServicesCommand
             $this->services,
             fn(array $s) => (int) $s['active'] !== 0 && (int) $s['execute_interval'] > 0,
         ));
+    }
+
+    protected function clearLease(string $name): int
+    {
+        $exists = array_filter($this->services, fn(array $s) => $s['name'] === $name);
+        if ($exists === []) {
+            return 0;
+        }
+        $this->unlockedServices[] = $name;
+        return 1;
     }
 }

--- a/tests/Tests/Isolated/Common/Command/BackgroundServicesCommandTest.php
+++ b/tests/Tests/Isolated/Common/Command/BackgroundServicesCommandTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Isolated\Common\Command;
 
 use OpenEMR\Common\Command\BackgroundServicesCommand;
-use OpenEMR\Common\Database\TableTypes;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Services\Background\BackgroundServiceDefinition;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
- * @phpstan-import-type BackgroundServicesRow from TableTypes
+ * @phpstan-import-type BackgroundServicesQueryRow from BackgroundServiceDefinition
  */
 #[Group('isolated')]
 #[Group('background-services')]
@@ -37,7 +37,7 @@ class BackgroundServicesCommandTest extends TestCase
     }
 
     /**
-     * @return BackgroundServicesRow
+     * @return BackgroundServicesQueryRow
      */
     private static function makeService(
         string $name,
@@ -60,6 +60,7 @@ class BackgroundServicesCommandTest extends TestCase
             'require_once' => null,
             'sort_order' => '100',
             'lock_expires_at' => $lockExpiresAt,
+            'lease_is_live' => $lockExpiresAt !== null && $running === 1 ? '1' : '0',
         ];
     }
 
@@ -255,7 +256,7 @@ class BackgroundServicesCommandTest extends TestCase
 /**
  * Stub that provides fixture data instead of hitting the database.
  *
- * @phpstan-import-type BackgroundServicesRow from TableTypes
+ * @phpstan-import-type BackgroundServicesQueryRow from BackgroundServiceDefinition
  */
 class BackgroundServicesCommandStub extends BackgroundServicesCommand
 {
@@ -263,7 +264,7 @@ class BackgroundServicesCommandStub extends BackgroundServicesCommand
     public array $unlockedServices = [];
 
     /**
-     * @param list<BackgroundServicesRow> $services
+     * @param list<BackgroundServicesQueryRow> $services
      */
     public function __construct(private readonly array $services = [])
     {
@@ -284,13 +285,13 @@ class BackgroundServicesCommandStub extends BackgroundServicesCommand
         ));
     }
 
-    protected function clearLease(string $name): int
+    protected function clearLease(string $name): bool
     {
         $exists = array_filter($this->services, fn(array $s) => $s['name'] === $name);
         if ($exists === []) {
-            return 0;
+            return false;
         }
         $this->unlockedServices[] = $name;
-        return 1;
+        return true;
     }
 }

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceDefinitionTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceDefinitionTest.php
@@ -62,21 +62,38 @@ class BackgroundServiceDefinitionTest extends TestCase
         $this->assertNull($def->nextRun);
     }
 
+    /**
+     * @return array{name: string, title: string, function: string, require_once: ?string, execute_interval: numeric-string, sort_order: numeric-string, active: numeric-string, running: numeric-string, next_run: string, lock_expires_at: ?string, lease_is_live: ?numeric-string}
+     */
+    private static function row(
+        string $name = 'svc',
+        bool $active = true,
+        ?string $lockExpiresAt = null,
+        bool $leaseIsLive = false,
+        string $nextRun = '2026-03-28 10:15:00',
+        int $executeInterval = 5,
+    ): array {
+        return [
+            'name' => $name,
+            'title' => 'Service',
+            'function' => 'doWork',
+            'require_once' => null,
+            'execute_interval' => (string) $executeInterval,
+            'sort_order' => '100',
+            'active' => $active ? '1' : '0',
+            'running' => $leaseIsLive ? '1' : '0',
+            'next_run' => $nextRun,
+            'lock_expires_at' => $lockExpiresAt,
+            'lease_is_live' => $leaseIsLive ? '1' : '0',
+        ];
+    }
+
     public function testFromDatabaseRow(): void
     {
-        // Use string values to match ADOdb runtime behavior (numeric-string)
-        $row = [
-            'name' => 'phimail',
-            'title' => 'phiMail Direct Messaging',
-            'function' => 'phimail_check',
-            'require_once' => '/library/phimail.php',
-            'execute_interval' => '5',
-            'sort_order' => '100',
-            'active' => '1',
-            'running' => '0',
-            'next_run' => '2026-03-28 10:15:00',
-            'lock_expires_at' => null,
-        ];
+        $row = self::row(name: 'phimail', executeInterval: 5);
+        $row['title'] = 'phiMail Direct Messaging';
+        $row['function'] = 'phimail_check';
+        $row['require_once'] = '/library/phimail.php';
 
         $def = BackgroundServiceDefinition::fromDatabaseRow($row);
 
@@ -94,18 +111,7 @@ class BackgroundServiceDefinitionTest extends TestCase
 
     public function testFromDatabaseRowWithNullRequireOnce(): void
     {
-        $row = [
-            'name' => 'svc',
-            'title' => 'Service',
-            'function' => 'doWork',
-            'require_once' => null,
-            'execute_interval' => '10',
-            'sort_order' => '200',
-            'active' => '0',
-            'running' => '0',
-            'next_run' => '1970-01-01 00:00:00',
-            'lock_expires_at' => null,
-        ];
+        $row = self::row(active: false, nextRun: '1970-01-01 00:00:00', executeInterval: 10);
 
         $def = BackgroundServiceDefinition::fromDatabaseRow($row);
 
@@ -114,24 +120,14 @@ class BackgroundServiceDefinitionTest extends TestCase
         $this->assertFalse($def->active);
     }
 
-    public function testFromDatabaseRowDerivesRunningFromLiveLease(): void
+    public function testFromDatabaseRowReportsRunningWhenLeaseIsLive(): void
     {
-        // A lease far in the future -> running reports true.
-        $future = date('Y-m-d H:i:s', time() + 600);
-        $row = [
-            'name' => 'svc',
-            'title' => 'Service',
-            'function' => 'doWork',
-            'require_once' => null,
-            'execute_interval' => '5',
-            'sort_order' => '100',
-            'active' => '1',
-            // Stale `running` flag: DB still says running=1, but the
-            // authoritative signal is the lease expiration.
-            'running' => '1',
-            'next_run' => '2026-03-28 10:15:00',
-            'lock_expires_at' => $future,
-        ];
+        // The SQL-computed `lease_is_live` is authoritative — not the
+        // legacy `running` column, not a PHP-side comparison of
+        // `lock_expires_at` against `time()`. A worker crash that leaves
+        // `running = 1` but no live lease reports as running=false.
+        $future = '2099-01-01 00:00:00';
+        $row = self::row(lockExpiresAt: $future, leaseIsLive: true);
 
         $def = BackgroundServiceDefinition::fromDatabaseRow($row);
 
@@ -139,49 +135,13 @@ class BackgroundServiceDefinitionTest extends TestCase
         $this->assertSame($future, $def->lockExpiresAt);
     }
 
-    public function testFromDatabaseRowPrefersSqlComputedLeaseLivenessOverPhpClock(): void
+    public function testFromDatabaseRowReportsNotRunningWhenLeaseExpired(): void
     {
-        // Simulate PHP and DB clocks disagreeing: lock_expires_at reads as
-        // "far future" by the PHP clock, but the SQL-computed signal says
-        // the lease is not live. The SQL value wins because it shares a
-        // clock/timezone with acquireLock().
-        $farFuturePhpTime = date('Y-m-d H:i:s', time() + 86400);
-        $row = [
-            'name' => 'svc',
-            'title' => 'Service',
-            'function' => 'doWork',
-            'require_once' => null,
-            'execute_interval' => '5',
-            'sort_order' => '100',
-            'active' => '1',
-            'running' => '0',
-            'next_run' => '2026-03-28 10:15:00',
-            'lock_expires_at' => $farFuturePhpTime,
-            'lease_is_live' => '0',
-        ];
-
-        $def = BackgroundServiceDefinition::fromDatabaseRow($row);
-
-        $this->assertFalse($def->running);
-    }
-
-    public function testFromDatabaseRowTreatsExpiredLeaseAsNotRunning(): void
-    {
-        // Worker crashed without releasing its lease; `running = 1` was
-        // never cleared. The lease is expired, so `running` must be false.
-        $past = date('Y-m-d H:i:s', time() - 600);
-        $row = [
-            'name' => 'svc',
-            'title' => 'Service',
-            'function' => 'doWork',
-            'require_once' => null,
-            'execute_interval' => '5',
-            'sort_order' => '100',
-            'active' => '1',
-            'running' => '1',
-            'next_run' => '2026-03-28 10:15:00',
-            'lock_expires_at' => $past,
-        ];
+        // Stale lease left by a crashed worker: lock_expires_at is set,
+        // `running` column still says 1, but `lease_is_live` is 0 because
+        // the DB evaluated `lock_expires_at > NOW()` as false.
+        $past = '1999-01-01 00:00:00';
+        $row = self::row(lockExpiresAt: $past, leaseIsLive: false);
 
         $def = BackgroundServiceDefinition::fromDatabaseRow($row);
 
@@ -213,12 +173,12 @@ class BackgroundServiceDefinitionTest extends TestCase
         $this->assertSame('50', $array['sort_order']);
         $this->assertSame('1', $array['active']);
         $this->assertSame('0', $array['running']);
+        $this->assertSame('0', $array['lease_is_live']);
         $this->assertNull($array['lock_expires_at']);
     }
 
     public function testRoundTrip(): void
     {
-        $future = date('Y-m-d H:i:s', time() + 3600);
         $original = new BackgroundServiceDefinition(
             name: 'roundtrip',
             title: 'Roundtrip Test',
@@ -229,7 +189,7 @@ class BackgroundServiceDefinitionTest extends TestCase
             active: true,
             running: true,
             nextRun: '2026-03-28 12:00:00',
-            lockExpiresAt: $future,
+            lockExpiresAt: '2099-01-01 00:00:00',
         );
 
         $restored = BackgroundServiceDefinition::fromDatabaseRow($original->toArray());

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceDefinitionTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceDefinitionTest.php
@@ -75,6 +75,7 @@ class BackgroundServiceDefinitionTest extends TestCase
             'active' => '1',
             'running' => '0',
             'next_run' => '2026-03-28 10:15:00',
+            'lock_expires_at' => null,
         ];
 
         $def = BackgroundServiceDefinition::fromDatabaseRow($row);
@@ -88,6 +89,7 @@ class BackgroundServiceDefinitionTest extends TestCase
         $this->assertTrue($def->active);
         $this->assertFalse($def->running);
         $this->assertSame('2026-03-28 10:15:00', $def->nextRun);
+        $this->assertNull($def->lockExpiresAt);
     }
 
     public function testFromDatabaseRowWithNullRequireOnce(): void
@@ -102,6 +104,7 @@ class BackgroundServiceDefinitionTest extends TestCase
             'active' => '0',
             'running' => '0',
             'next_run' => '1970-01-01 00:00:00',
+            'lock_expires_at' => null,
         ];
 
         $def = BackgroundServiceDefinition::fromDatabaseRow($row);
@@ -109,6 +112,55 @@ class BackgroundServiceDefinitionTest extends TestCase
         $this->assertNull($def->requireOnce);
         $this->assertSame('1970-01-01 00:00:00', $def->nextRun);
         $this->assertFalse($def->active);
+    }
+
+    public function testFromDatabaseRowDerivesRunningFromLiveLease(): void
+    {
+        // A lease far in the future -> running reports true.
+        $future = date('Y-m-d H:i:s', time() + 600);
+        $row = [
+            'name' => 'svc',
+            'title' => 'Service',
+            'function' => 'doWork',
+            'require_once' => null,
+            'execute_interval' => '5',
+            'sort_order' => '100',
+            'active' => '1',
+            // Stale `running` flag: DB still says running=1, but the
+            // authoritative signal is the lease expiration.
+            'running' => '1',
+            'next_run' => '2026-03-28 10:15:00',
+            'lock_expires_at' => $future,
+        ];
+
+        $def = BackgroundServiceDefinition::fromDatabaseRow($row);
+
+        $this->assertTrue($def->running);
+        $this->assertSame($future, $def->lockExpiresAt);
+    }
+
+    public function testFromDatabaseRowTreatsExpiredLeaseAsNotRunning(): void
+    {
+        // Worker crashed without releasing its lease; `running = 1` was
+        // never cleared. The lease is expired, so `running` must be false.
+        $past = date('Y-m-d H:i:s', time() - 600);
+        $row = [
+            'name' => 'svc',
+            'title' => 'Service',
+            'function' => 'doWork',
+            'require_once' => null,
+            'execute_interval' => '5',
+            'sort_order' => '100',
+            'active' => '1',
+            'running' => '1',
+            'next_run' => '2026-03-28 10:15:00',
+            'lock_expires_at' => $past,
+        ];
+
+        $def = BackgroundServiceDefinition::fromDatabaseRow($row);
+
+        $this->assertFalse($def->running);
+        $this->assertSame($past, $def->lockExpiresAt);
     }
 
     public function testToArray(): void
@@ -135,10 +187,12 @@ class BackgroundServiceDefinitionTest extends TestCase
         $this->assertSame('50', $array['sort_order']);
         $this->assertSame('1', $array['active']);
         $this->assertSame('0', $array['running']);
+        $this->assertNull($array['lock_expires_at']);
     }
 
     public function testRoundTrip(): void
     {
+        $future = date('Y-m-d H:i:s', time() + 3600);
         $original = new BackgroundServiceDefinition(
             name: 'roundtrip',
             title: 'Roundtrip Test',
@@ -149,6 +203,7 @@ class BackgroundServiceDefinitionTest extends TestCase
             active: true,
             running: true,
             nextRun: '2026-03-28 12:00:00',
+            lockExpiresAt: $future,
         );
 
         $restored = BackgroundServiceDefinition::fromDatabaseRow($original->toArray());
@@ -162,5 +217,6 @@ class BackgroundServiceDefinitionTest extends TestCase
         $this->assertSame($original->active, $restored->active);
         $this->assertSame($original->running, $restored->running);
         $this->assertSame($original->nextRun, $restored->nextRun);
+        $this->assertSame($original->lockExpiresAt, $restored->lockExpiresAt);
     }
 }

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceDefinitionTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceDefinitionTest.php
@@ -139,6 +139,32 @@ class BackgroundServiceDefinitionTest extends TestCase
         $this->assertSame($future, $def->lockExpiresAt);
     }
 
+    public function testFromDatabaseRowPrefersSqlComputedLeaseLivenessOverPhpClock(): void
+    {
+        // Simulate PHP and DB clocks disagreeing: lock_expires_at reads as
+        // "far future" by the PHP clock, but the SQL-computed signal says
+        // the lease is not live. The SQL value wins because it shares a
+        // clock/timezone with acquireLock().
+        $farFuturePhpTime = date('Y-m-d H:i:s', time() + 86400);
+        $row = [
+            'name' => 'svc',
+            'title' => 'Service',
+            'function' => 'doWork',
+            'require_once' => null,
+            'execute_interval' => '5',
+            'sort_order' => '100',
+            'active' => '1',
+            'running' => '0',
+            'next_run' => '2026-03-28 10:15:00',
+            'lock_expires_at' => $farFuturePhpTime,
+            'lease_is_live' => '0',
+        ];
+
+        $def = BackgroundServiceDefinition::fromDatabaseRow($row);
+
+        $this->assertFalse($def->running);
+    }
+
     public function testFromDatabaseRowTreatsExpiredLeaseAsNotRunning(): void
     {
         // Worker crashed without releasing its lease; `running = 1` was

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -45,16 +45,6 @@ class BackgroundServiceRunnerTest extends TestCase
         $this->assertSame('skipped', $results[0]['status']);
     }
 
-    public function testRunSkipsAlreadyRunningService(): void
-    {
-        $runner = new BackgroundServiceRunnerStub(services: [
-            self::makeService('svc1', running: true),
-        ]);
-        $results = $runner->run('svc1');
-
-        $this->assertSame('skipped', $results[0]['status']);
-    }
-
     public function testRunReturnsAlreadyRunningWhenLockFailsDueToRunningProcess(): void
     {
         $runner = new BackgroundServiceRunnerStub(
@@ -160,20 +150,21 @@ class BackgroundServiceRunnerTest extends TestCase
     private static function makeService(
         string $name,
         bool $active = true,
-        bool $running = false,
         int $executeInterval = 5,
+        ?string $lockExpiresAt = null,
     ): array {
         // Use string values to match ADOdb runtime behavior (numeric-string)
         return [
             'name' => $name,
             'title' => $name,
             'active' => $active ? '1' : '0',
-            'running' => $running ? '1' : '0',
+            'running' => $lockExpiresAt !== null ? '1' : '0',
             'next_run' => '2020-01-01 00:00:00',
             'execute_interval' => (string) $executeInterval,
             'function' => 'test_function_' . $name,
             'require_once' => null,
             'sort_order' => '100',
+            'lock_expires_at' => $lockExpiresAt,
         ];
     }
 }

--- a/tests/Tests/Services/Background/BackgroundServiceRunnerIntegrationTest.php
+++ b/tests/Tests/Services/Background/BackgroundServiceRunnerIntegrationTest.php
@@ -120,6 +120,19 @@ class BackgroundServiceRunnerIntegrationTest extends TestCase
         $this->assertSame('not_due', $result);
     }
 
+    public function testAcquireReportsNotDueEvenWhenExpiredLeasePresent(): void
+    {
+        // Regression guard: a service with an expired (stale) lease AND
+        // a future next_run should report 'not_due' rather than
+        // 'already_running'. The stale timestamp is not a live lease.
+        $this->insertService(nextRun: date('Y-m-d H:i:s', time() + 600));
+        $this->setLeaseExpiry(date('Y-m-d H:i:s', time() - 600));
+
+        $result = $this->runner->callAcquireLock($this->fetchRow(), force: false);
+
+        $this->assertSame('not_due', $result);
+    }
+
     private function insertService(string $nextRun = '1970-01-01 00:00:00'): void
     {
         QueryUtils::sqlStatementThrowException(

--- a/tests/Tests/Services/Background/BackgroundServiceRunnerIntegrationTest.php
+++ b/tests/Tests/Services/Background/BackgroundServiceRunnerIntegrationTest.php
@@ -99,8 +99,11 @@ class BackgroundServiceRunnerIntegrationTest extends TestCase
         // SQL rather than comparing against PHP's time() to avoid
         // clock/timezone drift between the app and the DB session.
         $liveRow = QueryUtils::querySingleRow(
-            'SELECT 1 AS live FROM `background_services`'
-            . ' WHERE `name` = ? AND `lock_expires_at` > NOW()',
+            <<<'SQL'
+            SELECT 1 AS live
+              FROM `background_services`
+             WHERE `name` = ? AND `lock_expires_at` > NOW()
+            SQL,
             [self::TEST_SERVICE],
             false,
         );
@@ -152,9 +155,11 @@ class BackgroundServiceRunnerIntegrationTest extends TestCase
     private function insertService(int $nextRunMinutesFromNow = -100000): void
     {
         QueryUtils::sqlStatementThrowException(
-            'INSERT INTO `background_services`'
-            . ' (`name`, `title`, `active`, `running`, `next_run`, `execute_interval`, `function`, `sort_order`)'
-            . ' VALUES (?, ?, 1, 0, NOW() + INTERVAL ? MINUTE, 5, ?, 100)',
+            <<<'SQL'
+            INSERT INTO `background_services`
+                (`name`, `title`, `active`, `running`, `next_run`, `execute_interval`, `function`, `sort_order`)
+            VALUES (?, ?, 1, 0, NOW() + INTERVAL ? MINUTE, 5, ?, 100)
+            SQL,
             [self::TEST_SERVICE, 'Runner Lease Test', $nextRunMinutesFromNow, 'phpinfo'],
             true,
         );
@@ -168,9 +173,12 @@ class BackgroundServiceRunnerIntegrationTest extends TestCase
     private function setLeaseExpiryMinutesFromNow(int $minutesFromNow): void
     {
         QueryUtils::sqlStatementThrowException(
-            'UPDATE `background_services`'
-            . ' SET `running` = 1, `lock_expires_at` = NOW() + INTERVAL ? MINUTE'
-            . ' WHERE `name` = ?',
+            <<<'SQL'
+            UPDATE `background_services`
+               SET `running` = 1,
+                   `lock_expires_at` = NOW() + INTERVAL ? MINUTE
+             WHERE `name` = ?
+            SQL,
             [$minutesFromNow, self::TEST_SERVICE],
             true,
         );

--- a/tests/Tests/Services/Background/BackgroundServiceRunnerIntegrationTest.php
+++ b/tests/Tests/Services/Background/BackgroundServiceRunnerIntegrationTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * Integration tests for BackgroundServiceRunner's lease-based locking.
+ *
+ * These tests exercise the real SQL path (not mocked) against the test
+ * database. They cover the issue fixed by GH #11661: that a lease left
+ * behind by a crashed worker is automatically recovered on the next
+ * acquire attempt.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Services\Background;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Database\TableTypes;
+use OpenEMR\Services\Background\BackgroundServiceRunner;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @phpstan-import-type BackgroundServicesRow from TableTypes
+ */
+#[Group('background-services')]
+class BackgroundServiceRunnerIntegrationTest extends TestCase
+{
+    private const TEST_SERVICE = '_e2e_runner_lease';
+
+    private LeaseExposingRunner $runner;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->runner = new LeaseExposingRunner();
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `background_services` WHERE `name` = ?',
+            [self::TEST_SERVICE],
+            true,
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `background_services` WHERE `name` = ?',
+            [self::TEST_SERVICE],
+            true,
+        );
+        parent::tearDown();
+    }
+
+    public function testAcquireOnFreshServiceSucceedsAndSetsLease(): void
+    {
+        $this->insertService();
+
+        $result = $this->runner->callAcquireLock($this->fetchRow(), force: false);
+
+        $this->assertNull($result, 'Acquire should succeed on a fresh service');
+
+        $row = $this->fetchRow();
+        $this->assertNotNull(
+            $row['lock_expires_at'],
+            'Successful acquire must set lock_expires_at',
+        );
+        $this->assertSame('1', $row['running']);
+    }
+
+    public function testAcquireFailsWhenLiveLeaseHeld(): void
+    {
+        $this->insertService();
+        $this->setLeaseExpiry(date('Y-m-d H:i:s', time() + 600)); // 10 min future
+
+        $result = $this->runner->callAcquireLock($this->fetchRow(), force: true);
+
+        $this->assertSame('already_running', $result);
+    }
+
+    public function testAcquireStealsExpiredLease(): void
+    {
+        $this->insertService();
+        $this->setLeaseExpiry(date('Y-m-d H:i:s', time() - 600)); // 10 min past
+
+        $result = $this->runner->callAcquireLock($this->fetchRow(), force: true);
+
+        $this->assertNull($result, 'Expired lease must be stolen on next acquire');
+        $row = $this->fetchRow();
+        $this->assertNotNull($row['lock_expires_at']);
+        // New lease must be in the future, not the stale one we set.
+        $this->assertGreaterThan(time(), (int) strtotime((string) $row['lock_expires_at']));
+    }
+
+    public function testReleaseClearsLease(): void
+    {
+        $this->insertService();
+        $this->runner->callAcquireLock($this->fetchRow(), force: true);
+
+        $this->runner->callReleaseLock(self::TEST_SERVICE);
+
+        $row = $this->fetchRow();
+        $this->assertNull($row['lock_expires_at']);
+        $this->assertSame('0', $row['running']);
+    }
+
+    public function testAcquireReturnsNotDueWhenIntervalNotElapsed(): void
+    {
+        $this->insertService(nextRun: date('Y-m-d H:i:s', time() + 600));
+
+        $result = $this->runner->callAcquireLock($this->fetchRow(), force: false);
+
+        $this->assertSame('not_due', $result);
+    }
+
+    private function insertService(string $nextRun = '1970-01-01 00:00:00'): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'INSERT INTO `background_services`'
+            . ' (`name`, `title`, `active`, `running`, `next_run`, `execute_interval`, `function`, `sort_order`)'
+            . ' VALUES (?, ?, 1, 0, ?, 5, ?, 100)',
+            [self::TEST_SERVICE, 'Runner Lease Test', $nextRun, 'phpinfo'],
+            true,
+        );
+    }
+
+    private function setLeaseExpiry(string $expiresAt): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE `background_services` SET `running` = 1, `lock_expires_at` = ? WHERE `name` = ?',
+            [$expiresAt, self::TEST_SERVICE],
+            true,
+        );
+    }
+
+    /**
+     * @return BackgroundServicesRow
+     */
+    private function fetchRow(): array
+    {
+        /** @var list<BackgroundServicesRow> $rows */
+        $rows = QueryUtils::fetchRecordsNoLog(
+            'SELECT * FROM `background_services` WHERE `name` = ?',
+            [self::TEST_SERVICE],
+        );
+        $this->assertNotEmpty($rows, 'Test service row must exist');
+        return $rows[0];
+    }
+}
+
+/**
+ * Exposes the protected acquireLock/releaseLock methods for testing.
+ *
+ * @phpstan-import-type BackgroundServicesRow from TableTypes
+ */
+class LeaseExposingRunner extends BackgroundServiceRunner
+{
+    /**
+     * @param BackgroundServicesRow $service
+     */
+    public function callAcquireLock(array $service, bool $force): ?string
+    {
+        return $this->acquireLock($service, $force);
+    }
+
+    public function callReleaseLock(string $serviceName): void
+    {
+        $this->releaseLock($serviceName);
+    }
+}

--- a/tests/Tests/Services/Background/BackgroundServiceRunnerIntegrationTest.php
+++ b/tests/Tests/Services/Background/BackgroundServiceRunnerIntegrationTest.php
@@ -70,7 +70,9 @@ class BackgroundServiceRunnerIntegrationTest extends TestCase
             $row['lock_expires_at'],
             'Successful acquire must set lock_expires_at',
         );
-        $this->assertSame('1', $row['running']);
+        // The `running` column is derived/legacy; compare as int because
+        // Doctrine DBAL 4 may return tinyint as int rather than numeric-string.
+        $this->assertSame(1, (int) $row['running']);
     }
 
     public function testAcquireFailsWhenLiveLeaseHeld(): void
@@ -106,7 +108,7 @@ class BackgroundServiceRunnerIntegrationTest extends TestCase
 
         $row = $this->fetchRow();
         $this->assertNull($row['lock_expires_at']);
-        $this->assertSame('0', $row['running']);
+        $this->assertSame(0, (int) $row['running']);
     }
 
     public function testAcquireReturnsNotDueWhenIntervalNotElapsed(): void

--- a/tests/Tests/Services/Background/BackgroundServiceRunnerIntegrationTest.php
+++ b/tests/Tests/Services/Background/BackgroundServiceRunnerIntegrationTest.php
@@ -78,7 +78,7 @@ class BackgroundServiceRunnerIntegrationTest extends TestCase
     public function testAcquireFailsWhenLiveLeaseHeld(): void
     {
         $this->insertService();
-        $this->setLeaseExpiry(date('Y-m-d H:i:s', time() + 600)); // 10 min future
+        $this->setLeaseExpiryMinutesFromNow(10); // live
 
         $result = $this->runner->callAcquireLock($this->fetchRow(), force: true);
 
@@ -88,15 +88,23 @@ class BackgroundServiceRunnerIntegrationTest extends TestCase
     public function testAcquireStealsExpiredLease(): void
     {
         $this->insertService();
-        $this->setLeaseExpiry(date('Y-m-d H:i:s', time() - 600)); // 10 min past
+        $this->setLeaseExpiryMinutesFromNow(-10); // expired
 
         $result = $this->runner->callAcquireLock($this->fetchRow(), force: true);
 
         $this->assertNull($result, 'Expired lease must be stolen on next acquire');
         $row = $this->fetchRow();
         $this->assertNotNull($row['lock_expires_at']);
-        // New lease must be in the future, not the stale one we set.
-        $this->assertGreaterThan(time(), (int) strtotime((string) $row['lock_expires_at']));
+        // New lease must be live by the DB's own clock. Issue NOW() in
+        // SQL rather than comparing against PHP's time() to avoid
+        // clock/timezone drift between the app and the DB session.
+        $liveRow = QueryUtils::querySingleRow(
+            'SELECT 1 AS live FROM `background_services`'
+            . ' WHERE `name` = ? AND `lock_expires_at` > NOW()',
+            [self::TEST_SERVICE],
+            false,
+        );
+        $this->assertIsArray($liveRow, 'New lease must be in the future per DB clock');
     }
 
     public function testReleaseClearsLease(): void
@@ -113,7 +121,7 @@ class BackgroundServiceRunnerIntegrationTest extends TestCase
 
     public function testAcquireReturnsNotDueWhenIntervalNotElapsed(): void
     {
-        $this->insertService(nextRun: date('Y-m-d H:i:s', time() + 600));
+        $this->insertService(nextRunMinutesFromNow: 10);
 
         $result = $this->runner->callAcquireLock($this->fetchRow(), force: false);
 
@@ -125,30 +133,45 @@ class BackgroundServiceRunnerIntegrationTest extends TestCase
         // Regression guard: a service with an expired (stale) lease AND
         // a future next_run should report 'not_due' rather than
         // 'already_running'. The stale timestamp is not a live lease.
-        $this->insertService(nextRun: date('Y-m-d H:i:s', time() + 600));
-        $this->setLeaseExpiry(date('Y-m-d H:i:s', time() - 600));
+        $this->insertService(nextRunMinutesFromNow: 10);
+        $this->setLeaseExpiryMinutesFromNow(-10);
 
         $result = $this->runner->callAcquireLock($this->fetchRow(), force: false);
 
         $this->assertSame('not_due', $result);
     }
 
-    private function insertService(string $nextRun = '1970-01-01 00:00:00'): void
+    /**
+     * Insert the test service with next_run relative to the DB's NOW().
+     * Uses SQL arithmetic rather than PHP's time() so the test shares a
+     * clock with acquireLock().
+     *
+     * @param int $nextRunMinutesFromNow Positive for future, negative for
+     *   past (e.g. -100000 for "long past, always due").
+     */
+    private function insertService(int $nextRunMinutesFromNow = -100000): void
     {
         QueryUtils::sqlStatementThrowException(
             'INSERT INTO `background_services`'
             . ' (`name`, `title`, `active`, `running`, `next_run`, `execute_interval`, `function`, `sort_order`)'
-            . ' VALUES (?, ?, 1, 0, ?, 5, ?, 100)',
-            [self::TEST_SERVICE, 'Runner Lease Test', $nextRun, 'phpinfo'],
+            . ' VALUES (?, ?, 1, 0, NOW() + INTERVAL ? MINUTE, 5, ?, 100)',
+            [self::TEST_SERVICE, 'Runner Lease Test', $nextRunMinutesFromNow, 'phpinfo'],
             true,
         );
     }
 
-    private function setLeaseExpiry(string $expiresAt): void
+    /**
+     * Set the lease expiration relative to the DB's NOW(). Positive for a
+     * live lease, negative for an expired one. Uses SQL arithmetic so the
+     * test shares a clock with acquireLock().
+     */
+    private function setLeaseExpiryMinutesFromNow(int $minutesFromNow): void
     {
         QueryUtils::sqlStatementThrowException(
-            'UPDATE `background_services` SET `running` = 1, `lock_expires_at` = ? WHERE `name` = ?',
-            [$expiresAt, self::TEST_SERVICE],
+            'UPDATE `background_services`'
+            . ' SET `running` = 1, `lock_expires_at` = NOW() + INTERVAL ? MINUTE'
+            . ' WHERE `name` = ?',
+            [$minutesFromNow, self::TEST_SERVICE],
             true,
         );
     }

--- a/tests/Tests/Services/Background/BackgroundServicesCommandIntegrationTest.php
+++ b/tests/Tests/Services/Background/BackgroundServicesCommandIntegrationTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * Integration tests for BackgroundServicesCommand's protected DB methods.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Services\Background;
+
+use OpenEMR\Common\Command\BackgroundServicesCommand;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\Background\BackgroundServiceDefinition;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @phpstan-import-type BackgroundServicesQueryRow from BackgroundServiceDefinition
+ */
+#[Group('background-services')]
+class BackgroundServicesCommandIntegrationTest extends TestCase
+{
+    private const TEST_SERVICE = '_e2e_cmd_';
+
+    private CommandMethodExposer $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->command = new CommandMethodExposer();
+        $this->cleanup();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanup();
+        parent::tearDown();
+    }
+
+    private function cleanup(): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `background_services` WHERE `name` LIKE ?',
+            [self::TEST_SERVICE . '%'],
+            true,
+        );
+    }
+
+    private function insertService(string $suffix, bool $active = true, int $interval = 5): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            <<<'SQL'
+            INSERT INTO `background_services`
+                (`name`, `title`, `active`, `running`, `execute_interval`, `function`, `sort_order`)
+            VALUES (?, ?, ?, 0, ?, ?, 100)
+            SQL,
+            [self::TEST_SERVICE . $suffix, 'Test: ' . $suffix, $active ? 1 : 0, $interval, 'phpinfo'],
+            true,
+        );
+    }
+
+    public function testClearLeaseReturnsTrueForExistingService(): void
+    {
+        $this->insertService('clear');
+
+        $this->assertTrue($this->command->callClearLease(self::TEST_SERVICE . 'clear'));
+    }
+
+    public function testClearLeaseReturnsFalseForMissingService(): void
+    {
+        $this->assertFalse($this->command->callClearLease(self::TEST_SERVICE . 'nonexistent'));
+    }
+
+    public function testClearLeaseClearsLockExpiresAt(): void
+    {
+        $name = self::TEST_SERVICE . 'locked';
+        $this->insertService('locked');
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE `background_services` SET `running` = 1, `lock_expires_at` = NOW() + INTERVAL 60 MINUTE WHERE `name` = ?',
+            [$name],
+            true,
+        );
+
+        $this->command->callClearLease($name);
+
+        /** @var list<array{lock_expires_at: ?string, running: numeric-string}> $rows */
+        $rows = QueryUtils::fetchRecordsNoLog(
+            'SELECT `lock_expires_at`, `running` FROM `background_services` WHERE `name` = ?',
+            [$name],
+        );
+        $this->assertCount(1, $rows);
+        $this->assertNull($rows[0]['lock_expires_at']);
+        $this->assertSame(0, (int) $rows[0]['running']);
+    }
+
+    public function testFetchServicesComputesLeaseIsLive(): void
+    {
+        $this->insertService('fetch');
+
+        $rows = $this->command->callFetchServices();
+        $names = array_column($rows, 'name');
+        $idx = array_search(self::TEST_SERVICE . 'fetch', $names, true);
+
+        $this->assertIsInt($idx);
+        // No lease held → lease_is_live must be falsy.
+        $this->assertSame(0, (int) ($rows[$idx]['lease_is_live'] ?? -1));
+    }
+
+    public function testFetchActiveServicesFiltersCorrectly(): void
+    {
+        $this->insertService('active', active: true, interval: 5);
+        $this->insertService('inactive', active: false, interval: 5);
+        $this->insertService('manual', active: true, interval: 0);
+
+        $rows = $this->command->callFetchActiveServices();
+        $names = array_column($rows, 'name');
+
+        $this->assertContains(self::TEST_SERVICE . 'active', $names);
+        $this->assertNotContains(self::TEST_SERVICE . 'inactive', $names);
+        $this->assertNotContains(self::TEST_SERVICE . 'manual', $names);
+    }
+}
+
+/**
+ * Exposes the protected command methods for integration testing.
+ *
+ * @phpstan-import-type BackgroundServicesQueryRow from BackgroundServiceDefinition
+ */
+class CommandMethodExposer extends BackgroundServicesCommand
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function callClearLease(string $name): bool
+    {
+        return $this->clearLease($name);
+    }
+
+    /** @return list<BackgroundServicesQueryRow> */
+    public function callFetchServices(): array
+    {
+        return $this->fetchServices();
+    }
+
+    /** @return list<BackgroundServicesQueryRow> */
+    public function callFetchActiveServices(): array
+    {
+        return $this->fetchActiveServices();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #11661 — a single OOM event, SIGKILL, or container restart can permanently disable an OpenEMR background service (Email_Service, UUID_Service, phimail, etc.) because the row-level `running = 1` flag never gets cleared when the worker dies before its shutdown handler runs.

Replace the boolean flag with a timestamp-based lease:

- New column `background_services.lock_expires_at` (nullable `DATETIME`). Values are written via MySQL `NOW() + INTERVAL ? MINUTE` under whatever session timezone applies (OpenEMR syncs the MySQL session timezone to `gbl_time_zone` in `interface/globals.php`), so this is **not** guaranteed to be UTC. Liveness comparisons are self-consistent because every read and write uses `NOW()` in the same session.
- Acquire atomically *either* takes a free lock *or* steals an expired lease in a single UPDATE — no race, no separate sweeper cron needed.
- Release clears the lease (and the legacy `running` flag, which is kept for REST API compatibility but is now derived from the lease on read).
- When an expired lease is stolen, a PSR-3 warning is logged so operators get a signal instead of silent self-healing (crashed workers almost always mean an OOM kill worth investigating).
- New `bin/console background:services unlock --name=X` replaces the documented "run UPDATE directly against the database" workaround for the rare case of a genuinely hung service that shouldn't wait out its lease.

Lease duration is computed per-acquire as `max(60, 2×execute_interval)` capped at 24 hours. This gives short-interval services a reasonable recovery window without letting a misconfigured interval make a stuck lock unrecoverable.

## Why not `GET_LOCK()`?

Called out in the issue, but to summarize: MySQL's named-lock primitive is instance-scoped, not database-scoped. On installs where multiple OpenEMR sites share a MySQL server, two sites' `Email_Service` locks would serialize against each other. Namespacing hits the 64-char limit and adds connection-pool footguns.

## Behavior changes

- Admin report at `interface/reports/background_services.php` now renders "Busy" based on the live lease, so stuck locks from crashed workers (which used to report as "Yes" forever) now correctly show "No".
- The in-memory `running == 1` short-circuit in `BackgroundServiceRunner::run()` is removed — it would have bypassed the expired-lease recovery path. `acquireLock()` is now authoritative.

## Migration

Adds one column via `sql/8_1_0-to-8_1_1_upgrade.sql` using the existing `#IfMissingColumn` block. No data migration needed: existing rows start with `lock_expires_at = NULL`, which the new code treats as "free to acquire". An in-flight worker at upgrade time will have `running = 1` but no lease, so the first new-code acquire could theoretically race with it; this is a one-shot upgrade concern only.

## Test plan

- [x] `composer phpunit-isolated -- --filter BackgroundService` — 32 tests pass
- [x] `prek run --files <changed>` — phpcs, phpcbf, phpstan (level 10), rector, composer-require-checker all pass
- [ ] CI: full isolated + services integration suite, including the new `BackgroundServiceRunnerIntegrationTest` which exercises the real SQL path (acquire on fresh row, live-lease blocks, expired-lease steal, release clears timestamp, not-due path)
- [ ] Manual: verify the admin report renders "Busy: No" for a row with `running = 1, lock_expires_at = NULL` (simulates a stuck lock from the old scheme after upgrade)
- [ ] Manual: `bin/console background:services unlock --name=Email_Service` clears the lease