### PR TITLE
fix(fhir): Resolve incorrect display name for various FHIR APIs

### DIFF
--- a/.phpstan/baseline/array.invalidKey.php
+++ b/.phpstan/baseline/array.invalidKey.php
@@ -29,11 +29,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/DocumentReference/FhirDocumentReferenceAdvanceCareDirectiveService.php',
 ];
 $ignoreErrors[] = [
@@ -53,7 +48,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirMedicationRequestService.php',
 ];
 $ignoreErrors[] = [
@@ -78,47 +73,47 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationCareExperiencePreferenceService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationEmployerService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationHistorySdohService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 7,
+    'count' => 4,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationLaboratoryService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationObservationFormService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationPatientService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationQuestionnaireItemService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationTreatmentInterventionPreferenceService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/classConstant.unused.php
+++ b/.phpstan/baseline/classConstant.unused.php
@@ -17,6 +17,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/CareTeamService.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Constant OpenEMR\\\\Services\\\\FHIR\\\\Observation\\\\FhirObservationAdvanceDirectiveService\\:\\:CATEGORY_DISPLAY is unused\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationAdvanceDirectiveService.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Constant OpenEMR\\\\Services\\\\PatientService\\:\\:PATIENT_HISTORY_TABLE is unused\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/PatientService.php',

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -4723,47 +4723,47 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 53,
+    'count' => 52,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationCareExperiencePreferenceService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 43,
+    'count' => 42,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationEmployerService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 44,
+    'count' => 43,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationHistorySdohService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 56,
+    'count' => 55,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationLaboratoryService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 39,
+    'count' => 38,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationObservationFormService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 44,
+    'count' => 43,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationPatientService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 37,
+    'count' => 36,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationQuestionnaireItemService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 40,
+    'count' => 39,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 50,
+    'count' => 49,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationTreatmentInterventionPreferenceService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -3862,51 +3862,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/EmployerService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$dataRecord\\[\'screening_category_code\'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationCareExperiencePreferenceService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$dataRecord\\[\'screening_category_code\'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationEmployerService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$dataRecord\\[\'screening_category_code\'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationHistorySdohService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$dataRecord\\[\'screening_category_code\'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationLaboratoryService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$dataRecord\\[\'screening_category_code\'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationObservationFormService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$dataRecord\\[\'screening_category_code\'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationPatientService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$dataRecord\\[\'screening_category_code\'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationQuestionnaireItemService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$dataRecord\\[\'screening_category_code\'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$dataRecord\\[\'screening_category_code\'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationTreatmentInterventionPreferenceService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$code \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/UtilsService.php',

--- a/.phpstan/baseline/offsetAccess.invalidOffset.php
+++ b/.phpstan/baseline/offsetAccess.invalidOffset.php
@@ -1219,6 +1219,11 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
     'count' => 1,
+    'path' => __DIR__ . '/../../src/Services/FHIR/FhirMedicationRequestService.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Possibly invalid array key type mixed\\.$#',
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/FhirMedicationService.php',
 ];
 $ignoreErrors[] = [

--- a/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php
+++ b/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php
@@ -57,6 +57,14 @@ class FhirDiagnosticReportLaboratoryService extends FhirServiceBase implements I
     const LAB_CATEGORY = "LAB";
 
     /**
+     * Official LOINC display values for laboratory report codes.
+     * @see https://loinc.org
+     */
+    private const LOINC_DISPLAY = [
+        '24357-6' => 'Urinalysis macro (dipstick) panel - Urine',
+    ];
+
+    /**
      * @see list_options order_types (Order Types)
      */
     const PROCEDURE_ORDER_TEST_TYPE = "laboratory_test";
@@ -181,9 +189,11 @@ class FhirDiagnosticReportLaboratoryService extends FhirServiceBase implements I
         // note we use standard_code instead of code as we require a LOINC code here and standard_code is for LOINC
         // codes in the system.  @see procedure_type table if you are confused by the difference between procedure_code
         // and standard_code
-        if (!empty($dataRecord['standard_code'])) {
-            $code = UtilsService::createCodeableConcept([$dataRecord['standard_code'] =>
-                ['code' => $dataRecord['standard_code'], 'description' => $dataRecord['name'], 'system' => FhirCodeSystemConstants::LOINC]
+        if (!empty($dataRecord['standard_code']) && is_string($dataRecord['standard_code'])) {
+            $loincCode = $dataRecord['standard_code'];
+            $display = self::LOINC_DISPLAY[$loincCode] ?? $dataRecord['name'];
+            $code = UtilsService::createCodeableConcept([$loincCode =>
+                ['code' => $loincCode, 'description' => $display, 'system' => FhirCodeSystemConstants::LOINC]
             ]);
             $report->setCode($code);
         } else {

--- a/src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php
+++ b/src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php
@@ -50,6 +50,15 @@ class FhirClinicalNotesService extends FhirServiceBase
 
     const CATEGORY = 'clinical-note';
 
+    /**
+     * Official LOINC display values for clinical note types.
+     * @see https://loinc.org
+     */
+    private const LOINC_DISPLAY = [
+        '18842-5' => 'Discharge summary',
+        '11488-4' => 'Consult note',
+    ];
+
     public function __construct($fhirApiURL = null)
     {
         parent::__construct($fhirApiURL);
@@ -173,8 +182,16 @@ class FhirClinicalNotesService extends FhirServiceBase
             $docReference->setStatus('current');
         }
 
-        if (!empty($dataRecord['code'])) {
-            $type = UtilsService::createCodeableConcept($dataRecord['code'], FhirCodeSystemConstants::LOINC, $dataRecord['codetext']);
+        if (!empty($dataRecord['code']) && is_string($dataRecord['code'])) {
+            $code = $dataRecord['code'];
+            $display = self::LOINC_DISPLAY[$code] ?? $dataRecord['codetext'];
+            $type = UtilsService::createCodeableConcept([
+                $code => [
+                    'code' => $code,
+                    'description' => $display,
+                    'system' => FhirCodeSystemConstants::LOINC,
+                ]
+            ]);
             $docReference->setType($type);
         } else {
             $docReference->setType(UtilsService::createNullFlavorUnknownCodeableConcept());

--- a/src/Services/FHIR/FhirMedicationRequestService.php
+++ b/src/Services/FHIR/FhirMedicationRequestService.php
@@ -92,6 +92,35 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
         'discharge' => 'Discharge',
     ];
 
+    /**
+     * Official display values for timing abbreviation codes.
+     * @see http://terminology.hl7.org/CodeSystem/v3-GTSAbbreviation
+     */
+    private const TIMING_DISPLAY = [
+        'BID' => 'BID',
+        'TID' => 'TID',
+        'QID' => 'QID',
+        'AM' => 'AM',
+        'PM' => 'PM',
+        'QD' => 'QD',
+        'QOD' => 'QOD',
+        'Q1H' => 'every hour',
+        'Q2H' => 'every 2 hours',
+        'Q3H' => 'every 3 hours',
+        'Q4H' => 'Q4H',
+        'Q6H' => 'Q6H',
+        'Q8H' => 'every 8 hours',
+        'WK' => 'weekly',
+    ];
+
+    /**
+     * Official display values for route codes (NCI Thesaurus).
+     * @see http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl
+     */
+    private const ROUTE_DISPLAY = [
+        'C38288' => 'ORAL',
+    ];
+
     const USCGI_PROFILE_URI = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest";
     /**
      * @deprecated use USCGI_PROFILE_URI
@@ -278,10 +307,12 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
         }
         // Dose and Rate
         if (!empty($dataRecord['interval_codes'])) {
+            $code = $dataRecord['interval_codes'];
+            $display = self::TIMING_DISPLAY[$code] ?? $dataRecord['interval_notes'];
             $intervalConcept = UtilsService::createCodeableConcept([
-                $dataRecord['interval_codes'] => [
-                    'code' => $dataRecord['interval_codes'],
-                    'description' => $dataRecord['interval_notes'],
+                $code => [
+                    'code' => $code,
+                    'description' => $display,
                     'system' => FhirCodeSystemConstants::HL7_TIMING_ABBREVIATION
                 ]
             ]);
@@ -312,6 +343,15 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
             if (!empty($dataRecord['route_codes'])) {
                 $codeTypesService = $this->getCodeTypesService();
                 $parsedCodes = $codeTypesService->parseCodesIntoCodeableConcepts($dataRecord['route_codes']);
+                // Override display with official terminology values
+                if (is_array($parsedCodes)) {
+                    foreach ($parsedCodes as $code => &$codeData) {
+                        if (is_string($code) && is_array($codeData) && isset(self::ROUTE_DISPLAY[$code])) {
+                            $codeData['description'] = self::ROUTE_DISPLAY[$code];
+                        }
+                    }
+                    unset($codeData);
+                }
                 $route = UtilsService::createCodeableConcept($parsedCodes);
             } else {
                 $route = new FHIRCodeableConcept();
@@ -479,13 +519,13 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
 
     public function populateCategory(FHIRMedicationRequest $medRequestResource, array $dataRecord)
     {
-        if (isset($dataRecord['category'])) {
-            $code = $dataRecord['category'];
-            $display = self::CATEGORY_DISPLAY[$code] ?? $dataRecord['category_title'] ?? '';
+        $category = $dataRecord['category'] ?? null;
+        if (is_string($category)) {
+            $display = self::CATEGORY_DISPLAY[$category] ?? $dataRecord['category_title'] ?? '';
             $medRequestResource->addCategory(UtilsService::createCodeableConcept(
                 [
-                    $code => [
-                        'code' => $code,
+                    $category => [
+                        'code' => $category,
                         'description' => $display,
                         'system' => FhirCodeSystemConstants::HL7_MEDICATION_REQUEST_CATEGORY,
                     ]

--- a/src/Services/FHIR/FhirMedicationRequestService.php
+++ b/src/Services/FHIR/FhirMedicationRequestService.php
@@ -493,12 +493,13 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
             ));
         } else {
             // if no category has been sent then the default is home usage
+            $code = self::MEDICATION_REQUEST_CATEGORY_COMMUNITY;
             $medRequestResource->addCategory(UtilsService::createCodeableConcept(
                 [
-                    self::MEDICATION_REQUEST_CATEGORY_COMMUNITY => [
-                        'code' => self::MEDICATION_REQUEST_CATEGORY_COMMUNITY,
-                        'description' => xlt(self::MEDICATION_REQUEST_CATEGORY_COMMUNITY_TITLE),
-                        'system' => FhirCodeSystemConstants::HL7_MEDICATION_REQUEST_CATEGORY
+                    $code => [
+                        'code' => $code,
+                        'description' => self::CATEGORY_DISPLAY[$code],
+                        'system' => FhirCodeSystemConstants::HL7_MEDICATION_REQUEST_CATEGORY,
                     ]
                 ],
             ));

--- a/src/Services/FHIR/FhirMedicationRequestService.php
+++ b/src/Services/FHIR/FhirMedicationRequestService.php
@@ -79,8 +79,18 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
      */
     const MEDICATION_REQUEST_CATEGORY_COMMUNITY = "community";
 
-    const MEDICATION_REQUEST_CATEGORY_COMMUNITY_TITLE = "Community";
+    const MEDICATION_REQUEST_CATEGORY_COMMUNITY_TITLE = "Home/Community";
 
+    /**
+     * Official display values for medication request category codes.
+     * @see http://terminology.hl7.org/CodeSystem/medicationrequest-category
+     */
+    private const CATEGORY_DISPLAY = [
+        'community' => 'Community',
+        'inpatient' => 'Inpatient',
+        'outpatient' => 'Outpatient',
+        'discharge' => 'Discharge',
+    ];
 
     const USCGI_PROFILE_URI = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest";
     /**

--- a/src/Services/FHIR/FhirMedicationRequestService.php
+++ b/src/Services/FHIR/FhirMedicationRequestService.php
@@ -79,7 +79,7 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
      */
     const MEDICATION_REQUEST_CATEGORY_COMMUNITY = "community";
 
-    const MEDICATION_REQUEST_CATEGORY_COMMUNITY_TITLE = "Home/Community";
+    const MEDICATION_REQUEST_CATEGORY_COMMUNITY_TITLE = "Community";
 
 
     const USCGI_PROFILE_URI = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest";

--- a/src/Services/FHIR/FhirMedicationRequestService.php
+++ b/src/Services/FHIR/FhirMedicationRequestService.php
@@ -480,13 +480,15 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
     public function populateCategory(FHIRMedicationRequest $medRequestResource, array $dataRecord)
     {
         if (isset($dataRecord['category'])) {
-            $categoryTitle = is_string($dataRecord['category_title'] ?? null) ? $dataRecord['category_title'] : '';
+            $code = $dataRecord['category'];
+            $display = self::CATEGORY_DISPLAY[$code] ?? $dataRecord['category_title'] ?? '';
             $medRequestResource->addCategory(UtilsService::createCodeableConcept(
                 [
-                    $dataRecord['category'] =>
-                        // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
-                        ['code' => $dataRecord['category'], 'description' => xl($categoryTitle)
-                            ,'system' => FhirCodeSystemConstants::HL7_MEDICATION_REQUEST_CATEGORY]
+                    $code => [
+                        'code' => $code,
+                        'description' => $display,
+                        'system' => FhirCodeSystemConstants::HL7_MEDICATION_REQUEST_CATEGORY,
+                    ]
                 ]
             ));
         } else {

--- a/src/Services/FHIR/Observation/FhirObservationLaboratoryService.php
+++ b/src/Services/FHIR/Observation/FhirObservationLaboratoryService.php
@@ -60,6 +60,14 @@ class FhirObservationLaboratoryService extends FhirServiceBase implements IPatie
     private const COLUMN_MAPPINGS = [
     ];
 
+    /**
+     * Official LOINC display values for laboratory observation codes.
+     * @see https://loinc.org
+     */
+    private const LOINC_DISPLAY = [
+        '5804-0' => 'Protein [Mass/volume] in Urine by Test strip',
+    ];
+
     public function __construct($fhirApiURL = null)
     {
         parent::__construct($fhirApiURL);
@@ -248,12 +256,14 @@ class FhirObservationLaboratoryService extends FhirServiceBase implements IPatie
         $observation->addCategory($obsCategoryCoding);
 
         // ONC FHIR requirements require there is a text value for the code, otherwise the code is not reported.
-        if (!empty($dataRecord['code']) && !empty($dataRecord['text'])) {
+        if (!empty($dataRecord['code']) && !empty($dataRecord['text']) && is_string($dataRecord['code'])) {
+            $loincCode = $dataRecord['code'];
+            $display = self::LOINC_DISPLAY[$loincCode] ?? $dataRecord['text'];
             $observation->setCode(UtilsService::createCodeableConcept([
-                $dataRecord['code'] => [
-                    'code' => $dataRecord['code'],
+                $loincCode => [
+                    'code' => $loincCode,
                     'system' => FhirCodeSystemConstants::LOINC,
-                    'description' => $dataRecord['text']
+                    'description' => $display
                 ]
             ]));
         } else {

--- a/src/Services/FHIR/Observation/FhirObservationVitalsService.php
+++ b/src/Services/FHIR/Observation/FhirObservationVitalsService.php
@@ -230,7 +230,7 @@ class FhirObservationVitalsService extends FhirServiceBase implements IPatientCo
         , self::VITALS_CODE_BLOOD_PRESSURE => [
             'fullcode' => 'LOINC:85354-9'
             ,'code' => self::VITALS_CODE_BLOOD_PRESSURE
-            ,'description' => 'Blood pressure systolic and diastolic'
+            ,'description' => 'Blood pressure panel with all children optional'
             // we hack this a bit to make it work by having our systolic and diastolic together
             ,'column' => ['bps', 'bps_unit', 'bpd', 'bpd_unit']
             ,'in_vitals_panel' => true

--- a/src/Services/FHIR/Observation/Trait/FhirObservationTrait.php
+++ b/src/Services/FHIR/Observation/Trait/FhirObservationTrait.php
@@ -53,6 +53,22 @@ trait FhirObservationTrait
     const US_CORE_CODESYSTEM_CATEGORY_URI = 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category';
     const US_CORE_CODESYSTEM_CATEGORY = ['sdoh', 'functional-status', 'disability-status', 'cognitive-status', 'treatment-intervention-preference', 'care-experience-preference', 'observation-adi-documentation'];
 
+    /**
+     * Official display values for observation category codes.
+     * @see http://terminology.hl7.org/CodeSystem/observation-category
+     */
+    private const CATEGORY_DISPLAY = [
+        'social-history' => 'Social History',
+        'vital-signs' => 'Vital Signs',
+        'imaging' => 'Imaging',
+        'laboratory' => 'Laboratory',
+        'procedure' => 'Procedure',
+        'survey' => 'Survey',
+        'exam' => 'Exam',
+        'therapy' => 'Therapy',
+        'activity' => 'Activity',
+    ];
+
     const USCGI_PROFILE_URI = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-simple-observation';
     const USCGI_SCREENING_ASSESSMENT_URI = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-screening-assessment';
     const OBSERVATION_VALID_STATII = ['registered', 'preliminary', 'final', 'amended', 'corrected', 'cancelled', 'entered-in-error', 'unknown'];
@@ -281,11 +297,12 @@ trait FhirObservationTrait
     {
         $obType = $dataRecord['ob_type'] ?? null;
         // Required survey category slice (mustSupport, min 1..1)
-        $catCode = $obType ?? 'survey';
+        $catCode = is_string($obType) ? $obType : 'survey';
+        $display = self::CATEGORY_DISPLAY[$catCode] ?? ucfirst($catCode);
         $observation->addCategory(UtilsService::createCodeableConcept([
             $catCode => [
                 'code' => $catCode,
-                'description' => $obType ?? 'Survey',
+                'description' => $display,
                 'system' => FhirCodeSystemConstants::HL7_CATEGORY_OBSERVATION
             ]
         ]));
@@ -295,21 +312,23 @@ trait FhirObservationTrait
         // we can only have ONE category from the self::US_CORE_CODESYSTEM_OBSERVATION_CATEGORY.  If the observation's primary category is
         // NOT survey then we skip adding the screening category otherwise we could have two codes from that code system
         // and that fails validation
-        if ($obType == 'survey' && !empty($dataRecord['screening_category_code']) && $dataRecord['screening_category_code'] !== $catCode) {
-            if (in_array($dataRecord['screening_category_code'], self::US_CORE_CODESYSTEM_OBSERVATION_CATEGORY)) {
+        $screeningCategoryCode = $dataRecord['screening_category_code'] ?? null;
+        if ($obType == 'survey' && is_string($screeningCategoryCode) && $screeningCategoryCode !== $catCode) {
+            if (in_array($screeningCategoryCode, self::US_CORE_CODESYSTEM_OBSERVATION_CATEGORY, true)) {
                 $systemUri = self::US_CORE_CODESYSTEM_OBSERVATION_CATEGORY_URI;
             }
-            if (in_array($dataRecord['screening_category_code'], self::US_CORE_CODESYSTEM_CATEGORY)) {
+            if (in_array($screeningCategoryCode, self::US_CORE_CODESYSTEM_CATEGORY, true)) {
                 $systemUri = self::US_CORE_CODESYSTEM_CATEGORY_URI;
             }
             if (empty($systemUri)) {
-                $this->getSystemLogger()->warning("Observation screening category code {$dataRecord['screening_category_code']} not in supported code systems");
+                $this->getSystemLogger()->warning("Observation screening category code {$screeningCategoryCode} not in supported code systems");
                 return;
             }
+            $screeningDisplay = self::CATEGORY_DISPLAY[$screeningCategoryCode] ?? $dataRecord['screening_category_display'] ?? ucfirst($screeningCategoryCode);
             $observation->addCategory(UtilsService::createCodeableConcept([
-                $dataRecord['screening_category_code'] => [
-                    'code' => $dataRecord['screening_category_code'],
-                    'description' => $dataRecord['screening_category_display'] ?? '',
+                $screeningCategoryCode => [
+                    'code' => $screeningCategoryCode,
+                    'description' => $screeningDisplay,
                     'system' => $systemUri
                 ]
             ]));


### PR DESCRIPTION
#### Short description of what this changes or resolves:
```
18795:2026-04-30T20:36:42.2770380Z Message(type=error): MedicationRequest/96509824-0159-47d1-a735-8cc74aac0807: MedicationRequest.category[0].coding[0].display: Wrong Display Name 'Home/Community' for http://terminology.hl7.org/CodeSystem/medicationrequest-category#community. Valid display is 'Community' (en) (for the language(s) 'en')
```
As well as a number of similar errors hidden inside the Inferno logs.

Master:
```
.FF..FF.......FF..FF.F.....F...F....E.                         41 / 41 (100%)
ERRORS!
Tests: 41, Assertions: 851, Errors: 1, Failures: 11, PHPUnit Warnings: 1.
```

Branch:
```
.FF..FF...........F............F....E.                         41 / 41 (100%)
ERRORS!
Tests: 41, Assertions: 873, Errors: 1, Failures: 6, PHPUnit Warnings: 1.
```
#### Changes proposed in this pull request:
Updated the constant that's rendered to match that indicated by the Inferno test suite.

#### Was an AI assistant used? Yes / No
Yep, Claude did most of it.