### PR TITLE
refactor(cli): Separate "beta" CLI commands

### DIFF
--- a/cli
+++ b/cli
@@ -6,7 +6,7 @@ declare(strict_types=1);
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Tools\Console\ConsoleRunner;
 use Firehed\Container\TypedContainerInterface;
-use OpenEMR\Common\Command\{
+use OpenEMR\Console\Command\{
     InstallCommand,
 };
 use Symfony\Component\Console\Application;

--- a/config/cli.php
+++ b/config/cli.php
@@ -12,7 +12,7 @@
 
 declare(strict_types=1);
 
-namespace OpenEMR\Common\Command;
+namespace OpenEMR\Console\Command;
 
 return [
     InstallCommand::class,

--- a/src/Console/Command/InstallCommand.php
+++ b/src/Console/Command/InstallCommand.php
@@ -12,7 +12,7 @@
 
 declare(strict_types=1);
 
-namespace OpenEMR\Common\Command;
+namespace OpenEMR\Console\Command;
 
 use OpenEMR\Common\Installer\InstallerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Console/README.md
+++ b/src/Console/README.md
@@ -1,0 +1,9 @@
+# Console commands
+
+These commands intentionally differ from those in `OpenEMR\Common\Command`:
+
+1) They support (and may require) dependency injection with autowiring
+2) They leverage the `__invoke` Symfony Console tooling for improved/simplified type safety
+
+However, they only work in `./cli` and not `./bin/console`.
+The two will eventually be unified, but these are "clean break" commands without backwards compatibility concerns.

--- a/tests/Tests/Isolated/Console/Command/InstallCommandTest.php
+++ b/tests/Tests/Isolated/Console/Command/InstallCommandTest.php
@@ -10,10 +10,10 @@
 
 declare(strict_types=1);
 
-namespace OpenEMR\Tests\Isolated\Common\Command;
+namespace OpenEMR\Tests\Isolated\Console\Command;
 
-use OpenEMR\Common\Command\InstallCommand;
 use OpenEMR\Common\Installer\InstallerInterface;
+use OpenEMR\Console\Command\InstallCommand;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;


### PR DESCRIPTION
#### Short description of what this changes or resolves:
`bin/console` auto-detects and auto-imports commands in `OpenEMR\Common\Command`. Newer commands requiring DI and autowiring (tested and intended to be run under `./cli`) break under this model. This change (temporarily) separates the two.

#### Changes proposed in this pull request:
- Defines a new namespace for backwards-incompatible commands
- Moves the only command in this state to the new NS
- Adds brief README explaining reasoning

#### Was an AI assistant used? Yes / No
No