### PR TITLE
fix(upgrade): keep legacy devtools sed-rewrite working in sql_upgrade.php

### DIFF
--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -7563,7 +7563,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecordsNoLog\\(\\) instead of sqlStatementNoLog\\(\\)\\.$#',
-    'count' => 24,
+    'count' => 25,
     'path' => __DIR__ . '/../../src/Services/Utils/SQLUpgradeService.php',
 ];
 $ignoreErrors[] = [

--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -377,7 +377,22 @@ header('Content-type: text/html; charset=utf-8');
         <div id='processDetails' class='card card-body pb-2 h-50 overflow-auto collapse show'>
             <div class='col-md bg-light text-dark'>
                 <?php if (!empty($_POST['form_submit']) || $cliFromVersion !== null) {
-                    $form_old_version = $cliFromVersion ?? ($_POST['form_old_version'] ?? '');
+                    // Default the POST input so the literal assignment below does not warn under CLI.
+                    // The exact form `$form_old_version = $_POST['form_old_version'];` is preserved
+                    // so the legacy openemr-devops sed-rewrite in `devtoolsLibrary.source`
+                    // (`upgradeOpenEMR()`, used by `openemr-cmd drid` etc.) keeps working against
+                    // images that bundle the older devtools script. New callers should pass
+                    // --from=X.Y.Z on the CLI; the override below picks that up.
+                    // @phpstan-ignore openemr.forbiddenRequestGlobals (Required for write)
+                    $_POST['form_old_version'] ??= '';
+                    $form_old_version = $_POST['form_old_version'];
+                    if ($cliFromVersion !== null) {
+                        $form_old_version = $cliFromVersion;
+                    }
+
+                    if ($form_old_version === '') {
+                        die("sql_upgrade: refusing to run with no source version. Pass --from=X.Y.Z on the CLI or submit the form.\n");
+                    }
 
                     foreach ($versions as $version => $filename) {
                         if (strcmp($version, (string) $form_old_version) < 0) {

--- a/src/Services/Utils/SQLUpgradeService.php
+++ b/src/Services/Utils/SQLUpgradeService.php
@@ -737,8 +737,12 @@ class SQLUpgradeService implements ISQLUpgradeService
                             $eyeFormCategoryParent['rght'] + 5
                         ]
                     );
-                    // update categories_seq
-                    sqlStatementNoLog("UPDATE `categories_seq` SET `id` = (SELECT MAX(`id`) FROM `categories`)");
+                    // Reset categories_seq to MAX(categories.id). DELETE+INSERT instead of UPDATE
+                    // because categories_seq is a single-row sequence emulator with PRIMARY KEY on id;
+                    // an UPDATE without WHERE collapses every row to the same value and crashes with
+                    // a duplicate-key error if a stray second row is ever present.
+                    sqlStatementNoLog("DELETE FROM `categories_seq`");
+                    sqlStatementNoLog("INSERT INTO `categories_seq` (`id`) SELECT MAX(`id`) FROM `categories`");
                     $this->echo("<p class='text-success'>Completed conversion of categories for eye form insertion.</p>\n");
                     $this->flush_echo();
                     $skipping = false;


### PR DESCRIPTION
## Summary

`openemr-cmd dev-reset-install-demodata` (`drid`) currently corrupts a fresh demo install: the login screen renders without its logo and theme, and patient view crashes with SQL errors.

Fixes #11930 (the categories_seq half) and explains where the stray row originates.

## Root cause

#11906 changed the assignment in `sql_upgrade.php` from

```php
$form_old_version = $_POST['form_old_version'];
```

to a `??`-coalesced form. That line is the exact target of the legacy sed-based hack in `openemr-devops/.../devtoolsLibrary.source` (`upgradeOpenEMR()`, used by `openemr-cmd drid`). The sed pattern stopped matching, so `$form_old_version` silently became `''`.

With an empty source version, `strcmp($version, '') < 0` is always false, so the upgrade walks **every** SQL file from `2_6_0-to-2_6_1_upgrade.sql` onward. That file does:

```sql
INSERT INTO `categories_seq` VALUES (0);
```

…leaving the single-row sequence emulator with two rows `[0, 26]`. Several upgrade scripts then run `UPDATE categories_seq SET id = (SELECT MAX(id) FROM categories)` (no `WHERE`); each one collapses every row to the same value and fails with `Duplicate entry 'N' for key 'PRIMARY'`. Most of those failures are caught and logged ("Upgrading will continue"), but one isn't:

```
src/Services/Utils/SQLUpgradeService.php:741 (#IfEyeFormLaserCategoriesNeeded)
  sqlStatementNoLog("UPDATE `categories_seq` SET `id` = (SELECT MAX(`id`) FROM `categories`)");
```

`sqlStatementNoLog` throws on error, halting the upgrade before the default-globals INSERT loop at the bottom of `sql_upgrade.php` runs. The `globals` row for `login_page_layout`, `default_top_pane`, theme/logo settings, and many others is never created — hence the broken login styling and the patient-view SQL crash.

## Changes

- **`sql_upgrade.php`** — restore the literal `$form_old_version = $_POST['form_old_version'];` shape so the legacy `devtoolsLibrary.source` sed-rewrite keeps working. Apply the `--from=X.Y.Z` CLI override on a separate line (still works for callers that switched to the new flag from #11906). Default the `$_POST` key first to avoid the warning that #11939 was guarding against. Add a `die()` if the resolved version is empty, so future regressions of the legacy hack fail loudly instead of silently corrupting `categories_seq`.
- **`src/Services/Utils/SQLUpgradeService.php`** — in `#IfEyeFormLaserCategoriesNeeded`, replace the unguarded `UPDATE categories_seq SET id = ... (no WHERE)` with `DELETE FROM categories_seq` + `INSERT INTO categories_seq (id) SELECT MAX(id) FROM categories`. Defensive against any stray pre-existing row in the single-row sequence table.
- **`.phpstan/baseline/openemr.deprecatedSqlFunction.php`** — bumped count from 24 → 25 since the eye-laser block now has one extra `sqlStatementNoLog` call. Regenerated via `composer phpstan-baseline`.

## Test plan

- [x] `openemr-cmd drid` end-to-end: completes with exit 0, no `Duplicate entry` errors
- [x] `version` table shows `8.1.1`
- [x] `categories_seq` has the single expected row
- [x] All 523 globals (including `login_page_layout = 'login/layouts/vertical_band.html.twig'`) are seeded
- [x] Login page renders with logo + theme stylesheet (`public/themes/style_light.css`, `public/images/logos/core/login/primary/logo.png`)
- [x] Demo patients reachable
- [x] `composer phpstan` clean
- [x] `composer phpcs` clean
- [x] `composer phpunit-isolated --filter SqlUpgradeBootstrap` passes

## Follow-up

The sed-based version injection in `devtoolsLibrary.source` is fragile cross-repo coupling. A proper follow-up is to update that script (in `openemr/openemr-devops`) to use the new `--from=X.Y.Z` CLI flag from #11906 instead of rewriting `sql_upgrade.php` on the fly. After devtools is on the new flag, the literal-line workaround here can be removed.
