### PR TITLE
fix(smarty): save admin practice practice settings

### DIFF
--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -242,10 +242,8 @@ class Controller extends Smarty implements ControllerInterface
 
         // Smarty 4's __call makes is_callable() always return true on Smarty-derived
         // objects, so we must also check method_exists(). See PR #11163 regression.
-        $methodExists = function (string $method) use ($controllerObj): bool {
-            return method_exists($controllerObj, $method)
-                && is_callable([$controllerObj, $method]);
-        };
+        $methodExists = (fn(string $method): bool => method_exists($controllerObj, $method)
+            && is_callable([$controllerObj, $method]));
 
         $isProcessing = ($_POST['process'] ?? '') === 'true';
 

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Controller Class.
+ *
+ * @package OpenEMR
+ * @link    https://www.open-emr.org
+ * @author Stephen Waite <stephen.waite@open-emr.org>
+ * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\ControllerInterface;

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -240,27 +240,34 @@ class Controller extends Smarty implements ControllerInterface
             return is_string($result) ? $result : '';
         };
 
-        // Smarty 4's __call makes is_callable() always return true on Smarty-derived
-        // objects, so we must also check method_exists(). See PR #11163 regression.
-        $methodExists = (fn(string $method): bool => method_exists($controllerObj, $method)
-            && is_callable([$controllerObj, $method]));
-
         $isProcessing = ($_POST['process'] ?? '') === 'true';
 
-        if ($isProcessing && $methodExists($processMethod)) {
+        if ($isProcessing && $this->methodExists($controllerObj, $processMethod)) {
             $output .= $callMethod($processMethod);
             if ($controllerObj->_state === false) {
                 return $output;
             }
         }
 
-        if ($methodExists($actionMethod)) {
+        if ($this->methodExists($controllerObj, $actionMethod)) {
             $output .= $callMethod($actionMethod);
         } else {
             throw new NotFoundHttpException("Action '$action' does not exist on controller: $className");
         }
 
         return $output;
+    }
+
+    /**
+     * Check whether a method genuinely exists on a controller object.
+     *
+     * Smarty 4's __call makes is_callable() always return true on
+     * Smarty-derived objects, so we must also check method_exists().
+     */
+    private function methodExists(object $controllerObj, string $method): bool
+    {
+        return method_exists($controllerObj, $method)
+            && is_callable([$controllerObj, $method]);
     }
 
     public function _link($action = "default", $inlining = false)

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -230,16 +230,23 @@ class Controller extends Smarty implements ControllerInterface
             return is_string($result) ? $result : '';
         };
 
+        // Smarty 4's __call makes is_callable() always return true on Smarty-derived
+        // objects, so we must also check method_exists(). See PR #11163 regression.
+        $methodExists = function (string $method) use ($controllerObj): bool {
+            return method_exists($controllerObj, $method)
+                && is_callable([$controllerObj, $method]);
+        };
+
         $isProcessing = ($_POST['process'] ?? '') === 'true';
 
