### PR TITLE
feat(vitals): quick vitals form

### DIFF
--- a/interface/forms/vitals/quick_edit.php
+++ b/interface/forms/vitals/quick_edit.php
@@ -1,0 +1,49 @@
+<?php
+require_once("../../globals.php");
+
+use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Common\Csrf\CsrfUtils;
+
+$session = SessionWrapperFactory::getInstance()->getActiveSession();
+$pid = $_GET['pid'] ?? null;
+$encounter = $_GET['encounter'] ?? null;
+
+if (!$pid || !$encounter) {
+    die("Missing patient or encounter context.");
+}
+?>
+<div class="p-3">
+    <h4 class="mb-3">Quick Vitals Entry</h4>
+    <form id="quickVitalsForm">
+        <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken(session: $session)); ?>">
+        <input type="hidden" name="pid" value="<?php echo attr($pid); ?>">
+        <input type="hidden" name="encounter" value="<?php echo attr($encounter); ?>">
+
+        <div class="row">
+            <div class="col-6 mb-2">
+                <label>Weight (lbs)</label>
+                <input type="text" name="weight" class="form-control">
+            </div>
+            <div class="col-6 mb-2">
+                <label>Height (in)</label>
+                <input type="text" name="height" class="form-control">
+            </div>
+            <div class="col-6 mb-2">
+                <label>Pulse</label>
+                <input type="text" name="pulse" class="form-control">
+            </div>
+            <div class="col-6 mb-2">
+                <label>BP (Systolic/Diastolic)</label>
+                <div class="input-group">
+                    <input type="text" name="bps" placeholder="Sys" class="form-control">
+                    <input type="text" name="bpd" placeholder="Dia" class="form-control">
+                </div>
+            </div>
+        </div>
+
+        <div class="mt-4 text-right">
+            <button type="button" class="btn btn-secondary btn-cancel-vitals">Cancel</button>
+            <button type="button" id="saveQuickVitals" class="btn btn-primary">Save Vitals</button>
+        </div>
+    </form>
+</div>

