### PR TITLE
fix(billing): session crashes on posting page

### DIFF
--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -654,7 +654,7 @@ if (
 }
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
-$language_direction = $session->get('language_direction'); // fetch before output starts
+$language_direction = $session->get('language_direction'); // fetch before the <html> output begins
 ?>
 <html>
 <head>

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -654,6 +654,7 @@ if (
 }
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
+$language_direction = $session->get('language_direction'); // fetch before output starts
 ?>
 <html>
 <head>

--- a/library/js/xl/jquery-datetimepicker-2-5-4.js.php
+++ b/library/js/xl/jquery-datetimepicker-2-5-4.js.php
@@ -32,6 +32,8 @@
  *  support internationalization of dates; note this setting does not yet work with the timepicker yet)
  *   -oeFormatShortDate() function for when placing a default formatted date in the field
  *   -DateToYYYYMMDD() function when insert the formatted date into database or codebase works on it
+ * $language_direction - optional; if pre-set by the caller before any output is sent, the session
+ *  will not be reopened mid-output. If not set, it will be read from the active session here.
  *
  *
  * @package   OpenEMR
@@ -44,6 +46,8 @@
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Services\Utils\DateFormatterUtils;
 
+// If the caller already fetched $language_direction before output began,
+// skip the session read to avoid reopening the session after headers are sent.
 if (!isset($language_direction)) {
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
     $language_direction = $session->get('language_direction');

--- a/library/js/xl/jquery-datetimepicker-2-5-4.js.php
+++ b/library/js/xl/jquery-datetimepicker-2-5-4.js.php
@@ -44,8 +44,10 @@
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Services\Utils\DateFormatterUtils;
 
-$session = SessionWrapperFactory::getInstance()->getActiveSession();
-$language_direction = $session->get('language_direction');
+if (!isset($language_direction)) {
+    $session = SessionWrapperFactory::getInstance()->getActiveSession();
+    $language_direction = $session->get('language_direction');
+}
 ?>
     i18n:{
         en: {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
Fix headers-already-sent crash on sl_eob_search.php caused by datetimepicker 
reopening the session mid-output after PR #10244 refactored session access.
#### Changes proposed in this pull request:
- library/js/xl/jquery-datetimepicker-2-5-4.js.php: guard the getActiveSession() 
  call with isset($language_direction) to avoid reopening the session after headers 
  are sent; document $language_direction as a caller-settable input in the header block
- interface/billing/sl_eob_search.php: pre-fetch $language_direction from the session 
  at line 656 before any output begins, allowing the datetimepicker guard to skip the 
  mid-output session call

#### Was an AI assistant used? Yes
Claude.ai (Anthropic) was used to diagnose the root cause and develop the fix.
<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
