### PR TITLE
fix(login): default login_page_layout when globals row is missing (backport #11949 to rel-810)

### DIFF
--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -36127,11 +36127,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Events/Core/TemplatePageEvent.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Events\\\\Core\\\\TemplatePageEvent\\:\\:__construct\\(\\) has parameter \\$twigTemplate with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Events/Core/TemplatePageEvent.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Events\\\\Core\\\\TemplatePageEvent\\:\\:__construct\\(\\) has parameter \\$twigVariables with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Events/Core/TemplatePageEvent.php',
@@ -37842,21 +37837,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\AuthorizationController\\:\\:renderTwigPage\\(\\) has parameter \\$pageName with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\AuthorizationController\\:\\:renderTwigPage\\(\\) has parameter \\$template with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\AuthorizationController\\:\\:renderTwigPage\\(\\) has parameter \\$templateVars with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\AuthorizationController\\:\\:saveTrustedUser\\(\\) has parameter \\$clientId with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
@@ -39185,41 +39165,6 @@ $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\SMART\\\\PatientContextSearchController\\:\\:searchPatients\\(\\) has parameter \\$userUUID with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/SMART/PatientContextSearchController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\SMART\\\\SMARTAuthorizationController\\:\\:renderTwigJson\\(\\) has parameter \\$defaultTemplate with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/SMART/SMARTAuthorizationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\SMART\\\\SMARTAuthorizationController\\:\\:renderTwigJson\\(\\) has parameter \\$pageName with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/SMART/SMARTAuthorizationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\SMART\\\\SMARTAuthorizationController\\:\\:renderTwigJson\\(\\) has parameter \\$template with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/SMART/SMARTAuthorizationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\SMART\\\\SMARTAuthorizationController\\:\\:renderTwigJson\\(\\) has parameter \\$templateVars with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/SMART/SMARTAuthorizationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\SMART\\\\SMARTAuthorizationController\\:\\:renderTwigPage\\(\\) has parameter \\$pageName with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/SMART/SMARTAuthorizationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\SMART\\\\SMARTAuthorizationController\\:\\:renderTwigPage\\(\\) has parameter \\$template with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/SMART/SMARTAuthorizationController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\SMART\\\\SMARTAuthorizationController\\:\\:renderTwigPage\\(\\) has parameter \\$templateVars with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/SMART/SMARTAuthorizationController.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\TransactionRestController\\:\\:CreateTransaction\\(\\) has parameter \\$data with no type specified\\.$#',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -23107,11 +23107,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Events/Core/TemplatePageEvent.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Events\\\\Core\\\\TemplatePageEvent\\:\\:setTwigTemplate\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Events/Core/TemplatePageEvent.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Events\\\\Encounter\\\\EncounterButtonEvent\\:\\:displayButton\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Events/Encounter/EncounterButtonEvent.php',

--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -17,11 +17,13 @@
  * @author  Ken Chapple <ken@mi-squared.com>
  * @author  Daniel Pflieger <daniel@mi-squared.com> <daniel@growlingflea.com>
  * @author  Robert Down <robertdown@live.com>
+ * @author  Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2019 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2020 Tyler Wrenn <tyler@tylerwrenn.com>
  * @copyright Copyright (c) 2021 Ken Chapple <ken@mi-squared.com>
  * @copyright Copyright (c) 2021 Daniel Pflieger <daniel@mi-squared.com> <daniel@growlingflea.com>
  * @copyright Copyright (c) 2021-2023 Robert Down <robertdown@live.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -62,7 +64,11 @@ $secondaryLogo = $logoService->getLogo("core/login/secondary");
 $smallLogoOne = $logoService->getLogo("core/login/small_logo_1");
 $smallLogoTwo = $logoService->getLogo("core/login/small_logo_2");
 
-$layout = $globalsBag->get('login_page_layout');
+// Fall back to the documented default (see library/globals.inc.php) when the
+// `login_page_layout` row is absent — happens on freshly seeded databases that
+// haven't run the 7.0.0 → 7.0.1 upgrade. Without this the next line passes
+// null into TemplatePageEvent and the login page 500s with no way to recover.
+$layout = $globalsBag->getString('login_page_layout') ?: 'login/layouts/vertical_band.html.twig';
 
 // mdsupport - Add 'App' functionality for user interfaces without standard menu and frames
 // If this script is called with app parameter, validate it without showing other apps.

--- a/src/Events/Core/TemplatePageEvent.php
+++ b/src/Events/Core/TemplatePageEvent.php
@@ -9,9 +9,11 @@
  *
  * @author    Stephen Nielson <stephen@nielson.org>
  * @author    Robert Down <robertdown@live.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
  * @copyright Copyright (c) 2023 Robert Down <robertdown@live.com>
  * @copyright Copyright (c) 2023 Providence Healthtech
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -51,7 +53,7 @@ class TemplatePageEvent extends Event
      */
     private $pageName;
 
-    public function __construct(string $pageName, $context = [], $twigTemplate = "", $twigVariables = [])
+    public function __construct(string $pageName, $context = [], string $twigTemplate = "", $twigVariables = [])
     {
         $this->setContext($context);
         $this->setPageName($pageName);
@@ -123,7 +125,7 @@ class TemplatePageEvent extends Event
         $this->twigVariables = [];
     }
 
-    public function setTwigTemplate(string $template)
+    public function setTwigTemplate(string $template): self
     {
         $this->twigTemplate = $template;
         return $this;

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -7,8 +7,10 @@
  * @link      https://www.open-emr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2020 Jerry Padgett <sjpadgett@gmail.com>
  * @copyright Copyright (c) 2020 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -926,7 +928,10 @@ class AuthorizationController
         return $this->createServerResponse()->withStatus(Response::HTTP_TEMPORARY_REDIRECT)->withHeader("Location", $redirect);
     }
 
-    private function renderTwigPage($pageName, $template, $templateVars): ResponseInterface
+    /**
+     * @param array<string, mixed> $templateVars
+     */
+    private function renderTwigPage(string $pageName, string $template, array $templateVars): ResponseInterface
     {
         $twig = $this->getTwig();
         $templatePageEvent = new TemplatePageEvent($pageName, [], $template, $templateVars);

--- a/src/RestControllers/SMART/SMARTAuthorizationController.php
+++ b/src/RestControllers/SMART/SMARTAuthorizationController.php
@@ -5,7 +5,9 @@
  * @package openemr
  * @link      https://www.open-emr.org
  * @author    Stephen Nielson <stephen@nielson.org>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -323,7 +325,10 @@ class SMARTAuthorizationController
         return $this->twig;
     }
 
-    private function renderTwigPage($pageName, $template, $templateVars): ResponseInterface
+    /**
+     * @param array<string, mixed> $templateVars
+     */
+    private function renderTwigPage(string $pageName, string $template, array $templateVars): ResponseInterface
     {
         $twig = $this->getTwig();
         $templatePageEvent = new TemplatePageEvent($pageName, [], $template, $templateVars);
@@ -345,7 +350,10 @@ class SMARTAuthorizationController
         }
     }
 
