### PR TITLE
chore(ci): exclude config/ from test coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 ignore:
+- config/                # Container/service configuration — not directly testable
 - tests/PHPStan/         # Static analysis rules — not exercised by PHPUnit
 - tests/Rector/          # Rector rules — run outside PHPUnit coverage
 - tests/eventdispatcher/ # Example modules for documentation

--- a/phpunit-isolated.xml
+++ b/phpunit-isolated.xml
@@ -44,6 +44,7 @@ This file configures the kind that does not require initialization.
       <directory>.</directory>
     </include>
     <exclude>
+      <directory>config</directory>
       <directory>vendor</directory>
     </exclude>
   </source>

--- a/phpunit.integration.xml
+++ b/phpunit.integration.xml
@@ -42,6 +42,7 @@
       <directory>.</directory>
     </include>
     <exclude>
+      <directory>config</directory>
       <directory>vendor</directory>
     </exclude>
   </source>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -95,6 +95,7 @@ This file configures the kind that requires initialization.
       <directory>.</directory>
     </include>
     <exclude>
+      <directory>config</directory>
       <directory>vendor</directory>
     </exclude>
   </source>


### PR DESCRIPTION
## Summary
- Exclude `config/` from Codecov reporting via `codecov.yml`
- Exclude `config/` from PHPUnit coverage instrumentation in PHPUnit XML config files

The `config/` directory contains container/service wiring that is not directly executable code — any coverage from integration tests would not be meaningful.

Fixes #11652

Generated with [Claude Code](https://claude.ai/code)