### PR TITLE
fix(encounter): handle missing row and null uuid in encounter view form

### DIFF
--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -8597,11 +8597,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/newpatient/C_EncounterVisitForm.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'uuid\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/newpatient/C_EncounterVisitForm.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset 0 on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/newpatient/C_EncounterVisitForm.class.php',

--- a/interface/forms/newpatient/C_EncounterVisitForm.class.php
+++ b/interface/forms/newpatient/C_EncounterVisitForm.class.php
@@ -507,9 +507,14 @@ class C_EncounterVisitForm
         if ($viewmode) {
             $id = $_REQUEST['id'] ?? '';
             $result = sqlQuery("SELECT * FROM form_encounter WHERE id = ?", [$id]);
+            if (!is_array($result)) {
+                throw new \RuntimeException('Encounter not found for id ' . var_export($id, true));
+            }
             $encounter = $result;
             // it won't encode in the JSON if we don't convert this.
-            $encounter['uuid'] = UuidRegistry::uuidToString($result['uuid']);
+            $encounter['uuid'] = $result['uuid'] !== null
+                ? UuidRegistry::uuidToString($result['uuid'])
+                : '';
             $encounter_followup_id = $encounter['parent_encounter_id'] ?? null;
             if ($encounter_followup_id) {
                 $q = "SELECT fe.date as date, fe.encounter as encounter FROM form_encounter AS fe " .


### PR DESCRIPTION
## Summary

`C_EncounterVisitForm::render()` calls `UuidRegistry::uuidToString($result['uuid'])` immediately after `sqlQuery("SELECT * FROM form_encounter WHERE id = ?", [$id])` without checking whether the row was found, or whether the `uuid` column was populated. When the request carries a stale or invalid encounter id (e.g. a deleted encounter via a bookmarked URL), or the row exists but predates uuid backfill, `$result['uuid']` is `null` and `Ramsey\Uuid\Uuid::fromBytes(null)` throws:

```
PHP Notice: TypeError: Ramsey\Uuid\Uuid::fromBytes(): Argument #1 ($bytes) must be of type string, null given,
called in src/Common/Uuid/UuidRegistry.php on line 287
Stack trace:
#0 src/Common/Uuid/UuidRegistry.php(287): Ramsey\Uuid\Uuid::fromBytes(NULL)
#1 interface/forms/newpatient/C_EncounterVisitForm.class.php(504): UuidRegistry::uuidToString(NULL)
#2 interface/forms/newpatient/common.php(43): C_EncounterVisitForm->render(2)
```

This change:
- Throws `RuntimeException` when no row matches, instead of silently continuing with `$encounter = false` and crashing several lines later in an unrelated stack frame.
- Passes `''` through to `$encounter['uuid']` when the row exists but `uuid` is `null` (the comment on the original line notes this field is set so the array JSON-encodes — empty string preserves that intent).
- Drops the `offsetAccess.nonOffsetAccessible` baseline entry that covered the old unsafe access.

## Test plan

- [ ] View an existing encounter — renders normally
- [ ] Visit `view_form.php` with a deleted/invalid encounter id — surfaces the explicit "Encounter not found" error rather than a `fromBytes(null)` TypeError
- [ ] PHPStan passes (`composer phpstan`)

Assisted-by: Claude Code