### PR TITLE
fix(portal): add CSRF protection to payment handler

### DIFF
--- a/portal/lib/paylib.php
+++ b/portal/lib/paylib.php
@@ -14,6 +14,7 @@
 
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Billing\PaymentGateway;
+use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 
@@ -49,6 +50,10 @@ if ($session->get('portal_init') !== true) {
 }
 
 SessionUtil::setSession('portal_init', false);
+
+if (filter_input(INPUT_SERVER, 'REQUEST_METHOD') === 'POST') {
+    CsrfUtils::checkCsrfInput(INPUT_POST, subject: 'portal-payment', dieOnFail: true);
+}
 
 if ($_POST['mode'] == 'Sphere') {
     $cryptoGen = ServiceContainer::getCrypto();

--- a/portal/portal_payment.php
+++ b/portal/portal_payment.php
@@ -620,6 +620,7 @@ if (($_POST['form_save'] ?? null) || ($_REQUEST['receipt'] ?? null)) {
           style="text-align: center; margin: auto;">
 
     <form id="invoiceForm" method='post' action='<?php echo $globalsBag->getString("webroot") ?>/portal/portal_payment.php'>
+        <input type='hidden' name='csrf_token_form' value='<?php echo attr(CsrfUtils::collectCsrfToken($session, 'portal-payment')); ?>'/>
         <input type='hidden' name='form_pid' value='<?php echo attr($pid) ?>'/>
         <input type='hidden' name='form_save' value='<?php echo xla('Invoice'); ?>'/>
         <table>
@@ -1042,6 +1043,7 @@ if (($_POST['form_save'] ?? null) || ($_REQUEST['receipt'] ?? null)) {
                 <div class="modal-body">
                     <?php if ($globalsBag->get('payment_gateway') !== 'Stripe' && $globalsBag->get('payment_gateway') !== 'Sphere' && $globalsBag->get('payment_gateway') !== 'Rainforest') { ?>
                     <form id='paymentForm' method='post' action='<?php echo $globalsBag->getString("webroot") ?>/portal/lib/paylib.php'>
+                        <input type='hidden' name='csrf_token_form' value='<?php echo attr(CsrfUtils::collectCsrfToken($session, 'portal-payment')); ?>'/>
                         <fieldset>
                             <div class="form-group">
                                 <label label-default="label-default"
@@ -1112,6 +1114,7 @@ if (($_POST['form_save'] ?? null) || ($_REQUEST['receipt'] ?? null)) {
                     </form>
                     <?php } else { // stripe/sphere/rainforest ?>
                         <form method="post" name="payment-form" id="payment-form">
+                            <input type='hidden' name='csrf_token_form' value='<?php echo attr(CsrfUtils::collectCsrfToken($session, 'portal-payment')); ?>'/>
                             <fieldset>
                                 <div class="form-group">
                                     <label label-default="label-default"><?php echo xlt('Name on Card'); ?></label>

--- a/portal/portal_payment.php
+++ b/portal/portal_payment.php
@@ -102,6 +102,10 @@ $patdata = sqlQuery("SELECT " . "p.fname, p.mname, p.lname, p.postal_code, p.pub
 
 $alertmsg = ''; // anything here pops up in an alert box
 
+if (filter_input(INPUT_SERVER, 'REQUEST_METHOD') === 'POST') {
+    CsrfUtils::checkCsrfInput(INPUT_POST, subject: 'portal-payment', dieOnFail: true);
+}
+
 // If the Save button was clicked...
 if ($_POST['form_save'] ?? '') {
     $form_pid = $isPortal ? $pid : $_POST['form_pid'];


### PR DESCRIPTION
## Summary

- Add CSRF token validation to `portal/lib/paylib.php` for all POST requests
- Add CSRF token hidden fields to all payment forms in `portal/portal_payment.php`

This addresses a pre-existing vulnerability identified by a security scan on #11956.

## Test plan

- [ ] Verify payment flows (portal-save, review-save, AuthorizeNet, Stripe, Sphere) still work with valid session
- [ ] Verify requests without valid CSRF token are rejected with 403

🤖 Generated with [Claude Code](https://claude.ai/code)