### PR TITLE
fix(orm): fix multiple bugs in ORDataObject::_load_enum

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -18157,6 +18157,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Binary operation "\\." between mixed and \'\\.\' results in an error\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -3973,7 +3973,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -3973,7 +3973,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -2413,7 +2413,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -4502,11 +4502,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/ORDataObject/ContactRelation.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\ORDataObject\\\\ORDataObject\\:\\:_load_enum\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Common\\\\ORDataObject\\\\Person\\:\\:get_date_fields\\(\\) return type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/ORDataObject/Person.php',

--- a/.phpstan/baseline/nullCoalesce.offset.php
+++ b/.phpstan/baseline/nullCoalesce.offset.php
@@ -162,6 +162,16 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/ajax/payment_ajax.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Offset 0 on array\\<string, int\\> on left side of \\?\\? does not exist\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/classes/Document.class.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset 0 on array\\<string, int\\> on left side of \\?\\? does not exist\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/classes/X12Partner.class.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Offset \'height\' on array\\{0\\: int\\<0, max\\>, 1\\: int\\<0, max\\>, 2\\: int, 3\\: string, mime\\: string, channels\\?\\: int, bits\\?\\: int\\} on left side of \\?\\? does not exist\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/thumbnail/Thumbnail.class.php',

--- a/.phpstan/baseline/nullCoalesce.offset.php
+++ b/.phpstan/baseline/nullCoalesce.offset.php
@@ -162,16 +162,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/ajax/payment_ajax.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 0 on array\\<string, int\\> on left side of \\?\\? does not exist\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Document.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset 0 on array\\<string, int\\> on left side of \\?\\? does not exist\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/X12Partner.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Offset \'height\' on array\\{0\\: int\\<0, max\\>, 1\\: int\\<0, max\\>, 2\\: int, 3\\: string, mime\\: string, channels\\?\\: int, bits\\?\\: int\\} on left side of \\?\\? does not exist\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/thumbnail/Thumbnail.class.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -42977,31 +42977,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'enums\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset 0 on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset int\\<0, max\\> on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset mixed on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset string on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'created\' on array\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Session/SessionTracker.php',

--- a/.phpstan/baseline/property.nonObject.php
+++ b/.phpstan/baseline/property.nonObject.php
@@ -4983,7 +4983,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access property \\$enums on mixed\\.$#',
-    'count' => 4,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -16847,11 +16847,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Command/GenerateAccessTokenCommand.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$enum might not be defined\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$values might not be defined\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/ORDataObject/ORDataObject.php',

--- a/library/classes/Document.class.php
+++ b/library/classes/Document.class.php
@@ -233,7 +233,7 @@ class Document extends ORDataObject
         //this uses psuedo-class variables so it is really cheap
         $this->type_array = $this->_load_enum("type");
 
-        $this->type = $this->type_array[0] ?? '';
+        $this->type = array_key_first($this->type_array) ?? '';
         $this->size = 0;
         $this->date = date("Y-m-d H:i:s");
         $this->date_expires = null; // typically no expiration date here

--- a/library/classes/X12Partner.class.php
+++ b/library/classes/X12Partner.class.php
@@ -62,7 +62,7 @@ class X12Partner extends ORDataObject
         parent::__construct();
         $this->_table = "x12_partners";
         $this->processing_format_array = $this->_load_enum("processing_format", false);
-        $this->processing_format = $this->processing_format_array[0] ?? null;
+        $this->processing_format = array_key_first($this->processing_format_array);
         //most recent x12 version mandated by HIPAA and CMS
         // $this->x12_version = "004010X098A1";
         $this->x12_version = "005010X222A1";

