### PR TITLE
feat(vitals): add input validation for numeric fields 

### DIFF
--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -42,6 +42,52 @@ class C_FormVitals
     const OMIT_CIRCUMFERENCES_NO = 0;
     const OMIT_CIRCUMFERENCES_YES = 1;
 
+
+        // CARO: Fix ranges - code may reference an absolute max/min but I want only the warning max/min
+    private const VITAL_RANGES = [
+        'bps' => [
+            'warning_min' => 80,
+            'warning_max' => 180,
+            'label' => 'BP Systolic (mmHg)'
+        ],
+        'bpd' => [
+            'warning_min' => 40,
+            'warning_max' => 120,
+            'label' => 'BP Diastolic (mmHg)'
+        ],
+        'pulse' => [
+            'warning_min' => 40,
+            'warning_max' => 200,
+            'label' => 'Pulse (bpm)'
+        ],
+        'respiration' => [
+            'warning_min' => 8,
+            'warning_max' => 50,
+            'label' => 'Respiration (breaths/min)'
+        ],
+        'temperature' => [
+            'warning_min' => 95,
+            'warning_max' => 105,
+            'label' => 'Temperature (°F)'
+        ],
+        'weight' => [
+            'warning_min' => 5.5,
+            'warning_max' => 650,
+            'label' => 'Weight (lbs)'
+        ],
+        'height' => [
+            'warning_min' => 11,
+            'warning_max' => 98,
+            'label' => 'Height (in)'
+        ],
+        'oxygen_saturation' => [
+            'warning_min' => 90,
+            'warning_max' => 100,
+            'label' => 'Oxygen Saturation (%)'
+        ],
+    ];
+
+
     /**
      * @var array Hashmap of list option vital interpretations where the key is the option_id from list_options
      */
@@ -417,6 +463,20 @@ class C_FormVitals
             $_POST["temp_method"] = "";
         }
 
+
+         // CARO: New change but I still want to be able to save invalid data??
+        $validationResult = $this->validateVitals($_POST);
+        if (!$validationResult['valid']) {
+            $errorMessages = implode("\n", $validationResult['errors']);
+            error_log("Vitals validation failed: " . $errorMessages);
+            
+            // Set error session variable so it can be displayed to user
+            $_SESSION['vitals_validation_errors'] = $validationResult['errors'];
+            
+            // Stop processing - don't save invalid data
+            return;
+        }
+
         // grab our vitals data and then populate what is in the post
         $vitalsService = new VitalsService();
         $vitalsArray = [];
@@ -543,4 +603,98 @@ class C_FormVitals
         $vitals->set_groupname($session->get('authProvider'));
         $vitals->set_user($session->get('authUser'));
     }
