### PR TITLE
fix(ci): Run additional web workers in API integration tests

### DIFF
--- a/.github/workflows/test-frontcontroller.yml
+++ b/.github/workflows/test-frontcontroller.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Start server (bg)
         env:
-          ENVIRONMENT: ci
+          PHP_CLI_SERVER_WORKERS: '8'
         run: |
           php -S 0.0.0.0:8080 -t . public/index.php \
             > "${RUNNER_TEMP}/php-server.out.log" \


### PR DESCRIPTION
#### Short description of what this changes or resolves:
We're seeing intermittent CI failures in API and other integration tests that make requests to a locally-deployed webserver. I believe this is because it's using the PHP built-in server, which does not support multiple parallel requests by default.

I'm not sure if using `php -S` in CI makes sense; it's really only marginally useful for local dev and certainly not for production. Until we have "official" server configs (work in progress) I think it's a reasonable approach, but I consider this more of a workaround than a solution.

Of course, I also think that most (but not all) of the API testing shouldn't actually be exercising the network and rather just the endpoints, which would bypass the problem entirely, but that's a bigger project and a different discussion.

#### Changes proposed in this pull request:
- Set the env var that will spin up more workers, change to 8 from default (1)
- Remove the duplicative `ENVIRONMENT: ci` on the step since it's set at the workflow level

#### Was an AI assistant used? Yes / No
No