### PR TITLE
feat(crypto): add encryptForDatabase and decryptFromDatabase methods

### DIFF
--- a/src/BC/Crypto/Crypto.php
+++ b/src/BC/Crypto/Crypto.php
@@ -14,6 +14,7 @@ namespace OpenEMR\BC\Crypto;
 
 use BadMethodCallException;
 use OpenEMR\Common\Crypto\{
+    CryptoGenException,
     CryptoInterface,
     KeySource,
     KeyVersion,
@@ -126,5 +127,28 @@ final readonly class Crypto implements CryptoInterface
         } catch (Throwable) {
             return false;
         }
+    }
+
+    public function encryptForDatabase(?string $value): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+        return $this->encryptStandard($value, keySource: KeySource::Drive);
+    }
+
+    public function decryptFromDatabase(?string $value, ?int $minimumVersion = null): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+        if (!$this->cryptCheckStandard($value)) {
+            return $value;
+        }
+        $result = $this->decryptStandard($value, keySource: KeySource::Drive, minimumVersion: $minimumVersion);
+        if ($result === false) {
+            throw new CryptoGenException('Decryption failed');
+        }
+        return $result;
     }
 }

--- a/src/Common/Crypto/CryptoGen.php
+++ b/src/Common/Crypto/CryptoGen.php
@@ -133,6 +133,35 @@ class CryptoGen implements CryptoInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function encryptForDatabase(?string $value): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+        return $this->encryptStandard($value, keySource: KeySource::Drive);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function decryptFromDatabase(?string $value, ?int $minimumVersion = null): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+        if (!$this->cryptCheckStandard($value)) {
+            return $value;
+        }
+        $result = $this->decryptStandard($value, keySource: KeySource::Drive, minimumVersion: $minimumVersion);
+        if ($result === false) {
+            throw new CryptoGenException('Decryption failed');
+        }
+        return $result;
+    }
+
+    /**
      * Core encryption function
      *
      * @param  ?string   $sValue     Raw data to be encrypted

--- a/src/Common/Crypto/CryptoInterface.php
+++ b/src/Common/Crypto/CryptoInterface.php
@@ -41,4 +41,27 @@ interface CryptoInterface
      * @return bool True if valid, false otherwise
      */
     public function cryptCheckStandard(?string $value): bool;
+
+    /**
+     * Encrypts data for storage in the database.
+     *
+     * Uses KeySource::Drive explicitly for database field encryption.
+     *
+     * @param ?string $value The value to encrypt
+     * @return string The encrypted value, or empty string if input is null/empty
+     */
+    public function encryptForDatabase(?string $value): string;
+
+    /**
+     * Decrypts data retrieved from the database.
+     *
+     * If the value is not encrypted (no valid prefix), returns it unchanged (plaintext passthrough).
+     * If decryption fails, throws CryptoGenException.
+     *
+     * @param ?string $value The value to decrypt
+     * @param ?int $minimumVersion Minimum encryption version required
+     * @return string The decrypted value, or original value if not encrypted
+     * @throws CryptoGenException If decryption of encrypted data fails
+     */
+    public function decryptFromDatabase(?string $value, ?int $minimumVersion = null): string;
 }

--- a/tests/Tests/Isolated/BC/Crypto/CryptoTest.php
+++ b/tests/Tests/Isolated/BC/Crypto/CryptoTest.php
@@ -18,6 +18,7 @@ namespace OpenEMR\Tests\Isolated\BC\Crypto;
 
 use OpenEMR\BC\Crypto\Crypto;
 use OpenEMR\BC\Crypto\Key;
+use OpenEMR\Common\Crypto\CryptoGenException;
 use OpenEMR\Common\Crypto\KeySource;
 use OpenEMR\Common\Crypto\KeyVersion;
 use OpenEMR\Encryption\Cipher\Aes256CbcHmacSha256;
@@ -236,5 +237,74 @@ final class CryptoTest extends TestCase
         $encrypted = $this->crypto->encryptStandard('test data');
 
         self::assertTrue($this->crypto->cryptCheckStandard($encrypted));
