### PR TITLE
fix(main-tabs): restore default tab loading after login

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -3732,11 +3732,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/pwd_expires_alert.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/main/tabs/main.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'assets\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/src/Bootstrap.php',

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -3733,7 +3733,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/main/tabs/main.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -588,11 +588,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/tabs/main.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/public/claims.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -12222,11 +12222,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/tabs/main.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset mixed on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/tabs/main.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'active\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-claimrev-connect/public/setup.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -12222,21 +12222,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/tabs/main.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'notes\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/main/tabs/main.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'option_id\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/tabs/main.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'title\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/tabs/main.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset mixed on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/tabs/main.php',

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -38,7 +38,6 @@ use OpenEMR\Services\LogoService;
 use OpenEMR\Services\ProductRegistrationService;
 use OpenEMR\Services\VersionService;
 use OpenEMR\Telemetry\TelemetryService;
-use Symfony\Component\Filesystem\Path;
 
 const ENV_DISABLE_TELEMETRY = 'OPENEMR_DISABLE_TELEMETRY';
 
@@ -416,10 +415,27 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
             // For now, only the first tab is visible, this could be improved upon by further customizing the list options in a future feature request
             $visible = "true";
             $default_open_tabs = $session->get('default_open_tabs');
-            $fileroot = OEGlobalsBag::getInstance()->getKernel()->getProjectDir();
+            // Resolve the project root through realpath so the prefix check
+            // below operates on a path that has had symlinks resolved and `..`
+            // segments collapsed to the actual filesystem location, matching
+            // what `realpath()` returns for the candidate. If the project
+            // root itself doesn't resolve (should never happen in normal
+            // operation) every tab will fall through to the reject branch.
+            $fileroot = realpath(OEGlobalsBag::getInstance()->getKernel()->getProjectDir());
             foreach ($default_open_tabs as $i => $tab) :