-    private function renderTwigJson($pageName, $template, $templateVars, $defaultTemplate = null): ResponseInterface
+    /**
+     * @param array<string, mixed> $templateVars
+     */
+    private function renderTwigJson(string $pageName, string $template, array $templateVars, ?string $defaultTemplate = null): ResponseInterface
     {
         $twig = $this->getTwig();
         $templatePageEvent = new TemplatePageEvent($pageName, [], $template, $templateVars);

--- a/tests/Tests/Isolated/Events/Core/TemplatePageEventTest.php
+++ b/tests/Tests/Isolated/Events/Core/TemplatePageEventTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Isolated tests for TemplatePageEvent
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Events\Core;
+
+use OpenEMR\Events\Core\TemplatePageEvent;
+use PHPUnit\Framework\TestCase;
+
+class TemplatePageEventTest extends TestCase
+{
+    public function testConstructorStoresTemplate(): void
+    {
+        $event = new TemplatePageEvent('login/login.php', [], 'login/layouts/vertical_band.html.twig', ['k' => 'v']);
+
+        $this->assertSame('login/layouts/vertical_band.html.twig', $event->getTwigTemplate());
+        $this->assertSame(['k' => 'v'], $event->getTwigVariables());
+    }
+
+    public function testConstructorDefaultsToEmptyTemplate(): void
+    {
+        $event = new TemplatePageEvent('page');
+
+        $this->assertSame('', $event->getTwigTemplate());
+    }
+
+    public function testSetTwigTemplateRoundTrip(): void
+    {
+        $event = new TemplatePageEvent('page');
+        $event->setTwigTemplate('login/layouts/vertical_band.html.twig');
+
+        $this->assertSame('login/layouts/vertical_band.html.twig', $event->getTwigTemplate());
+    }
+
+    public function testSetTwigTemplateReturnsSelfForChaining(): void
+    {
+        $event = new TemplatePageEvent('page');
+        $this->assertSame($event, $event->setTwigTemplate('any.twig'));
+    }
+}


### PR DESCRIPTION
## Summary

Backports #11949 to `rel-810`.

Fixes the regression where `interface/login/login.php` returned HTTP 500 if `globals.login_page_layout` was missing (freshly seeded databases that haven't run the 7.0.0 → 7.0.1 upgrade). The null was passed into `TemplatePageEvent::setTwigTemplate(string)`, causing a `TypeError` and locking users out with no way to recover.

## Changes (cherry-picked from a58656f0)

- **`interface/login/login.php`**: default the layout to `login/layouts/vertical_band.html.twig` (matches `library/globals.inc.php:520`). Primary fix.
- **`src/Events/Core/TemplatePageEvent.php`**: add `: self` return type to `setTwigTemplate()` for fluent use.
- **`src/RestControllers/AuthorizationController.php`**, **`src/RestControllers/SMART/SMARTAuthorizationController.php`**: typed private `renderTwigPage` / `renderTwigJson` methods as the source fix for upstream `mixed → string` flow.
- **PHPStan baseline**: net **-80 lines** (obsolete entries removed by the source fixes; baseline regenerated cleanly on rel-810 with no additions).

## Backport notes

Cherry-picked the squashed merge commit cleanly — no conflicts. Baseline regeneration on rel-810 produced no diff, so the upstream baseline subtractions transfer 1:1.

## Test plan

- [ ] On a database missing `login_page_layout`: login page renders with the default layout instead of HTTP 500.
- [ ] On a normally-installed database: login page renders with the configured layout (no behavior change).
- [ ] OAuth2 flow (Authorization, SMART): login screens still render correctly.