+    }
+
+    public function testEncryptForDatabaseReturnsEncryptedString(): void
+    {
+        $plaintext = 'test data for encryption';
+
+        $encrypted = $this->crypto->encryptForDatabase($plaintext);
+
+        self::assertNotSame($plaintext, $encrypted);
+        self::assertStringStartsWith('007', $encrypted);
+    }
+
+    public function testEncryptForDatabaseReturnsEmptyStringForNull(): void
+    {
+        self::assertSame('', $this->crypto->encryptForDatabase(null));
+    }
+
+    public function testEncryptForDatabaseReturnsEmptyStringForEmptyString(): void
+    {
+        self::assertSame('', $this->crypto->encryptForDatabase(''));
+    }
+
+    public function testDecryptFromDatabaseDecryptsEncryptedValue(): void
+    {
+        $plaintext = 'encrypted test data';
+        $encrypted = $this->crypto->encryptForDatabase($plaintext);
+
+        $result = $this->crypto->decryptFromDatabase($encrypted);
+
+        self::assertSame($plaintext, $result);
+    }
+
+    public function testDecryptFromDatabasePassesThroughPlaintext(): void
+    {
+        $plaintext = 'this is not encrypted';
+
+        $result = $this->crypto->decryptFromDatabase($plaintext);
+
+        self::assertSame($plaintext, $result);
+    }
+
+    public function testDecryptFromDatabaseReturnsEmptyStringForNull(): void
+    {
+        self::assertSame('', $this->crypto->decryptFromDatabase(null));
+    }
+
+    public function testDecryptFromDatabaseReturnsEmptyStringForEmptyString(): void
+    {
+        self::assertSame('', $this->crypto->decryptFromDatabase(''));
+    }
+
+    public function testDecryptFromDatabaseThrowsOnCorruptedCiphertext(): void
+    {
+        $encrypted = $this->crypto->encryptForDatabase('test data');
+        $tampered = substr($encrypted, 0, 10) . 'X' . substr($encrypted, 11);
+
+        $this->expectException(CryptoGenException::class);
+
+        $this->crypto->decryptFromDatabase($tampered);
+    }
+
+    public function testEncryptForDatabaseRoundTrip(): void
+    {
+        $plaintext = CryptoFixtureManager::PLAINTEXT;
+
+        $encrypted = $this->crypto->encryptForDatabase($plaintext);
+        $decrypted = $this->crypto->decryptFromDatabase($encrypted);
+
+        self::assertSame($plaintext, $decrypted);
     }
 }

--- a/tests/Tests/Isolated/BC/Crypto/CryptoTest.php
+++ b/tests/Tests/Isolated/BC/Crypto/CryptoTest.php
@@ -291,7 +291,15 @@ final class CryptoTest extends TestCase
     public function testDecryptFromDatabaseThrowsOnCorruptedCiphertext(): void
     {
         $encrypted = $this->crypto->encryptForDatabase('test data');
-        $tampered = substr($encrypted, 0, 10) . 'X' . substr($encrypted, 11);
+
+        // Corrupt the actual binary data by decoding, flipping a bit, and re-encoding.
+        // This guarantees corruption regardless of the random encryption output.
+        $prefix = substr($encrypted, 0, 3);
+        $base64Part = substr($encrypted, 3);
+        $binary = base64_decode($base64Part, true);
+        self::assertIsString($binary);
+        $binary[10] = chr(ord($binary[10]) ^ 0x01);
+        $tampered = $prefix . base64_encode($binary);
 
         $this->expectException(CryptoGenException::class);
 

--- a/tests/Tests/Isolated/RestControllers/Authorization/EhrLaunchPatientContextTest.php
+++ b/tests/Tests/Isolated/RestControllers/Authorization/EhrLaunchPatientContextTest.php
@@ -55,6 +55,23 @@ class EhrLaunchPatientContextTest extends TestCase
             {
                 return $value !== null && str_starts_with($value, 'ENC:');
             }
+
+            public function encryptForDatabase(?string $value): string
+            {
+                return $this->encryptStandard($value);
+            }
+
+            public function decryptFromDatabase(?string $value, ?int $minimumVersion = null): string
+            {
+                if ($value === null || $value === '') {
+                    return '';
+                }
+                if (!$this->cryptCheckStandard($value)) {
+                    return $value;
+                }
+                $result = $this->decryptStandard($value, minimumVersion: $minimumVersion);
+                return $result === false ? '' : $result;
+            }
         };
         ServiceContainer::override(CryptoInterface::class, $crypto);
     }

--- a/tests/Tests/Unit/Common/Crypto/CryptoGenTest.php
+++ b/tests/Tests/Unit/Common/Crypto/CryptoGenTest.php
@@ -1075,8 +1075,15 @@ final class CryptoGenTest extends TestCase
     public function testDecryptFromDatabaseThrowsOnCorruptedCiphertext(): void
     {
         $encrypted = $this->cryptoGen->encryptForDatabase('test data');
-        // Tamper with the ciphertext (after the 3-byte prefix)
-        $tampered = substr($encrypted, 0, 10) . 'X' . substr($encrypted, 11);
+
+        // Corrupt the actual binary data by decoding, flipping a bit, and re-encoding.
+        // This guarantees corruption regardless of the random encryption output.
+        $prefix = substr($encrypted, 0, 3);
+        $base64Part = substr($encrypted, 3);
+        $binary = base64_decode($base64Part, true);
+        self::assertIsString($binary);
+        $binary[10] = chr(ord($binary[10]) ^ 0x01);
+        $tampered = $prefix . base64_encode($binary);
 
         $this->expectException(CryptoGenException::class);
 

--- a/tests/Tests/Unit/Common/Crypto/CryptoGenTest.php
+++ b/tests/Tests/Unit/Common/Crypto/CryptoGenTest.php
@@ -1004,4 +1004,101 @@ final class CryptoGenTest extends TestCase
             }
         }
     }
