### PR TITLE
fix(ci): prevent cross-Node-version cache contamination in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -242,7 +242,6 @@ jobs:
           public/themes/
         restore-keys: |
           ${{ runner.os }}-npm-build-${{ steps.parse.outputs.node_version }}-
-          ${{ runner.os }}-npm-build-
 
     ##
     # The 'cache-hit' output for actions/cache/restore is always false
@@ -272,7 +271,6 @@ jobs:
         key: ${{ steps.cache-keys.outputs.ccda-build }}
         restore-keys: |
           ${{ runner.os }}-ccda-build-${{ steps.parse.outputs.node_version }}-
-          ${{ runner.os }}-ccda-build-
 
     ##
     # The 'cache-hit' output for actions/cache/restore is always false
@@ -301,7 +299,6 @@ jobs:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
         restore-keys: |
           ${{ runner.os }}-node-${{ steps.parse.outputs.node_version }}-
-          ${{ runner.os }}-node-
 
     ##
     # The 'cache-hit' output for actions/cache/restore is always false


### PR DESCRIPTION
## Summary

The test workflow's `npm-build`, `ccda-build`, and `npm` caches had a catch-all restore-key prefix (e.g. `${{ runner.os }}-ccda-build-`) as a fallback after the Node-version-specific prefix. When a PR modifies a lockfile so the exact key misses, and no Node-version-specific cache exists for that new hash, the catch-all happily restores a cache compiled against a different Node ABI.

Concretely: dependabot PRs #11721 and #11722 (changes only to `ccdaservice/package-lock.json`) were failing the `PHP 8.2 - nginx - mariadb 11.8.6 / services` job with:

```
Error: The module '…/ccdaservice/node_modules/libxmljs2/build/Release/xmljs.node'
was compiled against a different Node.js version using NODE_MODULE_VERSION 127.
This version of Node.js requires NODE_MODULE_VERSION 137.
code: 'ERR_DLOPEN_FAILED'
```

`apache_82_118` in the matrix still runs on Node 22 (everything else moved to Node 24 in #11495). For every matrix run it populates `Linux-ccda-build-22-<lockfile-hash>`. When the Node-24 `nginx_82` job runs afterward with the same new lockfile hash, the exact `Linux-ccda-build-24-<hash>` key misses, the `Linux-ccda-build-24-` prefix finds nothing matching the new hash, and the catch-all `Linux-ccda-build-` restores the just-saved Node 22 cache — DLOPEN fails.

Master passes because its cache entries hit the exact key on the first try (no restore-key fallback needed).

This PR drops the broad catch-all restore-keys from the three affected caches, keeping only the Node-version-scoped prefix. A miss now triggers a rebuild, which is the correct outcome when the lockfile changed anyway.

## Test plan

- [ ] Dependabot PRs touching `ccdaservice/package-lock.json` stop failing the `services` job with `ERR_DLOPEN_FAILED`
- [ ] Cache hit rates remain acceptable on subsequent runs (node_version-prefixed restore still works when the exact key misses but the Node version is unchanged)