### PR TITLE
fix(faxsms): require appointments lib; log background-service errors

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php
@@ -39,7 +39,18 @@
  */
 
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
+
+// faxsms_getAlertPatientData() calls fetchEvents(), which lives in
+// library/appointments.inc.php. The popup entry rc_sms_notification.php
+// requires that file before requiring us; the CLI entry point in
+// run_notifications.php does not, so when this file is loaded from the
+// background-services orchestrator (Notification_Email_Task), fetchEvents
+// is undefined and the task throws "Call to undefined function fetchEvents()".
+// Co-locate the require with the function that needs it so any future
+// caller of this helpers file gets the dependency for free.
+require_once OEGlobalsBag::getInstance()->getString('srcdir') . '/appointments.inc.php';
 
 if (!function_exists('rc_sms_notification_cron_update_entry')) {
     /**

--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php
@@ -50,7 +50,7 @@ use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
 // is undefined and the task throws "Call to undefined function fetchEvents()".
 // Co-locate the require with the function that needs it so any future
 // caller of this helpers file gets the dependency for free.
-require_once OEGlobalsBag::getInstance()->getString('srcdir') . '/appointments.inc.php';
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/appointments.inc.php';
 
 if (!function_exists('rc_sms_notification_cron_update_entry')) {
     /**

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -286,7 +286,16 @@ class BackgroundServiceRunner
         try {
             $this->executeService($service);
             return ['name' => $name, 'status' => 'executed'];
-        } catch (\Throwable) {
+        } catch (\Throwable $e) {
+            // Without this log the orchestrator records status=error with
+            // no exception class, message, file, line, or trace anywhere.
+            // Diagnosing a service failure then requires attaching to a
+            // pod and running an instrumented one-shot script. See #11827
+            // for the silent regression that made this gap visible.
+            $this->logger->error('Background service execution failed.', [
+                'service' => $name,
+                'exception' => $e,
+            ]);
             return ['name' => $name, 'status' => 'error'];
         } finally {
             $this->safeReleaseLock($name);

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -290,8 +290,9 @@ class BackgroundServiceRunner
             // Without this log the orchestrator records status=error with
             // no exception class, message, file, line, or trace anywhere.
             // Diagnosing a service failure then requires attaching to a
-            // pod and running an instrumented one-shot script. See #11827
-            // for the silent regression that made this gap visible.
+            // pod and running an instrumented one-shot script. The cron
+            // regression in #11827 shipped undetected because this catch
+            // swallowed the exception.
             $this->logger->error('Background service execution failed.', [
                 'service' => $name,
                 'exception' => $e,

--- a/tests/Tests/Isolated/Modules/FaxSMS/Notification/RcSmsNotificationHelpersTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Notification/RcSmsNotificationHelpersTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Regression guard for the helpers file's own dependency loading.
+ *
+ * `rc_sms_notification_helpers.php` is loaded from two entry points:
+ * the popup `rc_sms_notification.php` (which separately requires
+ * `library/appointments.inc.php` before us) and the CLI bridge
+ * `run_notifications.php` driven by `bin/console background:services
+ * run --name=Notification_Email_Task` (which does not). When the
+ * helpers file did not pull `appointments.inc.php` itself, the CLI
+ * path threw `Call to undefined function fetchEvents()` from
+ * `faxsms_getAlertPatientData()` — and the orchestrator's silent
+ * catch (see `BackgroundServiceRunner::runOne` before #11827 follow-up)
+ * recorded `status=error` with no log line, so the regression shipped
+ * undetected. See issue #11827.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Modules\FaxSMS\Notification;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+#[Group('faxsms')]
+class RcSmsNotificationHelpersTest extends TestCase
+{
+    /**
+     * Load the helpers file in a fresh process with a stub
+     * `appointments.inc.php` on disk (pointed at by `$GLOBALS['srcdir']`)
+     * and assert that `fetchEvents()` is defined afterward. If the
+     * helpers file ever stops pulling `appointments.inc.php` itself,
+     * the CLI background-service path silently breaks again.
+     *
+     * Process isolation is required because `require_once` is process-
+     * scoped: a previous test that already loaded the helpers file
+     * (directly or transitively) would leave `function_exists()` true
+     * regardless of whether the require was wired up correctly.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testHelpersFileRequiresAppointmentsLibrary(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/oce_helpers_dep_' . uniqid('', true);
+        if (!mkdir($tempDir, 0700, true) && !is_dir($tempDir)) {
+            $this->fail("could not create temp dir {$tempDir}");
+        }
+
+        try {
+            // Stub appointments.inc.php with just enough to register the
+            // symbol the helpers file consumes via fetchEvents(). Avoids
+            // dragging in the real file's transitive requires (calendar
+            // includes, xl()) which aren't loaded under isolated tests.
+            file_put_contents(
+                $tempDir . '/appointments.inc.php',
+                "<?php\nfunction fetchEvents(): array { return []; }\n",
+            );
+            $GLOBALS['srcdir'] = $tempDir;
+
+            require_once dirname(__DIR__, 6)
+                . '/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php';
+
+            $this->assertTrue(
+                function_exists('fetchEvents'),
+                'rc_sms_notification_helpers.php must require appointments.inc.php so fetchEvents() is available to faxsms_getAlertPatientData()',
+            );
+        } finally {
+            @unlink($tempDir . '/appointments.inc.php');
+            @rmdir($tempDir);
+        }
+    }
+}

--- a/tests/Tests/Isolated/Modules/FaxSMS/Notification/RcSmsNotificationHelpersTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Notification/RcSmsNotificationHelpersTest.php
@@ -54,7 +54,11 @@ class RcSmsNotificationHelpersTest extends TestCase
     {
         $tempDir = sys_get_temp_dir() . '/oce_helpers_dep_' . uniqid('', true);
         if (!mkdir($tempDir, 0700, true) && !is_dir($tempDir)) {
+            // @codeCoverageIgnoreStart
+            // Defensive — only fires if the OS refuses to create a fresh
+            // tempdir, which is not a path real CI exercises.
             $this->fail("could not create temp dir {$tempDir}");
+            // @codeCoverageIgnoreEnd
         }
 
         try {

--- a/tests/Tests/Isolated/Modules/FaxSMS/Notification/RcSmsNotificationHelpersTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Notification/RcSmsNotificationHelpersTest.php
@@ -11,9 +11,9 @@
  * helpers file did not pull `appointments.inc.php` itself, the CLI
  * path threw `Call to undefined function fetchEvents()` from
  * `faxsms_getAlertPatientData()` — and the orchestrator's silent
- * catch (see `BackgroundServiceRunner::runOne` before #11827 follow-up)
- * recorded `status=error` with no log line, so the regression shipped
- * undetected. See issue #11827.
+ * catch in `BackgroundServiceRunner::runOne` (fixed in the sibling
+ * commit) recorded `status=error` with no log line, so the regression
+ * shipped undetected. See issue #11827.
  *
  * @package   OpenEMR
  *

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -20,6 +20,9 @@ use OpenEMR\Services\Background\BackgroundServiceRunner;
 use OpenEMR\Services\Background\SymfonyBackgroundServiceSpawner;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Psr\Log\NullLogger;
 
 /**
@@ -99,6 +102,45 @@ class BackgroundServiceRunnerTest extends TestCase
 
         $this->assertSame('error', $results[0]['status']);
         $this->assertContains('svc1', $runner->releasedLocks);
+    }
+
+    public function testRunOneLogsExceptionWhenExecuteServiceThrows(): void
+    {
+        // Without this log line the orchestrator records status=error
+        // with no exception class, message, file, line, or trace anywhere
+        // in the cron logs. Operators have no way to diagnose the
+        // failure without attaching to a pod and re-running the
+        // service under instrumentation. The catch is intentionally
+        // broad (\Throwable) — process-boundary cleanup must happen
+        // no matter what — but the diagnostic information must not
+        // be discarded along with the exception.
+        $logger = new RecordingLogger();
+        $thrown = new \RuntimeException('Service failure');
+        $runner = new BackgroundServiceRunnerStub(
+            services: [self::makeService('svc1')],
+            executeCallback: function (array $service) use ($thrown): void {
+                throw $thrown;
+            },
+            logger: $logger,
+        );
+
+        $results = $runner->run('svc1');
+
+        $this->assertSame('error', $results[0]['status']);
+
+        $errorRecords = array_values(array_filter(
+            $logger->records,
+            fn(array $record): bool => $record['level'] === LogLevel::ERROR,
+        ));
+        $this->assertCount(1, $errorRecords, 'exactly one error log line must be emitted on service failure');
+        $record = $errorRecords[0];
+        $this->assertSame('Background service execution failed.', (string) $record['message']);
+        $this->assertSame('svc1', $record['context']['service'] ?? null);
+        $this->assertSame(
+            $thrown,
+            $record['context']['exception'] ?? null,
+            "the thrown exception must be passed via the 'exception' context key so PSR-3 processors can format the trace and class name",
+        );
     }
 
     public function testRunAllDelegatesActiveServicesToSpawnerInOrder(): void
@@ -413,8 +455,9 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
         ?BackgroundServiceProcessSpawner $spawner = null,
         private readonly bool $orchestratorLockAcquirable = true,
         private readonly ?\Throwable $acquireLockThrows = null,
+        ?LoggerInterface $logger = null,
     ) {
-        parent::__construct(new NullLogger(), $spawner);
+        parent::__construct($logger ?? new NullLogger(), $spawner);
     }
 
     protected function getServices(?string $serviceName, bool $force): array
@@ -491,5 +534,28 @@ class RecordingSpawner implements BackgroundServiceProcessSpawner
         $this->forceArgs[] = $force;
         $this->timeoutArgs[] = $timeoutSeconds;
         return ['name' => $name, 'status' => $this->statusByName[$name] ?? 'error'];
+    }
+}
+
+/**
+ * Minimal PSR-3 logger that records every log call so tests can assert
+ * on level, message, and context without bringing in a Monolog handler.
+ */
+class RecordingLogger extends AbstractLogger
+{
+    // PSR-3 leaves the context array open: any keys, any values. Mirror
+    // that here so PHPStan doesn't reject callers that pass mixed-keyed
+    // context (which is legal under the interface even if our own call
+    // sites use string keys).
+    /** @var list<array{level: mixed, message: string|\Stringable, context: array<mixed>}> */
+    public array $records = [];
+
+    public function log($level, string|\Stringable $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+        ];
     }
 }


