### PR TITLE
ci(phpstan): add composer phpstan-baseline-reset to wipe and rebuild

### DIFF
--- a/.phpstan/README.md
+++ b/.phpstan/README.md
@@ -276,6 +276,14 @@ To regenerate the baseline after fixing violations:
 composer phpstan-baseline
 ```
 
+To wipe and rebuild the baseline from scratch (ignoring whatever is currently on disk):
+
+```bash
+composer phpstan-baseline-reset
+```
+
+This deletes every file under `.phpstan/baseline/`, writes a minimal empty `loader.php`, and then runs `composer phpstan-baseline` to rebuild the per-identifier files from the current codebase. Use this instead of `composer phpstan-baseline` when you want a clean regeneration — for example, when the baseline has drifted, or when the existing files are in a state PHPStan can't even load (leftover merge conflict markers, a truncated file, etc.).
+
 ### Fatal-category caps
 
 Certain baseline files hold errors for code that cannot run at load or call time. `.phpstan/fatal-baseline-caps.php` records the current count per file and `tests/Tests/Isolated/PHPStan/FatalBaselineCapsIsolatedTest.php` asserts the actual count equals the cap. Two modes:

--- a/.phpstan/reset-baseline.php
+++ b/.phpstan/reset-baseline.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Wipe the PHPStan baseline directory so `composer phpstan-baseline` can
+ * regenerate from a clean slate.
+ *
+ * Deletes every file under `.phpstan/baseline/` and writes a minimal
+ * `loader.php` with an empty includes list. PHPStan then starts with no
+ * pre-existing baseline and `composer phpstan-baseline` records the
+ * current set of errors from scratch. Useful when the baseline has
+ * drifted, when resolving the per-identifier split files by hand is not
+ * worth the effort, or when the baseline files are in a state PHPStan
+ * can't even load (e.g. leftover merge conflict markers).
+ *
+ * Run via `composer phpstan-baseline-reset`.
+ */
+
+declare(strict_types=1);
+
+$baselineDir = __DIR__ . '/baseline';
+
+if (!is_dir($baselineDir)) {
+    fwrite(STDERR, "Baseline directory not found: {$baselineDir}\n");
+    exit(1);
+}
+
+$deleted = 0;
+foreach (glob($baselineDir . '/*.php') ?: [] as $path) {
+    if (!unlink($path)) {
+        fwrite(STDERR, "Failed to delete: {$path}\n");
+        exit(1);
+    }
+    $deleted++;
+}
+
+$loader = <<<'PHP'
+<?php declare(strict_types = 1);
+
+return ['includes' => []];
+
+PHP;
+
+if (file_put_contents($baselineDir . '/loader.php', $loader) === false) {
+    fwrite(STDERR, "Failed to write loader.php\n");
+    exit(1);
+}
+
+echo "Wiped {$deleted} baseline file(s); wrote empty loader.php.\n";

--- a/composer.json
+++ b/composer.json
@@ -292,6 +292,10 @@
             "phpstan analyze --memory-limit=8G --configuration=phpstan.neon.dist --generate-baseline=.phpstan/baseline/loader.php",
             "php -d memory_limit=1g vendor/bin/split-phpstan-baseline .phpstan/baseline/loader.php --no-error-count"
         ],
+        "phpstan-baseline-reset": [
+            "@php .phpstan/reset-baseline.php",
+            "@phpstan-baseline"
+        ],
         "phpunit-isolated": "phpunit -c phpunit-isolated.xml",
         "rector-check": "php -d memory_limit=4g ./vendor/bin/rector process --dry-run",
         "rector-fix": "php -d memory_limit=4g ./vendor/bin/rector process",


### PR DESCRIPTION
## Summary

Adds a `composer phpstan-baseline-reset` script that deletes every file under `.phpstan/baseline/`, writes a minimal empty `loader.php`, and then runs `composer phpstan-baseline` to regenerate the per-identifier files from scratch.

## Why

The regular `composer phpstan-baseline` reuses the existing baseline as input, which is the wrong starting point when the baseline has drifted, or when the files are in a state PHPStan can't even load — for example, leftover merge conflict markers after resolving an upstream rebase. In those cases the only way to recover is to wipe and rebuild, and this script automates that.

## What's in the change

- `.phpstan/reset-baseline.php` — tiny PHP helper that deletes `.phpstan/baseline/*.php` and writes a valid empty `loader.php`.
- `composer.json` — new `phpstan-baseline-reset` script chains the helper and then `@phpstan-baseline`.
- `.phpstan/README.md` — documents when to prefer `phpstan-baseline-reset` over `phpstan-baseline`.

## Test plan

- [ ] `composer validate --strict` passes
- [ ] `php -l .phpstan/reset-baseline.php` passes
- [ ] On a worktree whose baseline contains leftover merge conflict markers, `composer phpstan-baseline-reset` wipes the directory, writes a valid empty `loader.php`, and then regenerates the full baseline successfully