### PR TITLE
chore(phpstan): drain Carecoordination module class.notFound + method.notFound

### DIFF
--- a/.phpstan/baseline/assign.propertyType.php
+++ b/.phpstan/baseline/assign.propertyType.php
@@ -287,26 +287,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Application/src/Application/Listener/Listener.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property Carecoordination\\\\Controller\\\\CarecoordinationController\\:\\:\\$carecoordinationTable \\(Carecoordination\\\\Controller\\\\Carecoordination\\\\Model\\\\CarecoordinationTable\\) does not accept Carecoordination\\\\Model\\\\CarecoordinationTable\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Carecoordination\\\\Controller\\\\CarecoordinationController\\:\\:\\$documentsController \\(Carecoordination\\\\Controller\\\\Documents\\\\Controller\\\\DocumentsController\\) does not accept Documents\\\\Controller\\\\DocumentsController\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Carecoordination\\\\Controller\\\\CarecoordinationController\\:\\:\\$listenerObject \\(Carecoordination\\\\Controller\\\\Application\\\\Listener\\\\Listener\\) does not accept Application\\\\Listener\\\\Listener\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Carecoordination\\\\Controller\\\\CcdController\\:\\:\\$documentsController \\(Carecoordination\\\\Controller\\\\Documents\\\\Controller\\\\DocumentsController\\) does not accept Documents\\\\Controller\\\\DocumentsController\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property Carecoordination\\\\Model\\\\CcdaGlobalsConfiguration\\:\\:\\$ccdaSections \\(array\\) does not accept mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGlobalsConfiguration.php',

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -1058,11 +1058,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 6,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
 ];

--- a/.phpstan/baseline/catch.neverThrown.php
+++ b/.phpstan/baseline/catch.neverThrown.php
@@ -14,6 +14,11 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Dead catch \\- Throwable is never thrown in the try block\\.$#',
     'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Dead catch \\- Throwable is never thrown in the try block\\.$#',
+    'count' => 1,
     'path' => __DIR__ . '/../../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/catch.neverThrown.php
+++ b/.phpstan/baseline/catch.neverThrown.php
@@ -14,11 +14,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Dead catch \\- Throwable is never thrown in the try block\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Dead catch \\- Throwable is never thrown in the try block\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/class.notFound.php
+++ b/.phpstan/baseline/class.notFound.php
@@ -57,46 +57,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Application/src/Application/Listener/Listener.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to method getDocumentsTable\\(\\) on an unknown class Carecoordination\\\\Controller\\\\Documents\\\\Controller\\\\DocumentsController\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method isZipUpload\\(\\) on an unknown class Carecoordination\\\\Controller\\\\Documents\\\\Controller\\\\DocumentsController\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method uploadAction\\(\\) on an unknown class Carecoordination\\\\Controller\\\\Documents\\\\Controller\\\\DocumentsController\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Carecoordination\\\\Controller\\\\CarecoordinationController\\:\\:\\$carecoordinationTable has unknown class Carecoordination\\\\Controller\\\\Carecoordination\\\\Model\\\\CarecoordinationTable as its type\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Carecoordination\\\\Controller\\\\CarecoordinationController\\:\\:\\$documentsController has unknown class Carecoordination\\\\Controller\\\\Documents\\\\Controller\\\\DocumentsController as its type\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Carecoordination\\\\Controller\\\\CarecoordinationController\\:\\:\\$listenerObject has unknown class Carecoordination\\\\Controller\\\\Application\\\\Listener\\\\Listener as its type\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method uploadAction\\(\\) on an unknown class Carecoordination\\\\Controller\\\\Documents\\\\Controller\\\\DocumentsController\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Carecoordination\\\\Controller\\\\CcdController\\:\\:\\$documentsController has unknown class Carecoordination\\\\Controller\\\\Documents\\\\Controller\\\\DocumentsController as its type\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Iterating over an object of an unknown class Installer\\\\Controller\\\\unknown_type\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1428,7 +1428,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 11,
+    'count' => 10,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.variable.php
+++ b/.phpstan/baseline/empty.variable.php
@@ -137,11 +137,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-weno/src/Services/WenoValidate.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$downloadccda in empty\\(\\) always exists and is not falsy\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$patientRecord in empty\\(\\) always exists and is not falsy\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php',

