### PR TITLE
fix(background-services): isolate run-all-due behind subprocess boundary

### DIFF
--- a/src/Common/Command/BackgroundServicesCommand.php
+++ b/src/Common/Command/BackgroundServicesCommand.php
@@ -176,11 +176,31 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
      * human-readable path so a child process's success/failure is
      * observable both in its JSON line and its exit code.
      *
+     * Reflects the per-invocation nonce the parent orchestrator passed
+     * via OPENEMR_BG_NONCE so the parent can authenticate this status
+     * line as its own and reject any forged line printed by the
+     * service's own code (e.g. from register_shutdown_function). The
+     * nonce is absent when the command is invoked directly (CLI, or
+     * via the REST single-service path, which doesn't use the JSON
+     * wire format); in that case we emit an empty string and the
+     * child-path consumer never checks it.
+     *
+     * Uses JSON_THROW_ON_ERROR so an encoding failure (e.g. a service
+     * name containing invalid UTF-8) surfaces as a non-zero exit with
+     * a visible JsonException rather than the parent silently coercing
+     * the result to 'error' because `(string) false` is an empty line.
+     *
      * @param array{name: string, status: string} $result
      */
     private function emitJsonResult(array $result, SymfonyStyle $io): int
     {
-        $io->writeln((string) json_encode($result));
+        $nonceEnv = getenv('OPENEMR_BG_NONCE');
+        $payload = [
+            'name' => $result['name'],
+            'status' => $result['status'],
+            'nonce' => is_string($nonceEnv) ? $nonceEnv : '',
+        ];
+        $io->writeln(json_encode($payload, JSON_THROW_ON_ERROR));
         return ($result['status'] === 'error' || $result['status'] === 'not_found')
             ? Command::FAILURE
             : Command::SUCCESS;

--- a/src/Common/Command/BackgroundServicesCommand.php
+++ b/src/Common/Command/BackgroundServicesCommand.php
@@ -47,6 +47,7 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
                     new InputArgument('action', InputArgument::REQUIRED, 'Action to perform: list, run, unlock, or crontab'),
                     new InputOption('name', null, InputOption::VALUE_REQUIRED, 'Service name (required for "unlock"; for "run", if omitted, runs all services that are due)'),
                     new InputOption('force', 'f', InputOption::VALUE_NONE, 'Bypass interval check (for "run"; ignored without --name)'),
+                    new InputOption('json', null, InputOption::VALUE_NONE, 'Emit a single JSON result line on stdout (for "run" with --name); suppresses human-readable output'),
                     new InputOption('php', null, InputOption::VALUE_REQUIRED, 'PHP binary path (for "crontab")', PHP_BINARY),
                 ])
             );
@@ -103,6 +104,17 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
         $nameRaw = $input->getOption('name');
         $name = is_string($nameRaw) && $nameRaw !== '' ? $nameRaw : null;
         $forceRequested = (bool) $input->getOption('force');
+        $json = (bool) $input->getOption('json');
+
+        // --json is the wire format the run-all-due orchestrator uses to
+        // parse child subprocess results (see BackgroundServiceRunner and
+        // SymfonyBackgroundServiceSpawner). It is only meaningful when
+        // running a single named service. The run-all-due path doesn't
+        // go through this command's stdout.
+        if ($json && $name === null) {
+            $io->error('--json requires --name (it is only meaningful for a single-service run).');
+            return Command::FAILURE;
+        }
 
         // --force is only meaningful when targeting a specific --name. Without
         // a name, honoring --force would switch BackgroundServiceRunner into
@@ -114,6 +126,15 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
             $io->warning('--force is ignored without --name; running only services that are due.');
         }
         $force = $name !== null && $forceRequested;
+
+        // Capture the name as a non-nullable local before the run so the
+        // JSON emit path below has a definite string fallback for the
+        // "service not found / empty results" case. The early return
+        // above guarantees name is non-null whenever $json is true.
+        if ($json && $name !== null) {
+            $result = $this->createRunner()->run($name, $force)[0] ?? ['name' => $name, 'status' => 'error'];
+            return $this->emitJsonResult($result, $io);
+        }
 
         $results = $this->createRunner()->run($name, $force);
 
@@ -147,6 +168,22 @@ class BackgroundServicesCommand extends Command implements IGlobalsAware
             }
         }
         return Command::SUCCESS;
+    }
+
+    /**
+     * Emit the single-service result as one JSON line for consumption by
+     * the run-all-due orchestrator. The exit code matches the
+     * human-readable path so a child process's success/failure is
+     * observable both in its JSON line and its exit code.
+     *
+     * @param array{name: string, status: string} $result
+     */
+    private function emitJsonResult(array $result, SymfonyStyle $io): int
+    {
+        $io->writeln((string) json_encode($result));
+        return ($result['status'] === 'error' || $result['status'] === 'not_found')
+            ? Command::FAILURE
+            : Command::SUCCESS;
     }
 
     protected function createRunner(): BackgroundServiceRunner

--- a/src/Services/Background/BackgroundServiceProcessSpawner.php
+++ b/src/Services/Background/BackgroundServiceProcessSpawner.php
@@ -30,13 +30,20 @@ interface BackgroundServiceProcessSpawner
      * its result.
      *
      * Implementations must NEVER let a subprocess failure propagate as an
-     * exception. Any termination reason (signal, non-zero exit, failure
-     * to parse child output) is converted into a result with
+     * exception. Any termination reason (signal, non-zero exit, timeout,
+     * failure to parse child output) is converted into a result with
      * `status => 'error'` and a log entry identifying the offending
      * service. The orchestrating loop relies on this contract to advance
      * to the next service without a catch block.
      *
+     * @param int $timeoutSeconds Hard wall-clock cap on how long the
+     *                            subprocess is allowed to run. Must be
+     *                            positive. The orchestrator derives this
+     *                            from the service's computed lease so a
+     *                            hung child cannot block the cron slot
+     *                            past the DB-side lease it holds.
+     *
      * @return array{name: string, status: string}
      */
-    public function spawn(string $name, bool $force): array;
+    public function spawn(string $name, bool $force, int $timeoutSeconds): array;
 }

--- a/src/Services/Background/BackgroundServiceProcessSpawner.php
+++ b/src/Services/Background/BackgroundServiceProcessSpawner.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Abstraction for launching a background service in a separate process.
+ *
+ * Process isolation is the only boundary that survives `exit()`, `die()`,
+ * or fatal errors inside a service function. No amount of `try`/`catch`
+ * in PHP can recover from them because they abort the process itself.
+ * `BackgroundServiceRunner::run(null, false)` delegates to an implementation
+ * of this interface for every active service so a single misbehaving
+ * service cannot abort the remaining services scheduled for the same tick.
+ * See GH issue #11794.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\Background;
+
+interface BackgroundServiceProcessSpawner
+{
+    /**
+     * Execute a single background service in a separate process and return
+     * its result.
+     *
+     * Implementations must NEVER let a subprocess failure propagate as an
+     * exception. Any termination reason (signal, non-zero exit, failure
+     * to parse child output) is converted into a result with
+     * `status => 'error'` and a log entry identifying the offending
+     * service. The orchestrating loop relies on this contract to advance
+     * to the next service without a catch block.
+     *
+     * @return array{name: string, status: string}
+     */
+    public function spawn(string $name, bool $force): array;
+}

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -57,13 +57,30 @@ class BackgroundServiceRunner
 
     private readonly LoggerInterface $logger;
 
-    public function __construct(?LoggerInterface $logger = null)
-    {
+    public function __construct(
+        ?LoggerInterface $logger = null,
+        private ?BackgroundServiceProcessSpawner $spawner = null,
+    ) {
         $this->logger = $logger ?? ServiceContainer::getLogger();
     }
 
     /**
      * Run one or all background services.
+     *
+     * ## Isolation model
+     *
+     * - **Single service (`$serviceName !== null`):** executed inline in
+     *   the current process. `acquireLock`/`executeService` failures are
+     *   caught as normal exceptions, but `exit()`/`die()`/fatals in the
+     *   service function will terminate this process just like any other
+     *   PHP script. Callers (REST, AJAX, CLI with --name) that invoke a
+     *   single named service accept that blast radius.
+     * - **Run-all-due (`$serviceName === null`):** each active, due
+     *   service is executed in its own subprocess via
+     *   `BackgroundServiceProcessSpawner`. This is the only safe way to
+     *   survive `exit()`/`die()`/fatal errors from one service. No
+     *   catch block in PHP can recover from them, so process boundaries
+     *   are the isolation mechanism. See GH #11794.
      *
      * @param string|null $serviceName Specific service name, or null for all
      * @param bool $force Bypass interval check
@@ -73,67 +90,133 @@ class BackgroundServiceRunner
      *   - 'skipped'         — inactive, or manual-mode without --force
      *   - 'already_running' — another process holds an unexpired lease
      *   - 'not_due'         — interval has not elapsed yet (NOW() <= next_run)
-     *   - 'error'           — exception during lock acquisition or execution
+     *   - 'error'           — exception during lock acquisition or execution,
+     *                         or subprocess terminated abnormally (run-all-due)
      *   - 'not_found'       — requested service name does not exist
      */
     public function run(?string $serviceName = null, bool $force = false): array
     {
-        $this->registerShutdownHandler();
-
         if ($serviceName === '') {
             $serviceName = null;
         }
 
-        $results = [];
+        if ($serviceName === null) {
+            return $this->runAllDueIsolated();
+        }
+
+        $this->registerShutdownHandler();
+
         $services = $this->getServices($serviceName, $force);
 
-        if ($serviceName !== null && $services === []) {
+        if ($services === []) {
             return [['name' => $serviceName, 'status' => 'not_found']];
         }
 
+        // Single named service: always exactly one row.
+        return [$this->runOne($services[0], $force)];
+    }
+
+    /**
+     * Orchestrate the run-all-due path with per-service subprocess
+     * isolation. Each active service scheduled on an interval is
+     * delegated to the process spawner; inactive services are reported
+     * as 'skipped' without spawning (skip-vs-run is trivially decidable
+     * from the row, no need to pay bootstrap cost to confirm).
+     *
+     * The spawner is responsible for turning any abnormal subprocess
+     * termination into `status => 'error'` with a log entry. This loop
+     * therefore advances through every service regardless of what the
+     * previous one did.
+     *
+     * @return list<array{name: string, status: string}>
+     */
+    private function runAllDueIsolated(): array
+    {
+        $services = $this->getServices(null, false);
+        $results = [];
+        $spawner = null;
+
         foreach ($services as $service) {
-            $name = $service['name'];
-
             // ADOdb returns string values; use loose comparison for DB row checks.
-            // Note: the `running` column is not consulted here — acquireLock()
-            // is authoritative and can steal a lease left by a crashed worker.
             if ($service['active'] == 0) {
-                $results[] = ['name' => $name, 'status' => 'skipped'];
+                $results[] = ['name' => $service['name'], 'status' => 'skipped'];
                 continue;
             }
-
-            // Manual-mode services (execute_interval = 0) require --force
-            if ($service['execute_interval'] == 0 && !$force) {
-                $results[] = ['name' => $name, 'status' => 'skipped'];
-                continue;
-            }
-
-            try {
-                $lockFailureReason = $this->acquireLock($service, $force);
-            } catch (SqlQueryException) {
-                $results[] = ['name' => $name, 'status' => 'error'];
-                continue;
-            }
-
-            if ($lockFailureReason !== null) {
-                $results[] = ['name' => $name, 'status' => $lockFailureReason];
-                continue;
-            }
-
-            // Only track for shutdown cleanup after lock is acquired
-            $this->currentServiceName = $name;
-
-            try {
-                $this->executeService($service);
-                $results[] = ['name' => $name, 'status' => 'executed'];
-            } catch (\Throwable) {
-                $results[] = ['name' => $name, 'status' => 'error'];
-            } finally {
-                $this->safeReleaseLock($name);
-                $this->currentServiceName = null;
-            }
+            // Lazy-construct the spawner only when at least one active
+            // service needs it. Installs with every service disabled
+            // shouldn't have to resolve PHP_BINARY / project dir.
+            $spawner ??= $this->resolveSpawner();
+            $results[] = $spawner->spawn($service['name'], false);
         }
         return $results;
+    }
+
+    /**
+     * Execute one already-fetched service row inline in the current process.
+     *
+     * Extracted from run() so that the run-all-due orchestrator can
+     * isolate each service via subprocess spawning while the single-
+     * named-service path continues to run inline. Called by the child
+     * side of a spawned subprocess (via run() with --name), not directly
+     * by the parent orchestrator.
+     *
+     * @param BackgroundServicesRow $service
+     * @return array{name: string, status: string}
+     */
+    private function runOne(array $service, bool $force): array
+    {
+        $name = $service['name'];
+
+        // ADOdb returns string values; use loose comparison for DB row checks.
+        // Note: the `running` column is not consulted here. acquireLock()
+        // is authoritative and can steal a lease left by a crashed worker.
+        if ($service['active'] == 0) {
+            return ['name' => $name, 'status' => 'skipped'];
+        }
+
+        // Manual-mode services (execute_interval = 0) require --force
+        if ($service['execute_interval'] == 0 && !$force) {
+            return ['name' => $name, 'status' => 'skipped'];
+        }
+
+        try {
+            $lockFailureReason = $this->acquireLock($service, $force);
+        } catch (SqlQueryException) {
+            return ['name' => $name, 'status' => 'error'];
+        }
+
+        if ($lockFailureReason !== null) {
+            return ['name' => $name, 'status' => $lockFailureReason];
+        }
+
+        // Only track for shutdown cleanup after lock is acquired
+        $this->currentServiceName = $name;
+
+        try {
+            $this->executeService($service);
+            return ['name' => $name, 'status' => 'executed'];
+        } catch (\Throwable) {
+            return ['name' => $name, 'status' => 'error'];
+        } finally {
+            $this->safeReleaseLock($name);
+            $this->currentServiceName = null;
+        }
+    }
+
+    /**
+     * Return the configured spawner, constructing the default
+     * SymfonyBackgroundServiceSpawner lazily if one was not injected.
+     *
+     * Kept separate so tests can inject a fake spawner via the
+     * constructor and avoid any PHP_BINARY / project-dir resolution.
+     */
+    private function resolveSpawner(): BackgroundServiceProcessSpawner
+    {
+        if ($this->spawner === null) {
+            $projectDir = OEGlobalsBag::getInstance()->getProjectDir();
+            $this->spawner = new SymfonyBackgroundServiceSpawner($projectDir, $this->logger);
+        }
+        return $this->spawner;
     }
 
     /**

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -51,6 +51,14 @@ class BackgroundServiceRunner
      */
     private const MAX_LEASE_MINUTES = 1440;
 
+    /**
+     * Slack added to the lease when computing the subprocess wall-clock
+     * timeout. The child's lease expires at lease_minutes; the parent
+     * waits a little longer so a child that's legitimately finishing up
+     * (flushing logs, closing connections) isn't killed on the boundary.
+     */
+    private const LEASE_GRACE_SECONDS = 60;
+
     private ?string $currentServiceName = null;
 
     private bool $shutdownRegistered = false;
@@ -146,7 +154,8 @@ class BackgroundServiceRunner
             // service needs it. Installs with every service disabled
             // shouldn't have to resolve PHP_BINARY / project dir.
             $spawner ??= $this->resolveSpawner();
-            $results[] = $spawner->spawn($service['name'], false);
+            $timeoutSeconds = $this->computeLeaseMinutes($service) * 60 + self::LEASE_GRACE_SECONDS;
+            $results[] = $spawner->spawn($service['name'], false, $timeoutSeconds);
         }
         return $results;
     }

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -59,6 +59,21 @@ class BackgroundServiceRunner
      */
     private const LEASE_GRACE_SECONDS = 60;
 
