### PR TITLE
fix(ci): disable patient birthday alert in e2e compose stack

### DIFF
--- a/ci/compose-shared-apache.yml
+++ b/ci/compose-shared-apache.yml
@@ -12,6 +12,9 @@ services:
       ENABLE_COVERAGE: ${ENABLE_COVERAGE:-false}
       PCOV_ON: ${ENABLE_COVERAGE:-false}
       SELENIUM_BASE_URL: http://openemr
+      # Disable the patient birthday-alert modal so e2e tests don't get blocked
+      # on the seed patient's birthday (DOB 1958-05-02). See issue #11980.
+      OPENEMR_SETTING_patient_birthday_alert: '0'
     healthcheck:
       test:
       - CMD

--- a/ci/compose-shared-nginx/compose.yml
+++ b/ci/compose-shared-nginx/compose.yml
@@ -5,6 +5,9 @@ services:
       OPENEMR_ENABLE_CI_PHP: "1"
       ENABLE_COVERAGE: "${ENABLE_COVERAGE:-false}"
       SELENIUM_BASE_URL: "http://nginx"
+      # Disable the patient birthday-alert modal so e2e tests don't get blocked
+      # on the seed patient's birthday (DOB 1958-05-02). See issue #11980.
+      OPENEMR_SETTING_patient_birthday_alert: "0"
     volumes:
     - ../:/usr/share/nginx/html/openemr
     - ./nginx/php.ini:/usr/local/etc/php/php.ini:ro


### PR DESCRIPTION
## Summary

The seed test patient's hard-coded DOB (`1958-05-02` in `PatientTestData::DOB`) combined with the default-on `patient_birthday_alert` global causes the `#bdayreminder` modal to pop up over the patient summary every May 2 in CI. Selenium hits `ElementClickInterceptedException` on every test that opens the patient chart, turning the entire e2e matrix red on master and rel-810.

This sets `OPENEMR_SETTING_patient_birthday_alert=0` in `ci/compose-shared-apache.yml` and `ci/compose-shared-nginx/compose.yml`. The flex image's `setGlobalSettings` hook applies the value at startup, and because the same compose chain runs in both the setup job (which dumps the DB snapshot) and the test job (which restores it and starts containers again), every variant — including the snapshot-based ones — picks up the override.

No production behavior changes; the global remains default-on outside CI.

Fixes #11980

## Test plan

- [ ] CI green on this PR (proves no regressions)
- [ ] Re-confirm a previously failing job (e.g. a master run from 2026-05-02) reproduces locally without this patch
- [ ] After merge, backport to `rel-810` (and any other active release branches at the time)