### PR TITLE
fix(db): Log all "helpfuldie" sql errors

### DIFF
--- a/library/sql.inc.php
+++ b/library/sql.inc.php
@@ -98,6 +98,7 @@ function sqlStatement($statement, $binds = false)
     try {
         return QueryUtils::sqlStatementThrowException($statement, $binds, noLog: false);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }
@@ -159,6 +160,7 @@ function sqlStatementNoLog($statement, $binds = false, $throw_exception_on_error
         if ($throw_exception_on_error) {
             throw $e;
         }
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }
@@ -241,6 +243,7 @@ function sqlInsert($statement, $binds = false)
     try {
         return QueryUtils::sqlInsert($statement, $binds);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("insert failed: $statement", $e->sqlError);
     }
 }
@@ -261,6 +264,7 @@ function sqlQuery($statement, $binds = false)
     try {
         return QueryUtils::querySingleRow($statement, $binds ?: []);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }
@@ -291,6 +295,7 @@ function sqlQueryNoLog($statement, $binds = false, $throw_exception_on_error = f
         if ($throw_exception_on_error) {
             throw $e;
         }
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }
@@ -332,6 +337,7 @@ function sqlInsertClean_audit($statement, $binds = false): void
     try {
         QueryUtils::sqlStatementThrowException($statement, $binds, noLog: true);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("insert failed: $statement", $e->sqlError);
     }
 }
@@ -434,6 +440,7 @@ function sqlQ($statement, $binds = false)
     try {
         return QueryUtils::sqlStatementThrowException($statement, $binds);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }


### PR DESCRIPTION
#### Short description of what this changes or resolves:
The older-style `HelpfulDie` does not particularly live up to its name. Fixing it the right way is removal in favor of everything using exceptions, which is an ongoing but massive task. Debugging is overly complex.

This logs the function and full stack trace any time the legacy global-namespace SQL functions catch/suppress/crash any sort of query failure. Yes, `HelpfulDie` makes an attempt to do this, but it's rather limited in how it works and doesn't go through the SystemLogger.

I was hoping this would help with diagnosing some Inferno test issues. It doesn't seem to, but I think it's still a worthwhile addition.

#### Changes proposed in this pull request:
Add an error-level log to all of the `catch` paths inside the older SQL functions, going to the system logger.

#### Was an AI assistant used? Yes / No
No