+
+
+    // CARO: CHECKKKK UNTIL END OF FILE
+        /**
+     * Validates vital values are within clinical ranges
+     * Returns validation errors array or empty array if valid
+     * 
+     * @param array $vitals The vitals data to validate
+     * @return array Array of validation errors, empty if no errors
+     */
+    private function validateVitalRanges($vitals)
+    {
+        $errors = [];
+        $warnings = [];
+
+        foreach ($vitals as $field => $value) {
+            // Skip empty values
+            if (empty($value) && $value !== 0 && $value !== "0") {
+                continue;
+            }
+
+            // Check if field is in our ranges configuration
+            if (!isset(self::VITAL_RANGES[$field])) {
+                continue;
+            }
+
+            $range = self::VITAL_RANGES[$field];
+            $numValue = (float) $value;
+
+            // Check for values outside clinical warning thresholds (warnings only)
+            if (
+                ($range['warning_min'] !== null && $numValue < $range['warning_min']) ||
+                ($range['warning_max'] !== null && $numValue > $range['warning_max'])
+            ) {
+                $warnings[$field] = $range['label'] . ' is outside typical range (' . $range['warning_min'] . '-' . $range['warning_max'] . '). You entered: ' . $value;
+            }
+        }
+
+        // Store warnings in a session variable that can be displayed to the user
+        if (!empty($warnings)) {
+            $_SESSION['vitals_warnings'] = $warnings;
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Validates logical constraints for vital signs
+     * E.g., systolic should be >= diastolic
+     * 
+     * @param array $vitals The vitals data
+     * @return array Array of validation errors, empty if valid
+     */
+    private function validateVitalConstraints($vitals)
+    {
+        $errors = [];
+
+        // Blood pressure constraint: systolic should be >= diastolic
+        $bps = isset($vitals['bps']) ? (float) $vitals['bps'] : null;
+        $bpd = isset($vitals['bpd']) ? (float) $vitals['bpd'] : null;
+
+        if ($bps !== null && $bpd !== null && $bps > 0 && $bpd > 0) {
+            if ($bps < $bpd) {
+                $errors['bps'] = 'BP Systolic must be greater than or equal to BP Diastolic. Systolic: ' . $bps . ', Diastolic: ' . $bpd;
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Main validation method called before saving
+     * 
+     * @param array $vitals The vitals data to validate
+     * @return array Array with 'valid' boolean and 'errors' array
+     */
+    private function validateVitals($vitals)
+    {
+        $rangeErrors = $this->validateVitalRanges($vitals);
+        $constraintErrors = $this->validateVitalConstraints($vitals);
+        
+        $allErrors = array_merge($rangeErrors, $constraintErrors);
+
+        return [
+            'valid' => empty($allErrors),
+            'errors' => $allErrors
+        ];
+    }
+
+
+
+
+
+
 }

--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -414,7 +414,12 @@ class C_FormVitals
             ,'patient_dob' => $patient_dob
             ,'show_pediatric_fields' => ($patient_age <= 20 || (preg_match('/month/', (string) $patient_age)))
             ,'has_id' => $form_id
+            ,'vitals_validation_errors' => $_SESSION['vitals_validation_errors'] ?? []
+            ,'vitals_warnings' => $_SESSION['vitals_warnings'] ?? []
         ];
+        unset($_SESSION['vitals_validation_errors']);
+        unset($_SESSION['vitals_warnings']);
+        
         $twig = (new TwigContainer($this->template_dir, OEGlobalsBag::getInstance()->getKernel()))->getTwig();
 
         echo $twig->render("vitals.html.twig", $data);

--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -27,6 +27,7 @@ use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\ListService;
 use OpenEMR\Services\VitalsService;
+use OpenEMR\Services\VitalsValidationService;
 
 class C_FormVitals
 {
@@ -41,52 +42,6 @@ class C_FormVitals
 
     const OMIT_CIRCUMFERENCES_NO = 0;
     const OMIT_CIRCUMFERENCES_YES = 1;
-
-
-        // CARO: Fix ranges - code may reference an absolute max/min but I want only the warning max/min
-    private const VITAL_RANGES = [
-        'bps' => [
-            'warning_min' => 80,
-            'warning_max' => 180,
-            'label' => 'BP Systolic (mmHg)'
-        ],
-        'bpd' => [
-            'warning_min' => 40,
-            'warning_max' => 120,
-            'label' => 'BP Diastolic (mmHg)'
-        ],
-        'pulse' => [
-            'warning_min' => 40,
-            'warning_max' => 200,
-            'label' => 'Pulse (bpm)'
-        ],
-        'respiration' => [
-            'warning_min' => 8,
-            'warning_max' => 50,
-            'label' => 'Respiration (breaths/min)'
-        ],
-        'temperature' => [
-            'warning_min' => 95,
-            'warning_max' => 105,
-            'label' => 'Temperature (°F)'
-        ],
-        'weight' => [
-            'warning_min' => 5.5,
-            'warning_max' => 650,
-            'label' => 'Weight (lbs)'
-        ],
-        'height' => [
-            'warning_min' => 11,
-            'warning_max' => 98,
-            'label' => 'Height (in)'
-        ],
-        'oxygen_saturation' => [
-            'warning_min' => 90,
-            'warning_max' => 100,
-            'label' => 'Oxygen Saturation (%)'
-        ],
-    ];
-
 
     /**
      * @var array Hashmap of list option vital interpretations where the key is the option_id from list_options
@@ -462,19 +417,24 @@ class C_FormVitals
         if ($temperature == '0' || $temperature == '') {
             $_POST["temp_method"] = "";
         }
+        /** @var array<string, mixed> $postedVitals */
+        $postedVitals = filter_input_array(INPUT_POST) ?? [];
+        $validationResult = (new VitalsValidationService())->validate($postedVitals);
+        if (count($validationResult['errors']) > 0) {
+            $errorMessages = implode("\n", array_values($validationResult['errors']));
+            ServiceContainer::getLogger()->warning("Vitals validation failed", ['errors' => $errorMessages]);
 
-
-         // CARO: New change but I still want to be able to save invalid data??
-        $validationResult = $this->validateVitals($_POST);
-        if (!$validationResult['valid']) {
-            $errorMessages = implode("\n", $validationResult['errors']);
-            error_log("Vitals validation failed: " . $errorMessages);
-            
             // Set error session variable so it can be displayed to user
             $_SESSION['vitals_validation_errors'] = $validationResult['errors'];
-            
+
             // Stop processing - don't save invalid data
             return;
+        }
+
+        if (count($validationResult['warnings']) > 0) {
+            $_SESSION['vitals_warnings'] = $validationResult['warnings'];
+        } else {
+            unset($_SESSION['vitals_warnings']);
         }
 
         // grab our vitals data and then populate what is in the post
@@ -603,98 +563,5 @@ class C_FormVitals
         $vitals->set_groupname($session->get('authProvider'));
         $vitals->set_user($session->get('authUser'));
     }
-
-
-    // CARO: CHECKKKK UNTIL END OF FILE
-        /**
-     * Validates vital values are within clinical ranges
-     * Returns validation errors array or empty array if valid
-     * 
-     * @param array $vitals The vitals data to validate
-     * @return array Array of validation errors, empty if no errors
-     */
-    private function validateVitalRanges($vitals)
-    {
-        $errors = [];
-        $warnings = [];
-
-        foreach ($vitals as $field => $value) {
-            // Skip empty values
-            if (empty($value) && $value !== 0 && $value !== "0") {
-                continue;
-            }
-
-            // Check if field is in our ranges configuration
-            if (!isset(self::VITAL_RANGES[$field])) {
-                continue;
-            }
-
-            $range = self::VITAL_RANGES[$field];
-            $numValue = (float) $value;
-
-            // Check for values outside clinical warning thresholds (warnings only)
-            if (
-                ($range['warning_min'] !== null && $numValue < $range['warning_min']) ||
-                ($range['warning_max'] !== null && $numValue > $range['warning_max'])
-            ) {
-                $warnings[$field] = $range['label'] . ' is outside typical range (' . $range['warning_min'] . '-' . $range['warning_max'] . '). You entered: ' . $value;
-            }
-        }
-
-        // Store warnings in a session variable that can be displayed to the user
-        if (!empty($warnings)) {
-            $_SESSION['vitals_warnings'] = $warnings;
-        }
-
-        return $errors;
-    }
-
-    /**
-     * Validates logical constraints for vital signs
-     * E.g., systolic should be >= diastolic
-     * 
-     * @param array $vitals The vitals data
-     * @return array Array of validation errors, empty if valid
-     */
-    private function validateVitalConstraints($vitals)
-    {
-        $errors = [];
-
-        // Blood pressure constraint: systolic should be >= diastolic
-        $bps = isset($vitals['bps']) ? (float) $vitals['bps'] : null;
-        $bpd = isset($vitals['bpd']) ? (float) $vitals['bpd'] : null;
-
-        if ($bps !== null && $bpd !== null && $bps > 0 && $bpd > 0) {
-            if ($bps < $bpd) {
-                $errors['bps'] = 'BP Systolic must be greater than or equal to BP Diastolic. Systolic: ' . $bps . ', Diastolic: ' . $bpd;
-            }
-        }
-
-        return $errors;
-    }
-
-    /**
-     * Main validation method called before saving
-     * 
-     * @param array $vitals The vitals data to validate
-     * @return array Array with 'valid' boolean and 'errors' array
-     */
-    private function validateVitals($vitals)
-    {
-        $rangeErrors = $this->validateVitalRanges($vitals);
-        $constraintErrors = $this->validateVitalConstraints($vitals);
-        
-        $allErrors = array_merge($rangeErrors, $constraintErrors);
-
-        return [
-            'valid' => empty($allErrors),
-            'errors' => $allErrors
-        ];
-    }
-
-
-
-
-
 
 }

--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -466,7 +466,7 @@ class C_FormVitals
 
          // CARO: New change but I still want to be able to save invalid data??
         $validationResult = $this->validateVitals($_POST);
-        if (!$validationResult['valid']) {
+        if (!empty($validationResult['errors'])) {
             $errorMessages = implode("\n", $validationResult['errors']);
             error_log("Vitals validation failed: " . $errorMessages);
             
@@ -476,6 +476,13 @@ class C_FormVitals
             // Stop processing - don't save invalid data
             return;
         }
+
+        if (!empty($validationResult['warnings'])) {
+            $_SESSION['vitals_warnings'] = $validationResult['warnings'];
+        } else {
+            unset($_SESSION['vitals_warnings']);
+        }
+
 
         // grab our vitals data and then populate what is in the post
         $vitalsService = new VitalsService();
@@ -608,10 +615,10 @@ class C_FormVitals
     // CARO: CHECKKKK UNTIL END OF FILE
         /**
      * Validates vital values are within clinical ranges
-     * Returns validation errors array or empty array if valid
+     * Returns validation warnings and hard validation errors.
      * 
      * @param array $vitals The vitals data to validate
-     * @return array Array of validation errors, empty if no errors
+     * @return array Array with validation errors and warnings.
      */
     private function validateVitalRanges($vitals)
     {
@@ -630,6 +637,10 @@ class C_FormVitals
             }
 
             $range = self::VITAL_RANGES[$field];
+             if (!is_numeric($value)) {
+                $errors[$field] = $range['label'] . ' must be numeric.';
+                continue;
+            }
             $numValue = (float) $value;
 
             // Check for values outside clinical warning thresholds (warnings only)
@@ -640,13 +651,8 @@ class C_FormVitals
                 $warnings[$field] = $range['label'] . ' is outside typical range (' . $range['warning_min'] . '-' . $range['warning_max'] . '). You entered: ' . $value;
             }
         }
-
-        // Store warnings in a session variable that can be displayed to the user
-        if (!empty($warnings)) {
-            $_SESSION['vitals_warnings'] = $warnings;
-        }
-
-        return $errors;
+         return ['errors' => $errors, 'warnings' => $warnings];
+     
     }
 
     /**
@@ -658,7 +664,7 @@ class C_FormVitals
      */
     private function validateVitalConstraints($vitals)
     {
-        $errors = [];
+        $warnings = [];
 
         // Blood pressure constraint: systolic should be >= diastolic
         $bps = isset($vitals['bps']) ? (float) $vitals['bps'] : null;
@@ -666,35 +672,29 @@ class C_FormVitals
 
         if ($bps !== null && $bpd !== null && $bps > 0 && $bpd > 0) {
             if ($bps < $bpd) {
-                $errors['bps'] = 'BP Systolic must be greater than or equal to BP Diastolic. Systolic: ' . $bps . ', Diastolic: ' . $bpd;
-            }
+                $warnings['bps'] = 'BP Systolic is less than BP Diastolic. Systolic: ' . $bps . ', Diastolic: ' . $bpd;
         }
 
-        return $errors;
+        return $warnings;
+        }
     }
