### PR TITLE
fix(mailer): hardcode UTF-8 CharSet to avoid null from missing global

### DIFF
--- a/.phpstan/baseline/assign.propertyType.php
+++ b/.phpstan/baseline/assign.propertyType.php
@@ -367,11 +367,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/classes/TreeMenu.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property MyMailer\\:\\:\\$CharSet \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/postmaster.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property MyMailer\\:\\:\\$Password \\(string\\) does not accept string\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/postmaster.php',

--- a/.phpstan/baseline/deadCode.unreachable.php
+++ b/.phpstan/baseline/deadCode.unreachable.php
@@ -288,11 +288,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Unreachable statement \\- code above always terminates\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/E2e/EmailTestServiceTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Unreachable statement \\- code above always terminates\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/E2e/FaxSmsEmailTest.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
@@ -1447,11 +1447,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/classes/Prescription.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use of the "global" keyword is forbidden \\(\\$HTML_CHARSET\\)\\. Use dependency injection instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/postmaster.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use of the "global" keyword is forbidden \\(\\$code_types\\)\\. Use dependency injection instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/contraception_billing_scan.inc.php',

--- a/library/classes/postmaster.php
+++ b/library/classes/postmaster.php
@@ -7,11 +7,15 @@
  * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2010 Open Support LLC
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2025 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+declare(strict_types=1);
 
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Database\QueryUtils;

--- a/library/classes/postmaster.php
+++ b/library/classes/postmaster.php
@@ -180,8 +180,16 @@ class MyMailer extends PHPMailer
      */
     function emailMethod(): void
     {
-        global $HTML_CHARSET;
-        $this->CharSet = $HTML_CHARSET;
+        // OpenEMR is hardcoded to UTF-8 (see interface/globals.php). Set it
+        // explicitly rather than reading the legacy $HTML_CHARSET global,
+        // which is not reliably defined in every entry point. PHPUnit, for
+        // example, loads its bootstrap via `include_once` inside a method
+        // scope, so the `$HTML_CHARSET = "UTF-8"` assignment in globals.php
+        // never escapes to global scope there. A null CharSet makes PHPMailer
+        // emit encoded-word subject headers with an empty charset declaration
+        // (=??Q?...?=) and triggers strlen(null) / strtolower(null)
+        // deprecations from PHPMailer on PHP 8.2+.
+        $this->CharSet = PHPMailer::CHARSET_UTF8;
         switch (OEGlobalsBag::getInstance()->get('EMAIL_METHOD')) {
             case "PHPMAIL":
                 $this->Mailer = "mail";

--- a/tests/Tests/E2e/EmailTestServiceTest.php
+++ b/tests/Tests/E2e/EmailTestServiceTest.php
@@ -57,15 +57,6 @@ class EmailTestServiceTest extends TestCase
     #[Test]
     public function directSendDeliversEmail(): void
     {
-        self::markTestSkipped(
-            'Send reports success but the message never arrives in Mailpit. '
-            . 'PHPMailer triggers strlen(null) / strtolower(null) deprecations '
-            . 'on this path, suggesting a null field somewhere in the direct '
-            . 'send. Re-enable after diagnosing (dump Mailpit state on '
-            . 'timeout to determine whether the email arrives with a '
-            . 'different subject or not at all).'
-        );
-
         $results = $this->service->test(
             EmailTestData::TEST_SENDER,
             EmailTestData::TEST_RECIPIENT,
@@ -103,14 +94,6 @@ class EmailTestServiceTest extends TestCase
     #[Test]
     public function queueTemplatedInsertsAndDelivers(): void
     {
-        self::markTestSkipped(
-            'Queue reports success but the templated message never arrives '
-            . 'in Mailpit after emailServiceRun(). Sibling queueInsertsAndDelivers '
-            . '(non-templated) passes with the same flush path, so the issue is '
-            . 'specific to template rendering — likely a null subject/body in '
-            . 'the templated output (see concurrent PHPMailer null-deprecations).'
-        );
-
         $results = $this->service->test(
             EmailTestData::TEST_SENDER,
             EmailTestData::TEST_RECIPIENT,


### PR DESCRIPTION
## Summary

Fixes #11624. Re-enables the two E2E tests that PR #11603 skipped (`directSendDeliversEmail` and `queueTemplatedInsertsAndDelivers`).

## Root cause

`MyMailer::emailMethod()` read `$HTML_CHARSET` via the `global` keyword. That variable is set at the top of `interface/globals.php` — but PHPUnit loads its bootstrap via `include_once` inside `TextUI\Application::loadBootstrapScript()`, so the top-level `$HTML_CHARSET = "UTF-8"` assignment is scoped to that method and never escapes to true global scope. In test context `global $HTML_CHARSET` was null, so `$this->CharSet` ended up null.

A null `CharSet` caused two symptoms:

1. PHPMailer triggered `strlen(null)` / `strtolower(null)` deprecations on PHP 8.2+ (PHPMailer.php lines 1618, 2571, 3625 — the `$this->CharSet` accesses in `preSend()`, `wrapText()`, and `encodeHeader()`).
2. PHPMailer emitted encoded-word subject headers with an empty charset declaration, e.g. `=??Q?OpenEMR_Email_Test_=E2=80=94_Direct_Send?=`. Mailpit cannot decode a header with no declared charset, so the raw encoded form was stored. Q-encoding turns spaces into underscores, so `waitForEmail`'s `stripos($subject, "Direct Send")` failed to match. The `queueInsertsAndDelivers` test passed by accident — its subject substring "Queue" has no space and survived the transformation. "Direct Send" and "Queue Templated" did not.

This also explains the issue's observation that the library reports success but the message "never arrives": the message *does* arrive in Mailpit; the subject just arrives malformed and the test helper's substring match can't find it.

## Fix

Set `CharSet` directly to `PHPMailer::CHARSET_UTF8`. OpenEMR is hardcoded to UTF-8 everywhere (`ini_set('default_charset', 'utf-8')`, `mb_internal_encoding('UTF-8')`, `$HTML_CHARSET = "UTF-8"`), so there is nothing to look up.

Three PHPStan baseline entries are no longer needed after this change and have been regenerated out:

- `openemr.forbiddenGlobalKeyword` for `$HTML_CHARSET` in `postmaster.php` (the `global` is gone)
- `assign.propertyType` for `MyMailer::$CharSet (string) does not accept mixed` (the assigned value is now a `string` constant)
- `deadCode.unreachable` for `EmailTestServiceTest.php` (the `markTestSkipped()` calls that made the test bodies unreachable are gone)

## Follow-up commit

A second commit applies OCE conventions to the touched file: adds `declare(strict_types=1)` to `postmaster.php` and an OpenCoreEMR copyright entry. PHPStan level 10 passes cleanly with `strict_types` enabled, confirming no existing caller relies on type coercion into `MyMailer`'s methods.

## Test plan

- [x] `vendor/bin/phpunit --testsuite email --filter EmailTestServiceTest` — 5/5 pass, including the two previously skipped tests
- [x] Full `email` suite — 10 active tests pass, 11 pre-existing skips in `FaxSmsEmailTest` / `NotificationCronEmailTest` are unrelated
- [x] `composer phpstan` — clean on full codebase after regenerating baseline
- [x] Pre-commit hooks (phpcs, phpcbf, phpstan, rector, composer-require-checker, codespell) all pass
