### PR TITLE
fix(ci): Inferno testsuite setup fixes

### DIFF
--- a/.github/workflows/inferno-test.yml
+++ b/.github/workflows/inferno-test.yml
@@ -385,12 +385,6 @@ jobs:
           coverage.inferno-phpunit.clover.xml
           coverage.inferno-http.clover.xml
 
-    - name: Show PHP error logs
-      if: ${{ !cancelled() }}
-      run: |
-        docker compose -f ci/inferno/compose.yml exec -T openemr cat /var/log/apache2/error.log || true
-        docker compose -f ci/inferno/compose.yml exec -T openemr cat /var/www/localhost/htdocs/openemr/sites/default/logs/*.txt 2>/dev/null || true
-
     - name: Show Docker logs
       if: ${{ !cancelled() }}
       run: docker compose -f ci/inferno/compose.yml logs

--- a/.github/workflows/inferno-test.yml
+++ b/.github/workflows/inferno-test.yml
@@ -388,9 +388,3 @@ jobs:
     - name: Show Docker logs
       if: ${{ !cancelled() }}
       run: docker compose -f ci/inferno/compose.yml logs
-
-    - name: Cleanup Docker resources
-      if: always()
-      run: |
-        docker compose -f ci/inferno/compose.yml down --volumes --remove-orphans || true
-        docker system prune -f || true

--- a/.github/workflows/inferno-test.yml
+++ b/.github/workflows/inferno-test.yml
@@ -385,6 +385,16 @@ jobs:
           coverage.inferno-phpunit.clover.xml
           coverage.inferno-http.clover.xml
 
+    - name: Show PHP error logs
+      if: ${{ !cancelled() }}
+      run: |
+        docker compose -f ci/inferno/compose.yml exec -T openemr cat /var/log/apache2/error.log || true
+        docker compose -f ci/inferno/compose.yml exec -T openemr cat /var/www/localhost/htdocs/openemr/sites/default/logs/*.txt 2>/dev/null || true
+
+    - name: Show Docker logs
+      if: ${{ !cancelled() }}
+      run: docker compose -f ci/inferno/compose.yml logs
+
     - name: Cleanup Docker resources
       if: always()
       run: |

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -18087,16 +18087,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../templates/super/rules/controllers/log/view.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \' \\- \' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Api/ApiTestClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'\\: \' and mixed results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/Api/ApiTestClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between "\\\\n  " and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Certification/HIT1/G10_Certification/BulkPatientExport311APITest.php',

--- a/ci/inferno/run.sh
+++ b/ci/inferno/run.sh
@@ -164,15 +164,7 @@ fix_redis_permissions() {
      docker run --rm -v "${PWD}/onc-certification-g10-test-kit/data/redis:/data" redis chown -R redis:redis /data
 }
 
-cleanup() {
-    echo 'Performing cleanup...'
-    docker compose down -v || true
-    echo 'Cleanup completed'
-}
-
 main() {
-    # Set up trap for cleanup on exit
-    trap cleanup EXIT
     # Compose Bake will either be ignored or it will make builds faster.
     export COMPOSE_BAKE=1
     # BuildKit accepts platform arguments.

--- a/ci/inferno/run.sh
+++ b/ci/inferno/run.sh
@@ -83,6 +83,12 @@ initialize_openemr() {
     install_configure
     "${HOME}/bin/openemr-cmd" pc inferno-files/files/resources/openemr-snapshots/2025-06-25-inferno-baseline.tgz
     "${HOME}/bin/openemr-cmd" rs 2025-06-25-inferno-baseline
+    #  Snapshot is from 7.0.3; run migrations to create any new tables
+    docker compose exec -T openemr php "${OPENEMR_DIR}/sql_upgrade.php" --from=7.0.3
+    # (may need to configure api globals here)
+    # Prevent password expiration from blocking OAuth password grant
+    docker compose exec -T openemr mysql -u openemr --password=openemr -h mysql openemr \
+        -e "UPDATE users_secure SET last_update_password = NOW()"
 
     # Configure coverage after containers are running and OpenEMR is initialized
     if [[ ${ENABLE_COVERAGE:-false} = true ]]; then

--- a/ci/inferno/run.sh
+++ b/ci/inferno/run.sh
@@ -198,10 +198,10 @@ main() {
       fi
     fi
 
+    fix_redis_permissions
     initialize_inferno
     check_inferno
     initialize_openemr
-    fix_redis_permissions
 
     # Run the test suite and capture exit code
     # shellcheck disable=SC2310

--- a/tests/Tests/Api/ApiTestClient.php
+++ b/tests/Tests/Api/ApiTestClient.php
@@ -253,20 +253,6 @@ class ApiTestClient
             $this->id_token = $responseBody->id_token;
             $this->access_token = $responseBody->access_token;
             $this->refresh_token = $responseBody->refresh_token;
-        } else {
-            $errorMessage = "Authorization failed with status code: " . $authResponse->getStatusCode();
-            /** @var \stdClass|null $errorBody */
-            $errorBody = json_decode((string) $authResponse->getBody());
-            if (isset($errorBody->error)) {
-                $errorMessage .= " - " . $errorBody->error;
-            }
-            if (isset($errorBody->error_description)) {
-                $errorMessage .= ": " . $errorBody->error_description;
-            }
-            if (isset($errorBody->hint)) {
-                $errorMessage .= ": " . $errorBody->hint;
-            }
-            throw new \RuntimeException($errorMessage);
         }
 
         return $authResponse;

--- a/tests/Tests/Api/ApiTestClient.php
+++ b/tests/Tests/Api/ApiTestClient.php
@@ -266,6 +266,7 @@ class ApiTestClient
             if (isset($errorBody->hint)) {
                 $errorMessage .= ": " . $errorBody->hint;
             }
+            throw new \RuntimeException($errorMessage);
         }
 
         return $authResponse;


### PR DESCRIPTION
#### Short description of what this changes or resolves:
Fixes some of the setup process used during the Inferno suite, which should upgrade some of its tests from "crashing, errors suppressed" to "failing, errors suppressed".

On master, CI shows this:
```
Tests: 40, Assertions: 7, Errors: 34, Failures: 6, PHPUnit Warnings: 1, Warnings: 1.
```

This improves the situation significantly:

```
Tests: 41, Assertions: 965, Errors: 1, Failures: 3, PHPUnit Warnings: 1, Skipped: 1.
```

Extracted from #11805

#### Changes proposed in this pull request:

- Adjust the tear-down process to not stop the containers (GHA will do this automatically), so we can dump the logs to aid in debgging; removes some steps that GHA will do automatically but just slow things down for us
- Dump the logs to aid in debugging
- Run the SQL upgrade script, since apparently the data fixture is from 7.0.3
- Fix redis permissions _before_ redis is needed
- Update a timer on an expired password so it doesn't cause failures
- ~Fixes a place in the test API client to actually throw the error that it constructs, rather than fail silently~ removes some dead code in test setup that was a red herring in earlier work

#### Was an AI assistant used? Yes / No
Yes, Claude did most of the work on the original PR