### PR TITLE
fix(local-api): bootstrap missing user UUID to prevent 500 on fresh installs

### DIFF
--- a/src/RestControllers/Authorization/LocalApiAuthorizationController.php
+++ b/src/RestControllers/Authorization/LocalApiAuthorizationController.php
@@ -5,6 +5,7 @@ namespace OpenEMR\RestControllers\Authorization;
 use OpenEMR\Common\Auth\UuidUserAccount;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Http\HttpRestRequest;
+use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\UserService;
 use Psr\Log\LoggerInterface;
@@ -61,7 +62,7 @@ class LocalApiAuthorizationController implements IAuthorizationStrategy
             throw new UnauthorizedHttpException("APICSRFTOKEN", "OpenEMR Error: internal api failed because csrf token did not match");
         }
         $userId = $session->get('authUserID');
-        if (empty($userId)) {
+        if ((!is_int($userId) && !is_string($userId)) || empty($userId)) {
             // unable to identify the user
             $this->logger->error("OpenEMR Error - api user account could not be identified, so forced exit", ['userId' => $userId]);
             throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR);
@@ -78,7 +79,31 @@ class LocalApiAuthorizationController implements IAuthorizationStrategy
                 'userRole' => $userRole]);
             throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR);
         }
-        $userUuid = $user['uuid'];
+        $userUuid = $user['uuid'] ?? null;
+        if ($userUuid === null || $userUuid === '') {
+            // Fresh installs (and upgrades pre-dating the users.uuid column) may
+            // have users without a UUID until UUID_Service runs. Populate on
+            // demand so LocalApi does not 500 on bootstrap. Mirrors the
+            // OAuth password-grant bootstrap in
+            // OpenIDConnect\Repositories\UserRepository::getAccountByPassword().
+            $this->bootstrapMissingUserUuids();
+            $user = $userService->getUser($userId);
+            if ($user === false) {
+                $this->logger->error(
+                    "OpenEMR Error - local api user not found after UUID bootstrap; forced exit",
+                    ['userId' => $userId]
+                );
+                throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR);
+            }
+            $userUuid = $user['uuid'] ?? null;
+            if ($userUuid === null || $userUuid === '') {
+                $this->logger->error(
+                    "OpenEMR Error - local api user has no UUID even after bootstrap; forced exit",
+                    ['userId' => $userId]
+                );
+                throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR);
+            }
+        }
         $request->attributes->set('userId', $userUuid);
         $request->attributes->set('clientId', null);
         $request->attributes->set('tokenId', $csrfToken);
@@ -100,5 +125,14 @@ class LocalApiAuthorizationController implements IAuthorizationStrategy
     public function setUserService(UserService $userService): void
     {
         $this->userService = $userService;
+    }
+
+    /**
+     * Populate missing UUIDs for the users table. Extracted for testability;
+     * delegates to the static UuidRegistry that hits the database.
+     */
+    protected function bootstrapMissingUserUuids(): void
+    {
+        UuidRegistry::createMissingUuidsForTables(['users']);
     }
 }

--- a/src/RestControllers/Authorization/LocalApiAuthorizationController.php
+++ b/src/RestControllers/Authorization/LocalApiAuthorizationController.php
@@ -4,6 +4,7 @@ namespace OpenEMR\RestControllers\Authorization;
 
 use OpenEMR\Common\Auth\UuidUserAccount;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\OEGlobalsBag;
