### PR TITLE
fix(background-services): resolve PHP CLI binary via PhpExecutableFinder

### DIFF
--- a/src/Services/Background/SymfonyBackgroundServiceSpawner.php
+++ b/src/Services/Background/SymfonyBackgroundServiceSpawner.php
@@ -21,6 +21,7 @@ namespace OpenEMR\Services\Background;
 use OpenEMR\BC\ServiceContainer;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
 final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServiceProcessSpawner
@@ -80,22 +81,52 @@ final readonly class SymfonyBackgroundServiceSpawner implements BackgroundServic
 
     private LoggerInterface $logger;
 
+    private string $phpBinary;
+
     /**
      * @param string      $projectDir Absolute path to the OpenEMR project
      *                                root (used to locate bin/console).
-     * @param string      $phpBinary  Absolute path to the PHP binary the
-     *                                child should run under. Defaults to
-     *                                PHP_BINARY, which matches the PHP
-     *                                currently running the parent,
-     *                                aligning FPM/CLI extensions, INI
-     *                                settings, and version.
+     * @param string|null $phpBinary  Absolute path to the PHP CLI binary
+     *                                the child should run under. When
+     *                                null or empty, resolves via
+     *                                PhpExecutableFinder so production
+     *                                works under SAPIs where PHP_BINARY
+     *                                is empty (Apache mod_php on Alpine,
+     *                                where the constant is "", not the
+     *                                CLI path). Test fixtures inject an
+     *                                explicit binary (e.g. /bin/sh).
      */
     public function __construct(
         private string $projectDir,
         ?LoggerInterface $logger = null,
-        private string $phpBinary = PHP_BINARY,
+        ?string $phpBinary = null,
     ) {
         $this->logger = $logger ?? ServiceContainer::getLogger();
+        $this->phpBinary = $phpBinary !== null && $phpBinary !== ''
+            ? $phpBinary
+            : self::resolvePhpBinary();
+    }
+
+    /**
+     * Find a PHP CLI binary suitable for the child subprocess.
+     *
+     * PhpExecutableFinder walks PHP_BINARY env, the PHP_BINARY constant
+     * (only when the parent is itself running CLI/cli-server/phpdbg),
+     * PHP_PATH, PHP_BINDIR, and finally $PATH. Under Apache mod_php the
+     * constant is empty and the SAPI is `apache2handler`, so the finder
+     * falls through to PHP_BINDIR / PATH and locates the bundled CLI.
+     */
+    private static function resolvePhpBinary(): string
+    {
+        $binary = (new PhpExecutableFinder())->find(false);
+        if ($binary === false || $binary === '') {
+            throw new \RuntimeException(
+                'Cannot locate a PHP CLI binary for background service subprocesses. '
+                . 'Set the PHP_BINARY or PHP_PATH environment variable, or place a '
+                . 'php executable on PATH.',
+            );
+        }
+        return $binary;
     }
 
     public function spawn(string $name, bool $force, int $timeoutSeconds): array

--- a/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerTest.php
+++ b/tests/Tests/Isolated/Services/Background/SymfonyBackgroundServiceSpawnerTest.php
@@ -473,6 +473,91 @@ class SymfonyBackgroundServiceSpawnerTest extends TestCase
         $this->assertSame('sleeps_forever', $this->logger->warnings[0]['context']['service'] ?? null);
         $this->assertSame(1, $this->logger->warnings[0]['context']['timeout_seconds'] ?? null);
     }