+    
 
     /**
      * Main validation method called before saving
      * 
      * @param array $vitals The vitals data to validate
-     * @return array Array with 'valid' boolean and 'errors' array
+     * @return array Array with 'errors' and 'warnings'
      */
     private function validateVitals($vitals)
     {
-        $rangeErrors = $this->validateVitalRanges($vitals);
-        $constraintErrors = $this->validateVitalConstraints($vitals);
-        
-        $allErrors = array_merge($rangeErrors, $constraintErrors);
+        $rangeValidation = $this->validateVitalRanges($vitals);
+        $constraintWarnings = $this->validateVitalConstraints($vitals);
 
         return [
-            'valid' => empty($allErrors),
-            'errors' => $allErrors
+            'errors' => $rangeValidation['errors'],
+            'warnings' => array_merge($rangeValidation['warnings'], $constraintWarnings)
         ];
     }
-
-
-
-
-
 
 }

--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -48,41 +48,49 @@ class C_FormVitals
         'bps' => [
             'warning_min' => 80,
             'warning_max' => 180,
+            'allow_negative' => false,
             'label' => 'BP Systolic (mmHg)'
         ],
         'bpd' => [
             'warning_min' => 40,
             'warning_max' => 120,
+            'allow_negative' => false,
             'label' => 'BP Diastolic (mmHg)'
         ],
         'pulse' => [
             'warning_min' => 40,
             'warning_max' => 200,
+            'allow_negative' => false,
             'label' => 'Pulse (bpm)'
         ],
         'respiration' => [
             'warning_min' => 8,
             'warning_max' => 50,
+            'allow_negative' => false,
             'label' => 'Respiration (breaths/min)'
         ],
         'temperature' => [
             'warning_min' => 95,
             'warning_max' => 105,
+            'allow_negative' => false,
             'label' => 'Temperature (°F)'
         ],
         'weight' => [
             'warning_min' => 5.5,
             'warning_max' => 650,
+            'allow_negative' => false,
             'label' => 'Weight (lbs)'
         ],
         'height' => [
             'warning_min' => 11,
             'warning_max' => 98,
+            'allow_negative' => false,
             'label' => 'Height (in)'
         ],
         'oxygen_saturation' => [
             'warning_min' => 90,
             'warning_max' => 100,
+            'allow_negative' => false,
             'label' => 'Oxygen Saturation (%)'
         ],
     ];
