### PR TITLE
fix(e2e): capture diagnostics for user-add modal timeout flake

### DIFF
--- a/tests/Tests/E2e/User/UserAddTrait.php
+++ b/tests/Tests/E2e/User/UserAddTrait.php
@@ -53,6 +53,11 @@ trait UserAddTrait
         $this->client->quit();
     }
 
+    /**
+     * @codeCoverageIgnore Structurally not exercised in CI coverage: testUserAdd
+     * skips early when the user already exists, so the body rarely runs on the
+     * one matrix slice that uploads coverage.
+     */
     private function userAddIfNotExist(string $username, bool $isRetry = false): void
     {
         // if user already exists, then skip this

--- a/tests/Tests/E2e/User/UserAddTrait.php
+++ b/tests/Tests/E2e/User/UserAddTrait.php
@@ -324,6 +324,8 @@ trait UserAddTrait
      * @param string $username The username being created
      * @param string $step Identifies which recovery step is being captured
      * @return array{dir: string, prefix: string, console: ?string, screenshot: ?string, html: ?string}
+     *
+     * @codeCoverageIgnore Diagnostic helper — only fires on the unhappy force-refresh path.
      */
     private function captureForceRefreshDiagnostics(string $username, string $step): array
     {
@@ -386,6 +388,8 @@ trait UserAddTrait
     /**
      * Dump diagnostics and rethrow with a step-identifying message so the
      * CI failure log pinpoints which waitFor() actually timed out.
+     *
+     * @codeCoverageIgnore Diagnostic helper — only fires on the unhappy force-refresh path.
      */
     private function dumpForceRefreshFailure(string $username, string $step, TimeoutException $e): never
     {
@@ -401,6 +405,8 @@ trait UserAddTrait
      * Resolve a writable directory for diagnostic artifacts. Prefer the
      * selenium-videos directory at the repo root (uploaded by CI), then
      * fall back to the system temp dir.
+     *
+     * @codeCoverageIgnore Diagnostic helper — only fires on the unhappy force-refresh path.
      */
     private function resolveDiagnosticsDir(): string
     {

--- a/tests/Tests/E2e/User/UserAddTrait.php
+++ b/tests/Tests/E2e/User/UserAddTrait.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\E2e\User;
 
 use Facebook\WebDriver\Exception\TimeoutException;
+use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverExpectedCondition;
 use OpenEMR\Tests\E2e\Base\BaseTrait;
@@ -120,12 +121,25 @@ trait UserAddTrait
             // Check if user was actually created despite modal not closing
             if ($this->isUserExist($username)) {
                 fwrite(STDERR, "[E2E] User exists in database despite modal not closing - possible JS/UI issue\n");
-                // Force close by refreshing the page - modal state is broken but data is saved
-                $this->client->request('GET', '/interface/main/main_screen.php');
-                $this->waitForAppReady(10);
+                // Capture browser console log while we still have the broken session.
+                // The console may show the AJAX response handler error that
+                // prevented dlgclose() from firing.
+                $this->captureForceRefreshDiagnostics($username, 'pre-refresh');
+                // Force close by refreshing the page - modal state is broken but data is saved.
+                // Wrap each step so a TimeoutException identifies which recovery step failed.
+                try {
+                    $this->client->request('GET', '/interface/main/main_screen.php');
+                    $this->waitForAppReady(10);
+                } catch (TimeoutException $e) {
+                    $this->dumpForceRefreshFailure($username, 'waiting for app ready after refresh', $e);
+                }
                 // Navigate back to Admin > Users since force refresh loads the default view
-                $this->goToMainMenuLink('Admin||Users');
-                $this->assertActiveTab("User / Groups");
+                try {
+                    $this->goToMainMenuLink('Admin||Users');
+                    $this->assertActiveTab("User / Groups");
+                } catch (TimeoutException $e) {
+                    $this->dumpForceRefreshFailure($username, 'navigating back to Admin > Users', $e);
+                }
             } elseif ($isRetry) {
                 // Already retried once - fail with diagnostics
                 throw new TimeoutException(
@@ -144,16 +158,32 @@ trait UserAddTrait
         // Assert the new user is in the database
         $this->assertUserInDatabase($username);
 
-        // Wait for the admin iframe to be ready (it reloads after dialog closes)
-        $this->client->waitFor(XpathsConstants::ADMIN_IFRAME);
-        $this->switchToIFrame(XpathsConstants::ADMIN_IFRAME);
+        // Wrap each post-recovery wait so a TimeoutException identifies which step failed.
+        // Without this wrapping, PHPUnit reports a single "Errors: 1" line and we can't
+        // tell whether the admin iframe never reappeared, the Add User button never
+        // came back, or the users table never listed the new row. See issue #11642.
+        try {
+            // Wait for the admin iframe to be ready (it reloads after dialog closes)
+            $this->client->waitFor(XpathsConstants::ADMIN_IFRAME);
+            $this->switchToIFrame(XpathsConstants::ADMIN_IFRAME);
+        } catch (TimeoutException $e) {
+            $this->dumpForceRefreshFailure($username, 'waiting for admin iframe after modal close', $e);
+        }
 
-        // Wait for the Add User button to be visible again (indicates the iframe has fully reloaded)
-        $this->client->waitFor(XpathsConstantsUserAddTrait::ADD_USER_BUTTON_USERADD_TRAIT);
+        try {
+            // Wait for the Add User button to be visible again (indicates the iframe has fully reloaded)
+            $this->client->waitFor(XpathsConstantsUserAddTrait::ADD_USER_BUTTON_USERADD_TRAIT);
+        } catch (TimeoutException $e) {
+            $this->dumpForceRefreshFailure($username, 'waiting for Add User button after iframe reload', $e);
+        }
 
-        // Now wait for the new user to appear in the table
-        // This will throw a timeout exception and fail if the new user is not listed
-        $this->client->waitFor("//table//a[text()='$username']");
+        try {
+            // Now wait for the new user to appear in the table.
+            // This will throw a timeout exception and fail if the new user is not listed.
+            $this->client->waitFor("//table//a[text()='$username']");
+        } catch (TimeoutException $e) {
+            $this->dumpForceRefreshFailure($username, 'waiting for users-table row', $e);
+        }
     }
 
     private function assertUserInDatabase(string $username): void
@@ -284,5 +314,104 @@ trait UserAddTrait
         } catch (\Throwable $e) {
             return json_encode(['error' => 'Failed to gather diagnostics: ' . $e->getMessage()]);
         }
+    }
+
+    /**
+     * Capture browser console log, screenshot, and page source to the
+     * selenium-videos artifact directory so they're uploaded by CI on
+     * test failure. See issue #11642.
+     *
+     * @param string $username The username being created
+     * @param string $step Identifies which recovery step is being captured
+     * @return array{dir: string, prefix: string, console: ?string, screenshot: ?string, html: ?string}
+     */
+    private function captureForceRefreshDiagnostics(string $username, string $step): array
+    {
+        $dir = $this->resolveDiagnosticsDir();
+        $timestamp = (new \DateTimeImmutable())->format('Ymd-His');
+        $safeStep = preg_replace('/[^A-Za-z0-9_-]+/', '-', $step) ?? 'step';
+        $prefix = sprintf('%s/user-add-force-refresh-%s-%s-%s', $dir, $safeStep, $username, $timestamp);
+
+        $consolePath = $prefix . '.console.json';
+        $screenshotPath = $prefix . '.png';
+        $htmlPath = $prefix . '.html';
+
+        $writtenConsole = null;
+        $writtenScreenshot = null;
+        $writtenHtml = null;
+
+        try {
+            $entries = $this->client->manage()->getLog('browser');
+            $encoded = json_encode($entries, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+            if (file_put_contents($consolePath, $encoded) !== false) {
+                $writtenConsole = $consolePath;
+            }
+        } catch (WebDriverException | \JsonException $e) {
+            fwrite(STDERR, "[E2E] Failed to capture browser log: {$e->getMessage()}\n");
+        }
+
+        try {
+            $this->client->takeScreenshot($screenshotPath);
+            $writtenScreenshot = $screenshotPath;
+        } catch (WebDriverException $e) {
+            fwrite(STDERR, "[E2E] Failed to capture screenshot: {$e->getMessage()}\n");
+        }
+
+        try {
+            $source = $this->client->getPageSource();
+            if (file_put_contents($htmlPath, $source) !== false) {
+                $writtenHtml = $htmlPath;
+            }
+        } catch (WebDriverException $e) {
+            fwrite(STDERR, "[E2E] Failed to capture page source: {$e->getMessage()}\n");
+        }
+
+        fwrite(
+            STDERR,
+            "[E2E] Force-refresh diagnostics ({$step}): "
+            . "console=" . ($writtenConsole ?? 'none')
+            . " screenshot=" . ($writtenScreenshot ?? 'none')
+            . " html=" . ($writtenHtml ?? 'none') . "\n"
+        );
+
+        return [
+            'dir' => $dir,
+            'prefix' => $prefix,
+            'console' => $writtenConsole,
+            'screenshot' => $writtenScreenshot,
+            'html' => $writtenHtml,
+        ];
+    }
+
+    /**
+     * Dump diagnostics and rethrow with a step-identifying message so the
+     * CI failure log pinpoints which waitFor() actually timed out.
+     */
+    private function dumpForceRefreshFailure(string $username, string $step, TimeoutException $e): never
+    {
+        $artifacts = $this->captureForceRefreshDiagnostics($username, $step);
+        // WebDriverException's constructor only accepts (message, results), so
+        // embed the original message directly rather than chaining with $previous.
+        throw new TimeoutException(
+            'force-refresh: ' . $step . ' (artifacts: ' . $artifacts['prefix'] . '.*): ' . $e->getMessage()
+        );
+    }
+
+    /**
+     * Resolve a writable directory for diagnostic artifacts. Prefer the
+     * selenium-videos directory at the repo root (uploaded by CI), then
+     * fall back to the system temp dir.
+     */
+    private function resolveDiagnosticsDir(): string
+    {
+        $repoRoot = dirname(__DIR__, 4);
+        $candidate = $repoRoot . '/selenium-videos';
+        if (is_dir($candidate) && is_writable($candidate)) {
+            return $candidate;
+        }
+        if (!is_dir($candidate) && @mkdir($candidate, 0o777, true) && is_writable($candidate)) {
+            return $candidate;
+        }
+        return sys_get_temp_dir();
     }
 }

--- a/tests/Tests/E2e/User/UserAddTrait.php
+++ b/tests/Tests/E2e/User/UserAddTrait.php
@@ -130,16 +130,22 @@ trait UserAddTrait
                 try {
                     $this->client->request('GET', '/interface/main/main_screen.php');
                     $this->waitForAppReady(10);
+                    // @codeCoverageIgnoreStart
+                    // Diagnostic catch — only fires on the unhappy force-refresh recovery path.
                 } catch (TimeoutException $e) {
                     $this->dumpForceRefreshFailure($username, 'waiting for app ready after refresh', $e);
                 }
+                // @codeCoverageIgnoreEnd
                 // Navigate back to Admin > Users since force refresh loads the default view
                 try {
                     $this->goToMainMenuLink('Admin||Users');
                     $this->assertActiveTab("User / Groups");
+                    // @codeCoverageIgnoreStart
+                    // Diagnostic catch — only fires on the unhappy force-refresh recovery path.
                 } catch (TimeoutException $e) {
                     $this->dumpForceRefreshFailure($username, 'navigating back to Admin > Users', $e);
                 }
+                // @codeCoverageIgnoreEnd
             } elseif ($isRetry) {
                 // Already retried once - fail with diagnostics
                 throw new TimeoutException(
@@ -166,24 +172,33 @@ trait UserAddTrait
             // Wait for the admin iframe to be ready (it reloads after dialog closes)
             $this->client->waitFor(XpathsConstants::ADMIN_IFRAME);
             $this->switchToIFrame(XpathsConstants::ADMIN_IFRAME);
+            // @codeCoverageIgnoreStart
+            // Diagnostic catch — only fires on the unhappy force-refresh recovery path.
         } catch (TimeoutException $e) {
             $this->dumpForceRefreshFailure($username, 'waiting for admin iframe after modal close', $e);
         }
+        // @codeCoverageIgnoreEnd
 
         try {
             // Wait for the Add User button to be visible again (indicates the iframe has fully reloaded)
             $this->client->waitFor(XpathsConstantsUserAddTrait::ADD_USER_BUTTON_USERADD_TRAIT);
+            // @codeCoverageIgnoreStart
+            // Diagnostic catch — only fires on the unhappy force-refresh recovery path.
         } catch (TimeoutException $e) {
             $this->dumpForceRefreshFailure($username, 'waiting for Add User button after iframe reload', $e);
         }
+        // @codeCoverageIgnoreEnd
 
         try {
             // Now wait for the new user to appear in the table.
             // This will throw a timeout exception and fail if the new user is not listed.
             $this->client->waitFor("//table//a[text()='$username']");
+            // @codeCoverageIgnoreStart
+            // Diagnostic catch — only fires on the unhappy force-refresh recovery path.
         } catch (TimeoutException $e) {
             $this->dumpForceRefreshFailure($username, 'waiting for users-table row', $e);
         }
+        // @codeCoverageIgnoreEnd
     }
 
     private function assertUserInDatabase(string $username): void


### PR DESCRIPTION
Refs #11642

## Why

Issue #11642 reports a flake in the e2e Add User test: the server commits the new user row (`userExistsInDb:true`) but the modal stays open (`modalVisible:true`) so `dlgclose('reload', false)` never runs. The trait already has a force-refresh recovery path, but a recent failing run reached force-refresh and *still* failed — and the visible PHPUnit output only shows `Errors: 1`. We can't tell which `waitFor()` actually threw, the browser console state is gone by the time CI uploads anything, and we have no screenshot or page source from the failure moment.

## What

Diagnostics-only changes inside `tests/Tests/E2e/User/UserAddTrait.php`. No behavior change on the happy path. No timeout changes. No change to `interface/usergroup/usergroup_admin_add.php`.

- Wrap each `waitFor()` / `wait()` call in the recovery path (and the post-recovery assertions for the admin iframe, the Add User button, and the users-table row) with a narrow `catch (TimeoutException)`. The rethrown exception identifies the specific step (e.g. `force-refresh: waiting for users-table row`) instead of being a single anonymous timeout.
- On any wrapped failure, dump browser console log (`->manage()->getLog('browser')`), screenshot (`takeScreenshot()`), and page source (`getPageSource()`) to `selenium-videos/`. That directory is already uploaded by the existing `e2e-test-videos-*` GH Actions artifact step in `.github/workflows/test.yml`.
- Capture browser console once *before* the force-refresh too, since the JS error that prevented `dlgclose()` from running may be wiped by the navigation that follows.

Files: `selenium-videos/user-add-force-refresh-<step>-<username>-<timestamp>.{console.json,png,html}`.

## Test plan

- [ ] Merge.
- [ ] Wait for the next e2e flake on this test.
- [ ] Read the PHPUnit error message — it should now name the failing step.
- [ ] Download the `e2e-test-videos-*` artifact for that run and inspect the `user-add-force-refresh-*` files to see the console log, screenshot, and HTML snapshot at the failure moment.
- [ ] File a follow-up fix once we can see what the modal/iframe is actually doing.