+    /**
+     * Name of the MySQL session-level advisory lock used to ensure only
+     * one run-all-due orchestrator runs concurrently across the whole
+     * database. An authenticated caller that repeatedly hits the HTTP
+     * run-all-due endpoint would otherwise be able to spawn
+     * N-services-worth of subprocesses per request; this lock makes the
+     * second concurrent invocation a no-op instead.
+     *
+     * GET_LOCK is session-scoped, so when the orchestrator process dies
+     * (SIGKILL, container restart, fatal), the DB session closes and the
+     * lock auto-releases. The name is prefixed with `openemr.` so it
+     * doesn't collide with anything else using GET_LOCK in the same DB.
+     */
+    private const ORCHESTRATOR_LOCK_NAME = 'openemr.bg_orchestrator';
+
     private ?string $currentServiceName = null;
 
     private bool $shutdownRegistered = false;
@@ -140,6 +155,29 @@ class BackgroundServiceRunner
      */
     private function runAllDueIsolated(): array
     {
+        // A single authenticated caller can trigger run-all-due via the
+        // HTTP endpoint. Without a global guard, N repeated requests
+        // would spawn N × (active services) subprocesses concurrently;
+        // each child's DB-level per-service lock would quickly reject
+        // the duplicate work, but the parent would still pay the cost
+        // of spawning, bootstrapping, and killing each child. The
+        // orchestrator lock collapses that into a single no-op result.
+        if (!$this->acquireOrchestratorLock()) {
+            return [['name' => 'orchestrator', 'status' => 'already_running']];
+        }
+
+        try {
+            return $this->runAllDueIsolatedUnlocked();
+        } finally {
+            $this->releaseOrchestratorLock();
+        }
+    }
+
+    /**
+     * @return list<array{name: string, status: string}>
+     */
+    private function runAllDueIsolatedUnlocked(): array
+    {
         $services = $this->getServices(null, false);
         $results = [];
         $spawner = null;
@@ -158,6 +196,50 @@ class BackgroundServiceRunner
             $results[] = $spawner->spawn($service['name'], false, $timeoutSeconds);
         }
         return $results;
+    }
+
+    /**
+     * Try to acquire the DB-wide orchestrator lock. Returns true on
+     * success (caller must release), false if another orchestrator is
+     * already running. Uses a session-level advisory lock (GET_LOCK)
+     * with a zero-second wait so the second concurrent caller fails
+     * fast rather than queueing.
+     */
+    protected function acquireOrchestratorLock(): bool
+    {
+        $row = QueryUtils::querySingleRow(
+            'SELECT GET_LOCK(?, 0) AS got',
+            [self::ORCHESTRATOR_LOCK_NAME],
+            false,
+        );
+        // GET_LOCK returns 1 on acquire, 0 on timeout, NULL on error.
+        // ADOdb may return either the native int or a numeric string
+        // depending on driver mode; accept both forms without casting
+        // through mixed (which PHPStan flags at level 9).
+        if (!is_array($row)) {
+            return false;
+        }
+        $got = $row['got'] ?? null;
+        return $got === 1 || $got === '1';
+    }
+
+    /**
+     * Release the orchestrator lock. Swallows errors because the lock
+     * auto-releases when the DB session closes; a failure here would
+     * at worst delay the next orchestrator tick by up to one cron
+     * interval (when FPM recycles the connection).
+     */
+    protected function releaseOrchestratorLock(): void
+    {
+        try {
+            QueryUtils::fetchRecordsNoLog(
+                'SELECT RELEASE_LOCK(?) AS released',
+                [self::ORCHESTRATOR_LOCK_NAME],
+            );
+        } catch (SqlQueryException) {
+            // Best-effort: GET_LOCK is session-scoped and will auto-release
+            // when the PHP process (and therefore the DB connection) ends.
+        }
     }
 
     /**

--- a/src/Services/Background/SymfonyBackgroundServiceSpawner.php
+++ b/src/Services/Background/SymfonyBackgroundServiceSpawner.php
@@ -66,6 +66,18 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
      */
     private const SERVICE_NAME_LOG_MAX = 64;
 
+    /**
+     * Env var the parent passes to the child carrying a per-invocation
+     * nonce. The child command emits the nonce as part of its JSON
+     * result and the parent rejects any JSON line whose nonce doesn't
+     * match. This closes the spoofing window where a
+     * `register_shutdown_function()` in the service's code prints a
+     * forged `{name, status}` line AFTER the command's legitimate one;
+     * without the nonce check the reverse-scanning parser would find
+     * the forged line first (CWE-345).
+     */
+    private const NONCE_ENV_VAR = 'OPENEMR_BG_NONCE';
+
     private LoggerInterface $logger;
 
     /**
@@ -100,7 +112,17 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
             $args[] = '--force';
         }
 
-        $process = new Process($args);
+        // Fresh nonce per invocation. 128 bits of randomness is enough to
+        // make guessing infeasible; the child reads it from env and echoes
+        // it in the JSON result, and the parent accepts the result only if
+        // the nonce matches.
+        $nonce = bin2hex(random_bytes(16));
+
+        // Symfony Process merges the supplied env with the parent's env by
+        // default (unlike the raw `proc_open` contract). So passing just
+        // the nonce here is enough; PATH, HOME, database credentials, etc.
+        // all still propagate.
+        $process = new Process($args, env: [self::NONCE_ENV_VAR => $nonce]);
         // Wall-clock cap derived from the service's computed lease so a hung
         // child cannot block the cron slot past its DB-side lease. Idle
         // timeout mirrors the hard cap: a service that produces no output
@@ -188,7 +210,7 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
             return ['name' => $name, 'status' => 'error'];
         }
 
-        $status = $this->parseJsonStatus($stdout, $name);
+        $status = $this->parseJsonStatus($stdout, $name, $nonce);
         if ($status === null) {
             // exit(0) without emitting a valid JSON status for the
             // expected service name means either the child terminated
@@ -215,11 +237,13 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
      * Scans from the end so any pre-bootstrap notices written to stdout
      * (deprecation warnings, misconfigured session_start, etc.) before
      * the command printed its result line are ignored. Validates that
-     * the line is tagged with the expected service name and an allowlisted
-     * status value so a misbehaving service cannot spoof its own status
-     * by printing a crafted JSON line before the command's own.
+     * the line is tagged with the expected service name, an allowlisted
+     * status value, AND the per-invocation nonce the parent passed to the
+     * child via env. Without the nonce check a `register_shutdown_function`
+     * in the service's own code could print a forged status line AFTER
+     * the command's legitimate one and win the reverse scan (CWE-345).
      */
