### PR TITLE
fix(encounter): use getBoolean for inhouse_pharmacy check in visit summary

### DIFF
--- a/interface/forms/newpatient/report.php
+++ b/interface/forms/newpatient/report.php
@@ -69,11 +69,9 @@ function newpatient_report($pid, $encounter, $cols, $id): void
             'posCode' => $posCode,
             'facility' => $facility_name,
         ];
-        /**
-         * @var OEGlobalsBag $globalsBag
-         */
-        $globalsBag = OEGlobalsBag::getInstance()->get('globalsBag');
-        if ($globalsBag->getInt(GlobalFeaturesEnum::INHOUSE_PHARMACY->value, 0) === 1) {
+        // interface/globals.php stores inhouse_pharmacy as a boolean (true for db
+        // values 1/2/3, false for 0/unset), so getInt() throws on the boolean.
+        if (OEGlobalsBag::getInstance()->getBoolean(GlobalFeaturesEnum::INHOUSE_PHARMACY->value)) {
             $encounterUuid = UuidRegistry::uuidToString($result['uuid']);
             $patientService = new PatientService();
             $patientUuid = UuidRegistry::uuidToString($patientService->getUuid($pid));


### PR DESCRIPTION
## Summary

Fixes #11982. Switch the encounter Visit Summary's `inhouse_pharmacy` check from `getInt(...) === 1` to `getBoolean(...)` so it matches the boolean type that `interface/globals.php` actually stores. Also drop the `OEGlobalsBag::getInstance()->get('globalsBag')` self-lookup (only worked because the local variable in `interface/globals.php` leaked into `$GLOBALS`) in favor of calling `OEGlobalsBag::getInstance()` directly.

`interface/globals.php` initializes `$globalsBag->set('inhouse_pharmacy', false)` and only ever overwrites it with `true` (for any non-zero db value). On a fresh install (`inhouse_pharmacy = '0'`), the global is the boolean `false`, and Symfony's `ParameterBag::getInt()` runs `filter_var(false, FILTER_VALIDATE_INT)` → `null` via `FILTER_NULL_ON_FAILURE` → throws `UnexpectedValueException`, which `FormReportRenderer` surfaces as `An error has occurred.` for every encounter that contains any saved form.

This bug has effectively existed since #9192 introduced the `getInt() === 1` check (the comparison would never have succeeded against the boolean either), but the `getInt()` exception was masked until OEGlobalsBag started routing through Symfony's strict filter path.

## Test plan

- [x] `php -l interface/forms/newpatient/report.php`
- [x] `composer phpcs -- interface/forms/newpatient/report.php`
- [x] `composer rector-check -- interface/forms/newpatient/report.php`
- [x] Reproduced the original throw on `master` against a seeded encounter (`UnexpectedValueException: Parameter value "inhouse_pharmacy" is invalid…`)
- [x] After the fix, `newpatient_report()` renders the encounter summary cleanly with `inhouse_pharmacy = '0'` in the db
- [ ] Manual verification in a browser (Visit Summary panel populated for an encounter with a saved Care Plan form)
