### PR TITLE
ci(phpstan): post baseline diff as a sticky PR comment

### DIFF
--- a/.github/workflows/phpstan-baseline-diff.yml
+++ b/.github/workflows/phpstan-baseline-diff.yml
@@ -1,0 +1,86 @@
+# Posts a sticky PR comment summarizing how the PHPStan baseline counts
+# differ vs master, per error identifier.
+#
+# Runs on workflow_run (not pull_request) so that comments can be posted on
+# pull requests from forks: workflow_run executes in the base repository's
+# context with a GITHUB_TOKEN that has `pull-requests: write`, whereas the
+# PHPStan workflow itself (triggered by pull_request) has a read-only token
+# when the PR comes from a fork.
+#
+# The PHPStan workflow uploads the regenerated baseline as the
+# `phpstan-baseline-php<version>` artifact on every PR outcome. This workflow
+# downloads that artifact and compares it against the master baseline files
+# checked into the repo.
+name: PHPStan Baseline Diff
+
+on:
+  workflow_run:
+    workflows: [PHPStan]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+concurrency:
+  # Serialize per PR head branch so rapid pushes don't race to post the
+  # comment; the sticky header makes the final run overwrite the prior
+  # comment either way, but cancelling the older run saves API calls.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    # Only process PR runs. Push-to-master runs don't need a PR comment.
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Resolve PR number from head SHA
+      id: pr
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        REPO: ${{ github.repository }}
+      run: |
+        # github.event.workflow_run.pull_requests is empty for fork PRs, so
+        # resolve the PR number by looking up PRs associated with the head
+        # commit. This works for both in-repo and fork PRs.
+        number=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" --jq '.[0].number')
+        if [ -z "$number" ]; then
+          echo "Could not resolve a PR number for commit ${HEAD_SHA}; skipping."
+          exit 0
+        fi
+        printf 'number=%s\n' "$number" >> "$GITHUB_OUTPUT"
+
+    - name: Checkout master baseline
+      if: steps.pr.outputs.number
+      uses: actions/checkout@v6
+      with:
+        ref: master
+        sparse-checkout: |
+          .phpstan
+        sparse-checkout-cone-mode: false
+
+    - name: Download PR baseline
+      if: steps.pr.outputs.number
+      uses: actions/download-artifact@v7
+      with:
+        name: phpstan-baseline-php8.5
+        path: pr-baseline
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        run-id: ${{ github.event.workflow_run.id }}
+
+    - name: Generate diff markdown
+      if: steps.pr.outputs.number
+      run: |
+        php .phpstan/baseline-diff.php .phpstan/baseline pr-baseline > diff.md
+        cat diff.md
+
+    - name: Post sticky comment
+      if: steps.pr.outputs.number
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: phpstan-baseline-diff
+        number: ${{ steps.pr.outputs.number }}
+        path: diff.md

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -118,10 +118,12 @@ jobs:
           echo 'Or run `composer phpstan-baseline` to regenerate the baseline locally.'
         } >> "$GITHUB_STEP_SUMMARY"
         exit 1
-    # Upload the resulting baseline as an artifact. This is intended mostly for
-    # debugging and isn't actively used by GH workflows.
+    # Upload the resulting baseline as an artifact. On PR events this runs on
+    # every outcome so the `phpstan-baseline-diff.yml` workflow can download
+    # the regenerated baseline and post a comparison vs master. On push events
+    # it only runs on failure, matching the prior debugging-oriented behavior.
     - name: Upload PHPStan Baseline
-      if: failure()
+      if: always() && (github.event_name == 'pull_request' || failure())
       uses: actions/upload-artifact@v7
       with:
         name: phpstan-baseline-php${{ matrix.php-version }}

