### PR TITLE
ci(ccdaservice): rename cache key to invalidate stale v127 binaries (backport #11862)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
           echo 'vendor=${{ runner.os }}-vendor-${{ steps.parse.outputs.php }}-${{ hashFiles('**/composer.lock', 'composer.json') }}'
           echo 'composer=${{ runner.os }}-composer-${{ steps.parse.outputs.php }}-${{ hashFiles('**/composer.lock', 'composer.json') }}'
           echo 'npm-build=${{ runner.os }}-npm-build-${{ steps.parse.outputs.node_version }}-${{ hashFiles('**/package-lock.json') }}'
-          echo 'ccda-build=${{ runner.os }}-ccda-build-${{ steps.parse.outputs.node_version }}-${{ hashFiles('**/ccdaservice/package-lock.json') }}'
+          echo 'ccda-build=${{ runner.os }}-ccdaservice-modules-${{ steps.parse.outputs.node_version }}-${{ hashFiles('**/ccdaservice/package-lock.json') }}'
           echo 'npm=${{ runner.os }}-node-${{ steps.parse.outputs.node_version }}-${{ hashFiles('**/package-lock.json') }}'
         } >> "$GITHUB_OUTPUT"
 
@@ -280,7 +280,7 @@ jobs:
           ccdaservice/packages/oe-cqm-service/node_modules/
         key: ${{ steps.cache-keys.outputs.ccda-build }}
         restore-keys: |
-          ${{ runner.os }}-ccda-build-${{ steps.parse.outputs.node_version }}-
+          ${{ runner.os }}-ccdaservice-modules-${{ steps.parse.outputs.node_version }}-
 
     ##
     # The 'cache-hit' output for actions/cache/restore is always false
@@ -354,7 +354,7 @@ jobs:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
 
     - name: Save CCDA build artifacts
-      if: ${{ inputs.save_node_cache && steps.ccda-build-cache-check.outputs.hit != 'true' }}
+      if: ${{ steps.ccda-build-cache-check.outputs.hit != 'true' }}
       uses: actions/cache/save@v5
       with:
         key: ${{ steps.cache-keys.outputs.ccda-build }}
@@ -500,8 +500,7 @@ jobs:
           ccdaservice/node_modules/
           ccdaservice/packages/oe-cqm-service/node_modules/
         restore-keys: |
-          ${{ runner.os }}-ccda-build-${{ needs.setup.outputs.node_version }}-
-          ${{ runner.os }}-ccda-build-
+          ${{ runner.os }}-ccdaservice-modules-${{ needs.setup.outputs.node_version }}-
 
     - name: Download setup snapshot
       uses: actions/download-artifact@v8


### PR DESCRIPTION
Backport of #11862 to `rel-810`.

Cherry-pick of 92ab547d199372682f7c34ad75a14f867d022efd; clean apply (auto-merged `.github/workflows/test.yml`).

Without this, the `services` test job on rel-810 fails with `ERR_DLOPEN_FAILED` on `libxmljs2/build/Release/xmljs.node` because cached node_modules contain v127 binaries incompatible with the runtime Node version. Renaming the cache key invalidates those stale entries.

Assisted-by: Claude Code