### PR TITLE
fix(rx): set linkMethod for Ensora eRx prescription button

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1220,6 +1220,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         $viewArgs['title'] = 'Prescription History';
                         $viewArgs['btnLabel'] = 'Add';
                         $viewArgs['btnLink'] = OEGlobalsBag::getInstance()->getWebRoot() . "/interface/eRx.php?page=compose";
+                        $viewArgs['linkMethod'] = 'html';
                     } else {
                         $viewArgs['btnLink'] = "editScripts('" . OEGlobalsBag::getInstance()->getWebRoot() . "/controller.php?prescription&list&id=" . attr_url($pid) . "')";
                         $viewArgs['linkMethod'] = "javascript";


### PR DESCRIPTION
## Summary

The eRx branch in `interface/patient_file/summary/demographics.php` sets `btnLink` but never sets `linkMethod`, so `card_base.html.twig` renders a dead `href=\"#\"` instead of linking to `eRx.php?page=compose`. The non-eRx branch at the same call site sets both fields. Add `linkMethod = 'html'` to match.

This is a small one-line fix to the Add (+) button on the Prescription History card when Ensora eRx is enabled (`erx_enable = 1`).

## Test plan

- [ ] Enable Ensora eRx (`erx_enable = 1`) in Admin → Globals → Connectors
- [ ] Open a patient's demographics summary
- [ ] Verify the + button on the Prescription History card navigates to the eRx compose page (`eRx.php?page=compose`)
- [ ] Disable eRx and verify the non-eRx branch still works (Edit button via `editScripts(...)`)

## Notes

- Affects `master` and `rel-810` (verified `rel-810` has the same code path at `demographics.php:1219-1227`).
- Discovered while preparing an OpenCoreEMR fork upgrade; fix originally landed in our internal branch as openCoreEMR/openemr-internal#243.