-        if ($isProcessing && is_callable([$controllerObj, $processMethod])) {
+        if ($isProcessing && $methodExists($processMethod)) {
             $output .= $callMethod($processMethod);
             if ($controllerObj->_state === false) {
                 return $output;
             }
         }
 
-        if ($isProcessing || is_callable([$controllerObj, $actionMethod])) {
+        if ($methodExists($actionMethod)) {
             $output .= $callMethod($actionMethod);
         } else {
             throw new NotFoundHttpException("Action '$action' does not exist on controller: $className");

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -5,8 +5,12 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
+ * @author    OpenEMR contributors
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @author    Stephen Waite <stephen.waite@open-emr.org>
- * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) OpenEMR contributors
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@open-emr.org>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -3,11 +3,11 @@
 /**
  * Controller Class.
  *
- * @package OpenEMR
- * @link    https://www.open-emr.org
- * @author Stephen Waite <stephen.waite@open-emr.org>
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@open-emr.org>
  * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@cmsvt.com>
- * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 use OpenEMR\Common\Acl\AccessDeniedHelper;

--- a/tests/Tests/RestControllers/ControllerRoutingTest.php
+++ b/tests/Tests/RestControllers/ControllerRoutingTest.php
@@ -185,4 +185,45 @@ class ControllerRoutingTest extends TestCase
         $this->assertArrayHasKey('sub_action', $dispatchParams);
         $this->assertSame('list', $dispatchParams['sub_action']);
     }
+
+    /**
+     * Controller extends Smarty, and Smarty's __call catches any undefined
+     * method call. This makes is_callable() return true for every method
+     * name on a Controller instance, even methods that don't actually exist.
+     *
+     * The methodExists() guard must combine is_callable() with method_exists()
+     * to distinguish genuinely-defined methods from phantom calls that would
+     * otherwise be dispatched into Smarty's extension handler (which throws
+     * "undefined extension class Smarty_Internal_Method_*" errors).
+     */
+    #[Test]
+    public function testMethodExistsGuardsAgainstSmartyPhantomMethods(): void
+    {
+        $smartyDescendant = new class extends \Controller {
+        };
+
+        $dispatcher = new \Controller();
+
+        $methodExists = new \ReflectionMethod(\Controller::class, 'methodExists');
+
+        // Document the trap: is_callable() alone returns true for any method
+        // name on a Smarty descendant because Smarty's __call catches all calls.
+        $this->assertTrue(
+            is_callable([$smartyDescendant, 'nonexistent_phantom_method']),
+            'Expected is_callable() to return true due to Smarty __call ' .
+            '(this assertion documents the trap that methodExists() guards against).'
+        );
+
+        // The guard must return false for phantom methods that only __call catches.
+        $this->assertFalse(
+            $methodExists->invoke($dispatcher, $smartyDescendant, 'nonexistent_phantom_method'),
+            'methodExists() must return false for phantom methods caught only by __call.'
+        );
+
+        // Positive case: a genuinely-defined method should return true.
+        $this->assertTrue(
+            $methodExists->invoke($dispatcher, $smartyDescendant, 'process_action'),
+            'methodExists() must return true for genuinely-defined methods.'
+        );
+    }
 }

--- a/tests/Tests/RestControllers/ControllerRoutingTest.php
+++ b/tests/Tests/RestControllers/ControllerRoutingTest.php
@@ -208,8 +208,14 @@ class ControllerRoutingTest extends TestCase
 
         // Document the trap: is_callable() alone returns true for any method
         // name on a Smarty descendant because Smarty's __call catches all calls.
+        // PHPStan can't model __call, so it concludes statically that
+        // is_callable() must be false — which is exactly the runtime trap
+        // this test documents and methodExists() guards against.
+        /** @phpstan-ignore-next-line function.impossibleType */
+        $isCallable = is_callable([$smartyDescendant, 'nonexistent_phantom_method']);
+        /** @phpstan-ignore-next-line method.impossibleType */
         $this->assertTrue(
-            is_callable([$smartyDescendant, 'nonexistent_phantom_method']),
+            $isCallable,
             'Expected is_callable() to return true due to Smarty __call ' .
             '(this assertion documents the trap that methodExists() guards against).'
         );


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
Two changes, both important

1. Added $methodExists closure with both method_exists() and is_callable(). This restores the guard the original act() had with the prominent comment about Smarty 4's __call.

2. Changed the second if condition from if ($isProcessing || is_callable(...)) to if ($methodExists($actionMethod)). The original || logic was a second bug — it would blindly call $actionMethod whenever $isProcessing was true, even if the method didn't exist. That's also how your pharmacy error surfaces: after the process_action_process check fails to match, the code falls through to call process_action unconditionally because $isProcessing is true, which again hits Smarty's __call.

#### Changes proposed in this pull request:


#### Was an AI assistant used? Yes 

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