@@ -82,11 +83,11 @@ class LocalApiAuthorizationController implements IAuthorizationStrategy
         $userUuid = $user['uuid'] ?? null;
         if ($userUuid === null || $userUuid === '') {
             // Fresh installs (and upgrades pre-dating the users.uuid column) may
-            // have users without a UUID until UUID_Service runs. Populate on
-            // demand so LocalApi does not 500 on bootstrap. Mirrors the
-            // OAuth password-grant bootstrap in
-            // OpenIDConnect\Repositories\UserRepository::getAccountByPassword().
-            $this->bootstrapMissingUserUuids();
+            // have users without a UUID until UUID_Service runs. Populate the
+            // UUID for this single user row on demand so LocalApi does not 500
+            // on bootstrap. Scoped to the authenticated user to avoid letting
+            // an authenticated request trigger a whole-table backfill.
+            $this->bootstrapMissingUserUuid($userId);
             $user = $userService->getUser($userId);
             if ($user === false) {
                 $this->logger->error(
@@ -128,11 +129,20 @@ class LocalApiAuthorizationController implements IAuthorizationStrategy
     }
 
     /**
-     * Populate missing UUIDs for the users table. Extracted for testability;
-     * delegates to the static UuidRegistry that hits the database.
+     * Populate the UUID for a single user row when missing. Extracted for
+     * testability; generates a UUID via UuidRegistry and writes only the
+     * target row so an authenticated request cannot trigger a whole-table
+     * backfill.
      */
-    protected function bootstrapMissingUserUuids(): void
+    protected function bootstrapMissingUserUuid(int|string $userId): void
     {
-        UuidRegistry::createMissingUuidsForTables(['users']);
+        $registry = new UuidRegistry(['table_name' => 'users']);
+        $uuidBytes = $registry->createUuid();
+        QueryUtils::sqlStatementThrowException(
+            "UPDATE `users` SET `uuid` = ? WHERE `id` = ? "
+            . "AND (`uuid` IS NULL OR `uuid` = '' "
+            . "OR `uuid` = '\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0')",
+            [$uuidBytes, $userId]
+        );
     }
 }

--- a/tests/Tests/Isolated/RestControllers/Authorization/LocalApiAuthorizationControllerTest.php
+++ b/tests/Tests/Isolated/RestControllers/Authorization/LocalApiAuthorizationControllerTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorageFactory;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class LocalApiAuthorizationControllerTest extends TestCase
@@ -106,5 +107,84 @@ class LocalApiAuthorizationControllerTest extends TestCase
 
         $this->expectException(UnauthorizedHttpException::class);
         $controller->authorizeRequest($request);
+    }
+
+    public function testAuthorizeRequestBootstrapsMissingUserUuid(): void
+    {
+        $userId = 1;
+        $uuid = '123e4567-e89b-12d3-a456-426614174000';
+        $userWithoutUuid = ['id' => $userId, 'username' => 'testuser', 'uuid' => null];
+        $userWithUuid = ['id' => $userId, 'username' => 'testuser', 'uuid' => $uuid];
+
+        $mockUserService = $this->createMock(UserService::class);
+        // First call returns user with no UUID, second (after bootstrap) returns populated.
+        $mockUserService->expects($this->exactly(2))
+            ->method('getUser')
+            ->willReturnOnConsecutiveCalls($userWithoutUuid, $userWithUuid);
+
+        $bootstrapCalls = 0;
+        $controller = new class (
+            $this->createMock(LoggerInterface::class),
+            new OEGlobalsBag(),
+            $bootstrapCalls,
+        ) extends LocalApiAuthorizationController {
+            public function __construct(LoggerInterface $logger, OEGlobalsBag $globalsBag, public int &$bootstrapCalls)
+            {
+                parent::__construct($logger, $globalsBag);
+            }
+            protected function bootstrapMissingUserUuids(): void
+            {
+                $this->bootstrapCalls++;
+            }
+        };
+        $controller->setUserService($mockUserService);
+
+        $request = $this->buildAuthenticatedRequest($userId);
+        $this->assertTrue(
+            $controller->authorizeRequest($request),
+            "Expected authorizeRequest to succeed after bootstrapping missing UUID",
+        );
+        $this->assertSame(1, $bootstrapCalls, "Expected bootstrap to be invoked exactly once");
+        $this->assertSame($uuid, $request->attributes->get('userId'));
+    }
+
+    public function testAuthorizeRequestFailsWhenBootstrapCannotProduceUuid(): void
+    {
+        $userId = 1;
+        $userWithoutUuid = ['id' => $userId, 'username' => 'testuser', 'uuid' => null];
+
+        $mockUserService = $this->createMock(UserService::class);
+        $mockUserService->expects($this->exactly(2))
+            ->method('getUser')
+            ->willReturn($userWithoutUuid);
+
+        $controller = new class (
+            $this->createMock(LoggerInterface::class),
+            new OEGlobalsBag(),
+        ) extends LocalApiAuthorizationController {
+            protected function bootstrapMissingUserUuids(): void
+            {
+                // Simulate bootstrap running but failing to produce a UUID (e.g. DB issue).
+            }
+        };
+        $controller->setUserService($mockUserService);
+
+        $request = $this->buildAuthenticatedRequest($userId);
+        $this->expectException(HttpException::class);
+        $controller->authorizeRequest($request);
+    }
+
+    private function buildAuthenticatedRequest(int $userId): HttpRestRequest
+    {
+        $request = new HttpRestRequest();
+        $sessionFactory = new MockFileSessionStorageFactory();
+        $sessionStorage = $sessionFactory->createStorage($request);
+        $session = new Session($sessionStorage);
+        $session->start();
+        CsrfUtils::setupCsrfKey($session);
+        $session->set('authUserID', $userId);
+        $request->setSession($session);
+        $request->headers->set('APICSRFTOKEN', CsrfUtils::collectCsrfToken($session, 'api') ?: '');
+        return $request;
     }
 }

