### PR TITLE
ci: add ScanCode license-scan workflow (PoC)

### DIFF
--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -6,6 +6,14 @@ on:
     - master
     - rel-*
   workflow_dispatch:
+    inputs:
+      scan_mode:
+        description: Scan scope
+        type: choice
+        options:
+        - full
+        - diff
+        default: full
 
 permissions:
   contents: read
@@ -17,8 +25,11 @@ concurrency:
 
 jobs:
   scancode:
-    name: ScanCode License Scan (PR diff)
+    name: ScanCode License Scan
     runs-on: ubuntu-latest
+    # Full-repo scans on a ~1M-LOC codebase can take a while; give the job
+    # headroom without hitting the 6-hour ceiling.
+    timeout-minutes: 180
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -33,15 +44,49 @@ jobs:
     - name: Install ScanCode Toolkit
       run: pipx install scancode-toolkit
 
-    - name: Stage changed files for scan
+    - name: Determine scan mode
+      id: mode
+      env:
+        EVENT: ${{ github.event_name }}
+        DISPATCH_MODE: ${{ github.event.inputs.scan_mode }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      # Resolution rules:
+      #   workflow_dispatch → whatever the user picked (default: full)
+      #   pull_request     → 'full' if the HEAD commit carries trailer
+      #                      `Scancode-Full-Scan: true`, otherwise 'diff'
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        case "$EVENT" in
+          workflow_dispatch)
+            mode="${DISPATCH_MODE:-full}"
+            ;;
+          pull_request)
+            trailer=$(
+              git log -1 --format='%(trailers:key=Scancode-Full-Scan,valueonly)' "$HEAD_SHA" \
+                | tr -d '[:space:]'
+            )
+            if [[ $trailer == 'true' ]]; then
+              mode='full'
+            else
+              mode='diff'
+            fi
+            ;;
+          *)
+            mode='diff'
+            ;;
+        esac
+        printf 'Scan mode: %s\n' "$mode"
+        echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
+    - name: Stage changed files for scan (diff mode)
       id: stage
+      if: steps.mode.outputs.mode == 'diff' && github.event_name == 'pull_request'
       env:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      # Only scan files added or modified in the PR so the check stays fast on
-      # a large repo. Exclude vendored / generated trees.
+      # Only scan files added or modified in the PR so the check stays fast.
+      # Exclude vendored / generated trees.
       run: |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
         mkdir -p scancode-input
         mapfile -t changed < <(
           git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" \
@@ -65,8 +110,8 @@ jobs:
         done
         printf 'Staged %d files for scan.\n' "${#changed[@]}"
 
-    - name: Run ScanCode
-      if: steps.stage.outputs.has_changes == 'true'
+    - name: Run ScanCode (diff)
+      if: steps.mode.outputs.mode == 'diff' && steps.stage.outputs.has_changes == 'true'
       # --license / --copyright: detect license text and copyright notices
       # --package: detect package manifests (composer.json, package.json, etc.)
       # --only-findings: skip files with no license/copyright findings in output
@@ -76,17 +121,46 @@ jobs:
           --copyright \
           --package \
           --only-findings \
-          --processes 2 \
+          --processes "$(nproc)" \
           --json-pp scancode-results.json \
           --html scancode-results.html \
           scancode-input
 
+    - name: Run ScanCode (full repo)
+      if: steps.mode.outputs.mode == 'full'
+      # Full-repo scan. Exclude vendored / generated trees that would dominate
+      # the output without adding useful findings, and skip the on-disk scan
+      # cache dir.
+      run: |
+        scancode \
+          --license \
+          --copyright \
+          --package \
+          --only-findings \
+          --processes "$(nproc)" \
+          --ignore 'vendor/*' \
+          --ignore 'node_modules/*' \
+          --ignore 'ccdaservice/node_modules/*' \
+          --ignore 'Documentation/*' \
+          --ignore '.git/*' \
+          --ignore 'scancode-input/*' \
+          --json-pp scancode-results.json \
+          --html scancode-results.html \
+          .
+
     - name: Summarize findings
-      if: steps.stage.outputs.has_changes == 'true'
+      if: |
+        steps.mode.outputs.mode == 'full'
+        || (steps.mode.outputs.mode == 'diff' && steps.stage.outputs.has_changes == 'true')
+      env:
+        SCAN_MODE: ${{ steps.mode.outputs.mode }}
       run: |
         python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
         import json
+        import os
         from collections import Counter
+
+        mode = os.environ.get('SCAN_MODE', 'unknown')
 
         with open('scancode-results.json') as fh:
             data = json.load(fh)
@@ -100,35 +174,49 @@ jobs:
             if not detections:
                 continue
             expressions = sorted({d.get('license_expression', 'unknown') for d in detections})
-            per_file.append((entry['path'], expressions))
+            path = entry['path']
+            # In diff mode the scan root is scancode-input/; strip it so paths
+            # shown in the summary match the repo layout.
+            if path.startswith('scancode-input/'):
+                path = path[len('scancode-input/'):]
+            per_file.append((path, expressions))
             for expr in expressions:
                 licenses[expr] += 1
 
-        print('## ScanCode License Findings')
+        print(f'## ScanCode License Findings ({mode} scan)')
         print()
         if not licenses:
-            print('No license text detected in changed files.')
+            print('No license text detected.')
         else:
             print('| License Expression | File Count |')
             print('|---|---|')
             for expr, count in licenses.most_common():
                 print(f'| `{expr}` | {count} |')
             print()
-            print('<details><summary>Per-file findings</summary>')
+            # Full-repo scans can produce thousands of per-file rows; cap the
+            # expanded list so the summary page stays usable.
+            limit = 500
+            shown = per_file if len(per_file) <= limit else per_file[:limit]
+            heading = 'Per-file findings'
+            if len(per_file) > limit:
+                heading = f'Per-file findings (first {limit} of {len(per_file)})'
+            print(f'<details><summary>{heading}</summary>')
             print()
             print('| File | License(s) |')
             print('|---|---|')
-            for path, exprs in per_file:
+            for path, exprs in shown:
                 print(f'| `{path}` | {", ".join(f"`{e}`" for e in exprs)} |')
             print()
             print('</details>')
         PY
 
     - name: Upload results as artifact
-      if: steps.stage.outputs.has_changes == 'true'
+      if: |
+        steps.mode.outputs.mode == 'full'
+        || (steps.mode.outputs.mode == 'diff' && steps.stage.outputs.has_changes == 'true')
       uses: actions/upload-artifact@v7
       with:
-        name: scancode-results
+        name: scancode-results-${{ steps.mode.outputs.mode }}
         path: |
           scancode-results.json
           scancode-results.html

--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -42,7 +42,13 @@ jobs:
         python-version: '3.12'
 
     - name: Install ScanCode Toolkit
-      run: pipx install scancode-toolkit
+      # Pinned so runs are reproducible; bumped manually for now. The official
+      # aboutcode-org/scancode-action is still tagged @beta (no stable
+      # release) and runs ScanCode.io pipelines, which produce a different
+      # output schema from the CLI — migrating would require rewriting the
+      # summary step. Revisit once the action stabilizes so Dependabot can
+      # maintain the version.
+      run: pipx install 'scancode-toolkit==32.5.0'
 
     - name: Determine scan mode
       id: mode
@@ -65,7 +71,7 @@ jobs:
               git log -1 --format='%(trailers:key=Scancode-Full-Scan,valueonly)' "$HEAD_SHA" \
                 | tr -d '[:space:]'
             )
-            if [[ $trailer == 'true' ]]; then
+            if [[ $trailer = 'true' ]]; then
               mode='full'
             else
               mode='diff'
