### PR TITLE
fix(db): Fix SQL upgrade syntax

### DIFF
--- a/sql/7_0_3-to-7_0_4_upgrade.sql
+++ b/sql/7_0_3-to-7_0_4_upgrade.sql
@@ -1309,10 +1309,15 @@ ALTER TABLE `procedure_order`
         COMMENT 'FHIR intent: order, plan, directive, proposal',
     ADD COLUMN `location_id` INT DEFAULT NULL
         COMMENT 'References facility.id for service location (FHIR locationReference)';
-ALTER TABLE `procedure_order`
-    ADD INDEX IF NOT EXISTS `idx_scheduled_date` (`scheduled_date`),
-    ADD INDEX IF NOT EXISTS `idx_order_intent` (`order_intent`),
-    ADD INDEX IF NOT EXISTS `idx_location_id` (`location_id`);
+#EndIf
+#IfNotIndex procedure_order idx_scheduled_date
+ALTER TABLE `procedure_order` ADD INDEX `idx_scheduled_date` (`scheduled_date`);
+#EndIf
+#IfNotIndex procedure_order idx_scheduled_date
+ALTER TABLE `procedure_order` ADD INDEX `idx_order_intent` (`order_intent`),
+#EndIf
+#IfNotIndex procedure_order idx_scheduled_date
+ALTER TABLE `procedure_order` ADD INDEX `idx_location_id` (`location_id`);
 #EndIf
 
 #IfNotRow2D list_options list_id ord_priority option_id routine

--- a/sql/7_0_3-to-7_0_4_upgrade.sql
+++ b/sql/7_0_3-to-7_0_4_upgrade.sql
@@ -1313,10 +1313,10 @@ ALTER TABLE `procedure_order`
 #IfNotIndex procedure_order idx_scheduled_date
 ALTER TABLE `procedure_order` ADD INDEX `idx_scheduled_date` (`scheduled_date`);
 #EndIf
-#IfNotIndex procedure_order idx_scheduled_date
+#IfNotIndex procedure_order idx_order_intent
 ALTER TABLE `procedure_order` ADD INDEX `idx_order_intent` (`order_intent`),
 #EndIf
-#IfNotIndex procedure_order idx_scheduled_date
+#IfNotIndex procedure_order idx_location_id
 ALTER TABLE `procedure_order` ADD INDEX `idx_location_id` (`location_id`);
 #EndIf
 


### PR DESCRIPTION
#### Short description of what this changes or resolves:
While working on #11805 I came across a bug when running a SQL upgrade. Invalid syntax! Since the block was conditional, you wouldn't always hit it. The Inferno data did.

#### Changes proposed in this pull request:
Splits the index additions into a syntactically-legal version without changing the results.

Well, technically the new conditionals could change the results, but the intent of what it did before was clear.

#### Was an AI assistant used? Yes / No
No