### PR TITLE
fix(csrf): stop rotating CSRF private key on every main_screen.php load

### DIFF
--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -8,9 +8,11 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Ranganath Pathak <pathak@scrs1.org>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2018 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2019 Ranganath Pathak <pathak@scrs1.org>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -382,14 +384,17 @@ if (isset($_POST['new_login_session_management'])) {
     } else {
         $_POST["clearPass"] = '';
     }
+    // Set up the csrf private_key
+    //  Note this key always remains private and never leaves server session. It is used to create
+    //  the csrf tokens.
+    //  Generated only on the new-login path. Rotating it on every main_screen.php load
+    //  invalidates CSRF tokens already embedded in long-lived iframes (e.g. dated_reminders,
+    //  which polls every 60s with the token captured at render time).
+    CsrfUtils::setupCsrfKey($session);
 } else {
     CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
     $session->migrate(false);
 }
-// Set up the csrf private_key
-//  Note this key always remains private and never leaves server session. It is used to create
-//  the csrf tokens.
-CsrfUtils::setupCsrfKey($session);
 // Set up the session uuid. This will be used for mapping session setting to database.
 //  At this time only used for lastupdate tracking
 SessionTracker::setupSessionDatabaseTracker();


### PR DESCRIPTION
## Summary

Loading `interface/main/main_screen.php` unconditionally regenerated the per-session CSRF private key, silently invalidating CSRF tokens already embedded in pages and iframes rendered before that load. Long-lived widgets that bake their token in at render time and poll on a fixed interval — most visibly `interface/main/dated_reminders/dated_reminders.php` (60s poll) — then logged `OpenEMR CSRF token authentication error` on every poll following any in-app reload of the top frame.

The rotation looks like it was meant only for the new-login path. This PR moves `CsrfUtils::setupCsrfKey($session)` inside the new-login branch so the key is generated once at login and not rotated on subsequent top-frame loads. The `else` branch is reached only after a successful CSRF check, which already requires an existing private key, so no key setup is needed there.

Fixes #11865.

## Test plan

- [ ] Log in, capture the CSRF token rendered into `dated_reminders.php`, reload `main_screen.php`, then re-POST the same token to `dated_reminders.php` — should now return 200 instead of 403.
- [ ] Confirm fresh login still works (the new-login branch still runs `setupCsrfKey`).
- [ ] Confirm `OpenEMR CSRF token authentication error` log entries no longer appear at the 60s polling cadence after navigating between top frames.
