### PR TITLE
fix(faxsms): catch up missed appointment-reminder ticks

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
@@ -37,7 +37,7 @@ class NotificationTaskManager
     }
 
     /**
-     * Check whether a reminder falls within the cron send window.
+     * Check whether a reminder is eligible to send on this tick.
      *
      * Both parameters use whole-hour granularity. $remainHour is the
      * difference between hours-until-appointment and the configured
@@ -46,15 +46,26 @@ class NotificationTaskManager
      *
      * $cronIntervalHours is the background-service execution interval
      * converted to hours (via getTaskHours()). Values below 1 are clamped
-     * to 1 so the window is never zero-width.
+     * to 1 so the upper bound is never zero-width.
+     *
+     * Only the upper bound is enforced here: a reminder more than
+     * $cronIntervalHours hours before its ideal send time is too early.
+     * No lower bound is applied so a missed tick (pod restart, deploy,
+     * lead-time change) does not silently drop the reminder. Dedup
+     * prevents repeats: the SQL filter excludes events whose
+     * pc_sendalertemail/pc_sendalertsms is already 'YES', and recurring
+     * events are additionally checked against notification_log keyed on
+     * (pc_eid, pc_eventDate, type). The runner is responsible for
+     * skipping appointments that have already started.
      */
     public static function isWithinCronWindow(int $remainHour, int $cronIntervalHours): bool
     {
-        // Enforce a minimum 1-hour window. getTaskHours() returns int, so
-        // sub-hour intervals (e.g. 30 minutes) truncate to 0 — which would
-        // make the window zero-width and silently suppress all sends.
+        // Clamp to a minimum 1-hour window. getTaskHours() returns int, so
+        // sub-hour intervals (e.g. 30 minutes) truncate to 0; without the
+        // clamp, an interval of 0 would only fire on the exact tick where
+        // remainHour == 0 and silently drop everything else.
         $cronIntervalHours = max(1, $cronIntervalHours);
-        return $remainHour >= -$cronIntervalHours && $remainHour <= $cronIntervalHours;
+        return $remainHour <= $cronIntervalHours;
     }
 
     /**

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Notification/AppointmentNotificationRunner.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Notification/AppointmentNotificationRunner.php
@@ -233,6 +233,13 @@ class AppointmentNotificationRunner
             return false;
         }
         $nowTs = $this->clock->now()->getTimestamp();
+        // Skip reminders for appointments that have already started.
+        // isWithinCronWindow has no lower bound (so missed ticks catch up
+        // on the next run); without this guard, a stale appointment that
+        // never got a reminder would still be picked up after it began.
+        if ($apptTs <= $nowTs) {
+            return false;
+        }
         $remainHour = self::computeRemainingHours($apptTs, $nowTs, $this->notificationHours);
         return NotificationTaskManager::isWithinCronWindow($remainHour, $this->cronIntervalHours);
     }

--- a/tests/Tests/Isolated/Modules/FaxSMS/Controller/NotificationTaskManagerTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Controller/NotificationTaskManagerTest.php
@@ -25,8 +25,36 @@ require_once __DIR__ . '/../../../../../../interface/modules/custom_modules/oe-m
 
 class NotificationTaskManagerTest extends TestCase
 {
-    #[DataProvider('cronWindowProvider')]
-    public function testIsWithinCronWindow(int $remainHour, int $cronInterval, bool $expected): void
+    /**
+     * Upper bound: a reminder more than $cronIntervalHours hours before
+     * its ideal send time is too early. The third column varies row by
+     * row because that is the behavior under test.
+     */
+    #[DataProvider('upperBoundProvider')]
+    public function testIsWithinCronWindowEnforcesUpperBound(int $remainHour, int $cronInterval, bool $expected): void
+    {
+        $this->assertSame($expected, NotificationTaskManager::isWithinCronWindow($remainHour, $cronInterval));
+    }
+
+    /**
+     * No lower bound: a missed tick must still send on the next run.
+     * The runner's per-event guard skips appointments that have already
+     * started; the SQL dedup prevents re-sends for already-notified
+     * events. So every row here is expected to pass — there's nothing
+     * to vary in a third column.
+     */
+    #[DataProvider('catchUpProvider')]
+    public function testIsWithinCronWindowAlwaysAcceptsCatchUpTicks(int $remainHour, int $cronInterval): void
+    {
+        $this->assertTrue(NotificationTaskManager::isWithinCronWindow($remainHour, $cronInterval));
+    }
+
+    /**
+     * Sub-hour and non-positive intervals must clamp to 1h. The third
+     * column is the expected decision for the clamped check.
+     */
+    #[DataProvider('intervalClampProvider')]
+    public function testIsWithinCronWindowClampsSubHourIntervals(int $remainHour, int $cronInterval, bool $expected): void
     {
         $this->assertSame($expected, NotificationTaskManager::isWithinCronWindow($remainHour, $cronInterval));
     }
