### PR TITLE
feat(cache): add PSR-16 cache abstraction with three backends

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,6 +106,7 @@
         "psr/http-factory": "^1.1",
         "psr/http-message": "^1.1",
         "psr/log": "^3.0.2",
+        "psr/simple-cache": "^3.0",
         "ramsey/uuid": "^4.9.2",
         "ringcentral/ringcentral-php": "^3.0.4",
         "robthree/twofactorauth": "^3.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "775ceeaea41586f19c89f01d2858898a",
+    "content-hash": "f8193a0dc6bdbba7fe5d23452e15058a",
     "packages": [
         {
             "name": "academe/authorizenet-objects",

--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -151,3 +151,14 @@ ALTER TABLE `openemr_postcalendar_events` MODIFY `pc_eventDate` date NOT NULL;
 #IfNotColumnTypeDefault openemr_postcalendar_events pc_endDate date NULL
 ALTER TABLE `openemr_postcalendar_events` MODIFY `pc_endDate` date DEFAULT NULL;
 #EndIf
+
+-- Generic PSR-16 cache backing store for the DatabaseCache backend.
+#IfNotTable app_cache
+CREATE TABLE `app_cache` (
+    `cache_key` VARCHAR(255) NOT NULL COMMENT 'PSR-16 cache key',
+    `cache_value` LONGBLOB NOT NULL COMMENT 'Serialized CacheEntry',
+    `expires_at` DATETIME DEFAULT NULL COMMENT 'NULL = no expiration',
+    PRIMARY KEY (`cache_key`),
+    KEY `idx_expires_at` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3,7 +3,7 @@
 --
 -- Keep v_database in sync with $v_database in version.php.
 -- CI will fail if they don't match.
--- v_database: 537
+-- v_database: 538
 --
 
 --
@@ -15368,6 +15368,16 @@ CREATE TABLE `preference_value_sets` (
     -- General Preferences
     INSERT INTO preference_value_sets(`loinc_code`,`answer_code`,`answer_system`,`answer_display`,`sort_order`,`active`) VALUES
     ('95541-9', 314433002, 'http://snomed.info/sct', 'Preference for health professional (finding)', 1, 1);
+
+-- Generic PSR-16 cache backing store for the DatabaseCache backend.
+DROP TABLE IF EXISTS `app_cache`;
+CREATE TABLE `app_cache` (
+    `cache_key` VARCHAR(255) NOT NULL COMMENT 'PSR-16 cache key',
+    `cache_value` LONGBLOB NOT NULL COMMENT 'Serialized CacheEntry',
+    `expires_at` DATETIME DEFAULT NULL COMMENT 'NULL = no expiration',
+    PRIMARY KEY (`cache_key`),
+    KEY `idx_expires_at` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`) VALUES ('lists', 'organization-type', 'Organization Type', 1);
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`) VALUES ('organization-type', 'prov', 'Healthcare Provider', 10);

--- a/sql/patch.sql
+++ b/sql/patch.sql
@@ -47,3 +47,14 @@
 
 --  #EndIf
 --    all blocks are terminated with and #EndIf statement.
+
+-- Generic PSR-16 cache backing store for the DatabaseCache backend.
+#IfNotTable app_cache
+CREATE TABLE `app_cache` (
+    `cache_key` VARCHAR(255) NOT NULL COMMENT 'PSR-16 cache key',
+    `cache_value` LONGBLOB NOT NULL COMMENT 'Serialized CacheEntry',
+    `expires_at` DATETIME DEFAULT NULL COMMENT 'NULL = no expiration',
+    PRIMARY KEY (`cache_key`),
+    KEY `idx_expires_at` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+#EndIf

--- a/src/Common/Cache/CacheEntry.php
+++ b/src/Common/Cache/CacheEntry.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Typed envelope for serialized cache entries.
+ *
+ * All PSR-16 cache backends in this namespace serialize and deserialize
+ * only this class. By restricting unserialize() to CacheEntry, we prevent
+ * PHP object injection attacks — no arbitrary classes can be instantiated
+ * from cached data.
+ *
+ * @link      https://www.open-emr.org
+ * @author    Milan Zivkovic <zivkovic.milan@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Cache;
+
+final readonly class CacheEntry
+{
+    /**
+     * @param mixed    $value     The cached value (scalars, arrays, null).
+     * @param int|null $expiresAt Unix timestamp when this entry expires, or null for no expiration.
+     */
+    public function __construct(
+        public mixed $value,
+        public ?int $expiresAt = null,
+    ) {
+    }
+
+    public function isExpired(int $now): bool
+    {
+        return $this->expiresAt !== null && $this->expiresAt < $now;
+    }
+
+    /**
+     * Allowed classes list for unserialize().
+     *
+     * @return array{allowed_classes: list<class-string>}
+     */
+    public static function unserializeOptions(): array
+    {
+        return ['allowed_classes' => [self::class]];
+    }
+}

--- a/src/Common/Cache/CacheException.php
+++ b/src/Common/Cache/CacheException.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Base cache exception for OpenEMR cache backends.
+ *
+ * Implements the PSR-16 marker interface so callers can catch cache
+ * failures via the standard contract.
+ *
+ * @link      https://www.open-emr.org
+ * @author    Milan Zivkovic <zivkovic.milan@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Cache;
+
+use Psr\SimpleCache\CacheException as PsrCacheException;
+
+final class CacheException extends \RuntimeException implements PsrCacheException
+{
+}

--- a/src/Common/Cache/CacheInvalidArgumentException.php
+++ b/src/Common/Cache/CacheInvalidArgumentException.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Thrown when a cache key is invalid per PSR-16 rules.
+ *
+ * @link      https://www.open-emr.org
+ * @author    Milan Zivkovic <zivkovic.milan@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Cache;
+
+use Psr\SimpleCache\InvalidArgumentException as PsrInvalidArgumentException;
+
+final class CacheInvalidArgumentException extends \InvalidArgumentException implements PsrInvalidArgumentException
+{
+}

--- a/src/Common/Cache/DatabaseCache.php
+++ b/src/Common/Cache/DatabaseCache.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * PSR-16 simple cache backed by a database table.
+ *
+ * Suitable for multi-instance and containerized deployments where all instances
+ * share the same database. Uses the `app_cache` table.
+ *
+ * @link      https://www.open-emr.org
+ * @author    Milan Zivkovic <zivkovic.milan@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Cache;
+
+use OpenEMR\Common\Database\QueryUtils;
+use Psr\SimpleCache\CacheInterface;
+
+final class DatabaseCache implements CacheInterface
+{
+    public const TABLE_NAME = 'app_cache';
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $this->validateKey($key);
+
+        $row = QueryUtils::fetchRecords(
+            'SELECT `cache_value`, `expires_at` FROM `' . self::TABLE_NAME . '` WHERE `cache_key` = ?',
+            [$key],
+        );
+
+        if ($row === []) {
+            return $default;
+        }
+
+        $record = $row[0];
+        $expiresAt = $record['expires_at'];
+        $cacheValue = $record['cache_value'];
+
+        if (is_string($expiresAt) && strtotime($expiresAt) < time()) {
+            $this->delete($key);
+            return $default;
+        }
+
+        if (!is_string($cacheValue)) {
+            $this->delete($key);
+            return $default;
+        }
+
+        $entry = @unserialize($cacheValue, CacheEntry::unserializeOptions());
+        if (!$entry instanceof CacheEntry) {
+            $this->delete($key);
+            return $default;
+        }
+
+        return $entry->value;
+    }
+
+    public function set(string $key, mixed $value, \DateInterval|int|null $ttl = null): bool
+    {
+        $this->validateKey($key);
+
+        $expiresAt = $this->ttlToDatetime($ttl);
+        $entry = new CacheEntry($value);
+        $serialized = serialize($entry);
+
+        $existing = QueryUtils::fetchRecords(
+            'SELECT 1 FROM `' . self::TABLE_NAME . '` WHERE `cache_key` = ?',
+            [$key],
+        );
+
+        if ($existing !== []) {
+            QueryUtils::sqlStatementThrowException(
+                'UPDATE `' . self::TABLE_NAME . '` SET `cache_value` = ?, `expires_at` = ? WHERE `cache_key` = ?',
+                [$serialized, $expiresAt, $key],
+            );
+        } else {
+            QueryUtils::sqlStatementThrowException(
+                'INSERT INTO `' . self::TABLE_NAME . '` (`cache_key`, `cache_value`, `expires_at`) VALUES (?, ?, ?)',
+                [$key, $serialized, $expiresAt],
+            );
+        }
+
+        return true;
+    }
+
+    public function delete(string $key): bool
+    {
+        $this->validateKey($key);
+
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `' . self::TABLE_NAME . '` WHERE `cache_key` = ?',
+            [$key],
+        );
+
+        return true;
+    }
+
+    public function clear(): bool
+    {
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `' . self::TABLE_NAME . '`',
+        );
+
+        return true;
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->get($key, $this) !== $this;
+    }
+
+    /**
+     * @param iterable<string> $keys
+     * @return iterable<string, mixed>
+     */
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $results = [];
+        foreach ($keys as $key) {
+            $results[$key] = $this->get($key, $default);
+        }
+
+        return $results;
+    }
+
+    /** @phpstan-ignore missingType.iterableValue (PSR-16 CacheInterface uses untyped iterable) */
+    public function setMultiple(iterable $values, \DateInterval|int|null $ttl = null): bool
+    {
+        $success = true;
+        /** @var string $key */
+        foreach ($values as $key => $value) {
+            if (!$this->set($key, $value, $ttl)) {
+                $success = false;
+            }
+        }
+
+        return $success;
+    }
+
+    /**
+     * @param iterable<string> $keys
+     */
+    public function deleteMultiple(iterable $keys): bool
+    {
+        $success = true;
+        foreach ($keys as $key) {
+            if (!$this->delete($key)) {
+                $success = false;
+            }
+        }
+
+        return $success;
+    }
+
+    /**
+     * Remove all expired entries. Intended to be called periodically (cron or on-demand).
+     */
+    public function purgeExpired(): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `' . self::TABLE_NAME . '` WHERE `expires_at` IS NOT NULL AND `expires_at` < NOW()',
+        );
+    }
+
+    private function ttlToDatetime(\DateInterval|int|null $ttl): ?string
+    {
+        if ($ttl === null) {
+            return null;
+        }
+
+        if ($ttl instanceof \DateInterval) {
+            return (new \DateTimeImmutable())->add($ttl)->format('Y-m-d H:i:s');
+        }
+
+        if ($ttl <= 0) {
+            return '1970-01-01 00:00:00';
+        }
+
+        return (new \DateTimeImmutable())->modify("+{$ttl} seconds")->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * @throws CacheInvalidArgumentException
+     */
+    private function validateKey(string $key): void
+    {
+        if ($key === '') {
+            throw new CacheInvalidArgumentException('Cache key must not be empty');
+        }
+
+        if (preg_match('/[{}()\/\\\\@:]/', $key) === 1) {
+            throw new CacheInvalidArgumentException(
+                "Cache key contains reserved characters: {$key}"
+            );
+        }
+
+        if (strlen($key) > 255) {
+            throw new CacheInvalidArgumentException(
+                "Cache key exceeds maximum length of 255 characters: {$key}"
+            );
+        }
+    }
+}

