### PR TITLE
ci(phpstan): gate fatal-category baseline entries from ever growing

### DIFF
--- a/.phpstan/README.md
+++ b/.phpstan/README.md
@@ -278,15 +278,21 @@ composer phpstan-baseline
 
 ### Fatal-category caps
 
-Certain baseline files hold errors for code that cannot run at load or call time:
+Certain baseline files hold errors for code that cannot run at load or call time. `.phpstan/fatal-baseline-caps.php` records the current count per file and `tests/Tests/Isolated/PHPStan/FatalBaselineCapsIsolatedTest.php` asserts the actual count equals the cap. Two modes:
 
-- `class.notFound`, `method.notFound`, `staticMethod.notFound`
-- `function.notFound`
-- `classConstant.notFound`, `constant.notFound`
-- `include.fileNotFound`, `includeOnce.fileNotFound`, `requireOnce.fileNotFound`
-- `return.missing`, `variable.undefined`
+- **Whole-file (`all`)** — every baseline entry counts. Used for identifiers where each entry is a symbol that simply doesn't exist:
+  - `class.notFound`, `method.notFound`, `staticMethod.notFound`, `trait.notFound`, `interface.notFound`
+  - `function.notFound`
+  - `classConstant.notFound`, `constant.notFound`
+  - `include.fileNotFound`, `includeOnce.fileNotFound`, `requireOnce.fileNotFound`, `require.fileNotFound`
+  - `return.missing`, `variable.undefined`
 
-These cannot be allowed to grow. `.phpstan/fatal-baseline-caps.php` records the current entry count for each file; `tests/Tests/Isolated/PHPStan/FatalBaselineCapsIsolatedTest.php` asserts that the actual count equals the cap. If you regenerate the baseline and a count changes:
+- **Confident non-object (`confidentNonObject`)** — only entries whose reported type narrows to a definitely-non-object (e.g. `on bool`, `on null`, `on array`) count. PHPStan also fires `*.nonObject` on `mixed` and class-union types like `SomeClass|null`; those aren't certain crashes and are excluded. Covered identifiers:
+  - `method.nonObject`, `staticMethod.nonObject`
+  - `property.nonObject`, `classConstant.nonObject`
+  - `clone.nonObject`
+
+If you regenerate the baseline and a count changes:
 
 - **Count went down** — lower the cap in `fatal-baseline-caps.php` to match.
 - **Count went up** — fix the underlying code instead of raising the cap. Each entry resolves to one of four fixes: delete dead code, wrap optional code in `class_exists()` / `function_exists()` / `defined()`, add a PHPStan stub, or install the missing dependency.

