### PR TITLE
refactor(document): extract storage path calculation for testability

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -9488,17 +9488,22 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and non\\-falsy\\-string results in an error\\.$#',
-    'count' => 3,
+    'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Document.class.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and string results in an error\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Document.class.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 19,
+    'count' => 15,
+    'path' => __DIR__ . '/../../library/classes/Document.class.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Binary operation "\\." between string and mixed results in an error\\.$#',
+    'count' => 4,
     'path' => __DIR__ . '/../../library/classes/Document.class.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -2573,7 +2573,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 18,
+    'count' => 16,
     'path' => __DIR__ . '/../../library/classes/Document.class.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/parameter.defaultValue.php
+++ b/.phpstan/baseline/parameter.defaultValue.php
@@ -57,11 +57,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/classes/Document.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Default value of the parameter \\#7 \\$path_depth \\(int\\) of method Document\\:\\:createDocument\\(\\) is incompatible with type string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Document.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Default value of the parameter \\#1 \\$foreign_id \\(string\\) of method Note\\:\\:notes_factory\\(\\) is incompatible with type int\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Note.class.php',

--- a/library/classes/Document.class.php
+++ b/library/classes/Document.class.php
@@ -1069,10 +1069,8 @@ class Document extends ORDataObject
             $filenameUuid = UuidRegistry::uuidToString($this->drive_uuid);
 
             $this->url = "file://" . $filepath . $filenameUuid;
-            if (is_numeric($path_depth)) {
-                // this is for when directory structure is more than one level
-                $this->path_depth = $path_depth;
-            }
+            // this is for when directory structure is more than one level
+            $this->path_depth = $path_depth;
 
             // Store the file.
             $storedData = OEGlobalsBag::getInstance()->getBoolean('drive_encryption') ? $cryptoGen->encryptStandard($data, keySource: KeySource::Database) : $data;

--- a/library/classes/Document.class.php
+++ b/library/classes/Document.class.php
@@ -66,6 +66,54 @@ class Document extends ORDataObject
     public const EXPIRES_DATE_FORMAT = 'Y-m-d H:i:s';
 
     /**
+     * Calculate the storage path for a document.
+     *
+     * This encapsulates the (legacy) logic for determining where a document
+     * should be stored, including path sanitization and the random subdirectory
+     * behavior for non-patient documents.
+     *
+     * Note: The patientId is only mutated to 0 when there's no higher level path
+     * AND the patient ID is invalid. In other cases it's returned unchanged.
+     * This matches the legacy behavior where $patient_id was conditionally
+     * reassigned before being used in set_foreign_id().
+     *
+     * @param string $higherLevelPath Optional subdirectory path (will be sanitized)
+     * @param int|string $patientId Patient ID or identifier string
+     * @param int $pathDepth Current path depth
+     * @param int $randomSubdir Random subdirectory number (1-10000) for non-patient docs
+     * @return array{relativePath: string, depth: int, patientId: int|string}
+     */
+    public static function calculateStoragePath(
+        string $higherLevelPath,
+        int|string $patientId,
+        int $pathDepth,
+        int $randomSubdir,
+    ): array {
+        $higherLevelPath = preg_replace("/[^A-Za-z0-9\/]/", "_", $higherLevelPath);
+        $validPatientId = ValidationUtils::validateInt($patientId, min: 1);
+
+        if ($higherLevelPath !== '' && $validPatientId !== false) {
+            $relativePath = $higherLevelPath . '/';
+        } elseif ($higherLevelPath !== '') {
+            $relativePath = $higherLevelPath . '/' . $randomSubdir . '/';
+            ++$pathDepth;
+        } elseif ($validPatientId === false) {
+            $relativePath = $patientId . '/' . $randomSubdir . '/';
+            $pathDepth = 2;
+            $patientId = 0;
+        } else {
+            $relativePath = $patientId . '/';
+            $pathDepth = 1;
+        }
+
+        return [
+            'relativePath' => $relativePath,
+            'depth' => $pathDepth,
+            'patientId' => $patientId,
+        ];
+    }
+
+    /**
      * @var string Binary of Unique User Identifier that is for both external reference to this entity and for future offline use.
      */
     public $uuid;