--- a/src/Common/ORDataObject/ORDataObject.php
+++ b/src/Common/ORDataObject/ORDataObject.php
@@ -176,7 +176,7 @@ class ORDataObject
      */
     protected function _load_enum(string $field_name, bool $blank = true): array
     {
-        if (empty($this->_table)) {
+        if ($this->_table === null || $this->_table === '') {
             return [];
         }
 

--- a/src/Common/ORDataObject/ORDataObject.php
+++ b/src/Common/ORDataObject/ORDataObject.php
@@ -12,6 +12,13 @@ use OpenEMR\Core\OEGlobalsBag;
 
 class ORDataObject
 {
+    /**
+     * @var array<string, list<string>>
+     * Cache of raw enum values keyed by "table.field_name".
+     * Stores cleaned values before blank/flip processing.
+     */
+    private static array $enumCache = [];
+
     // TODO: @adunsulag at some point we need to set this default to false
     // currently most objects assume we need to save when we call persist
     private $_isObjectModified = true;
@@ -160,51 +167,53 @@ class ORDataObject
     }
 
     /**
-     * Helper function that loads enumerations from the data as an array, this is also efficient
-     * because it uses pseudo-class variables so that it doesn't have to do database work for each instance
+     * Helper function that loads enumerations from the database as an array.
+     * Results are cached per table.field_name combination.
      *
-     * @param string  $field_name name of the enumeration in this objects table
-     * @param boolean $blank      optional value to include a empty element at position 0, default is true
-     * @return array array of values as name to index pairs found in the db enumeration of this field
+     * @param string $field_name name of the enumeration in this object's table
+     * @param bool   $blank      include an empty element at position 0 (default true)
+     * @return array<string, int> values as name-to-index pairs
      */
-    protected function _load_enum($field_name, $blank = true)
+    protected function _load_enum(string $field_name, bool $blank = true): array
     {
-        if (
-            !empty(OEGlobalsBag::getInstance()->get('static')['enums'][$this->_table][$field_name])
-            && is_array(OEGlobalsBag::getInstance()->get('static')['enums'][$this->_table][$field_name])
-            && !empty($this->_table)
-        ) {
-            return OEGlobalsBag::getInstance()->get('static')['enums'][$this->_table][$field_name];
-        } else {
-            $cols = $this->_db->MetaColumns($this->_table);
-            if ((is_array($cols) && !empty($cols)) || ($cols && !$cols->EOF)) {
-                //why is there a foreach here? at some point later there will be a scheme to autoload all enums
-                //for an object rather than 1x1 manually as it is now
-                foreach ($cols as $col) {
-                    if ($col->name == $field_name && $col->type == "enum") {
-                        for ($idx = 0; $idx < count($col->enums); $idx++) {
-                            $col->enums[$idx] = str_replace("'", "", $col->enums[$idx]);
-                        }
+        if (empty($this->_table)) {
+            return [];
+        }
 
-                        $enum = $col->enums;
-                        //for future use
-                        //$enum[$col->name] = $enum_types[1];
+        $cacheKey = $this->_table . '.' . $field_name;
+
+        if (!array_key_exists($cacheKey, self::$enumCache)) {
+            $cols = $this->_db->MetaColumns($this->_table);
+            $rawEnums = [];
+
+            if (is_array($cols) || ($cols && !$cols->EOF)) {
+                foreach ($cols as $col) {
+                    if ($col->name === $field_name && $col->type === 'enum') {
+                        foreach ($col->enums as $enumValue) {
+                            $rawEnums[] = str_replace("'", '', $enumValue);
+                        }
+                        break;
                     }
                 }
-
-                array_unshift($enum, " ");
-
-                //keep indexing consistent whether or not a blank is present
-                if (!$blank) {
-                    unset($enum[0]);
-                }
-
-                $enum = array_flip($enum);
-                OEGlobalsBag::getInstance()->get('static')['enums'][$this->_table][$field_name] = $enum;
             }
 
-            return $enum;
+            self::$enumCache[$cacheKey] = $rawEnums;
         }
+
+        $rawEnums = self::$enumCache[$cacheKey];
+
+        if ($rawEnums === []) {
+            return [];
+        }
+
+        $enum = $rawEnums;
+        array_unshift($enum, ' ');
+
+        if (!$blank) {
+            unset($enum[0]);
+        }
+
+        return array_flip($enum);
     }
 
     public function _utility_array($obj_ar, $reverse = false, $blank = true, $name_func = "get_name", $value_func = "get_id")

--- a/tests/Tests/Isolated/Common/ORDataObject/ORDataObjectLoadEnumTest.php
+++ b/tests/Tests/Isolated/Common/ORDataObject/ORDataObjectLoadEnumTest.php
@@ -164,7 +164,7 @@ class ORDataObjectLoadEnumTest extends TestCase
     {
         return new class ($columns) {
             /** @param list<object> $columns */
-            public function __construct(private array $columns)
+            public function __construct(private readonly array $columns)
             {
             }
 

--- a/tests/Tests/Isolated/Common/ORDataObject/ORDataObjectLoadEnumTest.php
+++ b/tests/Tests/Isolated/Common/ORDataObject/ORDataObjectLoadEnumTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * Tests for ORDataObject::_load_enum
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenEMR Foundation
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\ORDataObject;
+
+use OpenEMR\Common\ORDataObject\ORDataObject;
+use PHPUnit\Framework\TestCase;
+
+class ORDataObjectLoadEnumTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->clearEnumCache();
+    }
+
+    public function testLoadEnumWithBlankTrue(): void
+    {
+        $db = $this->createDbStub([
+            $this->createColumnObject('status', 'enum', ["'active'", "'inactive'", "'pending'"]),
+        ]);
+
+        $obj = $this->createTestableObject('test_table', $db);
+
+        /** @phpstan-ignore method.notFound (loadEnum added by anonymous subclass) */
+        $result = $obj->loadEnum('status', true);
+
+        self::assertSame([
+            ' ' => 0,
+            'active' => 1,
+            'inactive' => 2,
+            'pending' => 3,
+        ], $result);
+    }
+
+    public function testLoadEnumWithBlankFalse(): void
+    {
+        $db = $this->createDbStub([
+            $this->createColumnObject('status', 'enum', ["'active'", "'inactive'"]),
+        ]);
+
+        $obj = $this->createTestableObject('test_table', $db);
+
+        /** @phpstan-ignore method.notFound (loadEnum added by anonymous subclass) */
+        $result = $obj->loadEnum('status', false);
+
+        self::assertSame([
+            'active' => 1,
+            'inactive' => 2,
+        ], $result);
+    }
+
+    public function testLoadEnumReturnsEmptyArrayWhenTableNotSet(): void
+    {
+        $obj = $this->createTestableObject(null, null);
+
+        /** @phpstan-ignore method.notFound (loadEnum added by anonymous subclass) */
+        $result = $obj->loadEnum('status');
+
+        self::assertSame([], $result);
+    }
+
+    public function testLoadEnumReturnsEmptyArrayWhenFieldNotFound(): void
+    {
+        $db = $this->createDbStub([
+            $this->createColumnObject('other_field', 'enum', ["'value'"]),
+        ]);
+
+        $obj = $this->createTestableObject('test_table', $db);
+
+        /** @phpstan-ignore method.notFound (loadEnum added by anonymous subclass) */
+        $result = $obj->loadEnum('nonexistent');
+
+        self::assertSame([], $result);
+    }
+
+    public function testLoadEnumCachesResults(): void
+    {
+        $callCount = 0;
+        $db = new class ($callCount) {
+            private int $callCount;
+
+            public function __construct(int &$callCount)
+            {
+                $this->callCount = &$callCount;
+            }
+
+            /**
+             * @return list<object>
+             */
+            public function MetaColumns(string $table): array
+            {
+                $this->callCount++;
+                $col = new \stdClass();
+                $col->name = 'status';
+                $col->type = 'enum';
+                $col->enums = ["'active'"];
+                return [$col];
+            }
+        };
+
+        $obj = $this->createTestableObject('test_table', $db);
+
+        // Call twice
+        /** @phpstan-ignore method.notFound (loadEnum added by anonymous subclass) */
+        $obj->loadEnum('status');
+        /** @phpstan-ignore method.notFound (loadEnum added by anonymous subclass) */
+        $obj->loadEnum('status');
+
+        self::assertSame(1, $callCount);
+    }
+
+    public function testLoadEnumCacheIsSeparateForBlankParameter(): void
+    {
+        $db = $this->createDbStub([
+            $this->createColumnObject('status', 'enum', ["'active'"]),
+        ]);
+
+        $obj = $this->createTestableObject('test_table', $db);
+
+        /** @phpstan-ignore method.notFound (loadEnum added by anonymous subclass) */
+        $withBlank = $obj->loadEnum('status', true);
+        /** @phpstan-ignore method.notFound (loadEnum added by anonymous subclass) */
+        $withoutBlank = $obj->loadEnum('status', false);
+
+        self::assertSame([' ' => 0, 'active' => 1], $withBlank);
+        self::assertSame(['active' => 1], $withoutBlank);
+    }
+
+    private function createTestableObject(?string $table, ?object $db): ORDataObject
+    {
+        return new class ($table, $db) extends ORDataObject {
+            public function __construct(?string $table, ?object $db)
+            {
+                // Skip parent constructor to avoid OEGlobalsBag dependency
+                $this->_table = $table;
+                $this->_db = $db;
+            }
+
+            /**
+             * @return array<string, int>
+             */
+            public function loadEnum(string $fieldName, bool $blank = true): array
+            {
+                return $this->_load_enum($fieldName, $blank);
+            }
+        };
+    }
+
+    /**
+     * @param list<object> $columns
+     */
+    private function createDbStub(array $columns): object
+    {
+        return new class ($columns) {
+            /** @param list<object> $columns */
+            public function __construct(private array $columns)
+            {
+            }
+
+            /** @return list<object> */
+            public function MetaColumns(string $table): array
+            {
+                return $this->columns;
+            }
+        };
+    }
+
+    /**
+     * @param list<string> $enums
+     */
+    private function createColumnObject(string $name, string $type, array $enums): object
+    {
+        $col = new \stdClass();
+        $col->name = $name;
+        $col->type = $type;
+        $col->enums = $enums;
+        return $col;
+    }
+
+    private function clearEnumCache(): void
+    {
+        $reflection = new \ReflectionClass(ORDataObject::class);
+        $property = $reflection->getProperty('enumCache');
+        $property->setValue(null, []);
+    }
+}


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes multiple bugs in the `ORDataObject::_load_enum()` method that could cause undefined variable errors and incorrect caching behavior.

I came across issues that appeared to be suppressed working on #11550, surfaced only in PHP 8.4+ where _something_ was subtly different along the way. I still can't quite figure out what, though I'm reasonably sure there's a tweak to error handling and promotion getting surfaced.

Note: I'm working on a parallel branch to fix some of the type info in ORDataObject, so more phpstan stuff should get fixed there. I'm ignoring the temporary additions.

#### Changes proposed in this pull request:

- **Undefined variable fix**: Return empty array when no matching enum column is found (previously `$enum` was undefined)
- **Cache respects `$blank` parameter**: Cache raw enum values and apply the `$blank` parameter on each retrieval (previously cached results ignored `$blank` on subsequent calls)
- **Condition order fix**: Check `empty($this->_table)` before accessing cache arrays
- **Prevent mutation**: Copy enum values instead of modifying `$col->enums` in place
- **Working cache**: Use a static class property for caching (the previous `OEGlobalsBag::get('static')` approach assigned to a return value, which was a no-op)

#### Was an AI assistant used? Yes

Assisted-by trailer included in commit.

---
🤖 Generated with [Claude Code](https://claude.ai/code)