### PR TITLE
ci(e2e): capture diagnostics for InvalidSessionIdException flake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -620,6 +620,46 @@ jobs:
         path: junit-${{ matrix.suite }}.xml
 
     ##
+    # Selenium diagnostics for InvalidSessionIdException flake (#11725).
+    # Runs FIRST on failure so the selenium container is still alive — later
+    # E2e log steps can race with compose teardown. Captures container state,
+    # process tree, resource snapshot, and OOM/segfault evidence so the next
+    # silent Chrome death leaves a usable trace.
+    - name: Capture selenium diagnostics on failure
+      if: ${{ failure() && matrix.suite == 'e2e' }}
+      run: |
+        . ci/ciLibrary.source
+        mkdir -p selenium-diagnostics
+        # Container state — confirms whether selenium was up at failure time.
+        dc ps -a > selenium-diagnostics/docker-compose-ps.txt 2>&1 || true
+        # Process tree inside the selenium container.
+        dc top selenium > selenium-diagnostics/docker-compose-top.txt 2>&1 || true
+        # Memory/CPU snapshot — resolve service to container ID since
+        # `docker stats` does not accept compose service names.
+        selenium_cid=$(dc ps -q selenium 2>/dev/null || true)
+        if [[ -n "${selenium_cid}" ]]; then
+            docker stats --no-stream "${selenium_cid}" > selenium-diagnostics/docker-stats.txt 2>&1 || true
+        else
+            echo 'selenium service has no container at failure time' > selenium-diagnostics/docker-stats.txt
+        fi
+        # Kernel ring buffer — surface OOM-killer / segfault / chrome lines first,
+        # then a tail as fallback when the buffer is silent.
+        sudo dmesg -T 2>/dev/null | grep -iE 'oom|killed|segfault|chrome|selenium' \
+            > selenium-diagnostics/dmesg.matches.txt 2>&1 || true
+        sudo dmesg -T 2>/dev/null | tail -200 > selenium-diagnostics/dmesg.tail.txt 2>&1 || true
+        # Full selenium logs (also echoed to the job log by the later step, but
+        # capturing to a file makes them downloadable alongside the rest).
+        dc logs --no-color selenium > selenium-diagnostics/selenium.log 2>&1 || true
+
+    - name: Upload selenium diagnostics
+      if: ${{ failure() && matrix.suite == 'e2e' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: selenium-diagnostics-${{ needs.setup.outputs.docker_dir }}
+        path: selenium-diagnostics/
+        if-no-files-found: ignore
+
+    ##
     # E2E-specific post-test steps
     - name: E2e container logs
       if: ${{ !cancelled() && matrix.suite == 'e2e' }}
@@ -651,34 +691,6 @@ jobs:
       with:
         name: e2e-test-videos-${{ needs.setup.outputs.docker_dir }}
         path: selenium-videos/
-
-    ##
-    # Selenium diagnostics for InvalidSessionIdException flake (#11725).
-    # Captures runner kernel log + container process tree + resource stats so
-    # the next silent Chrome death leaves a usable trace. Only runs on failure
-    # to keep green-build noise down.
-    - name: Capture selenium diagnostics on failure
-      if: ${{ failure() && matrix.suite == 'e2e' }}
-      run: |
-        . ci/ciLibrary.source
-        mkdir -p selenium-diagnostics
-        # Kernel ring buffer — look for OOM-killer / segfault lines around the failure.
-        sudo dmesg | tail -200 > selenium-diagnostics/dmesg.tail.txt 2>&1 || true
-        # Process tree inside the selenium container at teardown.
-        dc top selenium > selenium-diagnostics/docker-compose-top.txt 2>&1 || true
-        # Memory/CPU snapshot at teardown.
-        docker stats --no-stream selenium > selenium-diagnostics/docker-stats.txt 2>&1 || true
-        # Full selenium logs (also echoed to the job log by the step above, but
-        # capturing to a file makes them downloadable alongside the rest).
-        dc logs --no-color selenium > selenium-diagnostics/selenium.log 2>&1 || true
-
-    - name: Upload selenium diagnostics
-      if: ${{ failure() && matrix.suite == 'e2e' }}
-      uses: actions/upload-artifact@v7
-      with:
-        name: selenium-diagnostics-${{ needs.setup.outputs.docker_dir }}
-        path: selenium-diagnostics/
-        if-no-files-found: ignore
 
     - name: Test Summary
       if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -652,6 +652,34 @@ jobs:
         name: e2e-test-videos-${{ needs.setup.outputs.docker_dir }}
         path: selenium-videos/
 
+    ##
+    # Selenium diagnostics for InvalidSessionIdException flake (#11725).
+    # Captures runner kernel log + container process tree + resource stats so
+    # the next silent Chrome death leaves a usable trace. Only runs on failure
+    # to keep green-build noise down.
+    - name: Capture selenium diagnostics on failure
+      if: ${{ failure() && matrix.suite == 'e2e' }}
+      run: |
+        . ci/ciLibrary.source
+        mkdir -p selenium-diagnostics
+        # Kernel ring buffer — look for OOM-killer / segfault lines around the failure.
+        sudo dmesg | tail -200 > selenium-diagnostics/dmesg.tail.txt 2>&1 || true
+        # Process tree inside the selenium container at teardown.
+        dc top selenium > selenium-diagnostics/docker-compose-top.txt 2>&1 || true
+        # Memory/CPU snapshot at teardown.
+        docker stats --no-stream selenium > selenium-diagnostics/docker-stats.txt 2>&1 || true
+        # Full selenium logs (also echoed to the job log by the step above, but
+        # capturing to a file makes them downloadable alongside the rest).
+        dc logs --no-color selenium > selenium-diagnostics/selenium.log 2>&1 || true
+
+    - name: Upload selenium diagnostics
+      if: ${{ failure() && matrix.suite == 'e2e' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: selenium-diagnostics-${{ needs.setup.outputs.docker_dir }}
+        path: selenium-diagnostics/
+        if-no-files-found: ignore
+
     - name: Test Summary
       if: ${{ always() }}
       run: |


### PR DESCRIPTION
Refs #11725.

## Summary

Diagnostics-only change motivated by the research in #11725. The Selenium standalone-chromium container occasionally returns `invalid session id: session deleted as the browser has closed the connection` mid-test, but the existing post-test `dc logs selenium` step has shown no OOM kill, no tab-crashed event, and no supervisord restart at the moment of failure. We can't pin down the silent Chrome death without more evidence, so this PR makes the next failure leave a usable trace.

Adds a failure-only step in the e2e job in `.github/workflows/test.yml` that writes the following to a `selenium-diagnostics/` directory and uploads it as a separate artifact:

- `dmesg | tail -200` from the runner (OOM-killer / segfault lines)
- `docker compose top selenium` (process tree inside the container at teardown)
- `docker stats --no-stream selenium` (memory/CPU at teardown)
- Full `docker compose logs selenium` written to a file (also still echoed to the job log by the existing step, but the file is downloadable alongside the rest)

No test behavior change. No image bumps, no `shm_size`, no restart policies. The new steps are gated on `failure() && matrix.suite == 'e2e'` so green builds are unaffected.

## Test plan

- [ ] Merge and wait for the next e2e flake on master
- [ ] On failure, download the `selenium-diagnostics-<docker_dir>` artifact from the run
- [ ] Inspect `dmesg.tail.txt`, `docker-compose-top.txt`, `docker-stats.txt`, and `selenium.log` for OOM-killer / segfault / resource-pressure signals around the failure timestamp
- [ ] Feed findings back into #11725 to choose the actual fix