### PR TITLE
fix(session): restore brief-lock pattern on long-running pages

### DIFF
--- a/interface/main/calendar/index.php
+++ b/interface/main/calendar/index.php
@@ -16,8 +16,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-// Set $sessionAllowWrite to true since pc_facility, pc_username, and viewtype are written to the session below.
-$sessionAllowWrite = true;
 require_once("../../globals.php");
 
 use OpenEMR\Common\Acl\AclMain;

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -27,9 +27,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-// Set $sessionAllowWrite to true since this script writes disablePreviousNameAdds to the session
-// on every load, alert_notify_pid whenever CDR is enabled, and pid + encounter when ?set_pid is provided.
-$sessionAllowWrite = true;
 require_once("../../globals.php");
 
 $srcdir = \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir();

--- a/src/Common/Session/Storage/ReadAndCloseNativeSessionStorage.php
+++ b/src/Common/Session/Storage/ReadAndCloseNativeSessionStorage.php
@@ -133,7 +133,7 @@ class ReadAndCloseNativeSessionStorage extends NativeSessionStorage
             return;
         }
 
-        ServiceContainer::getLogger()->warning(
+        ServiceContainer::getLogger()->debug(
             'Session reopened for writing after read_and_close',
             ['session_name' => session_name(), 'script' => $_SERVER['SCRIPT_NAME'] ?? 'unknown']
         );


### PR DESCRIPTION
## Summary

Follow-up to #11940. That PR silenced a `Session reopened for writing after read_and_close` warning that was firing tens of thousands of times per day in production by setting `$sessionAllowWrite = true` on five scripts. Reviewer @bradymiller [correctly pointed out](https://github.com/openemr/openemr/pull/11940#discussion_r3172162512) that `$sessionAllowWrite = true` holds the session lock for the entire request, while the prior pattern (open `read_and_close`, then briefly reopen-write-release via `SessionUtil::setSession()`) holds it only for microseconds. The original PR fixed the log noise but quietly increased lock-holding time on the two long-running pages, hurting concurrent-AJAX behavior for the active user.

This PR:

- **Demotes the reopen log line from `warning` to `debug`** in `ReadAndCloseNativeSessionStorage.php`. `withWritableSession()` deliberately drives this reopen as the design and immediately calls `save()` to release the lock, so logging the design path at warning level was misleading. Devs running debug-level logging can still find it.
- **Reverts `$sessionAllowWrite = true` on `interface/main/calendar/index.php` and `interface/patient_file/summary/demographics.php`**. Both pages already route their session writes through `SessionUtil::setSession()` / `SessionUtil::setUnsetSession()`, which handle the reopen+save cycle internally. After this change, the long render bodies of those two pages run with **no session lock held**, restoring concurrent-AJAX behavior.
- **Leaves** `$sessionAllowWrite = true` on the two short save-and-redirect scripts (`interface/new/new_comprehensive_save.php`, `interface/forms/newpatient/save.php`) — lock duration is comparable either way for those.
- **Leaves** the dead-code removal in `library/ajax/dated_reminders_counter.php` from #11940 alone — that stands on its own.

Net effect: log noise stays gone, dead code stays removed, but the two long-running pages stop holding the session lock for the duration of their render.

Refs #11934, follows up #11940.

## Test plan

- [ ] **Calendar facility/provider/view persistence** — change facility, provider, and view; navigate away and back; selections persist (writes to `pc_facility`, `pc_username`, `viewtype` still work).
- [ ] **Demographics every-load `disablePreviousNameAdds` write** — open any patient's Demographics summary; verify no `WARNING: Session reopened for writing after read_and_close` lines in `php-log` (default log level).
- [ ] **Demographics `?set_pid` + `?set_encounterid`** — visit Demographics with `?set_pid=N&set_encounterid=M`; pid + encounter become the active context.
- [ ] **CDR `alert_notify_pid` write** — with `enable_cdr` enabled, open a patient's Demographics; CDR alerts/popups behave as before.
- [ ] **Log-noise check at default log level** — exercise the calendar and demographics pages; zero `Session reopened for writing after read_and_close` lines in `php-log`.
- [ ] **Log message still emitted at debug** — with debug logging enabled, the message appears (proves the brief-lock pattern is firing as intended).
- [ ] **Concurrent-lock check** — two tabs as the same user: tab A loads a slow Demographics page; tab B fires an authenticated AJAX endpoint mid-load and returns promptly without waiting for A.