-    private function parseJsonStatus(string $stdout, string $expectedName): ?string
+    private function parseJsonStatus(string $stdout, string $expectedName, string $expectedNonce): ?string
     {
         $lines = preg_split('/\R/', trim($stdout));
         if ($lines === false) {
@@ -233,6 +257,14 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
             }
             $decoded = json_decode($line, true);
             if (!is_array($decoded)) {
+                continue;
+            }
+            // hash_equals is not strictly required here (the nonce is
+            // freshly generated, never persisted, and not a secret
+            // protecting anything else) but costs little and communicates
+            // intent: the comparison is for authentication, not lookup.
+            $decodedNonce = $decoded['nonce'] ?? null;
+            if (!is_string($decodedNonce) || !hash_equals($expectedNonce, $decodedNonce)) {
                 continue;
             }
             $decodedName = $decoded['name'] ?? null;

--- a/src/Services/Background/SymfonyBackgroundServiceSpawner.php
+++ b/src/Services/Background/SymfonyBackgroundServiceSpawner.php
@@ -20,10 +20,32 @@ namespace OpenEMR\Services\Background;
 
 use OpenEMR\BC\ServiceContainer;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
 final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServiceProcessSpawner
 {
+    /**
+     * Allowlist of status values the parent accepts from the child. Anything
+     * else is treated as a spoofed/corrupt line and the result is coerced to
+     * 'error'. Keep aligned with BackgroundServiceRunner::runOne().
+     */
+    private const ALLOWED_STATUSES = [
+        'executed',
+        'skipped',
+        'already_running',
+        'not_due',
+        'error',
+        'not_found',
+    ];
+
+    /**
+     * Cap for stderr/stdout snippets persisted in log context. Long enough
+     * to capture a typical stack trace header, short enough that a service
+     * dumping megabytes of output can't flood central logs.
+     */
+    private const LOG_SNIPPET_MAX = 2000;
+
     private LoggerInterface $logger;
 
     /**
@@ -44,7 +66,7 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
         $this->logger = $logger ?? ServiceContainer::getLogger();
     }
 
-    public function spawn(string $name, bool $force): array
+    public function spawn(string $name, bool $force, int $timeoutSeconds): array
     {
         $args = [
             $this->phpBinary,
@@ -59,12 +81,31 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
         }
 
         $process = new Process($args);
-        // Disable the default 60s timeout. Service runtime is bounded by
-        // the lease (see BackgroundServiceRunner::computeLeaseMinutes) and
-        // expected durations vary widely across services. A hung service
-        // is a lease problem, not a process-timeout problem.
-        $process->setTimeout(null);
-        $process->run();
+        // Wall-clock cap derived from the service's computed lease so a hung
+        // child cannot block the cron slot past its DB-side lease. Idle
+        // timeout mirrors the hard cap: a service that produces no output
+        // for its entire lease window is indistinguishable from a hang for
+        // orchestration purposes.
+        $process->setTimeout($timeoutSeconds);
+        $process->setIdleTimeout($timeoutSeconds);
+
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException) {
+            // Best-effort terminate. 5s grace for SIGTERM before SIGKILL so
+            // a cooperative child can flush buffers / release in-memory
+            // resources; we've already exceeded the lease so we don't wait
+            // indefinitely for it to clean up.
+            $process->stop(5);
+            $this->logger->warning(
+                'Background service subprocess timed out.',
+                [
+                    'service' => $name,
+                    'timeout_seconds' => $timeoutSeconds,
+                ],
+            );
+            return ['name' => $name, 'status' => 'error'];
+        }
 
         $exitCode = $process->getExitCode();
         if ($exitCode !== 0) {
@@ -76,24 +117,25 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
                 [
                     'service' => $name,
                     'exit_code' => $exitCode,
-                    'stderr' => $process->getErrorOutput(),
+                    'stderr' => $this->safeLogSnippet($process->getErrorOutput()),
                 ],
             );
             return ['name' => $name, 'status' => 'error'];
         }
 
-        $status = $this->parseJsonStatus($process->getOutput());
+        $status = $this->parseJsonStatus($process->getOutput(), $name);
         if ($status === null) {
-            // exit(0) without emitting the expected JSON line means the
-            // child terminated cleanly mid-execution without going
-            // through the command's return path. Still an isolation
-            // event. Log and flag as error so the orchestrator's
-            // result set reflects reality.
+            // exit(0) without emitting a valid JSON status for the
+            // expected service name means either the child terminated
+            // cleanly mid-execution or a misbehaving service printed a
+            // line we can't trust. Either way, it's an isolation event.
+            // Log and flag as error so the orchestrator's result set
+            // reflects reality.
             $this->logger->warning(
-                'Background service subprocess exited cleanly but emitted no JSON status.',
+                'Background service subprocess exited cleanly but emitted no valid JSON status.',
                 [
                     'service' => $name,
-                    'stdout' => $process->getOutput(),
+                    'stdout' => $this->safeLogSnippet($process->getOutput()),
                 ],
             );
             return ['name' => $name, 'status' => 'error'];
@@ -107,9 +149,12 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
      *
      * Scans from the end so any pre-bootstrap notices written to stdout
      * (deprecation warnings, misconfigured session_start, etc.) before
-     * the command printed its result line are ignored.
+     * the command printed its result line are ignored. Validates that
+     * the line is tagged with the expected service name and an allowlisted
+     * status value so a misbehaving service cannot spoof its own status
+     * by printing a crafted JSON line before the command's own.
      */
-    private function parseJsonStatus(string $stdout): ?string
+    private function parseJsonStatus(string $stdout, string $expectedName): ?string
     {
         $lines = preg_split('/\R/', trim($stdout));
         if ($lines === false) {
@@ -122,10 +167,38 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
                 continue;
             }
             $decoded = json_decode($line, true);
-            if (is_array($decoded) && isset($decoded['status']) && is_string($decoded['status'])) {
-                return $decoded['status'];
+            if (!is_array($decoded)) {
+                continue;
             }
+            $decodedName = $decoded['name'] ?? null;
+            if ($decodedName !== $expectedName) {
+                continue;
+            }
+            $status = $decoded['status'] ?? null;
+            if (!is_string($status) || !in_array($status, self::ALLOWED_STATUSES, true)) {
+                continue;
+            }
+            return $status;
         }
         return null;
+    }
+
+    /**
+     * Sanitize a subprocess output stream for inclusion in a log context.
+     *
+     * Strips ASCII control characters (except newline and tab) so that a
+     * malicious or buggy service cannot forge log lines via CR/LF/BEL,
+     * and truncates to LOG_SNIPPET_MAX bytes. Full output is not
+     * preserved; operators with access to the host can inspect the
+     * service directly.
+     */
+    private function safeLogSnippet(string $raw): string
+    {
+        $sanitized = preg_replace('/[\x00-\x08\x0B-\x1F\x7F]/', '', $raw) ?? '';
+        $sanitized = str_replace(["\r\n", "\r"], "\n", $sanitized);
+        if (strlen($sanitized) > self::LOG_SNIPPET_MAX) {
+            $sanitized = substr($sanitized, 0, self::LOG_SNIPPET_MAX) . '…[truncated]';
+        }
+        return $sanitized;
     }
 }

--- a/src/Services/Background/SymfonyBackgroundServiceSpawner.php
+++ b/src/Services/Background/SymfonyBackgroundServiceSpawner.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * Default BackgroundServiceProcessSpawner implementation. Launches each
+ * service via `php bin/console background:services run --name=<name>
+ * --json` using symfony/process and parses a single JSON result line
+ * from the child's stdout.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\Background;
+
+use OpenEMR\BC\ServiceContainer;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Process\Process;
+
+final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServiceProcessSpawner
+{
+    private LoggerInterface $logger;
+
+    /**
+     * @param string      $projectDir Absolute path to the OpenEMR project
+     *                                root (used to locate bin/console).
+     * @param string      $phpBinary  Absolute path to the PHP binary the
+     *                                child should run under. Defaults to
+     *                                PHP_BINARY, which matches the PHP
+     *                                currently running the parent,
+     *                                aligning FPM/CLI extensions, INI
+     *                                settings, and version.
+     */
+    public function __construct(
+        private string $projectDir,
+        ?LoggerInterface $logger = null,
+        private string $phpBinary = PHP_BINARY,
+    ) {
+        $this->logger = $logger ?? ServiceContainer::getLogger();
+    }
+
+    public function spawn(string $name, bool $force): array
+    {
+        $args = [
+            $this->phpBinary,
+            $this->projectDir . '/bin/console',
+            'background:services',
+            'run',
+            '--name=' . $name,
+            '--json',
+        ];
+        if ($force) {
+            $args[] = '--force';
+        }
+
+        $process = new Process($args);
+        // Disable the default 60s timeout. Service runtime is bounded by
+        // the lease (see BackgroundServiceRunner::computeLeaseMinutes) and
+        // expected durations vary widely across services. A hung service
+        // is a lease problem, not a process-timeout problem.
+        $process->setTimeout(null);
+        $process->run();
+
+        $exitCode = $process->getExitCode();
+        if ($exitCode !== 0) {
+            // Non-zero exit is how exit(N != 0), die(), and PHP fatals
+            // surface. Log the service name loudly so operators can find
+            // the offender without cross-referencing stdout/stderr.
+            $this->logger->warning(
+                'Background service subprocess exited non-zero.',
+                [
+                    'service' => $name,
+                    'exit_code' => $exitCode,
+                    'stderr' => $process->getErrorOutput(),
+                ],
+            );
+            return ['name' => $name, 'status' => 'error'];
+        }
+
+        $status = $this->parseJsonStatus($process->getOutput());
+        if ($status === null) {
+            // exit(0) without emitting the expected JSON line means the
+            // child terminated cleanly mid-execution without going
+            // through the command's return path. Still an isolation
+            // event. Log and flag as error so the orchestrator's
+            // result set reflects reality.
+            $this->logger->warning(
+                'Background service subprocess exited cleanly but emitted no JSON status.',
+                [
+                    'service' => $name,
+                    'stdout' => $process->getOutput(),
+                ],
+            );
+            return ['name' => $name, 'status' => 'error'];
+        }
+        return ['name' => $name, 'status' => $status];
+    }
+
+    /**
+     * Locate and decode the trailing JSON status line produced by
+     * `background:services run --name=<name> --json`.
+     *
+     * Scans from the end so any pre-bootstrap notices written to stdout
+     * (deprecation warnings, misconfigured session_start, etc.) before
+     * the command printed its result line are ignored.
+     */
+    private function parseJsonStatus(string $stdout): ?string
+    {
+        $lines = preg_split('/\R/', trim($stdout));
+        if ($lines === false) {
+            return null;
+        }
+
+        for ($i = count($lines) - 1; $i >= 0; $i--) {
+            $line = trim($lines[$i]);
+            if ($line === '' || $line[0] !== '{') {
+                continue;
+            }
+            $decoded = json_decode($line, true);
+            if (is_array($decoded) && isset($decoded['status']) && is_string($decoded['status'])) {
+                return $decoded['status'];
+            }
+        }
+        return null;
+    }
+}

--- a/src/Services/Background/SymfonyBackgroundServiceSpawner.php
+++ b/src/Services/Background/SymfonyBackgroundServiceSpawner.php
@@ -46,6 +46,26 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
      */
     private const LOG_SNIPPET_MAX = 2000;
 
+    /**
+     * Cap on in-memory buffering of each of the child's output streams.
+     * Symfony Process's default buffering grows unbounded; a misbehaving
+     * service that writes gigabytes to stdout/stderr would force the
+     * parent to allocate all of it before we ever look at it. The parent
+     * only needs a small tail of each stream (final JSON line, stack
+     * trace header) so we stream-read with a ceiling and stop the child
+     * on overflow. 64KiB is large enough to cover a verbose stack trace
+     * header but small enough to be cheap.
+     */
+    private const BUFFER_MAX_BYTES = 65536;
+
+    /**
+     * Cap on how many characters of the service name are persisted in
+     * log context. Service names originate from the DB so in theory they
+     * are operator-controlled, but treating them as untrusted for logging
+     * lets this class stay defensible in isolation.
+     */
+    private const SERVICE_NAME_LOG_MAX = 64;
+
     private LoggerInterface $logger;
 
     /**
@@ -89,8 +109,37 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
         $process->setTimeout($timeoutSeconds);
         $process->setIdleTimeout($timeoutSeconds);
 
+        // Stream each pipe into a local buffer with a hard per-stream
+        // ceiling. Symfony's internal buffering is unbounded, so without
+        // this a child dumping gigabytes of output would force the parent
+        // to allocate all of it. On overflow we kill the child immediately
+        // (stop(0)): we already have enough bytes for diagnostics, and
+        // continuing to read wastes CPU and RAM on output we'll never use.
+        $stdout = '';
+        $stderr = '';
+        $overflowed = false;
+        $callback = function (string $type, string $buffer) use (&$stdout, &$stderr, &$overflowed, $process): void {
+            if ($type === Process::OUT) {
+                if (strlen($stdout) < self::BUFFER_MAX_BYTES) {
+                    $stdout .= $buffer;
+                    if (strlen($stdout) >= self::BUFFER_MAX_BYTES) {
+                        $overflowed = true;
+                        $process->stop(0);
+                    }
+                }
+            } elseif ($type === Process::ERR) {
+                if (strlen($stderr) < self::BUFFER_MAX_BYTES) {
+                    $stderr .= $buffer;
+                    if (strlen($stderr) >= self::BUFFER_MAX_BYTES) {
+                        $overflowed = true;
+                        $process->stop(0);
+                    }
+                }
+            }
+        };
+
         try {
-            $process->run();
+            $process->run($callback);
         } catch (ProcessTimedOutException) {
             // Best-effort terminate. 5s grace for SIGTERM before SIGKILL so
             // a cooperative child can flush buffers / release in-memory
@@ -100,8 +149,24 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
             $this->logger->warning(
                 'Background service subprocess timed out.',
                 [
-                    'service' => $name,
+                    'service' => $this->safeServiceName($name),
                     'timeout_seconds' => $timeoutSeconds,
+                ],
+            );
+            return ['name' => $name, 'status' => 'error'];
+        }
+
+        if ($overflowed) {
+            // Child exceeded the per-stream output cap. Treat as an
+            // isolation event: the subprocess was killed mid-stream, so
+            // the remaining output and (most likely) the final JSON
+            // status line are lost. Log and flag as error.
+            $this->logger->warning(
+                'Background service subprocess exceeded output buffer cap and was terminated.',
+                [
+                    'service' => $this->safeServiceName($name),
+                    'buffer_max_bytes' => self::BUFFER_MAX_BYTES,
+                    'stderr' => $this->safeLogSnippet($stderr),
                 ],
             );
             return ['name' => $name, 'status' => 'error'];
@@ -115,15 +180,15 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
             $this->logger->warning(
                 'Background service subprocess exited non-zero.',
                 [
-                    'service' => $name,
+                    'service' => $this->safeServiceName($name),
                     'exit_code' => $exitCode,
-                    'stderr' => $this->safeLogSnippet($process->getErrorOutput()),
+                    'stderr' => $this->safeLogSnippet($stderr),
                 ],
             );
             return ['name' => $name, 'status' => 'error'];
         }
 
-        $status = $this->parseJsonStatus($process->getOutput(), $name);
+        $status = $this->parseJsonStatus($stdout, $name);
         if ($status === null) {
             // exit(0) without emitting a valid JSON status for the
             // expected service name means either the child terminated
@@ -134,8 +199,8 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
             $this->logger->warning(
                 'Background service subprocess exited cleanly but emitted no valid JSON status.',
                 [
-                    'service' => $name,
-                    'stdout' => $this->safeLogSnippet($process->getOutput()),
+                    'service' => $this->safeServiceName($name),
+                    'stdout' => $this->safeLogSnippet($stdout),
                 ],
             );
             return ['name' => $name, 'status' => 'error'];
@@ -186,18 +251,45 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
     /**
      * Sanitize a subprocess output stream for inclusion in a log context.
      *
-     * Strips ASCII control characters (except newline and tab) so that a
-     * malicious or buggy service cannot forge log lines via CR/LF/BEL,
-     * and truncates to LOG_SNIPPET_MAX bytes. Full output is not
-     * preserved; operators with access to the host can inspect the
-     * service directly.
+     * Strips ASCII control characters (except newline and tab), then
+     * escapes remaining newlines and tabs to their literal `\n`/`\t`
+     * forms so a single call to a line-oriented log backend (syslog,
+     * journald, plain-text files) cannot be split across multiple
+     * records by embedded whitespace. Truncates to LOG_SNIPPET_MAX
+     * bytes. Full output is not preserved; operators with access to
+     * the host can inspect the service directly.
      */
     private function safeLogSnippet(string $raw): string
     {
         $sanitized = preg_replace('/[\x00-\x08\x0B-\x1F\x7F]/', '', $raw) ?? '';
         $sanitized = str_replace(["\r\n", "\r"], "\n", $sanitized);
+        // Escape after control-char strip/normalize so the only newlines
+        // and tabs still present are the legitimate ones from child
+        // output, and every one of them becomes visible as a literal
+        // `\n`/`\t` in the log record rather than a control byte.
+        $sanitized = str_replace(["\n", "\t"], ['\\n', '\\t'], $sanitized);
         if (strlen($sanitized) > self::LOG_SNIPPET_MAX) {
             $sanitized = substr($sanitized, 0, self::LOG_SNIPPET_MAX) . '…[truncated]';
+        }
+        return $sanitized;
+    }
+
+    /**
+     * Sanitize a service name for inclusion in a log context.
+     *
+     * Service names come from the `background_services.name` column,
+     * which is operator-controlled in normal operation. Treat them as
+     * untrusted for logging anyway: strip all ASCII control characters
+     * (including newline and tab) and truncate to SERVICE_NAME_LOG_MAX
+     * so a misconfigured row can't smuggle a forged log line into the
+     * warning record. Unlike `safeLogSnippet`, no embedded whitespace
+     * is preserved since a legitimate service name never contains any.
+     */
+    private function safeServiceName(string $name): string
+    {
+        $sanitized = preg_replace('/[\x00-\x1F\x7F]/', '', $name) ?? '';
+        if (strlen($sanitized) > self::SERVICE_NAME_LOG_MAX) {
+            $sanitized = substr($sanitized, 0, self::SERVICE_NAME_LOG_MAX) . '…[truncated]';
         }
         return $sanitized;
     }

--- a/tests/Tests/Isolated/Common/Command/BackgroundServicesCommandTest.php
+++ b/tests/Tests/Isolated/Common/Command/BackgroundServicesCommandTest.php
@@ -303,6 +303,10 @@ class BackgroundServicesCommandTest extends TestCase
      * line on stdout and suppresses human-readable output. This is the
      * contract consumed by SymfonyBackgroundServiceSpawner in the
      * run-all-due orchestrator.
+     *
+     * The JSON also reflects the per-invocation nonce from OPENEMR_BG_NONCE
+     * so the parent orchestrator can authenticate the status line against
+     * forged lines printed by the service's own shutdown handlers (CWE-345).
      */
     public function testRunEmitsJsonLineWhenJsonOptionGiven(): void
     {
@@ -312,7 +316,12 @@ class BackgroundServicesCommandTest extends TestCase
         );
         $tester = $this->createTester($command);
 
-        $tester->execute(['action' => 'run', '--name' => 'phimail', '--json' => true]);
+        putenv('OPENEMR_BG_NONCE=nonce-under-test');
+        try {
+            $tester->execute(['action' => 'run', '--name' => 'phimail', '--json' => true]);
+        } finally {
+            putenv('OPENEMR_BG_NONCE');
+        }
 
         $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
         $output = trim($tester->getDisplay());
@@ -324,7 +333,10 @@ class BackgroundServicesCommandTest extends TestCase
         ));
         $this->assertCount(1, $lines, "Expected exactly one output line in --json mode, got: {$output}");
         $decoded = json_decode($lines[0], true);
