### PR TITLE
fix(faxsms): catch up missed appointment-reminder ticks (backport #11907 to rel-810)

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/NotificationTaskManager.php
@@ -37,7 +37,7 @@ class NotificationTaskManager
     }
 
     /**
-     * Check whether a reminder falls within the cron send window.
+     * Check whether a reminder is eligible to send on this tick.
      *
      * Both parameters use whole-hour granularity. $remainHour is the
      * difference between hours-until-appointment and the configured
@@ -46,15 +46,26 @@ class NotificationTaskManager
      *
      * $cronIntervalHours is the background-service execution interval
      * converted to hours (via getTaskHours()). Values below 1 are clamped
-     * to 1 so the window is never zero-width.
+     * to 1 so the upper bound is never zero-width.
+     *
+     * Only the upper bound is enforced here: a reminder more than
+     * $cronIntervalHours hours before its ideal send time is too early.
+     * No lower bound is applied so a missed tick (pod restart, deploy,
+     * lead-time change) does not silently drop the reminder. Dedup
+     * prevents repeats: the SQL filter excludes events whose
+     * pc_sendalertemail/pc_sendalertsms is already 'YES', and recurring
+     * events are additionally checked against notification_log keyed on
+     * (pc_eid, pc_eventDate, type). The runner is responsible for
+     * skipping appointments that have already started.
      */
     public static function isWithinCronWindow(int $remainHour, int $cronIntervalHours): bool
     {
-        // Enforce a minimum 1-hour window. getTaskHours() returns int, so
-        // sub-hour intervals (e.g. 30 minutes) truncate to 0 — which would
-        // make the window zero-width and silently suppress all sends.
+        // Clamp to a minimum 1-hour window. getTaskHours() returns int, so
+        // sub-hour intervals (e.g. 30 minutes) truncate to 0; without the
+        // clamp, an interval of 0 would only fire on the exact tick where
+        // remainHour == 0 and silently drop everything else.
         $cronIntervalHours = max(1, $cronIntervalHours);
-        return $remainHour >= -$cronIntervalHours && $remainHour <= $cronIntervalHours;
+        return $remainHour <= $cronIntervalHours;
     }
 
     /**

--- a/tests/Tests/Isolated/Modules/FaxSMS/Controller/NotificationTaskManagerTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Controller/NotificationTaskManagerTest.php
@@ -25,8 +25,36 @@ require_once __DIR__ . '/../../../../../../interface/modules/custom_modules/oe-m
 
 class NotificationTaskManagerTest extends TestCase
 {
-    #[DataProvider('cronWindowProvider')]
-    public function testIsWithinCronWindow(int $remainHour, int $cronInterval, bool $expected): void
+    /**
+     * Upper bound: a reminder more than $cronIntervalHours hours before
+     * its ideal send time is too early. The third column varies row by
+     * row because that is the behavior under test.
+     */
+    #[DataProvider('upperBoundProvider')]
+    public function testIsWithinCronWindowEnforcesUpperBound(int $remainHour, int $cronInterval, bool $expected): void
+    {
+        $this->assertSame($expected, NotificationTaskManager::isWithinCronWindow($remainHour, $cronInterval));
+    }
+
+    /**
+     * No lower bound: a missed tick must still send on the next run.
+     * The runner's per-event guard skips appointments that have already
+     * started; the SQL dedup prevents re-sends for already-notified
+     * events. So every row here is expected to pass — there's nothing
+     * to vary in a third column.
+     */
+    #[DataProvider('catchUpProvider')]
+    public function testIsWithinCronWindowAlwaysAcceptsCatchUpTicks(int $remainHour, int $cronInterval): void
+    {
+        $this->assertTrue(NotificationTaskManager::isWithinCronWindow($remainHour, $cronInterval));
+    }
+
+    /**
+     * Sub-hour and non-positive intervals must clamp to 1h. The third
+     * column is the expected decision for the clamped check.
+     */
+    #[DataProvider('intervalClampProvider')]
+    public function testIsWithinCronWindowClampsSubHourIntervals(int $remainHour, int $cronInterval, bool $expected): void
     {
         $this->assertSame($expected, NotificationTaskManager::isWithinCronWindow($remainHour, $cronInterval));
     }