### PR DESCRIPTION
## Summary

Two related fixes for the appointment-reminder cron flow under the unified `bin/console background:services run` orchestrator. Both regressions were introduced or made visible by #11846, which closed #11827.

**Fix 1 — `Call to undefined function fetchEvents()`.** When `Notification_Email_Task` fires from the CLI orchestrator path, `BackgroundReminderTask::run()` reaches `faxsms_getAlertPatientData()` which calls `fetchEvents()`. `fetchEvents()` is defined in `library/appointments.inc.php`. The popup entry `rc_sms_notification.php:84` requires that file before requiring `rc_sms_notification_helpers.php`; the CLI bridge in `run_notifications.php` does not. The helpers file is loaded but its dependency is missing, the task throws, and email reminders silently stop firing on every install that uses the unified runner.

This change co-locates the require with the function that needs it, using the same `OEGlobalsBag` accessor pattern as the popup entry. `appointments.inc.php` defines its functions inside `function_exists` checks, so `require_once` is safe regardless of which entry point loaded it first.

**Fix 2 — silent error path in `BackgroundServiceRunner::runOne`.** The `catch (\Throwable)` block bound the throwable without capturing the variable and discarded all diagnostic info, so a service failure showed up as `status: error` in the orchestrator results with no log line, no exception class, no message, no file, no line, and no trace anywhere. Diagnosing Fix 1 above required attaching to a running pod and re-invoking the service under instrumentation — that should not be the path for the next failure.