--- a/tests/Tests/Isolated/RestControllers/Authorization/LocalApiAuthorizationControllerTest.php
+++ b/tests/Tests/Isolated/RestControllers/Authorization/LocalApiAuthorizationControllerTest.php
@@ -123,18 +123,28 @@ class LocalApiAuthorizationControllerTest extends TestCase
             ->willReturnOnConsecutiveCalls($userWithoutUuid, $userWithUuid);
 
         $bootstrapCalls = 0;
+        $bootstrapUserIds = [];
         $controller = new class (
             $this->createMock(LoggerInterface::class),
             new OEGlobalsBag(),
             $bootstrapCalls,
+            $bootstrapUserIds,
         ) extends LocalApiAuthorizationController {
-            public function __construct(LoggerInterface $logger, OEGlobalsBag $globalsBag, public int &$bootstrapCalls)
-            {
+            /**
+             * @param list<int|string> $bootstrapUserIds
+             */
+            public function __construct(
+                LoggerInterface $logger,
+                OEGlobalsBag $globalsBag,
+                public int &$bootstrapCalls,
+                public array &$bootstrapUserIds,
+            ) {
                 parent::__construct($logger, $globalsBag);
             }
-            protected function bootstrapMissingUserUuids(): void
+            protected function bootstrapMissingUserUuid(int|string $userId): void
             {
                 $this->bootstrapCalls++;
+                $this->bootstrapUserIds[] = $userId;
             }
         };
         $controller->setUserService($mockUserService);
@@ -145,6 +155,7 @@ class LocalApiAuthorizationControllerTest extends TestCase
             "Expected authorizeRequest to succeed after bootstrapping missing UUID",
         );
         $this->assertSame(1, $bootstrapCalls, "Expected bootstrap to be invoked exactly once");
+        $this->assertSame([$userId], $bootstrapUserIds, "Expected bootstrap to be scoped to the authenticated user");
         $this->assertSame($uuid, $request->attributes->get('userId'));
     }
 
@@ -162,7 +173,7 @@ class LocalApiAuthorizationControllerTest extends TestCase
             $this->createMock(LoggerInterface::class),
             new OEGlobalsBag(),
         ) extends LocalApiAuthorizationController {
-            protected function bootstrapMissingUserUuids(): void
+            protected function bootstrapMissingUserUuid(int|string $userId): void
             {
                 // Simulate bootstrap running but failing to produce a UUID (e.g. DB issue).
             }


### PR DESCRIPTION
## Summary

`LocalApiAuthorizationController::authorizeRequest()` throws a 500 when the authenticated user has no UUID in the `users` table. That state is reachable on fresh installs (and upgrades pre-dating the `users.uuid` column) until `UUID_Service` happens to run. The crash surfaces as `Uuid::fromString(null)` once `setRequestUser()` is called downstream, so every local-API consumer breaks in that window.

Populate the UUID on demand when missing, mirroring the OAuth password-grant bootstrap in `OpenIDConnect\Repositories\UserRepository::getAccountByPassword()`. The bootstrap call is extracted into a protected `bootstrapMissingUserUuids()` method so tests can stub it without touching the database.

While narrowing the user-lookup path for PHPStan, replace the `mixed` session guard so `UserService::getUser()` is called with `int|string` — that also drops the corresponding baseline entry for this file.

## Why a separate PR

Discovered while bench-testing #11727 (migrate main-tab background services poll to the REST API). That PR surfaced the bug because it becomes the first LocalApi consumer that a fresh dev login hits before any OAuth path has populated the UUID. Fixing the bootstrap here keeps the background-services migration a pure REST-endpoint swap.

## Test plan

- [x] `composer phpunit-isolated -- --filter LocalApiAuthorizationControllerTest` — passes (7/7)
- [x] `composer phpstan` — clean, baseline entry for this file removed
- [x] All pre-commit hooks (phpcbf, phpcs, phpstan, rector, composer-require-checker, codespell) pass
- [x] Manual: fresh `docker/development-easy` install + LocalApi call with admin session that had no UUID now populates `users.uuid` and returns the expected 200 response; previously 500'd on `Uuid::fromString(null)`