-        $this->assertSame(['name' => 'phimail', 'status' => 'executed'], $decoded);
+        $this->assertSame(
+            ['name' => 'phimail', 'status' => 'executed', 'nonce' => 'nonce-under-test'],
+            $decoded,
+        );
     }
 
     public function testRunJsonModePropagatesErrorExitCode(): void
@@ -335,6 +347,10 @@ class BackgroundServicesCommandTest extends TestCase
         );
         $tester = $this->createTester($command);
 
+        // No nonce set: the command emits an empty-string nonce, which
+        // the parent parser rejects. A direct CLI operator calling the
+        // command outside the orchestrator never parses the JSON, so
+        // the empty nonce is harmless in that path.
         $tester->execute(['action' => 'run', '--name' => 'phimail', '--json' => true]);
 
         $this->assertSame(Command::FAILURE, $tester->getStatusCode());
@@ -345,7 +361,7 @@ class BackgroundServicesCommandTest extends TestCase
         ));
         $this->assertCount(1, $lines);
         $this->assertSame(
-            ['name' => 'phimail', 'status' => 'error'],
+            ['name' => 'phimail', 'status' => 'error', 'nonce' => ''],
             json_decode($lines[0], true),
         );
     }

--- a/tests/Tests/Isolated/Common/Command/BackgroundServicesCommandTest.php
+++ b/tests/Tests/Isolated/Common/Command/BackgroundServicesCommandTest.php
@@ -298,6 +298,73 @@ class BackgroundServicesCommandTest extends TestCase
         $this->assertTrue($command->runner->lastForce);
     }
 
