### PR TITLE
fix(ci): disable patient birthday alert in e2e compose stack (backport #11983 to rel-810)

### DIFF
--- a/ci/compose-shared-apache.yml
+++ b/ci/compose-shared-apache.yml
@@ -12,6 +12,9 @@ services:
       ENABLE_COVERAGE: ${ENABLE_COVERAGE:-false}
       PCOV_ON: ${ENABLE_COVERAGE:-false}
       SELENIUM_BASE_URL: http://openemr
+      # Disable the patient birthday-alert modal so e2e tests don't get blocked
+      # on the seed patient's birthday (DOB 1958-05-02). See issue #11980.
+      OPENEMR_SETTING_patient_birthday_alert: '0'
     healthcheck:
       test:
       - CMD

--- a/ci/compose-shared-nginx/compose.yml
+++ b/ci/compose-shared-nginx/compose.yml
@@ -5,6 +5,9 @@ services:
       OPENEMR_ENABLE_CI_PHP: "1"
       ENABLE_COVERAGE: "${ENABLE_COVERAGE:-false}"
       SELENIUM_BASE_URL: "http://nginx"
+      # Disable the patient birthday-alert modal so e2e tests don't get blocked
+      # on the seed patient's birthday (DOB 1958-05-02). See issue #11980.
+      OPENEMR_SETTING_patient_birthday_alert: "0"
     volumes:
     - ../:/usr/share/nginx/html/openemr
     - ./nginx/php.ini:/usr/local/etc/php/php.ini:ro


### PR DESCRIPTION
## Summary

Backport of #11983 to `rel-810`. Same root cause and same fix — adds `OPENEMR_SETTING_patient_birthday_alert=0` to the shared Apache and Nginx CI compose templates so the `#bdayreminder` modal doesn't intercept Selenium clicks on May 2 (the seed patient's hard-coded DOB is `1958-05-02`).

The flex image's `setGlobalSettings` startup hook applies the value in both the setup job (which dumps the DB snapshot) and the test job (which restores it and starts containers again), so every variant — including the snapshot-based ones — picks up the override.

No production behavior changes; the global remains default-on outside CI.

Refs #11980

## Test plan

- [ ] CI green on this PR (proves no regressions)
- [ ] Master fix (#11983) merged first so the two branches stay aligned