### PR TITLE
fix(vitals): drop duplicate growth-chart buttons from Vitals History

### DIFF
--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -322,6 +322,11 @@ class C_FormVitals
                 'type' => 'template'
                 ,'templateName' => 'vitals_growthchart_actions.html.twig'
                 ,'hide' => !$show_pediatric_fields
+                // Action buttons render once in the editable section and emit
+                // fixed ids (pdfchart/htmlchart). Rendering them again in the
+                // history table would duplicate those ids and break the jQuery
+                // click handlers bound to the first pair.
+                ,'renderInHistory' => false
             ]
         ];
 

--- a/interface/forms/vitals/templates/vitals/vitals_historical_values_complete.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals_historical_values_complete.html.twig
@@ -43,12 +43,10 @@
                             precision:field.precision, codes:field.codes, results: results, is_edit: false }
                         %}
                     {% endif %}
-                    {# Skip the growth-chart action buttons here. They are
-                       rendered once in the editable section above; rendering
-                       them again would produce duplicate id="pdfchart" /
-                       id="htmlchart" in the DOM, which breaks the jQuery
-                       click handlers on the second pair. #}
-                    {% if field.type == 'template' and field.templateName != 'vitals_growthchart_actions.html.twig' %}
+                    {# Fields can opt out of the read-only history table by
+                       setting renderInHistory: false in C_FormVitals. Default
+                       is to render. #}
+                    {% if field.type == 'template' and (field.renderInHistory ?? true) %}
                         {% include field.templateName with {vitals: vitals, field: field, results: results, is_edit: false } %}
                     {% endif %}
                 {% endfor %}

--- a/interface/forms/vitals/templates/vitals/vitals_historical_values_complete.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals_historical_values_complete.html.twig
@@ -43,7 +43,12 @@
                             precision:field.precision, codes:field.codes, results: results, is_edit: false }
                         %}
                     {% endif %}
-                    {% if field.type == 'template' %}
+                    {# Skip the growth-chart action buttons here. They are
+                       rendered once in the editable section above; rendering
+                       them again would produce duplicate id="pdfchart" /
+                       id="htmlchart" in the DOM, which breaks the jQuery
+                       click handlers on the second pair. #}
+                    {% if field.type == 'template' and field.templateName != 'vitals_growthchart_actions.html.twig' %}
                         {% include field.templateName with {vitals: vitals, field: field, results: results, is_edit: false } %}
                     {% endif %}
                 {% endfor %}


### PR DESCRIPTION
## Problem

The vitals form template renders the `vitalFields` array twice: once in the editable section (`vitals.html.twig`) and again in the Vitals History card (`vitals_historical_values_complete.html.twig`). One of those entries is a `template`-type field pointing at `vitals_growthchart_actions.html.twig`, which emits two buttons with `id=\"pdfchart\"` and `id=\"htmlchart\"`. The second render produces duplicate IDs in the DOM, so the jQuery handlers in `vitals.html.twig:184-186` (`$(\"#pdfchart\")` / `$(\"#htmlchart\")`) only bind to the first pair. The buttons in the Vitals History card render correctly but do nothing when clicked.

## Fix

Skip the growth-chart actions template specifically when rendering the history loop. Action buttons don't belong in a read-only history table, and the working pair in the editable section is unaffected. Other `template`-type fields (currently only `vitals_notes.html.twig`) continue to render in both sections.

## Test plan

- [x] Open a patient with vitals → editable Vitals form → upper Growth-Chart (PDF) and (HTML) buttons still open the chart in a new window.
- [x] Scroll down to the Vitals History card → no duplicate Growth-Chart buttons appear.
- [x] Other Notes (the only other `template`-type field today) still renders in the history table.