-                $_unsafe_url = preg_replace('/(\?.*)/m', '', Path::canonicalize($fileroot . DIRECTORY_SEPARATOR . $tab['notes']));
-                if (realpath($_unsafe_url) === false || !str_starts_with($_unsafe_url, $fileroot)) {
+                $notes = is_array($tab) ? ($tab['notes'] ?? null) : null;
+                // Resolve the candidate via realpath so symlinks pointing
+                // outside the project resolve to their real location, and so
+                // `..` segments in `notes` resolve before the prefix check.
+                // Append DIRECTORY_SEPARATOR to both sides so a sibling dir
+                // whose name shares a prefix with the project root (e.g.
+                // `<parent>/openemr_old/...` next to `<parent>/openemr/`)
+                // cannot slip through.
+                $relative = is_string($notes) ? (preg_replace('/\?.*$/', '', $notes) ?? '') : null;
+                $resolved = ($fileroot !== false && is_string($relative))
+                    ? realpath($fileroot . DIRECTORY_SEPARATOR . $relative)
+                    : false;
+                if ($fileroot === false || $resolved === false || !str_starts_with($resolved . DIRECTORY_SEPARATOR, $fileroot . DIRECTORY_SEPARATOR)) {
                     unset($default_open_tabs[$i]);
                     $session->set('default_open_tabs', $default_open_tabs);
                     continue;

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -37,6 +37,7 @@ use OpenEMR\Menu\MainMenuRole;
 use OpenEMR\Services\LogoService;
 use OpenEMR\Services\ProductRegistrationService;
 use OpenEMR\Services\VersionService;
+use OpenEMR\Tabs\DefaultTabsFilter;
 use OpenEMR\Telemetry\TelemetryService;
 
 const ENV_DISABLE_TELEMETRY = 'OPENEMR_DISABLE_TELEMETRY';
@@ -412,66 +413,26 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
     <script>
         <?php
         $default_open_tabs = $session->get('default_open_tabs');
-        if (is_array($default_open_tabs) && $default_open_tabs !== []) {
-            // For now, only the first tab is visible, this could be improved upon by further customizing the list options in a future feature request
-            $visible = "true";
-            // Resolve the project root through realpath so the prefix check
-            // below operates on a path that has had symlinks resolved and `..`
-            // segments collapsed to the actual filesystem location, matching
-            // what `realpath()` returns for the candidate. If the project
-            // root itself doesn't resolve (should never happen in normal
-            // operation) every tab is rejected up front.
-            $fileroot = realpath(OEGlobalsBag::getInstance()->getKernel()->getProjectDir());
-            if ($fileroot === false) {
-                // Project root must resolve; without it no candidate can
-                // pass the prefix check, so reject everything up front
-                // and skip the loop.
-                $session->set('default_open_tabs', []);
-            } else {
-                $tabs_changed = false;
-                foreach ($default_open_tabs as $i => $tab) {
-                    // Validate every field used to build the tab entry up
-                    // front so a malformed list_options row (missing key
-                    // or non-array entry) is dropped instead of raising
-                    // PHP warnings when the tabStatus args are assembled.
-                    if (!is_array($tab)) {
-                        unset($default_open_tabs[$i]);
-                        $tabs_changed = true;
-                        continue;
-                    }
-                    $notes = $tab['notes'] ?? null;
-                    $option_id = $tab['option_id'] ?? null;
-                    $title = $tab['title'] ?? null;
-                    if (!is_string($notes) || !is_string($option_id) || !is_string($title)) {
-                        unset($default_open_tabs[$i]);
-                        $tabs_changed = true;
-                        continue;
-                    }
-                    // Resolve the candidate via realpath so symlinks pointing
-                    // outside the project resolve to their real location, and so
-                    // `..` segments in `notes` resolve before the prefix check.
-                    // Append DIRECTORY_SEPARATOR to both sides so a sibling dir
-                    // whose name shares a prefix with the project root (e.g.
-                    // `<parent>/openemr_old/...` next to `<parent>/openemr/`)
-                    // cannot slip through.
-                    $relative = preg_replace('/\?.*$/', '', $notes) ?? '';
-                    $resolved = realpath($fileroot . DIRECTORY_SEPARATOR . $relative);
-                    if ($resolved === false || !str_starts_with($resolved . DIRECTORY_SEPARATOR, $fileroot . DIRECTORY_SEPARATOR)) {
-                        unset($default_open_tabs[$i]);
-                        $tabs_changed = true;
-                        continue;
-                    }
-                    $url = json_encode(OEGlobalsBag::getInstance()->getWebRoot() . "/" . $notes);
-                    $target = json_encode($option_id);
-                    $label = json_encode(xl("Loading") . " " . $title);
-                    $loading = xlj("Loading");
-                    echo "app_view_model.application_data.tabs.tabsList.push(new tabStatus($label, $url, $target, $loading, true, $visible, false));\n";
-                    $visible = "false";
-                }
-                if ($tabs_changed) {
-                    $session->set('default_open_tabs', $default_open_tabs);
-                }
-            }
+        $valid_tabs = (new DefaultTabsFilter())->filter(
+            $default_open_tabs,
+            OEGlobalsBag::getInstance()->getKernel()->getProjectDir(),
+        );
+        // Persist the filtered/normalized list back to the session if any
+        // entries were dropped or the legacy `id`/`label` keys were
+        // rewritten to the modern `option_id`/`title` shape, so the next
+        // load doesn't have to redo the work.
+        if ($valid_tabs !== $default_open_tabs) {
+            $session->set('default_open_tabs', $valid_tabs);
+        }
+        // For now, only the first tab is visible, this could be improved upon by further customizing the list options in a future feature request
+        $visible = "true";
+        foreach ($valid_tabs as $tab) {
+            $url = json_encode(OEGlobalsBag::getInstance()->getWebRoot() . "/" . $tab['notes']);
+            $target = json_encode($tab['option_id']);
+            $label = json_encode(xl("Loading") . " " . $tab['title']);
+            $loading = xlj("Loading");
+            echo "app_view_model.application_data.tabs.tabsList.push(new tabStatus($label, $url, $target, $loading, true, $visible, false));\n";
+            $visible = "false";
         }
         ?>
 

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -411,7 +411,7 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
 
     <script>
         <?php
-        if ($session->get('default_open_tabs')) :
+        if ($session->get('default_open_tabs')) {
             // For now, only the first tab is visible, this could be improved upon by further customizing the list options in a future feature request
             $visible = "true";
             $default_open_tabs = $session->get('default_open_tabs');
@@ -420,34 +420,45 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
             // segments collapsed to the actual filesystem location, matching
             // what `realpath()` returns for the candidate. If the project
             // root itself doesn't resolve (should never happen in normal
-            // operation) every tab will fall through to the reject branch.
+            // operation) every tab is rejected up front.
             $fileroot = realpath(OEGlobalsBag::getInstance()->getKernel()->getProjectDir());
-            foreach ($default_open_tabs as $i => $tab) :
-                $notes = is_array($tab) ? ($tab['notes'] ?? null) : null;
-                // Resolve the candidate via realpath so symlinks pointing
-                // outside the project resolve to their real location, and so
-                // `..` segments in `notes` resolve before the prefix check.
-                // Append DIRECTORY_SEPARATOR to both sides so a sibling dir
-                // whose name shares a prefix with the project root (e.g.
-                // `<parent>/openemr_old/...` next to `<parent>/openemr/`)
-                // cannot slip through.
-                $relative = is_string($notes) ? (preg_replace('/\?.*$/', '', $notes) ?? '') : null;
-                $resolved = ($fileroot !== false && is_string($relative))
-                    ? realpath($fileroot . DIRECTORY_SEPARATOR . $relative)
-                    : false;
-                if ($fileroot === false || $resolved === false || !str_starts_with($resolved . DIRECTORY_SEPARATOR, $fileroot . DIRECTORY_SEPARATOR)) {
-                    unset($default_open_tabs[$i]);
-                    $session->set('default_open_tabs', $default_open_tabs);
-                    continue;
+            if ($fileroot === false) {
+                // Project root must resolve; without it no candidate can
+                // pass the prefix check, so reject everything up front
+                // and skip the loop.
+                $session->set('default_open_tabs', []);
+            } else {
+                $tabs_changed = false;
+                foreach ($default_open_tabs as $i => $tab) {
+                    $notes = is_array($tab) ? ($tab['notes'] ?? null) : null;
+                    // Resolve the candidate via realpath so symlinks pointing
+                    // outside the project resolve to their real location, and so
+                    // `..` segments in `notes` resolve before the prefix check.
+                    // Append DIRECTORY_SEPARATOR to both sides so a sibling dir
+                    // whose name shares a prefix with the project root (e.g.
+                    // `<parent>/openemr_old/...` next to `<parent>/openemr/`)
+                    // cannot slip through.
+                    $relative = is_string($notes) ? (preg_replace('/\?.*$/', '', $notes) ?? '') : null;
+                    $resolved = is_string($relative)
+                        ? realpath($fileroot . DIRECTORY_SEPARATOR . $relative)
+                        : false;
+                    if ($resolved === false || !str_starts_with($resolved . DIRECTORY_SEPARATOR, $fileroot . DIRECTORY_SEPARATOR)) {
+                        unset($default_open_tabs[$i]);
+                        $tabs_changed = true;
+                        continue;
+                    }
+                    $url = json_encode(OEGlobalsBag::getInstance()->getWebRoot() . "/" . $tab['notes']);
+                    $target = json_encode($tab['option_id']);
+                    $label = json_encode(xl("Loading") . " " . $tab['title']);
+                    $loading = xlj("Loading");
+                    echo "app_view_model.application_data.tabs.tabsList.push(new tabStatus($label, $url, $target, $loading, true, $visible, false));\n";
+                    $visible = "false";
                 }
-                $url = json_encode(OEGlobalsBag::getInstance()->getWebRoot() . "/" . $tab['notes']);
-                $target = json_encode($tab['option_id']);
-                $label = json_encode(xl("Loading") . " " . $tab['title']);
-                $loading = xlj("Loading");
-                echo "app_view_model.application_data.tabs.tabsList.push(new tabStatus($label, $url, $target, $loading, true, $visible, false));\n";
-                $visible = "false";
-            endforeach;
-        endif;
+                if ($tabs_changed) {
+                    $session->set('default_open_tabs', $default_open_tabs);
+                }
+            }
+        }
         ?>
 
         app_view_model.application_data.user(new user_data_view_model(<?php echo json_encode($session->get("authUser"))

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -411,10 +411,10 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
 
     <script>
         <?php
-        if ($session->get('default_open_tabs')) {
+        $default_open_tabs = $session->get('default_open_tabs');
+        if (is_array($default_open_tabs) && $default_open_tabs !== []) {
             // For now, only the first tab is visible, this could be improved upon by further customizing the list options in a future feature request
             $visible = "true";
-            $default_open_tabs = $session->get('default_open_tabs');
             // Resolve the project root through realpath so the prefix check
             // below operates on a path that has had symlinks resolved and `..`
             // segments collapsed to the actual filesystem location, matching
@@ -430,7 +430,23 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
             } else {
                 $tabs_changed = false;
                 foreach ($default_open_tabs as $i => $tab) {
-                    $notes = is_array($tab) ? ($tab['notes'] ?? null) : null;
+                    // Validate every field used to build the tab entry up
+                    // front so a malformed list_options row (missing key
+                    // or non-array entry) is dropped instead of raising
+                    // PHP warnings when the tabStatus args are assembled.
+                    if (!is_array($tab)) {
+                        unset($default_open_tabs[$i]);
+                        $tabs_changed = true;
+                        continue;
+                    }
+                    $notes = $tab['notes'] ?? null;
+                    $option_id = $tab['option_id'] ?? null;
+                    $title = $tab['title'] ?? null;
+                    if (!is_string($notes) || !is_string($option_id) || !is_string($title)) {
+                        unset($default_open_tabs[$i]);
+                        $tabs_changed = true;
+                        continue;
+                    }
                     // Resolve the candidate via realpath so symlinks pointing
                     // outside the project resolve to their real location, and so
                     // `..` segments in `notes` resolve before the prefix check.
@@ -438,18 +454,16 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
                     // whose name shares a prefix with the project root (e.g.
                     // `<parent>/openemr_old/...` next to `<parent>/openemr/`)
                     // cannot slip through.
-                    $relative = is_string($notes) ? (preg_replace('/\?.*$/', '', $notes) ?? '') : null;
-                    $resolved = is_string($relative)
-                        ? realpath($fileroot . DIRECTORY_SEPARATOR . $relative)
-                        : false;
+                    $relative = preg_replace('/\?.*$/', '', $notes) ?? '';
+                    $resolved = realpath($fileroot . DIRECTORY_SEPARATOR . $relative);
                     if ($resolved === false || !str_starts_with($resolved . DIRECTORY_SEPARATOR, $fileroot . DIRECTORY_SEPARATOR)) {
                         unset($default_open_tabs[$i]);
                         $tabs_changed = true;
                         continue;
                     }
-                    $url = json_encode(OEGlobalsBag::getInstance()->getWebRoot() . "/" . $tab['notes']);
-                    $target = json_encode($tab['option_id']);
-                    $label = json_encode(xl("Loading") . " " . $tab['title']);
+                    $url = json_encode(OEGlobalsBag::getInstance()->getWebRoot() . "/" . $notes);
+                    $target = json_encode($option_id);
+                    $label = json_encode(xl("Loading") . " " . $title);
                     $loading = xlj("Loading");
                     echo "app_view_model.application_data.tabs.tabsList.push(new tabStatus($label, $url, $target, $loading, true, $visible, false));\n";
                     $visible = "false";

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -416,8 +416,8 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
             // For now, only the first tab is visible, this could be improved upon by further customizing the list options in a future feature request
             $visible = "true";
             $default_open_tabs = $session->get('default_open_tabs');
+            $fileroot = OEGlobalsBag::getInstance()->getKernel()->getProjectDir();
             foreach ($default_open_tabs as $i => $tab) :
-                $fileroot = OEGlobalsBag::getInstance()->getKernel()->getIncludeRoot();
                 $_unsafe_url = preg_replace('/(\?.*)/m', '', Path::canonicalize($fileroot . DIRECTORY_SEPARATOR . $tab['notes']));
                 if (realpath($_unsafe_url) === false || !str_starts_with($_unsafe_url, $fileroot)) {
                     unset($default_open_tabs[$i]);

--- a/src/Tabs/DefaultTabsFilter.php
+++ b/src/Tabs/DefaultTabsFilter.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Validate and normalize default-open-tab entries.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tabs;
+
+use OpenEMR\Common\Filesystem\SafeIncludeResolver;
+
+/**
+ * Filter the `default_open_tabs` session value before rendering it
+ * into the main tab shell.
+ *
+ * Each entry must:
+ *  - be an array with a string `notes` value (path under the project
+ *    root, optionally with a query string)
+ *  - have a string identifier — `option_id` (modern, from
+ *    `list_options.default_open_tabs`) or `id` (legacy, used by the
+ *    password-expiration / open-patient / load-calendar entries that
+ *    `interface/main/main_screen.php` prepends or appends)
+ *  - have a string display label — `title` (modern) or `label` (legacy)
+ *  - resolve to a real file under the project root via
+ *    `SafeIncludeResolver` so a rogue `notes` value cannot point at
+ *    arbitrary files
+ *
+ * Invalid or out-of-tree entries are dropped. Surviving entries are
+ * normalized to the modern key shape (`option_id` / `title`) so the
+ * rendering loop only has to deal with one variant.
+ */
+final class DefaultTabsFilter
+{
+    /**
+     * @param mixed $tabs Raw value pulled from the session
+     * @param string $projectDir Absolute filesystem path to the project root
+     * @return list<array{notes: string, option_id: string, title: string}>
+     */
+    public function filter(mixed $tabs, string $projectDir): array
+    {
+        if (!is_array($tabs)) {
+            return [];
+        }
+        $valid = [];
+        foreach ($tabs as $tab) {
+            $normalized = self::normalize($tab);
+            if ($normalized === null) {
+                continue;
+            }
+            if (!self::resolvesUnderRoot($normalized['notes'], $projectDir)) {
+                continue;
+            }
+            $valid[] = $normalized;
+        }
+        return $valid;
+    }
+
+    /**
+     * @return array{notes: string, option_id: string, title: string}|null
+     */
+    private static function normalize(mixed $tab): ?array
+    {
+        if (!is_array($tab)) {
+            return null;
+        }
+        $notes = $tab['notes'] ?? null;
+        $option_id = $tab['option_id'] ?? $tab['id'] ?? null;
+        $title = $tab['title'] ?? $tab['label'] ?? null;
+        if (!is_string($notes) || !is_string($option_id) || !is_string($title)) {
+            return null;
+        }
+        return ['notes' => $notes, 'option_id' => $option_id, 'title' => $title];
+    }
+
+    private static function resolvesUnderRoot(string $notes, string $projectDir): bool
+    {
+        $relative = preg_replace('/\?.*$/', '', $notes) ?? '';
+        if ($relative === '') {
+            return false;
+        }
+        return SafeIncludeResolver::resolve($projectDir, $relative) !== false;
+    }
+}

--- a/tests/Tests/Isolated/Tabs/DefaultTabsFilterTest.php
+++ b/tests/Tests/Isolated/Tabs/DefaultTabsFilterTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Tabs;
+
+use OpenEMR\Tabs\DefaultTabsFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+class DefaultTabsFilterTest extends TestCase
+{
+    /**
+     * Real file inside the repository that every fixture can resolve to.
+     * Picked because it lives at a stable project-root-relative path
+     * and is not a generated artifact.
+     */
+    private const FIXTURE_NOTES = 'composer.json';
+
+    private static function projectRoot(): string
+    {
+        return dirname(__DIR__, 4);
+    }
+
+    public function testFilterReturnsEmptyWhenInputIsNotAnArray(): void
+    {
+        $filter = new DefaultTabsFilter();
+        $this->assertSame([], $filter->filter('not-an-array', self::projectRoot()));
+        $this->assertSame([], $filter->filter(null, self::projectRoot()));
+        $this->assertSame([], $filter->filter(42, self::projectRoot()));
+    }
+
+    public function testFilterReturnsEmptyForEmptyArray(): void
+    {
+        $filter = new DefaultTabsFilter();
+        $this->assertSame([], $filter->filter([], self::projectRoot()));
+    }
+
+    public function testFilterReturnsEmptyWhenProjectRootDoesNotResolve(): void
+    {
+        $filter = new DefaultTabsFilter();
+        $tabs = [
+            ['notes' => self::FIXTURE_NOTES, 'option_id' => 'cal', 'title' => 'Calendar'],
+        ];
+        $missingRoot = '/nonexistent_root_' . uniqid('', true);
+        $this->assertSame([], $filter->filter($tabs, $missingRoot));
+    }
+
+    public function testFilterAcceptsModernShape(): void
+    {
+        $filter = new DefaultTabsFilter();
+        $tabs = [
+            ['notes' => self::FIXTURE_NOTES, 'option_id' => 'cal', 'title' => 'Calendar'],
+        ];
+
+        $this->assertSame(
+            [['notes' => self::FIXTURE_NOTES, 'option_id' => 'cal', 'title' => 'Calendar']],
+            $filter->filter($tabs, self::projectRoot()),
+        );
+    }
+
+    public function testFilterNormalizesLegacyIdAndLabelKeys(): void
+    {
+        $filter = new DefaultTabsFilter();
+        $tabs = [
+            ['notes' => self::FIXTURE_NOTES, 'id' => 'adm', 'label' => 'Password Reset'],
+        ];
+
+        $this->assertSame(
+            [['notes' => self::FIXTURE_NOTES, 'option_id' => 'adm', 'title' => 'Password Reset']],
+            $filter->filter($tabs, self::projectRoot()),
+        );
+    }
+
+    public function testFilterPrefersModernKeysWhenBothShapesArePresent(): void
+    {
+        $filter = new DefaultTabsFilter();
+        $tabs = [
+            [
+                'notes' => self::FIXTURE_NOTES,
+                'option_id' => 'modern_id',
+                'id' => 'legacy_id',
+                'title' => 'Modern Title',
+                'label' => 'Legacy Label',
+            ],
+        ];
+
+        $this->assertSame(
+            [['notes' => self::FIXTURE_NOTES, 'option_id' => 'modern_id', 'title' => 'Modern Title']],
+            $filter->filter($tabs, self::projectRoot()),
+        );
+    }
+
+    public function testFilterStripsQueryStringFromNotesBeforeResolving(): void
+    {
+        $filter = new DefaultTabsFilter();
+        $tabs = [
+            ['notes' => self::FIXTURE_NOTES . '?foo=bar&baz=qux', 'option_id' => 'cal', 'title' => 'Calendar'],
+        ];
+
+        // The notes value itself is preserved so the rendered URL keeps its query string.
+        $this->assertSame(
+            [['notes' => self::FIXTURE_NOTES . '?foo=bar&baz=qux', 'option_id' => 'cal', 'title' => 'Calendar']],
+            $filter->filter($tabs, self::projectRoot()),
+        );
+    }
+
+    /**
+     * @return array<string, array{0: array<int, mixed>}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function dropProvider(): array
+    {
+        $valid_notes = self::FIXTURE_NOTES;
+        return [
+            'non-array entry' => [['not-an-array']],
+            'missing notes' => [[['option_id' => 'cal', 'title' => 'Calendar']]],
+            'missing both option_id and id' => [[['notes' => $valid_notes, 'title' => 'Calendar']]],
+            'missing both title and label' => [[['notes' => $valid_notes, 'option_id' => 'cal']]],
+            'non-string notes' => [[['notes' => 42, 'option_id' => 'cal', 'title' => 'Calendar']]],
+            'non-string option_id' => [[['notes' => $valid_notes, 'option_id' => 42, 'title' => 'Calendar']]],
+            'non-string title' => [[['notes' => $valid_notes, 'option_id' => 'cal', 'title' => 42]]],
+            'notes points outside project root' => [[['notes' => '../etc/passwd', 'option_id' => 'cal', 'title' => 'Calendar']]],
+            'notes contains dotdot segment' => [[['notes' => 'src/../etc/passwd', 'option_id' => 'cal', 'title' => 'Calendar']]],
+            'notes targets nonexistent file' => [[['notes' => 'no_such_file_' . self::class . '.php', 'option_id' => 'cal', 'title' => 'Calendar']]],
+            'notes targets a directory' => [[['notes' => 'src', 'option_id' => 'cal', 'title' => 'Calendar']]],
+            'notes is empty after stripping query' => [[['notes' => '?foo=bar', 'option_id' => 'cal', 'title' => 'Calendar']]],
+        ];
+    }
+
+    /**
+     * @param array<int, mixed> $tabs
+     */
+    #[DataProvider('dropProvider')]
+    public function testFilterDropsInvalidEntries(array $tabs): void
+    {
+        $filter = new DefaultTabsFilter();
+        $this->assertSame([], $filter->filter($tabs, self::projectRoot()));
+    }
+
+    public function testFilterPreservesValidEntriesAlongsideInvalidOnes(): void
+    {
+        $filter = new DefaultTabsFilter();
+        $tabs = [
+            ['not-an-array'],
+            ['notes' => self::FIXTURE_NOTES, 'option_id' => 'cal', 'title' => 'Calendar'],
+            ['notes' => '../etc/passwd', 'option_id' => 'bad', 'title' => 'Bad'],
+            ['notes' => self::FIXTURE_NOTES, 'id' => 'adm', 'label' => 'Password Reset'],
+        ];
+
+        $this->assertSame(
+            [
+                ['notes' => self::FIXTURE_NOTES, 'option_id' => 'cal', 'title' => 'Calendar'],
+                ['notes' => self::FIXTURE_NOTES, 'option_id' => 'adm', 'title' => 'Password Reset'],
+            ],
+            $filter->filter($tabs, self::projectRoot()),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Logged-in users land on the main shell with no tabs (no calendar, no messages, no patient finder). The default-tab path-traversal guard in `interface/main/tabs/main.php` now uses `getKernel()->getIncludeRoot()` for the path prefix it concatenates with each tab's `notes` value. `getIncludeRoot()` returns `<project>/interface`, but `notes` values in `list_options.default_open_tabs` are project-root-relative (`interface/main/main_info.php`, `interface/patient_tracker/patient_tracker.php?…`, etc.). The concatenation produces `<project>/interface/interface/main/main_info.php`, `realpath()` returns false, and every tab is unset before render.

Switched to `getKernel()->getProjectDir()` so the prefix matches what the `notes` paths assume. Hoisted the lookup out of the foreach since the project dir is loop-invariant.

Regression from #11901.

## Test plan

- [x] Spin up `docker/development-easy/`; log in as `admin/pass`.
- [x] Confirm the calendar tab loads by default and the other configured default tabs are present in the tab strip.