### PR TITLE
refactor: replace literal preg_match prefix/suffix checks with native string functions

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -1773,7 +1773,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 8,
+    'count' => 7,
     'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -158,7 +158,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 5,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/edi_271.php',
 ];
 $ignoreErrors[] = [
@@ -313,7 +313,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 14,
+    'count' => 12,
     'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
 ];
 $ignoreErrors[] = [
@@ -478,7 +478,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 25,
+    'count' => 22,
     'path' => __DIR__ . '/../../interface/forms/vitals/growthchart/chart.php',
 ];
 $ignoreErrors[] = [
@@ -1383,7 +1383,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 19,
+    'count' => 16,
     'path' => __DIR__ . '/../../interface/patient_file/pos_checkout_ippf.php',
 ];
 $ignoreErrors[] = [
@@ -1653,7 +1653,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 44,
+    'count' => 9,
     'path' => __DIR__ . '/../../interface/reports/ippf_statistics.php',
 ];
 $ignoreErrors[] = [
@@ -2673,7 +2673,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 7,
+    'count' => 5,
     'path' => __DIR__ . '/../../portal/home.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -3848,7 +3848,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 9,
+    'count' => 8,
     'path' => __DIR__ . '/../../src/Services/Utils/SQLUpgradeService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1798,7 +1798,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 93,
+    'count' => 92,
     'path' => __DIR__ . '/../../interface/patient_file/pos_checkout_ippf.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -512,16 +512,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$ffname \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$filename \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$inbase \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
@@ -3275,11 +3265,6 @@ $ignoreErrors[] = [
     'message' => '#^Part \\$acokey \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/super/edit_layout_props.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$list_id \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/edit_list.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Part \\$srcdir \\(mixed\\) of encapsed string cannot be cast to string\\.$#',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -14792,16 +14792,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/reports/ippf_statistics.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function getAbortionMethod\\(\\) has parameter \\$code with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/ippf_statistics.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function getContraceptiveMethod\\(\\) has parameter \\$code with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/ippf_statistics.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function getGcacClientStatus\\(\\) has parameter \\$row with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_statistics.php',
@@ -14853,11 +14843,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Function ippf_stats_getListTitle\\(\\) has parameter \\$option with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/ippf_statistics.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function process_ippf_code\\(\\) has parameter \\$code with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_statistics.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -2048,7 +2048,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'name\' on mixed\\.$#',
-    'count' => 5,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/edi_271.php',
 ];
 $ignoreErrors[] = [
@@ -37448,7 +37448,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'pc_startTime\' on mixed\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../portal/home.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.notFound.php
+++ b/.phpstan/baseline/offsetAccess.notFound.php
@@ -132,11 +132,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/vitals/growthchart/chart.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'sex\' might not exist on \'\'\\|array\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/forms/vitals/growthchart/chart.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Offset 1 might not exist on array\\{\\}\\|array\\{non\\-falsy\\-string, non\\-falsy\\-string&numeric\\-string, non\\-falsy\\-string&numeric\\-string, non\\-falsy\\-string&numeric\\-string\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/find_appt_popup.php',

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -418,7 +418,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_FILES is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 10,
+    'count' => 6,
     'path' => __DIR__ . '/../../interface/billing/edi_271.php',
 ];
 $ignoreErrors[] = [
@@ -2758,7 +2758,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 13,
+    'count' => 12,
     'path' => __DIR__ . '/../../interface/patient_file/pos_checkout_ippf.php',
 ];
 $ignoreErrors[] = [
@@ -3403,7 +3403,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/super/edit_list.php',
 ];
 $ignoreErrors[] = [

--- a/interface/billing/edi_271.php
+++ b/interface/billing/edi_271.php
@@ -46,7 +46,8 @@ if (isset($_FILES) && !empty($_FILES)) {
     if (mime_content_type($_FILES['uploaded']['tmp_name']) != "text/plain") {
         $message .= xlt('You may only upload .txt files') . "<br />";
     }
-    if (preg_match("/(.*)\.(inc|php|php7|php8)$/i", (string) $_FILES['uploaded']['name']) !== 0) {
+    $uploadedExt = strtolower(pathinfo((string) $_FILES['uploaded']['name'], PATHINFO_EXTENSION));
+    if (in_array($uploadedExt, ['inc', 'php', 'php7', 'php8'], true)) {
         $message .= xlt('Invalid file type.') . "<br />";
     }
     if (!isset($message)) {

--- a/interface/billing/edi_271.php
+++ b/interface/billing/edi_271.php
@@ -38,7 +38,8 @@ $target = OEGlobalsBag::getInstance()->get('edi_271_file_path');
 $batch_log = '';
 
 if (isset($_FILES) && !empty($_FILES)) {
-    $target = $target . time() . basename((string) $_FILES['uploaded']['name']);
+    $uploadedName = (string) $_FILES['uploaded']['name'];
+    $target = $target . time() . basename($uploadedName);
 
     if ($_FILES['uploaded']['size'] > 350000) {
         $message .=  xlt('Your file is too large') . "<br />";
@@ -46,7 +47,7 @@ if (isset($_FILES) && !empty($_FILES)) {
     if (mime_content_type($_FILES['uploaded']['tmp_name']) != "text/plain") {
         $message .= xlt('You may only upload .txt files') . "<br />";
     }
-    $uploadedExt = strtolower(pathinfo((string) $_FILES['uploaded']['name'], PATHINFO_EXTENSION));
+    $uploadedExt = strtolower(pathinfo($uploadedName, PATHINFO_EXTENSION));
     if (in_array($uploadedExt, ['inc', 'php', 'php7', 'php8'], true)) {
         $message .= xlt('Invalid file type.') . "<br />";
     }
@@ -57,7 +58,7 @@ if (isset($_FILES) && !empty($_FILES)) {
             $uploadedFile = $cryptoGen->encryptStandard($uploadedFile, keySource: KeySource::Database);
         }
         if (file_put_contents($target, $uploadedFile)) {
-            $message = xlt('The following EDI file has been uploaded') . ': "' . text(basename((string) $_FILES['uploaded']['name'])) . '"';
+            $message = xlt('The following EDI file has been uploaded') . ': "' . text(basename($uploadedName)) . '"';
             $Response271 = file_get_contents($target);
             if ($cryptoGen->cryptCheckStandard($Response271)) {
                 $Response271 = $cryptoGen->decryptStandard($Response271, keySource: KeySource::Database);
@@ -65,10 +66,10 @@ if (isset($_FILES) && !empty($_FILES)) {
             if ($Response271) {
                 $batch_log = EDI270::parseEdi271($Response271);
             } else {
-                $message = xlt('The following EDI file upload failed to open') . ': "' . text(basename((string) $_FILES['uploaded']['name'])) . '"';
+                $message = xlt('The following EDI file upload failed to open') . ': "' . text(basename($uploadedName)) . '"';
             }
         } else {
-            $message = xlt('The following EDI file failed save to archive') . ': "' . text(basename((string) $_FILES['uploaded']['name'])) . '"';
+            $message = xlt('The following EDI file failed save to archive') . ': "' . text(basename($uploadedName)) . '"';
         }
     } else {
         $message .= xlt('Sorry, there was a problem uploading your file') . "<br /><br />";

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -51,7 +51,8 @@ if ($_GET['file']) {
     die("No filename was given.");
 }
 
-$ext = substr((string) $filename, strrpos((string) $filename, '.'));
+$filename = (string) $filename;
+$ext = substr($filename, strrpos($filename, '.'));
 $filebase = basename("/$filename", $ext);
 $faxcache = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/faxcache/$mode/$filebase";
 
@@ -127,10 +128,10 @@ if ($_POST['form_save']) {
         //
         if ($_POST['form_cb_copy_type'] == 1) {
             // Compute a target filename that does not yet exist.
-            $ffname = check_file_dir_name(trim((string) $_POST['form_filename']));
-            $i = strrpos((string) $ffname, '.');
+            $ffname = (string) check_file_dir_name(trim((string) $_POST['form_filename']));
+            $i = strrpos($ffname, '.');
             if ($i) {
-                $ffname = trim(substr((string) $ffname, 0, $i));
+                $ffname = trim(substr($ffname, 0, $i));
             }
 
             if (!$ffname) {

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -356,7 +356,7 @@ if ($_POST['form_save']) {
 
             $form_cb_delete = '2';
             while (false !== ($jfname = readdir($dh))) {
-                if (preg_match('/\.jpg$/', $jfname)) {
+                if (strtolower(pathinfo($jfname, PATHINFO_EXTENSION)) === 'jpg') {
                     $form_cb_delete = '1';
                 }
             }

--- a/interface/forms/vitals/growthchart/chart.php
+++ b/interface/forms/vitals/growthchart/chart.php
@@ -64,11 +64,13 @@ $vitalsService = new VitalsService();
 $isMetric = (((OEGlobalsBag::getInstance()->get('units_of_measurement') == 2) || (OEGlobalsBag::getInstance()->get('units_of_measurement') == 4)) ? true : false);
 
 $patient_data = "";
+$sex = '';
 if (isset($pid) && is_numeric($pid)) {
     $patient_data = getPatientData($pid, "fname, lname, sex, DATE_FORMAT(DOB,'%Y%m%d') as DOB");
     $nowAge = getPatientAge($patient_data['DOB']);
     $dob = $patient_data['DOB'];
     $name = $patient_data['fname'] . " " . $patient_data['lname'];
+    $sex = strtolower((string) $patient_data['sex']);
 }
 
 // The first data point in the DATA set is significant. It tells the date
@@ -164,13 +166,13 @@ if ($charttype == 'birth') {
     $HT_x = 1187; //start here to draw wt and height graph at bottom of Head circumference chart
     $HT_delta_x = 24.32;
 
-    if (str_starts_with(strtolower((string) $patient_data['sex']), 'male')) {
+    if (str_starts_with($sex, 'male')) {
         $chart = "birth-24mos_boys_HC.png";
 
         // added by BM for CSS html output
         $chartCss1 = "birth-24mos_boys_HC-1.png";
         $chartCss2 = "birth-24mos_boys_HC-2.png";
-    } elseif (str_starts_with(strtolower((string) $patient_data['sex']), 'female')) {
+    } elseif (str_starts_with($sex, 'female')) {
         $chart = "birth-24mos_girls_HC.png";
 
         // added by BM for CSS html output
@@ -216,13 +218,13 @@ if ($charttype == 'birth') {
     $bmi_dot_y = 1130;
     $bmi_delta_y = 37.15;
 
-    if (str_starts_with(strtolower((string) $patient_data['sex']), 'male')) {
+    if (str_starts_with($sex, 'male')) {
         $chart = "2-20yo_boys_BMI.png";
 
         // added by BM for CSS html output
         $chartCss1 = "2-20yo_boys_BMI-1.png";
         $chartCss2 = "2-20yo_boys_BMI-2.png";
-    } elseif (str_starts_with(strtolower((string) $patient_data['sex']), 'female')) {
+    } elseif (str_starts_with($sex, 'female')) {
         $chart = "2-20yo_girls_BMI.png";
 
         // added by BM for CSS html output

--- a/interface/forms/vitals/growthchart/chart.php
+++ b/interface/forms/vitals/growthchart/chart.php
@@ -164,13 +164,13 @@ if ($charttype == 'birth') {
     $HT_x = 1187; //start here to draw wt and height graph at bottom of Head circumference chart
     $HT_delta_x = 24.32;
 
-    if (preg_match('/^male/i', (string) $patient_data['sex'])) {
+    if (str_starts_with(strtolower((string) $patient_data['sex']), 'male')) {
         $chart = "birth-24mos_boys_HC.png";
 
         // added by BM for CSS html output
         $chartCss1 = "birth-24mos_boys_HC-1.png";
         $chartCss2 = "birth-24mos_boys_HC-2.png";
-    } elseif (preg_match('/^female/i', (string) $patient_data['sex'])) {
+    } elseif (str_starts_with(strtolower((string) $patient_data['sex']), 'female')) {
         $chart = "birth-24mos_girls_HC.png";
 
         // added by BM for CSS html output
@@ -216,13 +216,13 @@ if ($charttype == 'birth') {
     $bmi_dot_y = 1130;
     $bmi_delta_y = 37.15;
 
-    if (preg_match('/^male/i', (string) $patient_data['sex'])) {
+    if (str_starts_with(strtolower((string) $patient_data['sex']), 'male')) {
         $chart = "2-20yo_boys_BMI.png";
 
         // added by BM for CSS html output
         $chartCss1 = "2-20yo_boys_BMI-1.png";
         $chartCss2 = "2-20yo_boys_BMI-2.png";
-    } elseif (preg_match('/^female/i', (string) $patient_data['sex'])) {
+    } elseif (str_starts_with(strtolower((string) $patient_data['sex']), 'female')) {
         $chart = "2-20yo_girls_BMI.png";
 
         // added by BM for CSS html output

--- a/interface/patient_file/letter.php
+++ b/interface/patient_file/letter.php
@@ -554,15 +554,7 @@ while (false !== ($tfname = readdir($dh))) {
         continue;
     }
 
-    if (preg_match("/\.php$/", $tfname)) {
-        continue;
-    }
-
-    if (preg_match("/\.jpg$/", $tfname)) {
-        continue;
-    }
-
-    if (preg_match("/\.png$/", $tfname)) {
+    if (in_array(strtolower(pathinfo($tfname, PATHINFO_EXTENSION)), ['php', 'jpg', 'png'], true)) {
         continue;
     }
 

--- a/interface/patient_file/pos_checkout_ippf.php
+++ b/interface/patient_file/pos_checkout_ippf.php
@@ -429,9 +429,10 @@ function receiptPaymentLineIppf($paydate, $amount, $description = '', $method = 
     }
     echo " <tr>\n";
     echo "  <td";
-    if (!empty($billtime) && !str_starts_with((string) $billtime, '0000')) {
+    $billtimeStr = (string) $billtime;
+    if ($billtimeStr !== '' && !str_starts_with($billtimeStr, '0000')) {
         echo " title='" . xla('Entered') . ' ' .
-            text(oeFormatShortDate($billtime)) . attr(substr((string) $billtime, 10)) . "'";
+            text(oeFormatShortDate($billtime)) . attr(substr($billtimeStr, 10)) . "'";
     }
     echo ">" . text(oeFormatShortDate($paydate)) . "</td>\n";
     echo "  <td colspan='2'>" . text($refno) . "</td>\n";
@@ -1638,10 +1639,11 @@ if (!empty($_POST['form_save']) && !$alertmsg) {
 
     // Post discount.
     if ($_POST['form_discount'] != 0) {
+        $discount = trim((string) $_POST['form_discount']);
         if (OEGlobalsBag::getInstance()->getBoolean('discount_by_money')) {
-            $amount  = formatMoneyNumber(trim((string) $_POST['form_discount']));
+            $amount  = formatMoneyNumber($discount);
         } else {
-            $amount  = formatMoneyNumber(trim((string) $_POST['form_discount']) * $form_amount / 100);
+            $amount  = formatMoneyNumber($discount * $form_amount / 100);
         }
         $memo = trimPost('form_discount_type');
         $recorder = new Recorder();
@@ -2006,9 +2008,10 @@ while ($urow = sqlFetchArray($ures)) {
         "list_id = 'chargecats' AND activity = 1"
     );
     while ($tmprow = sqlFetchArray($tmpres)) {
+        $notes = (string) $tmprow['notes'];
         if (
-            preg_match('/ADJ=(\w+)/', (string) $tmprow['notes'], $matches) ||
-            preg_match('/ADJ="(.*?)"/', (string) $tmprow['notes'], $matches)
+            preg_match('/ADJ=(\w+)/', $notes, $matches) ||
+            preg_match('/ADJ="(.*?)"/', $notes, $matches)
         ) {
             echo "  if (customer == " . js_escape($tmprow['option_id']) . ") ret = " . js_escape($matches[1]) . ";\n";
         }

--- a/interface/patient_file/pos_checkout_ippf.php
+++ b/interface/patient_file/pos_checkout_ippf.php
@@ -2390,13 +2390,13 @@ while ($brow = sqlFetchArray($bres)) {
             if ($codetype !== 'IPPF2') {
                 continue;
             }
-            if (preg_match('/^211/', $code)) {
+            if (str_starts_with($code, '211')) {
                 $gcac_related_visit = true;
                 if (
-                    preg_match('/^211313030110/', $code) // Medical
-                    || preg_match('/^211323030230/', $code) // Surgical
-                    || preg_match('/^211403030110/', $code) // Incomplete Medical
-                    || preg_match('/^211403030230/', $code) // Incomplete Surgical
+                    str_starts_with($code, '211313030110') // Medical
+                    || str_starts_with($code, '211323030230') // Surgical
+                    || str_starts_with($code, '211403030110') // Incomplete Medical
+                    || str_starts_with($code, '211403030230') // Incomplete Surgical
                 ) {
                     $gcac_service_provided = true;
                 }

--- a/interface/patient_file/pos_checkout_normal.php
+++ b/interface/patient_file/pos_checkout_normal.php
@@ -1046,7 +1046,7 @@ function normal_generate_receipt($patient_id, $encounter = 0): void
                                                 if ($codetype !== 'IPPF') {
                                                     continue;
                                                 }
-                                                if (preg_match('/^25222/', $code)) {
+                                                if (str_starts_with($code, '25222')) {
                                                     $gcac_related_visit = true;
                                                     if (preg_match('/^25222[34]/', $code)) {
                                                         $gcac_service_provided = true;

--- a/interface/reports/appt_encounter_report.php
+++ b/interface/reports/appt_encounter_report.php
@@ -426,7 +426,7 @@ if (!empty($_POST['form_refresh'])) {
                                 continue;
                             }
 
-                            if (preg_match('/^25222/', $code)) {
+                            if (str_starts_with($code, '25222')) {
                                 $gcac_related_visit = true;
                             }
                         }

--- a/interface/reports/ippf_statistics.php
+++ b/interface/reports/ippf_statistics.php
@@ -226,36 +226,36 @@ function ippf_stats_genNumCell($num, $cnum): void
 // Translate an IPPF code to the corresponding descriptive name of its
 // contraceptive method, or to an empty string if none applies.
 //
-function getContraceptiveMethod($code)
+function getContraceptiveMethod(string $code)
 {
     $key = '';
-    if (str_starts_with((string) $code, '111101')) {
+    if (str_starts_with($code, '111101')) {
         $key = xl('Pills');
-    } elseif (preg_match('/^11111[1-9]/', (string) $code)) {
+    } elseif (preg_match('/^11111[1-9]/', $code)) {
         $key = xl('Injectables');
-    } elseif (preg_match('/^11112[1-9]/', (string) $code)) {
+    } elseif (preg_match('/^11112[1-9]/', $code)) {
         $key = xl('Implants');
-    } elseif (str_starts_with((string) $code, '111132')) {
+    } elseif (str_starts_with($code, '111132')) {
         $key = xl('Patch');
-    } elseif (str_starts_with((string) $code, '111133')) {
+    } elseif (str_starts_with($code, '111133')) {
         $key = xl('Vaginal Ring');
-    } elseif (str_starts_with((string) $code, '112141')) {
+    } elseif (str_starts_with($code, '112141')) {
         $key = xl('Male Condoms');
-    } elseif (str_starts_with((string) $code, '112142')) {
+    } elseif (str_starts_with($code, '112142')) {
         $key = xl('Female Condoms');
-    } elseif (preg_match('/^11215[1-9]/', (string) $code)) {
+    } elseif (preg_match('/^11215[1-9]/', $code)) {
         $key = xl('Diaphragms/Caps');
-    } elseif (preg_match('/^11216[1-9]/', (string) $code)) {
+    } elseif (preg_match('/^11216[1-9]/', $code)) {
         $key = xl('Spermicides');
-    } elseif (preg_match('/^11317[1-9]/', (string) $code)) {
+    } elseif (preg_match('/^11317[1-9]/', $code)) {
         $key = xl('IUD');
-    } elseif (str_starts_with((string) $code, '145212')) {
+    } elseif (str_starts_with($code, '145212')) {
         $key = xl('Emergency Contraception');
-    } elseif (preg_match('/^121181.13/', (string) $code)) {
+    } elseif (preg_match('/^121181.13/', $code)) {
         $key = xl('Female VSC');
-    } elseif (preg_match('/^122182.13/', (string) $code)) {
+    } elseif (preg_match('/^122182.13/', $code)) {
         $key = xl('Male VSC');
-    } elseif (preg_match('/^131191.10/', (string) $code)) {
+    } elseif (preg_match('/^131191.10/', $code)) {
         $key = xl('Awareness-Based');
     }
 
@@ -321,17 +321,17 @@ function getRelatedAbortionMethod($row)
 // Translate an IPPF code to the corresponding descriptive name of its
 // abortion method, or to an empty string if none applies.
 //
-function getAbortionMethod($code)
+function getAbortionMethod(string $code)
 {
     $key = '';
-    if (preg_match('/^25222[34]/', (string) $code)) {
-        if (str_starts_with((string) $code, '2522231')) {
+    if (preg_match('/^25222[34]/', $code)) {
+        if (str_starts_with($code, '2522231')) {
             $key = xl('D&C');
-        } elseif (str_starts_with((string) $code, '2522232')) {
+        } elseif (str_starts_with($code, '2522232')) {
             $key = xl('D&E');
-        } elseif (str_starts_with((string) $code, '2522233')) {
+        } elseif (str_starts_with($code, '2522233')) {
             $key = xl('MVA');
-        } elseif (str_starts_with((string) $code, '252224')) {
+        } elseif (str_starts_with($code, '252224')) {
             $key = xl('Medical');
         } else {
             $key = xl('Other Surgical');
@@ -576,7 +576,7 @@ function ippfLoadColumnData(string $key, array $row, int $quantity = 1): void
 
 // This is called for each IPPF service code that is selected.
 //
-function process_ippf_code($row, $code, $quantity = 1): void
+function process_ippf_code($row, string $code, $quantity = 1): void
 {
     global $areport, $arr_titles, $form_by, $form_content;
 
@@ -585,9 +585,9 @@ function process_ippf_code($row, $code, $quantity = 1): void
   // SRH including Family Planning
   //
     if ($form_by === '1') {
-        if (str_starts_with((string) $code, '1')) {
+        if (str_starts_with($code, '1')) {
             $key = xl('SRH - Family Planning');
-        } elseif (str_starts_with((string) $code, '2')) {
+        } elseif (str_starts_with($code, '2')) {
             $key = xl('SRH Non Family Planning');
         } else {
             if ($form_content != 5) {
@@ -595,33 +595,33 @@ function process_ippf_code($row, $code, $quantity = 1): void
             }
         }
     } elseif ($form_by === '3') { // General Service Category
-        if (str_starts_with((string) $code, '1')) {
+        if (str_starts_with($code, '1')) {
             $key = xl('SRH - Family Planning');
-        } elseif (str_starts_with((string) $code, '2')) {
+        } elseif (str_starts_with($code, '2')) {
             $key = xl('SRH Non Family Planning');
-        } elseif (str_starts_with((string) $code, '3')) {
+        } elseif (str_starts_with($code, '3')) {
             $key = xl('Non-SRH Medical');
-        } elseif (str_starts_with((string) $code, '4')) {
+        } elseif (str_starts_with($code, '4')) {
             $key = xl('Non-SRH Non-Medical');
         } else {
             $key = xl('Invalid Service Codes');
         }
     } elseif ($form_by === '13') { // Abortion-Related Category
-        if (str_starts_with((string) $code, '252221')) {
+        if (str_starts_with($code, '252221')) {
             $key = xl('Pre-Abortion Counseling');
-        } elseif (str_starts_with((string) $code, '252222')) {
+        } elseif (str_starts_with($code, '252222')) {
             $key = xl('Pre-Abortion Consultation');
-        } elseif (str_starts_with((string) $code, '252223')) {
+        } elseif (str_starts_with($code, '252223')) {
             $key = xl('Induced Abortion');
-        } elseif (str_starts_with((string) $code, '252224')) {
+        } elseif (str_starts_with($code, '252224')) {
             $key = xl('Medical Abortion');
-        } elseif (str_starts_with((string) $code, '252225')) {
+        } elseif (str_starts_with($code, '252225')) {
             $key = xl('Incomplete Abortion Treatment');
-        } elseif (str_starts_with((string) $code, '252226')) {
+        } elseif (str_starts_with($code, '252226')) {
             $key = xl('Post-Abortion Care');
-        } elseif (str_starts_with((string) $code, '252227')) {
+        } elseif (str_starts_with($code, '252227')) {
             $key = xl('Post-Abortion Counseling');
-        } elseif (str_starts_with((string) $code, '25222')) {
+        } elseif (str_starts_with($code, '25222')) {
             $key = xl('Other/Generic Abortion-Related');
         } else {
             if ($form_content != 5) {
@@ -714,7 +714,7 @@ function process_ippf_code($row, $code, $quantity = 1): void
     } elseif ($form_by === '8') { // Post-Abortion Care and Followup by Source.
         // Requirements just call for counting sessions, but this way the columns
         // can be anything - age category, religion, whatever.
-        if (preg_match('/^25222[567]/', (string) $code)) { // care, followup and incomplete abortion treatment
+        if (preg_match('/^25222[567]/', $code)) { // care, followup and incomplete abortion treatment
             $key = getGcacClientStatus($row);
         } else {
             return;
@@ -761,7 +761,7 @@ function process_ippf_code($row, $code, $quantity = 1): void
         //   Decided not to have the abortion
         //
     } elseif ($form_by === '12') {
-        if (str_starts_with((string) $code, '252221')) { // all pre-abortion counseling
+        if (str_starts_with($code, '252221')) { // all pre-abortion counseling
             $key = getGcacClientStatus($row);
         } else {
             return;

--- a/interface/reports/ippf_statistics.php
+++ b/interface/reports/ippf_statistics.php
@@ -229,19 +229,19 @@ function ippf_stats_genNumCell($num, $cnum): void
 function getContraceptiveMethod($code)
 {
     $key = '';
-    if (preg_match('/^111101/', (string) $code)) {
+    if (str_starts_with((string) $code, '111101')) {
         $key = xl('Pills');
     } elseif (preg_match('/^11111[1-9]/', (string) $code)) {
         $key = xl('Injectables');
     } elseif (preg_match('/^11112[1-9]/', (string) $code)) {
         $key = xl('Implants');
-    } elseif (preg_match('/^111132/', (string) $code)) {
+    } elseif (str_starts_with((string) $code, '111132')) {
         $key = xl('Patch');
-    } elseif (preg_match('/^111133/', (string) $code)) {
+    } elseif (str_starts_with((string) $code, '111133')) {
         $key = xl('Vaginal Ring');
-    } elseif (preg_match('/^112141/', (string) $code)) {
+    } elseif (str_starts_with((string) $code, '112141')) {
         $key = xl('Male Condoms');
-    } elseif (preg_match('/^112142/', (string) $code)) {
+    } elseif (str_starts_with((string) $code, '112142')) {
         $key = xl('Female Condoms');
     } elseif (preg_match('/^11215[1-9]/', (string) $code)) {
         $key = xl('Diaphragms/Caps');
@@ -249,7 +249,7 @@ function getContraceptiveMethod($code)
         $key = xl('Spermicides');
     } elseif (preg_match('/^11317[1-9]/', (string) $code)) {
         $key = xl('IUD');
-    } elseif (preg_match('/^145212/', (string) $code)) {
+    } elseif (str_starts_with((string) $code, '145212')) {
         $key = xl('Emergency Contraception');
     } elseif (preg_match('/^121181.13/', (string) $code)) {
         $key = xl('Female VSC');
@@ -325,13 +325,13 @@ function getAbortionMethod($code)
 {
     $key = '';
     if (preg_match('/^25222[34]/', (string) $code)) {
-        if (preg_match('/^2522231/', (string) $code)) {
+        if (str_starts_with((string) $code, '2522231')) {
             $key = xl('D&C');
-        } elseif (preg_match('/^2522232/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '2522232')) {
             $key = xl('D&E');
-        } elseif (preg_match('/^2522233/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '2522233')) {
             $key = xl('MVA');
-        } elseif (preg_match('/^252224/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '252224')) {
             $key = xl('Medical');
         } else {
             $key = xl('Other Surgical');
@@ -585,9 +585,9 @@ function process_ippf_code($row, $code, $quantity = 1): void
   // SRH including Family Planning
   //
     if ($form_by === '1') {
-        if (preg_match('/^1/', (string) $code)) {
+        if (str_starts_with((string) $code, '1')) {
             $key = xl('SRH - Family Planning');
-        } elseif (preg_match('/^2/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '2')) {
             $key = xl('SRH Non Family Planning');
         } else {
             if ($form_content != 5) {
@@ -595,33 +595,33 @@ function process_ippf_code($row, $code, $quantity = 1): void
             }
         }
     } elseif ($form_by === '3') { // General Service Category
-        if (preg_match('/^1/', (string) $code)) {
+        if (str_starts_with((string) $code, '1')) {
             $key = xl('SRH - Family Planning');
-        } elseif (preg_match('/^2/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '2')) {
             $key = xl('SRH Non Family Planning');
-        } elseif (preg_match('/^3/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '3')) {
             $key = xl('Non-SRH Medical');
-        } elseif (preg_match('/^4/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '4')) {
             $key = xl('Non-SRH Non-Medical');
         } else {
             $key = xl('Invalid Service Codes');
         }
     } elseif ($form_by === '13') { // Abortion-Related Category
-        if (preg_match('/^252221/', (string) $code)) {
+        if (str_starts_with((string) $code, '252221')) {
             $key = xl('Pre-Abortion Counseling');
-        } elseif (preg_match('/^252222/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '252222')) {
             $key = xl('Pre-Abortion Consultation');
-        } elseif (preg_match('/^252223/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '252223')) {
             $key = xl('Induced Abortion');
-        } elseif (preg_match('/^252224/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '252224')) {
             $key = xl('Medical Abortion');
-        } elseif (preg_match('/^252225/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '252225')) {
             $key = xl('Incomplete Abortion Treatment');
-        } elseif (preg_match('/^252226/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '252226')) {
             $key = xl('Post-Abortion Care');
-        } elseif (preg_match('/^252227/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '252227')) {
             $key = xl('Post-Abortion Counseling');
-        } elseif (preg_match('/^25222/', (string) $code)) {
+        } elseif (str_starts_with((string) $code, '25222')) {
             $key = xl('Other/Generic Abortion-Related');
         } else {
             if ($form_content != 5) {
@@ -761,7 +761,7 @@ function process_ippf_code($row, $code, $quantity = 1): void
         //   Decided not to have the abortion
         //
     } elseif ($form_by === '12') {
-        if (preg_match('/^252221/', (string) $code)) { // all pre-abortion counseling
+        if (str_starts_with((string) $code, '252221')) { // all pre-abortion counseling
             $key = getGcacClientStatus($row);
         } else {
             return;

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -563,7 +563,7 @@ function writeOptionLine($option_id, string $title, $seq, $default, $value, $map
         attr($codes) . "' onclick='select_clin_term_code(this)' size='25' maxlength='255' class='optin form-control form-control-sm' />";
     echo "</td>\n";
 
-    if (preg_match('/_issue_list$/', (string) $list_id)) {
+    if (str_ends_with((string) $list_id, '_issue_list')) {
         echo "  <td>";
         echo generate_select_list("opt[$opt_line_no][subtype]", 'issue_subtypes', $subtype, 'Subtype', ' ', 'optin');
         echo "</td>\n";
@@ -1381,7 +1381,7 @@ function writeITLine($it_array): void
 
                     <th><?php echo xlt('Code(s)'); ?></th>
                     <?php
-                    if (preg_match('/_issue_list$/', (string) $list_id)) { ?>
+                    if (str_ends_with((string) $list_id, '_issue_list')) { ?>
                         <th><?php echo xlt('Subtype'); ?></th>
                         <?php
                     }

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -43,7 +43,7 @@ if (empty($_REQUEST['list_id'] ?? null) && empty($_REQUEST['list_id_container'] 
     $list_id = 'language';
     $blank_list_id = true;
 } else {
-    $list_id = $_REQUEST['list_id'];
+    $list_id = (string) $_REQUEST['list_id'];
 }
 
 // Check authorization.
@@ -242,7 +242,7 @@ if ((($_POST['formaction'] ?? '') == 'save') && $list_id && $alertmsg == '') {
                     $notes = trim($iter['notes'] ?? '');
                 }
 
-                if (preg_match("/Eye_QP_/", (string) $list_id)) {
+                if (preg_match("/Eye_QP_/", $list_id)) {
                     if (preg_match("/^[BLR]/", $id)) {
                         $stuff = explode("_", $id)[0];
                         $iter['mapping'] = substr($stuff, 1);
@@ -1157,8 +1157,8 @@ function writeITLine($it_array): void
                              * Keep proper list name (otherwise list name changes according to
                              * the options shown on the screen).
                              */
-                            $list_id_container = $_GET["list_id_container"] ?? null;
-                            if (isset($_GET["list_id_container"]) && strlen((string) $list_id_container) > 0) {
+                            $list_id_container = (string) ($_GET["list_id_container"] ?? '');
+                            if ($list_id_container !== '') {
                                 $list_id = $list_id_container;
                             }
 

--- a/library/clinical_rules.php
+++ b/library/clinical_rules.php
@@ -2036,7 +2036,7 @@ function resolve_plans_sql($type = '', $patient_id = '0', $configurableOnly = fa
                 // merge the custom plan with the default plan
                 $mergedPlan = [];
                 foreach ($customPlan as $key => $value) {
-                    if ($value == null && preg_match("/_flag$/", (string) $key)) {
+                    if ($value == null && str_ends_with((string) $key, '_flag')) {
                         // use default setting
                         $mergedPlan[$key] = $plan[$key];
                     } else {
@@ -2205,7 +2205,7 @@ function resolve_rules_sql($type = '', $patient_id = '0', $configurableOnly = fa
                     // note this explicitly relies on type conversion, null, "", 0 becoming equal to null...
                     // if anything changes in language spec this might break.
                     // TODO: consider using strict comparison
-                    if ($value == null && preg_match("/_flag$/", (string) $key)) {
+                    if ($value == null && str_ends_with((string) $key, '_flag')) {
                         // use default setting
                         $mergedRule[$key] = $rule[$key];
                     } else {

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -692,7 +692,7 @@ function generate_form_field($frow, $currvalue): void
         if ($data_type == 46) {
             // support for single-selection list with comment support
             $selectedValues = explode("|", (string) $currvalue);
-            if (!preg_match('/^comment_/', (string) $currvalue) || (count($selectedValues) == 1)) {
+            if (!str_starts_with((string) $currvalue, 'comment_') || (count($selectedValues) == 1)) {
                 $display = "display:none";
                 $comment = "";
             } else {
@@ -4288,7 +4288,7 @@ function get_layout_form_value($frow, $prefix = 'form_')
             }
         } elseif ($data_type == 46) {
             $reslist = trim((string) $_POST["$prefix$field_id"]);
-            if (preg_match('/^comment_/', $reslist)) {
+            if (str_starts_with($reslist, 'comment_')) {
                 $res_comment = str_replace('|', ' ', $_POST["{$prefix}text_$field_id"]);
                 $value = $reslist . "|" . $res_comment;
             } else {

--- a/portal/home.php
+++ b/portal/home.php
@@ -190,7 +190,8 @@ function collectStyles(): array
         if (
             $tfname == 'style_blue.css' ||
             $tfname == 'style_pdf.css' ||
-            !preg_match("/^" . 'style_' . ".*\.css$/", $tfname)
+            !str_starts_with($tfname, 'style_') ||
+            !str_ends_with($tfname, '.css')
         ) {
             continue;
         }

--- a/portal/home.php
+++ b/portal/home.php
@@ -118,10 +118,11 @@ if ($appts) {
     foreach ($appts as $row) {
         $status_title = getListItemTitle('apptstat', $row['pc_apptstatus']);
         $count++;
+        $startTime = (string) $row['pc_startTime'];
         $dayname = xl(date('l', strtotime((string) $row['pc_eventDate'])));
         $dispampm = 'am';
-        $disphour = (int)substr((string) $row['pc_startTime'], 0, 2);
-        $dispmin = substr((string) $row['pc_startTime'], 3, 2);
+        $disphour = (int)substr($startTime, 0, 2);
+        $dispmin = substr($startTime, 3, 2);
         if ($disphour >= 12) {
             $dispampm = 'pm';
             if ($disphour > 12) {
@@ -152,10 +153,11 @@ if ($past_appts) {
     foreach ($past_appts as $row) {
         $status_title = getListItemTitle('apptstat', $row['pc_apptstatus']);
         $pastCount++;
+        $startTime = (string) $row['pc_startTime'];
         $dayname = xl(date('l', strtotime((string) $row['pc_eventDate'])));
         $dispampm = 'am';
-        $disphour = (int)substr((string) $row['pc_startTime'], 0, 2);
-        $dispmin = substr((string) $row['pc_startTime'], 3, 2);
+        $disphour = (int)substr($startTime, 0, 2);
+        $dispmin = substr($startTime, 3, 2);
         if ($disphour >= 12) {
             $dispampm = 'pm';
             if ($disphour > 12) {

--- a/portal/import_template.php
+++ b/portal/import_template.php
@@ -232,10 +232,10 @@ if ((count($_FILES['template_files']['name'] ?? []) > 0) && !empty($_FILES['temp
         }
         // parse out what we need
         $name = preg_replace("/[^A-Z0-9.]/i", " ", (string)$_FILES['template_files']['name'][$i]);
-        if (preg_match("/(.*)\.(php|php7|php8|doc|docx)$/i", (string)$name) !== 0) {
+        $parts = pathinfo((string)$name);
+        if (in_array(strtolower($parts['extension'] ?? ''), ['php', 'php7', 'php8', 'doc', 'docx'], true)) {
             die(xlt('Invalid file type.'));
         }
-        $parts = pathinfo((string)$name);
         $name = ucwords(strtolower($parts["filename"]));
         if (empty($patient)) {
             $patient = ['-1'];

--- a/portal/patient/fwk/libs/util/parsecsv.lib.php
+++ b/portal/patient/fwk/libs/util/parsecsv.lib.php
@@ -254,7 +254,7 @@ class parseCSV
         }
 
         $mode = ($append) ? 'at' : 'wt';
-        $is_php = (preg_match('/\.php$/i', (string) $file)) ? true : false;
+        $is_php = strtolower(pathinfo((string) $file, PATHINFO_EXTENSION)) === 'php';
         return $this->_wfile($file, $this->unparse($data, $fields, $append, $is_php), $mode);
     }
 
@@ -681,7 +681,7 @@ class parseCSV
                 $this->file = $file;
             }
 
-            if (preg_match('/\.php$/i', (string) $file) && preg_match('/<\?.*?\?>(.*)/ims', (string) $data, $strip)) {
+            if (strtolower(pathinfo((string) $file, PATHINFO_EXTENSION)) === 'php' && preg_match('/<\?.*?\?>(.*)/ims', (string) $data, $strip)) {
                 $data = ltrim($strip [1]);
             }
 

--- a/src/Services/Utils/SQLUpgradeService.php
+++ b/src/Services/Utils/SQLUpgradeService.php
@@ -1289,7 +1289,7 @@ class SQLUpgradeService implements ISQLUpgradeService
     {
         $res = sqlStatement("SELECT DISTINCT form_id FROM layout_options ORDER BY form_id");
         while ($row = sqlFetchArray($res)) {
-            $form_id = $row['form_id'];
+            $form_id = (string)$row['form_id'];
             $props = [
                 'title' => 'Unknown',
                 'mapping' => 'Core',
@@ -1297,7 +1297,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 'activity' => '1',
                 'option_value' => '0',
             ];
-            if (str_starts_with((string)$form_id, 'LBF')) {
+            if (str_starts_with($form_id, 'LBF')) {
                 $props = sqlQuery(
                     "SELECT title, mapping, notes, activity, option_value FROM list_options WHERE list_id = 'lbfnames' AND option_id = ?",
                     [$form_id]
@@ -1308,7 +1308,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 if (empty($props['mapping'])) {
                     $props['mapping'] = 'Clinical';
                 }
-            } elseif (str_starts_with((string)$form_id, 'LBT')) {
+            } elseif (str_starts_with($form_id, 'LBT')) {
                 $props = sqlQuery(
                     "SELECT title, mapping, notes, activity, option_value FROM list_options WHERE list_id = 'transactions' AND option_id = ?",
                     [$form_id]

--- a/src/Services/Utils/SQLUpgradeService.php
+++ b/src/Services/Utils/SQLUpgradeService.php
@@ -466,7 +466,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 if ($skipping) {
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
-            } elseif (preg_match('/^#IfNotMigrateClickOptions/', $line)) {
+            } elseif (str_starts_with($line, '#IfNotMigrateClickOptions')) {
                 if ($this->tableExists("issue_types")) {
                     $skipping = true;
                 } else {
@@ -478,7 +478,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 if ($skipping) {
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
-            } elseif (preg_match('/^#IfNotListOccupation/', $line)) {
+            } elseif (str_starts_with($line, '#IfNotListOccupation')) {
                 if (($this->listExists("Occupation")) || (!$this->columnExists('patient_data', 'occupation'))) {
                     $skipping = true;
                 } else {
@@ -491,7 +491,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 if ($skipping) {
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
-            } elseif (preg_match('/^#IfNotListReaction/', $line)) {
+            } elseif (str_starts_with($line, '#IfNotListReaction')) {
                 if (($this->listExists("reaction")) || (!$this->columnExists('lists', 'reaction'))) {
                     $skipping = true;
                 } else {
@@ -504,7 +504,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 if ($skipping) {
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
-            } elseif (preg_match('/^#IfNotListImmunizationManufacturer/', $line)) {
+            } elseif (str_starts_with($line, '#IfNotListImmunizationManufacturer')) {
                 if ($this->listExists("Immunization_Manufacturer")) {
                     $skipping = true;
                 } else {
@@ -517,7 +517,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 if ($skipping) {
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
-            } elseif (preg_match('/^#IfNotWenoRx/', $line)) {
+            } elseif (str_starts_with($line, '#IfNotWenoRx')) {
                 if ($this->tableHasRow('erx_weno_drugs', "drug_id", '1008') == true) {
                     $skipping = true;
                 } else {
@@ -530,7 +530,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
                 // convert all *text types to use default null setting
-            } elseif (preg_match('/^#IfTextNullFixNeeded/', $line)) {
+            } elseif (str_starts_with($line, '#IfTextNullFixNeeded')) {
                 $items_to_convert = sqlStatement(
                     "SELECT col.`table_name` AS table_name, col.`column_name` AS column_name,
       col.`data_type` AS data_type, col.`column_comment` AS column_comment
@@ -575,7 +575,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 if ($skipping) {
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
-            } elseif (preg_match('/^#IfInnoDBMigrationNeeded/', $line)) {
+            } elseif (str_starts_with($line, '#IfInnoDBMigrationNeeded')) {
                 // find MyISAM tables and attempt to convert them
                 //tables that need to skip InnoDB migration (stay at MyISAM for now)
                 $tables_skip_migration = ['form_eye_mag'];
@@ -610,7 +610,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 if ($skipping) {
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
-            } elseif (preg_match('/^#ConvertLayoutProperties/', $line)) {
+            } elseif (str_starts_with($line, '#ConvertLayoutProperties')) {
                 if ($skipping) {
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 } else {
@@ -618,7 +618,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                     $this->flush_echo();
                     $this->convertLayoutProperties();
                 }
-            } elseif (preg_match('/^#IfDocumentNamingNeeded/', $line)) {
+            } elseif (str_starts_with($line, '#IfDocumentNamingNeeded')) {
                 $emptyNames = sqlStatementNoLog("SELECT `id`, `url`, `name`, `couch_docid` FROM `documents` WHERE `name` = '' OR `name` IS NULL");
                 if (sqlNumRows($emptyNames) > 0) {
                     $this->echo("<p>Converting document names.</p>\n");
@@ -644,7 +644,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 if ($skipping) {
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
-            } elseif (preg_match('/^#IfVitalsDatesNeeded/', $line)) {
+            } elseif (str_starts_with($line, '#IfVitalsDatesNeeded')) {
                 $emptyDates = sqlStatementNoLog("SELECT fv.id as vitals_id, f.date as new_date FROM form_vitals fv LEFT JOIN forms f on fv.id = f.form_id WHERE fv.date = '0000-00-00 00:00:00' AND f.form_name = 'Vitals'");
                 if (sqlNumRows($emptyDates) > 0) {
                     $this->echo("<p>Converting empty vital dates.</p>\n");
@@ -661,7 +661,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 if ($skipping) {
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
-            } elseif (preg_match('/^#IfMBOEncounterNeeded/', $line)) {
+            } elseif (str_starts_with($line, '#IfMBOEncounterNeeded')) {
                 $emptyMBOEncounters = sqlStatementNoLog("SELECT `pid` FROM `form_misc_billing_options` WHERE `encounter` IS NULL");
                 if (sqlNumRows($emptyMBOEncounters) > 0) {
                     $this->echo("<p class='text-info'>Linking encounters to misc billing options forms.</p>\n");
@@ -703,7 +703,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 if ($skipping) {
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
-            } elseif (preg_match('/^#IfEyeFormLaserCategoriesNeeded/', $line)) {
+            } elseif (str_starts_with($line, '#IfEyeFormLaserCategoriesNeeded')) {
                 $eyeFormCategoryParent = sqlQueryNoLog("SELECT `id`, `rght` FROM `categories` WHERE `name` = 'Eye Module'");
                 $eyeFormAntSegLaser = sqlQueryNoLog("SELECT `id` FROM `categories` WHERE `name` = 'AntSeg Laser - Eye'");
                 if (!empty($eyeFormCategoryParent) && empty($eyeFormAntSegLaser)) {
@@ -748,7 +748,7 @@ class SQLUpgradeService implements ISQLUpgradeService
                 if ($skipping) {
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
-            } elseif (preg_match('/^#IfCareTeamsV1MigrationNeeded/', $line)) {
+            } elseif (str_starts_with($line, '#IfCareTeamsV1MigrationNeeded')) {
                 $sql = "SELECT COLUMN_COMMENT = 'Deprecated field, use care_team_member table instead' AS is_migrated
                     FROM INFORMATION_SCHEMA.COLUMNS
                     WHERE TABLE_SCHEMA = DATABASE()
@@ -762,14 +762,14 @@ class SQLUpgradeService implements ISQLUpgradeService
                     $skipping = true;
                     $this->echo("<p class='text-success'>$skip_msg $line</p>\n");
                 }
-            } elseif (preg_match('/^#EndIf/', $line)) {
+            } elseif (str_starts_with($line, '#EndIf')) {
                 $skipping = false;
             }
 
-            if (preg_match('/^#SpecialSql/', $line)) {
+            if (str_starts_with($line, '#SpecialSql')) {
                 $special = true;
                 $line = " ";
-            } elseif (preg_match('/^#EndSpecialSql/', $line)) {
+            } elseif (str_starts_with($line, '#EndSpecialSql')) {
                 $special = false;
                 $trim = false;
                 $line = " ";
@@ -1112,11 +1112,11 @@ class SQLUpgradeService implements ISQLUpgradeService
             $this->echo("Importing clickoption setting<br />");
             while (!feof($file_handle)) {
                 $line_of_text = fgets($file_handle);
-                if (preg_match('/^#/', $line_of_text)) {
+                if ($line_of_text === false || $line_of_text === "") {
                     continue;
                 }
 
-                if ($line_of_text == "") {
+                if (str_starts_with($line_of_text, '#')) {
                     continue;
                 }
 


### PR DESCRIPTION
Closes #11880.

Convert `preg_match` calls that only match a literal prefix or suffix to `str_starts_with()` / `str_ends_with()`, or `pathinfo()` for file-extension checks. Skip cases that use capture groups, character classes, or alternation that can't be expressed cleanly without a regex.

In `SQLUpgradeService::clickOptionsMigrate()`, guard against `fgets()` returning `false` explicitly rather than letting it coerce silently into `preg_match`. The matching baseline ignore is dropped.

## Test plan

- [x] `composer phpcs`
- [x] `composer phpstan` (baseline shrinks by one entry)
- [x] `composer php-syntax-check`
- [ ] CI green