### PR TITLE
fix(faxsms): tighten oe_faxsms_queue schema for utf8mb4 compatibility

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/sql/5_1_0-to-6_0_0_upgrade.sql
+++ b/interface/modules/custom_modules/oe-module-faxsms/sql/5_1_0-to-6_0_0_upgrade.sql
@@ -3,10 +3,22 @@
 ALTER TABLE `module_faxsms_credentials` ADD `updated` DATETIME DEFAULT CURRENT_TIMESTAMP;
 #EndIf
 
-#IfNotIndex oe_faxsms_queue uniq_account_job_id
+#IfIndex oe_faxsms_queue uniq_account_job_id
+ALTER TABLE `oe_faxsms_queue` DROP INDEX `uniq_account_job_id`;
+#EndIf
+
+#IfNotColumnType oe_faxsms_queue account varchar(63)
+ALTER TABLE `oe_faxsms_queue` MODIFY `account` VARCHAR(63) DEFAULT NULL;
+#EndIf
+
+#IfNotColumnType oe_faxsms_queue job_id varchar(128)
+ALTER TABLE `oe_faxsms_queue` MODIFY `job_id` VARCHAR(128) DEFAULT NULL COMMENT 'Guid of fax';
+#EndIf
+
+#IfNotIndex oe_faxsms_queue uniq_account_job_id_v2
 DELETE FROM `oe_faxsms_queue` WHERE `job_id` IS NULL OR TRIM(`job_id`) = '' OR TRIM(`job_id`) = 'NULL';
 DELETE FROM oe_faxsms_queue WHERE id NOT IN ( SELECT id FROM ( SELECT MIN(id) AS id FROM oe_faxsms_queue GROUP BY account, job_id) keep);
-ALTER TABLE `oe_faxsms_queue` ADD UNIQUE KEY `uniq_account_job_id` (`account`(255), `job_id`(255));
+ALTER TABLE `oe_faxsms_queue` ADD UNIQUE KEY `uniq_account_job_id_v2` (`account`, `job_id`);
 #EndIf
 
 #IfMissingColumn oe_faxsms_queue status

