### PR TITLE
ci: key phpstan and rector caches on tool version, not composer.lock

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -35,14 +35,27 @@ jobs:
     # (it bundles some type-incomplete polyfills which can throw off results)
     - name: Remove Rector
       run: composer remove --dev --optimize-autoloader rector/rector
+    # Resolve the installed phpstan version so the cache key invalidates on
+    # tool bumps but survives unrelated dependency changes. Hashing the whole
+    # composer.lock over-invalidates; fallback restore would otherwise serve
+    # a cache produced by a different phpstan, silently corrupting results.
+    - name: Resolve PHPStan version
+      id: phpstan-version
+      run: |
+        version=$(jq -r '
+          (.packages + .["packages-dev"])[]
+          | select(.name == "phpstan/phpstan")
+          | .version
+        ' composer.lock)
+        printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
     - name: PHPStan Cache
       # https://phpstan.org/user-guide/result-cache
       uses: actions/cache@v5
       with:
         path: tmp-phpstan # same as in phpstan.neon
-        key: phpstan-result-cache-${{ github.run_id }}
+        key: phpstan-result-cache-${{ steps.phpstan-version.outputs.version }}-${{ hashFiles('phpstan.neon.dist', '.phpstan/**', 'tests/PHPStan/**') }}-${{ github.run_id }}
         restore-keys: |
-          phpstan-result-cache-
+          phpstan-result-cache-${{ steps.phpstan-version.outputs.version }}-${{ hashFiles('phpstan.neon.dist', '.phpstan/**', 'tests/PHPStan/**') }}-
     - name: PHPStan Diagnose
       run: vendor/bin/phpstan --memory-limit=8G diagnose
     # Use CI config which sets reportUnmatchedIgnoredErrors: false so this step

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -31,12 +31,26 @@ jobs:
       with:
         php-version: ${{ matrix.php-version }}
 
+    # Resolve the installed rector version so the cache key invalidates on
+    # tool bumps but survives unrelated dependency changes. Hashing the whole
+    # composer.lock over-invalidates; fallback restore would otherwise serve
+    # a cache produced by a different rector, silently corrupting results.
+    - name: Resolve Rector version
+      id: rector-version
+      run: |
+        version=$(jq -r '
+          (.packages + .["packages-dev"])[]
+          | select(.name == "rector/rector")
+          | .version
+        ' composer.lock)
+        printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
     - name: Rector Cache
       uses: actions/cache@v5
       with:
         path: /tmp/rector
-        key: ${{ runner.os }}-rector-${{ hashFiles('rector.php', 'composer.lock') }}-${{ github.run_id }}
-        restore-keys: ${{ runner.os }}-rector-${{ hashFiles('rector.php', 'composer.lock') }}-
+        key: ${{ runner.os }}-rector-${{ steps.rector-version.outputs.version }}-${{ hashFiles('rector.php') }}-${{ github.run_id }}
+        restore-keys: ${{ runner.os }}-rector-${{ steps.rector-version.outputs.version }}-${{ hashFiles('rector.php') }}-
 
     - name: Create Rector cache directory
       run: mkdir -p /tmp/rector


### PR DESCRIPTION
## Summary

- phpstan and rector CI caches were restoring fallback entries produced by different tool versions, silently corrupting analysis results. Observed on openemr/openemr#11713 (Dependabot bump of phpstan 2.1.46 → 2.1.50 and rector 2.4.1 → 2.4.2).
- Key the caches on the resolved tool version (extracted from `composer.lock` via `jq`) plus the tool's own config files. Unrelated dependency bumps keep caches warm; tool bumps invalidate cleanly with no fallback to a foreign-version cache.
- Scope: `.github/workflows/phpstan.yml`, `.github/workflows/rector.yml`.

### Why not hash the whole composer.lock?

Hashing `composer.lock` over-invalidates the cache on every unrelated dependency bump, turning every Dependabot PR into a cold run. Resolving the specific tool version narrows invalidation to the changes that actually affect cache correctness.

### Why drop `composer.lock` from the rector restore-keys entirely?

Rector bundles its own namespace-prefixed phpstan internally. A top-level `phpstan/phpstan` bump does not change rector's behavior, so it should not evict rector's cache. The new key tracks only `rector/rector` + `rector.php`. If rector gains companion packages in the future (e.g. `rector/rector-phpunit`, `rector/rector-doctrine`), add them to the jq filter.

## Test plan

- [ ] First run after merge produces a cache miss for both workflows (expected — new key).
- [ ] Subsequent run on an unrelated code PR hits the cache (exact key match via `github.run_id` scope, or restore-keys fallback to same tool version + config).
- [ ] A Dependabot PR bumping phpstan/phpstan invalidates phpstan cache but leaves rector cache warm.
- [ ] A Dependabot PR bumping rector/rector invalidates rector cache but leaves phpstan cache warm.
- [ ] No fallback restores across tool versions (the prefix now embeds the resolved version).