@@ -472,8 +480,6 @@ class C_FormVitals
             
             // Set error session variable so it can be displayed to user
             $_SESSION['vitals_validation_errors'] = $validationResult['errors'];
-            
-            // Stop processing - don't save invalid data
             return;
         }
 
@@ -641,6 +647,12 @@ class C_FormVitals
                 $errors[$field] = $range['label'] . ' must be numeric.';
                 continue;
             }
+
+            if (isset($range['allow_negative']) && !$range['allow_negative'] && $numValue < 0) {
+                $errors[$field] = $range['label'] . ' cannot be negative.';
+                 continue;
+            
+            }
             $numValue = (float) $value;
 
             // Check for values outside clinical warning thresholds (warnings only)
@@ -673,10 +685,9 @@ class C_FormVitals
         if ($bps !== null && $bpd !== null && $bps > 0 && $bpd > 0) {
             if ($bps < $bpd) {
                 $warnings['bps'] = 'BP Systolic is less than BP Diastolic. Systolic: ' . $bps . ', Diastolic: ' . $bpd;
+                }
         }
-
         return $warnings;
-        }
     }
     
 

--- a/interface/forms/vitals/templates/vitals/vitals.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals.html.twig
@@ -51,6 +51,30 @@
         {% endif %}
         <div class="col-sm-12">
             <form id="vitalsForm" name="vitals" method="post" action="{{ FORM_ACTION|attr }}/interface/forms/vitals/save.php">
