### PR TITLE
fix(medex): decouple background service from legacy AJAX entry point

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -11492,11 +11492,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'https\\://\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/MedEx/API.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'recall_\' and mixed results in an error\\.$#',
     'count' => 5,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
@@ -11553,7 +11548,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 16,
+    'count' => 15,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -29892,11 +29892,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'PHP_SELF\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/MedEx/API.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'PID\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
@@ -29913,11 +29908,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'POSTCARDS_remote\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/MedEx/API.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'SERVER_NAME\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];

--- a/library/MedEx/API.php
+++ b/library/MedEx/API.php
@@ -125,9 +125,14 @@ class Practice extends Base
     {
         $fields2 = [];
         $fields3 = [];
-        $callback = "https://" . OEGlobalsBag::getInstance()->get('_SERVER')['SERVER_NAME'] . OEGlobalsBag::getInstance()->get('_SERVER')['PHP_SELF'];
-        $callback = str_replace('ajax/execute_background_services.php', 'MedEx/MedEx.php', $callback);
-        $fields2['callback_url'] = $callback;
+        // Build the callback URL from the globally-configured site address
+        // rather than inferring it from $_SERVER. $_SERVER is unavailable when
+        // this service runs via `bin/console background:services run`, which
+        // is the supported non-browser entry point. qualified_site_addr is
+        // composed from site_addr_oath + webroot in interface/globals.php and
+        // respects operator configuration in either environment.
+        $fields2['callback_url'] = OEGlobalsBag::getInstance()->getString('qualified_site_addr')
+            . '/library/MedEx/MedEx.php';
         $sqlQuery = "SELECT * FROM medex_prefs";
         $my_status = sqlQuery($sqlQuery);
         $providers = explode('|', (string) $my_status['ME_providers']);

--- a/library/MedEx/MedEx_background.php
+++ b/library/MedEx/MedEx_background.php
@@ -1,27 +1,34 @@
 <?php
 
 /**
- * /library/MedEx/medex_background.php
+ * library/MedEx/MedEx_background.php
  *
  * This file is executed as a background service. It synchronizes data with MedExBank.com,
  *      delivering events to be processed to MedEx AND receiving message outcomes from MedEx.
  *      MedEx_background.php receives message responses asynchronously.
- *      Consider setting this service to run q5 minutes in background_grounds:
- *          eg. every 5 minutes ==> active=1, execute_interval=5
+ *      Consider setting this service to run every 5 minutes in background_services:
+ *          e.g. every 5 minutes ==> active=1, execute_interval=5
  *
  *      While anyone is logged into your OpenEMR instance, this will run.
  *      Consider adding a cronjob to run this file also, so messaging for upcoming events
- *      will run even if no one is logged in, eg. the office is closed/vacation etc
+ *      will run even if no one is logged in, e.g. the office is closed/vacation etc.
  *
- *      eg. to run this file every 4 hours, crontab -e
- *      0 0,4,8,12,16,20 * * * /usr/bin/env php ROOT_DIR/library/ajax/execute_background_services.php
- *      You can add " >> /tmp/medex.log " to output success/failure to a log file.
+ *      e.g. to run this service every 4 hours via cron:
+ *          0 0,4,8,12,16,20 * * * /usr/bin/env php ROOT_DIR/bin/console background:services run --name=MedEx
+ *      For the full set of active services, generate a ready-to-install crontab with:
+ *          php bin/console background:services crontab
+ *      You can append " >> /tmp/medex.log " to output success/failure to a log file.
  *
- * @package MedEx
- * @link    http://www.MedExBank.com
- * @author  MedEx <support@MedExBank.com>
+ * @package   OpenEMR
+ * @subpackage MedEx
+ *
+ * @link      https://www.open-emr.org
+ * @link      https://www.MedExBank.com
+ * @author    MedEx <support@MedExBank.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2017 MedEx <support@MedExBank.com>
- * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 $ignoreAuth = true;


### PR DESCRIPTION
Closes #11672.

Two small fixes that unblock deprecation of `library/ajax/execute_background_services.php` (see #11667).

## Changes

### `library/MedEx/MedEx_background.php` docblock

The cron example pointed at `library/ajax/execute_background_services.php`, which is being deprecated. Operators copying it into a crontab today land on the legacy entry point. Updated to `bin/console background:services run --name=MedEx` and added a pointer to the `crontab` subcommand that generates the full ready-to-install schedule. Also fixes typos (`background_grounds` -> `background_services`, filename capitalization).

### `library/MedEx/API.php` callback URL

Previously built the MedEx webhook callback URL from `$_SERVER['PHP_SELF']` + `SERVER_NAME` and then did:

```php
str_replace('ajax/execute_background_services.php', 'MedEx/MedEx.php', $callback)
```

to rewrite the runner path into the webhook path. That hack:
- breaks entirely under `bin/console background:services run --name=MedEx` (no `PHP_SELF` in CLI)
- hard-codes the soon-to-be-removed AJAX entry point

Replaced with `qualified_site_addr`, which is already composed from `site_addr_oath` + `webroot` in `interface/globals.php` and works identically in both web and CLI contexts.

### PHPStan baseline

Regenerated to drop three now-unused ignores on `API.php` (SERVER_NAME/PHP_SELF offset access, `https://` binary op) and decrement the non-falsy-string binary-op count by one.

## Test plan

- [ ] CI
- [ ] Deploy-time smoke: verify MedEx sync still reports the correct callback URL with `site_addr_oath` explicitly configured