### PR TITLE
chore(db): Fix typo

### DIFF
--- a/sql/7_0_3-to-7_0_4_upgrade.sql
+++ b/sql/7_0_3-to-7_0_4_upgrade.sql
@@ -1314,7 +1314,7 @@ ALTER TABLE `procedure_order`
 ALTER TABLE `procedure_order` ADD INDEX `idx_scheduled_date` (`scheduled_date`);
 #EndIf
 #IfNotIndex procedure_order idx_order_intent
-ALTER TABLE `procedure_order` ADD INDEX `idx_order_intent` (`order_intent`),
+ALTER TABLE `procedure_order` ADD INDEX `idx_order_intent` (`order_intent`);
 #EndIf
 #IfNotIndex procedure_order idx_location_id
 ALTER TABLE `procedure_order` ADD INDEX `idx_location_id` (`location_id`);


### PR DESCRIPTION
Correction from #11866, which was incorrectly extracted from #11805.