### PR TITLE
fix(auth): remove unused redirect_token from OneTimeAuth

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -14612,16 +14612,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'Redirect token…\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Entities/ClientEntity.php',

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -3663,7 +3663,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 14,
+    'count' => 9,
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -30822,16 +30822,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OneTimeAuth\\:\\:decodePortalOneTime\\(\\) has parameter \\$redirect_token with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OneTimeAuth\\:\\:encodeLink\\(\\) has parameter \\$encrypted_redirect with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OneTimeAuth\\:\\:encodeLink\\(\\) has parameter \\$site_addr with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
@@ -30888,11 +30878,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OneTimeAuth\\:\\:insertOnetime\\(\\) has parameter \\$scope with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OneTimeAuth\\:\\:processOnetime\\(\\) has parameter \\$redirect_token with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -50582,11 +50582,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Fixtures/FixtureManagerTest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pubpid\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../tests/Tests/Fixtures/FixtureManagerTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'resourceType\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Fixtures/FixtureManagerTest.php',
@@ -51220,11 +51215,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'last_updated_time\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/Condition/FhirConditionProblemsHealthConcernServiceTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'patient\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/Condition/FhirConditionService3_1_1Test.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset 0 on mixed\\.$#',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -39702,16 +39702,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pid\' on mixed\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'to\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access an offset on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Entities/ScopePermissionObject.php',
@@ -50592,6 +50582,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Fixtures/FixtureManagerTest.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'pubpid\' on mixed\\.$#',
+    'count' => 2,
+    'path' => __DIR__ . '/../../tests/Tests/Fixtures/FixtureManagerTest.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'resourceType\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Fixtures/FixtureManagerTest.php',
@@ -51225,6 +51220,11 @@ $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'last_updated_time\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/Condition/FhirConditionProblemsHealthConcernServiceTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'patient\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/Condition/FhirConditionService3_1_1Test.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset 0 on mixed\\.$#',

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -4208,12 +4208,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 30,
+    'count' => 29,
     'path' => __DIR__ . '/../../portal/index.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 5,
