### PR TITLE
fix(ci): add NPI to user to qualify as Practitioner in Inferno tests

### DIFF
--- a/ci/inferno/run.sh
+++ b/ci/inferno/run.sh
@@ -89,6 +89,11 @@ initialize_openemr() {
     # Prevent password expiration from blocking OAuth password grant
     docker compose exec -T openemr mysql -u openemr --password=openemr -h mysql openemr \
         -e "UPDATE users_secure SET last_update_password = NOW()"
+    # Fix user to qualify as Practitioner: NPI AND (username OR valid abook_type)
+    # Snapshot predates commit 4af4c827f which added username/abook_type filtering
+    # See https://github.com/openemr/openemr/issues/11831#issuecomment-4341049367
+    docker compose exec -T openemr mysql -u openemr --password=openemr -h mysql openemr \
+        -e "UPDATE users SET abook_type = 'external_provider', npi = '0123456789' WHERE uuid = UNHEX(REPLACE('96889cb7-0f90-4d9e-9a6c-ac0e70c01cb1', '-', ''))"
 
     # Configure coverage after containers are running and OpenEMR is initialized
     if [[ ${ENABLE_COVERAGE:-false} = true ]]; then


### PR DESCRIPTION
## Summary

- Fixes Practitioner 404 error in Inferno certification tests
- The test snapshot has a user referenced as a Practitioner but lacking the NPI required by `FhirPractitionerService` filtering logic (added in 4af4c827f)
- Adds SQL to set `abook_type` and `npi` on the affected user after restoring the snapshot

Related: #11831, #11805.

## Test plan

Number of Inferno failures goes down, and there are no regressions

Master:
```
FFF..FF.......FF..FF.F...E.FE..F....E.                         41 / 41 (100%)

ERRORS!
Tests: 41, Assertions: 788, Errors: 3, Failures: 14, PHPUnit Warnings: 1.
```

This PR:
```
.FF..FF.......FF..FF.F...E.FE..F....E.                         41 / 41 (100%)

ERRORS!
Tests: 41, Assertions: 857, Errors: 3, Failures: 11, PHPUnit Warnings: 1.
```

🤖 Generated with [Claude Code](https://claude.ai/code)