--- a/.phpstan/README.md
+++ b/.phpstan/README.md
@@ -276,6 +276,23 @@ To regenerate the baseline after fixing violations:
 composer phpstan-baseline
 ```
 
+### Fatal-category caps
+
+Certain baseline files hold errors for code that cannot run at load or call time:
+
+- `class.notFound`, `method.notFound`, `staticMethod.notFound`
+- `function.notFound`
+- `classConstant.notFound`, `constant.notFound`
+- `include.fileNotFound`, `includeOnce.fileNotFound`, `requireOnce.fileNotFound`
+- `return.missing`, `variable.undefined`
+
+These cannot be allowed to grow. `.phpstan/fatal-baseline-caps.php` records the current entry count for each file; `tests/Tests/Isolated/PHPStan/FatalBaselineCapsIsolatedTest.php` asserts that the actual count equals the cap. If you regenerate the baseline and a count changes:
+
+- **Count went down** — lower the cap in `fatal-baseline-caps.php` to match.
+- **Count went up** — fix the underlying code instead of raising the cap. Each entry resolves to one of four fixes: delete dead code, wrap optional code in `class_exists()` / `function_exists()` / `defined()`, add a PHPStan stub, or install the missing dependency.
+
+See openemr/openemr#11792 for the plan to drive every cap to zero.
+
 ## Running PHPStan
 
 ```bash

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Entry caps for baseline files whose error identifiers represent code that
+ * cannot run: missing classes/methods/functions/constants, missing includes,
+ * missing return values, and undefined variables. These categories crash at
+ * load or call time — a new baseline entry is never the right answer, so the
+ * caps below only ever go down.
+ *
+ * Filename → maximum allowed count of `$ignoreErrors[] = [` entries. Tracked
+ * by tests/Tests/Isolated/PHPStan/FatalBaselineCapsIsolatedTest.php.
+ *
+ * When `composer phpstan-baseline` reduces a count, lower the cap in the same
+ * commit. When a count would go up, fix the underlying code instead of
+ * raising the cap.
+ *
+ * See openemr/openemr#11792 for the plan to drive every cap to zero.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+return [
+    'class.notFound.php' => 255,
+    'classConstant.notFound.php' => 0,
+    'constant.notFound.php' => 125,
+    'function.notFound.php' => 13,
+    'include.fileNotFound.php' => 4,
+    'includeOnce.fileNotFound.php' => 1,
+    'method.notFound.php' => 253,
+    'requireOnce.fileNotFound.php' => 4,
+    'return.missing.php' => 29,
+    'staticMethod.notFound.php' => 0,
+    'variable.undefined.php' => 3457,
+];

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -2,17 +2,27 @@
 
 /**
  * Entry caps for baseline files whose error identifiers represent code that
- * cannot run: missing classes/methods/functions/constants, missing includes,
- * missing return values, and undefined variables. These categories crash at
- * load or call time — a new baseline entry is never the right answer, so the
- * caps below only ever go down.
+ * cannot run. Two modes:
  *
- * Filename → maximum allowed count of `$ignoreErrors[] = [` entries. Tracked
- * by tests/Tests/Isolated/PHPStan/FatalBaselineCapsIsolatedTest.php.
+ *   - `all` — every `$ignoreErrors[] = [` entry in the file counts against
+ *     the cap. Used for identifiers like `class.notFound` where every entry
+ *     is a symbol that simply doesn't exist.
  *
- * When `composer phpstan-baseline` reduces a count, lower the cap in the same
- * commit. When a count would go up, fix the underlying code instead of
- * raising the cap.
+ *   - `confidentNonObject` — only entries whose reported type narrows to a
+ *     non-object (null, false, true, int, string, bool, float, array, ...)
+ *     count against the cap. PHPStan emits `*.nonObject` identifiers for
+ *     both "definitely a crash" types (e.g. `on bool`) and "I can't prove
+ *     it's an object" types (e.g. `on mixed`, `on SomeClass|null`). Only
+ *     the former are caught here.
+ *
+ * Caps only go down. When `composer phpstan-baseline` reduces a count,
+ * lower the cap in the same commit. When a count would go up, fix the
+ * underlying code instead of raising the cap.
+ *
+ * Preemptive zero caps (`require.fileNotFound`, `trait.notFound`,
+ * `interface.notFound`) block identifiers that aren't currently in the
+ * baseline — if one ever appears, the test fails instead of quietly
+ * baselining it.
  *
  * See openemr/openemr#11792 for the plan to drive every cap to zero.
  *
@@ -24,15 +34,27 @@
 declare(strict_types=1);
 
 return [
-    'class.notFound.php' => 255,
-    'classConstant.notFound.php' => 0,
-    'constant.notFound.php' => 125,
-    'function.notFound.php' => 13,
-    'include.fileNotFound.php' => 4,
-    'includeOnce.fileNotFound.php' => 1,
-    'method.notFound.php' => 253,
-    'requireOnce.fileNotFound.php' => 4,
-    'return.missing.php' => 29,
-    'staticMethod.notFound.php' => 0,
-    'variable.undefined.php' => 3457,
+    'all' => [
+        'class.notFound.php' => 255,
+        'classConstant.notFound.php' => 0,
+        'constant.notFound.php' => 125,
+        'function.notFound.php' => 13,
+        'include.fileNotFound.php' => 4,
+        'includeOnce.fileNotFound.php' => 1,
+        'interface.notFound.php' => 0,
+        'method.notFound.php' => 253,
+        'require.fileNotFound.php' => 0,
+        'requireOnce.fileNotFound.php' => 4,
+        'return.missing.php' => 29,
+        'staticMethod.notFound.php' => 0,
+        'trait.notFound.php' => 0,
+        'variable.undefined.php' => 3457,
+    ],
+    'confidentNonObject' => [
+        'classConstant.nonObject.php' => 1,
+        'clone.nonObject.php' => 0,
+        'method.nonObject.php' => 12,
+        'property.nonObject.php' => 8,
+        'staticMethod.nonObject.php' => 0,
+    ],
 ];

--- a/tests/Tests/Isolated/PHPStan/FatalBaselineCapsIsolatedTest.php
+++ b/tests/Tests/Isolated/PHPStan/FatalBaselineCapsIsolatedTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Isolated test: fatal-category PHPStan baseline entry caps.
+ *
+ * Enforces that baseline files for error identifiers representing code that
+ * cannot run — missing classes, methods, functions, constants, includes,
+ * missing return values, undefined variables — never grow. Each file has a
+ * committed cap in `.phpstan/fatal-baseline-caps.php`; this test asserts the
+ * actual entry count never exceeds its cap.
+ *
+ * See openemr/openemr#11792 for context and the plan to drive caps to zero.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\PHPStan;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class FatalBaselineCapsIsolatedTest extends TestCase
+{
+    private const REPO_ROOT = __DIR__ . '/../../../..';
+    private const CAPS_FILE = self::REPO_ROOT . '/.phpstan/fatal-baseline-caps.php';
+    private const BASELINE_DIR = self::REPO_ROOT . '/.phpstan/baseline';
+
+    #[DataProvider('capsProvider')]
+    public function testEntryCountMatchesCap(string $filename, int $cap): void
+    {
+        $path = self::BASELINE_DIR . '/' . $filename;
+        $count = file_exists($path)
+            ? preg_match_all('/\$ignoreErrors\[\] = \[/', (string) file_get_contents($path))
+            : 0;
+
+        if ($count > $cap) {
+            $this->fail(sprintf(
+                "%s has %d entries, exceeding cap of %d.\n"
+                    . "These categories represent code that cannot run at load/call time.\n"
+                    . "Do not raise the cap — fix the underlying code. See openemr/openemr#11792.",
+                $filename,
+                $count,
+                $cap
+            ));
+        }
+
+        // Caps must also track actual counts so a fix forces a decrement in the same PR.
+        $this->assertSame(
+            $cap,
+            $count,
+            sprintf(
+                "%s has %d entries but cap is %d.\n"
+                    . 'Caps must match actual counts — lower the entry in '
+                    . '`.phpstan/fatal-baseline-caps.php`.',
+                $filename,
+                $count,
+                $cap
+            )
+        );
+    }
+
+    /**
+     * @return array<string, array{string, int}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function capsProvider(): array
+    {
+        /** @var array<string, int> $caps */
+        $caps = require self::CAPS_FILE;
+        $cases = [];
+        foreach ($caps as $filename => $cap) {
+            $cases[$filename] = [$filename, $cap];
+        }
+        return $cases;
+    }
+}