+            {% if vitals_validation_errors is not empty %}
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            <h4 class="alert-heading">{{ "Validation Error"|xlt }}</h4>
+            <ul class="mb-0">
+                {% for field, message in vitals_validation_errors %}
+                <li><strong>{{ field|text }}:</strong> {{ message|text }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% endif %}
+
+        {% if vitals_warnings is not empty %}
+        <div class="alert alert-warning alert-dismissible fade show" role="alert">
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            <h4 class="alert-heading">{{ "Clinical Warning"|xlt }}</h4>
+            <p class="mb-2">{{ "The following vital values are outside typical ranges but have been submitted."|xlt }}</p>
+            <ul class="mb-0">
+                {% for field, message in vitals_warnings %}
+                <li><strong>{{ field|text }}:</strong> {{ message|text }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% endif %}
                 <input type="hidden" name="csrf_token_form" value="{{ CSRF_TOKEN_FORM|attr }}" />
                 {% if has_id %}
                 <div class="row">

--- a/interface/forms/vitals/templates/vitals/vitals_textbox.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals_textbox.html.twig
@@ -1,7 +1,11 @@
 {% if field.hide %}
 <tr class="hide">
     {%else %}
-<tr>
+
+
+
+<tr> {% if field.input in vitals_validation_errors %}
+class="table-danger"{% endif %}>
 {% endif %}
     <td class="graph" id="{{ field.input|attr }}"><span class="vitals-title">{{ field.title|text }}</span> {% if field.codes is not empty %}<small>({{ field.codes|text }})</small>{% endif %}</td>
     <td>{{ unit|text }}</td>
@@ -16,7 +20,11 @@
         <input type="text" class="form-control skip-template-editor" size='5' name='{{ field.input|attr }}' id='{{ field.input|attr }}_input'
                value="{% if attribute(vitals,field.vitalsValue) is numeric %}{{ attribute(vitals, field.vitalsValue)|attr }}{% endif %}"/>
         {% endif %}
-
+        {% if field.input in vitals_validation_errors %}
+        <div class="invalid-feedback d-block">
+            {{ vitals_validation_errors[field.input]|text }}
+        </div>
+        {% endif %}
     </td>
     <td class="editonly">
         {% include 'vitals_interpretation_selector.html.twig' with { input: field.input, vitalDetails:vitals.get_details_for_column(field.input) } %}

--- a/interface/forms/vitals/templates/vitals/vitals_textbox_conversion.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals_textbox_conversion.html.twig
@@ -15,6 +15,8 @@
     {% if units_of_measurement == MEASUREMENT_METRIC_ONLY  %}
     <tr class="hide">
     {% else %}
+        <tr {% if field.input in vitals_validation_errors %}class="table-danger"{% endif %}>
+    {% endif %}
     <tr>
     {% endif %}
     {% if units_of_measurement == MEASUREMENT_PERSIST_IN_METRIC  %}
@@ -43,6 +45,11 @@
                    data-system="usa" data-unit="{{ field.unit|attr }}" data-target-input="{{ field.input|attr }}_input"
                    data-target-input-conv="{{ field.input|attr }}_input_metric"
                    title='{{ field.vitalsValueUSAHelpTitle|default('')|attr }}'/>
