### PR TITLE
chore(deps): bump redis from 8.6 to 8.6 in /ci/compose-shared-redis-sentinel (backport #11808 to rel-810)

### DIFF
--- a/ci/compose-shared-redis-sentinel/docker-compose.yml
+++ b/ci/compose-shared-redis-sentinel/docker-compose.yml
@@ -19,7 +19,7 @@
 
 services:
   redis-master:
-    image: redis:8.6@sha256:83619e7d06f34b2f209c8ffae597329abaa9d59dbfca34844945c2f1d81a846c
+    image: redis:8.6@sha256:832d7785830f3f4b559300e6191fc914b15642c1935252338825cf4332200148
     container_name: redis-master
     # Config passed via command-line args instead of bind-mounted redis.conf.
     # Docker Compose resolves bind-mount paths relative to the first file in
@@ -27,19 +27,19 @@ services:
     # silently resolves to the wrong directory when this template is combined
     # with other compose files.
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --replica-announce-ip
-      - redis-master
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --replica-announce-ip
+    - redis-master
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "strongpassword", "ping"]
       interval: 5s
@@ -48,68 +48,68 @@ services:
       start_period: 10s
 
   redis-replica-1:
-    image: redis:8.6@sha256:83619e7d06f34b2f209c8ffae597329abaa9d59dbfca34844945c2f1d81a846c
+    image: redis:8.6@sha256:832d7785830f3f4b559300e6191fc914b15642c1935252338825cf4332200148
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --replicaof
-      - redis-master
-      - "6379"
-      - --replica-announce-ip
-      - redis-replica-1
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --replicaof
+    - redis-master
+    - "6379"
+    - --replica-announce-ip
+    - redis-replica-1
     depends_on:
       redis-master:
         condition: service_healthy
 
   redis-replica-2:
-    image: redis:8.6@sha256:83619e7d06f34b2f209c8ffae597329abaa9d59dbfca34844945c2f1d81a846c
+    image: redis:8.6@sha256:832d7785830f3f4b559300e6191fc914b15642c1935252338825cf4332200148
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --replicaof
-      - redis-master
-      - "6379"
-      - --replica-announce-ip
-      - redis-replica-2
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --replicaof
+    - redis-master
+    - "6379"
+    - --replica-announce-ip
+    - redis-replica-2
     depends_on:
       redis-master:
         condition: service_healthy
 
   sentinel-1:
-    image: redis:8.6@sha256:83619e7d06f34b2f209c8ffae597329abaa9d59dbfca34844945c2f1d81a846c
+    image: redis:8.6@sha256:832d7785830f3f4b559300e6191fc914b15642c1935252338825cf4332200148
     # Config is written inline to avoid bind-mount directory pollution — see file header.
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        printf '%s\n' \
-          'port 26379' \
-          'daemonize no' \
-          'sentinel resolve-hostnames yes' \
-          'sentinel announce-hostnames yes' \
-          'sentinel monitor redis-master redis-master 6379 2' \
-          'sentinel auth-pass redis-master strongpassword' \
-          'sentinel down-after-milliseconds redis-master 5000' \
-          'sentinel failover-timeout redis-master 60000' \
-          'sentinel parallel-syncs redis-master 1' \
-          > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+    - |
+      printf '%s\n' \
+        'port 26379' \
+        'daemonize no' \
+        'sentinel resolve-hostnames yes' \
+        'sentinel announce-hostnames yes' \
+        'sentinel monitor redis-master redis-master 6379 2' \
+        'sentinel auth-pass redis-master strongpassword' \
+        'sentinel down-after-milliseconds redis-master 5000' \
+        'sentinel failover-timeout redis-master 60000' \
+        'sentinel parallel-syncs redis-master 1' \
+        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
     depends_on:
       redis-master:
         condition: service_healthy
@@ -122,22 +122,22 @@ services:
       start_period: 15s
 
   sentinel-2:
-    image: redis:8.6@sha256:83619e7d06f34b2f209c8ffae597329abaa9d59dbfca34844945c2f1d81a846c
+    image: redis:8.6@sha256:832d7785830f3f4b559300e6191fc914b15642c1935252338825cf4332200148
     # Config is written inline to avoid bind-mount directory pollution — see file header.
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        printf '%s\n' \
-          'port 26379' \
-          'daemonize no' \
-          'sentinel resolve-hostnames yes' \
-          'sentinel announce-hostnames yes' \
-          'sentinel monitor redis-master redis-master 6379 2' \
-          'sentinel auth-pass redis-master strongpassword' \
-          'sentinel down-after-milliseconds redis-master 5000' \
-          'sentinel failover-timeout redis-master 60000' \
-          'sentinel parallel-syncs redis-master 1' \
-          > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+    - |
+      printf '%s\n' \
+        'port 26379' \
+        'daemonize no' \
+        'sentinel resolve-hostnames yes' \
+        'sentinel announce-hostnames yes' \
+        'sentinel monitor redis-master redis-master 6379 2' \
+        'sentinel auth-pass redis-master strongpassword' \
+        'sentinel down-after-milliseconds redis-master 5000' \
+        'sentinel failover-timeout redis-master 60000' \
+        'sentinel parallel-syncs redis-master 1' \
+        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
     depends_on:
       redis-master:
         condition: service_healthy


### PR DESCRIPTION
Backport of #11808 to `rel-810`.

Bumps the redis Docker image SHA in `ci/compose-shared-redis-sentinel/docker-compose.yml` to match what master has been running since 2026-04-24. The Sentinel mTLS CI variant uses this image; bringing rel-810 in sync may resolve a Twig template-render failure observed on #11960's Sentinel mTLS / e2e job that doesn't reproduce on master.

The diff also includes YAML-list indentation reflow from rel-810's `pretty-format-yaml` pre-commit hook (which Dependabot bypasses, so the file has been carrying its un-formatted upstream style). The only meaningful change is the five SHA bumps from `83619e7d…` to `832d77858…`.