--- a/tests/Tests/Isolated/PHPStan/FatalBaselineCapsIsolatedTest.php
+++ b/tests/Tests/Isolated/PHPStan/FatalBaselineCapsIsolatedTest.php
@@ -4,10 +4,14 @@
  * Isolated test: fatal-category PHPStan baseline entry caps.
  *
  * Enforces that baseline files for error identifiers representing code that
- * cannot run — missing classes, methods, functions, constants, includes,
- * missing return values, undefined variables — never grow. Each file has a
- * committed cap in `.phpstan/fatal-baseline-caps.php`; this test asserts the
- * actual entry count never exceeds its cap.
+ * cannot run never grow. `.phpstan/fatal-baseline-caps.php` holds two kinds
+ * of caps:
+ *
+ *   - `all` — cap applies to every `$ignoreErrors[] = [` entry in the file.
+ *   - `confidentNonObject` — cap applies only to entries whose reported
+ *     type narrows to a definitely-non-object (null / false / true / scalar
+ *     / array). PHPStan also fires `*.nonObject` on `mixed` and class-union
+ *     types, which aren't certain crashes; those are excluded.
  *
  * See openemr/openemr#11792 for context and the plan to drive caps to zero.
  *
@@ -31,38 +35,162 @@ class FatalBaselineCapsIsolatedTest extends TestCase
     private const CAPS_FILE = self::REPO_ROOT . '/.phpstan/fatal-baseline-caps.php';
     private const BASELINE_DIR = self::REPO_ROOT . '/.phpstan/baseline';
 