+    /**
+     * With --name and --json, the command emits exactly one JSON result
+     * line on stdout and suppresses human-readable output. This is the
+     * contract consumed by SymfonyBackgroundServiceSpawner in the
+     * run-all-due orchestrator.
+     */
+    public function testRunEmitsJsonLineWhenJsonOptionGiven(): void
+    {
+        $command = new BackgroundServicesCommandStub(
+            services: [],
+            runnerResults: [['name' => 'phimail', 'status' => 'executed']],
+        );
+        $tester = $this->createTester($command);
+
+        $tester->execute(['action' => 'run', '--name' => 'phimail', '--json' => true]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = trim($tester->getDisplay());
+        // Drop any banner spacing. The JSON line should be the only
+        // non-empty content emitted in --json mode.
+        $lines = array_values(array_filter(
+            preg_split('/\R/', $output) ?: [],
+            static fn($line) => trim((string) $line) !== '',
+        ));
+        $this->assertCount(1, $lines, "Expected exactly one output line in --json mode, got: {$output}");
+        $decoded = json_decode($lines[0], true);
+        $this->assertSame(['name' => 'phimail', 'status' => 'executed'], $decoded);
+    }
+
+    public function testRunJsonModePropagatesErrorExitCode(): void
+    {
+        $command = new BackgroundServicesCommandStub(
+            services: [],
+            runnerResults: [['name' => 'phimail', 'status' => 'error']],
+        );
+        $tester = $this->createTester($command);
+
+        $tester->execute(['action' => 'run', '--name' => 'phimail', '--json' => true]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $output = trim($tester->getDisplay());
+        $lines = array_values(array_filter(
+            preg_split('/\R/', $output) ?: [],
+            static fn($line) => trim((string) $line) !== '',
+        ));
+        $this->assertCount(1, $lines);
+        $this->assertSame(
+            ['name' => 'phimail', 'status' => 'error'],
+            json_decode($lines[0], true),
+        );
+    }
+
+    public function testRunJsonWithoutNameIsRejected(): void
+    {
+        // --json only makes sense for a single-service run. The
+        // run-all-due orchestrator never invokes this command without
+        // a name, so --json without --name is almost certainly a
+        // misuse. Fail fast instead of silently honoring it.
+        $command = new BackgroundServicesCommandStub(services: [], runnerResults: []);
+        $tester = $this->createTester($command);
+
+        $tester->execute(['action' => 'run', '--json' => true]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('--json requires --name', $tester->getDisplay());
+    }
+
     public function testUnknownAction(): void
     {
         $command = new BackgroundServicesCommandStub([]);

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Services\Background;
 
+use OpenEMR\Common\Database\SqlQueryException;
 use OpenEMR\Common\Database\TableTypes;
 use OpenEMR\Services\Background\BackgroundServiceProcessSpawner;
 use OpenEMR\Services\Background\BackgroundServiceRunner;
+use OpenEMR\Services\Background\SymfonyBackgroundServiceSpawner;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -270,6 +272,92 @@ class BackgroundServiceRunnerTest extends TestCase
         $this->assertTrue($executed);
     }
 
+    public function testRunTreatsEmptyStringServiceNameAsRunAllDue(): void
+    {
+        // The HTTP layer (and some CLI callers) can't always distinguish
+        // "no service name given" from "service name given as empty
+        // string". Both must funnel into the run-all-due path; any other
+        // handling would either spawn no subprocesses or try to look up
+        // a zero-length service name.
+        $spawner = new RecordingSpawner(['svc1' => 'executed']);
+        $runner = new BackgroundServiceRunnerStub(
+            services: [self::makeService('svc1')],
+            spawner: $spawner,
+        );
+
+        $results = $runner->run('');
+
+        // Run-all-due path was taken (single active service spawned)
+        // rather than the single-named path (which would have returned
+        // 'not_found' for the empty-string lookup).
+        $this->assertSame([['name' => 'svc1', 'status' => 'executed']], $results);
+        $this->assertSame(['svc1'], $spawner->spawnedNames);
+    }
+
+    public function testRunOneReturnsErrorWhenAcquireLockThrowsSqlQueryException(): void
+    {
+        // acquireLock raises SqlQueryException on transient DB failure
+        // (deadlock, dropped connection, lock-wait timeout). The runOne
+        // catch must surface that as status=error rather than
+        // propagating out of the orchestrator and aborting the
+        // remaining services in the same tick.
+        $runner = new BackgroundServiceRunnerStub(
+            services: [self::makeService('svc1')],
+            acquireLockThrows: new SqlQueryException(
+                sqlStatement: 'UPDATE background_services …',
+                message: 'db died',
+            ),
+        );
+
+        $results = $runner->run('svc1');
+
+        $this->assertSame([['name' => 'svc1', 'status' => 'error']], $results);
+        // The lock was never acquired, so releaseLock must not be called.
+        // A release against an un-acquired lease would be wrong: it could
+        // free another worker's in-flight lease if two stubs shared state.
+        $this->assertSame([], $runner->releasedLocks);
+    }
+
+    public function testResolveSpawnerLazilyConstructsDefaultSymfonySpawner(): void
+    {
+        // When no spawner is injected, the runner must defer constructing
+        // the default SymfonyBackgroundServiceSpawner until at least one
+        // active service needs it. This avoids resolving PHP_BINARY /
+        // project dir on an all-disabled install. Verified by invoking
+        // the private resolveSpawner() via reflection and asserting the
+        // returned instance is memoized across calls.
+        $priorFileroot = $GLOBALS['fileroot'] ?? null;
+        $GLOBALS['fileroot'] = sys_get_temp_dir();
+        try {
+            $runner = new BackgroundServiceRunner(new NullLogger());
+            $method = new \ReflectionMethod($runner, 'resolveSpawner');
+            $first = $method->invoke($runner);
+            $second = $method->invoke($runner);
+
+            $this->assertInstanceOf(SymfonyBackgroundServiceSpawner::class, $first);
+            $this->assertSame($first, $second, 'resolveSpawner must memoize so PHP_BINARY/project dir are resolved at most once');
+        } finally {
+            if ($priorFileroot === null) {
+                unset($GLOBALS['fileroot']);
+            } else {
+                $GLOBALS['fileroot'] = $priorFileroot;
+            }
+        }
+    }
+
+    public function testResolveSpawnerReturnsInjectedSpawnerWithoutConstructingDefault(): void
+    {
+        // When a spawner is injected via the constructor, resolveSpawner
+        // must return it unchanged — never fall through to the default
+        // construction path (which would resolve PHP_BINARY and project
+        // dir, needlessly).
+        $injected = new RecordingSpawner([]);
+        $runner = new BackgroundServiceRunner(new NullLogger(), $injected);
+        $method = new \ReflectionMethod($runner, 'resolveSpawner');
+
+        $this->assertSame($injected, $method->invoke($runner));
+    }
+
     /**
      * @return BackgroundServicesRow
      */
@@ -314,6 +402,9 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
      * @param string|null $lockFailureReason Null means lock acquired; a string is the failure reason returned to run()
      * @param (\Closure(BackgroundServicesRow): void)|null $executeCallback
      * @param bool $orchestratorLockAcquirable False simulates a second concurrent orchestrator attempt
+     * @param \Throwable|null $acquireLockThrows Exception to throw from acquireLock()
+     *        (simulates DB errors during lease acquire). When non-null, takes
+     *        precedence over $lockFailureReason.
      */
     public function __construct(
         private readonly array $services = [],
@@ -321,6 +412,7 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
         private readonly ?\Closure $executeCallback = null,
         ?BackgroundServiceProcessSpawner $spawner = null,
         private readonly bool $orchestratorLockAcquirable = true,
+        private readonly ?\Throwable $acquireLockThrows = null,
     ) {
         parent::__construct(new NullLogger(), $spawner);
     }
@@ -338,6 +430,9 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
 
     protected function acquireLock(array $service, bool $force): ?string
     {
+        if ($this->acquireLockThrows !== null) {
+            throw $this->acquireLockThrows;
+        }
         return $this->lockFailureReason;
     }
 

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -158,6 +158,32 @@ class BackgroundServiceRunnerTest extends TestCase
         $this->assertSame(['svc1', 'svc2'], $spawner->spawnedNames);
     }
 
+    public function testRunAllPassesLeaseDerivedTimeoutToSpawner(): void
+    {
+        // The spawner must receive a wall-clock cap tied to the service's
+        // computed lease so a hung child cannot block the cron slot past
+        // its DB-side lease (CWE-400 mitigation from PR review).
+        // execute_interval=5 -> max(MIN_LEASE=60, 5*2=10) = 60 min
+        // -> (60 * 60) + LEASE_GRACE_SECONDS (60) = 3660s.
+        // execute_interval=120 -> max(60, 240) = 240 min
+        // -> (240 * 60) + 60 = 14460s.
+        $spawner = new RecordingSpawner([
+            'short_interval_svc' => 'executed',
+            'long_interval_svc' => 'executed',
+        ]);
+        $runner = new BackgroundServiceRunnerStub(
+            services: [
+                self::makeService('short_interval_svc', executeInterval: 5),
+                self::makeService('long_interval_svc', executeInterval: 120),
+            ],
+            spawner: $spawner,
+        );
+
+        $runner->run();
+
+        $this->assertSame([3660, 14460], $spawner->timeoutArgs);
+    }
+
     public function testRunAllNeverPassesForceToSpawner(): void
     {
         // Even if the --force flag somehow reached run(null, true),
@@ -294,6 +320,9 @@ class RecordingSpawner implements BackgroundServiceProcessSpawner
     /** @var list<bool> */
     public array $forceArgs = [];
 
+    /** @var list<int> */
+    public array $timeoutArgs = [];
+
     /**
      * @param array<string, string> $statusByName
      */
@@ -301,10 +330,11 @@ class RecordingSpawner implements BackgroundServiceProcessSpawner
     {
     }
 
-    public function spawn(string $name, bool $force): array
+    public function spawn(string $name, bool $force, int $timeoutSeconds): array
     {
         $this->spawnedNames[] = $name;
         $this->forceArgs[] = $force;
+        $this->timeoutArgs[] = $timeoutSeconds;
         return ['name' => $name, 'status' => $this->statusByName[$name] ?? 'error'];
     }
 }

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Isolated\Services\Background;
 
 use OpenEMR\Common\Database\TableTypes;
+use OpenEMR\Services\Background\BackgroundServiceProcessSpawner;
 use OpenEMR\Services\Background\BackgroundServiceRunner;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 /**
  * @phpstan-import-type BackgroundServicesRow from TableTypes
@@ -97,26 +99,81 @@ class BackgroundServiceRunnerTest extends TestCase
         $this->assertContains('svc1', $runner->releasedLocks);
     }
 
-    public function testRunAllServicesInOrder(): void
+    public function testRunAllDelegatesActiveServicesToSpawnerInOrder(): void
     {
-        $order = [];
+        // Run-all-due isolates each active service behind a subprocess
+        // boundary so that exit()/die()/fatals in one service cannot
+        // abort subsequent services in the same tick (GH #11794).
+        // The parent loop skips inactive services without spawning;
+        // inactivity is trivially decidable from the row.
+        $spawner = new RecordingSpawner([
+            'svc1' => 'executed',
+            'svc2' => 'not_due',
+        ]);
         $runner = new BackgroundServiceRunnerStub(
             services: [
                 self::makeService('svc1'),
                 self::makeService('svc2'),
                 self::makeService('svc3', active: false),
             ],
-            executeCallback: function (array $service) use (&$order): void {
-                $order[] = $service['name'];
-            },
+            spawner: $spawner,
         );
+
         $results = $runner->run();
 
-        $this->assertCount(3, $results);
-        $this->assertSame('executed', $results[0]['status']);
+        $this->assertSame(
+            [
+                ['name' => 'svc1', 'status' => 'executed'],
+                ['name' => 'svc2', 'status' => 'not_due'],
+                ['name' => 'svc3', 'status' => 'skipped'],
+            ],
+            $results,
+        );
+        // Inactive services must never be spawned. Skip is a pure
+        // parent-side decision and spawning one wastes a bootstrap.
+        $this->assertSame(['svc1', 'svc2'], $spawner->spawnedNames);
+    }
+
+    public function testRunAllContinuesAfterSpawnerReportsError(): void
+    {
+        // Regression guard for GH #11794: a service whose subprocess
+        // exits abnormally (surfaced by the spawner as status=error)
+        // must not prevent subsequent services from being spawned.
+        $spawner = new RecordingSpawner([
+            'svc1' => 'error',
+            'svc2' => 'executed',
+        ]);
+        $runner = new BackgroundServiceRunnerStub(
+            services: [
+                self::makeService('svc1'),
+                self::makeService('svc2'),
+            ],
+            spawner: $spawner,
+        );
+
+        $results = $runner->run();
+
+        $this->assertSame('error', $results[0]['status']);
         $this->assertSame('executed', $results[1]['status']);
-        $this->assertSame('skipped', $results[2]['status']);
-        $this->assertSame(['svc1', 'svc2'], $order);
+        $this->assertSame(['svc1', 'svc2'], $spawner->spawnedNames);
+    }
+
+    public function testRunAllNeverPassesForceToSpawner(): void
+    {
+        // Even if the --force flag somehow reached run(null, true),
+        // the orchestrator deliberately drops it. The run-all-due
+        // path must behave identically to a pure cron-equivalent
+        // advance to stay consistent with the command's documented
+        // "--force is ignored without --name" semantics.
+        $spawner = new RecordingSpawner(['svc1' => 'executed']);
+        $runner = new BackgroundServiceRunnerStub(
+            services: [self::makeService('svc1')],
+            spawner: $spawner,
+        );
+
+        $runner->run(null, force: true);
+
+        $this->assertSame([false], $spawner->forceArgs);
     }
 
     public function testRunSkipsManualModeServiceWithoutForce(): void
@@ -188,7 +245,9 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
         private readonly array $services = [],
         private readonly ?string $lockFailureReason = null,
         private readonly ?\Closure $executeCallback = null,
+        ?BackgroundServiceProcessSpawner $spawner = null,
     ) {
+        parent::__construct(new NullLogger(), $spawner);
     }
 
     protected function getServices(?string $serviceName, bool $force): array
@@ -217,5 +276,35 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
         if ($this->executeCallback !== null) {
             ($this->executeCallback)($service);
         }
+    }
+}
+
+/**
+ * Test double for BackgroundServiceProcessSpawner that returns canned
+ * per-service statuses from a fixture map and records each invocation.
+ *
+ * Tests use this to exercise the run-all-due orchestrator without
+ * spawning actual PHP subprocesses.
+ */
+class RecordingSpawner implements BackgroundServiceProcessSpawner
+{
+    /** @var list<string> */
+    public array $spawnedNames = [];
+
+    /** @var list<bool> */
+    public array $forceArgs = [];
+
+    /**
+     * @param array<string, string> $statusByName
+     */
+    public function __construct(private readonly array $statusByName)
+    {
+    }
+
+    public function spawn(string $name, bool $force): array
+    {
+        $this->spawnedNames[] = $name;
+        $this->forceArgs[] = $force;
+        return ['name' => $name, 'status' => $this->statusByName[$name] ?? 'error'];
     }
 }

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -202,6 +202,49 @@ class BackgroundServiceRunnerTest extends TestCase
         $this->assertSame([false], $spawner->forceArgs);
     }
 
+    public function testRunAllSkipsWhenOrchestratorLockHeld(): void
+    {
+        // CWE-400 mitigation from PR review: run-all-due is reachable
+        // from an authenticated HTTP endpoint; repeated invocations
+        // must not multiply subprocess spawns. A second concurrent
+        // orchestrator returns a single "already_running" no-op row
+        // rather than re-spawning each active service.
+        $spawner = new RecordingSpawner(['svc1' => 'executed']);
+        $runner = new BackgroundServiceRunnerStub(
+            services: [self::makeService('svc1')],
+            spawner: $spawner,
+            orchestratorLockAcquirable: false,
+        );
+
+        $results = $runner->run();
+
+        $this->assertSame(
+            [['name' => 'orchestrator', 'status' => 'already_running']],
+            $results,
+        );
+        $this->assertSame([], $spawner->spawnedNames, 'No subprocesses must be spawned when the orchestrator lock is held');
+        $this->assertSame(0, $runner->orchestratorLockReleases, 'Must not release a lock we did not acquire');
+    }
+
+    public function testRunAllAcquiresAndReleasesOrchestratorLock(): void
+    {
+        // Paired with the previous test: the happy path acquires the
+        // orchestrator lock, spawns children, and releases on the way
+        // out regardless of per-service outcomes. The release is in a
+        // finally block so an exception in the inner loop still frees
+        // the lock for the next cron tick.
+        $spawner = new RecordingSpawner(['svc1' => 'executed']);
+        $runner = new BackgroundServiceRunnerStub(
+            services: [self::makeService('svc1')],
+            spawner: $spawner,
+        );
+
+        $runner->run();
+
+        $this->assertSame(1, $runner->orchestratorLockAcquires);
+        $this->assertSame(1, $runner->orchestratorLockReleases);
+    }
+
     public function testRunSkipsManualModeServiceWithoutForce(): void
     {
         $runner = new BackgroundServiceRunnerStub(
@@ -262,16 +305,22 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
     /** @var list<string> */
     public array $releasedLocks = [];
 
+    public int $orchestratorLockAcquires = 0;
+
+    public int $orchestratorLockReleases = 0;
+
     /**
      * @param list<BackgroundServicesRow> $services
      * @param string|null $lockFailureReason Null means lock acquired; a string is the failure reason returned to run()
      * @param (\Closure(BackgroundServicesRow): void)|null $executeCallback
+     * @param bool $orchestratorLockAcquirable False simulates a second concurrent orchestrator attempt
      */
     public function __construct(
         private readonly array $services = [],
         private readonly ?string $lockFailureReason = null,
         private readonly ?\Closure $executeCallback = null,
         ?BackgroundServiceProcessSpawner $spawner = null,
+        private readonly bool $orchestratorLockAcquirable = true,
     ) {
         parent::__construct(new NullLogger(), $spawner);
     }
@@ -302,6 +351,17 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
         if ($this->executeCallback !== null) {
             ($this->executeCallback)($service);
         }
+    }
+
+    protected function acquireOrchestratorLock(): bool
+    {
+        $this->orchestratorLockAcquires++;
+        return $this->orchestratorLockAcquirable;
+    }
+
+    protected function releaseOrchestratorLock(): void
+    {
+        $this->orchestratorLockReleases++;
     }
 }
 

--- a/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerPhpChildTest.php
+++ b/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerPhpChildTest.php
@@ -1,0 +1,316 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Background;
+
+use OpenEMR\Services\Background\SymfonyBackgroundServiceSpawner;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * End-to-end subprocess tests for SymfonyBackgroundServiceSpawner using
+ * a real PHP child. Complements SymfonyBackgroundServiceSpawnerTest
+ * (which exercises parser/logging logic against a /bin/sh fake) by
+ * covering the PHP-specific behaviors a bash fixture cannot:
+ *
+ *   - OPENEMR_BG_NONCE env-var propagation through Symfony Process into
+ *     the child's getenv() call.
+ *   - Real `die()` vs `exit(N)` vs uncaught exception exit-code
+ *     semantics, which surface as different branches in the spawner.
+ *   - register_shutdown_function() actually firing after the command's
+ *     legitimate output — the precise CWE-345 spoofing vector the
+ *     nonce protocol is designed to close.
+ *   - JSON_THROW_ON_ERROR actually raising a JsonException at
+ *     runtime and propagating out to a non-zero exit.
+ *   - Real PHP stdio buffering against the spawner's per-stream cap.
+ *
+ * The child runs under PHP_BINARY so it uses the same PHP build as the
+ * test suite — the same alignment production relies on when the
+ * orchestrator spawns `PHP_BINARY bin/console`.
+ */
+#[Group('isolated')]
+#[Group('background-services')]
+class SymfonyBackgroundServiceSpawnerPhpChildTest extends TestCase
+{
+    private string $fakeProjectDir;
+
+    private string $fakeConsoleScript;
+
+    private CapturingLogger $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // The spawner invokes `{phpBinary} {projectDir}/bin/console ...`.
+        // We leave phpBinary at its default (PHP_BINARY) and point it
+        // at a real PHP fixture script that dispatches on the --name=
+        // argument, so each test case can exercise a different PHP-
+        // level misbehavior against the actual PHP runtime.
+        $this->fakeProjectDir = sys_get_temp_dir() . '/oe-spawner-php-' . uniqid('', true);
+        mkdir($this->fakeProjectDir . '/bin', 0755, true);
+        $this->fakeConsoleScript = $this->fakeProjectDir . '/bin/console';
+        file_put_contents($this->fakeConsoleScript, <<<'PHP_WRAP'
+        <?php
+        // Fake console for SymfonyBackgroundServiceSpawnerPhpChildTest.
+        // Each --name= value exercises a different PHP-level behavior
+        // the bash-scripted fake cannot express: real exceptions,
+        // register_shutdown_function, JSON_THROW_ON_ERROR, etc.
+        declare(strict_types=1);
+
+        $name = '';
+        foreach ($argv as $arg) {
+            if (str_starts_with($arg, '--name=')) {
+                $name = substr($arg, strlen('--name='));
+                break;
+            }
+        }
+        $nonceEnv = getenv('OPENEMR_BG_NONCE');
+        $nonce = is_string($nonceEnv) ? $nonceEnv : '';
+
+        $emit = function (string $emitName, string $status) use ($nonce): void {
+            echo json_encode(
+                ['name' => $emitName, 'status' => $status, 'nonce' => $nonce],
+                JSON_THROW_ON_ERROR,
+            ), "\n";
+        };
+
+        switch ($name) {
+            case 'ok':
+                // Baseline: real PHP reads the env var, encodes JSON,
+                // and emits a valid status line. Proves the full
+                // nonce protocol works end-to-end through Symfony
+                // Process, not just through the bash test's echo.
+                $emit($name, 'executed');
+                exit(0);
+
+            case 'dies_without_json':
+                // die($msg) prints $msg to stdout and exits 0. A
+                // service that calls die("something went wrong")
+                // therefore produces a clean exit with no JSON
+                // trailer, which the spawner must coerce to error.
+                die("service called die()\n");
+
+            case 'exits_nonzero':
+                // Mirrors GH #11794: a service calls exit(N != 0)
+                // before the command's normal return path runs.
+                // The spawner's non-zero exit branch must coerce
+                // to error and log the service name.
+                fwrite(STDERR, "service aborting with exit(3)\n");
+                exit(3);
+
+            case 'throws_uncaught':
+                // Uncaught exception bubbles to PHP's default handler
+                // which prints to stderr and exits 255. Nothing in
+                // the child catches \Throwable, so this is the
+                // failure mode a register_shutdown_function wrapper
+                // inside the real command cannot silently swallow.
+                throw new \RuntimeException('service threw uncaught exception');
+
+            case 'shutdown_forges_status':
+                // CWE-345: register_shutdown_function fires AFTER
+                // the command's legitimate output is written. A
+                // naive reverse-scanning parser would prefer the
+                // forged line (written last, appears last). The
+                // parent's nonce check rejects the forged line
+                // because the forge cannot know the per-invocation
+                // nonce (random_bytes, never persisted).
+                register_shutdown_function(function () use ($name): void {
+                    echo json_encode([
+                        'name' => $name,
+                        'status' => 'executed',
+                        'nonce' => 'forged-by-shutdown-handler',
+                    ]), "\n";
+                });
+                $emit($name, 'error');
+                exit(0);
+
+            case 'floods_stdout':
+                // Writes past the spawner's per-stream cap (64KiB)
+                // using real PHP stdio. The spawner must kill the
+                // child and return error without attempting to
+                // parse the truncated stream.
+                for ($i = 0; $i < 200; $i++) {
+                    echo str_repeat('A', 1024);
+                }
+                // Unreachable once the cap fires: spawner calls
+                // stop(0) which SIGKILLs immediately.
+                $emit($name, 'executed');
+                exit(0);
+
+            case 'json_throws_from_non_utf8':
+                // Simulates the CWE-20 case the production command
+                // now guards against: a status value containing
+                // invalid UTF-8 cannot be encoded. With
+                // JSON_THROW_ON_ERROR (as emitJsonResult uses),
+                // the uncaught JsonException forces exit != 0 so
+                // the parent observes a real error instead of a
+                // silent empty line.
+                json_encode(
+                    ['name' => $name, 'status' => "\xFF\xFE"],
+                    JSON_THROW_ON_ERROR,
+                );
+                exit(0);
+
+            default:
+                fwrite(STDERR, "unrecognized fixture: $name\n");
+                exit(2);
+        }
+        PHP_WRAP);
+
+        $this->logger = new CapturingLogger();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->fakeConsoleScript)) {
+            unlink($this->fakeConsoleScript);
+        }
+        if (is_dir($this->fakeProjectDir . '/bin')) {
+            rmdir($this->fakeProjectDir . '/bin');
+        }
+        if (is_dir($this->fakeProjectDir)) {
+            rmdir($this->fakeProjectDir);
+        }
+        parent::tearDown();
+    }
+
+    private function makeSpawner(): SymfonyBackgroundServiceSpawner
+    {
+        // Leave phpBinary at its default (PHP_BINARY) so the fixture
+        // runs under the same PHP build as the tests, matching what
+        // production does.
+        return new SymfonyBackgroundServiceSpawner(
+            $this->fakeProjectDir,
+            $this->logger,
+        );
+    }
+
+    public function testNonceIsPropagatedAndStatusParsedFromRealPhpChild(): void
+    {
+        // End-to-end baseline: parent generates nonce, child reads it
+        // via getenv(), echoes it in JSON, parent verifies with
+        // hash_equals and accepts the status. A failure here means
+        // either Symfony Process isn't propagating env vars the way
+        // the spawner assumes, or the nonce protocol diverges between
+        // parent and child.
+        $result = $this->makeSpawner()->spawn('ok', false, 60);
+
+        $this->assertSame(['name' => 'ok', 'status' => 'executed'], $result);
+        $this->assertSame([], $this->logger->warnings);
+    }
+
+    public function testDieWithoutJsonIsReportedAsMissingStatus(): void
+    {
+        // `die("msg")` exits 0 with msg on stdout. The spawner's
+        // "no valid JSON" branch must coerce this to error and log
+        // the service name, so the orchestrator result set is
+        // honest about the child's silent abort.
+        $result = $this->makeSpawner()->spawn('dies_without_json', false, 60);
+
+        $this->assertSame(['name' => 'dies_without_json', 'status' => 'error'], $result);
+        $this->assertNotEmpty($this->logger->warnings);
+        $this->assertSame(
+            'dies_without_json',
+            $this->logger->warnings[0]['context']['service'] ?? null,
+        );
+    }
+
+    public function testExitNonzeroFromRealPhpChildIsReportedAsError(): void
+    {
+        // Matches the GH #11794 failure mode (exit/die/fatal before
+        // the command's legitimate return) but with a real PHP child
+        // instead of a bash `exit 137`. Confirms PHP's exit-code
+        // surfacing lines up with Process::getExitCode() as the
+        // spawner expects.
+        $result = $this->makeSpawner()->spawn('exits_nonzero', false, 60);
+
+        $this->assertSame(['name' => 'exits_nonzero', 'status' => 'error'], $result);
+        $this->assertNotEmpty($this->logger->warnings);
+        $this->assertSame(3, $this->logger->warnings[0]['context']['exit_code'] ?? null);
+    }
+
+    public function testUncaughtExceptionFromRealPhpChildIsReportedAsError(): void
+    {
+        // An uncaught exception in the child invokes PHP's default
+        // handler and exits 255. The spawner treats this the same as
+        // any other non-zero exit. A service that threw without the
+        // subprocess boundary would take down the orchestrator with
+        // it under the old inline runner.
+        $result = $this->makeSpawner()->spawn('throws_uncaught', false, 60);
+
+        $this->assertSame(['name' => 'throws_uncaught', 'status' => 'error'], $result);
+        $this->assertNotEmpty($this->logger->warnings);
+        $this->assertSame(255, $this->logger->warnings[0]['context']['exit_code'] ?? null);
+    }
+
+    public function testShutdownFunctionForgedStatusLineIsRejectedWithRealRegister(): void
+    {
+        // CWE-345: the forged line is produced by a real PHP
+        // register_shutdown_function, which runs after the command's
+        // legitimate stdout is flushed. The parent's reverse scan
+        // therefore sees the forged line *first*. The nonce check
+        // rejects it (the forge uses a bogus nonce string) and the
+        // parser continues to the legitimate line, whose status is
+        // "error" in this fixture. A passing test means the forged
+        // "executed" status was not accepted.
+        $result = $this->makeSpawner()->spawn('shutdown_forges_status', false, 60);
+
+        $this->assertSame(['name' => 'shutdown_forges_status', 'status' => 'error'], $result);
+        $this->assertSame(
+            [],
+            $this->logger->warnings,
+            'Legitimate error status should not log a spawner warning',
+        );
+    }
+
+    public function testFloodedStdoutFromRealPhpChildTerminatesChildAndReturnsError(): void
+    {
+        // Exercises the BUFFER_MAX_BYTES (64KiB) cap against real PHP
+        // stdio instead of `yes A | head`. The spawner must kill the
+        // child once its stdout buffer reaches the cap, regardless
+        // of whether the child ever emits a JSON status line.
+        $start = microtime(true);
+        $result = $this->makeSpawner()->spawn('floods_stdout', false, 60);
+        $elapsed = microtime(true) - $start;
+
+        $this->assertSame(['name' => 'floods_stdout', 'status' => 'error'], $result);
+        $this->assertLessThan(15.0, $elapsed, 'Spawner must kill overflowing child quickly');
+        $this->assertNotEmpty($this->logger->warnings);
+        $this->assertSame(
+            65536,
+            $this->logger->warnings[0]['context']['buffer_max_bytes'] ?? null,
+        );
+    }
+
+    public function testJsonEncodeFailureInChildSurfacesAsNonzeroExit(): void
+    {
+        // CWE-20 end-to-end: BackgroundServicesCommand::emitJsonResult
+        // now uses JSON_THROW_ON_ERROR. A status that fails UTF-8
+        // validation used to silently become `false` and be written
+        // as the empty string (clean exit, no JSON — parser coerced
+        // to error, but with no useful diagnostic). With
+        // JSON_THROW_ON_ERROR the uncaught JsonException forces
+        // exit 255, so the spawner logs a real exit code and stderr
+        // snippet instead of a ghost. This fixture reproduces that
+        // path by invoking the same flag with invalid UTF-8.
+        $result = $this->makeSpawner()->spawn('json_throws_from_non_utf8', false, 60);
+
+        $this->assertSame(['name' => 'json_throws_from_non_utf8', 'status' => 'error'], $result);
+        $this->assertNotEmpty($this->logger->warnings);
+        $this->assertSame(
+            255,
+            $this->logger->warnings[0]['context']['exit_code'] ?? null,
+            'Uncaught JsonException must surface as PHP\'s standard 255 exit code',
+        );
+    }
+}

