### PR TITLE
fix(clinical-notes): correct i18formatting asset name typo

### DIFF
--- a/interface/forms/clinical_notes/templates/new.html.twig
+++ b/interface/forms/clinical_notes/templates/new.html.twig
@@ -18,7 +18,7 @@ The Edit/Create template of the clinical note form.
 #}
 {% extends "core/base.html.twig" %}
 {% block head %}
-    {{ setupHeader(['i18next', 'il8formatting', 'datetime-picker','datetime-picker-translated']) }}
+    {{ setupHeader(['i18next', 'i18formatting', 'datetime-picker','datetime-picker-translated']) }}
     <script src="{{ webroot }}/interface/forms/clinical_notes/clinical-notes.js?v={{ assetVersion|url_encode }}"></script>
     <script>
         if (window.oeFormsClinicalNotes) {


### PR DESCRIPTION
## Summary

The new clinical_notes form requested an asset called `il8formatting` (lowercase L + digit 8) instead of `i18formatting` (digit 1 + digit 8). The bundle does not exist under that name, so the locale formatting assets never loaded and every render of the form logged:

```
OpenEMR.ERROR: Not all selected assets were included in header
{"selectedAssets":["i18next","il8formatting","datetime-picker","datetime-picker-translated"], ...}
```

Date/number/currency formatting on the new clinical_notes form fell back to the browser default rather than the user's OpenEMR locale settings.

Every other call site already uses the correct spelling (`interface/main/tabs/main.php`, `templates/core/base.html.twig`, `templates/portal/base.html.twig`, `interface/forms/observation/templates/observation_edit.html.twig`, and the registry entry in `config/config.yaml`).

Fixes #11936

## Test plan

- [ ] Open a new clinical note from a patient encounter
- [ ] Confirm the PHP error log no longer contains "Not all selected assets were included in header" for this form
- [ ] Confirm date/number formatting on the form respects the user's locale