### PR TITLE
fix(faxsms): notification cron fixes (backport #11846 + #11922 to rel-810)

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -4633,18 +4633,18 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
-    'count' => 5,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'\\|\\|\\|\' results in an error\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 16,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
+    'count' => 9,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',

--- a/.phpstan/baseline/cast.int.php
+++ b/.phpstan/baseline/cast.int.php
@@ -293,11 +293,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to int\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to int\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/utility.php',
 ];

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -883,11 +883,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/setup_services.php',
 ];

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1213,11 +1213,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 5,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 15,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/setup_services.php',
 ];

--- a/.phpstan/baseline/method.notFound.php
+++ b/.phpstan/baseline/method.notFound.php
@@ -382,11 +382,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-ehi-exporter/src/Bootstrap.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to an undefined method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\ClickatellSMSClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EmailClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\SignalWireClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\TwilioSMSClient\\:\\:emailReminder\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to an undefined method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:addListener\\(\\)\\.$#',
     'count' => 7,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/openemr.bootstrap.php',

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -909,32 +909,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Function cron_GetNotificationData\\(\\) return type has no value type specified in iterable type array\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function cron_InsertNotificationLogEntryFaxsms\\(\\) has parameter \\$db_sms_msg with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function cron_InsertNotificationLogEntryFaxsms\\(\\) has parameter \\$prow with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function cron_SetMessage\\(\\) has parameter \\$db_sms_msg with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function cron_SetMessage\\(\\) has parameter \\$prow with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function isValidPhone\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Function getTwigNamespaces\\(\\) return type has no value type specified in iterable type array\\.$#',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -9572,11 +9572,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/phone-services/voice_webhook.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function isValidPhone\\(\\) has parameter \\$phone with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\BootstrapService\\:\\:getModuleRegistry\\(\\) has parameter \\$modId with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/BootstrapService.php',

--- a/.phpstan/baseline/nullCoalesce.variable.php
+++ b/.phpstan/baseline/nullCoalesce.variable.php
@@ -372,16 +372,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/index.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$args on left side of \\?\\? always exists and is not nullable\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$db_patient on left side of \\?\\? always exists and is not nullable\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$vendors on left side of \\?\\? always exists and is not nullable\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/setup_services.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -15247,66 +15247,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/phone-services/voice_webhook.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'email_message\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'email_sender\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'email_subject\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'message\' on mixed\\.$#',
-    'count' => 7,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'notification_hours\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pc_catname\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pc_recurrspec\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'smsHours\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'smsMessage\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'sms_gateway_type\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'type\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset 0 on mixed\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'active\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/setup_services.php',

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -1944,12 +1944,12 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',

--- a/.phpstan/baseline/openemr.forbiddenErrorLog.php
+++ b/.phpstan/baseline/openemr.forbiddenErrorLog.php
@@ -73,11 +73,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
     'count' => 6,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/webhook_receiver.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
@@ -744,7 +744,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Use of the "global" keyword is forbidden \\(\\$bTestRun\\)\\. Use dependency injection instead\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use of the "global" keyword is forbidden \\(\\$pid\\)\\. Use dependency injection instead\\.$#',

--- a/.phpstan/baseline/openemr.noGlobalNsFunctions.php
+++ b/.phpstan/baseline/openemr.noGlobalNsFunctions.php
@@ -2322,44 +2322,29 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/phone-services/voice_webhook.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function cron_GetNotificationData may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function cron_InsertNotificationLogEntryFaxsms may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function cron_SetMessage may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function displayHelp may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Function cron_GetNotificationData may not be defined in the global namespace\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Function cron_InsertNotificationLogEntryFaxsms may not be defined in the global namespace\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Function faxsms_getAlertPatientData may not be defined in the global namespace\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function formatErrorMessage may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function isValidPhone may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Function rc_sms_notification_cron_update_entry may not be defined in the global namespace\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Function doEmailNotificationTask may not be defined in the global namespace\\.$#',

--- a/.phpstan/baseline/return.unusedType.php
+++ b/.phpstan/baseline/return.unusedType.php
@@ -32,11 +32,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-dorn/ModuleManagerListener.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function isValidPhone\\(\\) never returns array so it can be removed from the return type\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\:\\:processMessageStoreList\\(\\) never returns false so it can be removed from the return type\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -12047,11 +12047,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/contact.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$cred might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$selectedService might not be defined\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/setup_services.php',

--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
@@ -1,95 +1,127 @@
 <?php
 
 /**
- * Email or SMS Cron Notification
+ * Admin popup / argv entry for appointment-reminder scan-and-send.
  *
- * Run by cron every hour, look for appointments in pre-notification period and
- * send an SMS reminder
+ * This file is the UI-facing entry point: admins trigger it from
+ * `messageUI.php` / `setup_email.php` as a popup (dry-run and live
+ * modes) and operators can invoke it from the CLI for one-shot runs
+ * (see README-GUIDE.md for argv usage). Both paths keep the ACL gate
+ * — a front-desk user without "patients/appt" access must not be
+ * able to trigger reminder delivery, whether they land here through
+ * a browser popup or an interactive shell.
  *
+ * The `bin/console background:services run` entry point lives in
+ * `run_notifications.php` and deliberately does NOT require this
+ * file, because there is no interactive session to ACL-check and
+ * because the HTML chrome below would just be written into the
+ * cron log. See issue #11827 for the silent-success bug that
+ * triggered this split.
+ *
+ * The scan-and-send pipeline is
+ * `OpenEMR\Modules\FaxSMS\Notification\AppointmentNotificationRunner`.
+ * The procedural SQL/formatting helpers used by both entry points
+ * live in `rc_sms_notification_helpers.php`.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
  * @author    Unknown
  * @author    Larry Lart
  * @author    Jerry Padgett
  * @author    Robert Down
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Unknown
  * @copyright Copyright (c) 2008 Larry Lart
  * @copyright Copyright (c) 2018-2024 Jerry Padgett
  * @copyright Copyright (c) 2021 Robert Down <robertdown@live.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ *
+ * @codeCoverageIgnore Top-level admin popup / argv entry point. Mixes
+ *     globals.php bootstrap, raw `$_GET` writes for site/type, ACL gating
+ *     against the live session, and HTML chrome — none of which is
+ *     reachable from an isolated test. The reusable scan-and-send logic
+ *     lives in `AppointmentNotificationRunner` and is covered there.
  */
 
-//hack add for command line version
-use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Controller\AppDispatch;
+use OpenEMR\Modules\FaxSMS\Controller\NotificationTaskManager;
 use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
-use OpenEMR\Modules\FaxSMS\Exception\EmailSendFailedException;
-use OpenEMR\Modules\FaxSMS\Exception\InvalidEmailAddressException;
-use OpenEMR\Modules\FaxSMS\Exception\SmtpNotConfiguredException;
+use OpenEMR\Modules\FaxSMS\Notification\AppointmentNotificationRunner;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 $_SERVER['REQUEST_URI'] = $_SERVER['PHP_SELF'];
 $_SERVER['SERVER_NAME'] = 'localhost';
-$backpic = "";
-$clientApp = null;
-$emailApp = null;
-// for cron
-$error = '';
-$runtime = [];
 
