### PR TITLE
fix(csrf): stop rotating CSRF private key on every main_screen.php load (backport #11888 to rel-810)

### DIFF
--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -8,9 +8,11 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Ranganath Pathak <pathak@scrs1.org>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2018 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2019 Ranganath Pathak <pathak@scrs1.org>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -382,14 +384,17 @@ if (isset($_POST['new_login_session_management'])) {
     } else {
         $_POST["clearPass"] = '';
     }
+    // Set up the csrf private_key
+    //  Note this key always remains private and never leaves server session. It is used to create
+    //  the csrf tokens.
+    //  Generated only on the new-login path. Rotating it on every main_screen.php load
+    //  invalidates CSRF tokens already embedded in long-lived iframes (e.g. dated_reminders,
+    //  which polls every 60s with the token captured at render time).
+    CsrfUtils::setupCsrfKey($session);
 } else {
     CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
     $session->migrate(false);
 }
-// Set up the csrf private_key
-//  Note this key always remains private and never leaves server session. It is used to create
-//  the csrf tokens.
-CsrfUtils::setupCsrfKey($session);
 // Set up the session uuid. This will be used for mapping session setting to database.
 //  At this time only used for lastupdate tracking
 SessionTracker::setupSessionDatabaseTracker();


### PR DESCRIPTION
## Summary

Backport of #11888 to `rel-810`.

Loading `interface/main/main_screen.php` unconditionally regenerated the per-session CSRF private key, silently invalidating CSRF tokens already embedded in long-lived iframes. The most visible victim is `interface/main/dated_reminders/dated_reminders.php`, which polls every 60s with the token captured at render time and logs `OpenEMR CSRF token authentication error` on every poll after any in-app reload of the top frame.

Moves `CsrfUtils::setupCsrfKey($session)` inside the new-login branch so the key is generated once at login and not rotated on subsequent top-frame loads. The `else` branch is reached only after a successful CSRF check, which already requires an existing private key.

Refs #11865, #11888.

## Test plan

- [ ] Log in, capture the CSRF token rendered into `dated_reminders.php`, reload `main_screen.php`, then re-POST the same token to `dated_reminders.php` — should now return 200 instead of 403.
- [ ] Confirm fresh login still works.
- [ ] Confirm the 60s-cadence `OpenEMR CSRF token authentication error` log entries no longer appear after navigating between top frames.