@@ -36,24 +64,45 @@ class NotificationTaskManagerTest extends TestCase
      *
      * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
-    public static function cronWindowProvider(): array
+    public static function upperBoundProvider(): array
     {
         return [
-            'exactly on time'                    => [0, 1, true],
-            'one hour early with 1h interval'    => [1, 1, true],
-            'one hour late with 1h interval'     => [-1, 1, true],
-            'two hours early with 1h interval'   => [2, 1, false],
-            'two hours late with 1h interval'    => [-2, 1, false],
-            'within 24h window (positive)'       => [12, 24, true],
-            'within 24h window (negative)'       => [-12, 24, true],
-            'at boundary of 24h window'          => [24, 24, true],
-            'at negative boundary of 24h window' => [-24, 24, true],
-            'outside 24h window'                 => [25, 24, false],
-            'far outside window'                 => [100, 24, false],
-            'old 150h window was a no-op'        => [100, 150, true],
-            'zero interval clamps to 1h'         => [1, 0, true],
-            'zero interval rejects 2h early'     => [2, 0, false],
-            'negative interval clamps to 1h'     => [0, -5, true],
+            'exactly on time'                  => [0, 1, true],
+            'one hour early with 1h interval'  => [1, 1, true],
+            'two hours early with 1h interval' => [2, 1, false],
+            'within 24h window (positive)'     => [12, 24, true],
+            'at boundary of 24h window'        => [24, 24, true],
+            'outside 24h window'               => [25, 24, false],
+            'far outside window'               => [100, 24, false],
+        ];
+    }
+
+    /**
+     * @return array<string, array{int, int}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function catchUpProvider(): array
+    {
+        return [
+            'one hour late with 1h interval'  => [-1, 1],
+            'two hours late with 1h interval' => [-2, 1],
+            'far late with 1h interval'       => [-100, 1],
+            'far late with 24h interval'      => [-1000, 24],
+        ];
+    }
+
+    /**
+     * @return array<string, array{int, int, bool}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function intervalClampProvider(): array
+    {
+        return [
+            'zero interval clamps to 1h'     => [1, 0, true],
+            'zero interval rejects 2h early' => [2, 0, false],
+            'negative interval clamps to 1h' => [0, -5, true],
         ];
     }
 }


### PR DESCRIPTION
Backport of #11907 to `rel-810`.

## Backport notes

The upstream commit modified four files:

- `src/Controller/NotificationTaskManager.php` — backported as-is. This is the core fix: drop the lower bound on `isWithinCronWindow` so a missed cron tick still sends the reminder on the next run instead of dropping it forever.
- `tests/Controller/NotificationTaskManagerTest.php` — backported as-is. Splits the cron-window data provider into three behavior buckets (upper-bound, catch-up, sub-hour clamp).
- `src/Notification/AppointmentNotificationRunner.php` — **omitted**. This file was introduced by #11846, which was not backported to `rel-810`. The upstream hunk added a per-event guard that skipped past appointments. rel-810's legacy notification path doesn't have a runner class to extend, so the guard has nowhere to live.
- `tests/Notification/AppointmentNotificationRunnerTest.php` — **omitted**, same reason.

## Safety on rel-810 without the runner guard

The runner guard was a defense-in-depth check; the actual dedup that prevents re-sending past reminders comes from two layers that already exist on rel-810:

1. The SQL filter excludes events whose `pc_sendalertemail`/`pc_sendalertsms` is already `'YES'`.
2. Recurring events are checked against `notification_log` keyed on `(pc_eid, pc_eventDate, type)`.

Both layers were added in earlier rel-810 commits (#11588, #11589) and are unaffected by this change.

## Test plan

- [ ] CI green on rel-810
- [ ] Smoke check: trigger a missed-tick scenario on a rel-810 instance and confirm the reminder fires on the following run rather than being silently dropped