--- a/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerTest.php
@@ -50,7 +50,11 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
         file_put_contents($this->fakeConsoleScript, <<<'SH'
             #!/bin/sh
             # Fake console for SymfonyBackgroundServiceSpawnerTest.
-            # Selects behavior based on the --name= argument.
+            # Selects behavior based on the --name= argument. The spawner
+            # passes the per-invocation nonce via OPENEMR_BG_NONCE; each
+            # fixture that produces a legitimate status line echoes the
+            # same nonce so the parent accepts it.
+            n="${OPENEMR_BG_NONCE:-}"
             for arg in "$@"; do
                 case "$arg" in
                     --name=clean_exit_no_json)
@@ -61,23 +65,37 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
                         exit 137
                         ;;
                     --name=emits_executed)
-                        echo '{"name":"emits_executed","status":"executed"}'
+                        printf '{"name":"emits_executed","status":"executed","nonce":"%s"}\n' "$n"
                         exit 0
                         ;;
                     --name=prints_garbage_then_json)
                         echo "PHP Deprecated: something"
-                        echo '{"name":"prints_garbage_then_json","status":"not_due"}'
+                        printf '{"name":"prints_garbage_then_json","status":"not_due","nonce":"%s"}\n' "$n"
                         exit 0
                         ;;
                     --name=json_missing_status)
-                        echo '{"name":"json_missing_status"}'
+                        printf '{"name":"json_missing_status","nonce":"%s"}\n' "$n"
                         exit 0
                         ;;
                     --name=name_mismatch)
-                        # Simulates a misbehaving service that prints a
-                        # forged status line tagged with a different
-                        # service name, attempting to spoof a success.
-                        echo '{"name":"not_the_expected_one","status":"executed"}'
+                        # Service that prints a forged status line tagged
+                        # with the right nonce but the wrong service name.
+                        # Parser must still reject it on the name check.
+                        printf '{"name":"not_the_expected_one","status":"executed","nonce":"%s"}\n' "$n"
+                        exit 0
+                        ;;
+                    --name=shutdown_forges_status)
+                        # Simulates the CWE-345 spoofing vector: the
+                        # command emits its legitimate JSON (error), then
+                        # a register_shutdown_function in the service's
+                        # own code prints a forged "executed" line AFTER
+                        # the command's own line. The parser scans from
+                        # the end, so without the nonce check the forged
+                        # line would win. With the nonce check, the forged
+                        # line (no/wrong nonce) is rejected and the
+                        # legitimate line's "error" wins.
+                        printf '{"name":"shutdown_forges_status","status":"error","nonce":"%s"}\n' "$n"
+                        echo '{"name":"shutdown_forges_status","status":"executed","nonce":"forged-by-shutdown-handler"}'
                         exit 0
                         ;;
                     --name=stderr_with_control_chars)
@@ -98,7 +116,7 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
                         yes A | head -c 200000
                         # Reach here only if yes is terminated by a
                         # broken pipe before we can emit the status.
-                        echo '{"name":"floods_stdout","status":"executed"}'
+                        printf '{"name":"floods_stdout","status":"executed","nonce":"%s"}\n' "$n"
                         exit 0
                         ;;
                     --name=sleeps_forever)
@@ -210,6 +228,23 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
 
         $this->assertSame(['name' => 'name_mismatch', 'status' => 'error'], $result);
         $this->assertNotEmpty($this->logger->warnings);
+    }
+
+    public function testShutdownFunctionForgedStatusLineIsRejectedByNonceCheck(): void
+    {
+        // CWE-345: a service's own register_shutdown_function() fires
+        // AFTER the command's legitimate JSON is written. Without the
+        // nonce check, the reverse-scanning parser would find the
+        // forged "executed" line (written second, appears last) first
+        // and accept it. With the nonce check, the forged line has no
+        // valid nonce and is skipped, so the parser falls through to
+        // the command's own line — whose status is "error" in this
+        // fixture — and returns that. A passing test means the forged
+        // status was rejected without the forged line being accepted.
+        $result = $this->makeSpawner()->spawn('shutdown_forges_status', false, 60);
+
+        $this->assertSame(['name' => 'shutdown_forges_status', 'status' => 'error'], $result);
+        $this->assertSame([], $this->logger->warnings, 'Legitimate error status should not log a spawner warning');
     }
 
     public function testStderrIsSanitizedAndTruncatedBeforeLogging(): void

--- a/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerTest.php
@@ -55,6 +55,14 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
             # fixture that produces a legitimate status line echoes the
             # same nonce so the parent accepts it.
             n="${OPENEMR_BG_NONCE:-}"
+            # Check for --force flag once, used by fixtures that want to
+            # branch on it. Looped separately from the per-name dispatch.
+            force=0
+            for arg in "$@"; do
+                if [ "$arg" = "--force" ]; then
+                    force=1
+                fi
+            done
             for arg in "$@"; do
                 case "$arg" in
                     --name=clean_exit_no_json)