--- a/src/Common/Cache/FilesystemCache.php
+++ b/src/Common/Cache/FilesystemCache.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * PSR-16 simple cache backed by the local filesystem.
+ *
+ * Each cache entry is stored as a serialized file. Suitable for single-instance
+ * deployments and development. For multi-instance or containerized environments,
+ * prefer DatabaseCache or RedisCache.
+ *
+ * @link      https://www.open-emr.org
+ * @author    Milan Zivkovic <zivkovic.milan@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+
+final readonly class FilesystemCache implements CacheInterface
+{
+    private string $directory;
+
+    /**
+     * @param string $directory Absolute path to the cache directory.
+     */
+    public function __construct(string $directory)
+    {
+        $realpath = realpath($directory);
+        if ($realpath === false || !is_dir($realpath)) {
+            throw new CacheException("Cache directory does not exist: {$directory}");
+        }
+        if (!is_writable($realpath)) {
+            throw new CacheException("Cache directory is not writable: {$directory}");
+        }
+        $this->directory = $realpath;
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $this->validateKey($key);
+
+        $path = $this->pathForKey($key);
+        if (!is_file($path)) {
+            return $default;
+        }
+
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            return $default;
+        }
+
+        $entry = @unserialize($contents, CacheEntry::unserializeOptions());
+        if (!$entry instanceof CacheEntry) {
+            @unlink($path);
+            return $default;
+        }
+
+        if ($entry->isExpired(time())) {
+            @unlink($path);
+            return $default;
+        }
+
+        return $entry->value;
+    }
+
+    public function set(string $key, mixed $value, \DateInterval|int|null $ttl = null): bool
+    {
+        $this->validateKey($key);
+
+        $expiresAt = $this->ttlToTimestamp($ttl);
+        $entry = new CacheEntry($value, $expiresAt);
+
+        $path = $this->pathForKey($key);
+        $tempPath = $path . '.' . bin2hex(random_bytes(4)) . '.tmp';
+
+        $written = file_put_contents($tempPath, serialize($entry));
+        if ($written === false) {
+            @unlink($tempPath);
+            return false;
+        }
+
+        return rename($tempPath, $path);
+    }
+
+    public function delete(string $key): bool
+    {
+        $this->validateKey($key);
+
+        $path = $this->pathForKey($key);
+        if (!is_file($path)) {
+            return true;
+        }
+
+        return @unlink($path);
+    }
+
+    public function clear(): bool
+    {
+        $files = glob($this->directory . DIRECTORY_SEPARATOR . '*.cache');
+        if ($files === false) {
+            return false;
+        }
+
+        $success = true;
+        foreach ($files as $file) {
+            if (!@unlink($file)) {
+                $success = false;
+            }
+        }
+
+        return $success;
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->get($key, $this) !== $this;
+    }
+
+    /**
+     * @param iterable<string> $keys
+     * @return iterable<string, mixed>
+     */
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $results = [];
+        foreach ($keys as $key) {
+            $results[$key] = $this->get($key, $default);
+        }
+
+        return $results;
+    }
+
+    /** @phpstan-ignore missingType.iterableValue (PSR-16 CacheInterface uses untyped iterable) */
+    public function setMultiple(iterable $values, \DateInterval|int|null $ttl = null): bool
+    {
+        $success = true;
+        /** @var string $key */
+        foreach ($values as $key => $value) {
+            if (!$this->set($key, $value, $ttl)) {
+                $success = false;
+            }
+        }
+
+        return $success;
+    }
+
+    /**
+     * @param iterable<string> $keys
+     */
+    public function deleteMultiple(iterable $keys): bool
+    {
+        $success = true;
+        foreach ($keys as $key) {
+            if (!$this->delete($key)) {
+                $success = false;
+            }
+        }
+
+        return $success;
+    }
+
+    private function pathForKey(string $key): string
+    {
+        return $this->directory . DIRECTORY_SEPARATOR . hash('sha256', $key) . '.cache';
+    }
+
+    private function ttlToTimestamp(\DateInterval|int|null $ttl): ?int
+    {
+        if ($ttl === null) {
+            return null;
+        }
+
+        if ($ttl instanceof \DateInterval) {
+            $now = new \DateTimeImmutable();
+            return $now->add($ttl)->getTimestamp();
+        }
+
+        if ($ttl <= 0) {
+            return 0;
+        }
+
+        return time() + $ttl;
+    }
+
+    /**
+     * @throws CacheInvalidArgumentException
+     */
+    private function validateKey(string $key): void
+    {
+        if ($key === '') {
+            throw new CacheInvalidArgumentException('Cache key must not be empty');
+        }
+
+        if (preg_match('/[{}()\/\\\\@:]/', $key) === 1) {
+            throw new CacheInvalidArgumentException(
+                "Cache key contains reserved characters: {$key}"
+            );
+        }
+    }
+}