--- a/.phpstan/baseline-diff.php
+++ b/.phpstan/baseline-diff.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * Render a markdown summary comparing two PHPStan baseline directories.
+ *
+ * Given a "base" baseline directory (typically master) and a "head" baseline
+ * directory (typically the PR), counts the total number of suppressed error
+ * occurrences per identifier (the sum of each entry's `count` field) and
+ * emits a GitHub-flavored markdown report on stdout:
+ *
+ *   - Identifiers whose occurrence count differs between base and head, as
+ *     a table sorted by the absolute delta, descending.
+ *   - Identifiers that did not change, collapsed inside a <details> block.
+ *   - A totals row (base, head, delta).
+ *
+ * The baseline files are valid PHP that assemble `$ignoreErrors = [...]`;
+ * this script loads them via `require` inside an isolated function scope
+ * and sums `count` across entries.
+ *
+ * Usage:
+ *   php .phpstan/baseline-diff.php <base-dir> <head-dir>
+ *
+ * Intended for the PHPStan Baseline Diff workflow, but runnable locally
+ * against any two baseline directories.
+ */
+
+declare(strict_types=1);
+
+if ($argc !== 3) {
+    fwrite(STDERR, "Usage: php {$argv[0]} <base-dir> <head-dir>\n");
+    exit(2);
+}
+
+$baseDir = $argv[1];
+$headDir = $argv[2];
+
+if (!is_dir($baseDir)) {
+    fwrite(STDERR, "Base baseline directory not found: {$baseDir}\n");
+    exit(2);
+}
+
+if (!is_dir($headDir)) {
+    fwrite(STDERR, "Head baseline directory not found: {$headDir}\n");
+    exit(2);
+}
+
+/**
+ * Load a baseline file in an isolated scope and return the sum of `count`
+ * fields. Returns 0 for a missing file so identifiers that only exist on
+ * one side are handled naturally.
+ */
+function count_occurrences(string $file): int
+{
+    if (!is_file($file)) {
+        return 0;
+    }
+    $ignoreErrors = [];
+    require $file;
+    return array_sum(array_column($ignoreErrors, 'count'));
+}
+
+/**
+ * @return list<string>
+ */
+function list_identifiers(string $dir): array
+{
+    $ids = [];
+    foreach (glob($dir . '/*.php') ?: [] as $path) {
+        $name = basename($path, '.php');
+        if ($name === 'loader') {
+            continue;
+        }
+        $ids[] = $name;
+    }
+    return $ids;
+}
+
+/**
+ * @param array{id: string, base: int, head: int, delta: int} $a
+ * @param array{id: string, base: int, head: int, delta: int} $b
+ */
+function compare_by_abs_delta(array $a, array $b): int
+{
+    $cmp = abs($b['delta']) <=> abs($a['delta']);
+    if ($cmp !== 0) {
+        return $cmp;
+    }
+    return strcmp($a['id'], $b['id']);
+}
+
+/**
+ * @param array{id: string, base: int, head: int, delta: int} $a
+ * @param array{id: string, base: int, head: int, delta: int} $b
+ */
+function compare_by_id(array $a, array $b): int
+{
+    return strcmp($a['id'], $b['id']);
+}
+
+$identifiers = array_values(array_unique(array_merge(
+    list_identifiers($baseDir),
+    list_identifiers($headDir),
+)));
+sort($identifiers);
+
+/** @var list<array{id: string, base: int, head: int, delta: int}> $rows */
+$rows = [];
+$baseTotal = 0;
+$headTotal = 0;
+foreach ($identifiers as $id) {
+    $base = count_occurrences($baseDir . '/' . $id . '.php');
+    $head = count_occurrences($headDir . '/' . $id . '.php');
+    $baseTotal += $base;
+    $headTotal += $head;
+    $rows[] = [
+        'id' => $id,
+        'base' => $base,
+        'head' => $head,
+        'delta' => $head - $base,
+    ];
+}
+
+$changed = array_values(array_filter($rows, static fn(array $r): bool => $r['delta'] !== 0));
+$unchanged = array_values(array_filter($rows, static fn(array $r): bool => $r['delta'] === 0));
+
+usort($changed, compare_by_abs_delta(...));
+usort($unchanged, compare_by_id(...));
+
+$delta = $headTotal - $baseTotal;
+
+/**
+ * Format a signed delta for display ("+3", "-7", "0").
+ */
+function format_delta(int $n): string
+{
+    if ($n > 0) {
+        return '+' . $n;
+    }
+    return (string) $n;
+}
+
+echo "## PHPStan Baseline Diff\n\n";
+
+if ($changed === []) {
+    echo "No baseline changes vs master. ";
+    echo "Total suppressed occurrences: **" . number_format($baseTotal) . "** ";
+    echo "across " . count($unchanged) . " identifier(s).\n";
+    exit(0);
+}
+
+echo "| Identifier | Master | PR | Δ |\n";
+echo "|---|---:|---:|---:|\n";
+foreach ($changed as $row) {
+    printf(
+        "| `%s` | %s | %s | %s |\n",
+        $row['id'],
+        number_format($row['base']),
+        number_format($row['head']),
+        format_delta($row['delta']),
+    );
+}
+printf(
+    "| **Total** | **%s** | **%s** | **%s** |\n",
+    number_format($baseTotal),
+    number_format($headTotal),
+    format_delta($delta),
+);
+
+echo "\n";
+printf(
+    "%d identifier(s) changed, %d unchanged.\n",
+    count($changed),
+    count($unchanged),
+);
+
+if ($unchanged !== []) {
+    echo "\n<details>\n";
+    echo "<summary>Unchanged identifiers (" . count($unchanged) . ")</summary>\n\n";
+    echo "| Identifier | Occurrences |\n";
+    echo "|---|---:|\n";
+    foreach ($unchanged as $row) {
+        printf("| `%s` | %s |\n", $row['id'], number_format($row['base']));
+    }
+    echo "\n</details>\n";
+}


### PR DESCRIPTION
## Summary

- New workflow (`phpstan-baseline-diff.yml`) triggers on `workflow_run` after the main `PHPStan` workflow completes on a PR, and posts a sticky comment comparing per-identifier baseline **occurrences** (sum of each entry's `count`) vs master.
- Changed identifiers appear in a sorted table (by |Δ| desc); unchanged ones collapse into a `<details>` block; if nothing moves, the comment is a one-liner.
- Widens the existing baseline-artifact upload step in `phpstan.yml` so it runs on every PR outcome (not just failures) — that's the artifact the new workflow consumes.
- Counting lives in `.phpstan/baseline-diff.php` (runnable locally: `php .phpstan/baseline-diff.php <master-dir> <pr-dir>`).

## Design notes

- **Fork PRs covered.** Uses `workflow_run` (not `pull_request_target`) so the comment step runs in the base-repo context with `pull-requests: write`, with no exposure to untrusted PR code. PR number is resolved from `head_sha` via `gh api repos/.../commits/$SHA/pulls`, which works for both in-repo and fork PRs (`workflow_run.pull_requests` is empty for forks).
- **No artifact plumbing on master.** Master's committed baseline is already enforced by CI to match what PHPStan generates, so the new workflow just reads the checked-in `.phpstan/baseline/*.php` via a sparse checkout.
- **New third-party action:** `marocchino/sticky-pull-request-comment@v2`. No prior PR-commenting action in this repo to match; this is the widely-used option. Happy to swap for raw `gh api` calls if preferred.
- **Not a required check.** Informational only; a failure to post shouldn't block merging.

## Sample output

A synthetic PR that drops one identifier and trims 10 occurrences from another produces:

> ## PHPStan Baseline Diff
>
> | Identifier | Master | PR | Δ |
> |---|---:|---:|---:|
> | \`argument.type\` | 28,919 | 28,909 | -10 |
> | \`argument.templateType\` | 3 | 0 | -3 |
> | **Total** | **159,877** | **159,864** | **-13** |
>
> 2 identifier(s) changed, 172 unchanged.
>
> <details><summary>Unchanged identifiers (172)</summary> ... </details>

## Test plan

- [ ] Verify the new workflow triggers on this PR and posts the sticky comment
- [ ] Confirm the comment updates (not duplicates) after a follow-up push
- [ ] Confirm it works on a subsequent fork PR (wait for a real one, or ask a contributor to retrigger)
- [ ] Spot-check that the occurrence totals match what a local `composer phpstan-baseline` produces