### PR TITLE
fix(encounter): handle missing row and null uuid in encounter view form (backport #11883)

### DIFF
--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -9027,11 +9027,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/newpatient/C_EncounterVisitForm.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'uuid\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/newpatient/C_EncounterVisitForm.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset 0 on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/newpatient/C_EncounterVisitForm.class.php',

--- a/interface/forms/newpatient/C_EncounterVisitForm.class.php
+++ b/interface/forms/newpatient/C_EncounterVisitForm.class.php
@@ -507,9 +507,14 @@ class C_EncounterVisitForm
         if ($viewmode) {
             $id = $_REQUEST['id'] ?? '';
             $result = sqlQuery("SELECT * FROM form_encounter WHERE id = ?", [$id]);
+            if (!is_array($result)) {
+                throw new \RuntimeException('Encounter not found for id ' . var_export($id, true));
+            }
             $encounter = $result;
             // it won't encode in the JSON if we don't convert this.
-            $encounter['uuid'] = UuidRegistry::uuidToString($result['uuid']);
+            $encounter['uuid'] = $result['uuid'] !== null
+                ? UuidRegistry::uuidToString($result['uuid'])
+                : '';
             $encounter_followup_id = $encounter['parent_encounter_id'] ?? null;
             if ($encounter_followup_id) {
                 $q = "SELECT fe.date as date, fe.encounter as encounter FROM form_encounter AS fe " .


### PR DESCRIPTION
Backport of #11883 to `rel-810`.

Cherry-pick of f11828929ad8c1a67d2abc5cabe4ee2e3d8f018a; clean apply (auto-merged the PHPStan baseline file).

## Summary

`C_EncounterVisitForm::render()` calls `UuidRegistry::uuidToString($result['uuid'])` immediately after a `sqlQuery` lookup against `form_encounter` without checking whether the row was found, or whether the `uuid` column was populated. A request with a stale/invalid encounter id, or a legacy row predating uuid backfill, triggers `Ramsey\Uuid\Uuid::fromBytes(null)` and a fatal `TypeError`.

This change throws `RuntimeException` when no row matches, passes `''` through when the row exists but `uuid` is `null`, and drops the now-unmatched PHPStan baseline entry.

## Test plan

- [ ] View an existing encounter — renders normally
- [ ] Visit `view_form.php` with a deleted/invalid encounter id — surfaces the explicit "Encounter not found" error rather than a `fromBytes(null)` TypeError
- [ ] PHPStan passes (`composer phpstan`)

Assisted-by: Claude Code