@@ -85,16 +91,14 @@ jobs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       # Only scan files added or modified in the PR so the check stays fast.
-      # Exclude vendored / generated trees.
+      # git-diff already excludes untracked/ignored paths (vendor/,
+      # node_modules/, etc.); only Documentation/ needs an explicit pathspec
+      # since it is tracked.
       run: |
         mkdir -p scancode-input
         mapfile -t changed < <(
           git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" \
-            -- \
-            ':!vendor' \
-            ':!node_modules' \
-            ':!ccdaservice/node_modules' \
-            ':!Documentation'
+            -- ':!Documentation'
         )
         if (( ${#changed[@]} == 0 )); then
           echo 'No files to scan.'
@@ -104,7 +108,12 @@ jobs:
         echo 'has_changes=true' >> "$GITHUB_OUTPUT"
         for f in "${changed[@]}"; do
           if [[ -f $f ]]; then
-            mkdir -p "scancode-input/$(dirname "$f")"
+            # Parameter expansion — ${f%/*} strips the trailing /basename. For
+            # top-level files (no slash) the expansion returns $f unchanged,
+            # so fall back to '.' in that case.
+            d="${f%/*}"
+            [[ $d = "$f" ]] && d='.'
+            mkdir -p "scancode-input/$d"
             cp "$f" "scancode-input/$f"
           fi
         done
@@ -128,22 +137,25 @@ jobs:
 
     - name: Run ScanCode (full repo)
       if: steps.mode.outputs.mode == 'full'
-      # Full-repo scan. Exclude vendored / generated trees that would dominate
-      # the output without adding useful findings, and skip the on-disk scan
-      # cache dir.
+      # Full-repo scan. Ignore patterns come from .scancode-ignore so the set
+      # of excluded paths is version-controlled alongside the repo. Blank
+      # lines and # comments in that file are stripped.
       run: |
+        ignore_args=()
+        while IFS= read -r line; do
+          line="${line%%#*}"
+          line="${line#"${line%%[![:space:]]*}"}"
+          line="${line%"${line##*[![:space:]]}"}"
+          [[ -z $line ]] && continue
+          ignore_args+=(--ignore "$line")
+        done < .scancode-ignore
         scancode \
           --license \
           --copyright \
           --package \
           --only-findings \
           --processes "$(nproc)" \
-          --ignore 'vendor/*' \
-          --ignore 'node_modules/*' \
-          --ignore 'ccdaservice/node_modules/*' \
-          --ignore 'Documentation/*' \
-          --ignore '.git/*' \
-          --ignore 'scancode-input/*' \
+          "${ignore_args[@]}" \
           --json-pp scancode-results.json \
           --html scancode-results.html \
           .
@@ -154,8 +166,8 @@ jobs:
         || (steps.mode.outputs.mode == 'diff' && steps.stage.outputs.has_changes == 'true')
       env:
         SCAN_MODE: ${{ steps.mode.outputs.mode }}
+      shell: python
       run: |
-        python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
         import json
         import os
         from collections import Counter
@@ -165,8 +177,8 @@ jobs:
         with open('scancode-results.json') as fh:
             data = json.load(fh)
 
-        licenses = Counter()
-        per_file = []
+        licenses: Counter[str] = Counter()
+        per_file: list[tuple[str, list[str]]] = []
         for entry in data.get('files', []):
             if entry.get('type') != 'file':
                 continue
@@ -183,32 +195,34 @@ jobs:
             for expr in expressions:
                 licenses[expr] += 1
 
-        print(f'## ScanCode License Findings ({mode} scan)')
-        print()
+        lines: list[str] = [f'## ScanCode License Findings ({mode} scan)', '']
         if not licenses:
-            print('No license text detected.')
+            lines.append('No license text detected.')
         else:
-            print('| License Expression | File Count |')
-            print('|---|---|')
-            for expr, count in licenses.most_common():
-                print(f'| `{expr}` | {count} |')
-            print()
-            # Full-repo scans can produce thousands of per-file rows; cap the
-            # expanded list so the summary page stays usable.
+            lines.append('| License Expression | File Count |')
+            lines.append('|---|---|')
+            lines.extend(f'| `{expr}` | {count} |' for expr, count in licenses.most_common())
+            lines.append('')
+            # Full-repo scans can produce thousands of rows; cap the expanded
+            # list so the summary page stays usable.
             limit = 500
-            shown = per_file if len(per_file) <= limit else per_file[:limit]
+            shown = per_file[:limit]
             heading = 'Per-file findings'
             if len(per_file) > limit:
                 heading = f'Per-file findings (first {limit} of {len(per_file)})'
-            print(f'<details><summary>{heading}</summary>')
-            print()
-            print('| File | License(s) |')
-            print('|---|---|')
-            for path, exprs in shown:
-                print(f'| `{path}` | {", ".join(f"`{e}`" for e in exprs)} |')
-            print()
-            print('</details>')
-        PY
+            lines.append(f'<details><summary>{heading}</summary>')
+            lines.append('')
+            lines.append('| File | License(s) |')
+            lines.append('|---|---|')
+            lines.extend(
+                f'| `{path}` | {", ".join(f"`{e}`" for e in exprs)} |'
+                for path, exprs in shown
+            )
+            lines.append('')
+            lines.append('</details>')
+
+        with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as out:
+            out.write('\n'.join(lines) + '\n')
 
     - name: Upload results as artifact
       if: |

--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -1,0 +1,135 @@
+name: License Scan (ScanCode)
+
+on:
+  pull_request:
+    branches:
+    - master
+    - rel-*
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  scancode:
+    name: ScanCode License Scan (PR diff)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install ScanCode Toolkit
+      run: pipx install scancode-toolkit
+
+    - name: Stage changed files for scan
+      id: stage
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      # Only scan files added or modified in the PR so the check stays fast on
+      # a large repo. Exclude vendored / generated trees.
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        mkdir -p scancode-input
+        mapfile -t changed < <(
+          git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" \
+            -- \
+            ':!vendor' \
+            ':!node_modules' \
+            ':!ccdaservice/node_modules' \
+            ':!Documentation'
+        )
+        if (( ${#changed[@]} == 0 )); then
+          echo 'No files to scan.'
+          echo 'has_changes=false' >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo 'has_changes=true' >> "$GITHUB_OUTPUT"
+        for f in "${changed[@]}"; do
+          if [[ -f $f ]]; then
+            mkdir -p "scancode-input/$(dirname "$f")"
+            cp "$f" "scancode-input/$f"
+          fi
+        done
+        printf 'Staged %d files for scan.\n' "${#changed[@]}"
+
+    - name: Run ScanCode
+      if: steps.stage.outputs.has_changes == 'true'
+      # --license / --copyright: detect license text and copyright notices
+      # --package: detect package manifests (composer.json, package.json, etc.)
+      # --only-findings: skip files with no license/copyright findings in output
+      run: |
+        scancode \
+          --license \
+          --copyright \
+          --package \
+          --only-findings \
+          --processes 2 \
+          --json-pp scancode-results.json \
+          --html scancode-results.html \
+          scancode-input
+
+    - name: Summarize findings
+      if: steps.stage.outputs.has_changes == 'true'
+      run: |
+        python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+        import json
+        from collections import Counter
+
+        with open('scancode-results.json') as fh:
+            data = json.load(fh)
+
+        licenses = Counter()
+        per_file = []
+        for entry in data.get('files', []):
+            if entry.get('type') != 'file':
+                continue
+            detections = entry.get('license_detections', []) or []
+            if not detections:
+                continue
+            expressions = sorted({d.get('license_expression', 'unknown') for d in detections})
+            per_file.append((entry['path'], expressions))
+            for expr in expressions:
+                licenses[expr] += 1
+
+        print('## ScanCode License Findings')
+        print()
+        if not licenses:
+            print('No license text detected in changed files.')
+        else:
+            print('| License Expression | File Count |')
+            print('|---|---|')
+            for expr, count in licenses.most_common():
+                print(f'| `{expr}` | {count} |')
+            print()
+            print('<details><summary>Per-file findings</summary>')
+            print()
+            print('| File | License(s) |')
+            print('|---|---|')
+            for path, exprs in per_file:
+                print(f'| `{path}` | {", ".join(f"`{e}`" for e in exprs)} |')
+            print()
+            print('</details>')
+        PY
+
+    - name: Upload results as artifact
+      if: steps.stage.outputs.has_changes == 'true'
+      uses: actions/upload-artifact@v7
+      with:
+        name: scancode-results
+        path: |
+          scancode-results.json
+          scancode-results.html
+        retention-days: 30

--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -152,6 +152,10 @@ jobs:
       if: steps.stage.outputs.has_changes == 'true'
       env:
         SCAN_MODE: diff
+        # Fail the job (and emit per-file annotations) when ScanCode detects
+        # any of these license expressions. Leave empty to run in
+        # report-only mode.
+        SCANCODE_DISALLOWED_LICENSES: 'proprietary-license,commercial-license'
       run: python3 tools/ci/scancode-summary.py scancode-results.json
 
     - name: Upload artifact
@@ -296,6 +300,7 @@ jobs:
     - name: Summarize findings
       env:
         SCAN_MODE: full
+        SCANCODE_DISALLOWED_LICENSES: 'proprietary-license,commercial-license'
       run: python3 tools/ci/scancode-summary.py scancode-results.json
 
     - name: Upload final artifact

--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -23,35 +23,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  # Pinned so runs are reproducible; bumped manually for now. The official
+  # aboutcode-org/scancode-action is still tagged @beta (no stable release)
+  # and runs ScanCode.io pipelines, which produce a different output schema
+  # from the CLI — migrating would require rewriting the summary step.
+  # Revisit once the action stabilizes so Dependabot can maintain the version.
+  SCANCODE_VERSION: '32.5.0'
+
 jobs:
-  scancode:
-    name: ScanCode License Scan
+  mode:
+    name: Determine scan mode
     runs-on: ubuntu-latest
-    # Full-repo scans on a ~1M-LOC codebase can take a while; give the job
-    # headroom without hitting the 6-hour ceiling.
-    timeout-minutes: 180
+    outputs:
+      mode: ${{ steps.m.outputs.mode }}
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
+    - uses: actions/checkout@v6
       with:
-        fetch-depth: 0
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-
-    - name: Install ScanCode Toolkit
-      # Pinned so runs are reproducible; bumped manually for now. The official
-      # aboutcode-org/scancode-action is still tagged @beta (no stable
-      # release) and runs ScanCode.io pipelines, which produce a different
-      # output schema from the CLI — migrating would require rewriting the
-      # summary step. Revisit once the action stabilizes so Dependabot can
-      # maintain the version.
-      run: pipx install 'scancode-toolkit==32.5.0'
-
-    - name: Determine scan mode
-      id: mode
+        fetch-depth: 2
+    - name: Resolve mode
+      id: m
       env:
         EVENT: ${{ github.event_name }}
         DISPATCH_MODE: ${{ github.event.inputs.scan_mode }}
@@ -84,9 +75,26 @@ jobs:
         printf 'Scan mode: %s\n' "$mode"
         echo "mode=$mode" >> "$GITHUB_OUTPUT"
 
-    - name: Stage changed files for scan (diff mode)
+  diff:
+    name: ScanCode License Scan (diff)
+    needs: mode
+    if: needs.mode.outputs.mode == 'diff'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install ScanCode Toolkit
+      run: pipx install "scancode-toolkit==${SCANCODE_VERSION}"
+
+    - name: Stage changed files
       id: stage
-      if: steps.mode.outputs.mode == 'diff' && github.event_name == 'pull_request'
       env:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -95,6 +103,7 @@ jobs:
       # node_modules/, etc.); only Documentation/ needs an explicit pathspec
       # since it is tracked.
       run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
         mkdir -p scancode-input
         mapfile -t changed < <(
           git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" \
@@ -108,9 +117,7 @@ jobs:
         echo 'has_changes=true' >> "$GITHUB_OUTPUT"
         for f in "${changed[@]}"; do
           if [[ -f $f ]]; then
-            # Parameter expansion — ${f%/*} strips the trailing /basename. For
-            # top-level files (no slash) the expansion returns $f unchanged,
-            # so fall back to '.' in that case.
+            # Parameter expansion; fall back to '.' for top-level files.
             d="${f%/*}"
             [[ $d = "$f" ]] && d='.'
             mkdir -p "scancode-input/$d"
@@ -119,11 +126,8 @@ jobs:
         done
         printf 'Staged %d files for scan.\n' "${#changed[@]}"
 
-    - name: Run ScanCode (diff)
-      if: steps.mode.outputs.mode == 'diff' && steps.stage.outputs.has_changes == 'true'
-      # --license / --copyright: detect license text and copyright notices
-      # --package: detect package manifests (composer.json, package.json, etc.)
-      # --only-findings: skip files with no license/copyright findings in output
+    - name: Run ScanCode
+      if: steps.stage.outputs.has_changes == 'true'
       run: |
         scancode \
           --license \
@@ -135,103 +139,152 @@ jobs:
           --html scancode-results.html \
           scancode-input
 
-    - name: Run ScanCode (full repo)
-      if: steps.mode.outputs.mode == 'full'
-      # Full-repo scan. Ignore patterns come from .scancode-ignore so the set
-      # of excluded paths is version-controlled alongside the repo. Blank
-      # lines and # comments in that file are stripped.
+    - name: Summarize findings
+      if: steps.stage.outputs.has_changes == 'true'
+      env:
+        SCAN_MODE: diff
+      run: python3 tools/ci/scancode-summary.py scancode-results.json
+
+    - name: Upload artifact
+      if: steps.stage.outputs.has_changes == 'true'
+      uses: actions/upload-artifact@v7
+      with:
+        name: scancode-results-diff
+        path: |
+          scancode-results.json
+          scancode-results.html
+        retention-days: 30
+
+  shard:
+    # Full-repo scans fan out across 8 runners. hash(path) % 8 partitions the
+    # tracked-file set so every file lands on exactly one shard. ScanCode's
+    # license matcher is CPU-bound, so the speedup scales nearly linearly with
+    # the shard count; 8 shards is a balance between wall-clock time and
+    # aggregate-minutes budget.
+    name: ScanCode License Scan (shard ${{ matrix.shard }}/8)
+    needs: mode
+    if: needs.mode.outputs.mode == 'full'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+    env:
+      SHARDS: '8'
+      SHARD: ${{ matrix.shard }}
+    steps:
+    - uses: actions/checkout@v6
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install ScanCode Toolkit
+      run: pipx install "scancode-toolkit==${SCANCODE_VERSION}"
+
+    - name: Stage shard files
+      # Enumerate every tracked file (excluding .scancode-ignore patterns),
+      # hash the path, and stage the files whose hash bucket matches this
+      # shard. Sharding on the path rather than on git's file order keeps the
+      # partition stable across runs — reruns of shard N scan the same files.
       run: |
-        ignore_args=()
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        excludes=()
         while IFS= read -r line; do
           line="${line%%#*}"
           line="${line#"${line%%[![:space:]]*}"}"
           line="${line%"${line##*[![:space:]]}"}"
           [[ -z $line ]] && continue
-          ignore_args+=(--ignore "$line")
+          # Strip trailing /* for git pathspec (exclude the whole tree).
+          clean="${line%/\*}"
+          excludes+=(":(exclude)${clean}")
         done < .scancode-ignore
+        mkdir -p scancode-shard-input
+        mapfile -t files < <(git ls-files -- . "${excludes[@]}")
+        count=0
+        for f in "${files[@]}"; do
+          hash_hex=$(printf '%s' "$f" | md5sum | cut -c1-8)
+          idx=$(( 0x$hash_hex % SHARDS ))
+          (( idx == SHARD )) || continue
+          [[ -f $f ]] || continue
+          d="${f%/*}"
+          [[ $d = "$f" ]] && d='.'
+          mkdir -p "scancode-shard-input/$d"
+          cp "$f" "scancode-shard-input/$f"
+          count=$(( count + 1 ))
+        done
+        printf 'Shard %d/%d staged %d files (of %d total tracked).\n' \
+          "$SHARD" "$SHARDS" "$count" "${#files[@]}"
+
+    - name: Run ScanCode
+      run: |
         scancode \
           --license \
           --copyright \
           --package \
           --only-findings \
           --processes "$(nproc)" \
-          "${ignore_args[@]}" \
-          --json-pp scancode-results.json \
-          --html scancode-results.html \
-          .
+          --json-pp "scancode-shard-${SHARD}.json" \
+          scancode-shard-input
 
-    - name: Summarize findings
-      if: |
-        steps.mode.outputs.mode == 'full'
-        || (steps.mode.outputs.mode == 'diff' && steps.stage.outputs.has_changes == 'true')
-      env:
-        SCAN_MODE: ${{ steps.mode.outputs.mode }}
-      shell: python
-      run: |
-        import json
-        import os
-        from collections import Counter
-
-        mode = os.environ.get('SCAN_MODE', 'unknown')
-
-        with open('scancode-results.json') as fh:
-            data = json.load(fh)
-
-        licenses: Counter[str] = Counter()
-        per_file: list[tuple[str, list[str]]] = []
-        for entry in data.get('files', []):
-            if entry.get('type') != 'file':
-                continue
-            detections = entry.get('license_detections', []) or []
-            if not detections:
-                continue
-            expressions = sorted({d.get('license_expression', 'unknown') for d in detections})
-            path = entry['path']
-            # In diff mode the scan root is scancode-input/; strip it so paths
-            # shown in the summary match the repo layout.
-            if path.startswith('scancode-input/'):
-                path = path[len('scancode-input/'):]
-            per_file.append((path, expressions))
-            for expr in expressions:
-                licenses[expr] += 1
-
-        lines: list[str] = [f'## ScanCode License Findings ({mode} scan)', '']
-        if not licenses:
-            lines.append('No license text detected.')
-        else:
-            lines.append('| License Expression | File Count |')
-            lines.append('|---|---|')
-            lines.extend(f'| `{expr}` | {count} |' for expr, count in licenses.most_common())
-            lines.append('')
-            # Full-repo scans can produce thousands of rows; cap the expanded
-            # list so the summary page stays usable.
-            limit = 500
-            shown = per_file[:limit]
-            heading = 'Per-file findings'
-            if len(per_file) > limit:
-                heading = f'Per-file findings (first {limit} of {len(per_file)})'
-            lines.append(f'<details><summary>{heading}</summary>')
-            lines.append('')
-            lines.append('| File | License(s) |')
-            lines.append('|---|---|')
-            lines.extend(
-                f'| `{path}` | {", ".join(f"`{e}`" for e in exprs)} |'
-                for path, exprs in shown
-            )
-            lines.append('')
-            lines.append('</details>')
-
-        with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as out:
-            out.write('\n'.join(lines) + '\n')
-
-    - name: Upload results as artifact
-      if: |
-        steps.mode.outputs.mode == 'full'
-        || (steps.mode.outputs.mode == 'diff' && steps.stage.outputs.has_changes == 'true')
+    - name: Upload shard artifact
       uses: actions/upload-artifact@v7
       with:
-        name: scancode-results-${{ steps.mode.outputs.mode }}
-        path: |
-          scancode-results.json
-          scancode-results.html
+        name: scancode-shard-${{ matrix.shard }}
+        path: scancode-shard-${{ matrix.shard }}.json
+        retention-days: 7
+
+  aggregate:
+    name: ScanCode License Scan (aggregate)
+    needs: [mode, shard]
+    if: needs.mode.outputs.mode == 'full'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Download shard artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: shards
+        pattern: scancode-shard-*
+        merge-multiple: true
+
+    - name: Merge shard results
+      # ScanCode JSON top-level is {headers:[...], files:[...]}; the files
+      # arrays are disjoint across shards so concatenation is sufficient.
+      shell: python
+      run: |
+        import glob
+        import json
+
+        merged: dict = {'headers': [], 'files': []}
+        for path in sorted(glob.glob('shards/scancode-shard-*.json')):
+            with open(path) as fh:
+                data = json.load(fh)
+            merged['headers'].extend(data.get('headers', []))
+            merged['files'].extend(data.get('files', []))
+
+        with open('scancode-results.json', 'w') as fh:
+            json.dump(merged, fh)
+
+        print(f'Merged {len(merged["files"])} file entries from '
+              f'{len(merged["headers"])} shard headers.')
+
+    - name: Summarize findings
+      env:
+        SCAN_MODE: full
+      run: python3 tools/ci/scancode-summary.py scancode-results.json
+
+    - name: Upload final artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: scancode-results-full
+        path: scancode-results.json
         retention-days: 30

--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -86,7 +86,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -128,7 +128,12 @@ jobs:
 
     - name: Run ScanCode
       if: steps.stage.outputs.has_changes == 'true'
+      # ScanCode exits 1 when individual files fail (timeouts, parser
+      # crashes) but still completes the overall scan and writes its
+      # reports. Treat that as non-fatal so the summary + upload steps run.
+      # Any exit code > 1 is a real failure.
       run: |
+        rc=0
         scancode \
           --license \
           --copyright \
@@ -137,7 +142,11 @@ jobs:
           --processes "$(nproc)" \
           --json-pp scancode-results.json \
           --html scancode-results.html \
-          scancode-input
+          scancode-input \
+          || rc=$?
+        if (( rc > 1 )); then
+          exit "$rc"
+        fi
 
     - name: Summarize findings
       if: steps.stage.outputs.has_changes == 'true'
@@ -176,7 +185,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -218,7 +227,10 @@ jobs:
           "$SHARD" "$SHARDS" "$count" "${#files[@]}"
 
     - name: Run ScanCode
+      # Per-file scan errors (exit 1) are non-fatal; see the diff job's
+      # comment on the same pattern.
       run: |
+        rc=0
         scancode \
           --license \
           --copyright \
@@ -226,7 +238,11 @@ jobs:
           --only-findings \
           --processes "$(nproc)" \
           --json-pp "scancode-shard-${SHARD}.json" \
-          scancode-shard-input
+          scancode-shard-input \
+          || rc=$?
+        if (( rc > 1 )); then
+          exit "$rc"
+        fi
 
     - name: Upload shard artifact
       uses: actions/upload-artifact@v7
@@ -245,7 +261,7 @@ jobs:
       with:
         fetch-depth: 1
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -99,15 +99,15 @@ jobs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       # Only scan files added or modified in the PR so the check stays fast.
-      # git-diff already excludes untracked/ignored paths (vendor/,
-      # node_modules/, etc.); only Documentation/ needs an explicit pathspec
-      # since it is tracked.
+      # Exclusions come from .scancode-ignore, the same list the full-repo
+      # shards use, so a path ignored by one mode is ignored by both.
       run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        mapfile -t excludes < <(python3 tools/ci/scancode-pathspecs.py)
         mkdir -p scancode-input
         mapfile -t changed < <(
           git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" \
-            -- ':!Documentation'
+            -- . "${excludes[@]}"
         )
         if (( ${#changed[@]} == 0 )); then
           echo 'No files to scan.'
@@ -136,6 +136,7 @@ jobs:
         rc=0
         scancode \
           --license \
+          --license-references \
           --copyright \
           --package \
           --only-findings \
@@ -153,9 +154,8 @@ jobs:
       env:
         SCAN_MODE: diff
         # Fail the job (and emit per-file annotations) when ScanCode detects
-        # any of these license expressions. Leave empty to run in
-        # report-only mode.
-        SCANCODE_DISALLOWED_LICENSES: 'proprietary-license,commercial-license'
+        # a license the policy denies. Unset to run in report-only mode.
+        SCANCODE_POLICY_FILE: tools/ci/license-policy.json
       run: python3 tools/ci/scancode-summary.py scancode-results.json
 
     - name: Upload artifact
@@ -205,16 +205,7 @@ jobs:
       # partition stable across runs — reruns of shard N scan the same files.
       run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        excludes=()
-        while IFS= read -r line; do
-          line="${line%%#*}"
-          line="${line#"${line%%[![:space:]]*}"}"
-          line="${line%"${line##*[![:space:]]}"}"
-          [[ -z $line ]] && continue
-          # Strip trailing /* for git pathspec (exclude the whole tree).
-          clean="${line%/\*}"
-          excludes+=(":(exclude)${clean}")
-        done < .scancode-ignore
+        mapfile -t excludes < <(python3 tools/ci/scancode-pathspecs.py)
         mkdir -p scancode-shard-input
         mapfile -t files < <(git ls-files -- . "${excludes[@]}")
         count=0
@@ -239,6 +230,7 @@ jobs:
         rc=0
         scancode \
           --license \
+          --license-references \
           --copyright \
           --package \
           --only-findings \
@@ -279,30 +271,37 @@ jobs:
         merge-multiple: true
 
     - name: Merge shard results
-      # ScanCode JSON top-level is {headers:[...], files:[...]}; the files
-      # arrays are disjoint across shards so concatenation is sufficient.
+      # ScanCode JSON top-level is {headers, files, license_references, ...}.
+      # The files arrays are disjoint across shards so concatenation is
+      # sufficient; license_references describes the license catalogue and
+      # repeats across shards, so dedupe it by key.
       shell: python
       run: |
         import glob
         import json
 
-        merged: dict = {'headers': [], 'files': []}
+        merged: dict = {'headers': [], 'files': [], 'license_references': []}
+        references: dict = {}
         for path in sorted(glob.glob('shards/scancode-shard-*.json')):
             with open(path) as fh:
                 data = json.load(fh)
             merged['headers'].extend(data.get('headers', []))
             merged['files'].extend(data.get('files', []))
+            for ref in data.get('license_references', []) or []:
+                references.setdefault(ref['key'], ref)
+        merged['license_references'] = list(references.values())
 
         with open('scancode-results.json', 'w') as fh:
             json.dump(merged, fh)
 
-        print(f'Merged {len(merged["files"])} file entries from '
+        print(f'Merged {len(merged["files"])} file entries and '
+              f'{len(references)} license references from '
               f'{len(merged["headers"])} shard headers.')
 
     - name: Summarize findings
       env:
         SCAN_MODE: full
-        SCANCODE_DISALLOWED_LICENSES: 'proprietary-license,commercial-license'
+        SCANCODE_POLICY_FILE: tools/ci/license-policy.json
       run: python3 tools/ci/scancode-summary.py scancode-results.json
 
     - name: Upload final artifact

--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -159,7 +159,9 @@ jobs:
       run: python3 tools/ci/scancode-summary.py scancode-results.json
 
     - name: Upload artifact
-      if: steps.stage.outputs.has_changes == 'true'
+      # always(): the summary step exits non-zero on a policy violation, and
+      # the scan report is exactly what a reviewer needs in that case.
+      if: always() && steps.stage.outputs.has_changes == 'true'
       uses: actions/upload-artifact@v7
       with:
         name: scancode-results-diff
@@ -304,6 +306,8 @@ jobs:
       run: python3 tools/ci/scancode-summary.py scancode-results.json
 
     - name: Upload final artifact
+      # always(): see the diff job's upload step.
+      if: always()
       uses: actions/upload-artifact@v7
       with:
         name: scancode-results-full

--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -270,7 +270,7 @@ jobs:
         python-version: '3.12'
 
     - name: Download shard artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: shards
         pattern: scancode-shard-*

--- a/.scancode-ignore
+++ b/.scancode-ignore
@@ -9,6 +9,13 @@ ccdaservice/node_modules/*
 # Generated documentation (SchemaSpy HTML, etc.).
 Documentation/*
 
+# Minified bundles and source maps — no useful license text, and
+# occasional pathological files crash scancode workers.
+*.map
+*.min.js
+*.min.css
+
 # Git metadata and the workflow's own staging directory.
 .git/*
 scancode-input/*
+scancode-shard-input/*

--- a/.scancode-ignore
+++ b/.scancode-ignore
@@ -1,0 +1,14 @@
+# Glob patterns passed to `scancode --ignore`. One pattern per line; blank
+# lines and comments ignored. Used by .github/workflows/scancode.yml.
+
+# Vendored / generated directories.
+vendor/*
+node_modules/*
+ccdaservice/node_modules/*
+
+# Generated documentation (SchemaSpy HTML, etc.).
+Documentation/*
+
+# Git metadata and the workflow's own staging directory.
+.git/*
+scancode-input/*

--- a/.scancode-ignore
+++ b/.scancode-ignore
@@ -1,5 +1,7 @@
-# Glob patterns passed to `scancode --ignore`. One pattern per line; blank
-# lines and comments ignored. Used by .github/workflows/scancode.yml.
+# Paths excluded from license scanning. One glob per line; blank lines and
+# comments ignored. Converted to git exclude pathspecs by
+# tools/ci/scancode-pathspecs.py and applied by both scan modes in
+# .github/workflows/scancode.yml.
 
 # Vendored / generated directories.
 vendor/*
@@ -19,3 +21,7 @@ Documentation/*
 .git/*
 scancode-input/*
 scancode-shard-input/*
+
+# The license policy names the licenses it denies, so scanning it would
+# report the policy as a violation of itself.
+tools/ci/license-policy.json

--- a/tools/ci/license-policy.json
+++ b/tools/ci/license-policy.json
@@ -1,0 +1,17 @@
+{
+    "$schema-note": "License policy consumed by tools/ci/scancode-summary.py. Keys under 'deny' are ScanCode license keys (see https://scancode-licensedb.aboutcode.org/); values are the reason shown in the CI annotation. 'deny_categories' matches ScanCode's license category taxonomy and catches keys not listed individually.",
+    "policy_url": "https://github.com/openemr/openemr/blob/master/tools/ci/license-policy.json",
+    "deny_categories": [
+        "Commercial",
+        "Proprietary Free"
+    ],
+    "category_reasons": {
+        "Commercial": "Commercial licenses require a paid agreement and cannot be redistributed under OpenEMR's GPL-3.0 license.",
+        "Proprietary Free": "Proprietary terms restrict redistribution and modification, which is incompatible with OpenEMR's GPL-3.0 license."
+    },
+    "deny": {
+        "commercial-license": "Requires a paid commercial agreement, so the code cannot be redistributed as part of OpenEMR under GPL-3.0.",
+        "proprietary-license": "Proprietary terms forbid redistribution and modification, which OpenEMR's GPL-3.0 license requires."
+    },
+    "allow_note": "Everything not matched by 'deny' or 'deny_categories' is permitted. OpenEMR ships under GPL-3.0, so GPL-compatible permissive licenses (MIT, BSD, Apache-2.0, ISC) and GPL-family copyleft licenses are fine; the gate exists to catch commercial and proprietary text pasted into the tree."
+}

--- a/tools/ci/scancode-demo-fixture.txt
+++ b/tools/ci/scancode-demo-fixture.txt
@@ -1,0 +1,21 @@
+DO NOT MERGE — Temporary fixture for the ScanCode PoC (PR #11739).
+
+The workflow disallows `proprietary-license` and `commercial-license` so
+this file should trip the policy check, emit a GitHub annotation, and
+fail the job. Revert the commit that introduced this file before merge.
+
+---
+
+Copyright (c) 2026 Acme Widgets Inc. All rights reserved.
+
+This source code is proprietary and confidential. Unauthorized copying
+of this file, via any medium, is strictly prohibited. No part of this
+work may be reproduced, distributed, or transmitted in any form or by
+any means, including photocopying, recording, or other electronic or
+mechanical methods, without the prior written permission of Acme
+Widgets Inc.
+
+This software is licensed only to licensees who have executed a written
+Commercial License Agreement with Acme Widgets Inc. Use of this
+software without a valid Commercial License Agreement is strictly
+prohibited.

--- a/tools/ci/scancode-demo-fixture.txt
+++ b/tools/ci/scancode-demo-fixture.txt
@@ -1,8 +1,9 @@
 DO NOT MERGE — Temporary fixture for the ScanCode PoC (PR #11739).
 
-The workflow disallows `proprietary-license` and `commercial-license` so
-this file should trip the policy check, emit a GitHub annotation, and
-fail the job. Revert the commit that introduced this file before merge.
+The license text below is denied by tools/ci/license-policy.json, so this
+file should trip the policy check, emit a GitHub annotation anchored to the
+offending lines, and fail the job. Revert the commit that introduced this
+file before merge.
 
 ---
 

--- a/tools/ci/scancode-pathspecs.py
+++ b/tools/ci/scancode-pathspecs.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Convert .scancode-ignore glob patterns into git exclude pathspecs.
+
+Prints one ``:(exclude)<pattern>`` pathspec per line, for use with
+``git ls-files`` / ``git diff`` in .github/workflows/scancode.yml. Keeping the
+conversion here means the diff-mode and full-mode jobs share one exclusion
+list instead of drifting apart.
+"""
+from __future__ import annotations
+
+import sys
+
+DEFAULT_IGNORE_FILE = '.scancode-ignore'
+
+
+def pathspecs(lines: list[str]) -> list[str]:
+    specs = []
+    for raw in lines:
+        pattern = raw.split('#', 1)[0].strip()
+        if pattern == '':
+            continue
+        # Strip a trailing /* so the pathspec excludes the whole subtree
+        # rather than only its immediate children.
+        if pattern.endswith('/*'):
+            pattern = pattern[:-2]
+        specs.append(f':(exclude){pattern}')
+    return specs
+
+
+def main(argv: list[str]) -> int:
+    path = argv[1] if len(argv) > 1 else DEFAULT_IGNORE_FILE
+    with open(path) as fh:
+        lines = fh.readlines()
+    for spec in pathspecs(lines):
+        print(spec)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tools/ci/scancode-summary.py
+++ b/tools/ci/scancode-summary.py
@@ -10,6 +10,11 @@ Environment variables:
     PER_FILE_LIMIT
                 Maximum number of per-file rows to include in the collapsible
                 details block. Defaults to 500.
+    SCANCODE_DISALLOWED_LICENSES
+                Comma-separated list of license expressions that should fail
+                the job. Matching files are also annotated via
+                ``::error file=...::`` so they surface in the PR diff view.
+                Unset / empty disables enforcement (informational mode).
 """
 from __future__ import annotations
 
@@ -27,12 +32,18 @@ def main(argv: list[str]) -> int:
     results_path = argv[1]
     mode = os.environ.get('SCAN_MODE', 'unknown')
     limit = int(os.environ.get('PER_FILE_LIMIT', '500'))
+    disallowed = frozenset(
+        expr.strip()
+        for expr in os.environ.get('SCANCODE_DISALLOWED_LICENSES', '').split(',')
+        if expr.strip()
+    )
 
     with open(results_path) as fh:
         data = json.load(fh)
 
     licenses: Counter[str] = Counter()
     per_file: list[tuple[str, list[str]]] = []
+    violations: list[tuple[str, str]] = []
     for entry in data.get('files', []):
         if entry.get('type') != 'file':
             continue
@@ -49,6 +60,8 @@ def main(argv: list[str]) -> int:
         per_file.append((path, expressions))
         for expr in expressions:
             licenses[expr] += 1
+            if expr in disallowed:
+                violations.append((path, expr))
 
     lines: list[str] = [f'## ScanCode License Findings ({mode} scan)', '']
     if not licenses:
@@ -73,6 +86,12 @@ def main(argv: list[str]) -> int:
         lines.append('')
         lines.append('</details>')
 
+    if violations:
+        lines.append('')
+        lines.append(f'**Policy violations:** {len(violations)} '
+                     f'file(s) detected with disallowed licenses '
+                     f'({", ".join(f"`{e}`" for e in sorted(disallowed))}).')
+
     output = '\n'.join(lines) + '\n'
     summary_path = os.environ.get('GITHUB_STEP_SUMMARY')
     if summary_path:
@@ -80,7 +99,14 @@ def main(argv: list[str]) -> int:
             out.write(output)
     else:
         sys.stdout.write(output)
-    return 0
+
+    # Emit GitHub Actions annotations for each violation so they surface in
+    # the PR "Files changed" view, not just in the step summary.
+    for path, expr in violations:
+        title = f'Disallowed license: {expr}'
+        message = f'{path} matches a license expression on the disallow list'
+        print(f'::error file={path},title={title}::{message}')
+    return 1 if violations else 0
 
 
 if __name__ == '__main__':

--- a/tools/ci/scancode-summary.py
+++ b/tools/ci/scancode-summary.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Render a ScanCode JSON report as a GitHub Actions step summary.
+
+Reads the ScanCode JSON report passed as the first argument and appends a
+markdown summary to ``$GITHUB_STEP_SUMMARY`` (or stdout if the variable is
+unset — useful for local testing).
+
+Environment variables:
+    SCAN_MODE   Label shown in the summary heading ("diff" or "full").
+    PER_FILE_LIMIT
+                Maximum number of per-file rows to include in the collapsible
+                details block. Defaults to 500.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections import Counter
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f'usage: {argv[0]} <scancode-results.json>', file=sys.stderr)
+        return 2
+
+    results_path = argv[1]
+    mode = os.environ.get('SCAN_MODE', 'unknown')
+    limit = int(os.environ.get('PER_FILE_LIMIT', '500'))
+
+    with open(results_path) as fh:
+        data = json.load(fh)
+
+    licenses: Counter[str] = Counter()
+    per_file: list[tuple[str, list[str]]] = []
+    for entry in data.get('files', []):
+        if entry.get('type') != 'file':
+            continue
+        detections = entry.get('license_detections', []) or []
+        if not detections:
+            continue
+        expressions = sorted({d.get('license_expression', 'unknown') for d in detections})
+        path = entry['path']
+        # Normalize scan-root prefixes so paths match the repo layout.
+        for prefix in ('scancode-input/', 'scancode-shard-input/'):
+            if path.startswith(prefix):
+                path = path[len(prefix):]
+                break
+        per_file.append((path, expressions))
+        for expr in expressions:
+            licenses[expr] += 1
+
+    lines: list[str] = [f'## ScanCode License Findings ({mode} scan)', '']
+    if not licenses:
+        lines.append('No license text detected.')
+    else:
+        lines.append('| License Expression | File Count |')
+        lines.append('|---|---|')
+        lines.extend(f'| `{expr}` | {count} |' for expr, count in licenses.most_common())
+        lines.append('')
+        shown = per_file[:limit]
+        heading = 'Per-file findings'
+        if len(per_file) > limit:
+            heading = f'Per-file findings (first {limit} of {len(per_file)})'
+        lines.append(f'<details><summary>{heading}</summary>')
+        lines.append('')
+        lines.append('| File | License(s) |')
+        lines.append('|---|---|')
+        lines.extend(
+            f'| `{path}` | {", ".join(f"`{e}`" for e in exprs)} |'
+            for path, exprs in shown
+        )
+        lines.append('')
+        lines.append('</details>')
+
+    output = '\n'.join(lines) + '\n'
+    summary_path = os.environ.get('GITHUB_STEP_SUMMARY')
+    if summary_path:
+        with open(summary_path, 'a') as out:
+            out.write(output)
+    else:
+        sys.stdout.write(output)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tools/ci/scancode-summary.py
+++ b/tools/ci/scancode-summary.py
@@ -5,65 +5,300 @@ Reads the ScanCode JSON report passed as the first argument and appends a
 markdown summary to ``$GITHUB_STEP_SUMMARY`` (or stdout if the variable is
 unset — useful for local testing).
 
+Policy enforcement is driven by a checked-in JSON policy file (see
+``tools/ci/license-policy.json``). Files whose detected licenses violate the
+policy are annotated with ``::error file=...,line=...::`` so the finding lands
+on the offending lines in the PR "Files changed" view, and the job exits
+non-zero.
+
 Environment variables:
     SCAN_MODE   Label shown in the summary heading ("diff" or "full").
     PER_FILE_LIMIT
                 Maximum number of per-file rows to include in the collapsible
                 details block. Defaults to 500.
-    SCANCODE_DISALLOWED_LICENSES
-                Comma-separated list of license expressions that should fail
-                the job. Matching files are also annotated via
-                ``::error file=...::`` so they surface in the PR diff view.
-                Unset / empty disables enforcement (informational mode).
+    SCANCODE_POLICY_FILE
+                Path to the license policy JSON. Unset / empty disables
+                enforcement (informational mode).
 """
 from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from collections import Counter
 
+# ScanCode license expressions are SPDX-like: keys joined by boolean operators
+# and grouped with parentheses. Split on those so policy is evaluated against
+# individual license keys rather than the composed expression string — a file
+# whose detection composes three keys must trip a policy that denies any one
+# of them, which a set-membership test on the whole expression would miss.
+EXPRESSION_SPLIT_RE = re.compile(r'[\s()]+')
+EXPRESSION_OPERATORS = frozenset({'AND', 'OR', 'WITH'})
 
-def main(argv: list[str]) -> int:
-    if len(argv) != 2:
-        print(f'usage: {argv[0]} <scancode-results.json>', file=sys.stderr)
-        return 2
+SCAN_ROOT_PREFIXES = ('scancode-input/', 'scancode-shard-input/')
 
-    results_path = argv[1]
-    mode = os.environ.get('SCAN_MODE', 'unknown')
-    limit = int(os.environ.get('PER_FILE_LIMIT', '500'))
-    disallowed = frozenset(
-        expr.strip()
-        for expr in os.environ.get('SCANCODE_DISALLOWED_LICENSES', '').split(',')
-        if expr.strip()
-    )
+# Cap the per-annotation detail so a file matching a dozen rules does not
+# produce an unreadable wall of text in the PR diff view.
+MAX_RULES_PER_ANNOTATION = 3
 
-    with open(results_path) as fh:
-        data = json.load(fh)
 
+def parse_license_keys(expression: str | None) -> list[str]:
+    """Return the individual license keys in a ScanCode license expression."""
+    if not expression:
+        return []
+    keys = []
+    for token in EXPRESSION_SPLIT_RE.split(expression):
+        if not token or token.upper() in EXPRESSION_OPERATORS:
+            continue
+        if token not in keys:
+            keys.append(token)
+    return keys
+
+
+def strip_scan_root(path: str) -> str:
+    """Normalize the scan-root prefix so paths match the repo layout."""
+    for prefix in SCAN_ROOT_PREFIXES:
+        if path.startswith(prefix):
+            return path[len(prefix):]
+    return path
+
+
+def escape_data(value: str) -> str:
+    """Escape a GitHub Actions workflow-command message body."""
+    return value.replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
+
+
+def escape_property(value: str) -> str:
+    """Escape a GitHub Actions workflow-command property value.
+
+    Properties are comma-separated ``key=value`` pairs terminated by ``::``,
+    so commas and colons inside a value must be encoded or they truncate the
+    annotation.
+    """
+    return escape_data(value).replace(':', '%3A').replace(',', '%2C')
+
+
+class Policy:
+    """License policy loaded from JSON. See tools/ci/license-policy.json."""
+
+    def __init__(self, path: str, data: dict) -> None:
+        self.path = path
+        self.url = data.get('policy_url', '')
+        self.deny: dict[str, str] = data.get('deny', {}) or {}
+        self.deny_categories: dict[str, None] = {
+            c: None for c in data.get('deny_categories', []) or []
+        }
+        self.category_reasons: dict[str, str] = data.get('category_reasons', {}) or {}
+
+    @classmethod
+    def load(cls, path: str) -> Policy:
+        with open(path) as fh:
+            return cls(path, json.load(fh))
+
+    @property
+    def uses_categories(self) -> bool:
+        return bool(self.deny_categories)
+
+    def violation_reason(self, key: str, category: str | None) -> str | None:
+        """Return why ``key`` is denied, or None if the policy permits it."""
+        if key in self.deny:
+            return self.deny[key] or 'Denied by license policy.'
+        if category is not None and category in self.deny_categories:
+            return self.category_reasons.get(
+                category,
+                f'Licenses in the "{category}" category are not permitted.',
+            )
+        return None
+
+    def describe(self) -> list[str]:
+        lines = [f'Policy: [`{self.path}`]({self.url})' if self.url
+                 else f'Policy: `{self.path}`', '']
+        if self.deny_categories:
+            cats = ', '.join(f'`{c}`' for c in self.deny_categories)
+            lines.append(f'- Denied categories: {cats}')
+        if self.deny:
+            keys = ', '.join(f'`{k}`' for k in sorted(self.deny))
+            lines.append(f'- Denied license keys: {keys}')
+        lines.append('- Everything else is allowed.')
+        lines.append('')
+        return lines
+
+
+class Violation:
+    def __init__(
+        self,
+        path: str,
+        key: str,
+        name: str,
+        category: str | None,
+        reason: str,
+        reference_url: str,
+        matches: list[dict],
+    ) -> None:
+        self.path = path
+        self.key = key
+        self.name = name
+        self.category = category
+        self.reason = reason
+        self.reference_url = reference_url
+        # Strongest evidence first — that is what the annotation anchors to.
+        self.matches = sorted(
+            matches, key=lambda m: m.get('score') or 0, reverse=True
+        )
+
+    @property
+    def best(self) -> dict:
+        return self.matches[0]
+
+    def title(self) -> str:
+        label = self.name or self.key
+        return f'Disallowed license: {label} ({self.key})'
+
+    def message(self) -> str:
+        best = self.best
+        category = f' [{self.category}]' if self.category else ''
+        lines = [
+            f'Detected license `{self.key}`{category}'
+            + (f' — {self.name}' if self.name else '')
+            + '.',
+            f'{self.reason}',
+            '',
+            'Evidence:',
+        ]
+        for match in self.matches[:MAX_RULES_PER_ANNOTATION]:
+            start = match.get('start_line')
+            end = match.get('end_line')
+            span = f'line {start}' if start == end else f'lines {start}-{end}'
+            lines.append(
+                f'  - {span}: {match.get("score")}% score, '
+                f'{match.get("match_coverage")}% coverage, '
+                f'rule {match.get("rule_identifier")}'
+            )
+        extra = len(self.matches) - MAX_RULES_PER_ANNOTATION
+        if extra > 0:
+            lines.append(f'  - ...and {extra} further match(es).')
+        lines.append('')
+        if self.reference_url:
+            lines.append(f'About this license: {self.reference_url}')
+        rule_url = best.get('rule_url')
+        if rule_url:
+            lines.append(f'Matching rule: {rule_url}')
+        return '\n'.join(lines)
+
+    def annotation(self, policy: Policy) -> str:
+        best = self.best
+        body = self.message()
+        location = f'See {policy.url}' if policy.url else ''
+        body += f'\nAllowed vs. denied licenses are defined in {policy.path}.'
+        if location:
+            body += f' {location}'
+        props = [
+            f'file={escape_property(self.path)}',
+            f'title={escape_property(self.title())}',
+        ]
+        start = best.get('start_line')
+        end = best.get('end_line')
+        if isinstance(start, int):
+            props.insert(1, f'line={start}')
+            if isinstance(end, int) and end >= start:
+                props.insert(2, f'endLine={end}')
+        return f'::error {",".join(props)}::{escape_data(body)}'
+
+
+def build_reference_index(data: dict) -> dict[str, dict]:
+    """Index ``license_references`` by license key.
+
+    Populated by ScanCode's ``--license-references`` option; supplies the
+    human-readable name, category, and LicenseDB URL used in annotations.
+    """
+    index = {}
+    for ref in data.get('license_references', []) or []:
+        key = ref.get('key')
+        if key:
+            index[key] = ref
+    return index
+
+
+def collect_violations(
+    data: dict, policy: Policy, refs: dict[str, dict]
+) -> tuple[list[Violation], Counter[str], list[tuple[str, list[str]]]]:
     licenses: Counter[str] = Counter()
     per_file: list[tuple[str, list[str]]] = []
-    violations: list[tuple[str, str]] = []
+    violations: list[Violation] = []
+
     for entry in data.get('files', []):
         if entry.get('type') != 'file':
             continue
         detections = entry.get('license_detections', []) or []
         if not detections:
             continue
-        expressions = sorted({d.get('license_expression', 'unknown') for d in detections})
-        path = entry['path']
-        # Normalize scan-root prefixes so paths match the repo layout.
-        for prefix in ('scancode-input/', 'scancode-shard-input/'):
-            if path.startswith(prefix):
-                path = path[len(prefix):]
-                break
+
+        path = strip_scan_root(entry['path'])
+        expressions = sorted({
+            d.get('license_expression', 'unknown') for d in detections
+        })
         per_file.append((path, expressions))
         for expr in expressions:
             licenses[expr] += 1
-            if expr in disallowed:
-                violations.append((path, expr))
 
+        # Group every match by the individual license key it attributes, so a
+        # compound detection is judged key by key.
+        by_key: dict[str, list[dict]] = {}
+        for detection in detections:
+            for match in detection.get('matches', []) or []:
+                for key in parse_license_keys(match.get('license_expression')):
+                    by_key.setdefault(key, []).append(match)
+
+        for key, matches in sorted(by_key.items()):
+            ref = refs.get(key, {})
+            category = ref.get('category')
+            reason = policy.violation_reason(key, category)
+            if reason is None:
+                continue
+            violations.append(Violation(
+                path=path,
+                key=key,
+                name=ref.get('short_name') or ref.get('name') or '',
+                category=category,
+                reason=reason,
+                reference_url=ref.get('licensedb_url')
+                or f'https://scancode-licensedb.aboutcode.org/{key}',
+                matches=matches,
+            ))
+
+    return violations, licenses, per_file
+
+
+def render_summary(
+    mode: str,
+    licenses: Counter[str],
+    per_file: list[tuple[str, list[str]]],
+    violations: list[Violation],
+    policy: Policy | None,
+    limit: int,
+) -> str:
     lines: list[str] = [f'## ScanCode License Findings ({mode} scan)', '']
+
+    if violations:
+        lines.append(f'### ❌ {len(violations)} policy violation(s)')
+        lines.append('')
+        lines.append('| File | License | Category | Lines | Why |')
+        lines.append('|---|---|---|---|---|')
+        for v in violations:
+            best = v.best
+            start, end = best.get('start_line'), best.get('end_line')
+            span = f'{start}' if start == end else f'{start}-{end}'
+            label = f'`{v.key}`' + (f' ({v.name})' if v.name else '')
+            lines.append(
+                f'| `{v.path}` | [{label}]({v.reference_url}) '
+                f'| {v.category or "unknown"} | {span} | {v.reason} |'
+            )
+        lines.append('')
+
+    if policy is not None:
+        lines.extend(policy.describe())
+
     if not licenses:
         lines.append('No license text detected.')
     else:
@@ -86,13 +321,54 @@ def main(argv: list[str]) -> int:
         lines.append('')
         lines.append('</details>')
 
-    if violations:
-        lines.append('')
-        lines.append(f'**Policy violations:** {len(violations)} '
-                     f'file(s) detected with disallowed licenses '
-                     f'({", ".join(f"`{e}`" for e in sorted(disallowed))}).')
+    return '\n'.join(lines) + '\n'
 
-    output = '\n'.join(lines) + '\n'
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f'usage: {argv[0]} <scancode-results.json>', file=sys.stderr)
+        return 2
+
+    results_path = argv[1]
+    mode = os.environ.get('SCAN_MODE', 'unknown')
+    limit = int(os.environ.get('PER_FILE_LIMIT', '500'))
+    policy_file = os.environ.get('SCANCODE_POLICY_FILE', '').strip()
+
+    with open(results_path) as fh:
+        data = json.load(fh)
+
+    policy = Policy.load(policy_file) if policy_file else None
+    refs = build_reference_index(data)
+
+    if policy is not None and policy.uses_categories and not refs:
+        # Without license_references there are no categories, so a
+        # category-based policy would silently pass everything.
+        print(
+            f'::error::{policy.path} denies license categories but the '
+            'ScanCode report contains no license_references — rerun the scan '
+            'with --license-references.',
+            file=sys.stderr,
+        )
+        return 2
+
+    if policy is None:
+        violations, licenses, per_file = [], Counter(), []
+        for entry in data.get('files', []):
+            if entry.get('type') != 'file':
+                continue
+            detections = entry.get('license_detections', []) or []
+            if not detections:
+                continue
+            expressions = sorted({
+                d.get('license_expression', 'unknown') for d in detections
+            })
+            per_file.append((strip_scan_root(entry['path']), expressions))
+            for expr in expressions:
+                licenses[expr] += 1
+    else:
+        violations, licenses, per_file = collect_violations(data, policy, refs)
+
+    output = render_summary(mode, licenses, per_file, violations, policy, limit)
     summary_path = os.environ.get('GITHUB_STEP_SUMMARY')
     if summary_path:
         with open(summary_path, 'a') as out:
@@ -100,12 +376,9 @@ def main(argv: list[str]) -> int:
     else:
         sys.stdout.write(output)
 
-    # Emit GitHub Actions annotations for each violation so they surface in
-    # the PR "Files changed" view, not just in the step summary.
-    for path, expr in violations:
-        title = f'Disallowed license: {expr}'
-        message = f'{path} matches a license expression on the disallow list'
-        print(f'::error file={path},title={title}::{message}')
+    # Annotations surface in the PR "Files changed" view, not just the summary.
+    for violation in violations:
+        print(violation.annotation(policy))
     return 1 if violations else 0
 
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs [ScanCode Toolkit](https://github.com/nexB/scancode-toolkit) on files changed in a PR, to detect embedded license text, copyright notices, and package manifests.

This is a **proof of concept**. The intent is to start a conversation about whether OpenEMR wants a per-file license-compliance check in CI. Nothing is wired up as a required check, and the workflow never fails — it only reports findings.

## Motivation

Tools like Snyk check *declared* dependency licenses from `composer.json` / `package.json`. They do not detect cases where source code licensed under a different license (MIT, Apache, BSD, etc.) has been copy-pasted into the repo. ScanCode fingerprints license text inside files themselves, so it can distinguish GPL vs LGPL vs MIT vs Apache findings on a per-file basis. This is the class of problem that came up on #11416 (where code from an MIT-licensed upstream is being imported).

## How it works

- Trigger: `pull_request` against `master` / `rel-*`, plus `workflow_dispatch`.
- Scans only files added/modified in the PR (excluding `vendor`, `node_modules`, `ccdaservice/node_modules`, `Documentation`). Scoping to the diff keeps runtime manageable on a ~1M-LOC repo.
- ScanCode runs with `--license --copyright --package --only-findings`.
- Results are summarized in the GitHub Actions step summary (a table of license expressions + per-file breakdown) and uploaded as a JSON + HTML artifact for 30 days.
- The job is non-fatal — it surfaces findings but does not block merges.

## Not in scope for this PR

- Full-repo scans (would need scheduled runs + caching).
- SARIF upload / Code Scanning integration (ScanCode output would need mapping).
- A policy/allowlist of acceptable license expressions with fail-on-violation.
- SPDX SBOM generation.

Happy to iterate on any of these in follow-ups if there's interest. Also open to scrapping this in favor of [REUSE](https://reuse.software/) (stricter — requires `SPDX-License-Identifier` headers in every file).

## Test plan

- [ ] Workflow runs on this PR and produces a step summary table of license findings for the one changed file (the workflow itself).
- [ ] Artifact `scancode-results` contains `scancode-results.json` and `scancode-results.html`.
- [ ] Confirm the job surfaces the `apache-2.0` / `gpl-3.0` distinctions we'd expect if ScanCode is working.
