### PR TITLE
ci(phpstan): make baseline-diff PR lookup tolerant of API failures

### DIFF
--- a/.github/workflows/phpstan-baseline-diff.yml
+++ b/.github/workflows/phpstan-baseline-diff.yml
@@ -46,7 +46,11 @@ jobs:
         # github.event.workflow_run.pull_requests is empty for fork PRs, so
         # resolve the PR number by looking up PRs associated with the head
         # commit. This works for both in-repo and fork PRs.
-        number=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" --jq '.[0].number')
+        # `|| true` prevents `set -e` from aborting if `gh api` fails (e.g.
+        # 404 when the head SHA isn't reachable in this repo because a fork
+        # branch was rebased or force-pushed). `// empty` makes jq emit
+        # nothing instead of `null` on an empty array.
+        number=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" --jq '.[0].number // empty' 2>/dev/null || true)
         if [ -z "$number" ]; then
           echo "Could not resolve a PR number for commit ${HEAD_SHA}; skipping."
           exit 0


### PR DESCRIPTION
## Summary

The `Resolve PR number from head SHA` step in `phpstan-baseline-diff.yml` runs under `bash -e`. When `gh api .../commits/<sha>/pulls` fails (e.g. 404 because a fork branch was rebased or force-pushed and the SHA is no longer reachable in `openemr/openemr`), gh exits non-zero with `unexpected end of JSON input` and `set -e` aborts the script — the empty-check on the next line never runs and the job fails instead of skipping cleanly.

Example failure: https://github.com/openemr/openemr/actions/runs/24994565235/job/73188082969

## Changes

- `|| true` so a failed lookup does not abort the script
- `// empty` so jq emits nothing instead of `null` on an empty array
- `2>/dev/null` to keep the log clean

The existing `if [ -z "$number" ]; then ... exit 0` skip path then handles the empty result gracefully.

## Test plan

- [ ] Re-run the failing scenario (fork PR with unreachable head SHA) and confirm the job exits 0 with the "Could not resolve a PR number" message instead of failing
- [ ] Normal PR runs continue to resolve and post the sticky comment