@@ -36,10 +64,9 @@ class NotificationTaskManagerTest extends TestCase
      *
      * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
-    public static function cronWindowProvider(): array
+    public static function upperBoundProvider(): array
     {
         return [
-            // Upper bound is enforced: do not fire too early.
             'exactly on time'                  => [0, 1, true],
             'one hour early with 1h interval'  => [1, 1, true],
             'two hours early with 1h interval' => [2, 1, false],
@@ -47,17 +74,35 @@ class NotificationTaskManagerTest extends TestCase
             'at boundary of 24h window'        => [24, 24, true],
             'outside 24h window'               => [25, 24, false],
             'far outside window'               => [100, 24, false],
-            'zero interval clamps to 1h'       => [1, 0, true],
-            'zero interval rejects 2h early'   => [2, 0, false],
-            // No lower bound: a missed tick must still send on the next
-            // run. The runner's per-event check skips appointments that
-            // have already started; the SQL dedup prevents re-sends for
-            // already-notified events.
-            'one hour late with 1h interval'   => [-1, 1, true],
-            'two hours late with 1h interval'  => [-2, 1, true],
-            'far late with 1h interval'        => [-100, 1, true],
-            'far late with 24h interval'       => [-1000, 24, true],
-            'negative interval clamps to 1h'   => [0, -5, true],
+        ];
+    }
+
+    /**
+     * @return array<string, array{int, int}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function catchUpProvider(): array
+    {
+        return [
+            'one hour late with 1h interval'  => [-1, 1],
+            'two hours late with 1h interval' => [-2, 1],
+            'far late with 1h interval'       => [-100, 1],
+            'far late with 24h interval'      => [-1000, 24],
+        ];
+    }
+
+    /**
+     * @return array<string, array{int, int, bool}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function intervalClampProvider(): array
+    {
+        return [
+            'zero interval clamps to 1h'     => [1, 0, true],
+            'zero interval rejects 2h early' => [2, 0, false],
+            'negative interval clamps to 1h' => [0, -5, true],
         ];
     }
 }

--- a/tests/Tests/Isolated/Modules/FaxSMS/Controller/NotificationTaskManagerTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Controller/NotificationTaskManagerTest.php
@@ -39,21 +39,25 @@ class NotificationTaskManagerTest extends TestCase
     public static function cronWindowProvider(): array
     {
         return [
-            'exactly on time'                    => [0, 1, true],
-            'one hour early with 1h interval'    => [1, 1, true],
-            'one hour late with 1h interval'     => [-1, 1, true],
-            'two hours early with 1h interval'   => [2, 1, false],
-            'two hours late with 1h interval'    => [-2, 1, false],
-            'within 24h window (positive)'       => [12, 24, true],
-            'within 24h window (negative)'       => [-12, 24, true],
-            'at boundary of 24h window'          => [24, 24, true],
-            'at negative boundary of 24h window' => [-24, 24, true],
-            'outside 24h window'                 => [25, 24, false],
-            'far outside window'                 => [100, 24, false],
-            'old 150h window was a no-op'        => [100, 150, true],
-            'zero interval clamps to 1h'         => [1, 0, true],
-            'zero interval rejects 2h early'     => [2, 0, false],
-            'negative interval clamps to 1h'     => [0, -5, true],
+            // Upper bound is enforced: do not fire too early.
+            'exactly on time'                  => [0, 1, true],
+            'one hour early with 1h interval'  => [1, 1, true],
+            'two hours early with 1h interval' => [2, 1, false],
+            'within 24h window (positive)'     => [12, 24, true],
+            'at boundary of 24h window'        => [24, 24, true],
+            'outside 24h window'               => [25, 24, false],
+            'far outside window'               => [100, 24, false],
+            'zero interval clamps to 1h'       => [1, 0, true],
+            'zero interval rejects 2h early'   => [2, 0, false],
+            // No lower bound: a missed tick must still send on the next
+            // run. The runner's per-event check skips appointments that
+            // have already started; the SQL dedup prevents re-sends for
+            // already-notified events.
+            'one hour late with 1h interval'   => [-1, 1, true],
+            'two hours late with 1h interval'  => [-2, 1, true],
+            'far late with 1h interval'        => [-100, 1, true],
+            'far late with 24h interval'       => [-1000, 24, true],
+            'negative interval clamps to 1h'   => [0, -5, true],
         ];
     }
 }

--- a/tests/Tests/Isolated/Modules/FaxSMS/Notification/AppointmentNotificationRunnerTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Notification/AppointmentNotificationRunnerTest.php
@@ -305,6 +305,57 @@ class AppointmentNotificationRunnerTest extends TestCase
         $this->assertSame(0, $client->sendCalls);
     }
 
+    public function testRunCatchesUpReminderForLateAppointmentStillInFuture(): void
+    {
+        // Simulate a tick that ran several hours after the ideal send
+        // moment because of an outage. The clock is anchored at 2026-04-14
+        // 10:00; lead time = 24h, cron interval = 1h. An appointment at
+        // 2026-04-15 04:00 has remainHour = -6 — well below the old
+        // lower bound — but is still 18h in the future, so the catch-up
+        // path should pick it up rather than silently dropping it.
+        $client = new FakeSmsClient();
+        $runner = $this->makeSmsRunner(
+            client: $client,
+            dryRun: false,
+            appointments: [$this->makeRow([
+                'phone_cell'   => '2125551234',
+                'pc_eventDate' => '2026-04-15',
+                'pc_startTime' => '04:00:00',
+            ])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->scanned);
+        $this->assertSame(1, $result->inWindow);
+        $this->assertSame(1, $result->sent);
+        $this->assertSame(1, $client->sendCalls);
+    }
+
+    public function testRunSkipsAppointmentThatHasAlreadyStarted(): void
+    {
+        // Removing the lower bound on isWithinCronWindow could otherwise
+        // let a stale row for a past appointment send a misleading
+        // reminder. The runner's per-event guard skips anything whose
+        // start time is at or before "now".
+        $client = new FakeSmsClient();
+        $runner = $this->makeSmsRunner(
+            client: $client,
+            dryRun: false,
+            appointments: [$this->makeRow([
+                'phone_cell'   => '2125551234',
+                'pc_eventDate' => '2026-04-14',
+                'pc_startTime' => '09:00:00',
+            ])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->scanned);
+        $this->assertSame(0, $result->inWindow);
+        $this->assertSame(0, $client->sendCalls);
+    }
+
     public function testRunSmsHappyPathSendsAndLogsAndMarks(): void
     {
         $client = new FakeSmsClient();


### PR DESCRIPTION
## Summary

`NotificationTaskManager::isWithinCronWindow` enforces both an upper *and* a lower bound on when a reminder is eligible to send: the ideal send time must be within `±cronIntervalHours` of the current tick. That means any gap longer than the cron interval — pod restart, deploy, lead-time change in admin settings, even just a heavily loaded host that misses one tick — silently drops the reminder forever, because the next tick already considers the event "too late".

This PR drops the lower bound. A reminder more than `cronIntervalHours` hours before its ideal send time is still too early, but a reminder past its ideal moment will now send on the next run instead of being skipped. Existing dedup keeps it from sending twice:

- The SQL filter in `faxsms_getAlertPatientData` already excludes events whose `pc_sendalertemail`/`pc_sendalertsms` is `'YES'` (set by `markNotified` after a successful send).
- Recurring events are additionally checked against `notification_log` keyed on `(pc_eid, pc_eventDate, type)`.

To make sure removing the lower bound can't surface a misleading reminder for a past appointment, `AppointmentNotificationRunner::isInCronWindow` now also skips any event whose start time is at or before "now". A stale row that never got a reminder will be quietly left alone once the appointment has begun.

### Files

- `interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php` — drop the lower bound, expand the docblock with the rationale and the dedup mechanisms it relies on.
- `interface/modules/custom_modules/oe-module-faxsms/src/Notification/AppointmentNotificationRunner.php` — add the past-appointment guard.
- `tests/Tests/Isolated/Modules/FaxSMS/Controller/NotificationTaskManagerTest.php` — replace the now-invalid lower-bound test cases with positive cases asserting that late ticks still send.
- `tests/Tests/Isolated/Modules/FaxSMS/Notification/AppointmentNotificationRunnerTest.php` — add `testRunCatchesUpReminderForLateAppointmentStillInFuture` and `testRunSkipsAppointmentThatHasAlreadyStarted`.

## Test plan

- [x] `phpunit-isolated.xml --filter 'NotificationTaskManager|AppointmentNotificationRunner'` passes (45 tests / 89 assertions)
- [x] `phpstan analyse` on the four touched files reports no errors
- [x] PHP syntax check on all four files
- [ ] Reviewer: confirm that for an install whose `Notification_Email_Task` cron interval is 1h and `EMAIL_NOTIFICATION_HOUR` is 20, an appointment that previously missed its 17:15 tick (because the ideal send moment was 17:00 but it arrived 15 min late) sends on the next 18:15 tick instead of being silently dropped