### PR TITLE
refactor(globals): rename 'Default Password Expiration Days' to 'Password Expiration Days'

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2178,10 +2178,10 @@ $GLOBALS_METADATA = [
         ],
 
         'password_expiration_days' => [
-            xl('Default Password Expiration Days'),
+            xl('Password Expiration Days'),
             'num',                            // data type
             '180',                            // default
-            xl('Default password expiration period in days. 0 means this feature is disabled.')
+            xl('Password expiration period in days. 0 means this feature is disabled.')
         ],
 
         'password_grace_time' => [


### PR DESCRIPTION
## Summary

The `password_expiration_days` global is labeled **Default Password Expiration Days**, which implies a per-user override exists. No such override exists — the value is applied uniformly to every user wherever expiration is checked:

- `src/Common/Auth/AuthUtils.php:1088` (`checkPasswordNotExpired`)
- `interface/main/main_screen.php:416`
- `interface/main/pwd_expires_alert.php:34`
- `interface/usergroup/usergroup_admin.php:663`

Dropping "Default" from the label and description makes the setting's behavior match its name.

No behavioral change — only the human-readable label and description text.

## Test plan

- [ ] Administration → Globals → Security shows the setting as "Password Expiration Days"
- [ ] Setting the value still expires passwords as before (tested via existing auth flow)