### PR TITLE
chore(db): Pre-create Doctrine migrations table

### DIFF
--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -154,7 +154,7 @@ ALTER TABLE `openemr_postcalendar_events` MODIFY `pc_endDate` date DEFAULT NULL;
 
 #IfNotTable migrations
 CREATE TABLE `migrations` (
-    `version` varchar(191) COLLATE utf8mb4_general_ci NOT NULL,
+    `version` varchar(191) NOT NULL,
     `executed_at` datetime DEFAULT NULL,
     `execution_duration_ms` int DEFAULT NULL,
     PRIMARY KEY (`version`)

--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -151,3 +151,12 @@ ALTER TABLE `openemr_postcalendar_events` MODIFY `pc_eventDate` date NOT NULL;
 #IfNotColumnTypeDefault openemr_postcalendar_events pc_endDate date NULL
 ALTER TABLE `openemr_postcalendar_events` MODIFY `pc_endDate` date DEFAULT NULL;
 #EndIf
+
+#IfNotTable migrations
+CREATE TABLE `migrations` (
+    `version` varchar(191) COLLATE utf8mb4_general_ci NOT NULL,
+    `executed_at` datetime DEFAULT NULL,
+    `execution_duration_ms` int DEFAULT NULL,
+    PRIMARY KEY (`version`)
+) ENGINE=InnoDB;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -15388,7 +15388,7 @@ INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`) VALUES ('org
 -- schema comparisons.
 DROP TABLE IF EXISTS `migrations`;
 CREATE TABLE `migrations` (
-    `version` varchar(191) COLLATE utf8mb4_general_ci NOT NULL,
+    `version` varchar(191) NOT NULL,
     `executed_at` datetime DEFAULT NULL,
     `execution_duration_ms` int DEFAULT NULL,
     PRIMARY KEY (`version`)

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -15382,3 +15382,14 @@ INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`) VALUES ('org
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`) VALUES ('organization-type', 'cg', 'Community Group', 100);
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`) VALUES ('organization-type', 'bus', 'Non-Healthcare Business or Corporation', 110);
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`) VALUES ('organization-type', 'other', 'Other', 120);
+
+-- Doctrine Migrations tracking
+-- Their tooling will create this automatically, but having it here simplifies
+-- schema comparisons.
+DROP TABLE IF EXISTS `migrations`;
+CREATE TABLE `migrations` (
+    `version` varchar(191) COLLATE utf8mb4_general_ci NOT NULL,
+    `executed_at` datetime DEFAULT NULL,
+    `execution_duration_ms` int DEFAULT NULL,
+    PRIMARY KEY (`version`)
+) ENGINE=InnoDB;

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3,7 +3,7 @@
 --
 -- Keep v_database in sync with $v_database in version.php.
 -- CI will fail if they don't match.
--- v_database: 537
+-- v_database: 538
 --
 
 --

--- a/version.php
+++ b/version.php
@@ -31,7 +31,7 @@ $v_realpatch = '0';
 //
 // Keep in sync with the v_database comment in sql/database.sql.
 // CI will fail if they don't match.
-$v_database = 537;
+$v_database = 538;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
#### Short description of what this changes or resolves:
This simplifies diffing the schemas between doctrine/migrations and the existing schema tooling.

#### Changes proposed in this pull request:
Adds the same migrations table schema that Doctrine itself does

#### Was an AI assistant used? Yes / No
No