### PR TITLE
refactor(uuid): scope auth-path UUID bootstrap to single row

### DIFF
--- a/src/Common/Auth/OpenIDConnect/Repositories/UserRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/UserRepository.php
@@ -92,7 +92,11 @@ class UserRepository implements UserRepositoryInterface, IdentityProviderInterfa
             $auth = new AuthUtils('api');
             if ($auth->confirmPassword($username, $password)) {
                 $id = $auth->getUserId();
-                UuidRegistry::createMissingUuidsForTables(['users']);
+                if (!is_int($id) && !is_string($id)) {
+                    $this->logger?->error("Unable to resolve user id after password grant login");
+                    return false;
+                }
+                UuidRegistry::createMissingUuidForRow('users', 'id', $id);
                 $uuid = sqlQueryNoLog("SELECT `uuid` FROM `users` WHERE `id` = ?", [$id])['uuid'];
                 if (empty($uuid)) {
                     $this->getSystemLogger()->error("Unable to map uuid for user when creating oauth password grant token");
@@ -134,7 +138,11 @@ class UserRepository implements UserRepositoryInterface, IdentityProviderInterfa
             $auth = new AuthUtils('portal-api');
             if ($auth->confirmPassword($username, $password, $email)) {
                 $id = $auth->getPatientId();
-                UuidRegistry::createMissingUuidsForTables(['patient_data']);
+                if (!is_int($id) && !is_string($id)) {
+                    $this->logger?->error("Unable to resolve patient id after password grant login");
+                    return false;
+                }
+                UuidRegistry::createMissingUuidForRow('patient_data', 'pid', $id);
                 $uuid = sqlQueryNoLog("SELECT `uuid` FROM `patient_data` WHERE `pid` = ?", [$id])['uuid'];
                 if (empty($uuid)) {
                     $this->getSystemLogger()->error("Unable to map uuid for patient when creating oauth password grant token");

--- a/src/Common/Uuid/UuidRegistry.php
+++ b/src/Common/Uuid/UuidRegistry.php
@@ -233,6 +233,46 @@ class UuidRegistry
         }
     }
 
+    /**
+     * Populate the UUID for a single row when missing, keyed by the caller's
+     * id column. Intended for code paths (authentication, authorization) that
+     * need to ensure the current principal has a UUID without letting an
+     * authenticated request trigger a whole-table backfill across every row
+     * missing a UUID. Prefer this over createMissingUuidsForTables() whenever
+     * the caller already knows which row it cares about.
+     *
+     * Generates a UUID via the registry (so it is inserted into uuid_registry
+     * like any other) and updates only the row matching the supplied id,
+     * guarded against NULL / empty / all-zero byte UUID values so the update
+     * is idempotent.
+     *
+     * @param string     $tableName table registered in UUID_TABLE_DEFINITIONS
+     * @param string     $idColumn  column to match in the WHERE clause
+     * @param int|string $idValue   id value to match
+     * @throws \InvalidArgumentException if the table is unknown or the id column is not a valid identifier
+     */
+    public static function createMissingUuidForRow(string $tableName, string $idColumn, int|string $idValue): void
+    {
+        if (!isset(self::UUID_TABLE_DEFINITIONS[$tableName])) {
+            throw new \InvalidArgumentException(
+                "UuidRegistry::createMissingUuidForRow: unknown table '" . $tableName . "'"
+            );
+        }
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $idColumn) !== 1) {
+            throw new \InvalidArgumentException(
+                "UuidRegistry::createMissingUuidForRow: invalid id column '" . $idColumn . "'"
+            );
+        }
+        $registry = new self(['table_name' => $tableName]);
+        $uuidBytes = $registry->createUuid();
+        QueryUtils::sqlStatementThrowException(
+            "UPDATE `" . $tableName . "` SET `uuid` = ? WHERE `" . $idColumn . "` = ? "
+            . "AND (`uuid` IS NULL OR `uuid` = '' "
+            . "OR `uuid` = '\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0')",
+            [$uuidBytes, $idValue]
+        );
+    }
+
 
     // Helper function for above populateAllMissingUuids function
     private static function appendPopulateLog($table, $count, &$logEntry)

--- a/src/Common/Uuid/UuidRegistry.php
+++ b/src/Common/Uuid/UuidRegistry.php
@@ -241,10 +241,16 @@ class UuidRegistry
      * missing a UUID. Prefer this over createMissingUuidsForTables() whenever
      * the caller already knows which row it cares about.
      *
-     * Generates a UUID via the registry (so it is inserted into uuid_registry
-     * like any other) and updates only the row matching the supplied id,
-     * guarded against NULL / empty / all-zero byte UUID values so the update
-     * is idempotent.
+     * Generates a candidate UUID without inserting into uuid_registry, runs
+     * a guarded UPDATE against NULL / empty / all-zero byte UUID values on
+     * the target row, and only then records the UUID in uuid_registry when
+     * the UPDATE actually wrote a row. This keeps the call idempotent and
+     * avoids leaking orphaned uuid_registry entries when the row already
+     * has a UUID or does not exist.
+     *
+     * The all-zero byte comparison is bound as a parameter rather than
+     * embedded as a backslash-escaped SQL literal so the predicate works
+     * regardless of the connection's NO_BACKSLASH_ESCAPES mode.
      *
      * @param string     $tableName table registered in UUID_TABLE_DEFINITIONS
      * @param string     $idColumn  column to match in the WHERE clause
@@ -264,13 +270,17 @@ class UuidRegistry
             );
         }
         $registry = new self(['table_name' => $tableName]);