--- a/src/Common/Cache/RedisCache.php
+++ b/src/Common/Cache/RedisCache.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * PSR-16 simple cache backed by Redis via the ext-redis PHP extension.
+ *
+ * Suitable for high-traffic and multi-instance deployments. Uses the
+ * native `\Redis` class supplied by the `ext-redis` extension that
+ * OpenEMR already requires (`ext-redis: *` in composer.json), the same
+ * client used by `LockingRedisSessionHandler`.
+ *
+ * @link      https://www.open-emr.org
+ * @author    Milan Zivkovic <zivkovic.milan@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+
+final readonly class RedisCache implements CacheInterface
+{
+    private const KEY_PREFIX = 'app_cache:';
+
+    public function __construct(
+        private \Redis $client,
+    ) {
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $this->validateKey($key);
+
+        $raw = $this->client->get(self::KEY_PREFIX . $key);
+        if ($raw === false) {
+            return $default;
+        }
+        if (!is_string($raw)) {
+            return $default;
+        }
+
+        $entry = @unserialize($raw, CacheEntry::unserializeOptions());
+        if (!$entry instanceof CacheEntry) {
+            $this->delete($key);
+            return $default;
+        }
+
+        return $entry->value;
+    }
+
+    public function set(string $key, mixed $value, \DateInterval|int|null $ttl = null): bool
+    {
+        $this->validateKey($key);
+
+        $prefixedKey = self::KEY_PREFIX . $key;
+        $entry = new CacheEntry($value);
+        $serialized = serialize($entry);
+
+        $seconds = $this->ttlToSeconds($ttl);
+
+        if ($seconds !== null) {
+            if ($seconds <= 0) {
+                $this->client->del($prefixedKey);
+                return true;
+            }
+            $this->client->setex($prefixedKey, $seconds, $serialized);
+        } else {
+            $this->client->set($prefixedKey, $serialized);
+        }
+
+        return true;
+    }
+
+    public function delete(string $key): bool
+    {
+        $this->validateKey($key);
+
+        $this->client->del(self::KEY_PREFIX . $key);
+
+        return true;
+    }
+
+    public function clear(): bool
+    {
+        $pattern = self::KEY_PREFIX . '*';
+        $cursor = null;
+
+        do {
+            /** @var list<string>|false $keys */
+            $keys = $this->client->scan($cursor, $pattern, 100);
+
+            if (is_array($keys) && $keys !== []) {
+                $this->client->del(...$keys);
+            }
+        } while ($cursor !== 0 && $cursor !== '0' && $cursor !== null);
+
+        return true;
+    }
+
+    public function has(string $key): bool
+    {
+        $this->validateKey($key);
+
+        return (bool) $this->client->exists(self::KEY_PREFIX . $key);
+    }
+
+    /**
+     * @param iterable<string> $keys
+     * @return iterable<string, mixed>
+     */
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $results = [];
+        foreach ($keys as $key) {
+            $results[$key] = $this->get($key, $default);
+        }
+
+        return $results;
+    }
+
+    /** @phpstan-ignore missingType.iterableValue (PSR-16 CacheInterface uses untyped iterable) */
+    public function setMultiple(iterable $values, \DateInterval|int|null $ttl = null): bool
+    {
+        $success = true;
+        /** @var string $key */
+        foreach ($values as $key => $value) {
+            if (!$this->set($key, $value, $ttl)) {
+                $success = false;
+            }
+        }
+
+        return $success;
+    }
+
+    /**
+     * @param iterable<string> $keys
+     */
+    public function deleteMultiple(iterable $keys): bool
+    {
+        $success = true;
+        foreach ($keys as $key) {
+            if (!$this->delete($key)) {
+                $success = false;
+            }
+        }
+
+        return $success;
+    }
+
+    private function ttlToSeconds(\DateInterval|int|null $ttl): ?int
+    {
+        if ($ttl === null) {
+            return null;
+        }
+
+        if ($ttl instanceof \DateInterval) {
+            $now = new \DateTimeImmutable();
+            return $now->add($ttl)->getTimestamp() - $now->getTimestamp();
+        }
+
+        return $ttl;
+    }
+
+    /**
+     * @throws CacheInvalidArgumentException
+     */
+    private function validateKey(string $key): void
+    {
+        if ($key === '') {
+            throw new CacheInvalidArgumentException('Cache key must not be empty');
+        }
+
+        if (preg_match('/[{}()\/\\\\@:]/', $key) === 1) {
+            throw new CacheInvalidArgumentException(
+                "Cache key contains reserved characters: {$key}"
+            );
+        }
+    }
+}

