### PR TITLE
chore(phpstan): cap phpDoc.parseError baseline at zero

### DIFF
--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -43,6 +43,7 @@ return [
         'includeOnce.fileNotFound.php' => 0,
         'interface.notFound.php' => 0,
         'method.notFound.php' => 141,
+        'phpDoc.parseError.php' => 0,
         'require.fileNotFound.php' => 0,
         'requireOnce.fileNotFound.php' => 0,
         'return.missing.php' => 0,


### PR DESCRIPTION
#11904 cleared every entry from `.phpstan/baseline/phpDoc.parseError.php`. Add the identifier to `.phpstan/fatal-baseline-caps.php` with a preemptive zero cap so any new PHPDoc parse error trips the `FatalBaselineCapsIsolatedTest` check instead of getting silently baselined.

## Summary
- Add `'phpDoc.parseError.php' => 0` to the `all` section of `fatal-baseline-caps.php`.

## Test plan
- [x] `composer phpunit-isolated -- --filter FatalBaselineCapsIsolatedTest` (20/20 pass).