### PR TITLE
fix(e2e): wait for post-login title transition to avoid race

### DIFF
--- a/tests/Tests/E2e/Login/LoginTrait.php
+++ b/tests/Tests/E2e/Login/LoginTrait.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\E2e\Login;
 
+use Facebook\WebDriver\Exception\TimeoutException;
+use Facebook\WebDriver\WebDriver;
 use OpenEMR\Tests\E2e\Base\BaseTrait;
 use OpenEMR\Tests\E2e\Login\LoginTestData;
 
@@ -80,6 +82,23 @@ trait LoginTrait
         $form['authUser'] = $name;
         $form['clearPass'] = $password;
         $this->crawler = $this->client->submit($form);
+        if ($goalPass) {
+            // The post-login redirect is asynchronous: submit() returns
+            // once the POST responds, but the browser still needs to
+            // follow the redirect and load the main shell before
+            // document.title transitions from 'OpenEMR Login' to
+            // 'OpenEMR'. Under CI load the lag is long enough that
+            // reading getTitle() immediately races the redirect and
+            // fails with "Expected 'OpenEMR'; actual 'OpenEMR Login'".
+            try {
+                $this->client->wait(10)->until(
+                    static fn(WebDriver $driver): bool => $driver->getTitle() === 'OpenEMR'
+                );
+            } catch (TimeoutException) {
+                // Fall through so the assertSame below reports the
+                // actual title for diagnostic purposes.
+            }
+        }
         $title = $this->client->getTitle();
         if ($goalPass) {
             $this->assertSame('OpenEMR', $title, 'Login FAILED');


### PR DESCRIPTION
Closes #11641.

## Summary

- E2E login currently reads `document.title` immediately after `$this->client->submit($form)`. Under CI load, the post-login redirect hasn't completed yet, so the title is still `'OpenEMR Login'` and the assertion fails.
- Add a short `WebDriverWait` (10s) for the title to transition to `'OpenEMR'` before re-reading it for the assertion, on the `$goalPass` path only.
- A `TimeoutException` falls through so the existing `assertSame` reports the actual title for diagnostic purposes rather than a generic timeout.

## Why this location

The race is inside `LoginTrait::performLogin`, which is reused by every E2E test (`LoginTrait` is the login entry point). Fixing it here eliminates the flake for every test rather than one-off waits at call sites.

## Test plan

- [ ] `composer phpstan` clean on changed file
- [ ] E2E test matrix (PHP 8.3/8.4/8.5 × apache/nginx × mariadb) no longer surfaces `-'OpenEMR' / +'OpenEMR Login'` assertion on login
- [ ] Negative-path test (`$goalPass=false`) still asserts `'OpenEMR Login'` without any wait