--- a/.phpstan/baseline/empty.variable.php
+++ b/.phpstan/baseline/empty.variable.php
@@ -137,6 +137,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-weno/src/Services/WenoValidate.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Variable \\$downloadccda in empty\\(\\) always exists and is not falsy\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Variable \\$patientRecord in empty\\(\\) always exists and is not falsy\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php',

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -2007,11 +2007,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/Module.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method fetchXmlDocuments\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method updateDocumentCategoryUsingCatname\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
@@ -2022,14 +2017,9 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method updateDocumentCategory\\(\\) on mixed\\.$#',
+    'message' => '#^Cannot call method updateDocumentCategoryUsingCatname\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method date_format\\(\\) on mixed\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method z_xlt\\(\\) on mixed\\.$#',
@@ -9747,18 +9737,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method getAttribute\\(\\) on DOMNameSpaceNode\\|DOMNode\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method item\\(\\) on DOMNodeList\\<DOMNameSpaceNode\\|DOMNode\\>\\|false\\.$#',
     'count' => 3,
-    'path' => __DIR__ . '/../../tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method setAttribute\\(\\) on DOMNameSpaceNode\\|DOMNode\\|null\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.notFound.php
+++ b/.phpstan/baseline/method.notFound.php
@@ -107,111 +107,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Application/src/Application/Controller/SendtoController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Carecoordination\\\\Controller\\\\CarecoordinationController\\:\\:CommonPlugin\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Carecoordination\\\\Controller\\\\CarecoordinationController\\:\\:Documents\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Laminas\\\\Stdlib\\\\RequestInterface\\:\\:getPost\\(\\)\\.$#',
-    'count' => 13,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Laminas\\\\Stdlib\\\\RequestInterface\\:\\:getQuery\\(\\)\\.$#',
-    'count' => 9,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Carecoordination\\\\Controller\\\\CcdController\\:\\:updateDocumentCategoryUsingCatname\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Laminas\\\\Stdlib\\\\RequestInterface\\:\\:getPost\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Laminas\\\\Stdlib\\\\RequestInterface\\:\\:getQuery\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method object\\:\\:document_fetch\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method object\\:\\:fetch_cat_id\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method object\\:\\:fetch_uploaded_documents\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method object\\:\\:getDocument\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Laminas\\\\Stdlib\\\\RequestInterface\\:\\:getPost\\(\\)\\.$#',
-    'count' => 11,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Laminas\\\\Stdlib\\\\RequestInterface\\:\\:getQuery\\(\\)\\.$#',
-    'count' => 18,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Carecoordination\\\\Controller\\\\EncountermanagerController\\:\\:CommonPlugin\\(\\)\\.$#',
-    'count' => 5,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Laminas\\\\Stdlib\\\\RequestInterface\\:\\:getPost\\(\\)\\.$#',
-    'count' => 27,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Laminas\\\\Stdlib\\\\RequestInterface\\:\\:getQuery\\(\\)\\.$#',
-    'count' => 13,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Laminas\\\\Stdlib\\\\RequestInterface\\:\\:getPost\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/MapperController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Laminas\\\\Stdlib\\\\RequestInterface\\:\\:getPost\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/SetupController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method Documents\\\\Model\\\\DocumentsTable\\:\\:getIssues\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method DOMNameSpaceNode\\|DOMNode\\:\\:insertBefore\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaUserPreferencesTransformer.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method DOMNameSpaceNode\\|DOMNode\\:\\:removeChild\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaUserPreferencesTransformer.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to an undefined method Ccr\\\\Controller\\\\CcrController\\:\\:CommonPlugin\\(\\)\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Ccr/src/Ccr/Controller/CcrController.php',
@@ -900,21 +795,6 @@ $ignoreErrors[] = [
     'message' => '#^Call to an undefined method OpenEMR\\\\Services\\\\Search\\\\ISearchField\\:\\:getChildren\\(\\)\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/FhirLocationServiceTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method DOMNameSpaceNode\\|DOMNode\\:\\:getAttribute\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method DOMNameSpaceNode\\|DOMNode\\:\\:hasAttribute\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to an undefined method DOMNameSpaceNode\\|DOMNode\\:\\:setAttribute\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to an undefined method OpenEMR\\\\FHIR\\\\SMART\\\\ExternalClinicalDecisionSupport\\\\DecisionSupportInterventionEntity\\:\\:populateServiceWithFhirQuestionnaire\\(\\)\\.$#',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -11282,11 +11282,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method Carecoordination\\\\Model\\\\CarecoordinationTable\\:\\:getIssues\\(\\) has parameter \\$pid with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method Carecoordination\\\\Model\\\\CarecoordinationTable\\:\\:getLabResults\\(\\) has parameter \\$data with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',

--- a/.phpstan/baseline/missingType.property.php
+++ b/.phpstan/baseline/missingType.property.php
@@ -2522,21 +2522,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Application/src/Application/Plugin/CommonPlugin.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property Carecoordination\\\\Controller\\\\CcdController\\:\\:\\$carecoordinationTable has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Carecoordination\\\\Controller\\\\CcdController\\:\\:\\$documentsTable has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property Carecoordination\\\\Controller\\\\CcdController\\:\\:\\$listenerObject has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property Carecoordination\\\\Controller\\\\EncounterccdadispatchController\\:\\:\\$components has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -6082,11 +6082,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method Carecoordination\\\\Controller\\\\CcdController\\:\\:getDocumentsTable\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method Carecoordination\\\\Controller\\\\CcdController\\:\\:importAction\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -16762,11 +16762,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset 0 on mixed\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'encounter\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',

--- a/.phpstan/baseline/openemr.exitInCatchOrFinally.php
+++ b/.phpstan/baseline/openemr.exitInCatchOrFinally.php
@@ -73,7 +73,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^exit/die inside a catch block swallows the caught exception and aborts the process\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenCatchType.php
+++ b/.phpstan/baseline/openemr.forbiddenCatchType.php
@@ -263,7 +263,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^catch \\(Throwable\\) would suppress Error, which is forbidden\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/preDec.type.php
+++ b/.phpstan/baseline/preDec.type.php
@@ -4,11 +4,6 @@ $ignoreErrors = [];
 $ignoreErrors[] = [
     'message' => '#^Cannot use \\-\\- on mixed\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaUserPreferencesTransformer.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot use \\-\\- on mixed\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/printed_fee_sheet.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/property.notFound.php
+++ b/.phpstan/baseline/property.notFound.php
@@ -167,21 +167,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/EtherFaxClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Access to an undefined property DOMNameSpaceNode\\|DOMNode\\:\\:\\$childElementCount\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaUserPreferencesTransformer.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Access to an undefined property DOMNameSpaceNode\\|DOMNode\\:\\:\\$firstChild\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaUserPreferencesTransformer.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Access to an undefined property DOMNameSpaceNode\\|DOMNode\\:\\:\\$lastElementChild\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaUserPreferencesTransformer.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Access to an undefined property Carecoordination\\\\Model\\\\ModuleconfigTable\\:\\:\\$applicationTable\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/ModuleconfigTable.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -1027,19 +1027,9 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Application/src/Application/Model/SendtoTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method Carecoordination\\\\Controller\\\\CarecoordinationController\\:\\:getCarecoordinationTable\\(\\) should return Carecoordination\\\\Model\\\\CarecoordinationTable but returns Carecoordination\\\\Controller\\\\Carecoordination\\\\Model\\\\CarecoordinationTable\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method Carecoordination\\\\Controller\\\\CarecoordinationController\\:\\:indexAction\\(\\) should return Laminas\\\\View\\\\Model\\\\ViewModel but returns Laminas\\\\Http\\\\Response\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method Carecoordination\\\\Controller\\\\CcdController\\:\\:getCarecoordinationTable\\(\\) should return object but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method Carecoordination\\\\Controller\\\\EncounterccdadispatchController\\:\\:getEncounterccdadispatchTable\\(\\) should return Carecoordination\\\\Model\\\\EncounterccdadispatchTable but returns mixed\\.$#',
@@ -10830,11 +10820,6 @@ $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Tests\\\\Services\\\\FHIR\\\\QuestionnaireResponse\\\\FhirQuestionnaireResponseFormServiceIntegrationTest\\:\\:createTestQuestionnaireResponse\\(\\) should return string but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/QuestionnaireResponse/FhirQuestionnaireResponseFormServiceIntegrationTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Tests\\\\Services\\\\Modules\\\\CareCoordination\\\\Model\\\\CcdaServiceDocumentRequestorTest\\:\\:getDocumentGenerationTime\\(\\) should return string but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php',
 ];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -10292,11 +10292,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$content might not be defined\\.$#',
-    'count' => 8,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$result might not be defined\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -10293,7 +10293,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Variable \\$content might not be defined\\.$#',
-    'count' => 6,
+    'count' => 8,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 return [
     'all' => [
-        'class.notFound.php' => 237,
+        'class.notFound.php' => 229,
         'classConstant.notFound.php' => 0,
         'constant.notFound.php' => 0,
         'function.notFound.php' => 0,
         'include.fileNotFound.php' => 0,
         'includeOnce.fileNotFound.php' => 0,
         'interface.notFound.php' => 0,
-        'method.notFound.php' => 184,
+        'method.notFound.php' => 160,
         'require.fileNotFound.php' => 0,
         'requireOnce.fileNotFound.php' => 0,
         'return.missing.php' => 0,

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -48,7 +48,7 @@ return [
         'return.missing.php' => 0,
         'staticMethod.notFound.php' => 0,
         'trait.notFound.php' => 0,
-        'variable.undefined.php' => 3075,
+        'variable.undefined.php' => 3074,
     ],
     'confidentNonObject' => [
         'classConstant.nonObject.php' => 0,

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
@@ -35,20 +35,14 @@ use OpenEMR\Services\Cda\CdaValidateDocuments;
  */
 class CarecoordinationController extends AbstractActionController
 {
-    private readonly CarecoordinationTable $carecoordinationTable;
-
-    private readonly DocumentsController $documentsController;
-
     private readonly Listener $listenerObject;
 
     private readonly string $date_format;
 
-    public function __construct(CarecoordinationTable $table, DocumentsController $documentsController)
+    public function __construct(private readonly CarecoordinationTable $carecoordinationTable, private readonly DocumentsController $documentsController)
     {
-        $this->carecoordinationTable = $table;
         $this->listenerObject = new Listener();
         $this->date_format = ApplicationTable::dateFormat(OEGlobalsBag::getInstance()->get('date_display_format'));
-        $this->documentsController = $documentsController;
     }
 
     /**

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
@@ -28,27 +28,20 @@ use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\Cda\CdaValidateDocuments;
 
+/**
+ * @method \Application\Plugin\CommonPlugin CommonPlugin()
+ * @method \Documents\Plugin\Documents Documents()
+ * @method \Laminas\Http\Request getRequest()
+ */
 class CarecoordinationController extends AbstractActionController
 {
-    /**
-     * @var Carecoordination\Model\CarecoordinationTable
-     */
-    private $carecoordinationTable;
+    private readonly CarecoordinationTable $carecoordinationTable;
 
-    /**
-     * @var Documents\Controller\DocumentsController
-     */
-    private $documentsController;
+    private readonly DocumentsController $documentsController;
 
-    /**
-     * @var Application\Listener\Listener
-     */
-    private $listenerObject;
+    private readonly Listener $listenerObject;
 
-    /**
-     * @var string
-     */
-    private $date_format;
+    private readonly string $date_format;
 
     public function __construct(CarecoordinationTable $table, DocumentsController $documentsController)
     {

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php
@@ -26,28 +26,16 @@ use OpenEMR\Common\Session\SessionWrapperFactory;
  */
 class CcdController extends AbstractActionController
 {
-    protected CcdTable $ccdTable;
-
-    protected CarecoordinationTable $carecoordinationTable;
-
-    protected DocumentsTable $documentsTable;
-
     protected Listener $listenerObject;
 
-    private readonly DocumentsController $documentsController;
-
     public function __construct(
-        CcdTable $ccdTable,
-        CarecoordinationTable $carecoordinationTable,
-        DocumentsTable $documentsTable,
-        DocumentsController $documentsController
+        protected CcdTable $ccdTable,
+        protected CarecoordinationTable $carecoordinationTable,
+        protected DocumentsTable $documentsTable,
+        private readonly DocumentsController $documentsController
     ) {
 
         $this->listenerObject = new Listener();
-        $this->ccdTable = $ccdTable;
-        $this->carecoordinationTable = $carecoordinationTable;
-        $this->documentsTable = $documentsTable;
-        $this->documentsController = $documentsController;
     }
 
     /*
@@ -113,7 +101,7 @@ class CcdController extends AbstractActionController
         $xml_content                      =    $this->getCarecoordinationTable()->getDocument($document_id);
 
         $xmltoarray                       =    new \Laminas\Config\Reader\Xml();
-        $array                            =    $xmltoarray->fromString((string) $xml_content);
+        $array                            =    $xmltoarray->fromString($xml_content);
 
         $this->getCcdTable()->import($array, $document_id);
 

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CcdController.php
@@ -21,22 +21,20 @@ use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 
+/**
+ * @method \Laminas\Http\Request getRequest()
+ */
 class CcdController extends AbstractActionController
 {
-    /**
-     * @var \Carecoordination\Model\CcdTable
-     */
-    protected $ccdTable;
+    protected CcdTable $ccdTable;
 
-    protected $carecoordinationTable;
+    protected CarecoordinationTable $carecoordinationTable;
 
-    protected $documentsTable;
+    protected DocumentsTable $documentsTable;
 
-    protected $listenerObject;
-    /**
-     * @var Documents\Controller\DocumentsController
-     */
-    private $documentsController;
+    protected Listener $listenerObject;
+
+    private readonly DocumentsController $documentsController;
 
     public function __construct(
         CcdTable $ccdTable,
@@ -79,7 +77,7 @@ class CcdController extends AbstractActionController
                 if ($row['doc_type'] == 'CCD') {
                     $_REQUEST["document_id"] = $row['doc_id'];
                     $this->importAction();
-                    $this->updateDocumentCategoryUsingCatname($row['doc_type'], $row['doc_id']);
+                    $this->documentsController->getDocumentsTable()->updateDocumentCategoryUsingCatname($row['doc_type'], $row['doc_id']);
                 }
             }
         }
@@ -132,16 +130,12 @@ class CcdController extends AbstractActionController
     {
         return $this->ccdTable;
     }
-    /**
-     * Table gateway
-     * @return object
-     */
-    public function getCarecoordinationTable()
+    public function getCarecoordinationTable(): CarecoordinationTable
     {
         return $this->carecoordinationTable;
     }
 
-    public function getDocumentsTable()
+    public function getDocumentsTable(): DocumentsTable
     {
         return $this->documentsTable;
     }

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
@@ -30,6 +30,9 @@ use OpenEMR\Common\Utils\XmlUtils;
 use OpenEMR\Cqm\QrdaControllers\QrdaReportController;
 use XSLTProcessor;
 
+/**
+ * @method \Laminas\Http\Request getRequest()
+ */
 class EncounterccdadispatchController extends AbstractActionController
 {
     protected $data;
@@ -238,14 +241,14 @@ class EncounterccdadispatchController extends AbstractActionController
 
                 // split content if unstructured is included from service.
                 $unstructured = "";
-                if (substr_count($content, '</ClinicalDocument>') === 2) {
-                    $d = explode('</ClinicalDocument>', $content);
+                if (substr_count((string) $content, '</ClinicalDocument>') === 2) {
+                    $d = explode('</ClinicalDocument>', (string) $content);
                     $content = $d[0] . '</ClinicalDocument>';
                     $unstructured = $d[1] . '</ClinicalDocument>';
                 }
 
                 if ($view && !$downloadccda) {
-                    if (str_starts_with($content, 'ERROR:')) {
+                    if (str_starts_with((string) $content, 'ERROR:')) {
                         echo "<h3>" . text($content) . "</h3>";
                         ServiceContainer::getLogger()->error("EncounterccdadispatchController: Error generating CCDA: {message}", ['message' => $content]);
                         die();

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
@@ -242,14 +242,15 @@ class EncounterccdadispatchController extends AbstractActionController
 
                 // split content if unstructured is included from service.
                 $unstructured = "";
-                if (substr_count((string) $content, '</ClinicalDocument>') === 2) {
-                    $d = explode('</ClinicalDocument>', (string) $content);
+                $content = strval($content);
+                if (substr_count($content, '</ClinicalDocument>') === 2) {
+                    $d = explode('</ClinicalDocument>', $content);
                     $content = $d[0] . '</ClinicalDocument>';
                     $unstructured = $d[1] . '</ClinicalDocument>';
                 }
 
                 if ($view && !$downloadccda) {
-                    if (str_starts_with((string) $content, 'ERROR:')) {
+                    if (str_starts_with($content, 'ERROR:')) {
                         echo "<h3>" . text($content) . "</h3>";
                         ServiceContainer::getLogger()->error("EncounterccdadispatchController: Error generating CCDA: {message}", ['message' => $content]);
                         die();

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
@@ -81,6 +81,7 @@ class EncounterccdadispatchController extends AbstractActionController
 
         $representedOrganization = $this->getEncounterccdadispatchTable()->getRepresentedOrganization();
 
+        $content = '';
         $request = $this->getRequest();
         $this->patient_id = $request->getQuery('pid');
         $this->encounter_id = $request->getQuery('encounter');
@@ -310,25 +311,11 @@ class EncounterccdadispatchController extends AbstractActionController
             die();
         }
 
-        try {
-            ob_clean();
-            if (!empty($_POST['sent_by_app'] ?? '')) {
-                echo $content;
-                exit;
-            }
-            if (empty($downloadccda)) {
-                $practice_filename = "CCDA_{$this->patient_id}.xml";
-                header("Cache-Control: public");
-                header("Content-Description: File Transfer");
-                header("Content-Disposition: attachment; filename=" . $practice_filename);
-                header("Content-Type: application/download");
-                header("Content-Transfer-Encoding: binary");
-                echo $content;
-            }
-            exit;
-        } catch (\Throwable $e) {
-            die($e->getMessage());
+        ob_clean();
+        if (!empty($_POST['sent_by_app'] ?? '')) {
+            echo $content;
         }
+        exit;
     }
 
     /**

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php
@@ -34,6 +34,10 @@ use OpenEMR\Services\Qrda\QrdaReportService;
 use OpenEMR\Validators\ProcessingResult;
 use XSLTProcessor;
 
+/**
+ * @method \Application\Plugin\CommonPlugin CommonPlugin()
+ * @method \Laminas\Http\Request getRequest()
+ */
 class EncountermanagerController extends AbstractActionController
 {
     // TODO: is there a better place for this?  These are the values from the applications/sendto/sendto.phtml for

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/MapperController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/MapperController.php
@@ -18,6 +18,9 @@ use Laminas\View\Model\ViewModel;
 
 // TODO: this class appears to be deprecated as nothing else refers to it.  It looks like it does the same thing as the SetupController does...
 // Recommend removing this if it's not used.
+/**
+ * @method \Laminas\Http\Request getRequest()
+ */
 class MapperController extends AbstractActionController
 {
     protected $mapperTable;

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/SetupController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/SetupController.php
@@ -16,6 +16,9 @@ use Application\Listener\Listener;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
+/**
+ * @method \Laminas\Http\Request getRequest()
+ */
 class SetupController extends AbstractActionController
 {
     /**

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -1153,18 +1153,6 @@ class CarecoordinationTable
     }
 
     /**
-     * @param $pid
-     * @return mixed
-     */
-    public function getIssues($pid)
-    {
-        // @todo Beware getIssues() doesn't exist in DocumentTable()! Method not used
-        $doc_obj = new DocumentsTable();
-        $issues = $doc_obj->getIssues($pid);
-        return $issues;
-    }
-
-    /**
      * @return string
      */
     public function getCategoryIDs(): string

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaUserPreferencesTransformer.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaUserPreferencesTransformer.php
@@ -81,6 +81,9 @@ class CcdaUserPreferencesTransformer
                     $foundSectionNodes = $xpath->query("n1:component[n1:section/n1:templateId/@root = '" . $section . "']", $body);
                     if ($foundSectionNodes !== false && $foundSectionNodes->length > 0) {
                         foreach ($foundSectionNodes as $node) {
+                            if (!$node instanceof \DOMNode) {
+                                continue;
+                            }
                             // if our found node is already the first child we will just leave it alone and skip over.
                             if ($node !== $body->firstChild) {
                                 // if firstChild is empty it will just append
@@ -96,7 +99,11 @@ class CcdaUserPreferencesTransformer
                 // component sections until we get to our max number of nodes
                 if ($body->childElementCount && $body->childElementCount > $maxChildren) {
                     for ($i = $body->childElementCount; $i > $maxChildren; --$i) {
-                        $body->removeChild($body->lastElementChild);
+                        $lastElement = $body->lastElementChild;
+                        if ($lastElement === null) {
+                            break;
+                        }
+                        $body->removeChild($lastElement);
                     }
                 }
             }

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaUserPreferencesTransformer.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaUserPreferencesTransformer.php
@@ -73,6 +73,9 @@ class CcdaUserPreferencesTransformer
         $structuredBodies = $xpath->query($query);
 
         foreach ($structuredBodies as $body) {
+            if (!$body instanceof \DOMElement) {
+                continue;
+            }
             if (!empty($sortedSections)) {
                 foreach ($sortedSections as $section) {
                     $foundSectionNodes = $xpath->query("n1:component[n1:section/n1:templateId/@root = '" . $section . "']", $body);

--- a/tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php
+++ b/tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php
@@ -176,9 +176,8 @@ class CcdaServiceDocumentRequestorTest extends TestCase
 
             $currentNodeId = $path->query(".//hl7:id", $currentNode)->item(0);
             $expectedNodeId = $expectedXpath->query(".//hl7:id", $expectedNode)->item(0);
-            if (!$currentNodeId instanceof \DOMElement || !$expectedNodeId instanceof \DOMElement) {
-                throw new \RuntimeException('Expected DOMElement for hl7:id node');
-            }
+            static::assertInstanceOf(\DOMElement::class, $currentNodeId);
+            static::assertInstanceOf(\DOMElement::class, $expectedNodeId);
 
             $expectedRootId = $expectedNodeId->getAttribute('root');
             $currentNodeId->setAttribute('root', $expectedRootId);

--- a/tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php
+++ b/tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php
@@ -99,7 +99,7 @@ class CcdaServiceDocumentRequestorTest extends TestCase
         $xpath = new DOMXPath($xml);
         $xpath->registerNamespace('hl7', 'urn:hl7-org:v3');
         $effectiveTime = $xpath->query("//hl7:effectiveTime")->item(0);
-        if ($effectiveTime && $effectiveTime->hasAttribute('value')) {
+        if ($effectiveTime instanceof \DOMElement && $effectiveTime->hasAttribute('value')) {
             return $effectiveTime->getAttribute('value');
         } else {
             throw new \RuntimeException('effectiveTime element with value attribute not found in XML');
@@ -114,7 +114,9 @@ class CcdaServiceDocumentRequestorTest extends TestCase
         $expr = '//*[@value="' . $currentTimestamp .  '"]';
         $timestampValues = $xpath->query($expr);
         foreach ($timestampValues as $timestamp) {
-            $timestamp->setAttribute('value', $newTimeStamp);
+            if ($timestamp instanceof \DOMElement) {
+                $timestamp->setAttribute('value', $newTimeStamp);
+            }
         }
 
         $dateTime = \DateTimeImmutable::createFromFormat("Ymd", $currentTimestamp);
@@ -174,6 +176,9 @@ class CcdaServiceDocumentRequestorTest extends TestCase
 
             $currentNodeId = $path->query(".//hl7:id", $currentNode)->item(0);
             $expectedNodeId = $expectedXpath->query(".//hl7:id", $expectedNode)->item(0);
+            if (!$currentNodeId instanceof \DOMElement || !$expectedNodeId instanceof \DOMElement) {
+                throw new \RuntimeException('Expected DOMElement for hl7:id node');
+            }
 
             $expectedRootId = $expectedNodeId->getAttribute('root');
             $currentNodeId->setAttribute('root', $expectedRootId);

--- a/tests/Tests/Services/Modules/Carecoordination/Model/CcdaUserPreferencesTransformerTest.php
+++ b/tests/Tests/Services/Modules/Carecoordination/Model/CcdaUserPreferencesTransformerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Services\Modules\CareCoordination\Model;
+
+use Carecoordination\Model\CcdaUserPreferencesTransformer;
+use DOMDocument;
+use DOMXPath;
+use PHPUnit\Framework\TestCase;
+
+class CcdaUserPreferencesTransformerTest extends TestCase
+{
+    private const NS = 'urn:hl7-org:v3';
+    private const DOC_OID = '2.16.840.1.113883.10.20.22.1.2';
+    private const ALLERGIES_OID = '2.16.840.1.113883.10.20.22.2.6.1';
+    private const MEDS_OID = '2.16.840.1.113883.10.20.22.2.1.1';
+    private const PROBLEMS_OID = '2.16.840.1.113883.10.20.22.2.5.1';
+
+    public function testTransformReordersSectionsByPreference(): void
+    {
+        $xml = $this->buildCcda([self::ALLERGIES_OID, self::MEDS_OID, self::PROBLEMS_OID]);
+
+        $transformer = new CcdaUserPreferencesTransformer(
+            maxSections: 0,
+            sortPreferences: [self::DOC_OID => [self::PROBLEMS_OID, self::MEDS_OID]],
+        );
+
+        $this->assertSame(
+            [self::PROBLEMS_OID, self::MEDS_OID, self::ALLERGIES_OID],
+            $this->extractSectionOrder($transformer->transform($xml)),
+        );
+    }
+
+    public function testTransformTruncatesToMaxSections(): void
+    {
+        $xml = $this->buildCcda([self::ALLERGIES_OID, self::MEDS_OID, self::PROBLEMS_OID]);
+
+        $transformer = new CcdaUserPreferencesTransformer(maxSections: 2);
+
+        $this->assertCount(2, $this->extractSectionOrder($transformer->transform($xml)));
+    }
+
+    public function testTransformAppliesDefaultSortWhenDocTypeUnknown(): void
+    {
+        $xml = $this->buildCcda([self::ALLERGIES_OID, self::MEDS_OID]);
+
+        $transformer = new CcdaUserPreferencesTransformer(
+            maxSections: 0,
+            sortPreferences: ['default' => [self::MEDS_OID]],
+        );
+
+        $this->assertSame(
+            [self::MEDS_OID, self::ALLERGIES_OID],
+            $this->extractSectionOrder($transformer->transform($xml)),
+        );
+    }
+
+    public function testGettersAndSettersRoundTrip(): void
+    {
+        $transformer = new CcdaUserPreferencesTransformer();
+
+        $transformer->setMaxSections(7)->setSortPreferences(['a' => ['b']]);
+
+        $this->assertSame(7, $transformer->getMaxSections());
+        $this->assertSame(['a' => ['b']], $transformer->getSortPreferences());
+    }
+
+    /**
+     * @param list<string> $sectionOids
+     */
+    private function buildCcda(array $sectionOids): string
+    {
+        $sections = '';
+        foreach ($sectionOids as $oid) {
+            $sections .= "<component><section><templateId root=\"$oid\"/></section></component>";
+        }
+
+        $doc = self::DOC_OID;
+        $ns = self::NS;
+        return <<<XML
+            <?xml version="1.0"?>
+            <ClinicalDocument xmlns="$ns">
+                <templateId root="$doc"/>
+                <component>
+                    <structuredBody>$sections</structuredBody>
+                </component>
+            </ClinicalDocument>
+            XML;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractSectionOrder(mixed $xml): array
+    {
+        $this->assertIsString($xml);
+
+        $dom = new DOMDocument();
+        $dom->loadXML($xml);
+        $xpath = new DOMXPath($dom);
+        $xpath->registerNamespace('n1', self::NS);
+
+        $nodes = $xpath->query('//n1:structuredBody/n1:component/n1:section/n1:templateId');
+        $this->assertNotFalse($nodes);
+
+        $oids = [];
+        foreach ($nodes as $node) {
+            if ($node instanceof \DOMElement) {
+                $oids[] = $node->getAttribute('root');
+            }
+        }
+        return $oids;
+    }
+}


### PR DESCRIPTION
Drain `class.notFound` and `method.notFound` baseline entries originating in the Carecoordination zend module. Fourth phase-4 module batch following the eRx drain (#11825).

## Source changes

**Controller property native types.** Convert PHPDoc-typed properties on `CarecoordinationController` and `CcdController` to native types (constructor property promotion applied via Rector). PHPStan was resolving docblocks like `@var Documents\Controller\DocumentsController` relative to the `Carecoordination\Controller` namespace, producing `class.notFound` for nonexistent paths.

**`@method` tags for Laminas MVC plugins.** `$this->CommonPlugin()` and `$this->Documents()` resolve through Laminas' plugin manager via `__call`. Add explicit `@method` declarations on the controllers that invoke them, plus `@method \Laminas\Http\Request getRequest()` to narrow the request type so `getPost()`/`getQuery()` resolve.

**Fix `CcdController::uploadAction()` bug.** The method was calling `$this->updateDocumentCategoryUsingCatname()` on itself, which does not exist on the controller. The sibling `CarecoordinationController::uploadAction()` calls it correctly via `$this->documentsController->getDocumentsTable()->updateDocumentCategoryUsingCatname()` — apply the same call here. Dead since at least 2014; PHPStan would have caught it as `method.notFound` if the entry hadn't been baselined.

**Remove dead `CarecoordinationTable::getIssues()`.** Body called `DocumentsTable::getIssues()` which does not exist. Author left an inline `Method not used` TODO; grep confirms no callers.

**Remove dead try/catch in `EncounterccdadispatchController::indexAction()`.** The block wrapped only `echo`/`exit` calls that cannot throw.

**`getCarecoordinationTable()` / `getDocumentsTable()` return types.** Changing the docblock from `@return object` to a real return type collapses several `method.notFound` entries that were `Cannot call method ... on object`.

**DOM narrowing.** `CcdaUserPreferencesTransformer` and `CcdaServiceDocumentRequestorTest` iterate `\DOMNodeList` results and call element-only methods (`insertBefore`, `setAttribute`, `getAttribute`). Add `instanceof \DOMElement` and `instanceof \DOMNode` guards plus a null-check on `lastElementChild` so the type system sees the narrowing.

**Content type narrowing in `EncounterccdadispatchController::indexAction()`.** Initialize `$content = ''` up front and call `strval($content)` before substring operations to avoid Rector flip-flop between `RecastingRemovalRector` (full-codebase) and `NullToStrictStringFuncCallArgRector` (single-file).

## Tests

Adds `CcdaUserPreferencesTransformerTest` covering `transform()` (sort, truncate, default-fallback) and the getter/setter round-trip. Lifts patch coverage on this PR.

## Counts

| Identifier | Before | After | Delta |
|---|---:|---:|---:|
| `class.notFound` | 237 | 229 | -8 |
| `method.notFound` | 184 | 160 | -24 |
| `method.nonObject` | 1995 | 1991 | -4 |
| `argument.type` | 14973 | 14972 | -1 |
| `assign.propertyType` | 388 | 384 | -4 |
| `cast.string` | 807 | 806 | -1 |
| `missingType.parameter` | 9488 | 9487 | -1 |
| `missingType.property` | 6198 | 6195 | -3 |
| `missingType.return` | 5913 | 5912 | -1 |
| `offsetAccess.nonOffsetAccessible` | 10757 | 10756 | -1 |
| `preDec.type` | 9 | 8 | -1 |
| `property.notFound` | 135 | 132 | -3 |
| `return.type` | 2167 | 2164 | -3 |
| `variable.undefined` | 3075 | 3074 | -1 |

Caps in `.phpstan/fatal-baseline-caps.php` updated to match.

Refs #11792.

## Test plan
- [x] `composer phpstan-baseline` regenerates cleanly
- [x] `composer phpunit-isolated -- --filter=FatalBaselineCaps` passes
- [x] `composer phpcs` clean on edited files
- [x] Pre-commit hooks (rector, phpcs, phpstan, codespell, composer-require-checker) all pass
