### PR TITLE
fix: guard undefined keys and legacy PHP warnings flagged in production logs

### DIFF
--- a/interface/forms/newpatient/C_EncounterVisitForm.class.php
+++ b/interface/forms/newpatient/C_EncounterVisitForm.class.php
@@ -676,7 +676,7 @@ class C_EncounterVisitForm
         $posOptions = $this->getPosOptionsForTemplate($facilityPosCode);
 // END AI GENERATED CODE
 
-        if (Utilities::isDateEmpty($encounter['onset_date'])) {
+        if (Utilities::isDateEmpty($encounter['onset_date'] ?? null)) {
             $encounter['onset_date'] = null;
         }
 

--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -1305,7 +1305,8 @@ function &postcalendar_userapi_pcGetEvents($args)
     $event->setProviderID($providerID ?? $provider_id ?? null);
 
     $result = OEGlobalsBag::getInstance()->getKernel()->getEventDispatcher()->dispatch($event, CalendarUserGetEventsFilter::EVENT_NAME);
-    return $result->getEventsByDays();
+    $eventsByDays = $result->getEventsByDays();
+    return $eventsByDays;
 }
 
 //===========================

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -280,17 +280,8 @@ class Controller extends Smarty implements ControllerInterface
 
     private static function escapeForTextNode(mixed $value): string
     {
-        if ($value === null) {
-            return '';
-        }
-        if (is_string($value)) {
-            return htmlspecialchars($value, ENT_NOQUOTES);
-        }
-        if (is_int($value) || is_float($value) || is_bool($value)) {
-            return htmlspecialchars((string) $value, ENT_NOQUOTES);
-        }
-        if (is_object($value) && method_exists($value, '__toString')) {
-            return htmlspecialchars((string) $value, ENT_NOQUOTES);
+        if (is_string($value) || is_int($value) || is_float($value) || is_bool($value) || $value instanceof \Stringable) {
+            return \text((string) $value);
         }
         return '';
     }

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -69,6 +69,9 @@ class Controller extends Smarty implements ControllerInterface
          $this->setCompileDir((new CacheDirectory())->for('openemr-smarty'));
          $this->setCompileCheck(true);
          $this->setPluginsDir([__DIR__ . "/../smarty/plugins", OEGlobalsBag::getInstance()->getKernel()->getVendorDir() . "/smarty/smarty/libs/plugins"]);
+         // Register {$x|text} explicitly so Smarty does not fall back to the
+         // deprecated unregistered-function path when escaping for text nodes.
+         $this->registerPlugin('modifier', 'text', self::escapeForTextNode(...));
          $this->assign("PROCESS", "true");
          $this->assign("HEADER", "<html><head></head><body>");
          $this->assign("FOOTER", "</body></html>");
@@ -273,6 +276,23 @@ class Controller extends Smarty implements ControllerInterface
     {
         return method_exists($controllerObj, $method)
             && is_callable([$controllerObj, $method]);
+    }
+
+    private static function escapeForTextNode(mixed $value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+        if (is_string($value)) {
+            return htmlspecialchars($value, ENT_NOQUOTES);
+        }
+        if (is_int($value) || is_float($value) || is_bool($value)) {
+            return htmlspecialchars((string) $value, ENT_NOQUOTES);
+        }
+        if (is_object($value) && method_exists($value, '__toString')) {
+            return htmlspecialchars((string) $value, ENT_NOQUOTES);
+        }
+        return '';
     }
 
     public function _link($action = "default", $inlining = false)

--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -377,7 +377,7 @@ header('Content-type: text/html; charset=utf-8');
         <div id='processDetails' class='card card-body pb-2 h-50 overflow-auto collapse show'>
             <div class='col-md bg-light text-dark'>
                 <?php if (!empty($_POST['form_submit']) || $cliFromVersion !== null) {
-                    $form_old_version = $cliFromVersion ?? $_POST['form_old_version'];
+                    $form_old_version = $cliFromVersion ?? ($_POST['form_old_version'] ?? '');
 
                     foreach ($versions as $version => $filename) {
                         if (strcmp($version, (string) $form_old_version) < 0) {


### PR DESCRIPTION
## Summary

Fixes #11935.

Quiets four small recurring warnings/notices from production logs:

- `sql_upgrade.php`: default `$_POST['form_old_version']` to `''` so a GET load (no posted form) does not warn.
- `interface/forms/newpatient/C_EncounterVisitForm.class.php`: guard `$encounter['onset_date']` for legacy rows where the column was never populated.
- `interface/main/calendar/modules/PostCalendar/pnuserapi.php`: assign the event-dispatch result to a local variable before returning, so the by-reference return signature on `postcalendar_userapi_pcGetEvents()` stops triggering "Only variable references should be returned by reference."
- `library/classes/Controller.class.php`: register the `text` modifier as a Smarty plugin so `{$x|text}` no longer falls back to the deprecated unregistered-function path. The implementation narrows to scalar/Stringable values and delegates to the global `text()` helper.

## Test plan

- [ ] Open `sql_upgrade.php` via GET; confirm no `Undefined array key "form_old_version"` warning.
- [ ] View an encounter whose row was created before `onset_date` was tracked; confirm no `Undefined array key "onset_date"` warning.
- [ ] Load the calendar; confirm no `Only variable references should be returned by reference` notice from `pnuserapi.php`.
- [ ] Render a Controller-driven Smarty page that uses `|text` (e.g. document list, insurance company list); confirm output is unchanged and no `Using unregistered function "text"` deprecation appears.