--- a/library/classes/Document.class.php
+++ b/library/classes/Document.class.php
@@ -929,7 +929,7 @@ class Document extends ORDataObject
    * @param  string  $mimetype     MIME type
    * @param  string  &$data        The actual data to store (not encoded)
    * @param  string  $higher_level_path Optional subdirectory within the local document repository
-   * @param  string  $path_depth   Number of directory levels in $higher_level_path, if specified
+   * @param  int     $path_depth   Number of directory levels in $higher_level_path, if specified
    * @param  integer $owner        Owner/user/service that is requesting this action
    * @param  string  $tmpfile      The tmp location of file (require for thumbnail generator)
    * @param  string  $date_expires The datetime that the document should no longer be accessible in the system
@@ -944,7 +944,7 @@ class Document extends ORDataObject
         $mimetype,
         &$data,
         $higher_level_path = '',
-        $path_depth = 1,
+        int $path_depth = 1,
         $owner = 0,
         $tmpfile = null,
         $date_expires = null,
@@ -1048,28 +1048,15 @@ class Document extends ORDataObject
 
             // Storing document files locally.
             $repository = OEGlobalsBag::getInstance()->get('oer_config')['documents']['repository'];
-            $higher_level_path = preg_replace("/[^A-Za-z0-9\/]/", "_", $higher_level_path);
-            $validPatientId = ValidationUtils::validateInt($patient_id, min: 1);
-            if ((!empty($higher_level_path)) && $validPatientId !== false) {
-                // Allow higher level directory structure in documents directory and a patient is mapped.
-                $filepath = $repository . $higher_level_path . "/";
-            } elseif (!empty($higher_level_path)) {
-                // Allow higher level directory structure in documents directory and there is no patient mapping
-                // (will create up to 10000 random directories and increment the path_depth by 1).
-                $filepath = $repository . $higher_level_path . '/' . random_int(1, 10000)  . '/';
-                ++$path_depth;
-            } elseif ($validPatientId === false) {
-                // This is the default action except there is no patient mapping (when patient_id is 00 or direct)
-                // (will create up to 10000 random directories and set the path_depth to 2).
-                $filepath = $repository . $patient_id . '/' . random_int(1, 10000)  . '/';
-                $path_depth = 2;
-                $patient_id = 0;
-            } else {
-                // This is the default action where the patient is used as one level directory structure
-                // in documents directory.
-                $filepath = $repository . $patient_id . '/';
-                $path_depth = 1;
-            }
+            $storagePathResult = self::calculateStoragePath(
+                higherLevelPath: $higher_level_path,
+                patientId: $patient_id,
+                pathDepth: $path_depth,
+                randomSubdir: random_int(1, 10000),
+            );
+            $filepath = $repository . $storagePathResult['relativePath'];
+            $path_depth = $storagePathResult['depth'];
+            $patient_id = $storagePathResult['patientId'];
 
             if (!file_exists($filepath)) {
                 if (!mkdir($filepath, 0700, true)) {

--- a/tests/Tests/Isolated/DocumentStoragePathTest.php
+++ b/tests/Tests/Isolated/DocumentStoragePathTest.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Isolated;
 
 use Document;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(Document::class)]
 #[Group('isolated')]
 class DocumentStoragePathTest extends TestCase
 {

--- a/tests/Tests/Isolated/DocumentStoragePathTest.php
+++ b/tests/Tests/Isolated/DocumentStoragePathTest.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated;
+
+use Document;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Document::class)]
+#[Group('isolated')]
+class DocumentStoragePathTest extends TestCase
+{
+    /**
+     * @return array<string, array{
+     *   higherLevelPath: string,
+     *   patientId: int|string,
+     *   pathDepth: int,
+     *   randomSubdir: int,
+     *   expectedPath: string,
+     *   expectedDepth: int,
+     *   expectedPatientId: int|string,
+     * }>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function storagePathProvider(): array
+    {
+        return [
+            'valid patient, no higher level path' => [
+                'higherLevelPath' => '',
+                'patientId' => 123,
+                'pathDepth' => 1,
+                'randomSubdir' => 5000,
+                'expectedPath' => '123/',
+                'expectedDepth' => 1,
+                'expectedPatientId' => 123,
+            ],
+            'valid patient, with higher level path' => [
+                'higherLevelPath' => 'ccda/imports',
+                'patientId' => 456,
+                'pathDepth' => 1,
+                'randomSubdir' => 9999,
+                'expectedPath' => 'ccda/imports/',
+                'expectedDepth' => 1,
+                'expectedPatientId' => 456,
+            ],
+            'invalid patient (string), no higher level path - uses random subdir' => [
+                'higherLevelPath' => '',
+                'patientId' => 'direct',
+                'pathDepth' => 1,
+                'randomSubdir' => 42,
+                'expectedPath' => 'direct/42/',
+                'expectedDepth' => 2,
+                'expectedPatientId' => 0,
+            ],
+            'invalid patient (zero), no higher level path - uses random subdir' => [
+                'higherLevelPath' => '',
+                'patientId' => 0,
+                'pathDepth' => 1,
+                'randomSubdir' => 1,
+                'expectedPath' => '0/1/',
+                'expectedDepth' => 2,
+                'expectedPatientId' => 0,
+            ],
+            'invalid patient (zero), with higher level path - uses random subdir' => [
+                'higherLevelPath' => 'exports',
+                'patientId' => 0,
+                'pathDepth' => 1,
+                'randomSubdir' => 7777,
+                'expectedPath' => 'exports/7777/',
+                'expectedDepth' => 2,
+                'expectedPatientId' => 0,
+            ],
+            'invalid patient (string), with higher level path - preserves patientId' => [
+                'higherLevelPath' => 'ccda/exports',
+                'patientId' => 'direct',
+                'pathDepth' => 1,
+                'randomSubdir' => 1234,
+                'expectedPath' => 'ccda/exports/1234/',
+                'expectedDepth' => 2,
+                'expectedPatientId' => 'direct',
+            ],
+            'path depth is preserved when not overwritten' => [
+                'higherLevelPath' => 'custom/path',
+                'patientId' => 99,
+                'pathDepth' => 5,
+                'randomSubdir' => 1,
+                'expectedPath' => 'custom/path/',
+                'expectedDepth' => 5,
+                'expectedPatientId' => 99,
+            ],
+        ];
+    }
+
+    /**
+     * @param int|string $patientId
+     */
+    #[DataProvider('storagePathProvider')]
+    public function testCalculateStoragePath(
+        string $higherLevelPath,
+        int|string $patientId,
+        int $pathDepth,
+        int $randomSubdir,
+        string $expectedPath,
+        int $expectedDepth,
+        int|string $expectedPatientId,
+    ): void {
+        $result = Document::calculateStoragePath(
+            higherLevelPath: $higherLevelPath,
+            patientId: $patientId,
+            pathDepth: $pathDepth,
+            randomSubdir: $randomSubdir,
+        );
+
+        self::assertSame($expectedPath, $result['relativePath']);
+        self::assertSame($expectedDepth, $result['depth']);
+        self::assertSame($expectedPatientId, $result['patientId']);
+    }
+
+    /**
+     * @return array<string, array{input: string, expected: string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function sanitizationProvider(): array
+    {
+        return [
+            'alphanumeric unchanged' => [
+                'input' => 'foo/bar',
+                'expected' => 'foo/bar/',
+            ],
+            'dashes replaced' => [
+                'input' => 'foo-bar',
+                'expected' => 'foo_bar/',
+            ],
+            'special chars replaced' => [
+                'input' => 'foo@bar#baz',
+                'expected' => 'foo_bar_baz/',
+            ],
+            'spaces replaced' => [
+                'input' => 'foo bar',
+                'expected' => 'foo_bar/',
+            ],
+            'multiple slashes preserved' => [
+                'input' => 'a/b/c/d',
+                'expected' => 'a/b/c/d/',
+            ],
+            'dots replaced' => [
+                'input' => 'file.name',
+                'expected' => 'file_name/',
+            ],
+        ];
+    }
+
+    #[DataProvider('sanitizationProvider')]
+    public function testHigherLevelPathSanitization(string $input, string $expected): void
+    {
+        $result = Document::calculateStoragePath(
+            higherLevelPath: $input,
+            patientId: 1,
+            pathDepth: 1,
+            randomSubdir: 1,
+        );
+
+        self::assertSame($expected, $result['relativePath']);
+    }
+}

--- a/tests/Tests/Isolated/DocumentTest.php
+++ b/tests/Tests/Isolated/DocumentTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 #[Group('isolated')]
-class DocumentStoragePathTest extends TestCase
+class DocumentTest extends TestCase
 {
     /**
      * @return array<string, array{
@@ -33,7 +33,7 @@ class DocumentStoragePathTest extends TestCase
      *
      * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
-    public static function storagePathProvider(): array
+    public static function calculateStoragePathProvider(): array
     {
         return [
             'valid patient, no higher level path' => [
@@ -72,6 +72,15 @@ class DocumentStoragePathTest extends TestCase
                 'expectedDepth' => 2,
                 'expectedPatientId' => 0,
             ],
+            'invalid patient (negative), no higher level path - uses random subdir' => [
+                'higherLevelPath' => '',
+                'patientId' => -5,
+                'pathDepth' => 1,
+                'randomSubdir' => 999,
+                'expectedPath' => '-5/999/',
+                'expectedDepth' => 2,
+                'expectedPatientId' => 0,
+            ],
             'invalid patient (zero), with higher level path - uses random subdir' => [
                 'higherLevelPath' => 'exports',
                 'patientId' => 0,
@@ -104,8 +113,9 @@ class DocumentStoragePathTest extends TestCase
 
     /**
      * @param int|string $patientId
+     * @param int|string $expectedPatientId
      */
-    #[DataProvider('storagePathProvider')]
+    #[DataProvider('calculateStoragePathProvider')]
     public function testCalculateStoragePath(
         string $higherLevelPath,
         int|string $patientId,
@@ -132,7 +142,7 @@ class DocumentStoragePathTest extends TestCase
      *
      * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
-    public static function sanitizationProvider(): array
+    public static function calculateStoragePathSanitizationProvider(): array
     {
         return [
             'alphanumeric unchanged' => [
@@ -162,8 +172,8 @@ class DocumentStoragePathTest extends TestCase
         ];
     }
 
-    #[DataProvider('sanitizationProvider')]
-    public function testHigherLevelPathSanitization(string $input, string $expected): void
+    #[DataProvider('calculateStoragePathSanitizationProvider')]
+    public function testCalculateStoragePathSanitization(string $input, string $expected): void
     {
         $result = Document::calculateStoragePath(
             higherLevelPath: $input,


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Extracts the storage path calculation logic from `Document::createDocument()` into a testable static method (Document extends ORDataObject which is hard coupled to the DB), preparing for future Flysystem integration.

#### Changes proposed in this pull request:

- Add `Document::calculateStoragePath()` static method that encapsulates the legacy 4-branch path determination logic:
  - Valid patient + higherLevelPath → uses higherLevelPath only
  - Invalid patient + higherLevelPath → adds random subdir, increments depth
  - Invalid patient + no higherLevelPath → adds random subdir, depth=2, patientId=0
  - Valid patient + no higherLevelPath → uses patientId, depth=1
- Add comprehensive isolated tests (13 test cases) covering all branches and path sanitization
- Wire the new method into `createDocument()`, replacing inline logic
- Add `int` type hint to `$path_depth` parameter
- Remove redundant `is_numeric()` check (now guaranteed by type)
- Update PHPStan baseline (net reduction in baseline entries)

#### Was an AI assistant used? Yes

All commits include `Assisted-by: Claude Code` trailer.

---

🤖 Generated with [Claude Code](https://claude.ai/code)