+
+    public function testEncryptForDatabaseReturnsEncryptedString(): void
+    {
+        $plaintext = 'test data for encryption';
+
+        $encrypted = $this->cryptoGen->encryptForDatabase($plaintext);
+
+        $this->assertNotSame($plaintext, $encrypted);
+        $this->assertStringStartsWith(KeyVersion::CURRENT->toPaddedString(), $encrypted);
+    }
+
+    public function testEncryptForDatabaseReturnsEmptyStringForNull(): void
+    {
+        $result = $this->cryptoGen->encryptForDatabase(null);
+
+        $this->assertSame('', $result);
+    }
+
+    public function testEncryptForDatabaseReturnsEmptyStringForEmptyString(): void
+    {
+        $result = $this->cryptoGen->encryptForDatabase('');
+
+        $this->assertSame('', $result);
+    }
+
+    public function testEncryptForDatabaseProducesDecryptableOutput(): void
+    {
+        $plaintext = 'roundtrip test data';
+
+        $encrypted = $this->cryptoGen->encryptForDatabase($plaintext);
+        $decrypted = $this->cryptoGen->decryptFromDatabase($encrypted);
+
+        $this->assertSame($plaintext, $decrypted);
+    }
+
+    public function testDecryptFromDatabaseDecryptsEncryptedValue(): void
+    {
+        $plaintext = 'encrypted test data';
+        $encrypted = $this->cryptoGen->encryptForDatabase($plaintext);
+
+        $result = $this->cryptoGen->decryptFromDatabase($encrypted);
+
+        $this->assertSame($plaintext, $result);
+    }
+
+    public function testDecryptFromDatabasePassesThroughPlaintext(): void
+    {
+        $plaintext = 'this is not encrypted';
+
+        $result = $this->cryptoGen->decryptFromDatabase($plaintext);
+
+        $this->assertSame($plaintext, $result);
+    }
+
+    public function testDecryptFromDatabaseReturnsEmptyStringForNull(): void
+    {
+        $result = $this->cryptoGen->decryptFromDatabase(null);
+
+        $this->assertSame('', $result);
+    }
+
+    public function testDecryptFromDatabaseReturnsEmptyStringForEmptyString(): void
+    {
+        $result = $this->cryptoGen->decryptFromDatabase('');
+
+        $this->assertSame('', $result);
+    }
+
+    public function testDecryptFromDatabaseThrowsOnCorruptedCiphertext(): void
+    {
+        $encrypted = $this->cryptoGen->encryptForDatabase('test data');
+        // Tamper with the ciphertext (after the 3-byte prefix)
+        $tampered = substr($encrypted, 0, 10) . 'X' . substr($encrypted, 11);
+
+        $this->expectException(CryptoGenException::class);
+
+        $this->cryptoGen->decryptFromDatabase($tampered);
+    }
+
+    public function testDecryptFromDatabaseRespectsMinimumVersion(): void
+    {
+        $encrypted = $this->cryptoGen->encryptForDatabase('test data');
+
+        $result = $this->cryptoGen->decryptFromDatabase($encrypted, minimumVersion: 7);
+
+        $this->assertSame('test data', $result);
+    }
+
+    public function testDecryptFromDatabaseThrowsWhenBelowMinimumVersion(): void
+    {
+        $encrypted = $this->cryptoGen->encryptForDatabase('test data');
+
+        $this->expectException(CryptoGenException::class);
+
+        // v7 ciphertext should fail when minimumVersion=8 (tests the path)
+        $this->cryptoGen->decryptFromDatabase($encrypted, minimumVersion: 8);
+    }
 }


### PR DESCRIPTION
## Summary

Adds two new helper methods to `CryptoInterface` for database field encryption:

- `encryptForDatabase(?string $value): string` — encrypts with explicit `KeySource::Drive`
- `decryptFromDatabase(?string $value, ?int $minimumVersion = null): string` — handles plaintext passthrough and throws `CryptoGenException` on decryption failure

These methods provide a cleaner interface than the existing `encryptStandard()`/`decryptStandard()` methods for database field encryption (or lack thereof, since it's applied situationally depending on certain runtime flags):

1. **Explicit KeySource** — uses `KeySource::Drive` explicitly instead of relying on defaults
2. **Plaintext passthrough** — `decryptFromDatabase()` checks `cryptCheckStandard()` first and returns unencrypted values unchanged
3. **Throwing on failure** — `decryptFromDatabase()` throws `CryptoGenException` instead of returning `false`, making errors visible

A follow-up PR will migrate call sites to use these methods. This doesn't change any of the other planned cryptographic overhauls, but should ease the transition.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)