--- a/interface/modules/custom_modules/oe-module-faxsms/table.sql
+++ b/interface/modules/custom_modules/oe-module-faxsms/table.sql
@@ -12,9 +12,9 @@ UNIQUE KEY `vendor` (`auth_user`,`vendor`)
 
 CREATE TABLE IF NOT EXISTS `oe_faxsms_queue` (
 `id` int(11) NOT NULL AUTO_INCREMENT,
-`account` tinytext,
+`account` varchar(63) DEFAULT NULL,
 `uid` int(11) DEFAULT NULL,
-`job_id` text COMMENT 'Guid of fax',
+`job_id` varchar(128) DEFAULT NULL COMMENT 'Guid of fax',
 `date` datetime DEFAULT current_timestamp(),
 `receive_date` datetime DEFAULT NULL,
 `deleted` int(1) NOT NULL DEFAULT 0,
@@ -37,10 +37,22 @@ UPDATE categories_seq SET id = (select MAX(id) from categories);
 ALTER TABLE `module_faxsms_credentials` ADD `updated` DATETIME DEFAULT CURRENT_TIMESTAMP;
 #Endif
 
-#IfNotIndex oe_faxsms_queue uniq_account_job_id
+#IfIndex oe_faxsms_queue uniq_account_job_id
+ALTER TABLE `oe_faxsms_queue` DROP INDEX `uniq_account_job_id`;
+#EndIf
+
+#IfNotColumnType oe_faxsms_queue account varchar(63)
+ALTER TABLE `oe_faxsms_queue` MODIFY `account` VARCHAR(63) DEFAULT NULL;
+#EndIf
+
+#IfNotColumnType oe_faxsms_queue job_id varchar(128)
+ALTER TABLE `oe_faxsms_queue` MODIFY `job_id` VARCHAR(128) DEFAULT NULL COMMENT 'Guid of fax';
+#EndIf
+
+#IfNotIndex oe_faxsms_queue uniq_account_job_id_v2
 DELETE FROM `oe_faxsms_queue` WHERE `job_id` IS NULL OR TRIM(`job_id`) = '' OR TRIM(`job_id`) = 'NULL';
 DELETE FROM oe_faxsms_queue WHERE id NOT IN ( SELECT id FROM ( SELECT MIN(id) AS id FROM oe_faxsms_queue GROUP BY account, job_id) keep);
-ALTER TABLE `oe_faxsms_queue` ADD UNIQUE KEY `uniq_account_job_id` (`account`(255), `job_id`(255));
+ALTER TABLE `oe_faxsms_queue` ADD UNIQUE KEY `uniq_account_job_id_v2` (`account`, `job_id`);
 #EndIf
 
 #IfMissingColumn oe_faxsms_queue status


### PR DESCRIPTION
## Summary

`interface/modules/custom_modules/oe-module-faxsms/table.sql` adds a unique key on `oe_faxsms_queue (account, job_id)` with prefix `(account(255), job_id(255))`. On any fresh install whose default database charset is `utf8mb4`, this `ALTER` fails with:

```
Specified key was too long; max key length is 255 bytes
```

The InstallerController catches the SqlQueryException, logs it via `SystemLogger`, and surfaces the unrelated message `"ERROR: could not open table.sql, broken form?"` in the Modules Manager UI. `modules.sql_run` stays `0` and the FaxSMS module cannot be activated until the failing prefix is fixed.

This change tightens the underlying schema so the unique constraint matches what the application actually stores, removing the prefix index entirely.

## Failure matrix

`account` is declared `tinytext`. `tinytext` has a hard 255-byte data length limit. An index prefix in characters translates to a byte length based on the column's effective charset:

| Column charset | Bytes per char | Bytes for `account(255)` | Result |
|---|---|---|---|
| `latin1` / `ascii` | 1 | 255 | OK (fits in 255-byte tinytext) |
| `utf8mb3` | 3 | 765 | FAIL (765 > 255) |
| `utf8mb4` | 4 | 1020 | FAIL (1020 > 255) |

`account` inherits its charset from the database default at `CREATE TABLE` time (no explicit `CHARACTER SET` clause). So whether this `ALTER` succeeds depends entirely on the target database's default charset.

### Where this fails today

- Fresh installs where `CREATE DATABASE` ran with `CHARACTER SET utf8mb4`. This is the modern OpenEMR default and the default on Cloud SQL MySQL/MariaDB.
- Any install on a server whose `character_set_database` is `utf8mb4` or `utf8mb3` when the FaxSMS module is registered for the first time.

### Where this does not fail (but only by coincidence)

- Legacy installs where `account` ended up as `latin1`, either because `CREATE DATABASE` predated the utf8mb4 default or because the operator opted out. `latin1` is one byte per char, so `account(255)` fits the tinytext cap exactly.
- Installs that registered the FaxSMS module **before** the unique key was added (PR #10171, 2026-01-24). For those, `table.sql` was processed once without the failing line, `modules.sql_run` flipped to `1`, and `table.sql` is not re-executed on subsequent upgrades. The `oe_faxsms_queue` table simply never gets the index. So an "old" install plus a "new" `table.sql` does not retry the failing `ALTER`. Only **fresh** installs against the new `table.sql` hit the failure.

That second case is why the bug went unnoticed: every install that had FaxSMS configured before #10171 keeps working, and only fresh installs since then surface the regression.

## What this changes

The columns are narrowed to match what the application actually writes, and the unique key drops the prefix entirely:

| | Before | After |
|---|---|---|
| `account` | `tinytext` (255 bytes) | `VARCHAR(63)` |
| `job_id` | `text` (65 KB, comment preserved) | `VARCHAR(128)` |
| Unique key | `uniq_account_job_id (account(63), job_id(128))` (prefix) | `uniq_account_job_id_v2 (account, job_id)` (full value) |

### Why these specific sizes

- **`account` → `VARCHAR(63)`**: With utf8mb4 (4 bytes/char), 63 chars × 4 = 252 bytes, comfortably under the 255-byte per-key-part limit. Vendor account identifiers (Twilio Account SIDs are 34 chars, RingCentral and Sinch identifiers are shorter) fit easily.
- **`job_id` → `VARCHAR(128)`**: Vendor message identifiers — UUIDs are 36 chars, Twilio SIDs 34 — fit with comfortable headroom. 128 chars × 4 = 512 bytes, well under both the legacy 767-byte InnoDB prefix limit and the modern 3072-byte DYNAMIC row format limit.

Total per-row index footprint: 252 + 512 = 764 bytes. Works regardless of MariaDB/MySQL version or `innodb_large_prefix` setting.

### Why drop the prefix entirely

With `tinytext` and a prefix index, a latin1 install could have stored an `account` value longer than 63 chars whose first 63 chars collided with another row. The `GROUP BY account, job_id` dedupe checks full content, but the prefix index only enforces uniqueness on the prefix — so the dedupe and the constraint operated on different keys. With full-value uniqueness on narrowed columns, both operate on the same key.

## Migration shape

Each step is independently guarded so the migration is idempotent across re-runs:

```sql
#IfIndex oe_faxsms_queue uniq_account_job_id
ALTER TABLE `oe_faxsms_queue` DROP INDEX `uniq_account_job_id`;
#EndIf

#IfNotColumnType oe_faxsms_queue account varchar(63)
ALTER TABLE `oe_faxsms_queue` MODIFY `account` VARCHAR(63) DEFAULT NULL;
#EndIf

#IfNotColumnType oe_faxsms_queue job_id varchar(128)
ALTER TABLE `oe_faxsms_queue` MODIFY `job_id` VARCHAR(128) DEFAULT NULL COMMENT 'Guid of fax';
#EndIf

#IfNotIndex oe_faxsms_queue uniq_account_job_id_v2
DELETE FROM ...
ALTER TABLE `oe_faxsms_queue` ADD UNIQUE KEY `uniq_account_job_id_v2` (`account`, `job_id`);
#EndIf
```

The index is renamed to `uniq_account_job_id_v2` so the `#IfIndex` drop only fires once: subsequent re-runs see the new name, find the old name absent, and skip the drop entirely. (`DROP INDEX IF EXISTS` would have been simpler but is unsupported on MySQL 5.7, which is still in our integration test matrix.)

This applies to both `table.sql` (initial registration) and `sql/5_1_0-to-6_0_0_upgrade.sql` (the explicit Modules Manager "Upgrade SQL" path), so neither the fresh-install nor the explicit-upgrade path stays broken on utf8mb4 databases.

## Test plan

Verified empirically on a Cloud SQL MariaDB 10.11 install with `character_set_database=utf8mb4`, `collation_database=utf8mb4_general_ci`, `innodb_default_row_format=dynamic`:

| Statement | Result |
|---|---|
| `ALTER TABLE oe_faxsms_queue ADD UNIQUE KEY uniq_account_job_id (account(255), job_id(255))` | FAIL: `Specified key was too long; max key length is 255 bytes` |
| `MODIFY account VARCHAR(63); MODIFY job_id VARCHAR(128); ADD UNIQUE KEY uniq_account_job_id_v2 (account, job_id)` (this PR) | OK |

After this fix, `bin/console modules:install` (or the equivalent UI install flow) on a fresh utf8mb4 install completes `table.sql` successfully on first try and `modules.sql_run` is set to `1`.

Existing installs that already have the broken prefix index get the column-type narrowing and the new full-value index on next module re-registration or explicit upgrade. Steady-state re-runs are no-ops.
