### PR TITLE
fix(ci): Turn off redis persistence in inferno tests

### DIFF
--- a/ci/inferno/compose.yml
+++ b/ci/inferno/compose.yml
@@ -80,6 +80,8 @@ services:
     extends:
       file: onc-certification-g10-test-kit/docker-compose.yml
       service: redis
+    # Disable persistence - this is ephemeral CI infrastructure
+    command: redis-server --save "" --appendonly no
   hl7_validator_service:
     extends:
       file: onc-certification-g10-test-kit/docker-compose.yml

--- a/ci/inferno/run.sh
+++ b/ci/inferno/run.sh
@@ -166,10 +166,6 @@ collect_inferno_coverage() {
     echo 'Inferno coverage collection completed'
 }
 
-fix_redis_permissions() {
-     docker run --rm -v "${PWD}/onc-certification-g10-test-kit/data/redis:/data" redis chown -R redis:redis /data
-}
-
 main() {
     # Compose Bake will either be ignored or it will make builds faster.
     export COMPOSE_BAKE=1
@@ -204,7 +200,6 @@ main() {
       fi
     fi
 
-    fix_redis_permissions
     initialize_inferno
     check_inferno
     initialize_openemr


### PR DESCRIPTION
#### Short description of what this changes or resolves:
There's a latent data race in the Inferno suite which is exposed in #11906 once the sql upgrade actually does something. Redis gets put into a weird state with persistence. Since it's CI, there's no need for it at all. Turning it off fixes the problem and stops everything from getting wedged.

There should be no apparent changes here yet, but it fixes a problem from the other branch, and the two changes really have no business landing together (the other needs to be on the release branch for upgraders, this doesn't).

#### Changes proposed in this pull request:
Disable redis persistence in CI.

#### Was an AI assistant used? Yes / No
Claude