### PR TITLE
fix(deps): sync package-lock.json with xmldom 0.9.10 update

### DIFF
--- a/ccdaservice/package-lock.json
+++ b/ccdaservice/package-lock.json
@@ -152,9 +152,9 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.9.9",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
-            "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
+            "version": "0.9.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+            "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
             "license": "MIT",
             "engines": {
                 "node": ">=14.6"
@@ -4605,7 +4605,7 @@
             "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
-                "@xmldom/xmldom": "0.9.9",
+                "@xmldom/xmldom": "0.9.10",
                 "compression": "1.8.1",
                 "cqm-execution": "4.4.1",
                 "cqm-models": "4.3.1",


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes CI failure in Inferno tests caused by package-lock.json being out of sync after the xmldom dependency bump in #11775.

#### Changes proposed in this pull request:

- Regenerated `ccdaservice/package-lock.json` to reflect the @xmldom/xmldom 0.9.9 → 0.9.10 update

#### Was an AI assistant used? Yes

🤖 Generated with [Claude Code](https://claude.ai/code)