--- a/interface/forms/vitals/quick_save.php
+++ b/interface/forms/vitals/quick_save.php
@@ -1,0 +1,51 @@
+<?php
+require_once("../../globals.php");
+
+use OpenEMR\Common\Csrf\CsrfUtils;
+
+header('Content-Type: application/json');
+
+try {
+    CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+
+    $pid = $_POST['pid'] ?? null;
+    $encounter = $_POST['encounter'] ?? null;
+
+    if (empty($pid) || empty($encounter)) {
+        echo json_encode(["success" => false, "error" => "Missing Context"]);
+        exit;
+    }
+
+    $date = date("Y-m-d H:i:s");
+    
+    // Parse values safely to prevent MySQL strict mode errors (numeric fields need NULL, not empty strings)
+    $weight = !empty($_POST['weight']) ? (float)$_POST['weight'] : null;
+    $height = !empty($_POST['height']) ? (float)$_POST['height'] : null;
+    $pulse  = !empty($_POST['pulse'])  ? (int)$_POST['pulse']   : null;
+    $bps    = !empty($_POST['bps'])    ? (int)$_POST['bps']     : null;
+    $bpd    = !empty($_POST['bpd'])    ? (int)$_POST['bpd']     : null;
+    
+    // 1. Insert into form_vitals. CRITICAL: activity MUST be 1 for the report to display it.
+    $v_sql = "INSERT INTO form_vitals (date, pid, activity, weight, height, pulse, bps, bpd) 
+              VALUES (?, ?, 1, ?, ?, ?, ?, ?)";
+    
+    $v_id = sqlInsert($v_sql, [$date, $pid, $weight, $height, $pulse, $bps, $bpd]);
+
+    // 2. Register the form to the encounter
+    $f_sql = "INSERT INTO forms (date, encounter, form_name, form_id, pid, user, groupname, authorized, deleted, formdir) 
+              VALUES (?, ?, 'Vitals', ?, ?, ?, ?, 1, 0, 'vitals')";
+    
+    sqlStatement($f_sql, [
+        $date, 
+        $encounter, 
+        $v_id, 
+        $pid, 
+        $_SESSION['authUser'] ?? 'admin', 
+        $_SESSION['authProvider'] ?? 'Default'
+    ]);
+
+    echo json_encode(["success" => true]);
+} catch (Throwable $e) {
+    echo json_encode(["success" => false, "error" => $e->getMessage()]);
+}
+exit;

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -626,7 +626,65 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
             placeHtml("track_anything_fragment.php", "track_anything_ps_expand");
             <?php if ($vitals_is_registered && AclMain::aclCheckCore('patients', 'med')) { ?>
             // Initialize the Vitals form if it is registered and user is authorized.
-            placeHtml("vitals_fragment.php", "vitals_ps_expand");
+            placeHtml("vitals_fragment.php", "vitals_ps_expand").then(() => {
+                // Handler for opening the modal
+                $(document).off('click.quickVitals').on('click.quickVitals', '.quick-vitals-btn', function () {
+                    let pid = $(this).data('pid') || top.pid;
+                    let encounter = $(this).data('encounter') || top.encounter;
+
+                    $.post("quick_vitals_save.php", {
+                        pid: pid,
+                        encounter: encounter,
+                        csrf_token_form: <?php echo js_escape(CsrfUtils::collectCsrfToken(session: $session)); ?>
+                    }, function (res) {
+                        if (res.success) {
+                            $.get("/interface/forms/vitals/quick_edit.php", { pid: pid, encounter: res.encounter }, function (html) {
+                                $("#quickVitalsModal, .quick-vitals-backdrop").remove();
+                                $("body").append(`
+                                    <div id="quickVitalsModal" style="display:block; position:fixed; top:50%; left:50%; transform:translate(-50%, -50%); z-index:3000; background:#fff; width:500px; padding:20px; border-radius:8px; box-shadow: 0 0 20px rgba(0,0,0,0.4);">
+                                        ${html}
+                                    </div>
+                                    <div class="modal-backdrop fade show quick-vitals-backdrop" style="z-index:2999; background: rgba(0,0,0,0.5); position:fixed; top:0; left:0; width:100%; height:100%;"></div>
+                                `);
+                            });
+                        } else {
+                            alert("App Error: " + res.error);
+                        }
+                    }, "json").fail(function(xhr) {
+                        console.error("Quick Vitals initialization failed:", xhr.responseText);
+                        alert("An error occurred while loading the vitals form.");
+                    });
+                });
+
+                // 2. SAVE HANDLER
+                $(document).off('click.vitalsSave').on('click.vitalsSave', '#saveQuickVitals', function () {
+                    $.ajax({
+                        url: "/interface/forms/vitals/quick_save.php",
+                        type: "POST",
+                        data: $('#quickVitalsForm').serialize(),
+                        dataType: "json",
+                        success: function (res) {
+                            if (res.success) {
+                                $("#quickVitalsModal, .quick-vitals-backdrop").remove();
+                                // Reload the fragment to show the new data
+                                placeHtml("vitals_fragment.php", "vitals_ps_expand");
+                            } else {
+                                alert("Save Failed: " + res.error);
+                            }
+                        },
+                        error: function (xhr) {
+                            $("#quickVitalsModal, .quick-vitals-backdrop").remove();
+                            console.error("Quick Vitals save failed:", xhr.responseText);
+                            alert("An error occurred while saving vitals. Please check your connection.");
+                        }
+                    });
+                });
+
+                // 3. CANCEL HANDLER
+                $(document).on('click', '.btn-cancel-vitals', function() {
+                    $("#quickVitalsModal, .quick-vitals-backdrop").remove();
+                });
+            });
             <?php } ?>
 
             <?php if (OEGlobalsBag::getInstance()->getBoolean('enable_cdr') && OEGlobalsBag::getInstance()->getBoolean('enable_cdr_crw')) { ?>

--- a/interface/patient_file/summary/quick_vitals_save.php
+++ b/interface/patient_file/summary/quick_vitals_save.php
@@ -1,0 +1,55 @@
+<?php
+// MUST BE FIRST. No headers before this!
+require_once("../../globals.php");
+
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Session\SessionWrapperFactory;
+
+header('Content-Type: application/json');
+
+try {
+    $session = SessionWrapperFactory::getInstance()->getActiveSession();
+    CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+
+    $pid = $_POST['pid'] ?? null;
+    if (empty($pid)) {
+        echo json_encode(["success" => false, "error" => "No Patient ID provided."]);
+        exit;
+    }
+
+    $encounter = $_POST['encounter'] ?? null;
+
+    // 1. THE STALE ENCOUNTER CHECK
+    // If the frontend gave us an encounter, verify it belongs to TODAY.
+    if (!empty($encounter)) {
+        $check = sqlQuery("SELECT encounter FROM form_encounter WHERE pid = ? AND encounter = ? AND DATE(date) = CURDATE()", [$pid, $encounter]);
+        if (empty($check['encounter'])) {
+            // It's an old encounter from a previous visit. Clear it so we create a new one.
+            $encounter = null;
+        }
+    }
+
+    // 2. See if there is ANY encounter for today already
+    if (empty($encounter)) {
+        $row = sqlQuery("SELECT encounter FROM form_encounter WHERE pid = ? AND DATE(date) = CURDATE() ORDER BY date DESC LIMIT 1", [$pid]);
+        if (!empty($row['encounter'])) {
+            $encounter = $row['encounter'];
+        }
+    }
+
+    // 3. STILL empty? That means absolutely no visits today. Create a brand new one!
+    if (empty($encounter)) {
+        $enc_row = sqlQuery("SELECT MAX(encounter) AS max_enc FROM form_encounter");
+        $encounter = ($enc_row['max_enc'] ?? 0) + 1;
+        
+        $facility = $_SESSION['login_facility'] ?? 1;
+        
+        sqlStatement("INSERT INTO form_encounter (pid, encounter, date, reason, facility_id, sensitivity) VALUES (?, ?, NOW(), 'Quick Vitals', ?, 'normal')", [$pid, $encounter, $facility]);
+    }
+
+    echo json_encode(["success" => true, "encounter" => (int)$encounter]);
+
+} catch (Throwable $e) {
+    echo json_encode(["success" => false, "error" => $e->getMessage()]);
+}
+exit;

--- a/interface/patient_file/summary/vitals_fragment.php
+++ b/interface/patient_file/summary/vitals_fragment.php
@@ -20,8 +20,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 
 ?>
-<div id='vitals''><!--outer div-->
-<?php
+<div id='vitals'><?php
 //retrieve most recent set of vitals.
 $result = sqlQuery("SELECT FORM_VITALS.date, FORM_VITALS.id FROM form_vitals AS FORM_VITALS LEFT JOIN forms AS FORMS ON FORM_VITALS.id = FORMS.form_id WHERE FORM_VITALS.pid=? AND FORMS.deleted != '1' ORDER BY FORM_VITALS.date DESC", [$pid]);
 
@@ -46,3 +45,6 @@ if (!$result) { //If there are no disclosures recorded
   </span><?php
 } ?>
 </div>
+<button class="btn btn-primary quick-vitals-btn" data-pid="<?php echo attr($pid); ?>" data-encounter="<?php echo attr($session->get('encounter') ?? ''); ?>">
+  <?php echo xlt('Enter Quick Vitals'); ?>
+</button>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

Final project for software engineering class: contribute to an open-sourced project.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

https://github.com/openemr/openemr/issues/10606 

#### Short description of what this changes or resolves:
This adds a "Quick Vitals Entry" button to the Medical Record Dashboard so providers can input weight, height, pulse, and BP via a quick pop-up, rather than navigating to a separate charting screen.

#### Changes proposed in this pull request:
* **UI:** Added a trigger button to `vitals_fragment.php` and built an AJAX modal workflow in `demographics.php`.
* **Encounter Logic:** Added `quick_vitals_save.php` to smartly link vitals to a same-day encounter (or create a new one) while ignoring historical visits. 
* **Database:** Added `quick_save.php` to securely save the vitals and set the `activity`, `formdir`, and `deleted` flags so the dashboard immediately renders the new data.

#### Was an AI assistant used? Yes / No
Yes (Gemini)



Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
N/A