### PR TITLE
ci: harden e2e test step against rerun cascade failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -552,7 +552,6 @@ jobs:
         setup_e2e_bookends ${{ needs.setup.outputs.webserver }}
 
     - name: Run ${{ matrix.suite }} tests
-      if: ${{ success() || failure() }}
       run: |
         . ci/ciLibrary.source
         build_test ${{ matrix.suite }}
@@ -627,36 +626,42 @@ jobs:
     # silent Chrome death leaves a usable trace.
     - name: Capture selenium diagnostics on failure
       if: ${{ failure() && matrix.suite == 'e2e' }}
+      env:
+        # Write under RUNNER_TEMP so this step still works when the workspace
+        # is owned by the apache user (the openemr container chowns its
+        # bind-mounted workdir on startup, leaving the runner unable to mkdir
+        # in `.` when prereq steps were skipped).
+        DIAG_DIR: ${{ runner.temp }}/selenium-diagnostics
       run: |
         . ci/ciLibrary.source
-        mkdir -p selenium-diagnostics
+        mkdir -p "${DIAG_DIR}"
         # Container state — confirms whether selenium was up at failure time.
-        dc ps -a > selenium-diagnostics/docker-compose-ps.txt 2>&1 || true
+        dc ps -a > "${DIAG_DIR}/docker-compose-ps.txt" 2>&1 || true
         # Process tree inside the selenium container.
-        dc top selenium > selenium-diagnostics/docker-compose-top.txt 2>&1 || true
+        dc top selenium > "${DIAG_DIR}/docker-compose-top.txt" 2>&1 || true
         # Memory/CPU snapshot — resolve service to container ID since
         # `docker stats` does not accept compose service names.
         selenium_cid=$(dc ps -q selenium 2>/dev/null || true)
         if [[ -n "${selenium_cid}" ]]; then
-            docker stats --no-stream "${selenium_cid}" > selenium-diagnostics/docker-stats.txt 2>&1 || true
+            docker stats --no-stream "${selenium_cid}" > "${DIAG_DIR}/docker-stats.txt" 2>&1 || true
         else
-            echo 'selenium service has no container at failure time' > selenium-diagnostics/docker-stats.txt
+            echo 'selenium service has no container at failure time' > "${DIAG_DIR}/docker-stats.txt"
         fi
         # Kernel ring buffer — surface OOM-killer / segfault / chrome lines first,
         # then a tail as fallback when the buffer is silent.
         sudo dmesg -T 2>/dev/null | grep -iE 'oom|killed|segfault|chrome|selenium' \
-            > selenium-diagnostics/dmesg.matches.txt 2>&1 || true
-        sudo dmesg -T 2>/dev/null | tail -200 > selenium-diagnostics/dmesg.tail.txt 2>&1 || true
+            > "${DIAG_DIR}/dmesg.matches.txt" 2>&1 || true
+        sudo dmesg -T 2>/dev/null | tail -200 > "${DIAG_DIR}/dmesg.tail.txt" 2>&1 || true
         # Full selenium logs (also echoed to the job log by the later step, but
         # capturing to a file makes them downloadable alongside the rest).
-        dc logs --no-color selenium > selenium-diagnostics/selenium.log 2>&1 || true
+        dc logs --no-color selenium > "${DIAG_DIR}/selenium.log" 2>&1 || true
 
     - name: Upload selenium diagnostics
       if: ${{ failure() && matrix.suite == 'e2e' }}
       uses: actions/upload-artifact@v7
       with:
         name: selenium-diagnostics-${{ needs.setup.outputs.docker_dir }}
-        path: selenium-diagnostics/
+        path: ${{ runner.temp }}/selenium-diagnostics/
         if-no-files-found: ignore
 
     ##


### PR DESCRIPTION
## Summary

When the `setup-snapshot-<docker_dir>` artifact has expired (1-day retention) and only the failed e2e job is reran, the artifact download fails. The `Chmod`, `Dockers environment start`, and `Import database snapshot` steps then skip — but `Run e2e tests` was guarded with `if: \${{ success() || failure() }}` (equivalent to `!cancelled()`), so it ran anyway. Inside, it called `dockers_env_start` itself, which started the openemr container (chown'ing the bind-mounted workspace to apache), exited 1 because the e2e `COMPOSE_PROFILES` wasn't set, then the on-failure diagnostics step hit `mkdir: cannot create directory 'selenium-diagnostics': Permission denied` on the now apache-owned workdir.

Observed in https://github.com/openemr/openemr/actions/runs/25236709069/job/74119258860 (attempt 2, ~39h after attempt 1).

Two changes:

- Drop the `success() || failure()` guard from `Run e2e tests` so it skips cleanly when any prereq step fails, surfacing the real error (artifact missing) instead of cascading misleading downstream failures.
- Move `Capture selenium diagnostics` output under `\$RUNNER_TEMP` so the step works regardless of workspace ownership.

This does not change the artifact retention window itself; reruns >24h after the original run will still skip cleanly with a clear \"artifact not found\" error rather than hiding it behind a permission-denied stack trace.

## Test plan

- [ ] Workflow YAML lints (actionlint, yq) — passing locally
- [ ] CI runs green on this PR
- [ ] On a future stale-artifact rerun, `Run e2e tests` shows as skipped (not failed) and the diagnostics step either skips cleanly or uploads