### PR TITLE
refactor(logging): Support CipherSuiteInterface in EventAuditLogger

### DIFF
--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -14,6 +14,7 @@
 
 namespace OpenEMR\Common\Logging;
 
+use InvalidArgumentException;
 use OpenEMR\BC\{
     DatabaseConnectionFactory,
     DatabaseConnectionOptions,
@@ -23,7 +24,9 @@ use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Core\Traits\SingletonTrait;
+use OpenEMR\Encryption\CipherSuite;
 use Psr\Clock\ClockInterface;
+use SensitiveParameter;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
@@ -84,6 +87,7 @@ class EventAuditLogger
         return new self(
             sinks: $sinks,
             cryptoGen: ServiceContainer::getCrypto(),
+            cipherSuite: null,
             shouldEncrypt: $bag->getBoolean('enable_auditlog_encryption'),
             session: SessionWrapperFactory::getInstance()->getActiveSession(),
             config: $auditConfig,
@@ -97,13 +101,17 @@ class EventAuditLogger
      */
     public function __construct(
         private readonly array $sinks,
-        private readonly CryptoInterface $cryptoGen,
+        private readonly ?CryptoInterface $cryptoGen,
+        private readonly ?CipherSuite $cipherSuite,
         private readonly bool $shouldEncrypt,
         private readonly SessionInterface $session,
         private readonly AuditConfig $config,
         private readonly BreakglassCheckerInterface $breakglassChecker,
         private readonly ClockInterface $clock,
     ) {
+        if ($cryptoGen === null && $cipherSuite === null) {
+            throw new InvalidArgumentException('CipherSuite or CryptoGen MUST be provided, both were null');
+        }
     }
 
     /**
@@ -641,11 +649,11 @@ class EventAuditLogger
         }
 
         if ($this->shouldEncrypt) {
-            $comments = $this->cryptoGen->encryptStandard($comments);
+            $comments = $this->encrypt($comments);
             if ($api !== null) {
-                $api['request_url'] = ($api['request_url'] === '') ? '' : $this->cryptoGen->encryptStandard($api['request_url']);
-                $api['request_body'] = ($api['request_body'] === '') ? '' : $this->cryptoGen->encryptStandard($api['request_body']);
-                $api['response'] = ($api['response'] === '') ? '' : $this->cryptoGen->encryptStandard($api['response']);
+                $api['request_url'] = ($api['request_url'] === '') ? '' : $this->encrypt($api['request_url']);
+                $api['request_body'] = ($api['request_body'] === '') ? '' : $this->encrypt($api['request_body']);
+                $api['response'] = ($api['response'] === '') ? '' : $this->encrypt($api['response']);
             }
         } else {
             // Since storing binary elements (uuid), need to base64 to not jarble them and to ensure the auditing hashing works
@@ -803,5 +811,16 @@ class EventAuditLogger
         }
 
         return $event;
+    }
+
+    private function encrypt(#[SensitiveParameter] string $plaintext): string
+    {
+        if ($this->cipherSuite !== null) {
+            return $this->cipherSuite->encrypt($plaintext);
+        } elseif ($this->cryptoGen !== null) {
+            return $this->cryptoGen->encryptStandard($plaintext);
+        } else {
+            throw new InvalidArgumentException('Both crypto paths are null');
+        }
     }
 }

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -24,7 +24,7 @@ use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Core\Traits\SingletonTrait;
-use OpenEMR\Encryption\CipherSuite;
+use OpenEMR\Encryption\CipherSuiteInterface;
 use Psr\Clock\ClockInterface;
 use SensitiveParameter;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -102,7 +102,7 @@ class EventAuditLogger
     public function __construct(
         private readonly array $sinks,
         private readonly ?CryptoInterface $cryptoGen,
-        private readonly ?CipherSuite $cipherSuite,
+        private readonly ?CipherSuiteInterface $cipherSuite,
         private readonly bool $shouldEncrypt,
         private readonly SessionInterface $session,
         private readonly AuditConfig $config,

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -14,7 +14,6 @@
 
 namespace OpenEMR\Common\Logging;
 
-use InvalidArgumentException;
 use OpenEMR\BC\{
     DatabaseConnectionFactory,
     DatabaseConnectionOptions,
@@ -86,8 +85,7 @@ class EventAuditLogger
 
         return new self(
             sinks: $sinks,
-            cryptoGen: ServiceContainer::getCrypto(),
-            cipherSuite: null,
+            crypto: ServiceContainer::getCrypto(),
             shouldEncrypt: $bag->getBoolean('enable_auditlog_encryption'),
             session: SessionWrapperFactory::getInstance()->getActiveSession(),
             config: $auditConfig,
@@ -101,17 +99,13 @@ class EventAuditLogger
      */
     public function __construct(
         private readonly array $sinks,
-        private readonly ?CryptoInterface $cryptoGen,
-        private readonly ?CipherSuiteInterface $cipherSuite,
+        private readonly CipherSuiteInterface|CryptoInterface $crypto,
         private readonly bool $shouldEncrypt,
         private readonly SessionInterface $session,
         private readonly AuditConfig $config,
         private readonly BreakglassCheckerInterface $breakglassChecker,
         private readonly ClockInterface $clock,
     ) {
-        if ($cryptoGen === null && $cipherSuite === null) {
-            throw new InvalidArgumentException('CipherSuite or CryptoGen MUST be provided, both were null');
-        }
     }
 
     /**
@@ -815,12 +809,10 @@ class EventAuditLogger
 
     private function encrypt(#[SensitiveParameter] string $plaintext): string
     {
-        if ($this->cipherSuite !== null) {
-            return $this->cipherSuite->encrypt($plaintext);
-        } elseif ($this->cryptoGen !== null) {
-            return $this->cryptoGen->encryptStandard($plaintext);
+        if ($this->crypto instanceof CipherSuiteInterface) {
+            return $this->crypto->encrypt($plaintext);
         } else {
-            throw new InvalidArgumentException('Both crypto paths are null');
+            return $this->crypto->encryptStandard($plaintext);
         }
     }
 }

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Common\Logging;
 
-use InvalidArgumentException;
 use Lcobucci\Clock\FrozenClock;
 use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Logging\Audit\Event;
@@ -67,7 +66,7 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$sink1, $sink2],
-            cryptoGen: $this->crypto,
+            crypto: $this->crypto,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -102,7 +101,7 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$sink],
-            cryptoGen: $this->crypto,
+            crypto: $this->crypto,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -139,7 +138,7 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$sink],
-            cryptoGen: $this->crypto,
+            crypto: $this->crypto,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,
@@ -169,7 +168,7 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$sink],
-            cryptoGen: $this->crypto,
+            crypto: $this->crypto,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -190,7 +189,7 @@ class EventAuditLoggerTest extends TestCase
     {
         $logger = new EventAuditLogger(
             sinks: [],
-            cryptoGen: $this->crypto,
+            crypto: $this->crypto,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -224,7 +223,7 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$failingSink, $successSink],
-            cryptoGen: $this->crypto,
+            crypto: $this->crypto,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -261,7 +260,7 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$sink],
-            cryptoGen: $this->crypto,
+            crypto: $this->crypto,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,
@@ -300,7 +299,7 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$sink],
-            cryptoGen: $this->crypto,
+            crypto: $this->crypto,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -316,23 +315,6 @@ class EventAuditLoggerTest extends TestCase
             group: 'testgroup',
             comments: 'Test comments',
             patientId: 'NULL',
-        );
-    }
-
-    public function testConstructorThrowsWhenBothCryptoProvidersAreNull(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('CipherSuite or CryptoGen MUST be provided');
-
-        new EventAuditLogger(
-            sinks: [],
-            cryptoGen: null,
-            cipherSuite: null,
-            shouldEncrypt: false,
-            session: $this->session,
-            config: $this->config,
-            breakglassChecker: $this->breakglassChecker,
-            clock: $this->clock,
         );
     }
 
@@ -355,8 +337,7 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$sink],
-            cryptoGen: null,
-            cipherSuite: $cipherSuite,
+            crypto: $cipherSuite,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -68,7 +68,6 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$sink1, $sink2],
             cryptoGen: $this->crypto,
-            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -104,7 +103,6 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$sink],
             cryptoGen: $this->crypto,
-            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -142,7 +140,6 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$sink],
             cryptoGen: $this->crypto,
-            cipherSuite: null,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,
@@ -173,7 +170,6 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$sink],
             cryptoGen: $this->crypto,
-            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -195,7 +191,6 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [],
             cryptoGen: $this->crypto,
-            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -230,7 +225,6 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$failingSink, $successSink],
             cryptoGen: $this->crypto,
-            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -268,7 +262,6 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$sink],
             cryptoGen: $this->crypto,
-            cipherSuite: null,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,
@@ -308,7 +301,6 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$sink],
             cryptoGen: $this->crypto,
-            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Common\Logging;
 
+use InvalidArgumentException;
 use Lcobucci\Clock\FrozenClock;
 use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Logging\Audit\Event;
@@ -21,6 +22,7 @@ use OpenEMR\Common\Logging\Audit\SinkInterface;
 use OpenEMR\Common\Logging\AuditConfig;
 use OpenEMR\Common\Logging\BreakglassCheckerInterface;
 use OpenEMR\Common\Logging\EventAuditLogger;
+use OpenEMR\Encryption\CipherSuiteInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
@@ -322,6 +324,60 @@ class EventAuditLoggerTest extends TestCase
             group: 'testgroup',
             comments: 'Test comments',
             patientId: 'NULL',
+        );
+    }
+
+    public function testConstructorThrowsWhenBothCryptoProvidersAreNull(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('CipherSuite or CryptoGen MUST be provided');
+
+        new EventAuditLogger(
+            sinks: [],
+            cryptoGen: null,
+            cipherSuite: null,
+            shouldEncrypt: false,
+            session: $this->session,
+            config: $this->config,
+            breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
+        );
+    }
+
+    public function testRecordLogItemEncryptsCommentsViaCipherSuite(): void
+    {
+        $cipherSuite = $this->createMock(CipherSuiteInterface::class);
+        $cipherSuite->expects($this->once())
+            ->method('encrypt')
+            ->with('Sensitive data')
+            ->willReturn('ciphersuite-encrypted:Sensitive data');
+
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->once())
+            ->method('record')
+            ->with(self::callback(function (Event $event): bool {
+                self::assertSame('ciphersuite-encrypted:Sensitive data', $event->comments);
+                return true;
+            }))
+            ->willReturn(true);
+
+        $logger = new EventAuditLogger(
+            sinks: [$sink],
+            cryptoGen: null,
+            cipherSuite: $cipherSuite,
+            shouldEncrypt: true,
+            session: $this->session,
+            config: $this->config,
+            breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
+        );
+
+        $logger->recordLogItem(
+            success: 1,
+            event: 'login',
+            user: 'testuser',
+            group: 'testgroup',
+            comments: 'Sensitive data',
         );
     }
 }

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -66,6 +66,7 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$sink1, $sink2],
             cryptoGen: $this->crypto,
+            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -101,6 +102,7 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$sink],
             cryptoGen: $this->crypto,
+            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -138,6 +140,7 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$sink],
             cryptoGen: $this->crypto,
+            cipherSuite: null,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,
@@ -168,6 +171,7 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$sink],
             cryptoGen: $this->crypto,
+            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -189,6 +193,7 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [],
             cryptoGen: $this->crypto,
+            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -223,6 +228,7 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$failingSink, $successSink],
             cryptoGen: $this->crypto,
+            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -260,6 +266,7 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$sink],
             cryptoGen: $this->crypto,
+            cipherSuite: null,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,
@@ -299,6 +306,7 @@ class EventAuditLoggerTest extends TestCase
         $logger = new EventAuditLogger(
             sinks: [$sink],
             cryptoGen: $this->crypto,
+            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,

--- a/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
@@ -136,7 +136,7 @@ final class EventAuditLoggerTest extends TestCase
         // Get EventAuditLogger instance (works with existing singleton)
         $this->eventAuditLogger = new EventAuditLogger(
             sinks: [],
-            cryptoGen: ServiceContainer::getCrypto(),
+            crypto: ServiceContainer::getCrypto(),
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -518,7 +518,7 @@ final class EventAuditLoggerTest extends TestCase
 
         $eventAuditLogger = new EventAuditLogger(
             sinks: [],
-            cryptoGen: $this->createMock(CryptoGen::class),
+            crypto: $this->createMock(CryptoGen::class),
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -567,7 +567,7 @@ final class EventAuditLoggerTest extends TestCase
 
         $eventAuditLogger = new EventAuditLogger(
             sinks: [],
-            cryptoGen: $cryptoMock,
+            crypto: $cryptoMock,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,
@@ -673,7 +673,7 @@ final class EventAuditLoggerTest extends TestCase
 
         $eventAuditLogger = new EventAuditLogger(
             sinks: [],
-            cryptoGen: $cryptoMock,
+            crypto: $cryptoMock,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,

--- a/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
@@ -137,7 +137,6 @@ final class EventAuditLoggerTest extends TestCase
         $this->eventAuditLogger = new EventAuditLogger(
             sinks: [],
             cryptoGen: ServiceContainer::getCrypto(),
-            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -520,7 +519,6 @@ final class EventAuditLoggerTest extends TestCase
         $eventAuditLogger = new EventAuditLogger(
             sinks: [],
             cryptoGen: $this->createMock(CryptoGen::class),
-            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -570,7 +568,6 @@ final class EventAuditLoggerTest extends TestCase
         $eventAuditLogger = new EventAuditLogger(
             sinks: [],
             cryptoGen: $cryptoMock,
-            cipherSuite: null,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,
@@ -677,7 +674,6 @@ final class EventAuditLoggerTest extends TestCase
         $eventAuditLogger = new EventAuditLogger(
             sinks: [],
             cryptoGen: $cryptoMock,
-            cipherSuite: null,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,

--- a/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
@@ -137,6 +137,7 @@ final class EventAuditLoggerTest extends TestCase
         $this->eventAuditLogger = new EventAuditLogger(
             sinks: [],
             cryptoGen: ServiceContainer::getCrypto(),
+            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -519,6 +520,7 @@ final class EventAuditLoggerTest extends TestCase
         $eventAuditLogger = new EventAuditLogger(
             sinks: [],
             cryptoGen: $this->createMock(CryptoGen::class),
+            cipherSuite: null,
             shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
@@ -568,6 +570,7 @@ final class EventAuditLoggerTest extends TestCase
         $eventAuditLogger = new EventAuditLogger(
             sinks: [],
             cryptoGen: $cryptoMock,
+            cipherSuite: null,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,
@@ -674,6 +677,7 @@ final class EventAuditLoggerTest extends TestCase
         $eventAuditLogger = new EventAuditLogger(
             sinks: [],
             cryptoGen: $cryptoMock,
+            cipherSuite: null,
             shouldEncrypt: true,
             session: $this->session,
             config: $this->config,


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Updates EventAuditLogger to support the new `CipherSuiteInterface` encryption path alongside the existing `CryptoInterface`, allowing gradual migration to the new encryption system.

#### Changes proposed in this pull request:

- Adjust constructor of EAL to accept `CipherSuiteInterface` _or_ `CryptoInterface`
- Encryption prefers CipherSuiteInterface when available, falls back to CryptoInterface
- Add tests for new encryption paths; update call sites using named parameters

#### Was an AI assistant used? Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)