### PR TITLE
fix(db): convert declne_to_specfy in patient_data language and ethnicity

### DIFF
--- a/sql/8_0_0-to-8_1_0_upgrade.sql
+++ b/sql/8_0_0-to-8_1_0_upgrade.sql
@@ -140,12 +140,21 @@ ALTER TABLE `facility` ADD `organization_type` VARCHAR(50) NOT NULL DEFAULT 'pro
 
 --
 -- Rename the misspelled list_options option_id from 'declne_to_specfy' to 'decline_to_specify',
--- and update any patient_data.race records that reference the old value.
+-- and update any patient_data.race, patient_data.language, and patient_data.ethnicity
+-- records that reference the old value.
 -- See: https://github.com/openemr/openemr/issues/10385
 --
 
-#IfColumn patient_data race
+#IfRow patient_data race declne_to_specfy
 UPDATE `patient_data` SET `race` = 'decline_to_specify' WHERE `race` = 'declne_to_specfy';
+#EndIf
+
+#IfRow patient_data language declne_to_specfy
+UPDATE `patient_data` SET `language` = 'decline_to_specify' WHERE `language` = 'declne_to_specfy';
+#EndIf
+
+#IfRow patient_data ethnicity declne_to_specfy
+UPDATE `patient_data` SET `ethnicity` = 'decline_to_specify' WHERE `ethnicity` = 'declne_to_specfy';
 #EndIf
 
 #IfRow2D list_options list_id race option_id declne_to_specfy


### PR DESCRIPTION
## Summary

Follow-up to #10762, which renamed the misspelled `declne_to_specfy` race value to `decline_to_specify`. Brady's review on that PR flagged two issues in `sql/8_0_0-to-8_1_0_upgrade.sql` (originally `8_0_0-to-8_0_1_upgrade.sql`) that were never addressed before merge:

- The `patient_data.race` UPDATE was guarded by `#IfColumn patient_data race`, which is always true — the UPDATE ran on every upgrade even when there was nothing to convert. Switch to `#IfRow patient_data race declne_to_specfy` so it's skipped when no rows match.
- The same misspelled value can also appear in `patient_data.language` and `patient_data.ethnicity`. The `list_options` side already covers all three list_ids; this PR mirrors that on the patient row side.

Refs https://github.com/openemr/openemr/issues/10385, follow-up to https://github.com/openemr/openemr/pull/10762.

## Test plan

- [ ] Fresh install of 8.0.0 → upgrade to current master succeeds
- [ ] Tenant with `declne_to_specfy` in `patient_data.race` / `language` / `ethnicity` is migrated to `decline_to_specify`
- [ ] Tenant with no matching rows skips all three `#IfRow` blocks