### PR TITLE
fix(docker): remove obsolete --with-pic from dev-php-fpm 8.6 build

### DIFF
--- a/.github/workflows/build-dev-php-fpm-docker.yml
+++ b/.github/workflows/build-dev-php-fpm-docker.yml
@@ -3,33 +3,35 @@ name: Nightly Build development 8.6 php-fpm Docker
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 * * *' # (daily) run at 1 AM UTC
+  - cron: '0 1 * * *'   # (daily) run at 1 AM UTC
 
 permissions:
   contents: read
 
 jobs:
   build:
-    # Only run from master branch on the main repository
-    if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
+    env:
+      # Only publish the image from master of the canonical repo; other branches / forks build dry-run.
+      PUSH_IMAGE: ${{ github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master' }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:pre-build-dev-86 docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm
-          tags: openemr/dev-php-fpm:pre-build-dev-86
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      if: env.PUSH_IMAGE == 'true'
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build (and push on master) dev-php-fpm:pre-build-dev-86 docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm
+        tags: openemr/dev-php-fpm:pre-build-dev-86
+        platforms: linux/amd64
+        push: ${{ env.PUSH_IMAGE == 'true' }}
+        no-cache: true

--- a/docker/library/dockers/dev-php-fpm/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm/Dockerfile
@@ -90,6 +90,8 @@ RUN set -eux; \
 #	fi; \
 	git clone https://github.com/php/php-src php; \
 	cd php; \
+# PHP 8.6 only exists on master today (no 8.6 tag or PHP-8.6 branch yet), so we clone master.
+# The point of this nightly image is to catch breakage against in-development PHP 8.6 early.
 #	git checkout "$( \
 #		git for-each-ref --format='%(refname)' refs/tags \
 #		| grep -E 'refs/tags/php-8\.2[.0-9]+$' \
@@ -154,9 +156,7 @@ RUN set -eux; \
 # https://github.com/docker-library/php/issues/439
 		--with-mhash \
 		\
-# https://github.com/docker-library/php/issues/822
-		--with-pic \
-		\
+# --with-pic removed: newer Libtool rejects it as obsolete. PIC code is already produced via -fpic in PHP_CFLAGS above.
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)


### PR DESCRIPTION
## Summary

Two-part fix for the broken `Nightly Build development 8.6 php-fpm Docker` workflow.

### 1. Unbreak the build (`fix(docker): remove obsolete --with-pic`)

Removes `--with-pic` from the `dev-php-fpm` 8.6 Dockerfile's `./configure` invocation. An updated Libtool (newly pulled in by php-src's own autoconf regeneration) now rejects it as obsolete, and `--enable-option-checking=fatal` turns that into a hard build failure. PIC code is already produced via `-fpic` in `PHP_CFLAGS` (exported as `CFLAGS` immediately before `./configure`), so the flag was redundant.

Clarifies with a comment why the tag-pinning block stays disabled for now: PHP 8.6 has no tag or `PHP-8.6` branch yet, so pinning would require guessing at a commit SHA. The nightly image exists specifically to catch breakage against in-development 8.6 early — which is what happened here.

### 2. Allow dry-run from any branch (`ci(docker): allow dry-run ...`)

Before: the top-level job `if:` on `build-dev-php-fpm-docker.yml` prevented the build from running at all outside `openemr/openemr` master, so there was no way to exercise the Dockerfile from a PR branch without waiting for the nightly cron post-merge.

Now: the job runs anywhere `workflow_dispatch` is invoked (or the schedule fires). Only the Docker Hub login and image `push` are gated on `openemr/openemr` master via a `PUSH_IMAGE` env var. Feature branches (and forks with Actions enabled) get a dry-run build that verifies the Dockerfile compiles but does not publish.

Fixes #11639

## Test plan

- [x] `docker build` of `docker/library/dockers/dev-php-fpm/Dockerfile` succeeds locally with the `--with-pic` change
- [x] Final verify step (`php -v | grep ^8.6`, `php-fpm --test`) passes in the built image
- [x] Workflow YAML validates and passes `actionlint` (pre-commit)
- [ ] On a feature branch of `openemr/openemr`, `workflow_dispatch` runs the build dry-run (no login, `push: false`)
- [ ] On master post-merge, the scheduled / dispatched run publishes `openemr/dev-php-fpm:pre-build-dev-86` as before