+
+    public function testNullBinaryResolvesViaPhpExecutableFinder(): void
+    {
+        // Production code path: the BackgroundServiceRunner constructs
+        // the spawner with no $phpBinary argument, so resolution falls
+        // through to PhpExecutableFinder. Under the CLI test runner
+        // the finder returns PHP_BINARY (the test suite's own PHP
+        // binary); the assertion is that the resolved value is a
+        // non-empty executable path, not the empty string the bug
+        // surfaced as under Apache mod_php (openemr/openemr#11932).
+        $spawner = new SymfonyBackgroundServiceSpawner(
+            $this->fakeProjectDir,
+            $this->logger,
+            null,
+        );
+
+        $resolved = $this->readPhpBinary($spawner);
+        $this->assertNotSame('', $resolved);
+        $this->assertTrue(
+            is_executable($resolved),
+            'Resolved PHP binary must be executable: ' . $resolved,
+        );
+    }
+
+    public function testEmptyStringBinaryIsTreatedAsNullAndResolves(): void
+    {
+        // openemr/openemr#11932 reproduction at the constructor layer:
+        // Apache mod_php on Alpine evaluates the PHP_BINARY constant to
+        // "" (empty string, not null), which the previous default
+        // forwarded straight to Symfony Process and produced
+        // "First element must contain a non-empty program name". The
+        // constructor now treats "" the same as null and resolves via
+        // PhpExecutableFinder.
+        $spawner = new SymfonyBackgroundServiceSpawner(
+            $this->fakeProjectDir,
+            $this->logger,
+            '',
+        );
+
+        $resolved = $this->readPhpBinary($spawner);
+        $this->assertNotSame('', $resolved);
+    }
+
+    public function testConstructorThrowsWhenNoPhpBinaryCanBeResolved(): void
+    {
+        // PhpExecutableFinder honors the PHP_BINARY env var first; a
+        // non-existent path forces the finder's early-return-false
+        // branch even under the CLI SAPI, which exercises the
+        // spawner's RuntimeException guard. Without the guard the
+        // failure would manifest later inside Process::run() as the
+        // same opaque "non-empty program name" exception this fix
+        // exists to prevent.
+        $previous = getenv('PHP_BINARY');
+        putenv('PHP_BINARY=/nonexistent/__php_binary_for_test_' . uniqid('', true) . '__');
+
+        try {
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('Cannot locate a PHP CLI binary');
+            new SymfonyBackgroundServiceSpawner(
+                $this->fakeProjectDir,
+                $this->logger,
+                null,
+            );
+        } finally {
+            if ($previous === false) {
+                putenv('PHP_BINARY');
+            } else {
+                putenv('PHP_BINARY=' . $previous);
+            }
+        }
+    }
+
+    private function readPhpBinary(SymfonyBackgroundServiceSpawner $spawner): string
+    {
+        // Reflection peek: the resolved binary is a private property and
+        // there's no public accessor, but the alternative (actually
+        // spawning a child) requires a real PHP fixture and is covered
+        // by SymfonyBackgroundServiceSpawnerPhpChildTest. This test
+        // only needs to confirm the constructor populated a non-empty
+        // path.
+        $reflect = new \ReflectionProperty($spawner, 'phpBinary');
+        $value = $reflect->getValue($spawner);
+        self::assertIsString($value);
+        return $value;
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

`SymfonyBackgroundServiceSpawner::__construct` defaulted its `$phpBinary` parameter to the `PHP_BINARY` constant. Under the Alpine Apache mod_php build OpenEMR ships in `docker/development-easy/` (image `openemr/openemr:flex`), `PHP_BINARY` evaluates to the empty string. The spawner then constructed `new Process(['', '/path/to/bin/console', ...])` and Symfony Process threw `First element must contain a non-empty program name` on every `runAllDue` tick. No background service ran (no UUID assignment, no Email_Service, etc.), and the OpenEMR error log filled with `OpenEMR.ERROR: ExceptionHandlerListener exception` lines that masked unrelated failures.

The fix resolves the PHP CLI binary at construction time using `Symfony\Component\Process\PhpExecutableFinder`, which falls through `PHP_BINARY` env, the constant (only when the parent runs under CLI/cli-server/phpdbg), `PHP_PATH`, `PHP_BINDIR`, and `$PATH`. The constructor throws `\RuntimeException` if no binary can be found, so the failure surfaces with an actionable message instead of an opaque Process exception. The `$phpBinary` constructor parameter is preserved (now nullable) for explicit injection from tests.

## Why CI didn't catch this

Two layered gaps. Worth widening coverage in a follow-up but not in this PR (kept minimal so the cherry-pick path is unambiguous).

1. **All PHPUnit tests run under the CLI SAPI.** `apache_*` CI configurations boot the same `openemr/openemr:flex-*` image as production, but the test runner inside the container is invoked via `phpunit` (CLI), where `PHP_BINARY` is always populated. Existing spawner tests either pass `'/bin/sh'` explicitly or rely on the CLI test runner's `PHP_BINARY`. Neither path reached the empty-binary case.
2. **No API/E2E test exercises `POST /api/background_service/$run` over the web SAPI.** That endpoint is the only path where mod_php's empty `PHP_BINARY` reaches `new Process([...])` in production. `tests/Tests/Api/` contains no `BackgroundService*` test, and `e2e` does not visit the main tab long enough to fire the parasitic AJAX call.

PHPStan can't catch this either: `PHP_BINARY` is typed `string` at static-analysis time. The empty value is a SAPI runtime detail.

A reasonable follow-up: add an API test for `POST /api/background_service/$run` that runs against the apache CI configuration, so empty-`PHP_BINARY` regressions surface during the matrix instead of after deploy.

## Test plan

- [x] `composer phpunit-isolated -- --filter SymfonyBackgroundServiceSpawner` — 26 tests, 88 assertions, all green
- [x] Reproduce in a fresh `docker/development-easy/` stack on `upstream/master`: confirmed `First element must contain a non-empty program name` flooding `/var/log/apache2/error.log` once per `goRepeaterServices` interval
- [x] Apply fix, restart `openemr` container (clears opcache), reload main tab: parasitic `POST /apis/default/api/background_service/$run` returns `200` (was `500`); no further `ExceptionHandlerListener` lines
- [x] Confirmed under apache mod_php that `(new PhpExecutableFinder())->find(false)` resolves to `/usr/bin/php` even though `PHP_BINARY` constant is `""`
- [x] Pre-commit hooks: phpcs, phpstan, rector, composer-require-checker — all pass

Closes openemr/openemr#11932
