### PR TITLE
fix(installer): require igroup field during installation

### DIFF
--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -1450,6 +1450,10 @@ $config = 1; /////////////
             if (! $this->user_password_is_valid()) {
                 return false;
             }
+
+            if (! $this->igroup_is_valid()) {
+                return false;
+            }
         }
 
         // Validation of mysql database password

--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -238,6 +238,21 @@ class Installer implements InstallerInterface
     }
 
     /**
+     * Validate if the initial group is valid.
+     *
+     * @return bool True if initial group is valid, false otherwise
+     */
+    public function igroup_is_valid(): bool
+    {
+        if ($this->igroup === '') {
+            $this->error_message = "Initial group is invalid: '$this->igroup'";
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Validate if the database password is valid.
      *
      * @return bool True if password is valid, false otherwise

--- a/src/Common/Command/InstallCommand.php
+++ b/src/Common/Command/InstallCommand.php
@@ -44,6 +44,7 @@ class InstallCommand extends Command
         #[Option(description: 'OpenEMR admin display name')] string $oeAdminName = 'Administrator',
         #[Option(description: 'OpenEMR admin username')] string $oeAdminUsername = 'admin',
         #[Option(description: 'OpenEMR admin password')] string $oeAdminPassword = '',
+        #[Option(description: 'OpenEMR practice group name')] string $oeAdminGroup = 'Default',
     ): int {
         $io = new SymfonyStyle($input, $output);
 
@@ -72,6 +73,7 @@ class InstallCommand extends Command
             'iuser' => $oeAdminUsername,
             'iuname' => $oeAdminName,
             'iuserpass' => $oeAdminPassword,
+            'igroup' => $oeAdminGroup,
 
             // == Not user configurable ==
             'site' => 'default', // Only default site supported.

--- a/tests/Tests/Isolated/library/classes/InstallerTest.php
+++ b/tests/Tests/Isolated/library/classes/InstallerTest.php
@@ -146,6 +146,13 @@ class InstallerTest extends TestCase
         $this->assertFalse($this->installer->iuname_is_valid());
     }
 
+    public function testIgroupIsValid(): void
+    {
+        $this->assertTrue($this->installer->igroup_is_valid());
+        $this->installer->igroup = '';
+        $this->assertFalse($this->installer->igroup_is_valid());
+    }
+
     public function testPasswordIsValid(): void
     {
         $this->assertTrue($this->installer->password_is_valid());
@@ -641,6 +648,7 @@ class InstallerTest extends TestCase
             'create_site_directory',
             'disconnect',
             'grant_privileges',
+            'igroup_is_valid',
             'install_additional_users',
             'install_gacl',
             'insert_globals',
@@ -659,6 +667,7 @@ class InstallerTest extends TestCase
         $mockInstaller->expects($this->once())->method('login_is_valid')->willReturn(true);
         $mockInstaller->expects($this->once())->method('iuser_is_valid')->willReturn(true);
         $mockInstaller->expects($this->once())->method('user_password_is_valid')->willReturn(true);
+        $mockInstaller->expects($this->once())->method('igroup_is_valid')->willReturn(true);
         $mockInstaller->expects($this->once())->method('password_is_valid')->willReturn(true);
 
         // Mock database connection methods
@@ -707,6 +716,7 @@ class InstallerTest extends TestCase
             'create_dumpfiles',
             'disconnect',
             'grant_privileges',
+            'igroup_is_valid',
             'insert_globals',
             'install_additional_users',
             'install_gacl',
@@ -724,6 +734,7 @@ class InstallerTest extends TestCase
         $mockInstaller->expects($this->never())->method('login_is_valid');
         $mockInstaller->expects($this->never())->method('iuser_is_valid');
         $mockInstaller->expects($this->never())->method('user_password_is_valid');
+        $mockInstaller->expects($this->never())->method('igroup_is_valid');
 
         $mockInstaller->expects($this->once())->method('password_is_valid')->willReturn(true);
         $mockInstaller->expects($this->exactly(2))->method('root_database_connection')->willReturn(true);


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #11692

The `igroup` parameter was not validated during installation, leading to broken installations when using the CLI installer (which did not pass the parameter at all). Long story short, `empty` reared its ugly head.

#### Changes proposed in this pull request:

- Add `igroup_is_valid()` validation method to `Installer` class
- Call validation during `quick_install()` (alongside other user-related validations)
- Add `--oe-admin-group` option to CLI `install` command with default value "Default"
- Add test coverage for the new validation

#### Was an AI assistant used? Yes

All commits include the `Assisted-by: Claude Code` trailer.