### PR TITLE
docs(background-services): clarify register() active-flag policy

### DIFF
--- a/src/Services/Background/BackgroundServiceRegistry.php
+++ b/src/Services/Background/BackgroundServiceRegistry.php
@@ -29,9 +29,31 @@ class BackgroundServiceRegistry
     /**
      * Register or update a background service (idempotent upsert).
      *
-     * The ON DUPLICATE KEY UPDATE intentionally does NOT update `active`.
-     * This preserves the admin's enable/disable decision. Use setActive()
-     * to change a service's enabled state.
+     * ## Policy for the `active` flag: first install wins
+     *
+     * The `active` value from `$definition` is respected on initial INSERT
+     * and is never overwritten on subsequent upserts:
+     *
+     * - **Fresh row (no existing service with this name):** the
+     *   `$definition->active` value is written to the database. A module
+     *   can ship its default enabled state this way.
+     * - **Existing row:** title, function, require_once, execute_interval,
+     *   and sort_order are all updated, but `active` is left untouched.
+     *   This preserves any explicit enable/disable decision an admin has
+     *   made through the UI or via a prior migration.
+     *
+     * Consequence: two installs of the same module version can end up with
+     * different `active` values depending on whether the service existed
+     * before. This is intentional — runtime state belongs to the operator,
+     * not to the module package, and a module upgrade must not silently
+     * re-enable a service an admin has turned off.
+     *
+     * Modules that need to flip a service's active state on upgrade (for
+     * example, a security-driven kill switch) should call `setActive()`
+     * explicitly from a migration step, so the decision is reviewable at
+     * the call site rather than buried in package defaults.
+     *
+     * @see BackgroundServiceRegistry::setActive()
      */
     public function register(BackgroundServiceDefinition $definition): void
     {

--- a/tests/Tests/Services/Background/BackgroundServiceRegistryTest.php
+++ b/tests/Tests/Services/Background/BackgroundServiceRegistryTest.php
@@ -100,6 +100,43 @@ class BackgroundServiceRegistryTest extends TestCase
         $this->assertTrue($fetched->active);
     }
 
+    public function testRegisterRespectsActiveOnFirstInsertWhenTrue(): void
+    {
+        // First install wins: a definition shipping active=true is honored
+        // on the initial INSERT, so a module can enable its service by default.
+        $def = $this->makeDefinition('first_insert_true', active: true);
+        $this->registry->register($def);
+
+        $fetched = $this->registry->get($def->name);
+        $this->assertNotNull($fetched);
+        $this->assertTrue($fetched->active);
+    }
+
+    public function testRegisterUpsertPreservesActiveFalseWhenReRegisteredTrue(): void
+    {
+        // Inverse of testRegisterUpsertUpdatesFieldsButPreservesActive:
+        // a service that an admin has disabled stays disabled even if the
+        // module later re-registers with active=true. Runtime state always
+        // wins over package defaults.
+        $original = $this->makeDefinition('upsert_false_preserved', active: false);
+        $this->registry->register($original);
+
+        $reRegistered = new BackgroundServiceDefinition(
+            name: $original->name,
+            title: $original->title,
+            function: $original->function,
+            requireOnce: $original->requireOnce,
+            executeInterval: $original->executeInterval,
+            sortOrder: $original->sortOrder,
+            active: true,
+        );
+        $this->registry->register($reRegistered);
+
+        $fetched = $this->registry->get($original->name);
+        $this->assertNotNull($fetched);
+        $this->assertFalse($fetched->active);
+    }
+
     public function testUnregisterRemovesService(): void
     {
         $def = $this->makeDefinition('unregister');


### PR DESCRIPTION
Closes #11673.

Expands the `BackgroundServiceRegistry::register()` docblock to explicitly document the "first install wins" policy for the `active` flag. Before this PR, the policy was implicit: callers could not tell from the signature that passing `active: true` on an upsert would be silently ignored, leading to the subtle footgun called out in #11673 — two installs of the same module version ending up in different states depending on history.

## Policy (now explicit)

- On initial INSERT, the definition's `active` value is honored.
- On subsequent upserts, all other fields are updated but `active` is preserved so admin enable/disable decisions survive module upgrades.
- Modules that genuinely need to flip state on upgrade should call `setActive()` from a migration.

## Tests

Added two tests to `BackgroundServiceRegistryTest.php` covering the parts of the policy not yet exercised:

- `testRegisterRespectsActiveOnFirstInsertWhenTrue` — fresh insert with `active: true` is respected (complements the existing `testRegisterAndGet` which uses the `active: false` default).
- `testRegisterUpsertPreservesActiveFalseWhenReRegisteredTrue` — inverse of the existing upsert test: an admin-disabled service stays disabled even when the module re-registers with `active: true`.

The existing `testRegisterUpsertUpdatesFieldsButPreservesActive` already covered the primary `true -> false` preservation direction.

## Test plan

- [ ] CI (`services` suite runs these against a real DB via the `ci/apache_*` matrix)