--- a/tests/Tests/Integration/Common/Cache/DatabaseCacheTest.php
+++ b/tests/Tests/Integration/Common/Cache/DatabaseCacheTest.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * Integration tests for DatabaseCache against a real database.
+ *
+ * Requires Docker MySQL to be running with the app_cache table.
+ *
+ * @link      https://www.open-emr.org
+ * @author    Milan Zivkovic <zivkovic.milan@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Integration\Common\Cache;
+
+use OpenEMR\Common\Cache\CacheEntry;
+use OpenEMR\Common\Cache\CacheInvalidArgumentException;
+use OpenEMR\Common\Cache\DatabaseCache;
+use OpenEMR\Common\Database\QueryUtils;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DatabaseCacheTest extends TestCase
+{
+    private DatabaseCache $cache;
+
+    protected function setUp(): void
+    {
+        if (getenv('DISABLE_DATABASE') === '1') {
+            self::markTestSkipped('Integration test requires database');
+        }
+
+        $this->cache = new DatabaseCache();
+        $this->cleanTable();
+    }
+
+    protected function tearDown(): void
+    {
+        if (getenv('DISABLE_DATABASE') !== '1') {
+            $this->cleanTable();
+        }
+    }
+
+    private function cleanTable(): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `' . DatabaseCache::TABLE_NAME . '`',
+        );
+    }
+
+    public function testSetAndGet(): void
+    {
+        $this->cache->set('test-key', 'test-value');
+
+        self::assertSame('test-value', $this->cache->get('test-key'));
+    }
+
+    public function testGetReturnsDefaultForMissingKey(): void
+    {
+        self::assertNull($this->cache->get('nonexistent'));
+        self::assertSame('fallback', $this->cache->get('nonexistent', 'fallback'));
+    }
+
+    public function testSetOverwritesExistingKey(): void
+    {
+        $this->cache->set('key', 'first');
+        $this->cache->set('key', 'second');
+
+        self::assertSame('second', $this->cache->get('key'));
+    }
+
+    public function testSetWithIntTtl(): void
+    {
+        $this->cache->set('ttl-key', 'data', 3600);
+
+        self::assertSame('data', $this->cache->get('ttl-key'));
+    }
+
+    public function testSetWithDateIntervalTtl(): void
+    {
+        $this->cache->set('interval-key', 'data', new \DateInterval('PT1H'));
+
+        self::assertSame('data', $this->cache->get('interval-key'));
+    }
+
+    public function testSetWithZeroTtlExpires(): void
+    {
+        $this->cache->set('expired-key', 'data', 0);
+
+        self::assertNull($this->cache->get('expired-key'));
+    }
+
+    public function testSetWithNegativeTtlExpires(): void
+    {
+        $this->cache->set('negative-ttl', 'data', -1);
+
+        self::assertNull($this->cache->get('negative-ttl'));
+    }
+
+    public function testDelete(): void
+    {
+        $this->cache->set('to-delete', 'value');
+        $result = $this->cache->delete('to-delete');
+
+        self::assertTrue($result);
+        self::assertNull($this->cache->get('to-delete'));
+    }
+
+    public function testDeleteNonexistentReturnsTrue(): void
+    {
+        self::assertTrue($this->cache->delete('nonexistent'));
+    }
+
+    public function testClear(): void
+    {
+        $this->cache->set('a', 1);
+        $this->cache->set('b', 2);
+
+        $result = $this->cache->clear();
+
+        self::assertTrue($result);
+        self::assertNull($this->cache->get('a'));
+        self::assertNull($this->cache->get('b'));
+    }
+
+    public function testHas(): void
+    {
+        self::assertFalse($this->cache->has('missing'));
+
+        $this->cache->set('present', 'value');
+
+        self::assertTrue($this->cache->has('present'));
+    }
+
+    public function testGetMultiple(): void
+    {
+        $this->cache->set('m1', 'one');
+        $this->cache->set('m2', 'two');
+
+        /** @var array<string, mixed> $results */
+        $results = iterator_to_array($this->cache->getMultiple(['m1', 'm2', 'm3'], 'default'));
+
+        self::assertSame('one', $results['m1']);
+        self::assertSame('two', $results['m2']);
+        self::assertSame('default', $results['m3']);
+    }
+
+    public function testSetMultiple(): void
+    {
+        $result = $this->cache->setMultiple(['s1' => 'val1', 's2' => 'val2']);
+
+        self::assertTrue($result);
+        self::assertSame('val1', $this->cache->get('s1'));
+        self::assertSame('val2', $this->cache->get('s2'));
+    }
+
+    public function testDeleteMultiple(): void
+    {
+        $this->cache->set('d1', 'one');
+        $this->cache->set('d2', 'two');
+        $this->cache->set('d3', 'three');
+
+        $result = $this->cache->deleteMultiple(['d1', 'd3']);
+
+        self::assertTrue($result);
+        self::assertNull($this->cache->get('d1'));
+        self::assertSame('two', $this->cache->get('d2'));
+        self::assertNull($this->cache->get('d3'));
+    }
+
+    public function testPurgeExpiredRemovesOnlyExpiredEntries(): void
+    {
+        // Insert an already-expired entry directly
+        QueryUtils::sqlStatementThrowException(
+            'INSERT INTO `' . DatabaseCache::TABLE_NAME . '` (`cache_key`, `cache_value`, `expires_at`) VALUES (?, ?, ?)',
+            ['expired', serialize(new CacheEntry('old')), '2000-01-01 00:00:00'],
+        );
+
+        $this->cache->set('valid', 'still-here', 3600);
+
+        $this->cache->purgeExpired();
+
+        self::assertNull($this->cache->get('expired'));
+        self::assertSame('still-here', $this->cache->get('valid'));
+    }
+
+    public function testPurgeExpiredKeepsNullExpiryEntries(): void
+    {
+        $this->cache->set('no-expiry', 'forever');
+
+        $this->cache->purgeExpired();
+
+        self::assertSame('forever', $this->cache->get('no-expiry'));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function variousValueTypesProvider(): array
+    {
+        return [
+            'string' => ['hello'],
+            'integer' => [42],
+            'float' => [3.14],
+            'boolean true' => [true],
+            'boolean false' => [false],
+            'array' => [['nested' => [1, 2, 3]]],
+            'null' => [null],
+        ];
+    }
+
+    #[DataProvider('variousValueTypesProvider')]
+    public function testRoundTripsVariousTypes(mixed $value): void
+    {
+        $this->cache->set('typed', $value);
+
+        self::assertSame($value, $this->cache->get('typed'));
+    }
+
+    public function testRejectsEmptyKey(): void
+    {
+        $this->expectException(CacheInvalidArgumentException::class);
+
+        $this->cache->get('');
+    }
+
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function reservedCharacterKeyProvider(): array
+    {
+        return [
+            'curly open' => ['key{bad'],
+            'curly close' => ['key}bad'],
+            'paren open' => ['key(bad'],
+            'paren close' => ['key)bad'],
+            'slash' => ['key/bad'],
+            'backslash' => ['key\\bad'],
+            'at sign' => ['key@bad'],
+            'colon' => ['key:bad'],
+        ];
+    }
+
+    #[DataProvider('reservedCharacterKeyProvider')]
+    public function testRejectsKeysWithReservedCharacters(string $key): void
+    {
+        $this->expectException(CacheInvalidArgumentException::class);
+
+        $this->cache->get($key);
+    }
+
+    public function testRejectsKeyExceedingMaxLength(): void
+    {
+        $this->expectException(CacheInvalidArgumentException::class);
+
+        $this->cache->get(str_repeat('a', 256));
+    }
+}