-    #[DataProvider('capsProvider')]
-    public function testEntryCountMatchesCap(string $filename, int $cap): void
-    {
-        $path = self::BASELINE_DIR . '/' . $filename;
-        $count = file_exists($path)
-            ? preg_match_all('/\$ignoreErrors\[\] = \[/', (string) file_get_contents($path))
-            : 0;
+    /**
+     * Primitive type names PHPStan reports that definitely aren't objects.
+     *
+     * `mixed`, `object`, `iterable`, and any class/interface name are
+     * excluded — they don't prove the value is non-object at runtime.
+     */
+    private const NON_OBJECT_ATOMS = [
+        'null', 'false', 'true',
+        'int', 'string', 'bool', 'float', 'array', 'resource',
+        'void', 'never', 'scalar',
+    ];
 
+    private const NON_OBJECT_PREFIXES = [
+        'array<', 'list<', 'non-empty-array', 'non-empty-list',
+        'int<', 'non-empty-string', 'numeric-string', 'literal-string',
+        'lowercase-string', 'uppercase-string',
+        'positive-int', 'negative-int', 'non-negative-int', 'non-positive-int',
+        'class-string', 'interface-string', 'enum-string', 'trait-string',
+        'callable-string',
+    ];
+
+    #[DataProvider('wholeFileCapsProvider')]
+    public function testWholeFileEntryCountMatchesCap(string $filename, int $cap): void
+    {
+        $count = $this->countEntries($filename);
+        $this->assertCapMatches($filename, $count, $cap, 'entries');
+    }
+
+    #[DataProvider('confidentNonObjectCapsProvider')]
+    public function testConfidentNonObjectEntryCountMatchesCap(string $filename, int $cap): void
+    {
+        $count = $this->countConfidentNonObjectEntries($filename);
+        $this->assertCapMatches(
+            $filename,
+            $count,
+            $cap,
+            'entries whose reported type is definitely non-object'
+        );
+    }
+
+    private function assertCapMatches(string $filename, int $count, int $cap, string $what): void
+    {
         if ($count > $cap) {
             $this->fail(sprintf(
-                "%s has %d entries, exceeding cap of %d.\n"
-                    . "These categories represent code that cannot run at load/call time.\n"
-                    . "Do not raise the cap — fix the underlying code. See openemr/openemr#11792.",
+                "%s has %d %s, exceeding cap of %d.\n"
+                    . "This category represents code that crashes at load or call time.\n"
+                    . "Do not raise the cap — fix the underlying code.\n"
+                    . 'See openemr/openemr#11792.',
                 $filename,
                 $count,
+                $what,
                 $cap
             ));
         }
-
-        // Caps must also track actual counts so a fix forces a decrement in the same PR.
         $this->assertSame(
             $cap,
             $count,
             sprintf(
-                "%s has %d entries but cap is %d.\n"
-                    . 'Caps must match actual counts — lower the entry in '
-                    . '`.phpstan/fatal-baseline-caps.php`.',
+                "%s has %d %s but cap is %d.\n"
+                    . 'Lower the entry in `.phpstan/fatal-baseline-caps.php` to match.',
                 $filename,
                 $count,
+                $what,
                 $cap
             )
         );
+    }
+
+    private function countEntries(string $filename): int
+    {
+        $path = self::BASELINE_DIR . '/' . $filename;
+        if (!file_exists($path)) {
+            return 0;
+        }
+        $matches = preg_match_all(
+            '/\$ignoreErrors\[\] = \[/',
+            (string) file_get_contents($path)
+        );
+        // preg_match_all returns false only on a bad pattern; ours is a fixed literal.
+        return is_int($matches) ? $matches : 0;
+    }
+
+    private function countConfidentNonObjectEntries(string $filename): int
+    {
+        $path = self::BASELINE_DIR . '/' . $filename;
+        if (!file_exists($path)) {
+            return 0;
+        }
+        /** @var list<array{message: string, count: int, path: string}> $ignoreErrors */
+        $ignoreErrors = [];
+        require $path;
+        $count = 0;
+        foreach ($ignoreErrors as $entry) {
+            if (self::isConfidentlyNonObjectMessage((string) $entry['message'])) {
+                $count++;
+            }
+        }
+        return $count;
+    }
+
+    /**
+     * Extract the reported type from a PHPStan nonObject message and decide
+     * whether every union member is a non-object primitive. Returns false
+     * when the message can't be parsed or any union member could be an
+     * object (class name, `mixed`, `object`, `iterable`).
+     */
+    private static function isConfidentlyNonObjectMessage(string $pattern): bool
+    {
+        // Strip PHPStan's `#^...$#` regex anchors and unescape.
+        $inner = $pattern;
+        if (str_starts_with($inner, '#^')) {
+            $inner = substr($inner, 2);
+        }
+        if (str_ends_with($inner, '$#')) {
+            $inner = substr($inner, 0, -2);
+        }
+        $inner = str_replace(
+            ['\\\\', '\\|', '\\.', '\\(', '\\)', '\\$', '\\-'],
+            ['\\', '|', '.', '(', ')', '$', '-'],
+            $inner
+        );
+
+        if (preg_match('/^Cannot clone (?:non-object variable \$\w+ of type )?(.+)\.$/', $inner, $m)) {
+            $type = $m[1];
+        } elseif (preg_match('/ on (.+)\.$/', $inner, $m)) {
+            $type = $m[1];
+        } else {
+            return false;
+        }
+
+        foreach (explode('|', $type) as $part) {
+            if (!self::isNonObjectType(trim($part))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static function isNonObjectType(string $type): bool
+    {
+        if ($type === '') {
+            return false;
+        }
+        if (in_array($type, ['mixed', 'object', 'iterable'], true)) {
+            return false;
+        }
+        if (in_array($type, self::NON_OBJECT_ATOMS, true)) {
+            return true;
+        }
+        foreach (self::NON_OBJECT_PREFIXES as $prefix) {
+            if (str_starts_with($type, $prefix)) {
+                return true;
+            }
+        }
+        // Anything starting uppercase or with a namespace separator is a class/interface.
+        return false;
     }
 
     /**
@@ -70,12 +198,30 @@ class FatalBaselineCapsIsolatedTest extends TestCase
      *
      * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
-    public static function capsProvider(): array
+    public static function wholeFileCapsProvider(): array
     {
-        /** @var array<string, int> $caps */
+        return self::buildProviderCases('all');
+    }
+
+    /**
+     * @return array<string, array{string, int}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function confidentNonObjectCapsProvider(): array
+    {
+        return self::buildProviderCases('confidentNonObject');
+    }
+
+    /**
+     * @return array<string, array{string, int}>
+     */
+    private static function buildProviderCases(string $section): array
+    {
+        /** @var array{all: array<string, int>, confidentNonObject: array<string, int>} $caps */
         $caps = require self::CAPS_FILE;
         $cases = [];
-        foreach ($caps as $filename => $cap) {
+        foreach ($caps[$section] as $filename => $cap) {
             $cases[$filename] = [$filename, $cap];
         }
         return $cases;


### PR DESCRIPTION
## Summary

Adds a ratchet on PHPStan baseline entries for error identifiers representing code that cannot run at load or call time. Counts can only go down. A new entry in any of these categories fails CI instead of quietly landing in the baseline.

Nothing about today's PHPStan behavior changes — the baseline files are unchanged. This commit only locks in the current counts as a ceiling.

Closes part of #11792 (Phase 1).

### Gated identifiers

**Whole-file (every entry counts):**

| Identifier | Cap |
|---|---:|
| `variable.undefined` | 3457 |
| `class.notFound` | 255 |
| `method.notFound` | 253 |
| `constant.notFound` | 125 |
| `return.missing` | 29 |
| `function.notFound` | 13 |
| `include.fileNotFound` | 4 |
| `requireOnce.fileNotFound` | 4 |
| `includeOnce.fileNotFound` | 1 |
| `staticMethod.notFound` | 0 |
| `classConstant.notFound` | 0 |
| `require.fileNotFound` | 0 (preemptive) |
| `trait.notFound` | 0 (preemptive) |
| `interface.notFound` | 0 (preemptive) |

**Confident non-object (entries whose reported type narrows to null/false/scalar/array/etc. — excludes `on mixed` and class-union types that aren't certain crashes):**

| Identifier | Cap |
|---|---:|
| `method.nonObject` | 12 (`->isSuccessful()` on `bool` in payment flows, etc.) |
| `property.nonObject` | 8 |
| `classConstant.nonObject` | 1 |
| `staticMethod.nonObject` | 0 |
| `clone.nonObject` | 0 |

### How it works

- `.phpstan/fatal-baseline-caps.php` — per-file caps in two sections (`all` and `confidentNonObject`).
- `tests/Tests/Isolated/PHPStan/FatalBaselineCapsIsolatedTest.php` — runs in the existing `composer phpunit-isolated` suite and asserts the actual count equals the cap. Growth fails with guidance to fix the code. Shrinkage fails with guidance to lower the cap in the same PR, so reductions are never forgotten.
- `.phpstan/README.md` — documents the mechanism and the count-went-up / count-went-down workflow.

For the non-object case, the test parses each baseline entry's message pattern and checks whether every union member is a recognized non-object primitive (`null`, `false`, `true`, scalars, arrays, parametric forms like `class-string` and `non-empty-string`). `mixed`, `object`, `iterable`, and class/interface names disqualify an entry from counting.

## Why these identifiers

All represent code that crashes at runtime when the offending path is reached — missing classes/methods/functions/constants, missing includes, functions that don't return on all paths, undefined variables (fatal under strict error reporting), and non-object dereferences where PHPStan has narrowed the type to something that definitely isn't an object.

If PHPStan has to be told one of these exists, no production call path reaches it safely. New entries should always be fixed at the source:

- **Dead code** — delete it.
- **Optional/feature-flagged** — wrap in `class_exists()` / `function_exists()` / `defined()`.
- **Missing stub** — add to `scanFiles` / `scanDirectories` / an extension stub file.
- **Missing real dependency** — port or install it.

## Test plan

- [x] `composer phpunit-isolated` passes locally (19 / 19 cases)
- [x] `composer phpcs` passes on new/changed files
- [x] Pre-commit hooks (phpstan, rector, phpcbf, phpcs, codespell, composer-require-checker) all green
- [ ] CI green on this PR