### PR TITLE
fix(acl): XML-escape ACL screen output and reject HTML-special characters in username

### DIFF
--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -1788,7 +1788,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 6,
+    'count' => 5,
     'path' => __DIR__ . '/../../interface/usergroup/usergroup_admin.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/echo.nonString.php
+++ b/.phpstan/baseline/echo.nonString.php
@@ -723,7 +723,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 19,
+    'count' => 8,
     'path' => __DIR__ . '/../../library/ajax/adminacl_ajax.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -1408,7 +1408,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/usergroup/usergroup_admin.php',
 ];
 $ignoreErrors[] = [
@@ -2233,7 +2233,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 35,
+    'count' => 30,
     'path' => __DIR__ . '/../../src/Common/Acl/AclExtended.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -1403,7 +1403,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/usergroup/user_admin.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -3618,7 +3618,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 168,
+    'count' => 167,
     'path' => __DIR__ . '/../../interface/usergroup/usergroup_admin.php',
 ];
 $ignoreErrors[] = [
@@ -3663,7 +3663,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 81,
+    'count' => 71,
     'path' => __DIR__ . '/../../library/ajax/adminacl_ajax.php',
 ];
 $ignoreErrors[] = [

--- a/interface/usergroup/adminacl.php
+++ b/interface/usergroup/adminacl.php
@@ -38,6 +38,16 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
     <?php Header::setupHeader(); ?>
 
     <script>
+        // Escape a string for safe insertion into HTML attributes and text content.
+        function escHtml(str) {
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
         $(function () {
             //Bootstrap tooltip
             var groupTitle = <?php echo xlj('This section allows you to create and remove groups and modify or grant access privileges to existing groups. Check the check box to display section'); ?>;
@@ -226,11 +236,27 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
                     success: function(xml){
                         $("#membership_error").empty();
                         $("#membership").empty();
+                        var userIdx = 0;
                         $(xml).find("user").each(function(){
                             username = $(this).find("username").text();
-                            $("#membership").append("<div id='link_" + username + "'><span class='text'>" + username + "</span><a class='link_submit' href='no_javascript' id='" + username + "_membership_list' title='" + <?php echo xlj('Edit'); ?> + " " + username + "'>&nbsp;<i class='fa fa-pencil-alt' aria-hidden='true'></i></a></span><a class='link_submit' href='no_javascript' id='" + username +  "_membership_hide' style='display: none' title='" + <?php echo xlj('Hide'); ?> + " " + username + "'>&nbsp;<i class='fa fa-eye-slash' aria-hidden='true'></i></a><span class='alert' style='display: none;'>&nbsp;&nbsp;" + <?php echo xlj('This user is not a member of any group'); ?> + "!!!</span><span class='loading' style='display: none;'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + <?php echo xlj('LOADING'); ?> + "...</span></div><div id='error_" + username + "'></div><div id='" + username +  "' style='display: none'><div class='table-responsive'><table class='head'><thead><tr><th class='text-center'><span class='bold'>" + <?php echo xlj('Active'); ?> + "</span></th><th class='text-center'><span class='bold'>" + <?php echo xlj('Inactive'); ?> + "</span></th></tr><tbody><tr><td align='center'><select class='form-control' name='active[]' multiple></select><br /><p align='center'><input class='button_submit btn btn-primary btn-sm' type='button' title='" + <?php echo xlj('Remove'); ?> + "' id='" + username  + "_membership_remove' value=' >> '></p></td><td align='center'><select class='form-control' name='inactive[]' multiple></select><br /><p align='center'><input class='button_submit btn btn-primary btn-sm' type='button' title='" + <?php echo xlj('Add'); ?> + "' id='" + username + "_membership_add' value=' << ' ></p></td></tr></tbody></table></div></div>");
+                            var uid = 'u_' + userIdx++;
+                            var $row = $(
+                                "<div id='link_" + uid + "'>" +
+                                "<span class='text'></span>" +
+                                "<a class='link_submit' href='no_javascript' id='" + uid + "_membership_list' data-username=''>&nbsp;<i class='fa fa-pencil-alt' aria-hidden='true'></i></a>" +
+                                "<a class='link_submit' href='no_javascript' id='" + uid + "_membership_hide' data-username='' style='display: none'>&nbsp;<i class='fa fa-eye-slash' aria-hidden='true'></i></a>" +
+                                "<span class='alert' style='display: none;'>&nbsp;&nbsp;" + <?php echo xlj('This user is not a member of any group'); ?> + "!!!</span>" +
+                                "<span class='loading' style='display: none;'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + <?php echo xlj('LOADING'); ?> + "...</span>" +
+                                "</div>" +
+                                "<div id='error_" + uid + "'></div>" +
+                                "<div id='" + uid + "_content' style='display: none'><div class='table-responsive'><table class='head'><thead><tr><th class='text-center'><span class='bold'>" + <?php echo xlj('Active'); ?> + "</span></th><th class='text-center'><span class='bold'>" + <?php echo xlj('Inactive'); ?> + "</span></th></tr><tbody><tr><td align='center'><select class='form-control' name='active[]' multiple></select><br /><p align='center'><input class='button_submit btn btn-primary btn-sm' type='button' id='" + uid + "_membership_remove' data-username='' value=' >> '></p></td><td align='center'><select class='form-control' name='inactive[]' multiple></select><br /><p align='center'><input class='button_submit btn btn-primary btn-sm' type='button' id='" + uid + "_membership_add' data-username='' value=' << '></p></td></tr></tbody></table></div></div>"
+                            );
+                            // Set text content and data-username safely (no HTML interpolation)
+                            $row.find('span.text').text(username);
+                            $row.find('[data-username]').attr('data-username', username);
+                            $("#membership").append($row);
                             if ($(this).find("alert").text() == "no membership") {
-                                $("#link_" + username + " span.alert").show();
+                                $("#link_" + uid + " span.alert").show();
                             }
                         });
                         //Show the username list and remove loading indicator
@@ -314,18 +340,19 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
                 action = temparray[2];
                 return_value = temparray[3];
                 // Membership stuff needs special treatment because username may have underscores.
+                // Read username from data-username attribute to avoid parsing HTML-escaped IDs.
                 temparray = cthis.id.match(/^(.*)_membership_([a-z]+)$/);
                 if (temparray) {
-                    identity = temparray[1];
+                    var uid = temparray[1];
+                    identity = $(cthis).data('username') !== undefined ? $(cthis).data('username') : uid;
                     identityFormatted = identity;
                     control = 'membership';
                     action = temparray[2];
                     return_value = null;
-                    tempid = identity.replace(/([ .])/g,"\\$1");
-                    contentPointer = "#" + tempid;
-                    linkPointer = "#link_" + tempid;
+                    contentPointer = "#" + uid + "_content";
+                    linkPointer = "#link_" + uid;
                     linkPointerPost = "";
-                    errorPointer = "#error_" + tempid;
+                    errorPointer = "#error_" + uid;
                 }
                 if (control == "acl" || control == "aco") {
                     contentPointer = "#acl_" + identity + "_" + return_value;
@@ -484,7 +511,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
                         //Remove old errors, then display any new errors to user
                         $(errorPointer).empty();
                         $(xml).find("error").each(function(){
-                            $(errorPointer).append("<span class='alert'>" + $(this).text() + "<br /></span>");
+                            $(errorPointer).append("<span class='alert'>" + escHtml($(this).text()) + "<br /></span>");
                             $(errorPointer).show();
                         });
                     },

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -259,16 +259,14 @@ function toggle_password() {
     $acl_name = AclExtended::aclGetGroupTitles($iter["username"]);
     $bg_name = '';
     $selected_user_is_superuser = false;
-    if (is_countable($acl_name)) {
-        $bg_count = count($acl_name);
-        for ($i = 0; $i < $bg_count; $i++) {
-            if ($acl_name[$i] == "Emergency Login") {
-                $bg_name = $acl_name[$i];
-            }
-            //check if user member on group with superuser rule
-            if (AclExtended::isGroupIncludeSuperuser($acl_name[$i])) {
-                $selected_user_is_superuser = true;
-            }
+    $bg_count = count($acl_name);
+    for ($i = 0; $i < $bg_count; $i++) {
+        if ($acl_name[$i] == "Emergency Login") {
+            $bg_name = $acl_name[$i];
+        }
+        //check if user member on group with superuser rule
+        if (AclExtended::isGroupIncludeSuperuser($acl_name[$i])) {
+            $selected_user_is_superuser = true;
         }
     }
     $disabled_save = !$is_super_user && $selected_user_is_superuser ? 'disabled' : '';

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -104,8 +104,12 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
         $user_data = sqlFetchArray(sqlStatement("select * from users where id= ? ", [$_POST["id"]]));
 
         if (isset($_POST["username"])) {
-            sqlStatement("update users set username=? where id= ? ", [trim((string) $_POST["username"]), $_POST["id"]]);
-            sqlStatement("update `groups` set user=? where user= ?", [trim((string) $_POST["username"]), $user_data["username"]]);
+            $usernameUpdate = trim((string) $_POST["username"]);
+            if (preg_match('/[&<>"\'\x00-\x1F]/', $usernameUpdate)) {
+                die(xlt("Invalid username: HTML-special and control characters are not allowed."));
+            }
+            sqlStatement("update users set username=? where id= ? ", [$usernameUpdate, $_POST["id"]]);
+            sqlStatement("update `groups` set user=? where user= ?", [$usernameUpdate, $user_data["username"]]);
         }
 
         if ($_POST["taxid"]) {
@@ -340,7 +344,11 @@ if (isset($_POST["mode"])) {
         $calvar = (!empty($_POST["calendar"])) ? 1 : 0;
         $portalvar = (!empty($_POST["portal_user"])) ? 1 : 0;
 
-        $res = sqlQuery("select username from users where username = ?", [trim((string) $_POST['rumple'])]);
+        $usernameNew = trim((string) $_POST['rumple']);
+        if (preg_match('/[&<>"\'\x00-\x1F]/', $usernameNew)) {
+            die(xlt("Invalid username: HTML-special and control characters are not allowed."));
+        }
+        $res = sqlQuery("select username from users where username = ?", [$usernameNew]);
         $doit = true;
         if (!empty($res['username'])) {
             $doit = false;

--- a/library/ajax/adminacl_ajax.php
+++ b/library/ajax/adminacl_ajax.php
@@ -138,7 +138,7 @@ if ($_POST["control"] === "acl") {
         if (empty($_POST["identifier"])) {
             $form_error = true;
             $error[] = ("identifier_" . xl('Need to enter identifier') . "!");
-        } elseif (!ctype_alpha((string) $_POST["identifier"])) {
+        } elseif (!ctype_alpha(is_string($_POST["identifier"]) ? $_POST["identifier"] : '')) {
             $form_error = true;
             $error[] = ("identifier_" . xl('Please only use alphabetic characters with no spaces') . "!");
         } elseif (AclExtended::aclExist(false, $_POST["identifier"], $_POST["return_value"])) {

--- a/library/ajax/adminacl_ajax.php
+++ b/library/ajax/adminacl_ajax.php
@@ -64,50 +64,52 @@ if ($_POST["control"] === "username") {
 
 //PROCESS MEMBERSHIP REQUESTS
 if ($_POST["control"] === "membership") {
+    $postName = is_string($_POST["name"]) ? $_POST["name"] : '';
+
     if ($_POST["action"] === "list") {
         //return membership data
-        echo user_group_listings_xml($_POST["name"], $error);
+        echo user_group_listings_xml($postName, $error);
     }
 
     if ($_POST["action"] === "add") {
         if ($_POST["selection"][0] === "null") {
             //no selection, return soft error, and just return membership data
             $error[] = (xl('No group was selected') . "!");
-            echo user_group_listings_xml($_POST["name"], $error);
+            echo user_group_listings_xml($postName, $error);
             exit;
         }
 
         //add the group, then log it, then return updated membership data
-        AclExtended::addUserAros($_POST["name"], $_POST["selection"]);
-        EventAuditLogger::getInstance()->newEvent("security-administration-update", $session->get('authUser'), $session->get('authProvider'), 1, "Added " . $_POST["name"] . " to following access group(s): " . implode(', ', $_POST["selection"]));
-        echo user_group_listings_xml($_POST["name"], $error);
+        AclExtended::addUserAros($postName, $_POST["selection"]);
+        EventAuditLogger::getInstance()->newEvent("security-administration-update", $session->get('authUser'), $session->get('authProvider'), 1, "Added " . $postName . " to following access group(s): " . implode(', ', $_POST["selection"]));
+        echo user_group_listings_xml($postName, $error);
     }
 
     if ($_POST["action"] === "remove") {
         if ($_POST["selection"][0] === "null") {
             //no selection, return soft error, and just return membership data
             $error[] = (xl('No group was selected') . "!");
-            echo user_group_listings_xml($_POST["name"], $error);
+            echo user_group_listings_xml($postName, $error);
             exit;
         }
 
         // check if user is protected. If so, then state message unable to remove from admin group.
-        $userNametoID = (new UserService())->getIdByUsername($_POST["name"]);
-        $gacl_protect = checkUserSetting("gacl_protect", "1", $userNametoID) || $_POST["name"] === "admin" ? true : false;
+        $userNametoID = (new UserService())->getIdByUsername($postName);
+        $gacl_protect = checkUserSetting("gacl_protect", "1", $userNametoID) || $postName === "admin" ? true : false;
 
         if ($gacl_protect && in_array("Administrators", $_POST["selection"])) {
             //unable to remove admin user from administrators group, process remove,
             // send soft error, then return data
             $error[] = (xl('Not allowed to remove this user from the Administrators group') . "!");
-            AclExtended::removeUserAros($_POST["name"], $_POST["selection"]);
-            echo user_group_listings_xml($_POST["name"], $error);
+            AclExtended::removeUserAros($postName, $_POST["selection"]);
+            echo user_group_listings_xml($postName, $error);
             exit;
         }
 
         //remove the group(s), then log it, then return updated membership data
-        AclExtended::removeUserAros($_POST["name"], $_POST["selection"]);
-        EventAuditLogger::getInstance()->newEvent("security-administration-update", $session->get('authUser'), $session->get('authProvider'), 1, "Removed " . $_POST["name"] . " from following access group(s): " . implode(', ', $_POST["selection"]));
-        echo user_group_listings_xml($_POST["name"], $error);
+        AclExtended::removeUserAros($postName, $_POST["selection"]);
+        EventAuditLogger::getInstance()->newEvent("security-administration-update", $session->get('authUser'), $session->get('authProvider'), 1, "Removed " . $postName . " from following access group(s): " . implode(', ', $_POST["selection"]));
+        echo user_group_listings_xml($postName, $error);
     }
 }
 
@@ -268,9 +270,10 @@ function username_listings_xml(array $err): string
             continue;
         }
 
+        $iterUsername = is_string($iter["username"]) ? $iter["username"] : '';
         $message .= "\t<user>\n" .
-          "\t\t<username>" . xmlEscape((string) $iter["username"]) . "</username>\n";
-        $username_acl_groups = AclExtended::aclGetGroupTitles($iter["username"]);
+          "\t\t<username>" . xmlEscape($iterUsername) . "</username>\n";
+        $username_acl_groups = AclExtended::aclGetGroupTitles($iterUsername);
         if (!$username_acl_groups) {
             //not joined to any group, so send alert
             $message .= "\t\t<alert>no membership</alert>\n";
@@ -279,10 +282,8 @@ function username_listings_xml(array $err): string
         $message .= "\t</user>\n";
     }
 
-    if (isset($err)) {
-        foreach ($err as $value) {
-            $message .= "\t<error>" . xmlEscape($value) . "</error>\n";
-        }
+    foreach ($err as $value) {
+        $message .= "\t<error>" . xmlEscape($value) . "</error>\n";
     }
 
     $message .= "</response>\n";
@@ -308,12 +309,14 @@ function user_group_listings_xml(string $username, array $err): string
     "<response>\n" .
     "\t<inactive>\n";
     foreach ($list_acl_groups as $value) {
-        if ((!$username_acl_groups) || (!(in_array($value, $username_acl_groups)))) {
+        $groupValue = is_string($value) ? $value : '';
+        if ((!$username_acl_groups) || (!(in_array($groupValue, $username_acl_groups)))) {
+            $groupLabel = xl_gacl_group($groupValue);
             $message .= "\t\t<group>\n";
-            $message .= "\t\t\t<value>" . xmlEscape($value) . "</value>\n";
+            $message .= "\t\t\t<value>" . xmlEscape($groupValue) . "</value>\n";
 
             // Modified 6-2009 by BM - Translate gacl group name if applicable
-            $message .= "\t\t\t<label>" . xmlEscape((string) xl_gacl_group((string) $value)) . "</label>\n";
+            $message .= "\t\t\t<label>" . xmlEscape(is_string($groupLabel) ? $groupLabel : '') . "</label>\n";
 
             $message .= "\t\t</group>\n";
         }
@@ -323,21 +326,21 @@ function user_group_listings_xml(string $username, array $err): string
     "\t<active>\n";
     if ($username_acl_groups) {
         foreach ($username_acl_groups as $value) {
+            $groupValue = is_string($value) ? $value : '';
+            $groupLabel = xl_gacl_group($groupValue);
             $message .= "\t\t<group>\n";
-            $message .= "\t\t\t<value>" . xmlEscape($value) . "</value>\n";
+            $message .= "\t\t\t<value>" . xmlEscape($groupValue) . "</value>\n";
 
             // Modified 6-2009 by BM - Translate gacl group name if applicable
-            $message .= "\t\t\t<label>" . xmlEscape((string) xl_gacl_group((string) $value)) . "</label>\n";
+            $message .= "\t\t\t<label>" . xmlEscape(is_string($groupLabel) ? $groupLabel : '') . "</label>\n";
 
             $message .= "\t\t</group>\n";
         }
     }
 
     $message .= "\t</active>\n";
-    if (isset($err)) {
-        foreach ($err as $value) {
-            $message .= "\t<error>" . xmlEscape($value) . "</error>\n";
-        }
+    foreach ($err as $value) {
+        $message .= "\t<error>" . xmlEscape($value) . "</error>\n";
     }
 
     $message .= "</response>\n";

--- a/library/ajax/adminacl_ajax.php
+++ b/library/ajax/adminacl_ajax.php
@@ -309,14 +309,12 @@ function user_group_listings_xml(string $username, array $err): string
     "<response>\n" .
     "\t<inactive>\n";
     foreach ($list_acl_groups as $value) {
-        $groupValue = is_string($value) ? $value : '';
-        if ((!$username_acl_groups) || (!(in_array($groupValue, $username_acl_groups)))) {
-            $groupLabel = xl_gacl_group($groupValue);
+        if ((!$username_acl_groups) || (!(in_array($value, $username_acl_groups)))) {
             $message .= "\t\t<group>\n";
-            $message .= "\t\t\t<value>" . xmlEscape($groupValue) . "</value>\n";
+            $message .= "\t\t\t<value>" . xmlEscape($value) . "</value>\n";
 
             // Modified 6-2009 by BM - Translate gacl group name if applicable
-            $message .= "\t\t\t<label>" . xmlEscape(is_string($groupLabel) ? $groupLabel : '') . "</label>\n";
+            $message .= "\t\t\t<label>" . xmlEscape(xl_gacl_group($value)) . "</label>\n";
 
             $message .= "\t\t</group>\n";
         }
@@ -326,13 +324,11 @@ function user_group_listings_xml(string $username, array $err): string
     "\t<active>\n";
     if ($username_acl_groups) {
         foreach ($username_acl_groups as $value) {
-            $groupValue = is_string($value) ? $value : '';
-            $groupLabel = xl_gacl_group($groupValue);
             $message .= "\t\t<group>\n";
-            $message .= "\t\t\t<value>" . xmlEscape($groupValue) . "</value>\n";
+            $message .= "\t\t\t<value>" . xmlEscape($value) . "</value>\n";
 
             // Modified 6-2009 by BM - Translate gacl group name if applicable
-            $message .= "\t\t\t<label>" . xmlEscape(is_string($groupLabel) ? $groupLabel : '') . "</label>\n";
+            $message .= "\t\t\t<label>" . xmlEscape(xl_gacl_group($value)) . "</label>\n";
 
             $message .= "\t\t</group>\n";
         }

--- a/library/ajax/adminacl_ajax.php
+++ b/library/ajax/adminacl_ajax.php
@@ -266,7 +266,7 @@ function username_listings_xml($err)
         }
 
         $message .= "\t<user>\n" .
-          "\t\t<username>" . $iter["username"] . "</username>\n";
+          "\t\t<username>" . xmlEscape($iter["username"]) . "</username>\n";
         $username_acl_groups = AclExtended::aclGetGroupTitles($iter["username"]);
         if (!$username_acl_groups) {
             //not joined to any group, so send alert
@@ -278,7 +278,7 @@ function username_listings_xml($err)
 
     if (isset($err)) {
         foreach ($err as $value) {
-            $message .= "\t<error>" . $value . "</error>\n";
+            $message .= "\t<error>" . xmlEscape($value) . "</error>\n";
         }
     }
 
@@ -304,10 +304,10 @@ function user_group_listings_xml($username, $err)
     foreach ($list_acl_groups as $value) {
         if ((!$username_acl_groups) || (!(in_array($value, $username_acl_groups)))) {
             $message .= "\t\t<group>\n";
-            $message .= "\t\t\t<value>" . $value . "</value>\n";
+            $message .= "\t\t\t<value>" . xmlEscape($value) . "</value>\n";
 
             // Modified 6-2009 by BM - Translate gacl group name if applicable
-            $message .= "\t\t\t<label>" . xl_gacl_group($value) . "</label>\n";
+            $message .= "\t\t\t<label>" . xmlEscape(xl_gacl_group($value)) . "</label>\n";
 
             $message .= "\t\t</group>\n";
         }
@@ -318,10 +318,10 @@ function user_group_listings_xml($username, $err)
     if ($username_acl_groups) {
         foreach ($username_acl_groups as $value) {
             $message .= "\t\t<group>\n";
-            $message .= "\t\t\t<value>" . $value . "</value>\n";
+            $message .= "\t\t\t<value>" . xmlEscape($value) . "</value>\n";
 
             // Modified 6-2009 by BM - Translate gacl group name if applicable
-            $message .= "\t\t\t<label>" . xl_gacl_group($value) . "</label>\n";
+            $message .= "\t\t\t<label>" . xmlEscape(xl_gacl_group($value)) . "</label>\n";
 
             $message .= "\t\t</group>\n";
         }
@@ -330,7 +330,7 @@ function user_group_listings_xml($username, $err)
     $message .= "\t</active>\n";
     if (isset($err)) {
         foreach ($err as $value) {
-            $message .= "\t<error>" . $value . "</error>\n";
+            $message .= "\t<error>" . xmlEscape($value) . "</error>\n";
         }
     }
 
@@ -348,10 +348,10 @@ function error_xml($err)
     "<response>\n";
     if (is_array($err)) {
         foreach ($err as $value) {
-            $message .= "\t<error>" . $value . "</error>\n";
+            $message .= "\t<error>" . xmlEscape($value) . "</error>\n";
         }
     } else {
-        $message .= "\t<error>" . $err . "</error>\n";
+        $message .= "\t<error>" . xmlEscape($err) . "</error>\n";
     }
 
     $message .= "</response>\n";

--- a/library/ajax/adminacl_ajax.php
+++ b/library/ajax/adminacl_ajax.php
@@ -249,7 +249,10 @@ if ($_POST["control"] === "aco") {
 // to a group yet
 //   $err = error strings (array)
 //
-function username_listings_xml($err)
+/**
+ * @param array<int, string> $err
+ */
+function username_listings_xml(array $err): string
 {
     $message = "<?xml version=\"1.0\"?>\n" .
     "<response>\n";
@@ -266,7 +269,7 @@ function username_listings_xml($err)
         }
 
         $message .= "\t<user>\n" .
-          "\t\t<username>" . xmlEscape($iter["username"]) . "</username>\n";
+          "\t\t<username>" . xmlEscape((string) $iter["username"]) . "</username>\n";
         $username_acl_groups = AclExtended::aclGetGroupTitles($iter["username"]);
         if (!$username_acl_groups) {
             //not joined to any group, so send alert
@@ -292,7 +295,10 @@ function username_listings_xml($err)
 //   $username = username
 //   $err = error strings (array)
 //
-function user_group_listings_xml($username, $err)
+/**
+ * @param array<int, string> $err
+ */
+function user_group_listings_xml(string $username, array $err): string
 {
     $list_acl_groups = AclExtended::aclGetGroupTitleList();
     $username_acl_groups = AclExtended::aclGetGroupTitles($username);
@@ -307,7 +313,7 @@ function user_group_listings_xml($username, $err)
             $message .= "\t\t\t<value>" . xmlEscape($value) . "</value>\n";
 
             // Modified 6-2009 by BM - Translate gacl group name if applicable
-            $message .= "\t\t\t<label>" . xmlEscape(xl_gacl_group($value)) . "</label>\n";
+            $message .= "\t\t\t<label>" . xmlEscape((string) xl_gacl_group((string) $value)) . "</label>\n";
 
             $message .= "\t\t</group>\n";
         }
@@ -321,7 +327,7 @@ function user_group_listings_xml($username, $err)
             $message .= "\t\t\t<value>" . xmlEscape($value) . "</value>\n";
 
             // Modified 6-2009 by BM - Translate gacl group name if applicable
-            $message .= "\t\t\t<label>" . xmlEscape(xl_gacl_group($value)) . "</label>\n";
+            $message .= "\t\t\t<label>" . xmlEscape((string) xl_gacl_group((string) $value)) . "</label>\n";
 
             $message .= "\t\t</group>\n";
         }
@@ -342,7 +348,10 @@ function user_group_listings_xml($username, $err)
 // Returns error string(s) via xml
 //   $err = error (string or array)
 //
-function error_xml($err)
+/**
+ * @param string|array<int, string> $err
+ */
+function error_xml(string|array $err): string
 {
     $message = "<?xml version=\"1.0\"?>\n" .
     "<response>\n";

--- a/src/Common/Acl/AclExtended.php
+++ b/src/Common/Acl/AclExtended.php
@@ -117,7 +117,7 @@ class AclExtended
     // Returns a sorted array of all available Group Titles.
     //
     /**
-     * @return array<string>
+     * @return list<string>
      */
     public static function aclGetGroupTitleList($include_superusers = true)
     {
@@ -129,7 +129,7 @@ class AclExtended
             $arr_group_data = $gacl->get_group_data($value, 'ARO');
             // add if $include_superusers is true or group not include admin|super rule.
             if ($include_superusers || !self::isGroupIncludeSuperuser($arr_group_data[3])) {
-                $arr_group_titles[$value] = $arr_group_data[3];
+                $arr_group_titles[$value] = is_string($arr_group_data[3]) ? $arr_group_data[3] : '';
             }
         }
         sort($arr_group_titles);
@@ -138,11 +138,11 @@ class AclExtended
 
     //
     // Returns a sorted array of group Titles that a user belongs to.
-    // Returns 0 if does not belong to any group yet.
+    // Returns an empty array if the user does not belong to any group.
     //   $user_name = Username, which is login name.
     //
     /**
-     * @return array<string>|null
+     * @return list<string>
      */
     public static function aclGetGroupTitles($user_name)
     {
@@ -151,14 +151,16 @@ class AclExtended
         if ($user_aro_id) {
             $arr_group_id = $gacl->get_object_groups($user_aro_id, 'ARO', 'NO_RECURSE');
             if ($arr_group_id) {
+                $arr_group_titles = [];
                 foreach ($arr_group_id as $key => $value) {
                     $arr_group_data = $gacl->get_group_data($value, 'ARO');
-                    $arr_group_titles[$key] = $arr_group_data[3];
+                    $arr_group_titles[$key] = is_string($arr_group_data[3]) ? $arr_group_data[3] : '';
                 }
                 sort($arr_group_titles);
                 return $arr_group_titles;
             }
         }
+        return [];
     }
 
     //

--- a/src/Common/Acl/AclExtended.php
+++ b/src/Common/Acl/AclExtended.php
@@ -116,6 +116,9 @@ class AclExtended
     //
     // Returns a sorted array of all available Group Titles.
     //
+    /**
+     * @return array<string>
+     */
     public static function aclGetGroupTitleList($include_superusers = true)
     {
         $gacl = self::collectGaclApiObject();
@@ -138,6 +141,9 @@ class AclExtended
     // Returns 0 if does not belong to any group yet.
     //   $user_name = Username, which is login name.
     //
+    /**
+     * @return array<string>|null
+     */
     public static function aclGetGroupTitles($user_name)
     {
         $gacl = self::collectGaclApiObject();

--- a/src/Common/Auth/AuthUtils.php
+++ b/src/Common/Auth/AuthUtils.php
@@ -363,7 +363,7 @@ class AuthUtils
         }
 
         // Check to ensure user is in a acl group
-        if (AclExtended::aclGetGroupTitles($username) == 0) {
+        if (AclExtended::aclGetGroupTitles($username) === []) {
             if ($this->loginAuth || $this->apiAuth) {
                 // Utilize this during logins (and not during standard password checks within openemr such as esign)
                 $this->incrementIpLoginFailedCounter($ip['ip_string']);
@@ -1496,7 +1496,7 @@ class AuthUtils
         }
 
         // Check to ensure user is in a acl group
-        if (AclExtended::aclGetGroupTitles($user['username']) == 0) {
+        if (AclExtended::aclGetGroupTitles($user['username']) === []) {
             EventAuditLogger::getInstance()->newEvent($event, $user['username'], $authGroup, 0, $beginLog . ": " . $ip['ip_string'] . ". user with Google mail '" . $payload['email'] . "' is not in any phpGACL groups");
             return false;
         }

--- a/src/Validators/PractitionerValidator.php
+++ b/src/Validators/PractitionerValidator.php
@@ -38,7 +38,7 @@ class PractitionerValidator extends BaseValidator
                 );
                 $context->optional("email", "Email")->email();
                 $context->optional("username", "Username")->callback(
-                    fn($value): bool => preg_match('/[&<>"\'\x00-\x1F]/', (string) $value) === 0
+                    fn($value): bool => preg_match('/[&<>"\'\x00-\x1F]/', is_string($value) ? $value : '') === 0
                 );
             }
         );

--- a/src/Validators/PractitionerValidator.php
+++ b/src/Validators/PractitionerValidator.php
@@ -37,6 +37,11 @@ class PractitionerValidator extends BaseValidator
                     fn($value) => $this->validateId("id", "facility", $value)
                 );
                 $context->optional("email", "Email")->email();
+                $context->optional("username", "Username")->callback(
+                    function ($value): bool {
+                        return preg_match('/[&<>"\'\x00-\x1F]/', (string) $value) === 0;
+                    }
+                );
             }
         );
 

--- a/src/Validators/PractitionerValidator.php
+++ b/src/Validators/PractitionerValidator.php
@@ -38,9 +38,7 @@ class PractitionerValidator extends BaseValidator
                 );
                 $context->optional("email", "Email")->email();
                 $context->optional("username", "Username")->callback(
-                    function ($value): bool {
-                        return preg_match('/[&<>"\'\x00-\x1F]/', (string) $value) === 0;
-                    }
+                    fn($value): bool => preg_match('/[&<>"\'\x00-\x1F]/', (string) $value) === 0
                 );
             }
         );


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:

Fixes a correctness/availability bug where a username containing HTML-special characters (<, >, etc.) causes the ACL administration screen to fail with "ERROR, unable to collect data from server" - the jQuery `dataType: "xml"` AJAX call cannot parse a response containing unescaped user-controlled values. Also adds server-side input validation to reject such characters at every user-creation entry point as defense in depth. Reaching these entry points requires `admin/users` or `admin/super` ACL, so no privilege boundary is crossed, but the fix prevents the availability impact and hardens the input path. 

Fixes issue #11955 

#### Changes proposed in this pull request:

  - `library/ajax/adminacl_ajax.php`: wrap all dynamic values written into XML responses in `username_listings_xml()`, `user_group_listings_xml()`, and `error_xml()` with `xmlEscape()` - consistent with the pattern already used in `src/Common/Acl/AclExtended.php`
  - `interface/usergroup/adminacl.php`: replace the username-as-element-ID pattern with numeric UIDs (u_0, u_1, ...); display username via `.text()` and store via `.attr('data-username', ...)` so the raw username is never interpolated into an HTML string; adds `escHtml()` helper for any remaining string concatenation
  - `interface/usergroup/usergroup_admin.php`: reject usernames containing &, <, >, ", ', or control characters (\x00–\x1F) at both the `Add User ($_POST['rumple'])` and `update ($_POST['username'])` paths before any database operation
  - `src/Validators/PractitionerValidator.php`: add an optional username validation callback applying the same character set, covering `POST /api/practitioner (via PractitionerService::insert())` and the `REST update` path                                                                                                                                 
  - `src/Services/FHIR/FhirPractitionerService.php (POST /fhir/Practitioner)`: the FHIR path synthesizes usernames via `uniqid($lname . $fname)` - validation in `PractitionerValidator` during `insert()` covers this path; no separate change needed as `uniqid()` output is already safe


##### Testing:



Case 1
S1: Login as Admin user
S2: Admin -> Users -> Add User
S3: Provide input like `<img src=x onerror=alert(document.cookie)>` in the Username, First name and Last name fields.
<img width="3234" height="1278" alt="image" src="https://github.com/user-attachments/assets/37db8bd8-9929-43b4-8db5-4c726c2c564c" />

S4: Check the entries created at Admin -> Users tab and Admin -> ACL tab

###### Before fix: 
<img width="3254" height="916" alt="image" src="https://github.com/user-attachments/assets/c3ccec9d-2e56-4933-9933-f288692e3c67" />

###### After fix: 
<img width="1500" height="752" alt="image" src="https://github.com/user-attachments/assets/5327912c-d36c-43f9-b8a7-051b009ffa68" />



Case 2
S1: Login as Admin user
S2: Admin -> Users -> Add User
S3: Provide input like <script>alert(21)</script> in the Username, First name and Last name fields.
<img width="3406" height="1430" alt="image" src="https://github.com/user-attachments/assets/421b6fc4-77c3-4d63-94ae-9618c13e0ed3" />

S4: Check the entries created at Admin -> Users tab and Admin -> ACL tab
S5: Click on the corresponding entry for the user created in the ACL tab.

###### Before fix:
<img width="3440" height="1244" alt="image" src="https://github.com/user-attachments/assets/20ed9525-f47c-4219-a927-03d9dd7953a2" />
<img width="3448" height="1594" alt="image" src="https://github.com/user-attachments/assets/6e0d7aba-cf04-4cef-b429-994905ee132e" />

###### After fix:
<img width="1714" height="707" alt="image" src="https://github.com/user-attachments/assets/119858fe-d530-4e88-91e9-e0e2f4c0fbc4" />



#### Was an AI assistant used? Yes / No

Yes

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