+                   {% if field.input in vitals_validation_errors %}
+            <div class="invalid-feedback d-block">
+                {{ vitals_validation_errors[field.input]|text }}
+            </div>
+            {% endif %}
         </td>
         <td class="editonly">
             {% include 'vitals_interpretation_selector.html.twig' with { input: field.input, vitalDetails:vitals.get_details_for_column(field.input) } %}

--- a/interface/forms/vitals/vitals.js
+++ b/interface/forms/vitals/vitals.js
@@ -11,33 +11,183 @@
 
     let translations = {};
     let webroot = null;
+    const VITAL_RANGES = {
+        'bps': {
+            warning_min: 80, warning_max: 180,
+            label: 'BP Systolic (mmHg)'
+        },
+        'bpd': {
+            warning_min: 40, warning_max: 120,
+            label: 'BP Diastolic (mmHg)'
+        },
+        'pulse': {
+            warning_min: 40, warning_max: 200,
+            label: 'Pulse (bpm)'
+        },
+        'respiration': {
+            warning_min: 8, warning_max: 50,
+            label: 'Respiration (breaths/min)'
+        },
+        'temperature': {
+            warning_min: 95, warning_max: 105,
+            label: 'Temperature (°F)'
+        },
+        'weight': {
+            warning_min: 5.5, warning_max: 650,
+            label: 'Weight (lbs)'
+        },
+        'height': {
+            warning_min: 11, warning_max: 98,
+            label: 'Height (in)'
+        },
+        'oxygen_saturation': {
+            warning_min: 90, warning_max: 100,
+            label: 'Oxygen Saturation (%)'
+        }
+    };
 
