### PR TITLE
fix(care-plan): unify blank-row template through foreach

### DIFF
--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -373,7 +373,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 5,
+    'count' => 4,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -253,7 +253,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -4933,32 +4933,32 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'care_plan_type\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'code\' on mixed\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'codetext\' on mixed\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'date\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'date_end\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'description\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [
@@ -4968,22 +4968,22 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'proposed_date\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'title\' on mixed\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'user\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'value\' on mixed\\.$#',
-    'count' => 7,
+    'count' => 4,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -613,7 +613,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Variable \\$care_plan_type might not be defined\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [

--- a/interface/forms/care_plan/new.php
+++ b/interface/forms/care_plan/new.php
@@ -108,138 +108,65 @@ $reasonCodeStatii[ReasonStatusCodes::NONE]['description'] = xl("Select a status 
                         <legend><?php echo xlt('Enter Details'); ?></legend>
                         <div class="container">
                             <?php
-                            if (!empty($check_res)) {
-                                foreach ($check_res as $key => $obj) {
-                                    $context = "";
-                                    ?>
-                                    <div class="tb_row" id="tb_row_<?php echo attr($key) + 1; ?>">
-                                        <div class="form-row">
-                                            <div class="forms col-md-4">
-                                                <label for="code_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Code'); ?>:</label>
-                                                <input type="text" id="code_<?php echo attr($key) + 1; ?>" name="code[]" class="form-control code"
-                                                    value="<?php echo attr($obj["code"]); ?>" onclick='sel_code(<?php echo attr_js(OEGlobalsBag::getInstance()->getWebRoot()) ?>,
-                                                    this.parentElement.parentElement.parentElement.id);' data-toggle='tooltip' data-placement='bottom' title='<?php echo attr($obj['code']) . "'"; ?> />
-                                                <span id="displaytext_<?php echo attr($key) + 1; ?>"  class="displaytext help-block"><?php echo text($obj["codetext"] ?? ''); ?></span>
-                                                <input type="hidden" id="codetext_<?php echo attr($key) + 1; ?>" name="codetext[]" class="codetext" value="<?php echo attr($obj["codetext"]); ?>" />
-                                                <input type="hidden" id="user_<?php echo attr($key) + 1; ?>" name="user[]" class="user" value="<?php echo attr($obj["user"]); ?>" />
-                                            </div>
-                                            <div class="forms col-md-4">
-                                                <label for="code_date_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Date'); ?>:</label>
-                                                <input type=' text' id="code_date_<?php echo attr($key) + 1; ?>" name='code_date[]' class="form-control code_date datepicker" value='<?php echo attr($obj["date"]); ?>' title='<?php echo xla('yyyy-mm-dd HH:MM Date of service'); ?>' />
-                                            </div>
-                                            <div class="forms col-md-4">
-                                                <label for="care_plan_type_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Type'); ?>:</label>
-                                                <select name="care_plan_type[]" id="care_plan_type_<?php echo attr($key) + 1; ?>" class="form-control care_plan_type">
-                                                    <option value=""></option>
-                                                    <?php foreach ($care_plan_type as $value) :
-                                                        $selected = ($value['value'] == $obj["care_plan_type"]) ? 'selected="selected"' : '';
-                                                        if (!empty($selected)) {
-                                                            $context = $value['title'];
-                                                        }
-                                                        ?>
-                                                        <option value="<?php echo attr($value['value']); ?>" <?php echo $selected; ?>><?php echo text($value['title']); ?></option>
-                                                    <?php endforeach; ?>
-                                                </select>
-                                            </div>
-
-                                            <div class="form-row w-100 my-2">
-                                                <div class="forms col-md-3">
-                                                    <label for="proposed_date_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Target Date'); ?>:</label>
-                                                    <input type='text'
-                                                        id="proposed_date_<?php echo attr($key) + 1; ?>"
-                                                        name='proposed_date[]'
-                                                        class="form-control proposed_date datepicker"
-                                                        value='<?php echo attr($obj["proposed_date"] ?? ""); ?>'
-                                                        title='<?php echo xla('yyyy-mm-dd HH:MM Target or Achieve-by date'); ?>' />
-                                                </div>
-                                                <div class="forms col-md-3">
-                                                    <label for="end_date_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('End Date'); ?>:</label>
-                                                    <input type='text'
-                                                        id="end_date_<?php echo attr($key) + 1; ?>"
-                                                        name='end_date[]'
-                                                        class="form-control end_date datepicker"
-                                                        value='<?php echo attr($obj["date_end"] ?? ""); ?>'
-                                                        title='<?php echo xla('yyyy-mm-dd HH:MM planned end date'); ?>' />
-                                                </div>
-                                                <div class="forms col-md-3">
-                                                    <label for="status_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Status'); ?>:</label>
-                                                    <select name="plan_status[]" id="status_<?php echo attr($key) + 1; ?>" class="form-control plan_status">
-                                                        <option value=""></option>
-                                                        <?php foreach (($care_plan_status) as $opt) :
-                                                            $sel = ($opt['value'] == ($obj["plan_status"] ?? '')) ? 'selected="selected"' : ''; ?>
-                                                            <option value="<?php echo attr($opt['value']); ?>" <?php echo $sel; ?>>
-                                                                <?php echo text($opt['title']); ?>
-                                                            </option>
-                                                        <?php endforeach; ?>
-                                                    </select>
-                                                </div>
-                                            </div>
-
-                                            <div class="forms col-md-12">
-                                                <label for="description_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Description'); ?>:</label>
-                                                <textarea name="description[]" id="description_<?php echo attr($key) + 1; ?>" data-textcontext="<?php echo attr($context); ?>" class="form-control description" rows="6"><?php echo text($obj["description"]); ?></textarea>
-                                            </div>
-                                        </div>
-                                        <div class="form-row mt-2">
-                                            <div class="forms col-md-12 d-flex flex-row-reverse ">
-                                                <?php include("templates/careplan_actions.php"); ?>
-                                            </div>
-                                            <input type="hidden" name="count[]" id="count_<?php echo attr($key) + 1; ?>" class="count" value="<?php echo attr($key) + 1; ?>" />
-                                        </div>
-                                        <?php include "templates/careplan_reason_row.php"; ?>
-                                        <hr />
-                                    </div>
-                                <?php }
-                            } else { ?>
-                                <div class="tb_row" id="tb_row_1">
+                            foreach ($check_res ?: [[]] as $key => $obj) {
+                                $context = "";
+                                ?>
+                                <div class="tb_row" id="tb_row_<?php echo attr($key) + 1; ?>">
                                     <div class="form-row">
-                                        <div class="forms col-md-2">
-                                            <label for="code_1" class="h5"><?php echo xlt('Code'); ?>:</label>
-                                            <input type="text" id="code_1" name="code[]" class="form-control code" value="<?php echo attr($obj["code"] ?? ''); ?>" onclick='sel_code(<?php echo attr_js(OEGlobalsBag::getInstance()->getWebRoot()) ?>, this.parentElement.parentElement.parentElement.id || "");'>
-                                            <input type="hidden" id="user_1" name="user[]" class="user" value="<?php echo attr($obj["user"] ?? $session->get('authUser')); ?>" />
-                                            <span id="displaytext_1" class="displaytext help-block"></span>
-                                            <input type="hidden" id="codetext_1" name="codetext[]" class="codetext" value="<?php echo attr($obj["codetext"] ?? ''); ?>">
+                                        <div class="forms col-md-4">
+                                            <label for="code_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Code'); ?>:</label>
+                                            <input type="text" id="code_<?php echo attr($key) + 1; ?>" name="code[]" class="form-control code"
+                                                value="<?php echo attr($obj["code"] ?? ''); ?>" onclick='sel_code(<?php echo attr_js(OEGlobalsBag::getInstance()->getWebRoot()) ?>,
+                                                this.parentElement.parentElement.parentElement.id);' data-toggle='tooltip' data-placement='bottom' title='<?php echo attr($obj['code'] ?? ''); ?>' />
+                                            <span id="displaytext_<?php echo attr($key) + 1; ?>"  class="displaytext help-block"><?php echo text($obj["codetext"] ?? ''); ?></span>
+                                            <input type="hidden" id="codetext_<?php echo attr($key) + 1; ?>" name="codetext[]" class="codetext" value="<?php echo attr($obj["codetext"] ?? ''); ?>" />
+                                            <input type="hidden" id="user_<?php echo attr($key) + 1; ?>" name="user[]" class="user" value="<?php echo attr($obj["user"] ?? $session->get('authUser')); ?>" />
                                         </div>
-                                        <div class="forms col-md-2">
-                                            <label for="code_date_1" class="h5"><?php echo xlt('Date'); ?>:</label>
-                                            <input type='text' id="code_date_1" name='code_date[]' class="form-control code_date datepicker" value='<?php echo attr($obj["date"] ?? ''); ?>' title='<?php echo xla('yyyy-mm-dd Date of service'); ?>' />
+                                        <div class="forms col-md-4">
+                                            <label for="code_date_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Date'); ?>:</label>
+                                            <input type='text' id="code_date_<?php echo attr($key) + 1; ?>" name='code_date[]' class="form-control code_date datepicker" value='<?php echo attr($obj["date"] ?? ''); ?>' title='<?php echo xla('yyyy-mm-dd HH:MM Date of service'); ?>' />
                                         </div>
-                                        <div class="forms col-md-2">
-                                            <label for="care_plan_type_1" class="h5"><?php echo xlt('Type'); ?>:</label>
-                                            <select name="care_plan_type[]" id="care_plan_type_1" class="form-control care_plan_type">
+                                        <div class="forms col-md-4">
+                                            <label for="care_plan_type_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Type'); ?>:</label>
+                                            <select name="care_plan_type[]" id="care_plan_type_<?php echo attr($key) + 1; ?>" class="form-control care_plan_type">
                                                 <option value=""></option>
                                                 <?php foreach ($care_plan_type as $value) :
                                                     $selected = ($value['value'] == ($obj["care_plan_type"] ?? '')) ? 'selected="selected"' : '';
+                                                    if (!empty($selected)) {
+                                                        $context = $value['title'];
+                                                    }
                                                     ?>
                                                     <option value="<?php echo attr($value['value']); ?>" <?php echo $selected; ?>><?php echo text($value['title']); ?></option>
                                                 <?php endforeach; ?>
                                             </select>
                                         </div>
 
-                                        <div class="form-row w-100">
+                                        <div class="form-row w-100 my-2">
                                             <div class="forms col-md-3">
-                                                <label for="proposed_date_1" class="h5"><?php echo xlt('Target Date'); ?>:</label>
+                                                <label for="proposed_date_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Target Date'); ?>:</label>
                                                 <input type='text'
-                                                    id="proposed_date_1"
+                                                    id="proposed_date_<?php echo attr($key) + 1; ?>"
                                                     name='proposed_date[]'
                                                     class="form-control proposed_date datepicker"
                                                     value='<?php echo attr($obj["proposed_date"] ?? ""); ?>'
-                                                    title='<?php echo xla('yyyy-mm-dd Target or Achieve-by date'); ?>' />
+                                                    title='<?php echo xla('yyyy-mm-dd HH:MM Target or Achieve-by date'); ?>' />
                                             </div>
-                                                <label for="end_date_1" class="h5"><?php echo xlt('End Date'); ?>:</label>
+                                            <div class="forms col-md-3">
+                                                <label for="end_date_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('End Date'); ?>:</label>
                                                 <input type='text'
-                                                    id="end_date_1"
+                                                    id="end_date_<?php echo attr($key) + 1; ?>"
                                                     name='end_date[]'
                                                     class="form-control end_date datepicker"
                                                     value='<?php echo attr($obj["date_end"] ?? ""); ?>'
-                                                    title='<?php echo xla('yyyy-mm-dd planned end date'); ?>' />
+                                                    title='<?php echo xla('yyyy-mm-dd HH:MM planned end date'); ?>' />
                                             </div>
                                             <div class="forms col-md-3">
-                                                <label for="status_1" class="h5"><?php echo xlt('Status'); ?>:</label>
-                                                <select name="plan_status[]" id="status_1" class="form-control plan_status">
+                                                <label for="status_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Status'); ?>:</label>
+                                                <select name="plan_status[]" id="status_<?php echo attr($key) + 1; ?>" class="form-control plan_status">
                                                     <option value=""></option>
-                                                    <?php foreach (($care_plan_status) as $opt) : ?>
-                                                        <option value="<?php echo attr($opt['value']); ?>">
+                                                    <?php foreach (($care_plan_status) as $opt) :
+                                                        $sel = ($opt['value'] == ($obj["plan_status"] ?? '')) ? 'selected="selected"' : ''; ?>
+                                                        <option value="<?php echo attr($opt['value']); ?>" <?php echo $sel; ?>>
                                                             <?php echo text($opt['title']); ?>
                                                         </option>
                                                     <?php endforeach; ?>
@@ -247,19 +174,19 @@ $reasonCodeStatii[ReasonStatusCodes::NONE]['description'] = xl("Select a status 
                                             </div>
                                         </div>
 
-                                        <div class="forms col-md-6">
-                                            <label for="description_1" class="h5"><?php echo xlt('Description'); ?>:</label>
-                                            <textarea name="description[]" id="description_1" data-textcontext="" class="form-control description" rows="6"><?php echo text($obj["description"] ?? ''); ?></textarea>
+                                        <div class="forms col-md-12">
+                                            <label for="description_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Description'); ?>:</label>
+                                            <textarea name="description[]" id="description_<?php echo attr($key) + 1; ?>" data-textcontext="<?php echo attr($context); ?>" class="form-control description" rows="6"><?php echo text($obj["description"] ?? ''); ?></textarea>
                                         </div>
-                                        <div class="form-row w-100 mt-2 text-center">
-                                            <div class="forms col-md-12">
-                                                <?php include("templates/careplan_actions.php"); ?>
-                                            </div>
-                                            <input type="hidden" name="count[]" id="count_1" class="count" value="1" />
+                                    </div>
+                                    <div class="form-row mt-2">
+                                        <div class="forms col-md-12 d-flex flex-row-reverse ">
+                                            <?php include("templates/careplan_actions.php"); ?>
                                         </div>
-                                        <hr />
+                                        <input type="hidden" name="count[]" id="count_<?php echo attr($key) + 1; ?>" class="count" value="<?php echo attr($key) + 1; ?>" />
                                     </div>
                                     <?php include "templates/careplan_reason_row.php"; ?>
+                                    <hr />
                                 </div>
                             <?php } ?>
                         </div>


### PR DESCRIPTION
Resolves #11977. Tracks #11792.

## Summary

`interface/forms/care_plan/new.php` rendered the populated row through `foreach ($check_res as $key => $obj)` and the new-form blank row through a separate hard-coded `else` branch. The two branches had drifted:

- column widths differed (`col-md-2` × 3 instead of `col-md-4` × 3 for code/date/type; `col-md-6` instead of `col-md-12` for description),
- the End Date column was missing its `col-md-3` wrapper, leaving a stray full-width input and an unbalanced `</div>`,
- `$key` was never assigned in the `else` branch, so the two template includes (`templates/careplan_actions.php`, `templates/careplan_reason_row.php`) raised `Notice: Undefined variable $key` on every blank-form load,
- a stray leading space in `<input type=' text'>` was preserved in the surviving foreach branch (invalid HTML; browsers accept it via the unknown-input-type fallback to `text`).

Replace both branches with a single `foreach ($check_res ?: [[]] as $key => $obj)` over the populated rows or, when none exist, a single synthetic empty `$obj`. Add `?? ''` (and `?? $session->get('authUser')` for `user`) to the remaining bare `$obj` reads so the unified body tolerates the empty `$obj`. Drop the leading space from the date input's `type` attribute.

## Side-effect baseline drains

The deleted else branch contributed entries to several PHPStan baselines. Regenerating drops counts in:

| Baseline | new.php count |
|---|---|
| `argument.type.php` (`attr expects string, mixed given`) | 39 → 31 |
| `argument.type.php` (`text expects string, mixed given`) | 7 → 4 |
| `empty.notAllowed.php` | 5 → 4 |
| `foreach.nonIterable.php` | 3 → 2 |
| `offsetAccess.nonOffsetAccessible.php` (multiple offsets) | many → fewer |
| `variable.undefined.php` (`$care_plan_type`) | 2 → 1 |

No fatal-baseline-cap changes. `variable.undefined.php` is capped, but the ratchet test counts `$ignoreErrors[]` entries, not the per-entry `count` field; dropping new.php's count from 2 to 1 does not remove the entry, so the cap stays at 708.

The PHPStan template `$key might not be defined` baseline entries on `careplan_actions.php` / `careplan_reason_row.php` do not drain from this PR because PHPStan analyses templates standalone and does not follow `include()` into the foreach scope. Those entries are addressed by #11963 (which adds `@var int $key` PHPDoc to both templates).

## Test plan

- [x] `composer phpstan-baseline` regenerates cleanly; pre-commit (php-l, phpcs, phpstan, rector, require-checker) all pass.
- [x] `composer phpunit-isolated -- --filter FatalBaselineCapsIsolatedTest` passes.
- [x] Manual smoke test (Docker dev env, `admin` / `pass`):
  - [x] Open an encounter with no existing Care Plan form, add one. Blank row renders with code/date/type at one-third width, End Date in its own column next to Target Date and Status, Description full-width. No `Notice: Undefined variable $key` in `php_errors_log`.
  - [x] Click "Add Reason" on the blank row — the reason panel toggles open/closed (the templates emit matching `data-toggle-container="reason_code_0"` / `id="reason_code_0"` so the pairing is intact).
  - [x] Fill the row, save, reopen the form — saved data round-trips correctly (DB row in `form_care_plan` populated as expected).

## Out of scope

- Replacing the `include` pattern with a callable that takes `$key` as a parameter. The pattern recurs across `interface/forms/`; worth a separate effort.