-// Check for other arguments and perform your script logic
+// Parse CLI argv (key=value pairs) into $runtime.
+$runtime = [];
 $argc ??= 0;
 $argv ??= [];
 if ($argc > 1) {
     foreach ($argv as $k => $v) {
-        if ($k == 0) {
+        if ($k === 0) {
             continue;
         }
         $args = explode('=', $v);
-        if ((count($args ?? [])) > 1) {
+        if (count($args) > 1) {
             $runtime[trim($args[0])] = trim($args[1]);
         }
     }
 }
-$isCli = 0;
+
 if (php_sapi_name() === 'cli') {
-    $isCli = 1;
     $_SERVER["HTTP_HOST"] = "localhost";
     $ignoreAuth = true;
 }
 
-// so service can set some settings if needed on init.
+// So the service can set some settings if needed on init.
 $sessionAllowWrite = true;
 require_once(__DIR__ . "/../../../../globals.php");
 require_once(OEGlobalsBag::getInstance()->getSrcDir() . "/appointments.inc.php");
+require_once(__DIR__ . "/rc_sms_notification_helpers.php");
 
-// Check for help argument
 if ($argc > 1 && (in_array('--help', $argv) || in_array('-h', $argv))) {
     displayHelp();
     exit(0);
 }
 
-if (empty($runtime['site']) && empty($session->get('site_id')) && empty($_GET['site'])) {
-    echo xlt("Missing Site Id using default") . "\n";
-    $_GET['site'] = $runtime['site'] = 'default';
+$runtimeSite = $runtime['site'] ?? '';
+if ($runtimeSite !== '') {
+    $_GET['site'] = $runtimeSite;
 } else {
-    $_GET['site'] = $runtime['site'];
+    $sessionSite = $session->get('site_id');
+    $querySite = $_GET['site'] ?? '';
+    $sessionSiteIsBlank = !is_string($sessionSite) || $sessionSite === '';
+    $querySiteIsBlank = !is_string($querySite) || $querySite === '';
+    if ($sessionSiteIsBlank && $querySiteIsBlank) {
+        echo xlt("Missing Site Id using default") . "\n";
+        $_GET['site'] = $runtime['site'] = 'default';
+    }
 }
 
-$TYPE = '';
-if (!empty($runtime['type'])) {
-    $TYPE = strtoupper($runtime['type']);
+$runtimeType = $runtime['type'] ?? '';
+if ($runtimeType !== '') {
+    $TYPE = strtoupper($runtimeType);
 } elseif (($_GET['type'] ?? '') === 'email') {
     $TYPE = $runtime['type'] = "EMAIL";
 } else {
     $TYPE = $runtime['type'] = "SMS"; // default
 }
 
-$taskManager = new \OpenEMR\Modules\FaxSMS\Controller\NotificationTaskManager();
-$CRON_TIME = $taskManager->getTaskHours(strtolower($TYPE));
-// use service if needed
-if ($TYPE === "SMS") {
+$channel = NotificationChannel::fromLegacyType($TYPE);
+$taskManager = new NotificationTaskManager();
+$cronIntervalHours = $taskManager->getTaskHours(strtolower($TYPE));
+
+// Resolve the client for this channel. AppDispatch::getApiService()
+// constructs the vendor-specific client, which in turn runs the ACL
+// check against the active session. Keep the die-on-deny behavior
+// here: this path is always invoked by an interactive admin, so a
+// visible "Not Authorised!" page is the expected response.
+if ($channel === NotificationChannel::SMS) {
     $session->set('authUser', $runtime['user'] ?? $session->get('authUser'));
     $clientApp = AppDispatch::getApiService('sms');
     $cred = $clientApp->getCredentials();
@@ -97,33 +129,44 @@ if ($TYPE === "SMS") {
     if (!$clientApp->verifyAcl('patients', 'appt', $runtime['user'] ?? '')) {
         die("<h3>" . xlt("Not Authorised!") . "</h3>");
     }
-}
-if ($TYPE === "EMAIL") {
+} else {
     $session->set('authUser', $runtime['user'] ?? $session->get('authUser'));
-    $emailApp = AppDispatch::getApiService('email');
-    $cred = $emailApp->getEmailSetup();
+    $clientApp = AppDispatch::getApiService('email');
+    $cred = $clientApp->getEmailSetup();
 
-    if (!$emailApp->verifyAcl('patients', 'appt', $runtime['user'] ?? '')) {
+    if (!$clientApp->verifyAcl('patients', 'appt', $runtime['user'] ?? '')) {
         die("<h3>" . xlt("Not Authorised!") . "</h3>");
     }
 }
-// close writes
+
+// Close session writes so a long-running scan doesn't block other tabs.
 session_write_close();
 set_time_limit(0);
 
-$smsNotificationHourRaw = $cred['smsHours'] ?? $cred['notification_hours'] ?? 24;
-$SMS_NOTIFICATION_HOUR = is_numeric($smsNotificationHourRaw) ? (int) $smsNotificationHourRaw : 24;
-$MESSAGE = $cred['smsMessage'] ?? $cred['email_message'];
+$credArray = is_array($cred) ? $cred : [];
+$notificationHoursRaw = $credArray['smsHours'] ?? $credArray['notification_hours'] ?? 24;
+$notificationHours = is_numeric($notificationHoursRaw) ? (int) $notificationHoursRaw : 24;
+$messageTemplateRaw = $credArray['smsMessage'] ?? $credArray['email_message'] ?? '';
+$messageTemplate = is_string($messageTemplateRaw) ? $messageTemplateRaw : '';
+$vendor = AppDispatch::getModuleVendor();
+$gatewayType = is_string($vendor) ? $vendor : '';
 
-// check command line for quite option
-$bTestRun = isset($_REQUEST['dryrun']) ? 1 : 0;
-if (!empty($runtime['testrun'])) {
-    $bTestRun = 1;
-}
+$dryRun = isset($_REQUEST['dryrun']) || ($runtime['testrun'] ?? '') !== '';
 
-$db_sms_msg['type'] = $TYPE;
-$db_sms_msg['sms_gateway_type'] = AppDispatch::getModuleVendor();
-$db_sms_msg['message'] = $MESSAGE;
+// Exposed via the globals bag because `rc_sms_notification_cron_update_entry()`
+// in rc_sms_notification_helpers.php still reads `bTestRun` to short-circuit
+// dry-run updates. Removing that dependency is follow-up work.
+OEGlobalsBag::getInstance()->set('bTestRun', $dryRun);
+
+$runner = new AppointmentNotificationRunner(
+    channel: $channel,
+    client: $clientApp,
+    notificationHours: $notificationHours,
+    cronIntervalHours: $cronIntervalHours,
+    dryRun: $dryRun,
+    messageTemplate: $messageTemplate,
+    gatewayType: $gatewayType,
+);
 ?>
     <!DOCTYPE html>
     <html lang="eng">
@@ -143,358 +186,35 @@ $db_sms_msg['message'] = $MESSAGE;
                 <div class="text-center mt-2"><h2><?php echo xlt("Working and may take a few minutes to finish.") ?></h2></div>
             </div>
             <?php
-            if ($bTestRun) {
+            if ($dryRun) {
                 echo xlt("We are in Test Mode and no reminders will be sent. This test will check what reminders will be sent in when running Live Mode.");
             }
-            $db_patient = faxsms_getAlertPatientData(NotificationChannel::fromLegacyType($TYPE), $SMS_NOTIFICATION_HOUR);
-            echo "\n<br>" . xlt('Total of') . ": " . count($db_patient ?? []) . " " . xlt('Reminders Found') . " " . ($bTestRun ? xlt("and will be sending for reminders") . " " : xlt("and Sending for reminders ")) . ' ' . $SMS_NOTIFICATION_HOUR . ' ' . xlt("hrs from now.");
+            echo "<h3>======================== " . text($TYPE) . " | " . text(date("Y-m-d H:i:s")) . " =========================</h3>";
             ob_flush();
             flush();
-            // for every event found
-            $plast = '';
-            echo "<h3>======================== " . text($TYPE) . " | " . text(date("Y-m-d H:i:s")) . " =========================</h3>";
-            for ($p = 0; $p < count($db_patient); $p++) {
-                ob_flush();
-                flush();
-                $prow = $db_patient[$p];
-                $db_sms_msg['message'] = $MESSAGE;
 
-                $app_date = $prow['pc_eventDate'] . " " . $prow['pc_startTime'];
-                $app_time = strtotime($app_date);
-
-                $app_time_hour = round($app_time / 3600);
-                $curr_total_hour = round(time() / 3600);
-
-                $remaining_app_hour = round($app_time_hour - $curr_total_hour);
-                $remain_hour = round($remaining_app_hour - $SMS_NOTIFICATION_HOUR);
-
-                if ($plast != $prow['ulname']) {
-                    echo "<h4>" . xlt("For Provider") . ": " . text($prow['utitle']) . ' ' . text($prow['ufname']) . ' ' . text($prow['ulname']) . "</h4>";
-                    $plast = $prow['ulname'];
-                }
-                $strMsg = "<strong>* " . xlt("SEND NOTIFICATION BEFORE:") . $SMS_NOTIFICATION_HOUR . " | " . xlt("CRONJOB RUNS EVERY:") . $CRON_TIME . " | " . xlt("APPOINTMENT DATE TIME") . ': ' . $app_date . " | " . xlt("APPOINTMENT REMAINING HOURS") . ": " . text($remaining_app_hour) . " | " . xlt("SEND ALERT AFTER") . ': ' . text($remain_hour) . "</strong>";
-
-                // check in the interval
-                if (\OpenEMR\Modules\FaxSMS\Controller\NotificationTaskManager::isWithinCronWindow((int) $remain_hour, $CRON_TIME)) {
-                    //set message
-                    $db_sms_msg['message'] = cron_SetMessage($prow, $db_sms_msg);
-                    // send sms to patient - if not in test mode
-                    if ($TYPE == 'SMS' && $clientApp != null) {
-                        $isValid = isValidPhone($prow['phone_cell']);
-                        // send sms to patient - if not in test mode
-                        if ($bTestRun == 0 && $isValid) {
-                            $error = $clientApp->sendSMS(
-                                $prow['phone_cell'] ?? '',
-                                $db_sms_msg['email_subject'] ?? '',
-                                $db_sms_msg['message'] ?? '',
-                                $db_sms_msg['email_sender'] ?? ''
-                            );
-                            if (stripos((string) $error, 'error') !== false) {
-                                $strMsg .= " | " . xlt("Error:") . "<strong>" . text($error) . "</strong>\n";
-                                error_log($strMsg); // text
-                                echo(nl2br($strMsg));
-                                continue;
-                            } else {
-                                cron_InsertNotificationLogEntryFaxsms($TYPE, $prow, $db_sms_msg);
-                            }
-                        }
-                        if (!$isValid) {
-                            $strMsg .= "<strong style='color:red'>\n* " . xlt("INVALID Mobile Phone#") . text('$prow["phone_cell"]') . " " . xlt("SMS NOT SENT Patient") . ":</strong>" . text($prow['fname']) . " " . text($prow['lname']) . "</b>";
-                            $db_sms_msg['message'] = xlt("Error: INVALID Mobile Phone") . '# ' . text($prow['phone_cell']) . xlt("SMS NOT SENT For") . ": " . text($prow['fname']) . " " . text($prow['lname']);
-                            if ($bTestRun == 0) {
-                                cron_InsertNotificationLogEntryFaxsms($TYPE, $prow, $db_sms_msg);
-                            }
-                        } else {
-                            $strMsg .= " | " . xlt("SMS SENT SUCCESSFULLY TO") . "<strong> " . text($prow['phone_cell']) . "</strong>";
-                            rc_sms_notification_cron_update_entry(NotificationChannel::SMS, $prow['pid'], $prow['pc_eid'], $prow['pc_recurrtype']);
-                        }
-                        if ((int)$prow['pc_recurrtype'] > 0) {
-                            $row = fetchRecurrences($prow['pid']);
-                            $strMsg .= "\n<strong>" . xlt("A Recurring") . " " . text($row[0]['pc_catname']) . " " . xlt("Event Occurring") . " " . text($row[0]['pc_recurrspec']) . "</strong>";
-                        }
-                        $strMsg .= "\n" . text($db_sms_msg['message']) . "\n";
-                        echo(nl2br($strMsg));
-                    }
-                    if ($TYPE == 'EMAIL' && $emailApp != null) {
-                        $isValid = $emailApp->validEmail($prow['email']);
-                        if ($bTestRun == 0 && $isValid) {
-                            try {
-                                $emailApp->emailReminder(
-                                    $prow['email'] ?? '',
-                                    $db_sms_msg['message'],
-                                );
-                                // Success - create notification log entry
-                                cron_InsertNotificationLogEntryFaxsms($TYPE, $prow, $db_sms_msg);
-                            } catch (InvalidEmailAddressException) {
-                                $strMsg .= formatErrorMessage(xlt("Invalid email address"));
-                                echo(nl2br($strMsg));
-                                continue;
-                            } catch (SmtpNotConfiguredException) {
-                                $strMsg .= formatErrorMessage(xlt("SMTP not configured"));
-                                echo(nl2br($strMsg));
-                                continue;
-                            } catch (EmailSendFailedException $e) {
-                                $strMsg .= formatErrorMessage(xlt("Failed to send email") . ": " . text($e->getMessage()));
-                                echo(nl2br($strMsg));
-                                continue;
-                            } catch (\PHPMailer\PHPMailer\Exception $e) {
-                                $strMsg .= formatErrorMessage(xlt("Email error") . ": " . text($e->getMessage()));
-                                echo(nl2br($strMsg));
-                                continue;
-                            }
-                        }
-                        if (!$isValid) {
-                            $strMsg .= "<strong style='color:red'>\n* " . xlt("INVALID Email") . text('$prow["email"]') . " " . xlt("EMAIL NOT SENT Patient") . ":</strong>" . text($prow['fname']) . " " . text($prow['lname']) . "</b>";
-                            $db_sms_msg['message'] = xlt("Error: INVALID EMAIL") . '# ' . text($prow['email']) . xlt("EMAIL NOT SENT For") . ": " . text($prow['fname']) . " " . text($prow['lname']);
-                            if ($bTestRun == 0) {
-                                cron_InsertNotificationLogEntryFaxsms($TYPE, $prow, $db_sms_msg);
-                            }
-                        } else {
-                            $strMsg .= " | " . xlt("EMAILED SUCCESSFULLY TO") . "<strong> " . text($prow['email']) . "</strong>";
-                            rc_sms_notification_cron_update_entry(NotificationChannel::EMAIL, $prow['pid'], $prow['pc_eid'], $prow['pc_recurrtype']);
-                        }
-                        if ((int)$prow['pc_recurrtype'] > 0) {
-                            $row = fetchRecurrences($prow['pid']);
-                            $strMsg .= "\n<strong>" . xlt("A Recurring") . " " . text($row[0]['pc_catname']) . " " . xlt("Event Occurring") . " " . text($row[0]['pc_recurrspec']) . "</strong>";
-                        }
-                        $strMsg .= "\n" . text($db_sms_msg['message']) . "\n";
-                        echo(nl2br($strMsg));
-                    }
-                }
-            }
-            unset($clientApp);
-            unset($emailApp);
-            echo "<br /><h2>" . xlt("Done!") . "</h2>";
+            $result = $runner->run();
             ?>
+            <ul>
+                <li><?php echo xlt('Candidates scanned'); ?>: <strong><?php echo text((string) $result->scanned); ?></strong></li>
+                <li><?php echo xlt('In send window'); ?>: <strong><?php echo text((string) $result->inWindow); ?></strong></li>
+                <li><?php echo xlt('Sent'); ?>: <strong><?php echo text((string) $result->sent); ?></strong></li>
+                <li><?php echo xlt('Skipped (invalid recipient)'); ?>: <strong><?php echo text((string) $result->skippedInvalid); ?></strong></li>
+                <li><?php echo xlt('Failed'); ?>: <strong><?php echo text((string) $result->failed); ?></strong></li>
+            </ul>
+            <?php if ($result->hasFailures()) : ?>
+                <p class="text-danger"><?php echo xlt('One or more sends failed. Check the PHP error log for details.'); ?></p>
+            <?php endif; ?>
+            <h2><?php echo xlt("Done!"); ?></h2>
         </div>
     </body>
     </html>
-
 <?php
-function isValidPhone($phone): array|bool|string|null
-{
-    $justNums = preg_replace("/[^0-9]/", '', (string) $phone);
-    if (strlen((string) $justNums) === 11) {
-        $justNums = preg_replace("/^1/", '', (string) $justNums);
-    }
-    //if we have 10 digits left, it's probably valid.
-    if (strlen((string) $justNums) === 10) {
-        return $justNums;
-    } else {
-        return false;
-    }
-}
-
-/**
- * Mark a non-recurring appointment as already-notified for a given channel.
- *
- * Only the per-channel alert flag (pc_sendalertsms / pc_sendalertemail) is
- * updated. pc_apptstatus is intentionally left alone — it holds the real
- * appointment status set by front-desk staff (Pending, Arrived, etc.) and
- * must not be overwritten with notification metadata. See #11479.
- *
- * Recurring events are intentionally skipped: the pc_sendalertsms /
- * pc_sendalertemail columns live on the base event row which is shared by
- * every occurrence. Setting them would suppress reminders for all future
- * occurrences. Recurring-event dedup is handled in
- * faxsms_getAlertPatientData() by checking the notification_log keyed on
- * (pc_eid, pc_eventDate, type).
- */
-function rc_sms_notification_cron_update_entry(NotificationChannel $channel, int $pid, int $pc_eid, string $recur = ''): void
-{
-    global $bTestRun;
-
-    if ($bTestRun || (int)trim($recur) > 0) {
-        return;
-    }
-
-    $column = match ($channel) {
-        NotificationChannel::SMS   => 'pc_sendalertsms',
-        NotificationChannel::EMAIL => 'pc_sendalertemail',
-    };
-
-    $query = "UPDATE openemr_postcalendar_events SET {$column} = 'YES' WHERE pc_pid = ? AND pc_eid = ?";
-
-    QueryUtils::sqlStatementThrowException($query, [$pid, $pc_eid]);
-}
-
-/**
- * Cron Get Alert Patient Data
- *
- * Pass the notification channel and hours-ahead explicitly rather than reading
- * them from globals. The Background Services entry path loads this file via
- * require_once from inside a function, which traps the file's top-level
- * variables as function locals — `global $TYPE` then sees null and the wrong
- * WHERE clause runs, causing duplicate email reminders. See issue #11477.
- *
- * Renamed from `cron_GetAlertPatientData()` to a module-prefixed name to avoid
- * a PHP case-insensitive collision with a legacy `cron_getAlertpatientData()`
- * that historically lived in the (now-removed) `modules/sms_email_reminder`
- * module.
- *
- * @return list<array<mixed>>
- */
-function faxsms_getAlertPatientData(NotificationChannel $channel, int $notificationHour): array
-{
-    $where = match ($channel) {
-        NotificationChannel::EMAIL => " AND (p.hipaa_allowemail='YES' AND p.email<>'' AND e.pc_sendalertemail != 'YES' AND e.pc_apptstatus != 'x')",
-        NotificationChannel::SMS   => " AND (p.hipaa_allowsms='YES' AND p.phone_cell<>'' AND e.pc_sendalertsms != 'YES' AND e.pc_apptstatus != 'x')",
-    };
-    $adj_date = (int)date("H") + $notificationHour;
-    $check_date = date("Y-m-d", mktime($adj_date, 0, 0, (int)date("m"), (int)date("d"), (int)date("Y")));
-
-    $events = fetchEvents($check_date, $check_date, $where, 'u.lname,pc_startTime,p.lname');
-    if (!is_array($events)) {
-        return [];
-    }
-
-    // For recurring events, the events-table dedup columns
-    // (pc_sendalertsms/pc_sendalertemail) live on the base event row shared
-    // by all occurrences, so they cannot distinguish individual occurrence
-    // dates. Check the notification_log instead, keyed on
-    // (pc_eid, pc_eventDate, type).
-    // $channel is the PHP enum NotificationChannel ('SMS'/'EMAIL').
-    // notification_log.type is a MySQL enum('SMS','Email'). MySQL enum
-    // comparisons are case-insensitive, so the PHP value matches regardless
-    // of casing differences between the two enums.
-    $channelType = $channel->value;
-
-    // Collect recurring event IDs so we can batch-check notification_log
-    // in a single query instead of one query per occurrence. Use string
-    // keys to match the mixed types from fetchEvents() and notification_log
-    // without requiring casts from mixed.
-    /** @var array<string, true> */
-    $recurringEids = [];
-    foreach ($events as $event) {
-        if (!is_array($event)) {
-            continue;
-        }
-        $recurrtype = $event['pc_recurrtype'] ?? 0;
-        $pcEid = $event['pc_eid'] ?? null;
-        if (is_numeric($recurrtype) && $recurrtype > 0 && is_numeric($pcEid)) {
-            $recurringEids[(string)$pcEid] = true;
-        }
-    }
-
-    /** @var array<string, array<string, true>> */
-    $sentNotifications = [];
-    if ($recurringEids !== []) {
-        $pcEids = array_keys($recurringEids);
-        $placeholders = implode(',', array_fill(0, count($pcEids), '?'));
-        $rows = QueryUtils::fetchRecords(
-            "SELECT pc_eid, pc_eventDate FROM notification_log WHERE type = ? AND pc_eventDate = ? AND pc_eid IN ($placeholders)",
-            array_merge([$channelType, $check_date], $pcEids),
-        );
-        foreach ($rows as $row) {
-            $eid = $row['pc_eid'] ?? null;
-            $date = $row['pc_eventDate'] ?? null;
-            if (is_numeric($eid) && is_string($date)) {
-                $sentNotifications[(string)$eid][$date] = true;
-            }
-        }
-    }
-
-    $normalized = [];
-    foreach ($events as $event) {
-        if (!is_array($event)) {
-            continue;
-        }
-        $recurrtype = $event['pc_recurrtype'] ?? 0;
-        $eventDate = $event['pc_eventDate'] ?? '';
-        $pcEid = $event['pc_eid'] ?? null;
-        if (
-            is_numeric($recurrtype) && $recurrtype > 0
-            && is_string($eventDate)
-            && is_numeric($pcEid)
-            && isset($sentNotifications[(string)$pcEid][$eventDate])
-        ) {
-            continue;
-        }
-        $normalized[] = $event;
-    }
-    return $normalized;
-}
-
-/**
- * Cron Get Notification Data
- *
- * @param string $type
- * @return array|false
- */
-function cron_GetNotificationData($type): bool|array
-{
-    $db_sms_msg['notification_id'] = '';
-    $db_sms_msg['sms_gateway_type'] = '';
-
-    $query = "Select * From automatic_notification Where type = ?";
-    $db_sms_msg = sqlFetchArray(sqlStatement($query, [$type]));
-
-    return $db_sms_msg;
-}
-
-/**
- * Format an error message for display
- *
- * @param string $message The translated error message
- * @return string Formatted error message with HTML
- */
-function formatErrorMessage(string $message): string
-{
-    return " | " . xlt("Error:") . " <strong>" . $message . "</strong>\n";
-}
-
-/**
- * Cron Insert Notification Log Entry
- *
- * @param string $type
- * @param array  $prow
- * @param array  $db_sms_msg
- * @return void
- */
-function cron_InsertNotificationLogEntryFaxsms($type, $prow, $db_sms_msg): void
-{
-    $smsgateway_info = $type == 'SMS' ? "" : $db_sms_msg['email_sender'] . "|||" . $db_sms_msg['email_subject'];
-
-    $patient_info = $prow['title'] . " " . $prow['fname'] . " " . $prow['mname'] . " " . $prow['lname'] . "|||" . $prow['phone_cell'] . "|||" . $prow['email'];
-    $data_info = $prow['pc_eventDate'] . "|||" . $prow['pc_endDate'] . "|||" . $prow['pc_startTime'] . "|||" . $prow['pc_endTime'];
-    $sdate = date("Y-m-d H:i:s");
-    $sql_loginsert = "INSERT INTO `notification_log` (`iLogId` , `pid` , `pc_eid` , `sms_gateway_type` , `message` , `type` , `patient_info` , `smsgateway_info` , `pc_eventDate` , `pc_endDate` , `pc_startTime` , `pc_endTime` , `dSentDateTime`) VALUES (NULL,?,?,?,?,?,?,?,?,?,?,?,?)";
-
-    $safe = [$prow['pid'], $prow['pc_eid'], $db_sms_msg['sms_gateway_type'], $db_sms_msg['message'], $db_sms_msg['type'], $patient_info, $smsgateway_info, $prow['pc_eventDate'], $prow['pc_endDate'], $prow['pc_startTime'], $prow['pc_endTime'], $sdate];
-
-    sqlStatement($sql_loginsert, $safe);
-}
-
-/**
- * Cron Set Message
- *
- * @param array $prow
- * @param array $db_sms_msg
- * @return string
- */
-function cron_SetMessage($prow, $db_sms_msg): string
-{
-    $NAME = $prow['title'] . " " . $prow['fname'] . " " . $prow['mname'] . " " . $prow['lname'];
-    $apptProvider = $prow['utitle'] . ' ' . $prow['ufname'] . ' ' . $prow['ulname'];
-    $PROVIDER = $apptProvider;
-    $ORG = $prow['name'];
-    $dtWrk = strtotime($prow['pc_eventDate'] . ' ' . $prow['pc_startTime']);
-    $DATE = date('l F j, Y', $dtWrk);
-    $STARTTIME = date('g:i A', $dtWrk);
-    $ENDTIME = $prow['pc_endTime'];
-    $find_array = ["***NAME***", "***PROVIDER***", "***DATE***", "***STARTTIME***", "***ENDTIME***", "***ORG***"];
-    $replace_array = [$NAME, $PROVIDER, $DATE, $STARTTIME, $ENDTIME, $ORG];
-    $message = str_replace($find_array, $replace_array, $db_sms_msg['message']);
-    $message = text($message);
-
-    return $message;
-}
+unset($clientApp);
 
 function displayHelp(): void
 {
-    //echo text($helpt);
-    $help =
-        <<<HELP
+    $help = <<<HELP
 
 Usage:   php rc_sms_notification.php [options]
 Example: php rc_sms_notification.php site=default user=admin type=sms testrun=1

--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * Shared helpers for the appointment-reminder cron.
+ *
+ * Extracted from the popup entry point `rc_sms_notification.php` so
+ * non-UI callers (the CLI background-service wrapper in
+ * `run_notifications.php`, unit tests) can pull in just the procedural
+ * support functions without also loading the popup's HTML chrome and
+ * scan-and-send loop. Both entry points require_once this file.
+ *
+ * The scan-and-send pipeline itself lives in
+ * `OpenEMR\Modules\FaxSMS\Notification\AppointmentNotificationRunner`;
+ * the functions here are the thin SQL/formatting primitives that the
+ * runner and existing callers invoke.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Unknown
+ * @author    Larry Lart
+ * @author    Jerry Padgett
+ * @author    Robert Down
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Unknown
+ * @copyright Copyright (c) 2008 Larry Lart
+ * @copyright Copyright (c) 2018-2024 Jerry Padgett
+ * @copyright Copyright (c) 2021 Robert Down <robertdown@live.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ *
+ * @codeCoverageIgnore Procedural global-namespace SQL helpers loaded via
+ *     require_once from two entry points. Every function here either
+ *     issues raw SQL (notification_log inserts, calendar updates) or
+ *     reads `OEGlobalsBag` state set by those entry points. Exercising
+ *     them in isolation requires a real database; the orchestrator that
+ *     calls them (`AppointmentNotificationRunner`) is covered separately
+ *     in `tests/Tests/Isolated/Modules/FaxSMS/Notification/`.
+ */
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
+
+if (!function_exists('rc_sms_notification_cron_update_entry')) {
+    /**
+     * Mark a non-recurring appointment as already-notified for a given channel.
+     *
+     * Only the per-channel alert flag (pc_sendalertsms / pc_sendalertemail) is
+     * updated. pc_apptstatus is intentionally left alone — it holds the real
+     * appointment status set by front-desk staff (Pending, Arrived, etc.) and
+     * must not be overwritten with notification metadata. See #11479.
+     *
+     * Recurring events are intentionally skipped: the pc_sendalertsms /
+     * pc_sendalertemail columns live on the base event row which is shared by
+     * every occurrence. Setting them would suppress reminders for all future
+     * occurrences. Recurring-event dedup is handled in
+     * faxsms_getAlertPatientData() by checking the notification_log keyed on
+     * (pc_eid, pc_eventDate, type).
+     */
+    function rc_sms_notification_cron_update_entry(NotificationChannel $channel, int $pid, int $pc_eid, string $recur = ''): void
+    {
+        global $bTestRun;
+
+        if ($bTestRun || (int) trim($recur) > 0) {
+            return;
+        }
+
+        $column = match ($channel) {
+            NotificationChannel::SMS   => 'pc_sendalertsms',
+            NotificationChannel::EMAIL => 'pc_sendalertemail',
+        };
+
+        $query = "UPDATE openemr_postcalendar_events SET {$column} = 'YES' WHERE pc_pid = ? AND pc_eid = ?";
+
+        QueryUtils::sqlStatementThrowException($query, [$pid, $pc_eid]);
+    }
+}
+
+if (!function_exists('faxsms_getAlertPatientData')) {
+    /**
+     * Return appointments due for a reminder on the given channel.
+     *
+     * Pass the notification channel and hours-ahead explicitly rather than reading
+     * them from globals. The Background Services entry path loads this file via
+     * require_once from inside a function, which traps the file's top-level
+     * variables as function locals — `global $TYPE` then sees null and the wrong
+     * WHERE clause runs, causing duplicate email reminders. See issue #11477.
+     *
+     * Renamed from `cron_GetAlertPatientData()` to a module-prefixed name to avoid
+     * a PHP case-insensitive collision with a legacy `cron_getAlertpatientData()`
+     * that historically lived in the (now-removed) `modules/sms_email_reminder`
+     * module.
+     *
+     * @return list<array<mixed>>
+     */
+    function faxsms_getAlertPatientData(NotificationChannel $channel, int $notificationHour): array
+    {
+        $where = match ($channel) {
+            NotificationChannel::EMAIL => " AND (p.hipaa_allowemail='YES' AND p.email<>'' AND e.pc_sendalertemail != 'YES' AND e.pc_apptstatus != 'x')",
+            NotificationChannel::SMS   => " AND (p.hipaa_allowsms='YES' AND p.phone_cell<>'' AND e.pc_sendalertsms != 'YES' AND e.pc_apptstatus != 'x')",
+        };
+        $adj_date = (int) date("H") + $notificationHour;
+        $check_date = date("Y-m-d", mktime($adj_date, 0, 0, (int) date("m"), (int) date("d"), (int) date("Y")));
+
+        $events = fetchEvents($check_date, $check_date, $where, 'u.lname,pc_startTime,p.lname');
+        if (!is_array($events)) {
+            return [];
+        }
+
+        // For recurring events, the events-table dedup columns
+        // (pc_sendalertsms/pc_sendalertemail) live on the base event row shared
+        // by all occurrences, so they cannot distinguish individual occurrence
+        // dates. Check the notification_log instead, keyed on
+        // (pc_eid, pc_eventDate, type).
+        // $channel is the PHP enum NotificationChannel ('SMS'/'EMAIL').
+        // notification_log.type is a MySQL enum('SMS','Email'). MySQL enum
+        // comparisons are case-insensitive, so the PHP value matches regardless
+        // of casing differences between the two enums.
+        $channelType = $channel->value;
+
+        // Collect recurring event IDs so we can batch-check notification_log
+        // in a single query instead of one query per occurrence. Use string
+        // keys to match the mixed types from fetchEvents() and notification_log
+        // without requiring casts from mixed.
+        /** @var array<string, true> */
+        $recurringEids = [];
+        foreach ($events as $event) {
+            if (!is_array($event)) {
+                continue;
+            }
+            $recurrtype = $event['pc_recurrtype'] ?? 0;
+            $pcEid = $event['pc_eid'] ?? null;
+            if (is_numeric($recurrtype) && $recurrtype > 0 && is_numeric($pcEid)) {
+                $recurringEids[(string) $pcEid] = true;
+            }
+        }
+
+        /** @var array<string, array<string, true>> */
+        $sentNotifications = [];
+        if ($recurringEids !== []) {
+            $pcEids = array_keys($recurringEids);
+            $placeholders = implode(',', array_fill(0, count($pcEids), '?'));
+            $rows = QueryUtils::fetchRecords(
+                "SELECT pc_eid, pc_eventDate FROM notification_log WHERE type = ? AND pc_eventDate = ? AND pc_eid IN ($placeholders)",
+                array_merge([$channelType, $check_date], $pcEids),
+            );
+            foreach ($rows as $row) {
+                $eid = $row['pc_eid'] ?? null;
+                $date = $row['pc_eventDate'] ?? null;
+                if (is_numeric($eid) && is_string($date)) {
+                    $sentNotifications[(string) $eid][$date] = true;
+                }
+            }
+        }
+
+        $normalized = [];
+        foreach ($events as $event) {
+            if (!is_array($event)) {
+                continue;
+            }
+            $recurrtype = $event['pc_recurrtype'] ?? 0;
+            $eventDate = $event['pc_eventDate'] ?? '';
+            $pcEid = $event['pc_eid'] ?? null;
+            if (
+                is_numeric($recurrtype) && $recurrtype > 0
+                && is_string($eventDate)
+                && is_numeric($pcEid)
+                && isset($sentNotifications[(string) $pcEid][$eventDate])
+            ) {
+                continue;
+            }
+            $normalized[] = $event;
+        }
+        return $normalized;
+    }
+}
+
+if (!function_exists('cron_GetNotificationData')) {
+    /**
+     * Cron Get Notification Data
+     *
+     * @param string $type
+     * @return array|false
+     */
+    function cron_GetNotificationData($type): bool|array
+    {
+        $db_sms_msg['notification_id'] = '';
+        $db_sms_msg['sms_gateway_type'] = '';
+
+        $query = "Select * From automatic_notification Where type = ?";
+        $db_sms_msg = sqlFetchArray(sqlStatement($query, [$type]));
+
+        return $db_sms_msg;
+    }
+}
+
+if (!function_exists('cron_InsertNotificationLogEntryFaxsms')) {
+    /**
+     * Cron Insert Notification Log Entry
+     *
+     * @param string       $type
+     * @param array<mixed> $prow
+     * @param array<mixed> $db_sms_msg
+     */
+    function cron_InsertNotificationLogEntryFaxsms($type, $prow, $db_sms_msg): void
+    {
+        $smsgateway_info = $type == 'SMS' ? "" : $db_sms_msg['email_sender'] . "|||" . $db_sms_msg['email_subject'];
+
+        $patient_info = $prow['title'] . " " . $prow['fname'] . " " . $prow['mname'] . " " . $prow['lname'] . "|||" . $prow['phone_cell'] . "|||" . $prow['email'];
+        $data_info = $prow['pc_eventDate'] . "|||" . $prow['pc_endDate'] . "|||" . $prow['pc_startTime'] . "|||" . $prow['pc_endTime'];
+        $sdate = date("Y-m-d H:i:s");
+        $sql_loginsert = "INSERT INTO `notification_log` (`iLogId` , `pid` , `pc_eid` , `sms_gateway_type` , `message` , `type` , `patient_info` , `smsgateway_info` , `pc_eventDate` , `pc_endDate` , `pc_startTime` , `pc_endTime` , `dSentDateTime`) VALUES (NULL,?,?,?,?,?,?,?,?,?,?,?,?)";
+
+        $safe = [$prow['pid'], $prow['pc_eid'], $db_sms_msg['sms_gateway_type'], $db_sms_msg['message'], $db_sms_msg['type'], $patient_info, $smsgateway_info, $prow['pc_eventDate'], $prow['pc_endDate'], $prow['pc_startTime'], $prow['pc_endTime'], $sdate];
+
+        sqlStatement($sql_loginsert, $safe);
+    }
+}

--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php
@@ -39,7 +39,18 @@
  */
 
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
+
+// faxsms_getAlertPatientData() calls fetchEvents(), which lives in
+// library/appointments.inc.php. The popup entry rc_sms_notification.php
+// requires that file before requiring us; the CLI entry point in
+// run_notifications.php does not, so when this file is loaded from the
+// background-services orchestrator (Notification_Email_Task), fetchEvents
+// is undefined and the task throws "Call to undefined function fetchEvents()".
+// Co-locate the require with the function that needs it so any future
+// caller of this helpers file gets the dependency for free.
+require_once OEGlobalsBag::getInstance()->getSrcDir() . '/appointments.inc.php';
 
 if (!function_exists('rc_sms_notification_cron_update_entry')) {
     /**

--- a/interface/modules/custom_modules/oe-module-faxsms/library/run_notifications.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/run_notifications.php
@@ -1,23 +1,83 @@
 <?php
 
+/**
+ * CLI entry for the `Notification_Email_Task` / `Notification_SMS_Task`
+ * background services.
+ *
+ * `BackgroundServiceRunner::executeService()` (driven by `bin/console
+ * background:services run` and the legacy
+ * `library/ajax/execute_background_services.php` cron entry) dispatches
+ * background jobs by symbolic function name from the
+ * `background_services` table, so the two task entry points must live
+ * in the global namespace. Everything past CLI-to-legacy translation
+ * lives in `OpenEMR\Modules\FaxSMS\Notification\BackgroundReminderTask`.
+ *
+ * Both task functions populate `$_GET['site']` / `$_GET['type']` for
+ * legacy code paths (AppDispatch and the procedural helpers) that
+ * read them as their request context. The active site is resolved
+ * from the session (populated by `bin/console` or the legacy cron
+ * entry), falling back to 'default' so a misconfigured cron can't
+ * silently target the wrong site.
+ *
+ * Unlike the admin popup entry `rc_sms_notification.php`, this path:
+ *
+ *   - Does NOT render HTML; results are reported via PSR-3 log
+ *     context and surfaced to the operator through the service
+ *     status in `background_services` plus Symfony console output.
+ *   - Does NOT run an ACL check. The original scan-and-send page
+ *     called `die("Not Authorised!")` when invoked without a
+ *     populated interactive session, which `BackgroundServiceRunner`
+ *     counted as a successful run — the silent failure reported in
+ *     issue #11827. Background workers always bootstrap with
+ *     `$ignoreAuth = true`, which the FaxSMS `AppDispatch`
+ *     constructor honors to skip the session-scoped ACL gate.
+ *   - Throws when the runner reports failures so the orchestrator
+ *     records the service as `error`, not `executed`.
+ *
+ * The procedural helpers (SQL, dedup, log insert) live in
+ * `rc_sms_notification_helpers.php`.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Jerry Padgett
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2018-2024 Jerry Padgett
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ *
+ * @codeCoverageIgnore CLI-bootstrap shim that exists solely to bridge the
+ *     global-namespace function dispatch in `BackgroundServiceRunner` to
+ *     the typed `BackgroundReminderTask`. It writes `$_GET['site']` /
+ *     `$_GET['type']` for downstream legacy code, opens the active
+ *     session, and requires `globals.php` — none of which is reachable
+ *     in an isolated test. The reminder pipeline below the bridge is
+ *     covered in `AppointmentNotificationRunnerTest`. Removing this
+ *     file is tracked in #11848.
+ */
+
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
+use OpenEMR\Modules\FaxSMS\Notification\BackgroundReminderTask;
 
-function doEmailNotificationTask(): void
-{
-    $scheduled_task_flag = 1;
-    $_GET['type'] = 'email';
-    $session = SessionWrapperFactory::getInstance()->getActiveSession();
-    $_GET['site'] = $session->get('site_id');
+require_once(__DIR__ . '/rc_sms_notification_helpers.php');
 
-    require_once("rc_sms_notification.php");
+if (!function_exists('doEmailNotificationTask')) {
+    function doEmailNotificationTask(): void
+    {
+        $sessionSite = SessionWrapperFactory::getInstance()->getActiveSession()->get('site_id');
+        $_GET['site'] = is_string($sessionSite) && $sessionSite !== '' ? $sessionSite : 'default';
+        $_GET['type'] = 'email';
+        BackgroundReminderTask::run(NotificationChannel::EMAIL);
+    }
 }
 
-function doSmsNotificationTask(): void
-{
-    $scheduled_task_flag = 1;
-    $_GET['type'] = 'sms';
-    $session = SessionWrapperFactory::getInstance()->getActiveSession();
-    $_GET['site'] = $session->get('site_id');
-
-    require_once("rc_sms_notification.php");
+if (!function_exists('doSmsNotificationTask')) {
+    function doSmsNotificationTask(): void
+    {
+        $sessionSite = SessionWrapperFactory::getInstance()->getActiveSession()->get('site_id');
+        $_GET['site'] = is_string($sessionSite) && $sessionSite !== '' ? $sessionSite : 'default';
+        $_GET['type'] = 'sms';
+        BackgroundReminderTask::run(NotificationChannel::SMS);
+    }
 }

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
@@ -62,7 +62,15 @@ abstract class AppDispatch
             self::$_apiModule = $_REQUEST['type'] ?? $this->_session->get('oefax_current_module_type') ?? null;
         }
         $this->crypto = ServiceContainer::getCrypto();
-        if (!$this->verifyAcl()) {
+        // Background-service workers (bin/console background:services run,
+        // ajax/execute_background_services.php under cron) bootstrap with
+        // $ignoreAuth = true because there is no interactive session. In
+        // that context there is no authUser for AclMain to check against,
+        // so verifyAcl() would always fail and AccessDeniedHelper::deny()
+        // would exit(1) before the reminder job could run — the silent
+        // background-service failure reported in issue #11827.
+        $ignoreAuth = OEGlobalsBag::getInstance()->getBoolean('ignoreAuth');
+        if (!$ignoreAuth && !$this->verifyAcl()) {
             AccessDeniedHelper::deny('FaxSMS module access denied');
         }
         $this->dispatchActions();
@@ -145,7 +153,7 @@ abstract class AppDispatch
      * @param mixed|null $default
      * @return mixed|null
      */
-    public function getSession(string $param = null, mixed $default = null): mixed
+    public function getSession(?string $param = null, mixed $default = null): mixed
     {
         if ($param) {
             return $this->_session->get($param) ?? $default;

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Notification/AppointmentNotificationRunner.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Notification/AppointmentNotificationRunner.php
@@ -1,0 +1,391 @@
+<?php
+
+/**
+ * Scans pending appointments and delivers email or SMS reminders.
+ *
+ * Extracted from the top-level scan-and-send loop in
+ * `library/rc_sms_notification.php` so background services running under
+ * `bin/console background:services run` can invoke the delivery pipeline
+ * directly — without the HTML-popup chrome, the session-bound ACL gate,
+ * and the `die("Not Authorised!")` silent-success that #11827 reported.
+ *
+ * The runner owns only the "scan + decide window + send + log" pipeline.
+ * Transport construction (EmailClient / *SMSClient), credential loading,
+ * and ACL gating stay outside: the calling entry point resolves those and
+ * hands the runner a fully configured client.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\FaxSMS\Notification;
+
+use OpenEMR\Appointment\Reminder\ReminderRunResult;
+use OpenEMR\Modules\FaxSMS\Controller\AppDispatch;
+use OpenEMR\Modules\FaxSMS\Controller\EmailClient;
+use OpenEMR\Modules\FaxSMS\Controller\NotificationTaskManager;
+use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
+use OpenEMR\Modules\FaxSMS\Exception\EmailSendFailedException;
+use OpenEMR\Modules\FaxSMS\Exception\InvalidEmailAddressException;
+use OpenEMR\Modules\FaxSMS\Exception\SmtpNotConfiguredException;
+use PHPMailer\PHPMailer\Exception as PHPMailerException;
+use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+class AppointmentNotificationRunner
+{
+    private readonly LoggerInterface $logger;
+    private readonly ClockInterface $clock;
+
+    /**
+     * @param NotificationChannel $channel             Which reminder channel to process.
+     * @param AppDispatch         $client              Configured email or SMS client.
+     * @param int                 $notificationHours   Appointment lead time (hours ahead).
+     * @param int                 $cronIntervalHours   Background-service execution interval, in hours.
+     * @param bool                $dryRun              When true, scans and logs but sends nothing.
+     * @param string              $messageTemplate     Raw template with ***PLACEHOLDER*** tokens.
+     * @param string              $gatewayType         Vendor slug persisted to notification_log.
+     * @param LoggerInterface|null $logger             PSR-3 logger (NullLogger when omitted).
+     * @param ClockInterface|null  $clock              Injected clock for deterministic tests.
+     */
+    public function __construct(
+        private readonly NotificationChannel $channel,
+        private readonly AppDispatch $client,
+        private readonly int $notificationHours,
+        private readonly int $cronIntervalHours,
+        private readonly bool $dryRun,
+        private readonly string $messageTemplate,
+        private readonly string $gatewayType,
+        ?LoggerInterface $logger = null,
+        ?ClockInterface $clock = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+        $this->clock = $clock ?? new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable();
+            }
+        };
+    }
+
+    public function run(): ReminderRunResult
+    {
+        $appointments = $this->fetchPendingAppointments();
+        $scanned = count($appointments);
+        $inWindow = 0;
+        $sent = 0;
+        $skippedInvalid = 0;
+        $failed = 0;
+
+        foreach ($appointments as $row) {
+            if (!$this->isInCronWindow($row)) {
+                continue;
+            }
+            $inWindow++;
+
+            $outcome = $this->deliver($row);
+            match ($outcome) {
+                DeliveryOutcome::Sent => $sent++,
+                DeliveryOutcome::SkippedInvalid => $skippedInvalid++,
+                DeliveryOutcome::Failed => $failed++,
+                DeliveryOutcome::DryRun => null,
+            };
+        }
+
+        $result = new ReminderRunResult(
+            scanned: $scanned,
+            inWindow: $inWindow,
+            sent: $sent,
+            skippedInvalid: $skippedInvalid,
+            failed: $failed,
+        );
+
+        $this->logger->info('Appointment notification run complete.', [
+            'channel' => $this->channel->value,
+            'dry_run' => $this->dryRun,
+            ...$result->toArray(),
+        ]);
+
+        return $result;
+    }
+
+    /**
+     * Compute the signed remainder-to-send-window, in hours. Negative when
+     * the ideal send time has passed, 0 at the exact send moment.
+     */
+    public static function computeRemainingHours(
+        int $appointmentTimestamp,
+        int $nowTimestamp,
+        int $notificationHours,
+    ): int {
+        $apptHour = (int) round($appointmentTimestamp / 3600);
+        $nowHour = (int) round($nowTimestamp / 3600);
+        $remainingApptHour = $apptHour - $nowHour;
+        return (int) round($remainingApptHour - $notificationHours);
+    }
+
+    /**
+     * Substitute ***NAME*** / ***PROVIDER*** / ***DATE*** / ***STARTTIME*** /
+     * ***ENDTIME*** / ***ORG*** tokens in the message template with row data.
+     * Pure; callable from isolated tests without a DB.
+     *
+     * @param array<mixed> $row Event + patient row from faxsms_getAlertPatientData().
+     */
+    public static function renderMessage(string $template, array $row): string
+    {
+        $name = trim(sprintf(
+            '%s %s %s %s',
+            self::stringFromRow($row, 'title'),
+            self::stringFromRow($row, 'fname'),
+            self::stringFromRow($row, 'mname'),
+            self::stringFromRow($row, 'lname'),
+        ));
+        $provider = trim(sprintf(
+            '%s %s %s',
+            self::stringFromRow($row, 'utitle'),
+            self::stringFromRow($row, 'ufname'),
+            self::stringFromRow($row, 'ulname'),
+        ));
+        $org = self::stringFromRow($row, 'name');
+        $eventDate = self::stringFromRow($row, 'pc_eventDate');
+        $startTime = self::stringFromRow($row, 'pc_startTime');
+        $endTime = self::stringFromRow($row, 'pc_endTime');
+
+        $dt = strtotime(sprintf('%s %s', $eventDate, $startTime));
+        $dateStr = $dt !== false ? date('l F j, Y', $dt) : $eventDate;
+        $startStr = $dt !== false ? date('g:i A', $dt) : $startTime;
+
+        $replacements = [
+            '***NAME***' => $name,
+            '***PROVIDER***' => $provider,
+            '***DATE***' => $dateStr,
+            '***STARTTIME***' => $startStr,
+            '***ENDTIME***' => $endTime,
+            '***ORG***' => $org,
+        ];
+
+        return text(strtr($template, $replacements));
+    }
+
+    /**
+     * Pull a string value out of an event/patient row whose values are
+     * `mixed` per the type contract on the legacy fetchEvents() helpers.
+     * String values pass through verbatim; numeric values are stringified
+     * (lossless for ints and floats); anything else (null, bool, array,
+     * object) becomes the empty string. Centralizes the narrow-don't-cast
+     * logic so renderMessage and the delivery helpers don't have to.
+     *
+     * @param array<mixed> $row
+     */
+    private static function stringFromRow(array $row, string $key): string
+    {
+        $value = $row[$key] ?? null;
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        return '';
+    }
+
+    /**
+     * Normalize a phone string to 10 digits, stripping a leading country
+     * code of 1. Returns the normalized digits, or null when the input does
+     * not yield exactly 10 digits after cleanup.
+     */
+    public static function normalizePhone(?string $phone): ?string
+    {
+        $digits = preg_replace('/[^0-9]/', '', $phone ?? '');
+        if (!is_string($digits)) {
+            return null;
+        }
+        if (strlen($digits) === 11 && $digits[0] === '1') {
+            $digits = substr($digits, 1);
+        }
+        return strlen($digits) === 10 ? $digits : null;
+    }
+
+    /**
+     * @return list<array<mixed>>
+     */
+    protected function fetchPendingAppointments(): array
+    {
+        return faxsms_getAlertPatientData($this->channel, $this->notificationHours);
+    }
+
+    /**
+     * @param array<mixed> $row
+     */
+    private function isInCronWindow(array $row): bool
+    {
+        $eventDate = self::stringFromRow($row, 'pc_eventDate');
+        $startTime = self::stringFromRow($row, 'pc_startTime');
+        $apptTs = strtotime(sprintf('%s %s', $eventDate, $startTime));
+        if ($apptTs === false) {
+            return false;
+        }
+        $nowTs = $this->clock->now()->getTimestamp();
+        $remainHour = self::computeRemainingHours($apptTs, $nowTs, $this->notificationHours);
+        return NotificationTaskManager::isWithinCronWindow($remainHour, $this->cronIntervalHours);
+    }
+
+    /**
+     * @param array<mixed> $row
+     */
+    private function deliver(array $row): DeliveryOutcome
+    {
+        $message = self::renderMessage($this->messageTemplate, $row);
+        $logData = [
+            'type' => $this->channel->value,
+            'sms_gateway_type' => $this->gatewayType,
+            'message' => $message,
+            'email_sender' => '',
+            'email_subject' => '',
+        ];
+
+        return match ($this->channel) {
+            NotificationChannel::SMS => $this->deliverSms($row, $message, $logData),
+            NotificationChannel::EMAIL => $this->deliverEmail($row, $message, $logData),
+        };
+    }
+
+    /**
+     * @param array<mixed> $row
+     * @param array<mixed> $logData
+     */
+    private function deliverSms(array $row, string $message, array $logData): DeliveryOutcome
+    {
+        $phone = self::stringFromRow($row, 'phone_cell');
+        $normalized = self::normalizePhone($phone === '' ? null : $phone);
+        if ($normalized === null) {
+            $this->logger->warning('Skipping SMS reminder: invalid phone number.', [
+                'pid' => $row['pid'] ?? null,
+                'pc_eid' => $row['pc_eid'] ?? null,
+            ]);
+            if (!$this->dryRun) {
+                cron_InsertNotificationLogEntryFaxsms($this->channel->value, $row, array_merge($logData, [
+                    'message' => 'Error: INVALID Mobile Phone',
+                ]));
+            }
+            return DeliveryOutcome::SkippedInvalid;
+        }
+
+        if ($this->dryRun) {
+            return DeliveryOutcome::DryRun;
+        }
+
+        try {
+            /** @phpstan-ignore-next-line method.notFound (SMS client subclasses override this with 4-arg signature) */
+            $error = $this->client->sendSMS(
+                $normalized,
+                self::stringFromRow($logData, 'email_subject'),
+                $message,
+                self::stringFromRow($logData, 'email_sender'),
+            );
+        } catch (\RuntimeException $e) {
+            // Per-appointment delivery is best-effort: a runtime
+            // failure for one recipient (vendor ACL gate, transport
+            // error) records a Failed outcome and lets the batch keep
+            // processing. Anything not a RuntimeException — \Error
+            // subclasses or unexpected exception types — propagates
+            // so the operator sees a real run-level failure instead
+            // of an identical error stacking up across every row.
+            $this->logger->error('SMS reminder send threw an exception.', [
+                'pid' => $row['pid'] ?? null,
+                'pc_eid' => $row['pc_eid'] ?? null,
+                'exception' => $e,
+            ]);
+            return DeliveryOutcome::Failed;
+        }
+
+        if (is_string($error) && stripos($error, 'error') !== false) {
+            $this->logger->error('SMS reminder send reported an error.', [
+                'pid' => $row['pid'] ?? null,
+                'pc_eid' => $row['pc_eid'] ?? null,
+                'provider_error' => $error,
+            ]);
+            return DeliveryOutcome::Failed;
+        }
+
+        cron_InsertNotificationLogEntryFaxsms($this->channel->value, $row, $logData);
+        $this->markNotified($row);
+        return DeliveryOutcome::Sent;
+    }
+
+    /**
+     * @param array<mixed> $row
+     * @param array<mixed> $logData
+     */
+    private function deliverEmail(array $row, string $message, array $logData): DeliveryOutcome
+    {
+        $emailClient = $this->client;
+        if (!$emailClient instanceof EmailClient) {
+            throw new \LogicException('Email channel requires an EmailClient instance.');
+        }
+
+        $email = self::stringFromRow($row, 'email');
+        if (!$emailClient->validEmail($email)) {
+            $this->logger->warning('Skipping email reminder: invalid recipient.', [
+                'pid' => $row['pid'] ?? null,
+                'pc_eid' => $row['pc_eid'] ?? null,
+            ]);
+            if (!$this->dryRun) {
+                cron_InsertNotificationLogEntryFaxsms($this->channel->value, $row, array_merge($logData, [
+                    'message' => 'Error: INVALID EMAIL',
+                ]));
+            }
+            return DeliveryOutcome::SkippedInvalid;
+        }
+
+        if ($this->dryRun) {
+            return DeliveryOutcome::DryRun;
+        }
+
+        try {
+            $emailClient->emailReminder($email, $message);
+        } catch (InvalidEmailAddressException) {
+            return DeliveryOutcome::SkippedInvalid;
+        } catch (SmtpNotConfiguredException $e) {
+            $this->logger->error('Email reminder failed: SMTP not configured.', [
+                'exception' => $e,
+            ]);
+            return DeliveryOutcome::Failed;
+        } catch (EmailSendFailedException | PHPMailerException $e) {
+            $this->logger->error('Email reminder send threw an exception.', [
+                'pid' => $row['pid'] ?? null,
+                'pc_eid' => $row['pc_eid'] ?? null,
+                'exception' => $e,
+            ]);
+            return DeliveryOutcome::Failed;
+        }
+
+        cron_InsertNotificationLogEntryFaxsms($this->channel->value, $row, $logData);
+        $this->markNotified($row);
+        return DeliveryOutcome::Sent;
+    }
+
+    /**
+     * @param array<mixed> $row
+     */
+    private function markNotified(array $row): void
+    {
+        if ($this->dryRun) {
+            return;
+        }
+        $pid = $row['pid'] ?? null;
+        $pcEid = $row['pc_eid'] ?? null;
+        if (!is_numeric($pid) || !is_numeric($pcEid)) {
+            return;
+        }
+        $recur = self::stringFromRow($row, 'pc_recurrtype');
+        rc_sms_notification_cron_update_entry($this->channel, (int) $pid, (int) $pcEid, $recur);
+    }
+}

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Notification/BackgroundReminderTask.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Notification/BackgroundReminderTask.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Bridge between BackgroundServiceRunner and AppointmentNotificationRunner.
+ *
+ * `Notification_Email_Task` / `Notification_SMS_Task` are dispatched via
+ * the `background_services` table by symbolic function name, so the
+ * task entry points must live in the global namespace
+ * (`doEmailNotificationTask`, `doSmsNotificationTask` in
+ * `library/run_notifications.php`). Everything else they need —
+ * resolving the channel client, narrowing credentials, raising on
+ * failure so the orchestrator records `error` — lives here so the
+ * loose-function entry points stay tiny.
+ *
+ * This class deliberately does NOT touch `$_GET` / `$_REQUEST` / other
+ * superglobals; the caller in `library/run_notifications.php` is the
+ * system boundary that owns CLI-to-legacy translation. Keep this class
+ * superglobal-free so it can be exercised from a unit test and reused
+ * from any other entry point that already has a populated request
+ * context.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ *
+ * @codeCoverageIgnore Thin bridge: resolves the channel client through
+ *     `AppDispatch::getApiService()` (DB-backed), narrows credentials,
+ *     and constructs the runner. Each step pulls in live module
+ *     bootstrap state that an isolated test cannot supply. The
+ *     scan-and-send pipeline below this bridge is covered in
+ *     `AppointmentNotificationRunnerTest`. The follow-up issue #11848
+ *     proposes replacing this class with a PSR-11-resolved job, at
+ *     which point the bridge itself goes away.
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\FaxSMS\Notification;
+
+use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Modules\FaxSMS\Controller\AppDispatch;
+use OpenEMR\Modules\FaxSMS\Controller\EmailClient;
+use OpenEMR\Modules\FaxSMS\Controller\NotificationTaskManager;
+use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
+
+final class BackgroundReminderTask
+{
+    /**
+     * Shared body for the email and SMS background tasks.
+     *
+     * Throws on runner failures so `BackgroundServiceRunner` reports
+     * the service as `error` instead of silently recording `executed`.
+     */
+    public static function run(NotificationChannel $channel): void
+    {
+        $logger = ServiceContainer::getLogger();
+        $globals = OEGlobalsBag::getInstance();
+
+        // Publish ignoreAuth before resolving the client.
+        // AppDispatch::__construct() reads it via OEGlobalsBag and
+        // skips the session-scoped ACL gate when it's true — there is
+        // no interactive session for AclMain to check against. See
+        // issue #11827.
+        $globals->set('ignoreAuth', true);
+
+        $client = AppDispatch::getApiService($channel === NotificationChannel::EMAIL ? 'email' : 'sms');
+        if (!$client instanceof AppDispatch) {
+            throw new \RuntimeException(sprintf(
+                'Failed to resolve %s client for appointment reminders.',
+                $channel->value,
+            ));
+        }
+        $credentials = $client instanceof EmailClient
+            ? $client->getEmailSetup()
+            : $client->getCredentials();
+
+        // getCredentials() / getEmailSetup() are typed `mixed` because the
+        // various vendor clients return their own credential shapes.
+        // Narrow defensively so a misconfigured credential row can't
+        // smuggle non-scalar junk through.
+        $credentialsArray = is_array($credentials) ? $credentials : [];
+        $notificationHoursRaw = $credentialsArray['smsHours'] ?? $credentialsArray['notification_hours'] ?? 24;
+        $notificationHours = is_numeric($notificationHoursRaw) ? (int) $notificationHoursRaw : 24;
+        $messageTemplateRaw = $credentialsArray['smsMessage'] ?? $credentialsArray['email_message'] ?? '';
+        $messageTemplate = is_string($messageTemplateRaw) ? $messageTemplateRaw : '';
+        $vendor = AppDispatch::getModuleVendor();
+        $gatewayType = is_string($vendor) ? $vendor : '';
+
+        $cronIntervalHours = (new NotificationTaskManager())->getTaskHours(strtolower($channel->value));
+
+        // The background path never runs in dry-run mode; live delivery
+        // is the whole point of the scheduled task. Keep bTestRun in
+        // sync for the legacy helper that still reads it.
+        $globals->set('bTestRun', false);
+
+        set_time_limit(0);
+
+        $runner = new AppointmentNotificationRunner(
+            channel: $channel,
+            client: $client,
+            notificationHours: $notificationHours,
+            cronIntervalHours: $cronIntervalHours,
+            dryRun: false,
+            messageTemplate: $messageTemplate,
+            gatewayType: $gatewayType,
+            logger: $logger,
+        );
+
+        $result = $runner->run();
+
+        if ($result->hasFailures()) {
+            throw new \RuntimeException(sprintf(
+                'Appointment reminder run for %s completed with %d failure(s); see log for details.',
+                $channel->value,
+                $result->failed,
+            ));
+        }
+    }
+}

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Notification/DeliveryOutcome.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Notification/DeliveryOutcome.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Per-row delivery outcomes from AppointmentNotificationRunner.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\FaxSMS\Notification;
+
+enum DeliveryOutcome
+{
+    case Sent;
+    case SkippedInvalid;
+    case Failed;
+    case DryRun;
+}

--- a/src/Appointment/Reminder/ReminderRunResult.php
+++ b/src/Appointment/Reminder/ReminderRunResult.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Immutable result of an appointment-reminder run.
+ *
+ * Shared vocabulary for any module that scans upcoming appointments and
+ * dispatches reminders (SMS, email, third-party messaging, etc.). Lives in
+ * `src/` rather than inside a single module so modules can report results
+ * in a consistent shape without each one inventing its own counts array.
+ *
+ * The bodies of the individual per-module runners stay in their modules;
+ * only this result type is promoted to core. See issue #11827 for the
+ * original refactor and the follow-up issue for a core
+ * AppointmentReminderJob interface.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Appointment\Reminder;
+
+final readonly class ReminderRunResult
+{
+    /**
+     * @param int $scanned         Candidate appointments returned by the module's scan query.
+     * @param int $inWindow        Subset of candidates inside the send-now window.
+     * @param int $sent            Messages the transport reported as sent.
+     * @param int $skippedInvalid  Rows skipped because the recipient (phone/email) was invalid or ineligible.
+     * @param int $failed          Rows that hit a transport/provider error or caught exception.
+     */
+    public function __construct(
+        public int $scanned,
+        public int $inWindow,
+        public int $sent,
+        public int $skippedInvalid,
+        public int $failed,
+    ) {
+    }
+
+    public function hasFailures(): bool
+    {
+        return $this->failed > 0;
+    }
+
+    /**
+     * @return array{scanned: int, in_window: int, sent: int, skipped_invalid: int, failed: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'scanned' => $this->scanned,
+            'in_window' => $this->inWindow,
+            'sent' => $this->sent,
+            'skipped_invalid' => $this->skippedInvalid,
+            'failed' => $this->failed,
+        ];
+    }
+}

--- a/src/Services/Background/BackgroundServiceRunner.php
+++ b/src/Services/Background/BackgroundServiceRunner.php
@@ -125,7 +125,17 @@ class BackgroundServiceRunner
             try {
                 $this->executeService($service);
                 $results[] = ['name' => $name, 'status' => 'executed'];
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                // Without this log the orchestrator records status=error with
+                // no exception class, message, file, line, or trace anywhere.
+                // Diagnosing a service failure then requires attaching to a
+                // pod and running an instrumented one-shot script. The cron
+                // regression in #11827 shipped undetected because this catch
+                // swallowed the exception.
+                $this->logger->error('Background service execution failed.', [
+                    'service' => $name,
+                    'exception' => $e,
+                ]);
                 $results[] = ['name' => $name, 'status' => 'error'];
             } finally {
                 $this->safeReleaseLock($name);

--- a/tests/Tests/Isolated/Appointment/Reminder/ReminderRunResultTest.php
+++ b/tests/Tests/Isolated/Appointment/Reminder/ReminderRunResultTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Isolated test for the ReminderRunResult DTO.
+ *
+ * The DTO is read-only and its surface is small (counts, hasFailures(),
+ * toArray()), so the test pins the contract — particularly the
+ * snake_case keys on toArray() that PSR-3 logger context arrays rely
+ * on across modules.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Appointment\Reminder;
+
+use OpenEMR\Appointment\Reminder\ReminderRunResult;
+use PHPUnit\Framework\TestCase;
+
+class ReminderRunResultTest extends TestCase
+{
+    public function testStoresAllCounts(): void
+    {
+        $result = new ReminderRunResult(
+            scanned: 10,
+            inWindow: 6,
+            sent: 4,
+            skippedInvalid: 1,
+            failed: 1,
+        );
+
+        $this->assertSame(10, $result->scanned);
+        $this->assertSame(6, $result->inWindow);
+        $this->assertSame(4, $result->sent);
+        $this->assertSame(1, $result->skippedInvalid);
+        $this->assertSame(1, $result->failed);
+    }
+
+    public function testHasFailuresIsTrueWhenFailedNonZero(): void
+    {
+        $result = new ReminderRunResult(scanned: 1, inWindow: 1, sent: 0, skippedInvalid: 0, failed: 1);
+
+        $this->assertTrue($result->hasFailures());
+    }
+
+    public function testHasFailuresIsFalseWhenFailedZero(): void
+    {
+        $result = new ReminderRunResult(scanned: 5, inWindow: 5, sent: 4, skippedInvalid: 1, failed: 0);
+
+        $this->assertFalse($result->hasFailures());
+    }
+
+    public function testToArrayUsesSnakeCaseKeys(): void
+    {
+        $result = new ReminderRunResult(scanned: 7, inWindow: 5, sent: 3, skippedInvalid: 1, failed: 1);
+
+        $this->assertSame(
+            [
+                'scanned' => 7,
+                'in_window' => 5,
+                'sent' => 3,
+                'skipped_invalid' => 1,
+                'failed' => 1,
+            ],
+            $result->toArray(),
+        );
+    }
+}

--- a/tests/Tests/Isolated/Modules/FaxSMS/Notification/AppointmentNotificationRunnerTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Notification/AppointmentNotificationRunnerTest.php
@@ -1,0 +1,567 @@
+<?php
+
+/**
+ * Isolated tests for AppointmentNotificationRunner.
+ *
+ * Covers two layers:
+ *
+ *   1. The pure static helpers (`computeRemainingHours`, `normalizePhone`,
+ *      `renderMessage`) — pull them out and pin behavior independently
+ *      so refactoring the orchestrator can't quietly change phone
+ *      normalization or the cron-window math.
+ *
+ *   2. The `run()` orchestrator and the per-channel delivery helpers,
+ *      exercised through fake `AppDispatch` / `EmailClient` subclasses
+ *      that bypass the heavy real-world constructors. The fakes record
+ *      what the runner asked them to do; stub global functions
+ *      (`cron_InsertNotificationLogEntryFaxsms`,
+ *      `rc_sms_notification_cron_update_entry`, `text`) capture the
+ *      legacy SQL/log calls so we can assert that the dry-run path
+ *      doesn't insert log rows and the happy path does.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Modules\FaxSMS\Notification;
+
+// Spy lives in the global namespace (declared in runner_test_stubs.php
+// via bracketed namespace) so the in-namespace function stubs can write
+// to it. Alias it locally for terse references in the test class.
+use AppointmentNotificationRunnerTestSpy as RunnerTestSpy;
+use OpenEMR\Modules\FaxSMS\Controller\AppDispatch;
+use OpenEMR\Modules\FaxSMS\Controller\EmailClient;
+use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
+use OpenEMR\Modules\FaxSMS\Exception\EmailSendFailedException;
+use OpenEMR\Modules\FaxSMS\Exception\InvalidEmailAddressException;
+use OpenEMR\Modules\FaxSMS\Exception\SmtpNotConfiguredException;
+use OpenEMR\Modules\FaxSMS\Notification\AppointmentNotificationRunner;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+
+// Module classes live under interface/modules/custom_modules/oe-module-faxsms/
+// and aren't covered by the root composer autoloader. Require the chain
+// the test actually touches; everything else stays lazy.
+require_once __DIR__ . '/../../../../../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php';
+require_once __DIR__ . '/../../../../../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php';
+require_once __DIR__ . '/../../../../../../interface/modules/custom_modules/oe-module-faxsms/src/Exception/EmailException.php';
+require_once __DIR__ . '/../../../../../../interface/modules/custom_modules/oe-module-faxsms/src/Exception/EmailSendFailedException.php';
+require_once __DIR__ . '/../../../../../../interface/modules/custom_modules/oe-module-faxsms/src/Exception/InvalidEmailAddressException.php';
+require_once __DIR__ . '/../../../../../../interface/modules/custom_modules/oe-module-faxsms/src/Exception/SmtpNotConfiguredException.php';
+require_once __DIR__ . '/../../../../../../interface/modules/custom_modules/oe-module-faxsms/src/Notification/DeliveryOutcome.php';
+require_once __DIR__ . '/../../../../../../interface/modules/custom_modules/oe-module-faxsms/src/Notification/AppointmentNotificationRunner.php';
+
+// `text()` and the two procedural helpers (`cron_InsertNotificationLogEntryFaxsms`,
+// `rc_sms_notification_cron_update_entry`) are looked up unqualified by the
+// runner, which lands in OpenEMR\Modules\FaxSMS\Notification first. The
+// stubs and shared spy state live in `runner_test_stubs.php` because that
+// file uses bracketed namespace syntax to declare symbols in both the
+// runner's namespace and global at once — not possible from this file's
+// single-namespace declaration.
+require_once __DIR__ . '/runner_test_stubs.php';
+
+/**
+ * AppDispatch is abstract and constructs heavy session/ACL state;
+ * skip its constructor entirely and only implement the surface the
+ * runner actually calls.
+ */
+class FakeSmsClient extends AppDispatch
+{
+    public string|\Throwable $sendResult = '';
+    public int $sendCalls = 0;
+
+    public function __construct()
+    {
+        // Skip parent::__construct() — none of its session/crypto setup is needed.
+    }
+
+    public function sendSMS(string $toPhone = '', string $subject = '', string $message = '', string $from = ''): mixed
+    {
+        $this->sendCalls++;
+        if ($this->sendResult instanceof \Throwable) {
+            throw $this->sendResult;
+        }
+        return $this->sendResult;
+    }
+
+    // Remaining abstract surface — stubs that just satisfy the contract.
+    public function authenticate(): string|int|bool
+    {
+        return true;
+    }
+
+    public function sendFax(): string|bool
+    {
+        return true;
+    }
+
+    public function sendEmail(): mixed
+    {
+        return true;
+    }
+
+    public function fetchReminderCount(): string|bool
+    {
+        return '0';
+    }
+}
+
+class FakeEmailClient extends EmailClient
+{
+    public bool $emailIsValid = true;
+    public ?\Throwable $emailReminderThrows = null;
+    public int $emailReminderCalls = 0;
+
+    public function __construct()
+    {
+        // Skip parent::__construct() — module-enable check + crypto setup are not needed.
+    }
+
+    public function validEmail(mixed $email): bool
+    {
+        return $this->emailIsValid;
+    }
+
+    public function emailReminder(mixed $email, mixed $body): void
+    {
+        $this->emailReminderCalls++;
+        if ($this->emailReminderThrows !== null) {
+            throw $this->emailReminderThrows;
+        }
+    }
+}
+
+/**
+ * Subclass that returns a canned set of "pending appointments" instead
+ * of querying the database. `fetchPendingAppointments()` is `protected`
+ * on the base runner specifically to support this.
+ */
+class TestableRunner extends AppointmentNotificationRunner
+{
+    /** @var list<array<mixed>> */
+    public array $stubAppointments = [];
+
+    protected function fetchPendingAppointments(): array
+    {
+        return $this->stubAppointments;
+    }
+}
+
+/**
+ * Deterministic clock for cron-window math.
+ */
+class FixedClock implements ClockInterface
+{
+    public function __construct(private readonly \DateTimeImmutable $now)
+    {
+    }
+
+    public function now(): \DateTimeImmutable
+    {
+        return $this->now;
+    }
+}
+
+class AppointmentNotificationRunnerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        RunnerTestSpy::reset();
+    }
+
+    #[DataProvider('remainingHoursProvider')]
+    public function testComputeRemainingHours(
+        int $appointmentTimestamp,
+        int $nowTimestamp,
+        int $notificationHours,
+        int $expected,
+    ): void {
+        $this->assertSame(
+            $expected,
+            AppointmentNotificationRunner::computeRemainingHours(
+                $appointmentTimestamp,
+                $nowTimestamp,
+                $notificationHours,
+            ),
+        );
+    }
+
+    /**
+     * @return array<string, array{int, int, int, int}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function remainingHoursProvider(): array
+    {
+        $now = 1_745_000_000; // arbitrary anchor
+        return [
+            'appointment 24h out, lead time 24h, send now' => [$now + 86_400, $now, 24, 0],
+            'appointment 25h out, lead time 24h, 1h early' => [$now + 90_000, $now, 24, 1],
+            'appointment 23h out, lead time 24h, 1h late'  => [$now + 82_800, $now, 24, -1],
+            'lead time 0, appointment 5h out'              => [$now + 18_000, $now, 0, 5],
+            'lead time 48h, appointment 24h out'           => [$now + 86_400, $now, 48, -24],
+        ];
+    }
+
+    #[DataProvider('phoneProvider')]
+    public function testNormalizePhone(?string $input, ?string $expected): void
+    {
+        $this->assertSame($expected, AppointmentNotificationRunner::normalizePhone($input));
+    }
+
+    /**
+     * @return array<string, array{?string, ?string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function phoneProvider(): array
+    {
+        return [
+            'plain ten digits'             => ['2125551234', '2125551234'],
+            'leading 1 stripped'           => ['12125551234', '2125551234'],
+            'formatted with parens dashes' => ['(212) 555-1234', '2125551234'],
+            'plus-prefixed E.164'          => ['+12125551234', '2125551234'],
+            'too short'                    => ['555-1234', null],
+            'eleven-digit not starting 1'  => ['22125551234', null],
+            'empty string'                 => ['', null],
+            'null input'                   => [null, null],
+            'letters only'                 => ['no-digits-here', null],
+        ];
+    }
+
+    public function testRenderMessageSubstitutesAllTokens(): void
+    {
+        $template = '***NAME*** has an appointment with ***PROVIDER*** at ***ORG*** on ***DATE*** from ***STARTTIME*** to ***ENDTIME***.';
+        $row = [
+            'title' => 'Mr.',
+            'fname' => 'Pat',
+            'mname' => 'Q',
+            'lname' => 'Patient',
+            'utitle' => 'Dr.',
+            'ufname' => 'Alex',
+            'ulname' => 'Provider',
+            'name' => 'Acme Clinic',
+            'pc_eventDate' => '2026-04-15',
+            'pc_startTime' => '10:30:00',
+            'pc_endTime' => '11:00:00',
+        ];
+
+        $rendered = AppointmentNotificationRunner::renderMessage($template, $row);
+
+        $this->assertStringContainsString('Mr. Pat Q Patient', $rendered);
+        $this->assertStringContainsString('Dr. Alex Provider', $rendered);
+        $this->assertStringContainsString('Acme Clinic', $rendered);
+        $this->assertStringContainsString('Wednesday April 15, 2026', $rendered);
+        $this->assertStringContainsString('10:30 AM', $rendered);
+        $this->assertStringContainsString('11:00:00', $rendered);
+    }
+
+    public function testRenderMessageHandlesMissingFields(): void
+    {
+        // Missing optional fields should render as empty rather than
+        // surface "Notice: undefined index" warnings.
+        $template = 'Hello ***NAME***, see you ***DATE***.';
+        $rendered = AppointmentNotificationRunner::renderMessage($template, []);
+
+        $this->assertStringContainsString('Hello', $rendered);
+        $this->assertStringContainsString('see you', $rendered);
+    }
+
+    public function testRunReturnsZeroResultWhenNoAppointmentsPending(): void
+    {
+        $runner = $this->makeSmsRunner(client: new FakeSmsClient(), dryRun: false);
+
+        $result = $runner->run();
+
+        $this->assertSame(0, $result->scanned);
+        $this->assertSame(0, $result->inWindow);
+        $this->assertSame(0, $result->sent);
+        $this->assertSame(0, $result->failed);
+        $this->assertFalse($result->hasFailures());
+    }
+
+    public function testRunSkipsAppointmentsOutsideCronWindow(): void
+    {
+        // Lead time = 24h, cron window = 1h. Appointment 100h out — way
+        // outside the send-now window.
+        $client = new FakeSmsClient();
+        $runner = $this->makeSmsRunner(
+            client: $client,
+            dryRun: false,
+            appointments: [$this->makeRow(['phone_cell' => '2125551234', 'pc_eventDate' => '2030-01-01', 'pc_startTime' => '10:00:00'])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->scanned);
+        $this->assertSame(0, $result->inWindow);
+        $this->assertSame(0, $client->sendCalls);
+    }
+
+    public function testRunSmsHappyPathSendsAndLogsAndMarks(): void
+    {
+        $client = new FakeSmsClient();
+        $client->sendResult = '';
+        $runner = $this->makeSmsRunner(
+            client: $client,
+            dryRun: false,
+            appointments: [$this->makeRow(['phone_cell' => '2125551234'])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->scanned);
+        $this->assertSame(1, $result->inWindow);
+        $this->assertSame(1, $result->sent);
+        $this->assertSame(0, $result->failed);
+        $this->assertSame(1, $client->sendCalls);
+        $this->assertCount(1, RunnerTestSpy::$logCalls);
+        $this->assertCount(1, RunnerTestSpy::$markCalls);
+    }
+
+    public function testRunSmsInvalidPhoneIsSkippedAndLoggedAsInvalid(): void
+    {
+        $client = new FakeSmsClient();
+        $runner = $this->makeSmsRunner(
+            client: $client,
+            dryRun: false,
+            appointments: [$this->makeRow(['phone_cell' => 'not-a-phone'])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->skippedInvalid);
+        $this->assertSame(0, $client->sendCalls);
+        $this->assertCount(1, RunnerTestSpy::$logCalls);
+        $this->assertSame('Error: INVALID Mobile Phone', RunnerTestSpy::$logCalls[0]['logData']['message']);
+        $this->assertCount(0, RunnerTestSpy::$markCalls);
+    }
+
+    public function testRunSmsProviderErrorStringIsRecordedAsFailure(): void
+    {
+        $client = new FakeSmsClient();
+        $client->sendResult = 'error: gateway rejected';
+        $runner = $this->makeSmsRunner(
+            client: $client,
+            dryRun: false,
+            appointments: [$this->makeRow(['phone_cell' => '2125551234'])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->failed);
+        $this->assertTrue($result->hasFailures());
+        $this->assertCount(0, RunnerTestSpy::$markCalls);
+    }
+
+    public function testRunSmsRuntimeExceptionIsCaughtAndRecordedAsFailure(): void
+    {
+        $client = new FakeSmsClient();
+        $client->sendResult = new \RuntimeException('vendor ACL denied');
+        $runner = $this->makeSmsRunner(
+            client: $client,
+            dryRun: false,
+            appointments: [$this->makeRow(['phone_cell' => '2125551234'])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->failed);
+    }
+
+    public function testRunSmsDryRunNeitherSendsNorLogs(): void
+    {
+        $client = new FakeSmsClient();
+        $runner = $this->makeSmsRunner(
+            client: $client,
+            dryRun: true,
+            appointments: [$this->makeRow(['phone_cell' => '2125551234'])],
+        );
+
+        $result = $runner->run();
+
+        // DryRun outcome counts toward inWindow but neither sent nor failed.
+        $this->assertSame(1, $result->inWindow);
+        $this->assertSame(0, $result->sent);
+        $this->assertSame(0, $result->failed);
+        $this->assertSame(0, $client->sendCalls);
+        $this->assertCount(0, RunnerTestSpy::$logCalls);
+        $this->assertCount(0, RunnerTestSpy::$markCalls);
+    }
+
+    public function testRunEmailHappyPathSendsAndLogsAndMarks(): void
+    {
+        $client = new FakeEmailClient();
+        $runner = $this->makeEmailRunner(
+            client: $client,
+            dryRun: false,
+            appointments: [$this->makeRow(['email' => 'pat@example.com'])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->sent);
+        $this->assertSame(0, $result->failed);
+        $this->assertSame(1, $client->emailReminderCalls);
+        $this->assertCount(1, RunnerTestSpy::$logCalls);
+        $this->assertCount(1, RunnerTestSpy::$markCalls);
+    }
+
+    public function testRunEmailInvalidEmailIsSkippedAndLogged(): void
+    {
+        $client = new FakeEmailClient();
+        $client->emailIsValid = false;
+        $runner = $this->makeEmailRunner(
+            client: $client,
+            dryRun: false,
+            appointments: [$this->makeRow(['email' => 'not-an-email'])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->skippedInvalid);
+        $this->assertSame(0, $client->emailReminderCalls);
+        $this->assertSame('Error: INVALID EMAIL', RunnerTestSpy::$logCalls[0]['logData']['message']);
+    }
+
+    public function testRunEmailInvalidAddressExceptionIsTreatedAsSkippedInvalid(): void
+    {
+        $client = new FakeEmailClient();
+        $client->emailReminderThrows = new InvalidEmailAddressException('bad address');
+        $runner = $this->makeEmailRunner(
+            client: $client,
+            dryRun: false,
+            appointments: [$this->makeRow(['email' => 'pat@example.com'])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->skippedInvalid);
+        $this->assertSame(0, $result->failed);
+    }
+
+    public function testRunEmailSmtpNotConfiguredIsRecordedAsFailure(): void
+    {
+        $client = new FakeEmailClient();
+        $client->emailReminderThrows = new SmtpNotConfiguredException('SMTP not configured');
+        $runner = $this->makeEmailRunner(
+            client: $client,
+            dryRun: false,
+            appointments: [$this->makeRow(['email' => 'pat@example.com'])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->failed);
+    }
+
+    public function testRunEmailSendFailedExceptionIsRecordedAsFailure(): void
+    {
+        $client = new FakeEmailClient();
+        $client->emailReminderThrows = new EmailSendFailedException('transport failed');
+        $runner = $this->makeEmailRunner(
+            client: $client,
+            dryRun: false,
+            appointments: [$this->makeRow(['email' => 'pat@example.com'])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->failed);
+    }
+
+    public function testRunEmailDryRunDoesNotSend(): void
+    {
+        $client = new FakeEmailClient();
+        $runner = $this->makeEmailRunner(
+            client: $client,
+            dryRun: true,
+            appointments: [$this->makeRow(['email' => 'pat@example.com'])],
+        );
+
+        $result = $runner->run();
+
+        $this->assertSame(1, $result->inWindow);
+        $this->assertSame(0, $result->sent);
+        $this->assertSame(0, $client->emailReminderCalls);
+        $this->assertCount(0, RunnerTestSpy::$logCalls);
+    }
+
+    /**
+     * Build an SMS runner anchored to a clock that puts the row exactly
+     * at the send-now moment (lead time 24h, appt 24h out, cron 1h).
+     *
+     * @param list<array<mixed>> $appointments
+     */
+    private function makeSmsRunner(
+        FakeSmsClient $client,
+        bool $dryRun,
+        array $appointments = [],
+    ): TestableRunner {
+        return $this->makeRunner(NotificationChannel::SMS, $client, $dryRun, $appointments);
+    }
+
+    /**
+     * @param list<array<mixed>> $appointments
+     */
+    private function makeEmailRunner(
+        FakeEmailClient $client,
+        bool $dryRun,
+        array $appointments = [],
+    ): TestableRunner {
+        return $this->makeRunner(NotificationChannel::EMAIL, $client, $dryRun, $appointments);
+    }
+
+    /**
+     * @param list<array<mixed>> $appointments
+     */
+    private function makeRunner(
+        NotificationChannel $channel,
+        AppDispatch $client,
+        bool $dryRun,
+        array $appointments,
+    ): TestableRunner {
+        // Anchor "now" so each row's pc_eventDate/pc_startTime sits 24h
+        // ahead — exactly inside the cron window for lead time 24h.
+        $now = new \DateTimeImmutable('2026-04-14 10:00:00');
+        $runner = new TestableRunner(
+            channel: $channel,
+            client: $client,
+            notificationHours: 24,
+            cronIntervalHours: 1,
+            dryRun: $dryRun,
+            messageTemplate: 'Hi ***NAME***, your visit is on ***DATE***.',
+            gatewayType: 'fake',
+            logger: null,
+            clock: new FixedClock($now),
+        );
+        $runner->stubAppointments = $appointments;
+        return $runner;
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function makeRow(array $overrides = []): array
+    {
+        return array_merge([
+            'pid' => 42,
+            'pc_eid' => 7,
+            'pc_eventDate' => '2026-04-15',
+            'pc_startTime' => '10:00:00',
+            'pc_endTime' => '10:30:00',
+            'pc_recurrtype' => '0',
+            'fname' => 'Pat',
+            'lname' => 'Patient',
+            'name' => 'Acme Clinic',
+        ], $overrides);
+    }
+}

--- a/tests/Tests/Isolated/Modules/FaxSMS/Notification/RcSmsNotificationHelpersTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Notification/RcSmsNotificationHelpersTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Regression guard for the helpers file's own dependency loading.
+ *
+ * `rc_sms_notification_helpers.php` is loaded from two entry points:
+ * the popup `rc_sms_notification.php` (which separately requires
+ * `library/appointments.inc.php` before us) and the CLI bridge
+ * `run_notifications.php` driven by `bin/console background:services
+ * run --name=Notification_Email_Task` (which does not). When the
+ * helpers file did not pull `appointments.inc.php` itself, the CLI
+ * path threw `Call to undefined function fetchEvents()` from
+ * `faxsms_getAlertPatientData()` — and the orchestrator's silent
+ * catch in `BackgroundServiceRunner::run` (fixed in the sibling
+ * commit) recorded `status=error` with no log line, so the regression
+ * shipped undetected. See issue #11827.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Modules\FaxSMS\Notification;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+#[Group('faxsms')]
+class RcSmsNotificationHelpersTest extends TestCase
+{
+    /**
+     * Load the helpers file in a fresh process with a stub
+     * `appointments.inc.php` on disk (pointed at by `$GLOBALS['srcdir']`)
+     * and assert that `fetchEvents()` is defined afterward. If the
+     * helpers file ever stops pulling `appointments.inc.php` itself,
+     * the CLI background-service path silently breaks again.
+     *
+     * Process isolation is required because `require_once` is process-
+     * scoped: a previous test that already loaded the helpers file
+     * (directly or transitively) would leave `function_exists()` true
+     * regardless of whether the require was wired up correctly.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testHelpersFileRequiresAppointmentsLibrary(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/oce_helpers_dep_' . uniqid('', true);
+        if (!mkdir($tempDir, 0700, true) && !is_dir($tempDir)) {
+            // @codeCoverageIgnoreStart
+            // Defensive — only fires if the OS refuses to create a fresh
+            // tempdir, which is not a path real CI exercises.
+            $this->fail("could not create temp dir {$tempDir}");
+            // @codeCoverageIgnoreEnd
+        }
+
+        try {
+            // Stub appointments.inc.php with just enough to register the
+            // symbol the helpers file consumes via fetchEvents(). Avoids
+            // dragging in the real file's transitive requires (calendar
+            // includes, xl()) which aren't loaded under isolated tests.
+            file_put_contents(
+                $tempDir . '/appointments.inc.php',
+                "<?php\nfunction fetchEvents(): array { return []; }\n",
+            );
+            $GLOBALS['srcdir'] = $tempDir;
+
+            require_once dirname(__DIR__, 6)
+                . '/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php';
+
+            $this->assertTrue(
+                function_exists('fetchEvents'),
+                'rc_sms_notification_helpers.php must require appointments.inc.php so fetchEvents() is available to faxsms_getAlertPatientData()',
+            );
+        } finally {
+            @unlink($tempDir . '/appointments.inc.php');
+            @rmdir($tempDir);
+        }
+    }
+}

--- a/tests/Tests/Isolated/Modules/FaxSMS/Notification/runner_test_stubs.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Notification/runner_test_stubs.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Global-function stubs for AppointmentNotificationRunnerTest.
+ *
+ * The runner calls three procedural helpers at top of namespace
+ * (`text`, `cron_InsertNotificationLogEntryFaxsms`,
+ * `rc_sms_notification_cron_update_entry`). PHP resolves unqualified
+ * function calls inside `OpenEMR\Modules\FaxSMS\Notification` first
+ * to that namespace and then to global, so the stubs are declared
+ * here in the runner's own namespace to short-circuit the lookup
+ * with no DB dependency. The shared spy state lives in the global
+ * namespace so the test class can read/reset it.
+ *
+ * Bracketed namespace syntax is required so this file can declare
+ * symbols in two namespaces at once.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace {
+    if (!class_exists(\AppointmentNotificationRunnerTestSpy::class, false)) {
+        class AppointmentNotificationRunnerTestSpy
+        {
+            /** @var list<array{type: string, row: array<mixed>, logData: array<mixed>}> */
+            public static array $logCalls = [];
+            /** @var list<array{channel: string, pid: int, eid: int, recur: string}> */
+            public static array $markCalls = [];
+
+            public static function reset(): void
+            {
+                self::$logCalls = [];
+                self::$markCalls = [];
+            }
+        }
+    }
+}
+
+namespace OpenEMR\Modules\FaxSMS\Notification {
+    use AppointmentNotificationRunnerTestSpy;
+    use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
+
+    if (!function_exists('OpenEMR\\Modules\\FaxSMS\\Notification\\text')) {
+        function text(mixed $value): string
+        {
+            if ($value === null) {
+                return '';
+            }
+            if (is_string($value)) {
+                return htmlspecialchars($value, ENT_NOQUOTES);
+            }
+            if (is_int($value) || is_float($value) || is_bool($value)) {
+                return htmlspecialchars((string) $value, ENT_NOQUOTES);
+            }
+            return '';
+        }
+    }
+
+    if (!function_exists('OpenEMR\\Modules\\FaxSMS\\Notification\\cron_InsertNotificationLogEntryFaxsms')) {
+        /**
+         * Production helper signature is fully untyped; mirror that with
+         * `array<mixed>` so the runner's loosely-shaped legacy arrays
+         * pass static analysis without forcing extra narrowing.
+         *
+         * @param array<mixed> $row
+         * @param array<mixed> $logData
+         */
+        function cron_InsertNotificationLogEntryFaxsms(string $type, array $row, array $logData): bool
+        {
+            AppointmentNotificationRunnerTestSpy::$logCalls[] = [
+                'type' => $type,
+                'row' => $row,
+                'logData' => $logData,
+            ];
+            return true;
+        }
+    }
+
+    if (!function_exists('OpenEMR\\Modules\\FaxSMS\\Notification\\rc_sms_notification_cron_update_entry')) {
+        function rc_sms_notification_cron_update_entry(
+            NotificationChannel $channel,
+            int $pid,
+            int $eid,
+            string $recur,
+        ): void {
+            AppointmentNotificationRunnerTestSpy::$markCalls[] = [
+                'channel' => $channel->value,
+                'pid' => $pid,
+                'eid' => $eid,
+                'recur' => $recur,
+            ];
+        }
+    }
+}

--- a/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/BackgroundServiceRunnerTest.php
@@ -17,6 +17,10 @@ use OpenEMR\Common\Database\TableTypes;
 use OpenEMR\Services\Background\BackgroundServiceRunner;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 
 /**
  * @phpstan-import-type BackgroundServicesRow from TableTypes
@@ -95,6 +99,45 @@ class BackgroundServiceRunnerTest extends TestCase
 
         $this->assertSame('error', $results[0]['status']);
         $this->assertContains('svc1', $runner->releasedLocks);
+    }
+
+    public function testRunLogsExceptionWhenExecuteServiceThrows(): void
+    {
+        // Without this log line the orchestrator records status=error
+        // with no exception class, message, file, line, or trace anywhere
+        // in the cron logs. Operators have no way to diagnose the
+        // failure without attaching to a pod and re-running the
+        // service under instrumentation. The catch is intentionally
+        // broad (\Throwable) — process-boundary cleanup must happen
+        // no matter what — but the diagnostic information must not
+        // be discarded along with the exception.
+        $logger = new RecordingLogger();
+        $thrown = new \RuntimeException('Service failure');
+        $runner = new BackgroundServiceRunnerStub(
+            services: [self::makeService('svc1')],
+            executeCallback: function (array $service) use ($thrown): void {
+                throw $thrown;
+            },
+            logger: $logger,
+        );
+
+        $results = $runner->run('svc1');
+
+        $this->assertSame('error', $results[0]['status']);
+
+        $errorRecords = array_values(array_filter(
+            $logger->records,
+            fn(array $record): bool => $record['level'] === LogLevel::ERROR,
+        ));
+        $this->assertCount(1, $errorRecords, 'exactly one error log line must be emitted on service failure');
+        $record = $errorRecords[0];
+        $this->assertSame('Background service execution failed.', (string) $record['message']);
+        $this->assertSame('svc1', $record['context']['service'] ?? null);
+        $this->assertSame(
+            $thrown,
+            $record['context']['exception'] ?? null,
+            "the thrown exception must be passed via the 'exception' context key so PSR-3 processors can format the trace and class name",
+        );
     }
 
     public function testRunAllServicesInOrder(): void
@@ -188,7 +231,9 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
         private readonly array $services = [],
         private readonly ?string $lockFailureReason = null,
         private readonly ?\Closure $executeCallback = null,
+        ?LoggerInterface $logger = null,
     ) {
+        parent::__construct($logger ?? new NullLogger());
     }
 
     protected function getServices(?string $serviceName, bool $force): array
@@ -217,5 +262,28 @@ class BackgroundServiceRunnerStub extends BackgroundServiceRunner
         if ($this->executeCallback !== null) {
             ($this->executeCallback)($service);
         }
+    }
+}
+
+/**
+ * Minimal PSR-3 logger that records every log call so tests can assert
+ * on level, message, and context without bringing in a Monolog handler.
+ */
+class RecordingLogger extends AbstractLogger
+{
+    // PSR-3 leaves the context array open: any keys, any values. Mirror
+    // that here so PHPStan doesn't reject callers that pass mixed-keyed
+    // context (which is legal under the interface even if our own call
+    // sites use string keys).
+    /** @var list<array{level: mixed, message: string|\Stringable, context: array<mixed>}> */
+    public array $records = [];
+
+    public function log($level, string|\Stringable $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+        ];
     }
 }


### PR DESCRIPTION
## Summary

Backports both #11846 and #11922 to `rel-810`. They fix the appointment-reminder cron flow under the unified `bin/console background:services run` orchestrator, plus the observability gap that let the regression ship undetected. Bundled because #11922's only purpose is to fix what #11846 broke.

- **#11846** — `Notification_Email_Task` and `Notification_SMS_Task` were silently dying inside `AppDispatch::__construct()` when invoked from the CLI orchestrator, so the runner reported `executed` while no reminders went out. Replaces the silent-die path with a CLI-aware bridge plus a typed `AppointmentNotificationRunner` that throws `\RuntimeException` on failure and lets the orchestrator mark the service as `error`.
- **#11922** — fixes the two regressions surfaced by #11846 once it actually started reporting:
  - `Call to undefined function fetchEvents()` when `BackgroundReminderTask` runs from CLI: the helpers file now requires `library/appointments.inc.php` itself rather than relying on the popup entry to have loaded it.
  - `BackgroundServiceRunner` was capturing `\Throwable` without binding the variable, so the orchestrator emitted `status: error` with no log line, no class, no message, no trace. Now passes the exception through PSR-3 `'exception'` context so processors format the trace.

Closes #11827 on `rel-810`.

## Backport notes

- **`.phpstan/fatal-baseline-caps.php`** — only the `method.notFound`/`variable.undefined` cap row is dropped from the original; the file does not exist on `rel-810`.
- **`BackgroundServiceRunner` fix** — `rel-810` predates the `runOne()` extraction (master-only refactor), so the `\Throwable $e` capture and `$this->logger->error()` call land in the existing inline catch inside `run()`. Same observable behavior as upstream.
- **`BackgroundServiceRunnerTest`** — equivalent test renamed `testRunLogsExceptionWhenExecuteServiceThrows` (no `runOne` to reference); test stub now calls `parent::__construct(new NullLogger())` so the new `$this->logger->error()` call has a target. `RecordingLogger` helper class added verbatim from #11922.
- All other files cherry-picked clean.

## Test plan

- [x] `composer phpunit-isolated -- --filter='Background|Notification|Reminder'` — 134 tests, all green
- [x] `composer phpunit-isolated` — full isolated suite green (2,591 tests)
- [x] `composer phpstan-baseline` produces no diff against the cherry-picked baselines
- [x] `composer phpstan` — clean
- [x] `composer phpcs` — clean
- [x] `composer php-syntax-check` — clean
- [ ] Trigger `bin/console background:services run` against a clinic configured for SMS/email reminders and confirm the service status reports `error` (with PSR-3 detail in the log) when delivery fails, and `executed` when delivery succeeds
- [ ] Confirm the interactive popup at `interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php?type=sms&dryrun=1` still requires ACL and renders the dry-run table

## References

- Upstream PR: #11846 (squash `f6a431279e`)
- Upstream PR: #11922 (squash `127807d7c5`)
- Issue (closed by #11846): #11827