The catch type is unchanged (process-boundary cleanup must still happen on any throwable), and the return shape and exit codes are unchanged. The only change is that the exception is now passed to `$this->logger->error()` via the PSR-3 `'exception'` context key so processors (Monolog's `PsrLogMessageProcessor`, the bundled `SystemLogger`) format the trace and class name.

## Why one PR for two scopes

Fix 2 is the observability gap that allowed Fix 1 to ship undetected. They tell a coherent story: the user-visible bug, plus the gap that hid it.

## References

- Issue (closed): #11827
- Original fix PR (introduced these regressions): #11846

## Test plan

- [x] New isolated test `RcSmsNotificationHelpersTest::testHelpersFileRequiresAppointmentsLibrary` runs the helpers file in a separate process with a stub `appointments.inc.php` and asserts `function_exists('fetchEvents')` afterward. Fails before this change, passes after.
- [x] New isolated test `BackgroundServiceRunnerTest::testRunOneLogsExceptionWhenExecuteServiceThrows` asserts the `error`-level log line is emitted with the service name and the thrown exception in the PSR-3 context. Fails before this change, passes after.
- [x] `composer phpunit-isolated -- --filter='Background|Notification'` — 161 tests, all green.
- [x] `composer phpcs` — clean on all four touched files.
- [ ] `composer phpstan` — running.
