### PR TITLE
fix(ci): gate openemr on mysql service_healthy to avoid race

### DIFF
--- a/ci/compose-shared-mysql.yml
+++ b/ci/compose-shared-mysql.yml
@@ -5,6 +5,16 @@ services:
     - --character-set-server=utf8mb4
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD-SHELL
+      - mysql -uroot -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy


### PR DESCRIPTION
Closes #11643.

## Summary

- `ci/compose-shared-mysql.yml` had no healthcheck and used a bare `depends_on: - mysql` list, so the openemr container started as soon as the mysql container *process* started — not when MySQL was actually accepting connections.
- Under CI load the setup script races server initialisation and fails with `ERROR 2002 (HY000): Can't connect to server on 'mysql' (115)`. Downstream test jobs then fail in the PHPUnit bootstrap (`mysqli_query(): Argument #1 ($mysql) must be of type mysqli, false given`) because the database was never configured.
- Add a healthcheck + promote `depends_on.mysql` to the long form with `condition: service_healthy`, matching the pattern already used by `ci/compose-shared-mariadb.yml` and the MySQL services in `docker/development-insane/docker-compose.yml`.

## Why this test

The healthcheck runs `mysql -uroot -p$MYSQL_ROOT_PASSWORD -e 'SELECT 1'`, which is what the dev compose files already use. This is stricter than `mysqladmin ping` — during first-boot init, MySQL briefly listens on the socket before running initialisation scripts, then restarts. An actual `SELECT 1` only succeeds once MySQL is serving queries.

## Scope

Affects the four MySQL-backed CI configurations that `database-template: compose-shared-mysql.yml`:

- `ci/apache_85_57` (MySQL 5.7)
- `ci/apache_85_80` (MySQL 8.0)
- `ci/apache_85_84` (MySQL 8.4)
- `ci/apache_85_93` (MySQL 9.3)

MariaDB configurations are unaffected (they already have the equivalent gate via `ci/compose-shared-mariadb.yml`).

## Test plan

- [x] `docker compose -f ci/compose-shared-mysql.yml -f ci/compose-shared-apache.yml -f ci/compose-shared-selenium/docker-compose.yml -f ci/compose-shared-mailpit/compose.yml -f ci/apache_85_80/docker-compose.yml config` renders cleanly with the healthcheck on `mysql` and `condition: service_healthy` on `openemr`'s `depends_on.mysql`
- [ ] CI matrix (the four `apache_85_{57,80,84,93}` runs) no longer flakes with `ERROR 2002` during setup
- [ ] Steady-state test runs don't regress on startup time (healthcheck grace period is 1m, matches mariadb)