-    function vitalsFormSubmitted() {
-        var invalid = "";
+    function validateVitalValue(fieldId, value) {
+        if (!value || value === '' || isNaN(value)) {
+            return { valid: true, error: null, warning: null };
+        }
 
-        var elementsToValidate = ['weight_input_usa', 'weight_input_metric', 'height_input_usa', 'height_input_metric', 'bps_input', 'bpd_input'];
+        const numValue = parseFloat(value);
+        const range = VITAL_RANGES[fieldId];
 
-        for (var i = 0; i < elementsToValidate.length; i++) {
-            var current_elem_id = elementsToValidate[i];
-            var tag_name = vitalsTranslations[current_elem_id] || "<unknown_tag_name>";
+        if (!range) {
+            return { valid: true, error: null, warning: null };
+        }
 
-            document.getElementById(current_elem_id).classList.remove('error');
+         if (
+            (range.warning_min !== null && numValue < range.warning_min) ||
+            (range.warning_max !== null && numValue > range.warning_max)
+        ) {
+            return {
+                valid: true,
+                error: null,
+                warning: range.label + ' is outside typical range (' + range.warning_min + '-' + range.warning_max + ')'
+            };
+        }
 
-            if (isNaN(document.getElementById(current_elem_id).value)) {
-                invalid += vitalsTranslations['invalidField'] + ":" + vitalsTranslations[current_elem_id] + "\n";
-                document.getElementById(current_elem_id).className = document.getElementById(current_elem_id).className + " error";
-                document.getElementById(current_elem_id).focus();
-            }
+        return { valid: true, error: null, warning: null };
+    }
 
-            if (invalid.length > 0) {
-                invalid += "\n" + vitalsTranslations['validateFailed'];
-                alert(invalid);
-                return false;
-            } else {
-                return top.restoreSession();
-            }
+    /**
+     * Validate blood pressure constraint: systolic >= diastolic
+     */
+    function validateBPConstraint() {
+        const bpsInput = document.getElementById('bps_input');
+        const bpdInput = document.getElementById('bpd_input');
+        
+        if (!bpsInput || !bpdInput) return null;
+
+        const bps = parseFloat(bpsInput.value);
+        const bpd = parseFloat(bpdInput.value);
+
+        if (isNaN(bps) || isNaN(bpd) || bps === 0 || bpd === 0) {
+            return null;
+        }
+
+        if (bps < bpd) {
+            return 'BP Systolic must be greater than or equal to BP Diastolic';
+        }
+
+        return null;
+    }
+
+        /**
+     * Add visual feedback to a field (error or warning)
+     */
+    function updateFieldStatus(fieldId, validation) {
+        const field = document.getElementById(fieldId + '_input') || 
+                      document.getElementById(fieldId + '_input_usa') ||
+                      document.getElementById(fieldId + '_input_metric');
+        
+        if (!field) return;
+
+        // Remove existing feedback
+        field.classList.remove('is-invalid', 'is-warning');
+        const existingFeedback = field.parentElement?.querySelector('.invalid-feedback, .warning-feedback');
+        if (existingFeedback) {
+            existingFeedback.remove();
+        }
+
+        if (validation.error) {
+            field.classList.add('is-invalid');
+            const errorDiv = document.createElement('div');
+            errorDiv.className = 'invalid-feedback d-block';
+            errorDiv.textContent = validation.error;
+            field.parentElement?.appendChild(errorDiv);
+        } else if (validation.warning) {
+            field.classList.add('is-warning');
+            const warningDiv = document.createElement('div');
+            warningDiv.className = 'warning-feedback d-block';
+            warningDiv.style.color = '#856404';
+            warningDiv.textContent = '⚠ ' + validation.warning;
+            field.parentElement?.appendChild(warningDiv);
         }
     }
+    /**
+     * Real-time validation on field change
+     */
+    function onVitalFieldChange(event) {
+        const field = event.target;
+        const fieldId = field.id.replace('_input', '').replace('_usa', '').replace('_metric', '');
+        
+        const validation = validateVitalValue(fieldId, field.value);
+        updateFieldStatus(fieldId, validation);
+    }
+
+    function vitalsFormSubmitted() {
+        let hasErrors = false;
+        let errorMessages = [];
+        let warnings = [];
+
+        // UPDATED: Validate all vital fields with ranges
+        const fieldsToValidate = ['bps', 'bpd', 'pulse', 'respiration', 'temperature', 'weight', 'height', 'oxygen_saturation'];
+
+        for (let fieldId of fieldsToValidate) {
+            const field = document.getElementById(fieldId + '_input') ||
+                         document.getElementById(fieldId + '_input_usa') ||
+                         document.getElementById(fieldId + '_input_metric');
+            
+            if (!field || !field.value) continue;
+
+            const validation = validateVitalValue(fieldId, field.value);
+            updateFieldStatus(fieldId, validation);
+
+            if (!validation.valid) {
+                hasErrors = true;
+                errorMessages.push(validation.error);
+            } else if (validation.warning) {
+                warnings.push(validation.warning);
+            }
+        }
+
+        // Check BP constraint
+        const bpError = validateBPConstraint();
+        if (bpError) {
+            hasErrors = true;
+            errorMessages.push(bpError);
+            updateFieldStatus('bps', { valid: false, error: bpError, warning: null });
+        }
+
+        // Show errors or warnings
+        if (hasErrors) {
+            alert(errorMessages.join('\n'));
+            return false;
+        }
+
+        if (warnings.length > 0) {
+            const confirmMessage = warnings.join('\n') + '\n\nThese values are outside typical ranges. Continue anyway?';
+            if (!confirm(confirmMessage)) {
+                return false;
+            }
+        }
+
+        return top.restoreSession();
+    }
+
 
     function convInputElement(evt) {
         let node = evt.currentTarget;
@@ -87,6 +237,7 @@
         if (targetSaveUnit == "weight_input_usa" || targetSaveUnit == "height_input_usa") {
             calculateBMI();
         }
+         onVitalFieldChange(evt);
     }
 
     function initDOMEvents() {
@@ -117,6 +268,14 @@
         let vitalsConvInputs = vitalsForm.querySelectorAll(".vitals-conv-unit");
         vitalsConvInputs.forEach(function(node) {
             node.addEventListener('change', convInputElement);
+            node.addEventListener('blur', onVitalFieldChange);
+        });
+
+        const allVitalInputs = vitalsForm.querySelectorAll('input[type="text"][name]');
+        allVitalInputs.forEach(function(node) {
+            if (node.id && (node.id.includes('_input') || VITAL_RANGES[node.name])) {
+                node.addEventListener('blur', onVitalFieldChange);
+            }
         });
     }
     function init(webRootParam, vitalsTranslations) {

--- a/src/Services/VitalsService.php
+++ b/src/Services/VitalsService.php
@@ -313,7 +313,6 @@ class VitalsService extends BaseService
 
     public function save(array $vitals)
     {
-
         // this makes sure we whitelist only values that can be saved in the form.
         $vitalsForm = new FormVitals();
         $vitalsForm->populate_array($vitals);

--- a/src/Services/VitalsValidationService.php
+++ b/src/Services/VitalsValidationService.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * Vitals validation service.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services;
+
+class VitalsValidationService
+{
+    private const VITAL_RANGES = [
+        'bps' => [
+            'warning_min' => 80,
+            'warning_max' => 180,
+            'label' => 'BP Systolic (mmHg)'
+        ],
+        'bpd' => [
+            'warning_min' => 40,
+            'warning_max' => 120,
+            'label' => 'BP Diastolic (mmHg)'
+        ],
+        'pulse' => [
+            'warning_min' => 40,
+            'warning_max' => 200,
+            'label' => 'Pulse (bpm)'
+        ],
+        'respiration' => [
+            'warning_min' => 8,
+            'warning_max' => 50,
+            'label' => 'Respiration (breaths/min)'
+        ],
+        'temperature' => [
+            'warning_min' => 95,
+            'warning_max' => 105,
+            'label' => 'Temperature (°F)'
+        ],
+        'weight' => [
+            'warning_min' => 5.5,
+            'warning_max' => 650,
+            'label' => 'Weight (lbs)'
+        ],
+        'height' => [
+            'warning_min' => 11,
+            'warning_max' => 98,
+            'label' => 'Height (in)'
+        ],
+        'oxygen_saturation' => [
+            'warning_min' => 90,
+            'warning_max' => 100,
+            'label' => 'Oxygen Saturation (%)'
+        ],
+    ];
+
+    private const NON_NEGATIVE_FIELDS = [
+        'bps',
+        'bpd',
+        'pulse',
+        'respiration',
+        'temperature',
+        'weight',
+        'height',
+        'oxygen_saturation',
+        'oxygen_flow_rate',
+        'inhaled_oxygen_concentration',
+        'BMI',
+        'head_circ',
+        'waist_circ',
+        'ped_weight_height',
+        'ped_bmi',
+        'ped_head_circ',
+    ];
+
+    /**
+     * @param array<string, mixed> $vitals
+     * @return array{errors: array<string, string>, warnings: array<string, string>}
+     */
+    public function validate(array $vitals): array
+    {
+        $rangeValidation = $this->validateVitalRanges($vitals);
+        $constraintWarnings = $this->validateVitalConstraints($vitals);
+
+        return [
+            'errors' => $rangeValidation['errors'],
+            'warnings' => array_merge($rangeValidation['warnings'], $constraintWarnings)
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $vitals
+     * @return array{errors: array<string, string>, warnings: array<string, string>}
+     */
+    private function validateVitalRanges(array $vitals): array
+    {
+        $errors = [];
+        $warnings = [];
+
+        foreach ($vitals as $field => $value) {
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            $hasRange = isset(self::VITAL_RANGES[$field]);
+            $mustBeNonNegative = in_array($field, self::NON_NEGATIVE_FIELDS, true);
+            if (!$hasRange && !$mustBeNonNegative) {
+                continue;
+            }
+
+            $range = self::VITAL_RANGES[$field] ?? null;
+            $fieldLabel = $range['label'] ?? ucwords(str_replace('_', ' ', $field));
+            if (!is_numeric($value)) {
+                $errors[$field] = $fieldLabel . ' must be numeric.';
+                continue;
+            }
+
+            $numValue = (float) $value;
+            if ($mustBeNonNegative && $numValue < 0) {
+                $errors[$field] = $fieldLabel . ' cannot be negative.';
+                continue;
+            }
+
+            if (!$hasRange || $range === null) {
+                continue;
+            }
+
+            if ($numValue < $range['warning_min'] || $numValue > $range['warning_max']) {
+                $warnings[$field] = $range['label'] . ' is outside typical range (' . $range['warning_min'] . '-' . $range['warning_max'] . '). You entered: ' . $value;
+            }
+        }
+
+        return ['errors' => $errors, 'warnings' => $warnings];
+    }
+
+    /**
+     * @param array<string, mixed> $vitals
+     * @return array<string, string>
+     */
+    private function validateVitalConstraints(array $vitals): array
+    {
+        $warnings = [];
+        $bps = null;
+        $bpd = null;
+        if (array_key_exists('bps', $vitals) && is_numeric($vitals['bps'])) {
+            $bps = (float) $vitals['bps'];
+        }
+        if (array_key_exists('bpd', $vitals) && is_numeric($vitals['bpd'])) {
+            $bpd = (float) $vitals['bpd'];
+        }
+
+        if ($bps !== null && $bpd !== null && $bps > 0 && $bpd > 0 && $bps < $bpd) {
+            $warnings['bps'] = 'BP Systolic is less than BP Diastolic. Systolic: ' . $bps . ', Diastolic: ' . $bpd;
+        }
+
+        return $warnings;
+    }
+}


### PR DESCRIPTION
https://github.com/openemr/openemr/issues/10602

#### Short description of what this changes or resolves:
This allows users to only add numeric input in numeric fields, and blocks submission if negative values are added when not allowed. Additionally, this displays a warning if users add values out of soft ranges.


#### Changes proposed in this pull request:
Addition of back end and server side validation (numeric and negative) in C_FormVItals.class.php and vitals.js

#### Was an AI assistant used? Yes / No
Yes (Codex)