+    'count' => 4,
     'path' => __DIR__ . '/../../portal/index.php',
 ];
 $ignoreErrors[] = [

--- a/portal/index.php
+++ b/portal/index.php
@@ -105,14 +105,13 @@ if (!empty($_REQUEST['service_auth'] ?? null)) {
         // an external site domain.  We used to auto process via GET but now we submit via the POST in order to make it
         // a same site cookie origin request. This is a workaround for the Same-Site cookie blocking.
         $token = $_GET['service_auth'];
-        $ot = $oneTime->decodePortalOneTime($token, null, false);
+        $ot = $oneTime->decodePortalOneTime($token, logUpdate: false);
         $pin_required = $ot['actions']['enforce_auth_pin'] ? 1 : 0;
         CsrfUtils::setupCsrfKey($session);
         $twig = new TwigContainer(null, $globalsBag->getKernel());
         echo $twig->getTwig()->render('portal/login/autologin.html.twig', [
             'action' => $globalsBag->getString('web_root') . '/portal/index.php',
             'service_auth' => text($_GET['service_auth']),
-            'target' => text($_GET['target'] ?? null),
             'csrf_token' => CsrfUtils::collectCsrfToken($session, 'autologin'),
             'pagetitle' => xl("OpenEMR Patient Portal"),
             'images_static_relative' => $globalsBag->get('images_static_relative') ?? '',
@@ -121,13 +120,12 @@ if (!empty($_REQUEST['service_auth'] ?? null)) {
         exit;
     } elseif (!empty($_POST['service_auth'] ?? null)) {
         $token = $_POST['service_auth'];
-        $redirect_token = $_POST['target'] ?? null;
         $csrfToken = $_POST['csrf_token'] ?? null;
         try {
             if (!CsrfUtils::verifyCsrfToken($csrfToken, $session, 'autologin')) {
                 throw new OneTimeAuthException('Invalid CSRF token');
             }
-            $auth = $oneTime->processOnetime($token, $redirect_token);
+            $auth = $oneTime->processOnetime($token);
             $logit->portalLog('onetime login attempt', $auth['pid'], 'patient logged in and redirecting', '', '1');
             exit();
         } catch (OneTimeAuthExpiredException $exception) {

--- a/src/Common/Auth/OneTimeAuth.php
+++ b/src/Common/Auth/OneTimeAuth.php
@@ -57,7 +57,6 @@ class OneTimeAuth
 
     /**
      * @param array $p
-     * @param bool  $encrypt_redirect
      * @return array|bool
      * @throws \Exception
      *
@@ -76,9 +75,8 @@ class OneTimeAuth
      *        'max_access_count' => 0, // 0 = unlimited.
      *     ]
      */
-    public function createPortalOneTime(array $p, bool $encrypt_redirect = false): array|bool
+    public function createPortalOneTime(array $p): array|bool
     {
-        $redirect_token = null;
         $passed_in_pid = $p['pid'] ?? 0;
         $valid = PatientPortalService::isValidPortalPatient($passed_in_pid);
         if (empty($valid['valid'] ?? null) || empty($passed_in_pid)) {
@@ -98,14 +96,6 @@ class OneTimeAuth
         }
 
         $redirect_raw = trim((string)($p['redirect_link'] ?? null));
-        if (!empty($redirect_raw) && $encrypt_redirect) {
-            $redirect_plus = js_escape(['pid' => $passed_in_pid, 'to' => $redirect_raw]);
-            $redirect_token = $this->cryptoGen->encryptStandard($redirect_plus);
-            if (empty($redirect_token)) {
-                // since redirect should be in database we can continue.
-                $this->systemLogger->error(xlt("Onetime redirect failed encryption."));
-            }
-        }
         if (!empty($p['target_link'] ?? null)) {
             $site_addr = trim($p['target_link']);
         } elseif ($this->context == 'portal') {
@@ -126,9 +116,8 @@ class OneTimeAuth
         $actions = array_merge($actionDefaults, $p['actions'] ?? []); // from event data.
 
         // Create the encoded link and return the onetime token data set
-        $rtn['encoded_link'] = $this->encodeLink($site_addr, $token_encrypt, $redirect_token);
+        $rtn['encoded_link'] = $this->encodeLink($site_addr, $token_encrypt);
         $rtn['onetime_token'] = $token_encrypt;
-        $rtn['redirect_token'] = $redirect_token;
         $rtn['pin'] = $pin;
         $rtn['email'] = $email;
 
@@ -147,11 +136,10 @@ class OneTimeAuth
 
     /**
      * @param $onetime_token
-     * @param $redirect_token
      * @return array
      * @throws OneTimeAuthExpiredException
      */
-    public function decodePortalOneTime($onetime_token, $redirect_token = null, $logUpdate = true): array
+    public function decodePortalOneTime($onetime_token, $logUpdate = true): array
     {
         $auth = false;
         $rtn = [];
@@ -190,21 +178,7 @@ class OneTimeAuth
             $this->systemLogger->error($rtn['error']);
             throw new OneTimeAuthExpiredException($rtn['error'], $auth['pid']);
         }
-        // We'll rely on the stored redirect address as default.
-        // However, leave the option of using embedded encrypted redirect.
         $redirect = $t_info['redirect_url'] ?? null;
-        if (!empty($redirect_token)) {
-            $redirectTokenStr = is_string($redirect_token) ? $redirect_token : null;
-            if ($this->cryptoGen->cryptCheckStandard($redirectTokenStr)) {
-                $redirect_decrypted = $this->cryptoGen->decryptStandard($redirectTokenStr, minimumVersion: 6);
-                $redirect_array = json_decode($redirect_decrypted, true);
-                $redirect = $redirect_array['to'];
-                if (($redirect_array['pid'] != $auth['pid'] && !empty($redirect_array['pid']))) {
-                    throw new OneTimeAuthException(xlt("Error! credentials pid to and from don't match!"), $auth['pid']);
-                }
-                $this->systemLogger->debug("Redirect token decrypted: pid = " . $redirect_array['pid'] . " redirect = " . $redirect);
-            }
-        }
 
         $rtn['pid'] = $auth['pid'];
         $rtn['pin'] = $t_info['onetime_pin'];
@@ -226,10 +200,9 @@ class OneTimeAuth
     /**
      * @param $site_addr
      * @param $token_encrypt
-     * @param $encrypted_redirect
      * @return string
      */
-    private function encodeLink($site_addr, $token_encrypt, $encrypted_redirect = null): string
+    private function encodeLink($site_addr, $token_encrypt): string
     {
         $site_id = $this->session->get('site_id', 'default');
         if (stripos((string)$site_addr, "portal") !== false) {
@@ -259,18 +232,10 @@ class OneTimeAuth
                 'site' => $site_id
             ], '', '&', $enc_type));
         } else {
-            if (!empty($encrypted_redirect)) {
-                $encoded_link = sprintf($format, attr($site_addr), http_build_query([
-                    'service_auth' => $token_encrypt,
-                    'target' => $encrypted_redirect,
-                    'site' => $site_id
-                ], '', '&', $enc_type));
-            } else {
-                $encoded_link = sprintf($format, attr($site_addr), http_build_query([
-                    'service_auth' => $token_encrypt,
-                    'site' => $site_id
-                ], '', '&', $enc_type));
-            }
+            $encoded_link = sprintf($format, attr($site_addr), http_build_query([
+                'service_auth' => $token_encrypt,
+                'site' => $site_id
+            ], '', '&', $enc_type));
         }
         $this->systemLogger->debug("Onetime link " . text($encoded_link) . " encoded");
 
@@ -328,13 +293,12 @@ class OneTimeAuth
 
     /**
      * @param $token
-     * @param $redirect_token
      * @return array
      */
-    public function processOnetime($token, $redirect_token): array
+    public function processOnetime($token): array
     {
         try {
-            $auth = $this->decodePortalOneTime($token, $redirect_token);
+            $auth = $this->decodePortalOneTime($token);
             if ($auth["actions"]["enforce_auth_pin"]) {
                 $this->systemLogger->debug("Pin auth required");
                 if ($auth['pin'] != $_POST['login_pin'] ?? null) {

--- a/templates/portal/login/autologin.html.twig
+++ b/templates/portal/login/autologin.html.twig
@@ -37,7 +37,6 @@
         <form method="POST" id="autologinform" action="{{ action|attr }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token|attr }}" />
             <input type="hidden" name="service_auth" value="{{ service_auth|attr }}" />
-            <input type="hidden" name="target" value="{{ target|attr_url }}" />
             {% if pin_required %}
             <label for="login_pin">{{ "PIN Required value"|xlt }}</label>
             <input type="text" class="text-center m-1" maxlength="6" id="login_pin" name="login_pin" value="" />
@@ -47,10 +46,9 @@
             {% endif %}
         </form>
         {% if pin_required %}
-        <p>{{ "You are Required to confirm access by entering the companion PIN."|xlt }} {{ target|text }}</p>
+        <p>{{ "You are Required to confirm access by entering the companion PIN."|xlt }}</p>
         {% else %}
         <p>{{ "If you have not been redirected in a few seconds click the button above"|xlt }}</p>
-        <p>{{ "You will be sent to the following web page"|xlt }} {{ target|text }}</p>
         {% endif %}
     </div>
     <script>

--- a/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
+++ b/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
@@ -132,7 +132,6 @@ class TwigTemplateRenderTest extends TestCase
                 'action'                 => '/portal/autologin',
                 'csrf_token'             => 'test-csrf-token',
                 'service_auth'           => 'test-auth-value',
-                'target'                 => 'https://example.com/telehealth',
             ],
             $fixtureDir . '/autologin-pin-required.html',
         ];
@@ -146,7 +145,6 @@ class TwigTemplateRenderTest extends TestCase
                 'action'                 => '/portal/autologin',
                 'csrf_token'             => 'test-csrf-token',
                 'service_auth'           => 'test-auth-value',
-                'target'                 => 'https://example.com/telehealth',
             ],
             $fixtureDir . '/autologin-no-pin.html',
         ];

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/autologin-no-pin.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/autologin-no-pin.html
@@ -23,11 +23,9 @@
                 <form method="POST" id="autologinform" action="/portal/autologin">
             <input type="hidden" name="csrf_token" value="test-csrf-token" />
             <input type="hidden" name="service_auth" value="test-auth-value" />
-            <input type="hidden" name="target" value="https%3A%2F%2Fexample.com%2Ftelehealth" />
                         <input class="btn btn-lg btn-primary" type="submit" name="autoLoginSubmit" value="Go To Destination" />
                     </form>
                 <p>If you have not been redirected in a few seconds click the button above</p>
-        <p>You will be sent to the following web page https://example.com/telehealth</p>
             </div>
     <script>
         const pinRequired = false;

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/autologin-pin-required.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/autologin-pin-required.html
@@ -23,12 +23,11 @@
                 <form method="POST" id="autologinform" action="/portal/autologin">
             <input type="hidden" name="csrf_token" value="test-csrf-token" />
             <input type="hidden" name="service_auth" value="test-auth-value" />
-            <input type="hidden" name="target" value="https%3A%2F%2Fexample.com%2Ftelehealth" />
                         <label for="login_pin">PIN Required value</label>
             <input type="text" class="text-center m-1" maxlength="6" id="login_pin" name="login_pin" value="" />
             <input class="btn btn-sm btn-primary" type="submit" name="autoLoginSubmit" value="Authorize and Go To Destination" />
                     </form>
-                <p>You are Required to confirm access by entering the companion PIN. https://example.com/telehealth</p>
+                <p>You are Required to confirm access by entering the companion PIN.</p>
             </div>
     <script>
         const pinRequired = 1;


### PR DESCRIPTION
## Summary

This proactively fixes a high-risk (but, by the look of it, not actively exploitable) area that could lead to an open redirect vulnerability. It was discovered while working on #11956.

- Remove the unused `redirect_token` parameter and `encrypt_redirect` feature from `OneTimeAuth`
- The redirect URL is already stored in the database; this redundant URL-based mechanism added complexity without benefit
- Simplifies the onetime auth flow by using the database as the single source of truth for redirect URLs

## Background

The `redirect_token` feature allowed an encrypted redirect URL to be passed via URL/POST parameters, overriding the database-stored `redirect_url`. However:

1. The feature was never enabled - `encrypt_redirect` defaulted to `false` and no callers passed `true`
2. The infrastructure existed but served no purpose
3. Coupling redirect validation to the encryption layer is architecturally fragile

## Test plan

- [x] PHPStan passes
- [x] Twig template render tests updated and passing
- [ ] Manual test of onetime portal login flow

🤖 Generated with [Claude Code](https://claude.ai/code)