### PR TITLE
fix(security): validate db parameter in standard_tables_manage

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -12513,7 +12513,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 10,
+    'count' => 9,
     'path' => __DIR__ . '/../../library/standard_tables_capture.inc.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -12507,11 +12507,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/standard_tables_capture.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/standard_tables_capture.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 9,
     'path' => __DIR__ . '/../../library/standard_tables_capture.inc.php',

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -258,11 +258,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/code_systems/standard_tables_manage.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 36,
     'path' => __DIR__ . '/../../interface/drugs/add_edit_drug.php',
 ];

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -26417,11 +26417,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/standard_tables_capture.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function rmdir_recursive\\(\\) has parameter \\$dir with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/standard_tables_capture.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function rxnorm_import\\(\\) has parameter \\$is_windows_flag with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/standard_tables_capture.inc.php',

--- a/interface/code_systems/standard_tables_manage.php
+++ b/interface/code_systems/standard_tables_manage.php
@@ -21,6 +21,7 @@ require_once("$srcdir/standard_tables_capture.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\OEGlobalsBag;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 // Ensure script doesn't time out
 set_time_limit(0);
@@ -36,7 +37,7 @@ $db = $_GET['db'] ?? '0';
 // flows into filesystem paths (contrib/<db>, temporary_files_dir/<db>); an
 // unconstrained value enables directory traversal in temp_dir_cleanup().
 if (!in_array($db, ['ICD9', 'ICD10', 'RXNORM', 'SNOMED', 'CQM_VALUESET'], true)) {
-    throw new \InvalidArgumentException('Invalid database type');
+    throw new BadRequestHttpException('Invalid database type');
 }
 $version = $_GET['version'] ?? '0';
 $rf = $_GET['rf'] ?? '0';

--- a/interface/code_systems/standard_tables_manage.php
+++ b/interface/code_systems/standard_tables_manage.php
@@ -32,6 +32,12 @@ if (!AclMain::aclCheckCore('admin', 'super')) {
 }
 
 $db = $_GET['db'] ?? '0';
+// Restrict $db to the known set of supported standardized tables. The value
+// flows into filesystem paths (contrib/<db>, temporary_files_dir/<db>); an
+// unconstrained value enables directory traversal in temp_dir_cleanup().
+if (!in_array($db, ['ICD9', 'ICD10', 'RXNORM', 'SNOMED', 'CQM_VALUESET'], true)) {
+    throw new \InvalidArgumentException('Invalid database type');
+}
 $version = $_GET['version'] ?? '0';
 $rf = $_GET['rf'] ?? '0';
 $file_revision_date = $_GET['file_revision_date'] ?? '0';

--- a/library/standard_tables_capture.inc.php
+++ b/library/standard_tables_capture.inc.php
@@ -697,9 +697,18 @@ function temp_dir_cleanup($type): void
     }
     // Defense in depth: ensure the resolved target is contained within
     // $temporary_files_dir to prevent traversal via untrusted $type.
