### PR TITLE
refactor(globals): clean up stale $GLOBALS references in comments

### DIFF
--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -359,9 +359,7 @@ class C_Document extends Controller
         }
 
         $this->assign("error", $error);
-        //$this->_state = false;
         $_POST['process'] = "";
-        //return $this->fetch($GLOBALS['template_dir'] . "documents/" . $this->template_mod . "_upload.html");
     }
 
     public function note_action_process($patient_id)

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -3195,7 +3195,7 @@ function canvas_select($zone, $encounter, $pid)
  *
  *  If there is already a drawing for this zone in this encounter, it is pulled from
  *  from its stored location:
- *  $GLOBALS['web_root']."/sites/".$session->get('site_id')."/".$form_folder."/".$pid."/".$encounter."/".$side."_".$zone."_VIEW.png?".rand();
+ *  OEGlobalsBag::getInstance()->getWebRoot()."/sites/".$session->get('site_id')."/".$form_folder."/".$pid."/".$encounter."/".$side."_".$zone."_VIEW.png?".rand();
  *
  *  Otherwise a "BASE" image is pulled from the images directory of the form...  Customizable.
  *
@@ -5185,8 +5185,6 @@ function display_GlaucomaFlowSheet($pid, $bywhat = 'byday'): string
                     $count = 0;
                     foreach ($documents['docs_in_name']['VF'] as $VF) {
                         if ($count < 1) {
-                            //    $episode .= '<a onclick="openNewForm(\''.$GLOBALS['webroot'].'/controller.php?document&view&patient_id='.$pid.'&doc_id='.$id_to_show.'\',\'Documents\');"><img src="../../forms/'.$form_folder.'/images/jpg.png" class="little_image" /></a>';
-
                             $current_VF = '<tr><td class="GFS_td_1 blue">
                                 <a onclick="openNewForm(\'' . OEGlobalsBag::getInstance()->getWebRoot() . '/controller.php?document&view&patient_id=' . attr($pid) . '&doc_id=' . attr($VF['id']) . '\',\'Documents\');">
                                 <img src="../../forms/' . $form_folder . '/images/jpg.png" class="little_image" style="width:15px; height:15px;" /></a>

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/ModuleManagerListener.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/ModuleManagerListener.php
@@ -18,18 +18,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-/*
- * Do not declare a namespace
- * If you want Laminas manager to set namespace set it in getModuleNamespace
- * otherwise uncomment below and set path.
- *
- * */
-
-/*
-    $classLoader = new \OpenEMR\Core\ModulesClassLoader($GLOBALS['fileroot']);
-    $classLoader->registerNamespaceIfNotExists("OpenEMR\\Modules\\ClaimRevConnector\\", __DIR__ . DIRECTORY_SEPARATOR . 'src');
-*/
-
 use OpenEMR\Core\AbstractModuleActionListener;
 
 /* Allows maintenance of background tasks depending on Module Manager action. */

--- a/interface/modules/custom_modules/oe-module-dashboard-context/ModuleManagerListener.php
+++ b/interface/modules/custom_modules/oe-module-dashboard-context/ModuleManagerListener.php
@@ -18,18 +18,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-/*
- * Do not declare a namespace
- * If you want Lamina's manager to set namespace set it in getModuleNamespace
- * otherwise uncomment below and set path.
- *
- * */
-
-/*
-    $classLoader = new \OpenEMR\Core\ModulesClassLoader($GLOBALS['fileroot']);
-    $classLoader->registerNamespaceIfNotExists("OpenEMR\\Modules\\DashboardContext\\", __DIR__ . DIRECTORY_SEPARATOR . 'src');
-*/
-
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Core\AbstractModuleActionListener;
 use OpenEMR\Core\OEGlobalsBag;

--- a/interface/modules/custom_modules/oe-module-dorn/ModuleManagerListener.php
+++ b/interface/modules/custom_modules/oe-module-dorn/ModuleManagerListener.php
@@ -18,18 +18,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-/*
- * Do not declare a namespace
- * If you want Lamina's manager to set namespace set it in getModuleNamespace
- * otherwise uncomment below and set path.
- *
- * */
-
-/*
-    $classLoader = new \OpenEMR\Core\ModulesClassLoader($GLOBALS['fileroot']);
-    $classLoader->registerNamespaceIfNotExists("OpenEMR\\Modules\\Dorn\\", __DIR__ . DIRECTORY_SEPARATOR . 'src');
-*/
-
 use OpenEMR\Core\AbstractModuleActionListener;
 
 /* Allows maintenance of background tasks depending on Module Manager action. */

--- a/interface/modules/custom_modules/oe-module-faxsms/ModuleManagerListener.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/ModuleManagerListener.php
@@ -21,17 +21,6 @@ use OpenEMR\Modules\FaxSMS\BootstrapService;
  * @copyright Copyright (c) 2024 Jerry Padgett <sjpadgett@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
-/*
- * Do not declare a namespace
- * If you want Laminas manager to set namespace set it in getModuleNamespace
- * otherwise uncomment below and set path.
- *
- * */
-
-/*
-    $classLoader = new \OpenEMR\Core\ModulesClassLoader($GLOBALS['fileroot']);
-    $classLoader->registerNamespaceIfNotExists("OpenEMR\\Modules\\FaxSMS\\", __DIR__ . DIRECTORY_SEPARATOR . 'src');
-*/
 
 class ModuleManagerListener extends AbstractModuleActionListener
 {

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
@@ -205,7 +205,7 @@ class NotificationEventListener implements EventSubscriberInterface
      *   'expiry_interval' => "P2D", // valid for 2 days.
      *   'text_message' => "Please make a payment for your appointment.",
      *   'html_message' => "",
-     *   'redirect_url' => $GLOBALS['web_root'] . "/portal/home.php?site=" . urlencode($session->get('site_id')) . "&landOn=MakePayment",
+     *   'redirect_url' => OEGlobalsBag::getInstance()->getWebRoot() . "/portal/home.php?site=" . urlencode($session->get('site_id')) . "&landOn=MakePayment",
      *   'actions' => [
      *      'enforce_onetime_use' => true,
      *      'enforce_auth_pin' => true,

--- a/interface/modules/custom_modules/oe-module-prior-authorizations/ModuleManagerListener.php
+++ b/interface/modules/custom_modules/oe-module-prior-authorizations/ModuleManagerListener.php
@@ -18,18 +18,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-/*
- * Do not declare a namespace
- * If you want Laminas manager to set namespace set it in getModuleNamespace
- * otherwise uncomment below and set path.
- *
- * */
-
-/*
-    $classLoader = new \OpenEMR\Core\ModulesClassLoader($GLOBALS['fileroot']);
-    $classLoader->registerNamespaceIfNotExists("OpenEMR\\Modules\\ClaimRevConnector\\", __DIR__ . DIRECTORY_SEPARATOR . 'src');
-*/
-
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\AbstractModuleActionListener;
 

--- a/interface/modules/custom_modules/oe-module-weno/ModuleManagerListener.php
+++ b/interface/modules/custom_modules/oe-module-weno/ModuleManagerListener.php
@@ -18,18 +18,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-/*
- * Do not declare a namespace
- * If you want Laminas manager to set namespace set it in getModuleNamespace
- * otherwise uncomment below and set path.
- *
- * */
-
-/*
-    $classLoader = new \OpenEMR\Core\ModulesClassLoader($GLOBALS['fileroot']);
-    $classLoader->registerNamespaceIfNotExists("OpenEMR\\Modules\\WenoModule\\", __DIR__ . DIRECTORY_SEPARATOR . 'src');
-*/
-
 use OpenEMR\Core\AbstractModuleActionListener;
 use OpenEMR\Modules\WenoModule\Services\ModuleService;
 

--- a/interface/patient_file/history/history_sdoh_save.php
+++ b/interface/patient_file/history/history_sdoh_save.php
@@ -173,5 +173,4 @@ try {
     $logger->error("Exception saving sdoh record: " . $e->getMessage(), ['exception' => $e]);
     die(xlt("Error saving SDOH record."));
 }
-//header("Location: " . $GLOBALS['webroot'] . "/interface/patient_file/history/history_sdoh_widget.php?pid=" . urlencode((string) $pid));
 exit;

--- a/interface/patient_file/report/custom_report.php
+++ b/interface/patient_file/report/custom_report.php
@@ -278,7 +278,6 @@ function getContent()
             // include ALL form's report.php files
             $inclookupres = sqlStatement("select distinct formdir from forms where pid = ? AND deleted=0", [$pid]);
             while ($result = sqlFetchArray($inclookupres)) {
-                // include_once("{$GLOBALS['incdir']}/forms/" . $result["formdir"] . "/report.php");
                 $formdir = $result['formdir'];
             }
 

--- a/interface/reports/custom_report_range.php
+++ b/interface/reports/custom_report_range.php
@@ -296,13 +296,6 @@ if (!(empty($_POST['start']) || empty($_POST['end']))) {
     }
 
     foreach ($newpatient as $patient) {
-        /*
-        $inclookupres = sqlStatement("select distinct formdir from forms where pid='".$pids[$iCounter]."'");
-        while($result = sqlFetchArray($inclookupres)) {
-        include_once("{$GLOBALS['incdir']}/forms/" . $result["formdir"] . "/report.php");
-        }
-        */
-
         print "<div id='superbill_patientdata'>";
         print "<h1>" . xlt('Patient Data') . ":</h1>";
         printRecDataOne($patient_data_array, getRecPatientData($pids[$iCounter]), $N);

--- a/library/js/xl/datatables-net.js.php
+++ b/library/js/xl/datatables-net.js.php
@@ -6,7 +6,7 @@
  *
  * Example code in script:
  *    $translationsDatatablesOverride = array('search'=>(xla('Search all columns') . ':')) (optional php command)
- *    require($GLOBALS['srcdir'] . '/js/xl/datatables-net.js.php'); (php command)
+ *    require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/datatables-net.js.php'); (php command)
  *
  * Note there is a optional mechanism to override translations via the
  *  $translationsDatatablesOverride array.

--- a/library/js/xl/dygraphs.js.php
+++ b/library/js/xl/dygraphs.js.php
@@ -4,7 +4,7 @@
  * Internationalization by OpenEMR of the dygraphs asset.
  *
  * Example of use. When using dygraph asset, place following line before inclusion of dygraphs.js:
- *   require $GLOBALS['srcdir'] . '/js/xl/dygraphs.js.php'; (php command)
+ *   require OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/dygraphs.js.php'; (php command)
  *
  * @package OpenEMR
  * @link    https://www.open-emr.org

--- a/library/js/xl/jquery-datetimepicker-2-5-4-alternate.js.php
+++ b/library/js/xl/jquery-datetimepicker-2-5-4-alternate.js.php
@@ -8,7 +8,7 @@
  * need to instead send variables to the javascript script.
  *
  * Example code in the script that will use the picker:
- *    require($GLOBALS['srcdir'] . '/js/xl/jquery-datetimepicker-alternate-2-5-4.js.php'); (php command)
+ *    require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/jquery-datetimepicker-alternate-2-5-4.js.php'); (php command)
  *
  * Example code in the javascript for datepicker:
  *    $('.jquery-date-picker').datetimepicker({

--- a/library/js/xl/jquery-datetimepicker-2-5-4.js.php
+++ b/library/js/xl/jquery-datetimepicker-2-5-4.js.php
@@ -11,7 +11,7 @@
  *    $datetimepicker_showseconds = false; (php variable)
  *    $datetimepicker_formatInput = false; (php variable)
  *    $datetimepicker_maxDate = '+1970/01/01' (php variable) `+1970/01/01` means today for tomorrow use `+1970/01/02`
- *    require($GLOBALS['srcdir'] . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); (php command)
+ *    require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); (php command)
  *    can add any additional settings to datetimepicker here; need to prepend first setting with a comma
  *  });
  *  $('.datepicker').datetimepicker({
@@ -19,7 +19,7 @@
  *    $datetimepicker_showseconds = false; (php variable)
  *    $datetimepicker_formatInput = false; (php variable)
  *    $datetimepicker_minDate = '-1970/01/01'; (php variable)
- *    require($GLOBALS['srcdir'] . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); (php command)
+ *    require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); (php command)
  *    can add any additional settings to datetimepicker here; need to prepend first setting with a comma
  *  });
  *

--- a/library/js/xl/select2.js.php
+++ b/library/js/xl/select2.js.php
@@ -6,7 +6,7 @@
  *
  * Example code in script:
  *    $translationsSelect2Override = array('searching'=>(xla('Search') . ':')) (optional php command)
- *    require($GLOBALS['srcdir'] . '/js/xl/select2.js.php'); (php command)
+ *    require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/select2.js.php'); (php command)
  *
  * Note there is a optional mechanism to override translations via the
  *  $translationsSelect2Override array.

--- a/portal/messaging/messages.php
+++ b/portal/messaging/messages.php
@@ -580,9 +580,6 @@ function getAuthPortalUsers()
                             <li class="nav-item">
                                 <a class="nav-link" href="<?php echo $globalsBag->getString('web_root') ?>/portal/patient/provider" ng-show="!isPortal"><?php echo xlt('Exit Mail'); ?></a>
                             </li>
-                            <!--<li class="nav-item">
-                                <a class="nav-link" href="javascript:;" onclick='window.location.replace("<?php /*echo $GLOBALS['web_root'] */ ?>/portal/home.php")' ng-show="isPortal"><?php /*echo xlt('Exit'); */ ?></a>
-                            </li>-->
                         </ul>
                     </div>
                 </div>

--- a/src/Core/AbstractModuleActionListener.php
+++ b/src/Core/AbstractModuleActionListener.php
@@ -22,7 +22,7 @@
  * Do not declare a namespace in class extending this abstract class.
  * If you want Laminas manager to set namespace, set it in getModuleNamespace
  * otherwise use below at top of class to register namespace.
- * $classLoader = new \OpenEMR\Core\ModulesClassLoader($GLOBALS['fileroot']);
+ * $classLoader = new \OpenEMR\Core\ModulesClassLoader(OEGlobalsBag::getInstance()->getProjectDir());
  * $classLoader->registerNamespaceIfNotExists("OpenEMR\\Modules\\PortalPlugins\\", __DIR__ . DIRECTORY_SEPARATOR . 'src');
  * */
 


### PR DESCRIPTION
## Summary

After the kernel-path migration (#11263, #11570, #11757, #11758, #11759, #11760, #11761), a sweep for remaining `$GLOBALS['fileroot'|'incdir'|'srcdir'|'webroot'|'web_root'|'template_dir']` reads in production code found zero live uses — every remaining hit was inside a comment block. Most were dead commented-out code; a handful were developer documentation showing the outdated access pattern to future module authors.

This PR cleans them up:

- **Deletes** pure dead commented-out code (7 files)
- **Updates** developer docblocks and inline examples to show the modern typed accessor (`OEGlobalsBag::getInstance()->getProjectDir()`, `getSrcDir()`, `getWebRoot()`) (9 files)
- **Deletes** 6× duplicated namespace-registration template blocks in `ModuleManagerListener.php` files — the same example is already carried in the abstract base class, so the per-module copies were redundant noise

No behavior change: all edits are in comments or dead code paths.

## Test plan

- [x] `php -l` on all 19 modified files
- [x] `composer phpstan` (no new errors)
- [x] `composer phpcs` (clean)
- [x] `composer rector-check` (clean)
- [x] `composer require-checker` (clean)
- [ ] CI green