### PR TITLE
chore(deps): sync ccdaservice lockfile with @xmldom/xmldom 0.9.10

### DIFF
--- a/ccdaservice/package-lock.json
+++ b/ccdaservice/package-lock.json
@@ -152,9 +152,9 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.9.9",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
-            "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
+            "version": "0.9.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+            "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
             "license": "MIT",
             "engines": {
                 "node": ">=14.6"
@@ -4605,7 +4605,7 @@
             "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
-                "@xmldom/xmldom": "0.9.9",
+                "@xmldom/xmldom": "0.9.10",
                 "compression": "1.8.1",
                 "cqm-execution": "4.4.1",
                 "cqm-models": "4.3.1",


### PR DESCRIPTION
## Summary

Fixes master Inferno Certification Test failure caused by #11775.

Dependabot #11775 bumped `@xmldom/xmldom` from 0.9.9 → 0.9.10 in `ccdaservice/packages/oe-cda-schematron/package.json`, but the root `ccdaservice/package-lock.json` was not regenerated and still pinned 0.9.9. The Inferno job runs `cd ccdaservice && npm ci`, which refuses to install when a workspace member's `package.json` disagrees with the root lockfile:

```
npm error Invalid: lock file's @xmldom/xmldom@0.9.9 does not satisfy @xmldom/xmldom@0.9.10
```

See the red master run: https://github.com/openemr/openemr/actions/runs/24857178128/job/72773021199

This PR regenerates the single affected entry in `ccdaservice/package-lock.json` via `npm install --package-lock-only`. Diff is limited to the xmldom version + integrity hash.

## Test plan

- [x] `cd ccdaservice && npm ci` succeeds locally against the updated lockfile
- [ ] Inferno Certification Test passes in CI on this PR