--- a/tests/Tests/Isolated/Common/Cache/CacheEntryTest.php
+++ b/tests/Tests/Isolated/Common/Cache/CacheEntryTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * @link      https://www.open-emr.org
+ * @author    Milan Zivkovic <zivkovic.milan@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Cache;
+
+use OpenEMR\Common\Cache\CacheEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CacheEntryTest extends TestCase
+{
+    public function testConstructionWithValueAndExpiry(): void
+    {
+        $entry = new CacheEntry(value: 'some-data', expiresAt: 1700000000);
+
+        self::assertSame('some-data', $entry->value);
+        self::assertSame(1700000000, $entry->expiresAt);
+    }
+
+    public function testConstructionWithNullExpiry(): void
+    {
+        $entry = new CacheEntry(value: ['key' => 'val']);
+
+        self::assertSame(['key' => 'val'], $entry->value);
+        self::assertNull($entry->expiresAt);
+    }
+
+    public function testConstructionWithNullValue(): void
+    {
+        $entry = new CacheEntry(value: null, expiresAt: 1700000000);
+
+        self::assertNull($entry->value);
+    }
+
+    public function testIsExpiredReturnsTrueWhenPastExpiry(): void
+    {
+        $entry = new CacheEntry(value: 'data', expiresAt: 1000);
+
+        self::assertTrue($entry->isExpired(1001));
+    }
+
+    public function testIsExpiredReturnsTrueWhenExactlyAtExpiry(): void
+    {
+        // expiresAt < now is the condition, so equal means NOT expired
+        $entry = new CacheEntry(value: 'data', expiresAt: 1000);
+
+        self::assertFalse($entry->isExpired(1000));
+    }
+
+    public function testIsExpiredReturnsFalseWhenBeforeExpiry(): void
+    {
+        $entry = new CacheEntry(value: 'data', expiresAt: 2000);
+
+        self::assertFalse($entry->isExpired(1000));
+    }
+
+    public function testIsExpiredReturnsFalseWhenNoExpiry(): void
+    {
+        $entry = new CacheEntry(value: 'data');
+
+        self::assertFalse($entry->isExpired(PHP_INT_MAX));
+    }
+
+    public function testUnserializeOptionsAllowsOnlyCacheEntry(): void
+    {
+        $options = CacheEntry::unserializeOptions();
+
+        self::assertSame(['allowed_classes' => [CacheEntry::class]], $options);
+    }
+
+    public function testSerializeRoundTrip(): void
+    {
+        $original = new CacheEntry(value: ['nested' => [1, 2, 3]], expiresAt: 1700000000);
+        $serialized = serialize($original);
+
+        /** @var CacheEntry $restored */
+        $restored = unserialize($serialized, CacheEntry::unserializeOptions());
+
+        self::assertEquals($original, $restored);
+    }
+
+    public function testIsImmutable(): void
+    {
+        $reflection = new \ReflectionClass(CacheEntry::class);
+        self::assertTrue($reflection->isReadOnly());
+        self::assertTrue($reflection->isFinal());
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function variousValueTypesProvider(): array
+    {
+        return [
+            'string' => ['hello'],
+            'integer' => [42],
+            'float' => [3.14],
+            'boolean' => [true],
+            'array' => [['a', 'b']],
+            'null' => [null],
+        ];
+    }
+
+    #[DataProvider('variousValueTypesProvider')]
+    public function testAcceptsVariousValueTypes(mixed $value): void
+    {
+        $entry = new CacheEntry(value: $value);
+
+        self::assertSame($value, $entry->value);
+    }
+}

--- a/tests/Tests/Isolated/Common/Cache/FilesystemCacheTest.php
+++ b/tests/Tests/Isolated/Common/Cache/FilesystemCacheTest.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * @link      https://www.open-emr.org
+ * @author    Milan Zivkovic <zivkovic.milan@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Cache;
+
+use OpenEMR\Common\Cache\CacheException;
+use OpenEMR\Common\Cache\CacheInvalidArgumentException;
+use OpenEMR\Common\Cache\FilesystemCache;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class FilesystemCacheTest extends TestCase
+{
+    private string $cacheDir;
+    private FilesystemCache $cache;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir() . '/app_cache_test_' . bin2hex(random_bytes(8));
+        mkdir($this->cacheDir, 0o755, true);
+        $this->cache = new FilesystemCache($this->cacheDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cache->clear();
+        @rmdir($this->cacheDir);
+    }
+
+    public function testConstructorRejectsNonexistentDirectory(): void
+    {
+        $this->expectException(CacheException::class);
+        $this->expectExceptionMessage('Cache directory does not exist');
+
+        new FilesystemCache('/nonexistent/path/that/does/not/exist');
+    }
+
+    public function testGetReturnsDefaultForMissingKey(): void
+    {
+        self::assertNull($this->cache->get('nonexistent'));
+        self::assertSame('fallback', $this->cache->get('nonexistent', 'fallback'));
+    }
+
+    public function testSetAndGet(): void
+    {
+        self::assertTrue($this->cache->set('key1', 'value1'));
+        self::assertSame('value1', $this->cache->get('key1'));
+    }
+
+    public function testSetOverwritesExistingValue(): void
+    {
+        $this->cache->set('key1', 'original');
+        $this->cache->set('key1', 'updated');
+
+        self::assertSame('updated', $this->cache->get('key1'));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function cacheableValueProvider(): array
+    {
+        return [
+            'string' => ['hello'],
+            'integer' => [42],
+            'float' => [3.14],
+            'boolean true' => [true],
+            'boolean false' => [false],
+            'null' => [null],
+            'array' => [['a' => 1, 'b' => [2, 3]]],
+            'empty string' => [''],
+            'zero' => [0],
+            'empty array' => [[]],
+        ];
+    }
+
+    #[DataProvider('cacheableValueProvider')]
+    public function testCachesVariousTypes(mixed $value): void
+    {
+        $this->cache->set('typed', $value);
+        self::assertSame($value, $this->cache->get('typed'));
+    }
+
+    public function testSetWithIntTtl(): void
+    {
+        $this->cache->set('short-lived', 'data', 3600);
+        self::assertSame('data', $this->cache->get('short-lived'));
+    }
+
+    public function testSetWithDateIntervalTtl(): void
+    {
+        $this->cache->set('interval-lived', 'data', new \DateInterval('PT1H'));
+        self::assertSame('data', $this->cache->get('interval-lived'));
+    }
+
+    public function testExpiredEntryReturnsDefault(): void
+    {
+        // TTL of 0 or negative means already expired
+        $this->cache->set('expired', 'data', 0);
+        self::assertNull($this->cache->get('expired'));
+    }
+
+    public function testNegativeTtlReturnsDefault(): void
+    {
+        $this->cache->set('negative-ttl', 'data', -10);
+        self::assertNull($this->cache->get('negative-ttl'));
+    }
+
+    public function testNullTtlMeansNoExpiration(): void
+    {
+        $this->cache->set('forever', 'data', null);
+        self::assertSame('data', $this->cache->get('forever'));
+    }
+
+    public function testDelete(): void
+    {
+        $this->cache->set('to-delete', 'data');
+        self::assertTrue($this->cache->delete('to-delete'));
+        self::assertNull($this->cache->get('to-delete'));
+    }
+
+    public function testDeleteNonexistentKeyReturnsTrue(): void
+    {
+        self::assertTrue($this->cache->delete('never-existed'));
+    }
+
+    public function testClear(): void
+    {
+        $this->cache->set('a', '1');
+        $this->cache->set('b', '2');
+        $this->cache->set('c', '3');
+
+        self::assertTrue($this->cache->clear());
+
+        self::assertNull($this->cache->get('a'));
+        self::assertNull($this->cache->get('b'));
+        self::assertNull($this->cache->get('c'));
+    }
+
+    public function testHas(): void
+    {
+        self::assertFalse($this->cache->has('key'));
+        $this->cache->set('key', 'value');
+        self::assertTrue($this->cache->has('key'));
+    }
+
+    public function testHasReturnsFalseForExpired(): void
+    {
+        $this->cache->set('expired', 'data', 0);
+        self::assertFalse($this->cache->has('expired'));
+    }
+
+    public function testGetMultiple(): void
+    {
+        $this->cache->set('m1', 'v1');
+        $this->cache->set('m2', 'v2');
+
+        $results = $this->cache->getMultiple(['m1', 'm2', 'm3'], 'default');
+
+        self::assertSame(['m1' => 'v1', 'm2' => 'v2', 'm3' => 'default'], $results);
+    }
+
+    public function testSetMultiple(): void
+    {
+        self::assertTrue($this->cache->setMultiple(['s1' => 'v1', 's2' => 'v2']));
+
+        self::assertSame('v1', $this->cache->get('s1'));
+        self::assertSame('v2', $this->cache->get('s2'));
+    }
+
+    public function testDeleteMultiple(): void
+    {
+        $this->cache->set('d1', 'v1');
+        $this->cache->set('d2', 'v2');
+
+        self::assertTrue($this->cache->deleteMultiple(['d1', 'd2']));
+
+        self::assertNull($this->cache->get('d1'));
+        self::assertNull($this->cache->get('d2'));
+    }
+
+    public function testEmptyKeyThrows(): void
+    {
+        $this->expectException(CacheInvalidArgumentException::class);
+        $this->expectExceptionMessage('Cache key must not be empty');
+
+        $this->cache->get('');
+    }
+
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function reservedCharacterKeyProvider(): array
+    {
+        return [
+            'curly open' => ['key{bad'],
+            'curly close' => ['key}bad'],
+            'paren open' => ['key(bad'],
+            'paren close' => ['key)bad'],
+            'slash' => ['key/bad'],
+            'backslash' => ['key\\bad'],
+            'at sign' => ['key@bad'],
+            'colon' => ['key:bad'],
+        ];
+    }
+
+    #[DataProvider('reservedCharacterKeyProvider')]
+    public function testReservedCharacterKeysThrow(string $key): void
+    {
+        $this->expectException(CacheInvalidArgumentException::class);
+        $this->expectExceptionMessage('Cache key contains reserved characters');
+
+        $this->cache->get($key);
+    }
+
+    public function testCorruptedFileReturnsDefault(): void
+    {
+        // Write a corrupted cache file directly
+        $path = $this->cacheDir . '/' . hash('sha256', 'corrupted') . '.cache';
+        file_put_contents($path, 'not-valid-serialized-data');
+
+        self::assertNull($this->cache->get('corrupted'));
+        // File should be cleaned up
+        self::assertFileDoesNotExist($path);
+    }
+
+    public function testConcurrentSafeWrite(): void
+    {
+        // Ensure atomic writes via temp file + rename
+        $this->cache->set('atomic', 'value');
+        self::assertSame('value', $this->cache->get('atomic'));
+
+        // No orphan temp files
+        $tempFiles = glob($this->cacheDir . '/*.tmp');
+        self::assertSame([], $tempFiles);
+    }
+}

--- a/tests/Tests/Isolated/Common/Cache/RedisCacheTest.php
+++ b/tests/Tests/Isolated/Common/Cache/RedisCacheTest.php
@@ -1,0 +1,276 @@
+<?php
+
+/**
+ * @link      https://www.open-emr.org
+ * @author    Milan Zivkovic <zivkovic.milan@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Cache;
+
+use OpenEMR\Common\Cache\CacheInvalidArgumentException;
+use OpenEMR\Common\Cache\RedisCache;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * In-memory-backed \Redis mock pattern. Each test exercises the real
+ * RedisCache logic; the mock is wired with willReturnCallback to simulate
+ * a Redis server against the private $store/$ttls arrays.
+ */
+final class RedisCacheTest extends TestCase
+{
+    private \Redis&MockObject $client;
+
+    private RedisCache $cache;
+
+    /** @var array<string, string> */
+    private array $store = [];
+
+    /** @var array<string, int> */
+    private array $ttls = [];
+
+    protected function setUp(): void
+    {
+        $this->store = [];
+        $this->ttls = [];
+
+        $this->client = $this->getMockBuilder(\Redis::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['get', 'set', 'setex', 'del', 'exists', 'scan'])
+            ->getMock();
+
+        $this->wireMock();
+
+        $this->cache = new RedisCache($this->client);
+    }
+
+    public function testGetReturnsDefaultWhenKeyMissing(): void
+    {
+        self::assertNull($this->cache->get('missing'));
+        self::assertSame('default', $this->cache->get('missing', 'default'));
+    }
+
+    public function testGetReturnsCachedValue(): void
+    {
+        $this->cache->set('hit', 'cached-value');
+        self::assertSame('cached-value', $this->cache->get('hit'));
+    }
+
+    public function testGetHandlesFalseValue(): void
+    {
+        $this->cache->set('false-val', false);
+        self::assertFalse($this->cache->get('false-val', 'not-false'));
+    }
+
+    public function testSetWithoutTtl(): void
+    {
+        self::assertTrue($this->cache->set('key1', 'value1'));
+        self::assertSame('value1', $this->cache->get('key1'));
+        self::assertNull($this->getTtl('app_cache:key1'));
+    }
+
+    public function testSetWithIntTtl(): void
+    {
+        self::assertTrue($this->cache->set('key2', 'value2', 3600));
+        self::assertSame('value2', $this->cache->get('key2'));
+        self::assertSame(3600, $this->getTtl('app_cache:key2'));
+    }
+
+    public function testSetWithDateIntervalTtl(): void
+    {
+        self::assertTrue($this->cache->set('key3', 'value3', new \DateInterval('PT1H')));
+        self::assertSame('value3', $this->cache->get('key3'));
+        $ttl = $this->getTtl('app_cache:key3');
+        self::assertNotNull($ttl);
+        self::assertGreaterThanOrEqual(3598, $ttl);
+        self::assertLessThanOrEqual(3602, $ttl);
+    }
+
+    public function testSetWithZeroTtlDeletes(): void
+    {
+        $this->cache->set('zero-ttl', 'data');
+        $this->cache->set('zero-ttl', 'new-data', 0);
+        self::assertNull($this->cache->get('zero-ttl'));
+    }
+
+    public function testSetWithNegativeTtlDeletes(): void
+    {
+        $this->cache->set('neg-ttl', 'data');
+        $this->cache->set('neg-ttl', 'new-data', -5);
+        self::assertNull($this->cache->get('neg-ttl'));
+    }
+
+    public function testDelete(): void
+    {
+        $this->cache->set('to-delete', 'data');
+        self::assertTrue($this->cache->delete('to-delete'));
+        self::assertNull($this->cache->get('to-delete'));
+    }
+
+    public function testHasReturnsTrueWhenExists(): void
+    {
+        $this->cache->set('existing', 'value');
+        self::assertTrue($this->cache->has('existing'));
+    }
+
+    public function testHasReturnsFalseWhenMissing(): void
+    {
+        self::assertFalse($this->cache->has('missing'));
+    }
+
+    public function testEmptyKeyThrows(): void
+    {
+        $this->expectException(CacheInvalidArgumentException::class);
+        $this->expectExceptionMessage('Cache key must not be empty');
+
+        $this->cache->get('');
+    }
+
+    public function testReservedCharacterKeyThrows(): void
+    {
+        $this->expectException(CacheInvalidArgumentException::class);
+        $this->expectExceptionMessage('Cache key contains reserved characters');
+
+        $this->cache->get('key:bad');
+    }
+
+    public function testClear(): void
+    {
+        $this->cache->set('a', '1');
+        $this->cache->set('b', '2');
+
+        self::assertTrue($this->cache->clear());
+
+        self::assertNull($this->cache->get('a'));
+        self::assertNull($this->cache->get('b'));
+    }
+
+    public function testClearOnlyDeletesPrefixedKeys(): void
+    {
+        // Seed the backing store directly with one prefixed and one unprefixed key.
+        $this->store['app_cache:app-key'] = serialize('app-value');
+        $this->store['other:key'] = serialize('other-value');
+
+        $this->cache->clear();
+
+        self::assertArrayNotHasKey('app_cache:app-key', $this->store);
+        self::assertSame(serialize('other-value'), $this->store['other:key']);
+    }
+
+    public function testGetMultiple(): void
+    {
+        $this->cache->set('a', 'v1');
+
+        $results = $this->cache->getMultiple(['a', 'b'], 'default');
+
+        self::assertSame(['a' => 'v1', 'b' => 'default'], $results);
+    }
+
+    public function testSetMultiple(): void
+    {
+        self::assertTrue($this->cache->setMultiple(['x' => 'v1', 'y' => 'v2']));
+
+        self::assertSame('v1', $this->cache->get('x'));
+        self::assertSame('v2', $this->cache->get('y'));
+    }
+
+    public function testDeleteMultiple(): void
+    {
+        $this->cache->set('x', 'v1');
+        $this->cache->set('y', 'v2');
+
+        self::assertTrue($this->cache->deleteMultiple(['x', 'y']));
+
+        self::assertNull($this->cache->get('x'));
+        self::assertNull($this->cache->get('y'));
+    }
+
+    public function testCachesArrayValues(): void
+    {
+        $data = ['nested' => ['key' => 'value'], 'list' => [1, 2, 3]];
+
+        $this->cache->set('arr', $data);
+        self::assertSame($data, $this->cache->get('arr'));
+    }
+
+    public function testCachesNullValue(): void
+    {
+        $this->cache->set('null-val', null);
+        // null is cached, so get with a different default should return null
+        self::assertNull($this->cache->get('null-val', 'not-null'));
+    }
+
+    // ------------------------------------------------------------------
+    // Test helpers
+    // ------------------------------------------------------------------
+
+    private function getTtl(string $key): ?int
+    {
+        return $this->ttls[$key] ?? null;
+    }
+
+    private function wireMock(): void
+    {
+        $this->client->method('get')->willReturnCallback(
+            fn (string $key): string|false => $this->store[$key] ?? false,
+        );
+
+        $this->client->method('set')->willReturnCallback(
+            function (string $key, string $value): bool {
+                $this->store[$key] = $value;
+                unset($this->ttls[$key]);
+                return true;
+            },
+        );
+
+        $this->client->method('setex')->willReturnCallback(
+            function (string $key, int $seconds, string $value): bool {
+                $this->store[$key] = $value;
+                $this->ttls[$key] = $seconds;
+                return true;
+            },
+        );
+
+        // ext-redis del signature: del(array|string $key, string ...$other_keys): int|false
+        $this->client->method('del')->willReturnCallback(
+            function (array|string $key, string ...$others): int {
+                $keys = is_array($key) ? $key : array_merge([$key], $others);
+                $count = 0;
+                foreach ($keys as $k) {
+                    if (!is_string($k)) {
+                        continue;
+                    }
+                    if (isset($this->store[$k])) {
+                        unset($this->store[$k], $this->ttls[$k]);
+                        $count++;
+                    }
+                }
+                return $count;
+            },
+        );
+
+        $this->client->method('exists')->willReturnCallback(
+            fn (string $key): int => isset($this->store[$key]) ? 1 : 0,
+        );
+
+        // ext-redis scan signature: scan(&$iterator, ?string $pattern = null, int $count = 0, ?string $type = null): array|false
+        // We always return all matched keys in a single batch and signal
+        // completion by setting the iterator to 0.
+        $this->client->method('scan')->willReturnCallback(
+            function (mixed &$iterator, ?string $pattern = null): array|false {
+                $keys = array_keys($this->store);
+                $matched = $pattern === null
+                    ? $keys
+                    : array_values(array_filter(
+                        $keys,
+                        fn (string $k): bool => fnmatch($pattern, $k),
+                    ));
+                $iterator = 0;
+                return $matched === [] ? false : $matched;
+            },
+        );
+    }
+}

--- a/version.php
+++ b/version.php
@@ -31,7 +31,7 @@ $v_realpatch = '0';
 //
 // Keep in sync with the v_database comment in sql/database.sql.
 // CI will fail if they don't match.
-$v_database = 537;
+$v_database = 538;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Split of #11416 

# [2/4] PSR-16 cache abstraction with three backends

## Context

This is **part 2 of 4** in the SSO/OIDC/GCIP split (tracked in the original monolithic branch). The work has been broken into four independently shippable PRs for reviewer clarity:

| No. | Title | Status |
|---|-------|--------|
| 1 | OIDC core (discovery, validator, session refresh, events) | Waiting on No.2 |
| **2** | **PSR-16 cache abstraction with three backends** | **← this PR** |
| 3 | GCIP custom module | Waiting on No.1 |
| 4 | `login_counter_ip_tracker.php` hardening | Awaiting scope clarification |

Infrastructure-only — no current consumer in this PR. Designed for the forthcoming OIDC validator/discovery layer (PR No.1) and available for general reuse across OpenEMR (session caching, rate-limit state, route caching, etc.).

## What this adds

A PSR-16 (`psr/simple-cache`) cache abstraction under `OpenEMR\Common\Cache` with three backend implementations.

### Source (`src/Common/Cache/`)

| File | Purpose |
|------|---------|
| `CacheEntry.php` | Typed envelope for all cached values. Restricts `unserialize()` to this class only (allowed-classes whitelist) to prevent PHP object-injection attacks. |
| `CacheException.php` | Base cache exception. Implements `Psr\SimpleCache\CacheException` marker interface. |
| `CacheInvalidArgumentException.php` | Invalid-key exception. Implements `Psr\SimpleCache\InvalidArgumentException`. |
| `FilesystemCache.php` | PSR-16 backend using serialized files with atomic temp-file + rename writes. Suitable for single-instance deployments. |
| `DatabaseCache.php` | PSR-16 backend using the new `app_cache` table. Suitable for multi-instance deployments sharing a database. Includes `purgeExpired()` for periodic cleanup. |
| `RedisCache.php` | PSR-16 backend using the native `\Redis` class from `ext-redis` (the client OpenEMR already requires — same pattern as `LockingRedisSessionHandler`). Suitable for high-traffic and multi-instance deployments. |

All three concrete backends implement `Psr\SimpleCache\CacheInterface`. All three share:
- Key validation (non-empty, no reserved characters `{}()/\\@:`, length-bounded where the backend requires it)
- `CacheEntry` envelope for safe serialize/unserialize
- Full PSR-16 surface: `get`/`set`/`delete`/`clear`/`has`/`getMultiple`/`setMultiple`/`deleteMultiple`, `ttl` as `int|DateInterval|null`

### Schema

New generic `app_cache` table. Added to:
- `sql/database.sql` (full schema, fresh installs)
- `sql/8_1_0-to-8_1_1_upgrade.sql` (with `#IfNotTable` guard, existing 8.1.0 → 8.1.1 upgrades)
- `sql/patch.sql` (with `#IfNotTable` guard, patch path)

```sql
CREATE TABLE `app_cache` (
    `cache_key` VARCHAR(255) NOT NULL COMMENT 'PSR-16 cache key',
    `cache_value` LONGBLOB NOT NULL COMMENT 'Serialized CacheEntry',
    `expires_at` DATETIME DEFAULT NULL COMMENT 'NULL = no expiration',
    PRIMARY KEY (`cache_key`),
    KEY `idx_expires_at` (`expires_at`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
```

### Dependencies

- `psr/simple-cache ^3.0` declared as a **direct** dep in `composer.json`. It was already transitively available (brought in by `monolog/monolog` and others) but is now used directly by the new code, so `composer-require-checker` requires the explicit declaration.

### Version bump

- `$v_database` 537 → 538 (both `version.php` and `sql/database.sql` header comment)

## Tests

### Isolated (`tests/Tests/Isolated/Common/Cache/`, 74 tests)

- `CacheEntryTest` — construction, expiry semantics, safe-unserialize options, immutability
- `FilesystemCacheTest` — round-trip of various types, TTL semantics (int + `DateInterval`), directory validation, reserved-character keys, corrupted-file recovery, atomic writes (no orphan temp files)
- `RedisCacheTest` — same surface against a PHPUnit mock of `\Redis` wired with `willReturnCallback` to simulate an in-memory Redis. No real Redis server required.

### Integration (`tests/Tests/Integration/Common/Cache/`)

- `DatabaseCacheTest` — full surface against a real database, plus `purgeExpired()` behavior.

## Security considerations

- **Object-injection safe**: all backends call `unserialize()` with `CacheEntry::unserializeOptions()` which whitelists only `CacheEntry`. An attacker who writes malicious bytes into cache storage cannot instantiate arbitrary classes.
- **Key validation** rejects characters commonly used in injection attacks (braces, slashes, colons) and empty strings. `DatabaseCache` additionally enforces the 255-char column limit.
- **Atomic writes** in `FilesystemCache` via temp-file + rename — no partial-write races, no orphan temp files.
- **No privilege escalation surface** — cache code never executes cached content; it only returns values to callers.

## Review notes

- The cache classes live in `OpenEMR\Common\Cache` (not the OIDC namespace) because they are genuinely generic PSR-16 implementations with zero OIDC-aware behavior. This makes the abstraction reusable for any future feature that needs caching.
- `RedisCache` uses `\Redis` (the PECL extension) rather than Predis to match OpenEMR's existing Redis usage (`LockingRedisSessionHandler` uses `\Redis`)—no new PHP-library dep.
- The `app_cache` table name is intentionally generic ("application cache") rather than feature-specific, consistent with the framework convention used by Laravel and Symfony.

## Out of scope (explicit)

- **No wiring to any consumer** in this PR. The three backends stand alone. PR No.1 (OIDC core) will be the first consumer.
- **No default-backend selector** / factory. Consumers pick and inject the backend they need.
- **No cache-invalidation tooling** beyond `clear()` and `purgeExpired()` (on DatabaseCache). A cron-style periodic sweep is a follow-up if needed.

## Does your code include anything generated by an AI Engine? Yes.

## Assisted by Claude Code.