### PR TITLE
fix(ui): Fix crash from uncaught class in birthday popup

### DIFF
--- a/.phpstan/baseline/class.notFound.php
+++ b/.phpstan/baseline/class.notFound.php
@@ -117,11 +117,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/orders/receive_hl7_results.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to static method getInstance\\(\\) on an unknown class echoOEGlobalsBag\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/birthday_alert/birthday_pop.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Caught class MpdfException not found\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -2492,16 +2492,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/orders/order_manifest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method getImagesRelative\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/birthday_alert/birthday_pop.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method getKernel\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/birthday_alert/birthday_pop.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method Execute\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/encounter/cash_receipt.php',

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 return [
     'all' => [
-        'class.notFound.php' => 182,
+        'class.notFound.php' => 181,
         'classConstant.notFound.php' => 0,
         'constant.notFound.php' => 0,
         'function.notFound.php' => 0,

--- a/interface/patient_file/birthday_alert/birthday_pop.php
+++ b/interface/patient_file/birthday_alert/birthday_pop.php
@@ -30,7 +30,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 </head>
 <body>
     <div style="padding: 15px; text-align: center">
-        <p class="h2"><?php echo xlt('Happy Birthday');?>&ensp;<img src="<?=OEGlobalsBag::getInstance()->getKernel()->getImagesRelative()?>/balloons-154949_960_720.png" height="42" width="42"></p>
+        <p class="h2"><?php echo xlt('Happy Birthday');?>&ensp;<img src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getImagesRelative()?>/balloons-154949_960_720.png" height="42" width="42"></p>
 
         <?php if (OEGlobalsBag::getInstance()->getBoolean('patient_birthday_alert_manual_off')) { ?>
             <div class="checkbox">

--- a/interface/patient_file/birthday_alert/birthday_pop.php
+++ b/interface/patient_file/birthday_alert/birthday_pop.php
@@ -30,7 +30,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 </head>
 <body>
     <div style="padding: 15px; text-align: center">
-        <p class="h2"><?php echo xlt('Happy Birthday');?>&ensp;<img src="<?php echoOEGlobalsBag::getInstance()->getKernel()->getImagesRelative()?>/balloons-154949_960_720.png" height="42" width="42"></p>
+        <p class="h2"><?php echo xlt('Happy Birthday');?>&ensp;<img src="<?=OEGlobalsBag::getInstance()->getKernel()->getImagesRelative()?>/balloons-154949_960_720.png" height="42" width="42"></p>
 
         <?php if (OEGlobalsBag::getInstance()->getBoolean('patient_birthday_alert_manual_off')) { ?>
             <div class="checkbox">


### PR DESCRIPTION
#### Short description of what this changes or resolves:
```
openemr-1  | NOTICE: PHP message: OpenEMR.CRITICAL: Uncaught exception! {"exception":"[object] (Error(code: 0): Class \"echoOEGlobalsBag\" not found at /usr/share/nginx/html/openemr/interface/patient_file/birthday_alert/birthday_pop.php:33)
```

I suspect this was the root cause for #11983 (etc) but even without the crash I bet the e2e tests would be too fragile to proceed.

#### Changes proposed in this pull request:

- Fixes the missing space
- Updates baseline to reflect fix

#### Was an AI assistant used? Yes / No
No