-        $uuidBytes = $registry->createUuid();
+        $uuidBytes = $registry->getUnusedUuidBatch(1)[0];
+        $nilUuid = str_repeat("\0", 16);
         QueryUtils::sqlStatementThrowException(
-            "UPDATE `" . $tableName . "` SET `uuid` = ? WHERE `" . $idColumn . "` = ? "
-            . "AND (`uuid` IS NULL OR `uuid` = '' "
-            . "OR `uuid` = '\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0')",
-            [$uuidBytes, $idValue]
+            "UPDATE `" . $tableName . "` SET `uuid` = ? "
+            . "WHERE `" . $idColumn . "` = ? "
+            . "AND (`uuid` IS NULL OR `uuid` = '' OR `uuid` = ?)",
+            [$uuidBytes, $idValue, $nilUuid]
         );
+        if (QueryUtils::affectedRows() === 1) {
+            $registry->insertUuidsIntoRegistry([$uuidBytes]);
+        }
     }
 
 

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -1151,13 +1151,16 @@ class AuthorizationController
 
     protected function getUserUuid($userId, $userRole): string
     {
+        if (!is_int($userId) && !is_string($userId)) {
+            return '';
+        }
         switch ($userRole) {
             case 'users':
-                UuidRegistry::createMissingUuidsForTables(['users']);
+                UuidRegistry::createMissingUuidForRow('users', 'id', $userId);
                 $account_sql = "SELECT `uuid` FROM `users` WHERE `id` = ?";
                 break;
             case 'patient':
-                UuidRegistry::createMissingUuidsForTables(['patient_data']);
+                UuidRegistry::createMissingUuidForRow('patient_data', 'pid', $userId);
                 $account_sql = "SELECT `uuid` FROM `patient_data` WHERE `pid` = ?";
                 break;
             default:

--- a/src/Services/UserService.php
+++ b/src/Services/UserService.php
@@ -120,8 +120,8 @@ class UserService
 
         if (!empty($user)) {
             if (empty($user['uuid'])) {
-                // we should always have this setup, but create them just in case.
-                UuidRegistry::createMissingUuidsForTables(['users']);
+                // we should always have this setup, but create it just in case.
+                UuidRegistry::createMissingUuidForRow('users', 'id', $user['id']);
             }
         }
         return $user;

--- a/tests/Tests/Isolated/Common/Uuid/UuidRegistryTest.php
+++ b/tests/Tests/Isolated/Common/Uuid/UuidRegistryTest.php
@@ -3,6 +3,7 @@
 namespace OpenEMR\Tests\Isolated\Common\Uuid;
 
 use OpenEMR\Common\Uuid\UuidRegistry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidFactory;
 
@@ -33,5 +34,36 @@ class UuidRegistryTest extends TestCase
         $byteValue = UuidRegistry::uuidToBytes($stringValue);
         $this->assertEquals(UuidRegistry::uuidToBytes($stringValue), $byteValue);
         $this->assertEquals($stringValue, UuidRegistry::uuidToString($byteValue));
+    }
+
+    public function testCreateMissingUuidForRowRejectsUnknownTable(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/unknown table/');
+        UuidRegistry::createMissingUuidForRow('not_a_real_table', 'id', 1);
+    }
+
+    #[DataProvider('invalidIdColumns')]
+    public function testCreateMissingUuidForRowRejectsInvalidIdColumn(string $idColumn): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/invalid id column/');
+        UuidRegistry::createMissingUuidForRow('users', $idColumn, 1);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function invalidIdColumns(): array
+    {
+        return [
+            'sql injection attempt' => ['id`; DROP TABLE users; --'],
+            'leading digit' => ['1id'],
+            'hyphen' => ['user-id'],
+            'space' => ['user id'],
+            'empty string' => [''],
+        ];
     }
 }


### PR DESCRIPTION
## Summary

Add `UuidRegistry::createMissingUuidForRow()` and replace the four legacy auth-path call sites of `createMissingUuidsForTables(['users'])` / `createMissingUuidsForTables(['patient_data'])` so an authenticated password-grant or `verifyLogin` can no longer trigger a whole-table UUID backfill.

Call sites updated:
- `Common/Auth/OpenIDConnect/Repositories/UserRepository::getAccountByPassword` (OAuth password grant, both users and patient_data paths)
- `RestControllers/AuthorizationController::getUserUuid` (both users and patient_data paths)
- `Services/UserService::getSystemUser`

The shared helper validates the table name against the existing `UUID_TABLE_DEFINITIONS` whitelist and the id column against a strict identifier pattern (`^[A-Za-z_][A-Za-z0-9_]*$`) before running a targeted UPDATE with a zero-byte guard.

Follow-up to #11735, which scoped the equivalent LocalApi bootstrap. This PR addresses the remaining callers that share the same exposure, as noted in that PR's review thread.

## Why

An authenticated user hitting any of these entry points could schedule an arbitrarily large UPDATE covering every row in `users` or `patient_data` — DoS-shaped. Scoping to the single principal's row eliminates that exposure without changing observable behaviour for legitimate callers (the targeted UPDATE is a no-op when a UUID is already populated).

## Test plan

- [x] New isolated tests cover input validation in `UuidRegistry::createMissingUuidForRow` (unknown table, invalid id column — including SQL-injection attempt, leading digit, hyphen, space, empty string)
- [x] PHPStan level 10 clean
- [x] Full isolated suite passes
- [ ] Manual: OAuth password grant (users + patient)
- [ ] Manual: admin login via `verifyLogin`
- [ ] Manual: API call that exercises `UserService::getSystemUser`