### PR TITLE
ci(ccdaservice): rename cache key to invalidate stale v127 binaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
           echo 'vendor=${{ runner.os }}-vendor-${{ steps.parse.outputs.php }}-${{ hashFiles('**/composer.lock', 'composer.json') }}'
           echo 'composer=${{ runner.os }}-composer-${{ steps.parse.outputs.php }}-${{ hashFiles('**/composer.lock', 'composer.json') }}'
           echo 'npm-build=${{ runner.os }}-npm-build-${{ steps.parse.outputs.node_version }}-${{ hashFiles('**/package-lock.json') }}'
-          echo 'ccda-build=${{ runner.os }}-ccda-build-${{ steps.parse.outputs.node_version }}-${{ hashFiles('**/ccdaservice/package-lock.json') }}'
+          echo 'ccda-build=${{ runner.os }}-ccdaservice-modules-${{ steps.parse.outputs.node_version }}-${{ hashFiles('**/ccdaservice/package-lock.json') }}'
           echo 'npm=${{ runner.os }}-node-${{ steps.parse.outputs.node_version }}-${{ hashFiles('**/package-lock.json') }}'
         } >> "$GITHUB_OUTPUT"
 
@@ -280,7 +280,7 @@ jobs:
           ccdaservice/packages/oe-cqm-service/node_modules/
         key: ${{ steps.cache-keys.outputs.ccda-build }}
         restore-keys: |
-          ${{ runner.os }}-ccda-build-${{ steps.parse.outputs.node_version }}-
+          ${{ runner.os }}-ccdaservice-modules-${{ steps.parse.outputs.node_version }}-
 
     ##
     # The 'cache-hit' output for actions/cache/restore is always false
@@ -354,7 +354,7 @@ jobs:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
 
     - name: Save CCDA build artifacts
-      if: ${{ inputs.save_node_cache && steps.ccda-build-cache-check.outputs.hit != 'true' }}
+      if: ${{ steps.ccda-build-cache-check.outputs.hit != 'true' }}
       uses: actions/cache/save@v5
       with:
         key: ${{ steps.cache-keys.outputs.ccda-build }}
@@ -500,8 +500,7 @@ jobs:
           ccdaservice/node_modules/
           ccdaservice/packages/oe-cqm-service/node_modules/
         restore-keys: |
-          ${{ runner.os }}-ccda-build-${{ needs.setup.outputs.node_version }}-
-          ${{ runner.os }}-ccda-build-
+          ${{ runner.os }}-ccdaservice-modules-${{ needs.setup.outputs.node_version }}-
 
     - name: Download setup snapshot
       uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

Re-attempts the cache portion of #11852 (which was reverted in #11861), without the `npm rebuild libxmljs2 --build-from-source` change that broke the Node 22 services jobs.

- Rename ccdaservice node_modules cache prefix `ccda-build` → `ccdaservice-modules` so existing caches containing pre-v137 libxmljs2 binaries are no longer matched. A fresh `npm ci` will pull v137 prebuilts (available on npm since 2025-06-05).
- Drop the broad cross-Node-version `Linux-ccda-build-` fallback in the test job's restore-keys. Restoring a Node 22 cache on a Node 24 runner reproduces the same `NODE_MODULE_VERSION` mismatch this rename is meant to fix.
- Remove the `inputs.save_node_cache` gate on the Save CCDA build artifacts step so all matrix entries can save (fixes a race where only the first entry per Node version was saving).

This should unblock dependabot PRs (#11722, #11780, #11844) that fail with `NODE_MODULE_VERSION 127` vs `137` errors when the test runner restores a stale cache built before the v137 prebuilts existed.

### How this differs from #11852

PR #11852 bundled the cache rename with `npm rebuild libxmljs2 --build-from-source` in `ccda_build()`. The rebuild ran on the runner host and linked against the runner's libxml2/libstdc++. When the resulting `.node` binary was bind-mounted into the `openemr/openemr:flex-3.22-php-8.2` container (Node 22), the loader couldn't resolve the runtime dependencies, serveccda.js silently crashed, and CCDA service tests failed because the listener on :6661 never came up.

The rebuild was both unnecessary (v137 prebuilts exist) and harmful (broke Node 22 configs). This PR ships only the cache parts.

## Test plan

- [ ] All matrix services jobs pass (especially `apache_82_118` and `apache_82_118_redis_sentinel_mtls`, which broke under #11852)
- [ ] CCDA-related tests pass on both Node 22 and Node 24 paths