@@ -117,6 +125,45 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
                         # Reach here only if yes is terminated by a
                         # broken pipe before we can emit the status.
                         printf '{"name":"floods_stdout","status":"executed","nonce":"%s"}\n' "$n"
+                        exit 0
+                        ;;
+                    --name=reports_force)
+                        # Emits "executed" only when --force was passed,
+                        # "skipped" otherwise. Lets the test confirm the
+                        # spawner actually forwards --force to the child.
+                        if [ "$force" = "1" ]; then
+                            printf '{"name":"reports_force","status":"executed","nonce":"%s"}\n' "$n"
+                        else
+                            printf '{"name":"reports_force","status":"skipped","nonce":"%s"}\n' "$n"
+                        fi
+                        exit 0
+                        ;;
+                    --name=floods_stderr)
+                        # Writes well past the spawner's per-stream buffer
+                        # cap (64KiB) to stderr. Used to verify the cap is
+                        # enforced on the stderr side too, not just stdout.
+                        yes A | head -c 200000 >&2
+                        # Reach here only if yes is terminated by a
+                        # broken pipe before we can emit the status.
+                        printf '{"name":"floods_stderr","status":"executed","nonce":"%s"}\n' "$n"
+                        exit 0
+                        ;;
+                    --name=emits_non_array_json)
+                        # A line starting with `{` that does NOT decode to
+                        # a JSON object (malformed) exercises the
+                        # !is_array($decoded) branch in parseJsonStatus.
+                        # The parser must skip past it without erroring.
+                        echo '{not valid json at all'
+                        printf '{"name":"emits_non_array_json","status":"executed","nonce":"%s"}\n' "$n"
+                        exit 0
+                        ;;
+                    --name=only_non_array_json)
+                        # Same as above but WITHOUT a valid trailing line,
+                        # so parseJsonStatus falls through to null and the
+                        # spawner returns status=error. This covers the
+                        # !is_array continue-path without relying on a
+                        # subsequent valid line.
+                        echo '{ trailing but malformed'
                         exit 0
                         ;;
                     --name=sleeps_forever)
@@ -319,6 +366,95 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
             65536,
             $this->logger->warnings[0]['context']['buffer_max_bytes'] ?? null,
         );
+    }
+
+    public function testForceFlagIsForwardedToChildProcess(): void
+    {
+        // The spawner's `spawn($name, true, ...)` call must translate
+        // to a --force argument in argv so the child command bypasses
+        // the interval check. Without this, --force was set on the
+        // parent's run() but silently dropped before exec.
+        $withForce = $this->makeSpawner()->spawn('reports_force', true, 60);
+        $withoutForce = $this->makeSpawner()->spawn('reports_force', false, 60);
+
+        $this->assertSame(
+            ['name' => 'reports_force', 'status' => 'executed'],
+            $withForce,
+            '--force must reach the child when the caller requests it',
+        );
+        $this->assertSame(
+            ['name' => 'reports_force', 'status' => 'skipped'],
+            $withoutForce,
+            '--force must NOT reach the child when the caller does not request it',
+        );
+    }
+
+    public function testStderrOverflowTerminatesChildAndReturnsError(): void
+    {
+        // Symmetric to the stdout overflow case: a service that dumps
+        // unbounded output to stderr (e.g. a warn/notice storm) must
+        // still be killed once the per-stream cap is hit, so stderr
+        // alone can't exhaust parent memory (CWE-400).
+        $start = microtime(true);
+        $result = $this->makeSpawner()->spawn('floods_stderr', false, 60);
+        $elapsed = microtime(true) - $start;
+
+        $this->assertSame(['name' => 'floods_stderr', 'status' => 'error'], $result);
+        $this->assertLessThan(15.0, $elapsed, 'Spawner must kill overflowing child quickly');
+        $this->assertNotEmpty($this->logger->warnings);
+        $this->assertSame(
+            'floods_stderr',
+            $this->logger->warnings[0]['context']['service'] ?? null,
+        );
+        $this->assertSame(
+            65536,
+            $this->logger->warnings[0]['context']['buffer_max_bytes'] ?? null,
+        );
+    }
+
+    public function testNonArrayJsonLineIsSkippedAndLaterValidLineIsAccepted(): void
+    {
+        // parseJsonStatus must tolerate a line that starts with `{` but
+        // doesn't decode to a JSON object (malformed JSON). The parser
+        // skips it (continue) and keeps scanning; a subsequent valid
+        // status line must still win.
+        $result = $this->makeSpawner()->spawn('emits_non_array_json', false, 60);
+
+        $this->assertSame(['name' => 'emits_non_array_json', 'status' => 'executed'], $result);
+        $this->assertSame([], $this->logger->warnings);
+    }
+
+    public function testOnlyNonArrayJsonReturnsError(): void
+    {
+        // When the only `{`-prefixed line is malformed, parseJsonStatus
+        // scans every line, skips each one at the !is_array($decoded)
+        // branch, and returns null — the spawner then surfaces error.
+        $result = $this->makeSpawner()->spawn('only_non_array_json', false, 60);
+
+        $this->assertSame(['name' => 'only_non_array_json', 'status' => 'error'], $result);
+        $this->assertNotEmpty($this->logger->warnings);
+    }
+
+    public function testLongServiceNameIsTruncatedInLogContext(): void
+    {
+        // Service names come from the DB so in theory operator-
+        // controlled, but pathological rows or tests inserting long
+        // strings should not produce unbounded log records. The
+        // SERVICE_NAME_LOG_MAX cap trims to 64 chars + a truncation
+        // marker before logging (CWE-532 hygiene).
+        $longName = str_repeat('a', 100);
+        $result = $this->makeSpawner()->spawn($longName, false, 60);
+
+        // The returned `name` is the caller's input unchanged; only
+        // the *logged* service context is truncated.
+        $this->assertSame($longName, $result['name']);
+        $this->assertSame('error', $result['status']);
+        $this->assertNotEmpty($this->logger->warnings);
+
+        $loggedService = $this->logger->warnings[0]['context']['service'] ?? '';
+        self::assertIsString($loggedService);
+        $this->assertStringEndsWith('…[truncated]', $loggedService);
+        $this->assertStringStartsWith(str_repeat('a', 64), $loggedService);
     }
 
     public function testTimeoutReturnsErrorAndLogsService(): void

--- a/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerTest.php
@@ -82,10 +82,24 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
                         ;;
                     --name=stderr_with_control_chars)
                         # BEL, CR, and an overly long error body to
-                        # exercise the log-sanitization path.
-                        printf 'boom\a\rsecret\n' >&2
+                        # exercise the log-sanitization path. Includes a
+                        # trailing newline + tab in the middle so the
+                        # test can assert those are escaped (not stripped)
+                        # for line-oriented log backends.
+                        printf 'boom\a\rline1\nline2\tcol\n' >&2
                         printf '%.0sA' $(seq 1 3000) >&2
                         exit 3
+                        ;;
+                    --name=floods_stdout)
+                        # Writes well past the spawner's per-stream
+                        # buffer cap (64KiB). Used to verify the spawner
+                        # enforces the cap, terminates the child, and
+                        # returns error.
+                        yes A | head -c 200000
+                        # Reach here only if yes is terminated by a
+                        # broken pipe before we can emit the status.
+                        echo '{"name":"floods_stdout","status":"executed"}'
+                        exit 0
                         ;;
                     --name=sleeps_forever)
                         # Used only for the timeout test; the test uses
@@ -201,10 +215,11 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
     public function testStderrIsSanitizedAndTruncatedBeforeLogging(): void
     {
         // Subprocess stderr can contain PHI, stack traces, and control
-        // characters. The spawner must strip control chars (except
-        // newline/tab) to prevent log forging and truncate long output
-        // so one misbehaving service can't flood central logs
-        // (CWE-532 mitigation from PR review).
+        // characters. The spawner must strip control chars, escape
+        // newlines/tabs to literal "\n"/"\t" (CWE-117: a single log
+        // record must not be split across multiple lines by child
+        // output), and truncate long output so one misbehaving service
+        // can't flood central logs (CWE-532 mitigation from PR review).
         $result = $this->makeSpawner()->spawn('stderr_with_control_chars', false, 60);
 
         $this->assertSame(['name' => 'stderr_with_control_chars', 'status' => 'error'], $result);
@@ -214,8 +229,61 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
         self::assertIsString($stderr);
         $this->assertStringNotContainsString("\x07", $stderr, 'BEL must be stripped');
         $this->assertStringNotContainsString("\r", $stderr, 'CR must be normalized to LF');
+        $this->assertStringNotContainsString("\n", $stderr, 'Real LF must be escaped, not left embedded');
+        $this->assertStringNotContainsString("\t", $stderr, 'Real TAB must be escaped, not left embedded');
+        $this->assertStringContainsString('\\n', $stderr, 'LF must be rendered as literal \\n');
+        $this->assertStringContainsString('\\t', $stderr, 'TAB must be rendered as literal \\t');
         $this->assertLessThanOrEqual(2100, strlen($stderr), 'Log snippet must be truncated');
         $this->assertStringContainsString('[truncated]', $stderr);
+    }
+
+    public function testServiceNameIsSanitizedInLogContext(): void
+    {
+        // Service names originate from the `background_services.name`
+        // DB column. A misconfigured or malicious row containing
+        // CR/LF/BEL must not forge multi-line log records
+        // (CWE-117 mitigation from PR review). The fake console
+        // doesn't recognize this name so it exits non-zero, which
+        // exercises the service-name sanitization in the log context.
+        $smuggled = "evil\r\nFAKE: forged line\x07";
+        $result = $this->makeSpawner()->spawn($smuggled, false, 60);
+
+        // The result's `name` field is the caller-provided name
+        // unchanged; only the *logged* service field is sanitized.
+        $this->assertSame($smuggled, $result['name']);
+        $this->assertSame('error', $result['status']);
+        $this->assertNotEmpty($this->logger->warnings);
+
+        $loggedService = $this->logger->warnings[0]['context']['service'] ?? '';
+        self::assertIsString($loggedService);
+        $this->assertStringNotContainsString("\r", $loggedService);
+        $this->assertStringNotContainsString("\n", $loggedService);
+        $this->assertStringNotContainsString("\x07", $loggedService);
+        $this->assertSame('evilFAKE: forged line', $loggedService);
+    }
+
+    public function testStdoutOverflowTerminatesChildAndReturnsError(): void
+    {
+        // A service that dumps unbounded output must be killed before
+        // the parent buffers gigabytes of it (CWE-400 mitigation from
+        // PR review). The fake console writes 200KB to stdout; the
+        // spawner's 64KiB per-stream cap must trigger a stop() and an
+        // error result with no JSON parsing attempted.
+        $start = microtime(true);
+        $result = $this->makeSpawner()->spawn('floods_stdout', false, 60);
+        $elapsed = microtime(true) - $start;
+
+        $this->assertSame(['name' => 'floods_stdout', 'status' => 'error'], $result);
+        $this->assertLessThan(15.0, $elapsed, 'Spawner must kill overflowing child quickly');
+        $this->assertNotEmpty($this->logger->warnings);
+        $this->assertSame(
+            'floods_stdout',
+            $this->logger->warnings[0]['context']['service'] ?? null,
+        );
+        $this->assertSame(
+            65536,
+            $this->logger->warnings[0]['context']['buffer_max_bytes'] ?? null,
+        );
     }
 
     public function testTimeoutReturnsErrorAndLogsService(): void

