### PR TITLE
refactor(background-services): migrate module installers to Registry

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -5822,11 +5822,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\*" between mixed and 60 results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'Content\\-Type\\: \' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1273,11 +1273,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 23,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -3762,11 +3762,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimRevModuleSetup.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\ClaimRevConnector\\\\ClaimRevModuleSetup\\:\\:createBackGroundServices\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimRevModuleSetup.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\ClaimRevConnector\\\\ClaimRevModuleSetup\\:\\:deactivateSftpService\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimRevModuleSetup.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -15957,11 +15957,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/FaxDocumentService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'count\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'appKey\' on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -1783,7 +1783,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 7,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimRevModuleSetup.php',
 ];
 $ignoreErrors[] = [
@@ -2058,12 +2058,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecordsNoLog\\(\\) instead of sqlStatementNoLog\\(\\)\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) instead of sqlQueryNoLog\\(\\)\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php',
 ];
 $ignoreErrors[] = [

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimRevModuleSetup.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimRevModuleSetup.php
@@ -6,13 +6,17 @@
  * @link    https://www.open-emr.org
  *
  * @author    Brad Sharp <brad.sharp@claimrev.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2022 Brad Sharp <brad.sharp@claimrev.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 namespace OpenEMR\Modules\ClaimRevConnector;
 
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Services\Background\BackgroundServiceDefinition;
+use OpenEMR\Services\Background\BackgroundServiceRegistry;
 
 class ClaimRevModuleSetup
 {
@@ -79,21 +83,45 @@ class ClaimRevModuleSetup
         $result = sqlStatement($sql);
         return $result;
     }
-    public static function createBackGroundServices()
+    public static function createBackGroundServices(): void
     {
-        $sql = "DELETE FROM background_services WHERE name like '%ClaimRev%'";
-        sqlStatement($sql);
+        // Use BackgroundServiceRegistry so module upgrades don't silently
+        // reset an admin's enable/disable toggle. The Registry's "first
+        // install wins" policy preserves the active flag on upsert;
+        // reinstalling this module no longer wipes admin preferences the
+        // way the previous DELETE-then-INSERT pattern did.
+        $registry = new BackgroundServiceRegistry();
+        $billingPath = '/interface/modules/custom_modules/oe-module-claimrev-connect/src/Billing_Claimrev_Service.php';
+        $eligibilityPath = '/interface/modules/custom_modules/oe-module-claimrev-connect/src/Eligibility_ClaimRev_Service.php';
 
-        $sql = "INSERT INTO `background_services` (`name`, `title`, `active`, `running`, `next_run`, `execute_interval`, `function`, `require_once`, `sort_order`) VALUES
-            ('ClaimRev_Send', 'Send Claims To ClaimRev', 1, 0, '2017-05-09 17:39:10', 1, 'start_X12_Claimrev_send_files', '/interface/modules/custom_modules/oe-module-claimrev-connect/src/Billing_Claimrev_Service.php', 100);";
-        sqlStatement($sql);
+        $registry->register(new BackgroundServiceDefinition(
+            name: 'ClaimRev_Send',
+            title: 'Send Claims To ClaimRev',
+            function: 'start_X12_Claimrev_send_files',
+            requireOnce: $billingPath,
+            executeInterval: 1,
+            sortOrder: 100,
+            active: true,
+        ));
 
-        $sql = "INSERT INTO `background_services` (`name`, `title`, `active`, `running`, `next_run`, `execute_interval`, `function`, `require_once`, `sort_order`) VALUES
-            ('ClaimRev_Receive', 'Get Reports from ClaimRev', 1, 0, '2017-05-09 17:39:10', 240, 'start_X12_Claimrev_get_reports', '/interface/modules/custom_modules/oe-module-claimrev-connect/src/Billing_Claimrev_Service.php', 100);";
-        sqlStatement($sql);
+        $registry->register(new BackgroundServiceDefinition(
+            name: 'ClaimRev_Receive',
+            title: 'Get Reports from ClaimRev',
+            function: 'start_X12_Claimrev_get_reports',
+            requireOnce: $billingPath,
+            executeInterval: 240,
+            sortOrder: 100,
+            active: true,
+        ));
 
-        $sql = "INSERT INTO `background_services` (`name`, `title`, `active`, `running`, `next_run`, `execute_interval`, `function`, `require_once`, `sort_order`) VALUES
-            ('ClaimRev_Elig_Send_Receive', 'Send and Receive Eligibility from ClaimRev', 1, 0, '2017-05-09 17:39:10', 1, 'start_send_eligibility', '/interface/modules/custom_modules/oe-module-claimrev-connect/src/Eligibility_ClaimRev_Service.php', 100);";
-        sqlStatement($sql);
+        $registry->register(new BackgroundServiceDefinition(
+            name: 'ClaimRev_Elig_Send_Receive',
+            title: 'Send and Receive Eligibility from ClaimRev',
+            function: 'start_send_eligibility',
+            requireOnce: $eligibilityPath,
+            executeInterval: 1,
+            sortOrder: 100,
+            active: true,
+        ));
     }
 }

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
@@ -60,6 +60,11 @@ class NotificationTaskManager
     /**
      * Creates or updates the background Notification task.
      *
+     * $hours is the execution interval in whole hours. When $hours is 0
+     * (the default), the existing DB interval is read via getTaskHours()
+     * and used instead. The value stored in `background_services.execute_interval`
+     * is always in minutes, so both branches convert hours -> minutes.
+     *
      * Returns true when a new service row was created, false when an
      * existing row was updated (or when $type is invalid). Uses
      * BackgroundServiceRegistry so the admin's enable/disable toggle is
@@ -77,7 +82,12 @@ class NotificationTaskManager
             return false;
         }
 
-        $total_minutes = empty($hours) ? $this->getTaskHours($type) : $hours * 60;
+        // Callers treat $hours as an integer number of hours, but legacy
+        // code paths pass strings from $_POST. Normalize to int and fall
+        // back to the stored DB interval when no explicit value is given.
+        $hoursInt = is_numeric($hours) ? (int) $hours : 0;
+        $intervalHours = $hoursInt > 0 ? $hoursInt : $this->getTaskHours($type);
+        $total_minutes = $intervalHours * 60;
 
         $registry = new BackgroundServiceRegistry();
         $isNew = !$registry->exists($name);
@@ -86,7 +96,7 @@ class NotificationTaskManager
             title: 'Scheduled Automated Notifications',
             function: $fn,
             requireOnce: '/interface/modules/custom_modules/oe-module-faxsms/library/run_notifications.php',
-            executeInterval: (int) $total_minutes,
+            executeInterval: $total_minutes,
             sortOrder: 100,
             active: false,
         ));

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
@@ -5,11 +5,16 @@
  * @package        OpenEMR
  * @link           https://www.open-emr.org
  * @author         Jerry Padgett <sjpadgett@gmail.com>
+ * @author         Michael A. Smith <michael@opencoreemr.com>
  * @copyright      Copyright (c) 2025 <sjpadgett@gmail.com>
+ * @copyright      Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license        https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 namespace OpenEMR\Modules\FaxSMS\Controller;
+
+use OpenEMR\Services\Background\BackgroundServiceDefinition;
+use OpenEMR\Services\Background\BackgroundServiceRegistry;
 
 /**
  * Manages background task operations for Notifications.
@@ -53,7 +58,12 @@ class NotificationTaskManager
     }
 
     /**
-     * Creates or updates the background Notification task
+     * Creates or updates the background Notification task.
+     *
+     * Returns true when a new service row was created, false when an
+     * existing row was updated (or when $type is invalid). Uses
+     * BackgroundServiceRegistry so the admin's enable/disable toggle is
+     * preserved on re-registration.
      */
     public function manageService($type, $hours = 0): bool
     {
@@ -69,20 +79,19 @@ class NotificationTaskManager
 
         $total_minutes = empty($hours) ? $this->getTaskHours($type) : $hours * 60;
 
-        $sql = "SELECT COUNT(*) as count FROM `background_services` WHERE `name` = ?";
-        $result = sqlQueryNoLog($sql, [$name]);
-        if ($result['count'] > 0) {
-            $sql = "UPDATE `background_services` SET `execute_interval` = ? WHERE `name` = ?";
-            sqlStatementNoLog($sql, [$total_minutes, $name]);
-            return false;
-        }
+        $registry = new BackgroundServiceRegistry();
+        $isNew = !$registry->exists($name);
+        $registry->register(new BackgroundServiceDefinition(
+            name: $name,
+            title: 'Scheduled Automated Notifications',
+            function: $fn,
+            requireOnce: '/interface/modules/custom_modules/oe-module-faxsms/library/run_notifications.php',
+            executeInterval: (int) $total_minutes,
+            sortOrder: 100,
+            active: false,
+        ));
 
-        $sql = "INSERT INTO `background_services`
-                (`name`, `title`, `active`, `running`, `next_run`, `execute_interval`, `function`, `require_once`, `sort_order`)
-                VALUES (?, 'Scheduled Automated Notifications', '0', '0', current_timestamp(), ?, ?, '/interface/modules/custom_modules/oe-module-faxsms/library/run_notifications.php', '100')";
-        sqlStatementNoLog($sql, [$name, $total_minutes, $fn]);
-
-        return true;
+        return $isNew;
     }
 
     /**


### PR DESCRIPTION
Progresses #11670.

Migrates the ClaimRev and FaxSMS module installers from raw INSERT/UPDATE/DELETE on the `background_services` table to `BackgroundServiceRegistry::register()`. Registry upserts preserve the admin's active-flag toggle on module reinstall/upgrade (the "first install wins" policy documented in #11673), which the old ad-hoc SQL patterns did not.

## Migrations

### ClaimRev (`ClaimRevModuleSetup::createBackGroundServices`)

Previously: `DELETE FROM background_services WHERE name LIKE '%ClaimRev%'` followed by three raw `INSERT`s. That DELETE wiped admin preferences (active flag, sort_order) on every reinstall.

Now: three `$registry->register(new BackgroundServiceDefinition(...))` calls. Fresh-install behavior unchanged; fixes the admin-toggle-wipe regression on upgrade.

### FaxSMS (`NotificationTaskManager::manageService`)

Previously: `SELECT COUNT(*)` + UPDATE-or-INSERT, with the UPDATE branch updating only `execute_interval` (leaving title/function/require_once/sort_order stale if the module changed them).

Now: `$registry->exists()` + `$registry->register(...)`. The Registry upsert syncs all non-active fields, which is the desired behavior for module upgrades. The `bool` return preserves the "new row created" semantics for callers.

## Deliberately not migrated

`src/Telemetry/BackgroundTaskManager::modifyTelemetryTask` uses a similar SELECT+UPDATE-or-INSERT pattern, but `tests/Tests/Isolated/Telemetry/BackgroundTaskManagerTest.php` asserts exact SQL strings via a `DatabaseQueryTrait` stub that `BackgroundServiceRegistry` bypasses (Registry calls `QueryUtils` directly). Migrating it requires rewriting the tests and is deferred to a follow-up so this PR stays focused.

Other call sites found during audit (e.g., `ModuleManagerListener` enable/disable toggles in ClaimRev/Weno/Dorn, Weno's `checkBackgroundService()` force-reactivation, admin runtime toggles in `edit_globals.php` / `main/messages/save.php`) are runtime state mutations, not installers, and are out of scope for this migration.

## PHPStan baseline

Three baseline files shrink as a consequence of removing the ad-hoc SQL:

- `missingType.return.php` — `createBackGroundServices()` now has explicit `: void` return type.
- `openemr.deprecatedSqlFunction.php` — `sqlStatement()` count on ClaimRev setup drops 7 -> 3; `sqlStatementNoLog()` / `sqlQueryNoLog()` counts on FaxSMS drop similarly.
- `offsetAccess.nonOffsetAccessible.php` — one entry removed (the `['count']` access on the `sqlQueryNoLog` result is gone).

## Test plan

- [ ] CI
- [ ] Re-running the ClaimRev module installer does not reset admin enable/disable preferences (manual smoke if CI doesn't cover it)