+    // Also refuse to delete a symlinked root, which would let an attacker
+    // who can swap the directory for a symlink between this check and the
+    // recursive delete escape containment via TOCTOU.
+    if (is_link($target)) {
+        return;
+    }
     $resolvedBase = realpath($tempBase);
     $resolvedTarget = realpath($target);
     if ($resolvedBase === false || $resolvedTarget === false) {
+        return;
+    }
+    if (is_link($resolvedTarget)) {
         return;
     }
     if (!Path::isBasePath($resolvedBase, $resolvedTarget)) {

--- a/library/standard_tables_capture.inc.php
+++ b/library/standard_tables_capture.inc.php
@@ -741,6 +741,14 @@ function rmdir_recursive($dir): void
 
     foreach ($files as $file) {
         $file = $dir . '/' . $file;
+        // Treat symlinks as leaf nodes — unlink the link itself rather than
+        // recursing through it. is_dir() follows symlinks, so without this
+        // guard a symlink to an external directory would cause the recursion
+        // to delete files outside the intended tree.
+        if (is_link($file)) {
+            unlink($file);
+            continue;
+        }
         if (is_dir($file)) {
             rmdir_recursive($file);
             continue;

--- a/library/standard_tables_capture.inc.php
+++ b/library/standard_tables_capture.inc.php
@@ -19,7 +19,6 @@
 
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Codes\CodeTypeInstalledEvent;
-use Symfony\Component\Filesystem\Path;
 
 // Function to copy a package to temp
 // $type (RXNORM, SNOMED etc.)
@@ -711,7 +710,10 @@ function temp_dir_cleanup($type): void
     if (is_link($resolvedTarget)) {
         return;
     }
-    if (!Path::isBasePath($resolvedBase, $resolvedTarget)) {
+    // Require an immediate subdirectory of the base. This is stricter than
+    // isBasePath() (which allows nesting) and rules out values like '' or '.'
+    // that would otherwise resolve to the base itself and delete it whole.
+    if (dirname($resolvedTarget) !== $resolvedBase) {
         return;
     }
     rmdir_recursive($resolvedTarget);
@@ -742,8 +744,15 @@ function update_tracker_table($type, $revision, $version, $file_checksum)
 }
 
 // Function to delete an entire directory
-function rmdir_recursive($dir): void
+function rmdir_recursive(string $dir): void
 {
+    // Refuse a symlinked root: scandir() follows symlinks, so without this
+    // guard a TOCTOU swap of the directory for a symlink could redirect
+    // deletion outside the intended tree. Unlink the link itself instead.
+    if (is_link($dir)) {
+        unlink($dir);
+        return;
+    }
     $files = scandir($dir);
     array_shift($files);    // remove '.' from array
     array_shift($files);    // remove '..' from array

--- a/library/standard_tables_capture.inc.php
+++ b/library/standard_tables_capture.inc.php
@@ -19,6 +19,7 @@
 
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Codes\CodeTypeInstalledEvent;
+use Symfony\Component\Filesystem\Path;
 
 // Function to copy a package to temp
 // $type (RXNORM, SNOMED etc.)
@@ -689,9 +690,22 @@ function valueset_import($type)
 // $type (RXNORM etc.)
 function temp_dir_cleanup($type): void
 {
-    if (is_dir(OEGlobalsBag::getInstance()->getString('temporary_files_dir') . "/" . $type)) {
-        rmdir_recursive(OEGlobalsBag::getInstance()->getString('temporary_files_dir') . "/" . $type);
+    $tempBase = OEGlobalsBag::getInstance()->getString('temporary_files_dir');
+    $target = $tempBase . "/" . $type;
+    if (!is_dir($target)) {
+        return;
     }
+    // Defense in depth: ensure the resolved target is contained within
+    // $temporary_files_dir to prevent traversal via untrusted $type.
+    $resolvedBase = realpath($tempBase);
+    $resolvedTarget = realpath($target);
+    if ($resolvedBase === false || $resolvedTarget === false) {
+        return;
+    }
+    if (!Path::isBasePath($resolvedBase, $resolvedTarget)) {
+        return;
+    }
+    rmdir_recursive($resolvedTarget);
 }
 
 // Function to update version tracker table if successful

--- a/library/standard_tables_capture.inc.php
+++ b/library/standard_tables_capture.inc.php
@@ -707,9 +707,6 @@ function temp_dir_cleanup($type): void
     if ($resolvedBase === false || $resolvedTarget === false) {
         return;
     }
-    if (is_link($resolvedTarget)) {
-        return;
-    }
     // Require an immediate subdirectory of the base. This is stricter than
     // isBasePath() (which allows nesting) and rules out values like '' or '.'
     // that would otherwise resolve to the base itself and delete it whole.
@@ -754,6 +751,9 @@ function rmdir_recursive(string $dir): void
         return;
     }
     $files = scandir($dir);
+    if ($files === false) {
+        return;
+    }
     array_shift($files);    // remove '.' from array
     array_shift($files);    // remove '..' from array
 


### PR DESCRIPTION
## Summary

The `db` GET parameter on `interface/code_systems/standard_tables_manage.php` flows unsanitized into filesystem paths, including `temp_dir_cleanup()` which calls `rmdir_recursive()` on `$temporary_files_dir/<db>`. An unconstrained value enables directory traversal (e.g. `db=../../something`).

This PR:

- Validates `$db` against the existing whitelist of supported standardized tables (`['ICD9', 'ICD10', 'RXNORM', 'SNOMED', 'CQM_VALUESET']`) at the top of `standard_tables_manage.php`, throwing on anything else. The whitelist is the same one already used in `interface/code_systems/dataloads_ajax.php` to render the picker.
- As defense-in-depth, hardens `temp_dir_cleanup()` so the resolved cleanup target must remain within the configured `temporary_files_dir` (realpath + `Path::isBasePath()` containment check).
- Regenerates the PHPStan baseline — three pre-existing entries on the changed files drop out because the whitelist lets PHPStan narrow `$db` to a known string.

## Scope and impact

The endpoint is gated by `AclMain::aclCheckCore('admin', 'super')`, so direct exploitation requires super-admin access. A super-admin already has effectively unlimited access to the system (raw SQL via the backup admin pages, module install with arbitrary PHP, ACL configuration), so this isn't a privilege escalation. It's still worth fixing — both as input-handling hygiene and to avoid accidental misuse.

Closes #11768

## Test plan

- [ ] Manually load each supported `db` value (`ICD9`, `ICD10`, `RXNORM`, `SNOMED`, `CQM_VALUESET`) and confirm the install flow still works
- [ ] Manually pass an invalid `db` value and confirm the request is rejected
- [ ] CI green