### PR TITLE
fix(session): clean up callers that re-open read_and_close session

### DIFF
--- a/interface/forms/newpatient/save.php
+++ b/interface/forms/newpatient/save.php
@@ -12,6 +12,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Set $sessionAllowWrite to true since the encounter is written to the session via setencounter() below.
+$sessionAllowWrite = true;
 require_once(__DIR__ . "/../../globals.php");
 require_once("$srcdir/forms.inc.php");
 require_once("$srcdir/encounter.inc.php");

--- a/interface/main/calendar/index.php
+++ b/interface/main/calendar/index.php
@@ -16,6 +16,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Set $sessionAllowWrite to true since pc_facility, pc_username, and viewtype are written to the session below.
+$sessionAllowWrite = true;
 require_once("../../globals.php");
 
 use OpenEMR\Common\Acl\AclMain;

--- a/interface/new/new_comprehensive_save.php
+++ b/interface/new/new_comprehensive_save.php
@@ -12,6 +12,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Set $sessionAllowWrite to true since the new patient pid is written to the session via setpid() below.
+$sessionAllowWrite = true;
 require_once("../globals.php");
 
 use OpenEMR\BC\ServiceContainer;

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -27,6 +27,9 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Set $sessionAllowWrite to true since this script writes disablePreviousNameAdds to the session
+// on every load, alert_notify_pid whenever CDR is enabled, and pid + encounter when ?set_pid is provided.
+$sessionAllowWrite = true;
 require_once("../../globals.php");
 
 $srcdir = \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir();

--- a/library/ajax/dated_reminders_counter.php
+++ b/library/ajax/dated_reminders_counter.php
@@ -31,8 +31,6 @@ if (SessionTracker::isSessionExpired()) {
     echo json_encode(['timeoutMessage' => 'timeout']);
     exit;
 }
-// keep this below above time out check.
-OpenEMR\Common\Session\SessionUtil::setSession('keepAliveTime', time());
 
 $total_counts = [];
 $other_count = [];


### PR DESCRIPTION
## Summary

Resolves the recurring `Session reopened for writing after read_and_close` warnings emitted on a hot path in production. Each occurrence acquires and releases the session lock twice in the same request, defeating the read-and-close optimization and serializing concurrent AJAX requests for the same user. Tens of thousands of lines per day on a busy server.

Per-script disposition:

- **`library/ajax/dated_reminders_counter.php`** — removed the `keepAliveTime` session write entirely. The value is never read anywhere in the codebase, so the write was pure dead code (and the most chronic offender, firing once per minute per logged-in user). Verified with `git grep keepAliveTime`.
- **`interface/main/calendar/index.php`** — set `$sessionAllowWrite = true` (writes `pc_facility`, `pc_username`, `viewtype`).
- **`interface/new/new_comprehensive_save.php`** — set `$sessionAllowWrite = true` (writes new patient `pid` via `setpid()`).
- **`interface/patient_file/summary/demographics.php`** — set `$sessionAllowWrite = true` (writes `pid`, `encounter`, `alert_notify_pid`).
- **`interface/forms/newpatient/save.php`** — set `$sessionAllowWrite = true` (writes `encounter` via `setencounter()`).

The four `$sessionAllowWrite = true` additions follow the existing pattern (e.g. `interface/main/main_screen.php:20`, `interface/login/login.php:51`, `interface/usergroup/mfa_totp.php:18`). PHPStan's `ForbidDirectSessionWriteRule` already whitelists this pattern.

Closes #11934

## Test plan

- [ ] Sign in to OpenEMR; confirm the dated-reminders counter still polls and updates the message badge (no regression from removing the dead `keepAliveTime` write).
- [ ] Open the calendar; switch facility / provider / view; confirm selections persist across navigation (writes go to session as before).
- [ ] Add a new patient via the New/Search → Comprehensive form; confirm the new pid becomes the active patient context.
- [ ] Open a patient's Demographics; confirm pid + encounter context is established and CDR alerts behave as before.
- [ ] Create a new encounter via the encounter form; confirm it becomes the active encounter and the encounter list updates.
- [ ] Tail `error_log`; confirm `Session reopened for writing after read_and_close` no longer appears for these five scripts.