--- a/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Background;
+
+use OpenEMR\Services\Background\SymfonyBackgroundServiceSpawner;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Covers SymfonyBackgroundServiceSpawner's error/parse paths using a
+ * fake `bin/console` shell script as the child. The test injects a
+ * controlled project dir and PHP binary (`/bin/sh`) so the spawner
+ * shells out to a script we fully control rather than bootstrapping
+ * a real OpenEMR child.
+ */
+#[Group('isolated')]
+#[Group('background-services')]
+class SymfonyBackgroundServiceSpawnerTest extends TestCase
+{
+    private string $fakeProjectDir;
+
+    private string $fakeConsoleScript;
+
+    private CapturingLogger $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // The spawner invokes `{phpBinary} {projectDir}/bin/console ...`.
+        // By setting phpBinary to /bin/sh and pointing it at a script
+        // we control, the command-line invocation becomes
+        //   /bin/sh <script> background:services run --name=... --json [--force]
+        // which lets the script decide how to respond per service name.
+        $this->fakeProjectDir = sys_get_temp_dir() . '/oe-spawner-' . uniqid('', true);
+        mkdir($this->fakeProjectDir . '/bin', 0755, true);
+        $this->fakeConsoleScript = $this->fakeProjectDir . '/bin/console';
+        file_put_contents($this->fakeConsoleScript, <<<'SH'
+            #!/bin/sh
+            # Fake console for SymfonyBackgroundServiceSpawnerTest.
+            # Selects behavior based on the --name= argument.
+            for arg in "$@"; do
+                case "$arg" in
+                    --name=clean_exit_no_json)
+                        exit 0
+                        ;;
+                    --name=exits_nonzero)
+                        echo "fatal error" >&2
+                        exit 137
+                        ;;
+                    --name=emits_executed)
+                        echo '{"name":"emits_executed","status":"executed"}'
+                        exit 0
+                        ;;
+                    --name=prints_garbage_then_json)
+                        echo "PHP Deprecated: something"
+                        echo '{"name":"prints_garbage_then_json","status":"not_due"}'
+                        exit 0
+                        ;;
+                    --name=json_missing_status)
+                        echo '{"name":"json_missing_status"}'
+                        exit 0
+                        ;;
+                esac
+            done
+            echo "unrecognized fixture" >&2
+            exit 2
+            SH);
+        chmod($this->fakeConsoleScript, 0755);
+
+        $this->logger = new CapturingLogger();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->fakeConsoleScript)) {
+            unlink($this->fakeConsoleScript);
+        }
+        if (is_dir($this->fakeProjectDir . '/bin')) {
+            rmdir($this->fakeProjectDir . '/bin');
+        }
+        if (is_dir($this->fakeProjectDir)) {
+            rmdir($this->fakeProjectDir);
+        }
+        parent::tearDown();
+    }
+
+    private function makeSpawner(): SymfonyBackgroundServiceSpawner
+    {
+        // Shell out to /bin/sh <fake-console> so the spawner's
+        // PHP_BINARY-based invocation still produces a runnable
+        // command line, and each test case can control exit codes
+        // and stdout via the fake console's case statement.
+        return new SymfonyBackgroundServiceSpawner(
+            $this->fakeProjectDir,
+            $this->logger,
+            '/bin/sh',
+        );
+    }
+
+    public function testExecutedStatusParsedFromJson(): void
+    {
+        $result = $this->makeSpawner()->spawn('emits_executed', false);
+
+        $this->assertSame(['name' => 'emits_executed', 'status' => 'executed'], $result);
+        $this->assertSame([], $this->logger->warnings);
+    }
+
+    public function testStatusParsedFromTrailingJsonAmongstOtherOutput(): void
+    {
+        // PHP deprecation notices and similar pre-JSON stdout chatter
+        // must not prevent the spawner from finding the status line.
+        $result = $this->makeSpawner()->spawn('prints_garbage_then_json', false);
+
+        $this->assertSame(['name' => 'prints_garbage_then_json', 'status' => 'not_due'], $result);
+    }
+
+    public function testNonZeroExitReturnsErrorAndLogsService(): void
+    {
+        // Surfaces the exit()/die()/fatal case described in GH #11794:
+        // the child aborted before emitting JSON, so the parent must
+        // still get a well-formed result and a log entry naming the
+        // offending service.
+        $result = $this->makeSpawner()->spawn('exits_nonzero', false);
+
+        $this->assertSame(['name' => 'exits_nonzero', 'status' => 'error'], $result);
+        $this->assertNotEmpty($this->logger->warnings);
+        $this->assertSame('exits_nonzero', $this->logger->warnings[0]['context']['service'] ?? null);
+        $this->assertSame(137, $this->logger->warnings[0]['context']['exit_code'] ?? null);
+    }
+
+    public function testCleanExitWithoutJsonReturnsError(): void
+    {
+        // exit(0) with no JSON trailer means the child terminated
+        // early (e.g. a service called exit(0) before the command's
+        // normal return path). Treat as error. The result set must
+        // not silently report "ran successfully" for a process we
+        // have no status line from.
+        $result = $this->makeSpawner()->spawn('clean_exit_no_json', false);
+
+        $this->assertSame(['name' => 'clean_exit_no_json', 'status' => 'error'], $result);
+        $this->assertNotEmpty($this->logger->warnings);
+    }
+
+    public function testMalformedJsonStatusReturnsError(): void
+    {
+        // JSON line that decodes but lacks a string `status` field is
+        // the same failure mode as "no JSON at all": can't trust the
+        // result, so flag as error with a log entry.
+        $result = $this->makeSpawner()->spawn('json_missing_status', false);
+
+        $this->assertSame(['name' => 'json_missing_status', 'status' => 'error'], $result);
+    }
+}
+
+/**
+ * PSR-3 logger double that records warning calls for assertion.
+ */
+class CapturingLogger extends AbstractLogger implements LoggerInterface
+{
+    /** @var list<array{level: mixed, message: string|\Stringable, context: array<mixed>}> */
+    public array $warnings = [];
+
+    /**
+     * @param array<mixed> $context
+     */
+    public function log($level, string|\Stringable $message, array $context = []): void
+    {
+        // PSR-3 permits $level as any scalar; CapturingLogger only needs
+        // to match the literal 'warning' level, so compare after a
+        // string check rather than casting mixed.
+        if (is_string($level) && $level === 'warning') {
+            $this->warnings[] = ['level' => $level, 'message' => $message, 'context' => $context];
+        }
+    }
+}

--- a/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerTest.php
@@ -73,6 +73,27 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
                         echo '{"name":"json_missing_status"}'
                         exit 0
                         ;;
+                    --name=name_mismatch)
+                        # Simulates a misbehaving service that prints a
+                        # forged status line tagged with a different
+                        # service name, attempting to spoof a success.
+                        echo '{"name":"not_the_expected_one","status":"executed"}'
+                        exit 0
+                        ;;
+                    --name=stderr_with_control_chars)
+                        # BEL, CR, and an overly long error body to
+                        # exercise the log-sanitization path.
+                        printf 'boom\a\rsecret\n' >&2
+                        printf '%.0sA' $(seq 1 3000) >&2
+                        exit 3
+                        ;;
+                    --name=sleeps_forever)
+                        # Used only for the timeout test; the test uses
+                        # a very short subprocess timeout so this
+                        # doesn't actually delay the suite.
+                        sleep 30
+                        exit 0
+                        ;;
                 esac
             done
             echo "unrecognized fixture" >&2
@@ -112,7 +133,7 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
 
     public function testExecutedStatusParsedFromJson(): void
     {
-        $result = $this->makeSpawner()->spawn('emits_executed', false);
+        $result = $this->makeSpawner()->spawn('emits_executed', false, 60);
 
         $this->assertSame(['name' => 'emits_executed', 'status' => 'executed'], $result);
         $this->assertSame([], $this->logger->warnings);
@@ -122,7 +143,7 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
     {
         // PHP deprecation notices and similar pre-JSON stdout chatter
         // must not prevent the spawner from finding the status line.
-        $result = $this->makeSpawner()->spawn('prints_garbage_then_json', false);
+        $result = $this->makeSpawner()->spawn('prints_garbage_then_json', false, 60);
 
         $this->assertSame(['name' => 'prints_garbage_then_json', 'status' => 'not_due'], $result);
     }
@@ -133,7 +154,7 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
         // the child aborted before emitting JSON, so the parent must
         // still get a well-formed result and a log entry naming the
         // offending service.
-        $result = $this->makeSpawner()->spawn('exits_nonzero', false);
+        $result = $this->makeSpawner()->spawn('exits_nonzero', false, 60);
 
         $this->assertSame(['name' => 'exits_nonzero', 'status' => 'error'], $result);
         $this->assertNotEmpty($this->logger->warnings);
@@ -148,7 +169,7 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
         // normal return path). Treat as error. The result set must
         // not silently report "ran successfully" for a process we
         // have no status line from.
-        $result = $this->makeSpawner()->spawn('clean_exit_no_json', false);
+        $result = $this->makeSpawner()->spawn('clean_exit_no_json', false, 60);
 
         $this->assertSame(['name' => 'clean_exit_no_json', 'status' => 'error'], $result);
         $this->assertNotEmpty($this->logger->warnings);
@@ -159,9 +180,59 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
         // JSON line that decodes but lacks a string `status` field is
         // the same failure mode as "no JSON at all": can't trust the
         // result, so flag as error with a log entry.
-        $result = $this->makeSpawner()->spawn('json_missing_status', false);
+        $result = $this->makeSpawner()->spawn('json_missing_status', false, 60);
 
         $this->assertSame(['name' => 'json_missing_status', 'status' => 'error'], $result);
+    }
+
+    public function testForgedStatusLineWithWrongNameIsRejected(): void
+    {
+        // A service that writes `{"name":"something_else","status":"executed"}`
+        // to stdout (perhaps from a shutdown handler that fires after
+        // the command's own output) must not be able to spoof a
+        // successful status. The parser requires name == expected
+        // (CWE-345 mitigation from PR review).
+        $result = $this->makeSpawner()->spawn('name_mismatch', false, 60);
+
+        $this->assertSame(['name' => 'name_mismatch', 'status' => 'error'], $result);
+        $this->assertNotEmpty($this->logger->warnings);
+    }
+
+    public function testStderrIsSanitizedAndTruncatedBeforeLogging(): void
+    {
+        // Subprocess stderr can contain PHI, stack traces, and control
+        // characters. The spawner must strip control chars (except
+        // newline/tab) to prevent log forging and truncate long output
+        // so one misbehaving service can't flood central logs
+        // (CWE-532 mitigation from PR review).
+        $result = $this->makeSpawner()->spawn('stderr_with_control_chars', false, 60);
+
+        $this->assertSame(['name' => 'stderr_with_control_chars', 'status' => 'error'], $result);
+        $this->assertNotEmpty($this->logger->warnings);
+
+        $stderr = $this->logger->warnings[0]['context']['stderr'] ?? '';
+        self::assertIsString($stderr);
+        $this->assertStringNotContainsString("\x07", $stderr, 'BEL must be stripped');
+        $this->assertStringNotContainsString("\r", $stderr, 'CR must be normalized to LF');
+        $this->assertLessThanOrEqual(2100, strlen($stderr), 'Log snippet must be truncated');
+        $this->assertStringContainsString('[truncated]', $stderr);
+    }
+
+    public function testTimeoutReturnsErrorAndLogsService(): void
+    {
+        // A child that refuses to exit within its lease-derived
+        // timeout must not block the orchestrator indefinitely. The
+        // spawner kills the process and returns status=error
+        // (CWE-400 mitigation from PR review).
+        $start = microtime(true);
+        $result = $this->makeSpawner()->spawn('sleeps_forever', false, 1);
+        $elapsed = microtime(true) - $start;
+
+        $this->assertSame(['name' => 'sleeps_forever', 'status' => 'error'], $result);
+        $this->assertLessThan(15.0, $elapsed, 'Spawner must enforce the timeout');
+        $this->assertNotEmpty($this->logger->warnings);
+        $this->assertSame('sleeps_forever', $this->logger->warnings[0]['context']['service'] ?? null);
+        $this->assertSame(1, $this->logger->warnings[0]['context']['timeout_seconds'] ?? null);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #11794. The `run-all-due` path (CLI, AJAX, REST) iterated every active service in a single PHP process. `try`/`catch` cannot recover from `exit()`, `die()`, or fatal errors, so one misbehaving service aborted every service scheduled after it in the same tick.

This PR takes option 1 from the issue: subprocess-per-service, via `symfony/process` (already on the dependency list). Each active service runs behind a subprocess boundary, so a fatal in one service cannot take down the rest of the tick.

## What's new

- **`BackgroundServiceProcessSpawner`** — small interface the orchestrator depends on.
- **`SymfonyBackgroundServiceSpawner`** — default implementation. Runs `php bin/console background:services run --name=<name> --json` per service. Parses the trailing JSON status line from the child's stdout. Any subprocess failure (non-zero exit, missing/garbled JSON status) is converted into a `status=error` result and logged with the service name so operators can find the offender.
- **`BackgroundServicesCommand --json`** — new option on `run`. Requires `--name`. Emits a single JSON result line (`{"name":"…","status":"…"}`) as the last thing on stdout and returns a non-zero exit code on `error`/`not_found`. This is the wire protocol between the orchestrator and the child.
- **`BackgroundServiceRunner`** — `run(null, …)` now delegates each active service to the spawner. Inactive services are still pre-filtered in the parent so we don't pay a PHP bootstrap to report `skipped`. `--force` is deliberately dropped on the run-all-due path so it behaves as a cron-equivalent advance regardless of how it was invoked.

The single-service CLI path still runs inline. Those callers already have natural process isolation per invocation (one CLI command = one PHP process), and the subprocess boundary needs to live *above* a single `runOne` call.

## Tests

- `BackgroundServiceRunnerTest` — new orchestrator tests: spawn ordering, inactive-service skip (never spawned), continue after one subprocess reports `error`, `--force` dropped when orchestrating.
- `SymfonyBackgroundServiceSpawnerTest` — uses `/bin/sh` as the `phpBinary` pointing at a fake `bin/console` shell script that simulates: clean exit with JSON, clean exit without JSON, non-zero exit (137) with stderr, stdout chatter (deprecation notices) followed by the JSON line, and malformed JSON. Covers the parent's parsing and error-surfacing contract.
- `BackgroundServicesCommandTest` — `--json` emits exactly one JSON line, `--json` propagates non-zero exit on `status=error`, `--json` without `--name` is rejected with a clear message.

All 57 tests in the `background-services` group pass. PHPStan is clean at level 9.

## Notes

- No new dependencies. `symfony/process ^7.3` is already in `composer.json`.
- The child inherits the runner's shutdown handler from #11678, so a subprocess that terminates abnormally still releases its lease for the next tick.
- Follow-up: there's an obvious integration test that spawns a real subprocess calling `exit(1)` and verifies subsequent services still run. I've intentionally left that out of this PR to keep it focused; the unit tests cover the spawner/orchestrator contract explicitly. Happy to add the integration test in a follow-up if reviewers want belt-and-suspenders.

## Test plan

- [ ] CI green across unit, isolated, integration
- [ ] Verify in a dev environment that a service that `exit(1)`'s no longer blocks subsequent services on the same `bin/console background:services run` tick
- [ ] Verify the warning log entry clearly identifies the offending service