### PR TITLE
chore: backport milestone 8.1.0 to rel-810

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -15247,16 +15247,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'Redirect token…\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Entities/ClientEntity.php',

--- a/.phpstan/baseline/class.notFound.php
+++ b/.phpstan/baseline/class.notFound.php
@@ -157,11 +157,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/orders/receive_hl7_results.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to static method getInstance\\(\\) on an unknown class echoOEGlobalsBag\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/birthday_alert/birthday_pop.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Caught class MpdfException not found\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',

--- a/.phpstan/baseline/class.notFound.php
+++ b/.phpstan/baseline/class.notFound.php
@@ -167,6 +167,16 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Call to method dispatch\\(\\) on an unknown class EventDispatcher\\.$#',
+    'count' => 17,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^PHPDoc tag @var contains unknown class EventDispatcher\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Parameter \\$encounterId of method ESign\\\\Encounter_Log\\:\\:__construct\\(\\) has invalid type ESign\\\\unknown\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/ESign/Encounter/Log.php',

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -3678,7 +3678,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 14,
+    'count' => 9,
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -1243,7 +1243,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 4,
+    'count' => 6,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -3117,6 +3117,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_file/summary/dashboard_header.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Cannot call method addCard\\(\\) on mixed\\.$#',
+    'count' => 3,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Cannot call method canAdd\\(\\) on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
@@ -3137,13 +3142,28 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Cannot call method getAppendedInjection\\(\\) on mixed\\.$#',
+    'count' => 14,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Cannot call method getBackgroundColorClass\\(\\) on mixed\\.$#',
+    'count' => 2,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method getCards\\(\\) on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method getIdentifier\\(\\) on mixed\\.$#',
     'count' => 2,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method getPrependedInjection\\(\\) on mixed\\.$#',
+    'count' => 14,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -2967,16 +2967,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/orders/order_manifest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method getImagesRelative\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/birthday_alert/birthday_pop.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method getKernel\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/birthday_alert/birthday_pop.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method Execute\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/encounter/cash_receipt.php',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -33757,16 +33757,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OneTimeAuth\\:\\:decodePortalOneTime\\(\\) has parameter \\$redirect_token with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OneTimeAuth\\:\\:encodeLink\\(\\) has parameter \\$encrypted_redirect with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OneTimeAuth\\:\\:encodeLink\\(\\) has parameter \\$site_addr with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
@@ -33823,11 +33813,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OneTimeAuth\\:\\:insertOnetime\\(\\) has parameter \\$scope with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OneTimeAuth\\:\\:processOnetime\\(\\) has parameter \\$redirect_token with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -42232,16 +42232,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pid\' on mixed\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'to\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access an offset on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Entities/ScopePermissionObject.php',

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -4238,12 +4238,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 30,
+    'count' => 29,
     'path' => __DIR__ . '/../../portal/index.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 5,
+    'count' => 4,
     'path' => __DIR__ . '/../../portal/index.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/varTag.nativeType.php
+++ b/.phpstan/baseline/varTag.nativeType.php
@@ -7,6 +7,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/procedure_order/templates/procedure_specimen_row.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^PHPDoc tag @var with type EventDispatcher is not subtype of native type Symfony\\\\Component\\\\EventDispatcher\\\\EventDispatcherInterface\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
     'message' => '#^PHPDoc tag @var with type OpenEMR\\\\Services\\\\Qdm\\\\PopulationSet is not subtype of native type array\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/Qdm/ResultsCalculator.php',

--- a/acl_upgrade.php
+++ b/acl_upgrade.php
@@ -777,9 +777,43 @@ if ($acl_version < $upgrade_acl) {
     $acl_version = $upgrade_acl;
 }
 
-/* This is a template for a new revision, when needed
 // Upgrade for acl_version 13
 $upgrade_acl = 13;
+if ($acl_version < $upgrade_acl) {
+    echo "<B>UPGRADING ACCESS CONTROLS TO VERSION " . $upgrade_acl . ":</B></BR>";
+
+    //Collect the ACL ID numbers.
+    echo "<B>Checking to ensure all the proper ACL(access control list) are present:</B></BR>";
+    $clin_write = AclExtended::getAclIdNumber('Clinicians', 'write');
+    $clin_addonly = AclExtended::getAclIdNumber('Clinicians', 'addonly');
+
+    //Add new object Sections
+    echo "<BR/><B>Adding new object sections</B><BR/>";
+
+    //Add new Objects
+    echo "<BR/><B>Adding new objects</B><BR/>";
+
+    //Update already existing Objects
+    echo "<BR/><B>Upgrading objects</B><BR/>";
+
+    //Add new ACLs here (will return the ACL ID of newly created or already existing ACL)
+    // (will also place in the appropriate group and CREATE a new group if needed)
+    echo "<BR/><B>Adding ACLs(Access Control Lists) and groups</B><BR/>";
+
+    //Update the ACLs
+    echo "<BR/><B>Updating the ACLs(Access Control Lists)</B><BR/>";
+    AclExtended::shiftAcl($clin_addonly, 'Clinicians', 'patients', 'Patients', 'med', 'Medical/History (write,addonly optional)', 'addonly');
+    AclExtended::updateAcl($clin_write, 'Clinicians', 'patients', 'Patients', 'med', 'Medical/History (write,addonly optional)', 'write');
+
+    //DONE with upgrading to this version
+    $acl_version = $upgrade_acl;
+}
+
+
+
+/* This is a template for a new revision, when needed
+// Upgrade for acl_version 14
+$upgrade_acl = 14;
 if ($acl_version < $upgrade_acl) {
     echo "<B>UPGRADING ACCESS CONTROLS TO VERSION " . $upgrade_acl . ":</B></BR>";
 

--- a/interface/forms/clinical_notes/templates/new.html.twig
+++ b/interface/forms/clinical_notes/templates/new.html.twig
@@ -18,7 +18,7 @@ The Edit/Create template of the clinical note form.
 #}
 {% extends "core/base.html.twig" %}
 {% block head %}
-    {{ setupHeader(['i18next', 'il8formatting', 'datetime-picker','datetime-picker-translated']) }}
+    {{ setupHeader(['i18next', 'i18formatting', 'datetime-picker','datetime-picker-translated']) }}
     <script src="{{ webroot }}/interface/forms/clinical_notes/clinical-notes.js?v={{ assetVersion|url_encode }}"></script>
     <script>
         if (window.oeFormsClinicalNotes) {

--- a/interface/forms/newpatient/C_EncounterVisitForm.class.php
+++ b/interface/forms/newpatient/C_EncounterVisitForm.class.php
@@ -676,7 +676,7 @@ class C_EncounterVisitForm
         $posOptions = $this->getPosOptionsForTemplate($facilityPosCode);
 // END AI GENERATED CODE
 
-        if (Utilities::isDateEmpty($encounter['onset_date'])) {
+        if (Utilities::isDateEmpty($encounter['onset_date'] ?? null)) {
             $encounter['onset_date'] = null;
         }
 

--- a/interface/forms/newpatient/save.php
+++ b/interface/forms/newpatient/save.php
@@ -12,6 +12,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Set $sessionAllowWrite to true since the encounter is written to the session via setencounter() below.
+$sessionAllowWrite = true;
 require_once(__DIR__ . "/../../globals.php");
 require_once("$srcdir/forms.inc.php");
 require_once("$srcdir/encounter.inc.php");

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -269,8 +269,7 @@ if (empty($siteId) || !empty($_GET['site'])) {
                 $globalsBag->set('srcdir', $srcdir);
                 require_once("$srcdir/auth.inc.php");
             }
-            http_response_code(400);
-            die("Site ID is missing from session data!");
+            throw new \OpenEMR\Common\System\MissingSiteIdException();
         }
 
         $tmp = $_SERVER['HTTP_HOST'];

--- a/interface/main/calendar/index.php
+++ b/interface/main/calendar/index.php
@@ -16,6 +16,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Set $sessionAllowWrite to true since pc_facility, pc_username, and viewtype are written to the session below.
+$sessionAllowWrite = true;
 require_once("../../globals.php");
 require_once("$srcdir/calendar.inc.php");
 require_once("$srcdir/patient.inc.php");

--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -1288,7 +1288,8 @@ function &postcalendar_userapi_pcGetEvents($args)
     $event->setProviderID($providerID ?? $provider_id ?? null);
 
     $result = OEGlobalsBag::getInstance()->getKernel()->getEventDispatcher()->dispatch($event, CalendarUserGetEventsFilter::EVENT_NAME);
-    return $result->getEventsByDays();
+    $eventsByDays = $result->getEventsByDays();
+    return $eventsByDays;
 }
 
 //===========================

--- a/interface/new/new_comprehensive_save.php
+++ b/interface/new/new_comprehensive_save.php
@@ -12,6 +12,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Set $sessionAllowWrite to true since the new patient pid is written to the session via setpid() below.
+$sessionAllowWrite = true;
 require_once("../globals.php");
 
 use OpenEMR\BC\ServiceContainer;

--- a/interface/patient_file/birthday_alert/birthday_pop.php
+++ b/interface/patient_file/birthday_alert/birthday_pop.php
@@ -30,7 +30,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 </head>
 <body>
     <div style="padding: 15px; text-align: center">
-        <p class="h2"><?php echo xlt('Happy Birthday');?>&ensp;<img src="<?php echoOEGlobalsBag::getInstance()->getKernel()->getImagesRelative()?>/balloons-154949_960_720.png" height="42" width="42"></p>
+        <p class="h2"><?php echo xlt('Happy Birthday');?>&ensp;<img src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getImagesRelative()?>/balloons-154949_960_720.png" height="42" width="42"></p>
 
         <?php if (OEGlobalsBag::getInstance()->getBoolean('patient_birthday_alert_manual_off')) { ?>
             <div class="checkbox">

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -27,6 +27,9 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Set $sessionAllowWrite to true since this script writes disablePreviousNameAdds to the session
+// on every load, alert_notify_pid whenever CDR is enabled, and pid + encounter when ?set_pid is provided.
+$sessionAllowWrite = true;
 require_once("../../globals.php");
 
 require_once("$srcdir/lists.inc.php");

--- a/library/ajax/dated_reminders_counter.php
+++ b/library/ajax/dated_reminders_counter.php
@@ -31,8 +31,6 @@ if (SessionTracker::isSessionExpired()) {
     echo json_encode(['timeoutMessage' => 'timeout']);
     exit;
 }
-// keep this below above time out check.
-OpenEMR\Common\Session\SessionUtil::setSession('keepAliveTime', time());
 
 $total_counts = [];
 $other_count = [];

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -68,6 +68,9 @@ class Controller extends Smarty implements ControllerInterface
          $this->setCompileDir(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . '/documents/smarty/main');
          $this->setCompileCheck(true);
          $this->setPluginsDir([__DIR__ . "/../smarty/plugins", OEGlobalsBag::getInstance()->getKernel()->getVendorDir() . "/smarty/smarty/libs/plugins"]);
+         // Register {$x|text} explicitly so Smarty does not fall back to the
+         // deprecated unregistered-function path when escaping for text nodes.
+         $this->registerPlugin('modifier', 'text', self::escapeForTextNode(...));
          $this->assign("PROCESS", "true");
          $this->assign("HEADER", "<html><head></head><body>");
          $this->assign("FOOTER", "</body></html>");
@@ -272,6 +275,14 @@ class Controller extends Smarty implements ControllerInterface
     {
         return method_exists($controllerObj, $method)
             && is_callable([$controllerObj, $method]);
+    }
+
+    private static function escapeForTextNode(mixed $value): string
+    {
+        if (is_string($value) || is_int($value) || is_float($value) || is_bool($value) || $value instanceof \Stringable) {
+            return \text((string) $value);
+        }
+        return '';
     }
 
     public function _link($action = "default", $inlining = false)

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -1,5 +1,19 @@
 <?php
 
+/**
+ * Controller Class.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    OpenEMR contributors
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @author    Stephen Waite <stephen.waite@open-emr.org>
+ * @copyright Copyright (c) OpenEMR contributors
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@open-emr.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\ControllerInterface;
@@ -232,20 +246,32 @@ class Controller extends Smarty implements ControllerInterface
 
         $isProcessing = ($_POST['process'] ?? '') === 'true';
 
-        if ($isProcessing && is_callable([$controllerObj, $processMethod])) {
+        if ($isProcessing && $this->methodExists($controllerObj, $processMethod)) {
             $output .= $callMethod($processMethod);
             if ($controllerObj->_state === false) {
                 return $output;
             }
         }
 
-        if ($isProcessing || is_callable([$controllerObj, $actionMethod])) {
+        if ($this->methodExists($controllerObj, $actionMethod)) {
             $output .= $callMethod($actionMethod);
         } else {
             throw new NotFoundHttpException("Action '$action' does not exist on controller: $className");
         }
 
         return $output;
+    }
+
+    /**
+     * Check whether a method genuinely exists on a controller object.
+     *
+     * Smarty 4's __call makes is_callable() always return true on
+     * Smarty-derived objects, so we must also check method_exists().
+     */
+    private function methodExists(object $controllerObj, string $method): bool
+    {
+        return method_exists($controllerObj, $method)
+            && is_callable([$controllerObj, $method]);
     }
 
     public function _link($action = "default", $inlining = false)

--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -1230,7 +1230,7 @@ $config = 1; /////////////
         $gacl->add_acl(
             [
                 'encounters' => ['notes', 'relaxed'],
-                'patients' => ['demo', 'med', 'docs', 'notes','trans', 'reminder', 'alert', 'disclosure', 'rx', 'amendment', 'lab'],
+                'patients' => ['demo', 'docs', 'notes','trans', 'reminder', 'alert', 'disclosure', 'rx', 'amendment', 'lab'],
                 'sensitivities' => ['normal']
             ],
             null,
@@ -1243,6 +1243,20 @@ $config = 1; /////////////
             'Things that clinicians can read and enter but not modify'
         );
         // xl('Things that clinicians can read and enter but not modify')
+        $gacl->add_acl(
+            [
+                'patients' => ['med']
+            ],
+            null,
+            [$clin],
+            null,
+            null,
+            1,
+            1,
+            'write',
+            'Things that clinicians can read and modify'
+        );
+        // xl('Things that clinicians can read and modify')
         $gacl->add_acl(
             [
                 'placeholder' => ['filler']

--- a/library/sql.inc.php
+++ b/library/sql.inc.php
@@ -98,6 +98,7 @@ function sqlStatement($statement, $binds = false)
     try {
         return QueryUtils::sqlStatementThrowException($statement, $binds, noLog: false);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }
@@ -159,6 +160,7 @@ function sqlStatementNoLog($statement, $binds = false, $throw_exception_on_error
         if ($throw_exception_on_error) {
             throw $e;
         }
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }
@@ -241,6 +243,7 @@ function sqlInsert($statement, $binds = false)
     try {
         return QueryUtils::sqlInsert($statement, $binds);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("insert failed: $statement", $e->sqlError);
     }
 }
@@ -261,6 +264,7 @@ function sqlQuery($statement, $binds = false)
     try {
         return QueryUtils::querySingleRow($statement, $binds ?: []);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }
@@ -291,6 +295,7 @@ function sqlQueryNoLog($statement, $binds = false, $throw_exception_on_error = f
         if ($throw_exception_on_error) {
             throw $e;
         }
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }
@@ -332,6 +337,7 @@ function sqlInsertClean_audit($statement, $binds = false): void
     try {
         QueryUtils::sqlStatementThrowException($statement, $binds, noLog: true);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("insert failed: $statement", $e->sqlError);
     }
 }
@@ -434,6 +440,7 @@ function sqlQ($statement, $binds = false)
     try {
         return QueryUtils::sqlStatementThrowException($statement, $binds);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }

--- a/portal/index.php
+++ b/portal/index.php
@@ -105,14 +105,13 @@ if (!empty($_REQUEST['service_auth'] ?? null)) {
         // an external site domain.  We used to auto process via GET but now we submit via the POST in order to make it
         // a same site cookie origin request. This is a workaround for the Same-Site cookie blocking.
         $token = $_GET['service_auth'];
-        $ot = $oneTime->decodePortalOneTime($token, null, false);
+        $ot = $oneTime->decodePortalOneTime($token, logUpdate: false);
         $pin_required = $ot['actions']['enforce_auth_pin'] ? 1 : 0;
         CsrfUtils::setupCsrfKey($session);
         $twig = new TwigContainer(null, $globalsBag->getKernel());
         echo $twig->getTwig()->render('portal/login/autologin.html.twig', [
             'action' => $globalsBag->getString('web_root') . '/portal/index.php',
             'service_auth' => text($_GET['service_auth']),
-            'target' => text($_GET['target'] ?? null),
             'csrf_token' => CsrfUtils::collectCsrfToken($session, 'autologin'),
             'pagetitle' => xl("OpenEMR Patient Portal"),
             'images_static_relative' => $globalsBag->get('images_static_relative') ?? '',
@@ -121,13 +120,12 @@ if (!empty($_REQUEST['service_auth'] ?? null)) {
         exit;
     } elseif (!empty($_POST['service_auth'] ?? null)) {
         $token = $_POST['service_auth'];
-        $redirect_token = $_POST['target'] ?? null;
         $csrfToken = $_POST['csrf_token'] ?? null;
         try {
             if (!CsrfUtils::verifyCsrfToken($csrfToken, $session, 'autologin')) {
                 throw new OneTimeAuthException('Invalid CSRF token');
             }
-            $auth = $oneTime->processOnetime($token, $redirect_token);
+            $auth = $oneTime->processOnetime($token);
             $logit->portalLog('onetime login attempt', $auth['pid'], 'patient logged in and redirecting', '', '1');
             exit();
         } catch (OneTimeAuthExpiredException $exception) {

--- a/portal/lib/paylib.php
+++ b/portal/lib/paylib.php
@@ -14,6 +14,7 @@
 
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Billing\PaymentGateway;
+use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 
@@ -49,6 +50,10 @@ if ($session->get('portal_init') !== true) {
 }
 
 SessionUtil::setSession('portal_init', false);
+
+if (filter_input(INPUT_SERVER, 'REQUEST_METHOD') === 'POST') {
+    CsrfUtils::checkCsrfInput(INPUT_POST, subject: 'portal-payment', dieOnFail: true);
+}
 
 if ($_POST['mode'] == 'Sphere') {
     $cryptoGen = ServiceContainer::getCrypto();

--- a/portal/portal_payment.php
+++ b/portal/portal_payment.php
@@ -102,6 +102,10 @@ $patdata = sqlQuery("SELECT " . "p.fname, p.mname, p.lname, p.postal_code, p.pub
 
 $alertmsg = ''; // anything here pops up in an alert box
 
+if (filter_input(INPUT_SERVER, 'REQUEST_METHOD') === 'POST') {
+    CsrfUtils::checkCsrfInput(INPUT_POST, subject: 'portal-payment', dieOnFail: true);
+}
+
 // If the Save button was clicked...
 if ($_POST['form_save'] ?? '') {
     $form_pid = $isPortal ? $pid : $_POST['form_pid'];
@@ -620,6 +624,7 @@ if (($_POST['form_save'] ?? null) || ($_REQUEST['receipt'] ?? null)) {
           style="text-align: center; margin: auto;">
 
     <form id="invoiceForm" method='post' action='<?php echo $globalsBag->getString("webroot") ?>/portal/portal_payment.php'>
+        <input type='hidden' name='csrf_token_form' value='<?php echo attr(CsrfUtils::collectCsrfToken($session, 'portal-payment')); ?>'/>
         <input type='hidden' name='form_pid' value='<?php echo attr($pid) ?>'/>
         <input type='hidden' name='form_save' value='<?php echo xla('Invoice'); ?>'/>
         <table>
@@ -1042,6 +1047,7 @@ if (($_POST['form_save'] ?? null) || ($_REQUEST['receipt'] ?? null)) {
                 <div class="modal-body">
                     <?php if ($globalsBag->get('payment_gateway') !== 'Stripe' && $globalsBag->get('payment_gateway') !== 'Sphere' && $globalsBag->get('payment_gateway') !== 'Rainforest') { ?>
                     <form id='paymentForm' method='post' action='<?php echo $globalsBag->getString("webroot") ?>/portal/lib/paylib.php'>
+                        <input type='hidden' name='csrf_token_form' value='<?php echo attr(CsrfUtils::collectCsrfToken($session, 'portal-payment')); ?>'/>
                         <fieldset>
                             <div class="form-group">
                                 <label label-default="label-default"
@@ -1112,6 +1118,7 @@ if (($_POST['form_save'] ?? null) || ($_REQUEST['receipt'] ?? null)) {
                     </form>
                     <?php } else { // stripe/sphere/rainforest ?>
                         <form method="post" name="payment-form" id="payment-form">
+                            <input type='hidden' name='csrf_token_form' value='<?php echo attr(CsrfUtils::collectCsrfToken($session, 'portal-payment')); ?>'/>
                             <fieldset>
                                 <div class="form-group">
                                     <label label-default="label-default"><?php echo xlt('Name on Card'); ?></label>

--- a/sql/7_0_3-to-7_0_4_upgrade.sql
+++ b/sql/7_0_3-to-7_0_4_upgrade.sql
@@ -1314,7 +1314,7 @@ ALTER TABLE `procedure_order`
 ALTER TABLE `procedure_order` ADD INDEX `idx_scheduled_date` (`scheduled_date`);
 #EndIf
 #IfNotIndex procedure_order idx_order_intent
-ALTER TABLE `procedure_order` ADD INDEX `idx_order_intent` (`order_intent`),
+ALTER TABLE `procedure_order` ADD INDEX `idx_order_intent` (`order_intent`);
 #EndIf
 #IfNotIndex procedure_order idx_location_id
 ALTER TABLE `procedure_order` ADD INDEX `idx_location_id` (`location_id`);

--- a/sql/7_0_3-to-7_0_4_upgrade.sql
+++ b/sql/7_0_3-to-7_0_4_upgrade.sql
@@ -1309,10 +1309,15 @@ ALTER TABLE `procedure_order`
         COMMENT 'FHIR intent: order, plan, directive, proposal',
     ADD COLUMN `location_id` INT DEFAULT NULL
         COMMENT 'References facility.id for service location (FHIR locationReference)';
-ALTER TABLE `procedure_order`
-    ADD INDEX IF NOT EXISTS `idx_scheduled_date` (`scheduled_date`),
-    ADD INDEX IF NOT EXISTS `idx_order_intent` (`order_intent`),
-    ADD INDEX IF NOT EXISTS `idx_location_id` (`location_id`);
+#EndIf
+#IfNotIndex procedure_order idx_scheduled_date
+ALTER TABLE `procedure_order` ADD INDEX `idx_scheduled_date` (`scheduled_date`);
+#EndIf
+#IfNotIndex procedure_order idx_order_intent
+ALTER TABLE `procedure_order` ADD INDEX `idx_order_intent` (`order_intent`),
+#EndIf
+#IfNotIndex procedure_order idx_location_id
+ALTER TABLE `procedure_order` ADD INDEX `idx_location_id` (`location_id`);
 #EndIf
 
 #IfNotRow2D list_options list_id ord_priority option_id routine

--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -377,7 +377,7 @@ header('Content-type: text/html; charset=utf-8');
         <div id='processDetails' class='card card-body pb-2 h-50 overflow-auto collapse show'>
             <div class='col-md bg-light text-dark'>
                 <?php if (!empty($_POST['form_submit']) || $cliFromVersion !== null) {
-                    $form_old_version = $cliFromVersion ?? $_POST['form_old_version'];
+                    $form_old_version = $cliFromVersion ?? ($_POST['form_old_version'] ?? '');
 
                     foreach ($versions as $version => $filename) {
                         if (strcmp($version, (string) $form_old_version) < 0) {

--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -21,10 +21,24 @@
 // loads it later). The globals bag picks them up once globals.php runs.
 $GLOBALS['ongoing_sql_upgrade'] = true;
 
+$cliFromVersion = null;
 if (php_sapi_name() === 'cli') {
     // setting for when running as command line script
     // need this for output to be readable when running as command line
     $GLOBALS['force_simple_sql_upgrade'] = true;
+
+    // Set HTTP_HOST for CLI mode so globals.php can determine the site
+    // @phpstan-ignore openemr.forbiddenRequestGlobals (Required for write)
+    $_SERVER['HTTP_HOST'] = 'default';
+
+    assert(isset($argv));
+    // Parse --from=VERSION argument for CLI upgrades
+    foreach ($argv as $arg) {
+        if (str_starts_with($arg, '--from=')) {
+            $cliFromVersion = substr($arg, 7);
+            break;
+        }
+    }
 }
 
 // Checks if the server's PHP version is compatible with OpenEMR:
@@ -362,8 +376,8 @@ header('Content-type: text/html; charset=utf-8');
         </div>
         <div id='processDetails' class='card card-body pb-2 h-50 overflow-auto collapse show'>
             <div class='col-md bg-light text-dark'>
-                <?php if (!empty($_POST['form_submit'])) {
-                    $form_old_version = $_POST['form_old_version'];
+                <?php if (!empty($_POST['form_submit']) || $cliFromVersion !== null) {
+                    $form_old_version = $cliFromVersion ?? $_POST['form_old_version'];
 
                     foreach ($versions as $version => $filename) {
                         if (strcmp($version, (string) $form_old_version) < 0) {

--- a/src/Common/Auth/OneTimeAuth.php
+++ b/src/Common/Auth/OneTimeAuth.php
@@ -57,7 +57,6 @@ class OneTimeAuth
 
     /**
      * @param array $p
-     * @param bool  $encrypt_redirect
      * @return array|bool
      * @throws \Exception
      *
@@ -76,9 +75,8 @@ class OneTimeAuth
      *        'max_access_count' => 0, // 0 = unlimited.
      *     ]
      */
-    public function createPortalOneTime(array $p, bool $encrypt_redirect = false): array|bool
+    public function createPortalOneTime(array $p): array|bool
     {
-        $redirect_token = null;
         $passed_in_pid = $p['pid'] ?? 0;
         $valid = PatientPortalService::isValidPortalPatient($passed_in_pid);
         if (empty($valid['valid'] ?? null) || empty($passed_in_pid)) {
@@ -98,14 +96,6 @@ class OneTimeAuth
         }
 
         $redirect_raw = trim((string)($p['redirect_link'] ?? null));
-        if (!empty($redirect_raw) && $encrypt_redirect) {
-            $redirect_plus = js_escape(['pid' => $passed_in_pid, 'to' => $redirect_raw]);
-            $redirect_token = $this->cryptoGen->encryptStandard($redirect_plus);
-            if (empty($redirect_token)) {
-                // since redirect should be in database we can continue.
-                $this->systemLogger->error(xlt("Onetime redirect failed encryption."));
-            }
-        }
         if (!empty($p['target_link'] ?? null)) {
             $site_addr = trim($p['target_link']);
         } elseif ($this->context == 'portal') {
@@ -126,9 +116,8 @@ class OneTimeAuth
         $actions = array_merge($actionDefaults, $p['actions'] ?? []); // from event data.
 
         // Create the encoded link and return the onetime token data set
-        $rtn['encoded_link'] = $this->encodeLink($site_addr, $token_encrypt, $redirect_token);
+        $rtn['encoded_link'] = $this->encodeLink($site_addr, $token_encrypt);
         $rtn['onetime_token'] = $token_encrypt;
-        $rtn['redirect_token'] = $redirect_token;
         $rtn['pin'] = $pin;
         $rtn['email'] = $email;
 
@@ -147,11 +136,10 @@ class OneTimeAuth
 
     /**
      * @param $onetime_token
-     * @param $redirect_token
      * @return array
      * @throws OneTimeAuthExpiredException
      */
-    public function decodePortalOneTime($onetime_token, $redirect_token = null, $logUpdate = true): array
+    public function decodePortalOneTime($onetime_token, $logUpdate = true): array
     {
         $auth = false;
         $rtn = [];
@@ -190,21 +178,7 @@ class OneTimeAuth
             $this->systemLogger->error($rtn['error']);
             throw new OneTimeAuthExpiredException($rtn['error'], $auth['pid']);
         }
-        // We'll rely on the stored redirect address as default.
-        // However, leave the option of using embedded encrypted redirect.
         $redirect = $t_info['redirect_url'] ?? null;
-        if (!empty($redirect_token)) {
-            $redirectTokenStr = is_string($redirect_token) ? $redirect_token : null;
-            if ($this->cryptoGen->cryptCheckStandard($redirectTokenStr)) {
-                $redirect_decrypted = $this->cryptoGen->decryptStandard($redirectTokenStr, minimumVersion: 6);
-                $redirect_array = json_decode($redirect_decrypted, true);
-                $redirect = $redirect_array['to'];
-                if (($redirect_array['pid'] != $auth['pid'] && !empty($redirect_array['pid']))) {
-                    throw new OneTimeAuthException(xlt("Error! credentials pid to and from don't match!"), $auth['pid']);
-                }
-                $this->systemLogger->debug("Redirect token decrypted: pid = " . $redirect_array['pid'] . " redirect = " . $redirect);
-            }
-        }
 
         $rtn['pid'] = $auth['pid'];
         $rtn['pin'] = $t_info['onetime_pin'];
@@ -226,10 +200,9 @@ class OneTimeAuth
     /**
      * @param $site_addr
      * @param $token_encrypt
-     * @param $encrypted_redirect
      * @return string
      */
-    private function encodeLink($site_addr, $token_encrypt, $encrypted_redirect = null): string
+    private function encodeLink($site_addr, $token_encrypt): string
     {
         $site_id = $this->session->get('site_id', 'default');
         if (stripos((string)$site_addr, "portal") !== false) {
@@ -259,18 +232,10 @@ class OneTimeAuth
                 'site' => $site_id
             ], '', '&', $enc_type));
         } else {
-            if (!empty($encrypted_redirect)) {
-                $encoded_link = sprintf($format, attr($site_addr), http_build_query([
-                    'service_auth' => $token_encrypt,
-                    'target' => $encrypted_redirect,
-                    'site' => $site_id
-                ], '', '&', $enc_type));
-            } else {
-                $encoded_link = sprintf($format, attr($site_addr), http_build_query([
-                    'service_auth' => $token_encrypt,
-                    'site' => $site_id
-                ], '', '&', $enc_type));
-            }
+            $encoded_link = sprintf($format, attr($site_addr), http_build_query([
+                'service_auth' => $token_encrypt,
+                'site' => $site_id
+            ], '', '&', $enc_type));
         }
         $this->systemLogger->debug("Onetime link " . text($encoded_link) . " encoded");
 
@@ -328,13 +293,12 @@ class OneTimeAuth
 
     /**
      * @param $token
-     * @param $redirect_token
      * @return array
      */
-    public function processOnetime($token, $redirect_token): array
+    public function processOnetime($token): array
     {
         try {
-            $auth = $this->decodePortalOneTime($token, $redirect_token);
+            $auth = $this->decodePortalOneTime($token);
             if ($auth["actions"]["enforce_auth_pin"]) {
                 $this->systemLogger->debug("Pin auth required");
                 if ($auth['pin'] != $_POST['login_pin'] ?? null) {

--- a/src/Common/System/MissingSiteException.php
+++ b/src/Common/System/MissingSiteException.php
@@ -12,10 +12,12 @@
 
 namespace OpenEMR\Common\System;
 
-class MissingSiteException extends \RuntimeException
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class MissingSiteException extends BadRequestHttpException
 {
     public function __construct(string $message = "Site directory is not configured. OE_SITE_DIR must be set.", int $code = 0, ?\Throwable $previous = null)
     {
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, code: $code, previous: $previous);
     }
 }

--- a/src/Common/System/MissingSiteIdException.php
+++ b/src/Common/System/MissingSiteIdException.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MissingSiteIdException is thrown when the session does not contain a site ID.
+ *
+ * This extends MissingSiteException, which covers the broader case where the
+ * site directory is not configured. Catch MissingSiteException to handle both
+ * scenarios; catch MissingSiteIdException for the session-specific case only.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\System;
+
+class MissingSiteIdException extends MissingSiteException
+{
+    public function __construct(
+        string $message = 'Site ID is missing from session data.',
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/templates/portal/login/autologin.html.twig
+++ b/templates/portal/login/autologin.html.twig
@@ -37,7 +37,6 @@
         <form method="POST" id="autologinform" action="{{ action|attr }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token|attr }}" />
             <input type="hidden" name="service_auth" value="{{ service_auth|attr }}" />
-            <input type="hidden" name="target" value="{{ target|attr_url }}" />
             {% if pin_required %}
             <label for="login_pin">{{ "PIN Required value"|xlt }}</label>
             <input type="text" class="text-center m-1" maxlength="6" id="login_pin" name="login_pin" value="" />
@@ -47,10 +46,9 @@
             {% endif %}
         </form>
         {% if pin_required %}
-        <p>{{ "You are Required to confirm access by entering the companion PIN."|xlt }} {{ target|text }}</p>
+        <p>{{ "You are Required to confirm access by entering the companion PIN."|xlt }}</p>
         {% else %}
         <p>{{ "If you have not been redirected in a few seconds click the button above"|xlt }}</p>
-        <p>{{ "You will be sent to the following web page"|xlt }} {{ target|text }}</p>
         {% endif %}
     </div>
     <script>

--- a/tests/Tests/Isolated/Common/System/MissingSiteIdExceptionTest.php
+++ b/tests/Tests/Isolated/Common/System/MissingSiteIdExceptionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Isolated MissingSiteIdException Test
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\System;
+
+use OpenEMR\Common\System\MissingSiteException;
+use OpenEMR\Common\System\MissingSiteIdException;
+use PHPUnit\Framework\TestCase;
+
+class MissingSiteIdExceptionTest extends TestCase
+{
+    public function testDefaultMessage(): void
+    {
+        $exception = new MissingSiteIdException();
+        $this->assertSame('Site ID is missing from session data.', $exception->getMessage());
+    }
+
+    public function testCustomMessageAndPrevious(): void
+    {
+        $previous = new \RuntimeException('underlying');
+        $exception = new MissingSiteIdException('custom', 0, $previous);
+        $this->assertSame('custom', $exception->getMessage());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testCallersCanCatchAsMissingSiteException(): void
+    {
+        try {
+            throw new MissingSiteIdException();
+        } catch (MissingSiteException $caught) {
+            $this->assertSame('Site ID is missing from session data.', $caught->getMessage());
+        }
+    }
+
+    public function testProducesBadRequestHttpStatus(): void
+    {
+        $exception = new MissingSiteIdException();
+        $this->assertSame(400, $exception->getStatusCode());
+    }
+}

--- a/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
+++ b/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
@@ -132,7 +132,6 @@ class TwigTemplateRenderTest extends TestCase
                 'action'                 => '/portal/autologin',
                 'csrf_token'             => 'test-csrf-token',
                 'service_auth'           => 'test-auth-value',
-                'target'                 => 'https://example.com/telehealth',
             ],
             $fixtureDir . '/autologin-pin-required.html',
         ];
@@ -146,7 +145,6 @@ class TwigTemplateRenderTest extends TestCase
                 'action'                 => '/portal/autologin',
                 'csrf_token'             => 'test-csrf-token',
                 'service_auth'           => 'test-auth-value',
-                'target'                 => 'https://example.com/telehealth',
             ],
             $fixtureDir . '/autologin-no-pin.html',
         ];

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/autologin-no-pin.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/autologin-no-pin.html
@@ -23,11 +23,9 @@
                 <form method="POST" id="autologinform" action="/portal/autologin">
             <input type="hidden" name="csrf_token" value="test-csrf-token" />
             <input type="hidden" name="service_auth" value="test-auth-value" />
-            <input type="hidden" name="target" value="https%3A%2F%2Fexample.com%2Ftelehealth" />
                         <input class="btn btn-lg btn-primary" type="submit" name="autoLoginSubmit" value="Go To Destination" />
                     </form>
                 <p>If you have not been redirected in a few seconds click the button above</p>
-        <p>You will be sent to the following web page https://example.com/telehealth</p>
             </div>
     <script>
         const pinRequired = false;

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/autologin-pin-required.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/autologin-pin-required.html
@@ -23,12 +23,11 @@
                 <form method="POST" id="autologinform" action="/portal/autologin">
             <input type="hidden" name="csrf_token" value="test-csrf-token" />
             <input type="hidden" name="service_auth" value="test-auth-value" />
-            <input type="hidden" name="target" value="https%3A%2F%2Fexample.com%2Ftelehealth" />
                         <label for="login_pin">PIN Required value</label>
             <input type="text" class="text-center m-1" maxlength="6" id="login_pin" name="login_pin" value="" />
             <input class="btn btn-sm btn-primary" type="submit" name="autoLoginSubmit" value="Authorize and Go To Destination" />
                     </form>
-                <p>You are Required to confirm access by entering the companion PIN. https://example.com/telehealth</p>
+                <p>You are Required to confirm access by entering the companion PIN.</p>
             </div>
     <script>
         const pinRequired = 1;

--- a/tests/Tests/RestControllers/ControllerRoutingTest.php
+++ b/tests/Tests/RestControllers/ControllerRoutingTest.php
@@ -185,4 +185,51 @@ class ControllerRoutingTest extends TestCase
         $this->assertArrayHasKey('sub_action', $dispatchParams);
         $this->assertSame('list', $dispatchParams['sub_action']);
     }
+
+    /**
+     * Controller extends Smarty, and Smarty's __call catches any undefined
+     * method call. This makes is_callable() return true for every method
+     * name on a Controller instance, even methods that don't actually exist.
+     *
+     * The methodExists() guard must combine is_callable() with method_exists()
+     * to distinguish genuinely-defined methods from phantom calls that would
+     * otherwise be dispatched into Smarty's extension handler (which throws
+     * "undefined extension class Smarty_Internal_Method_*" errors).
+     */
+    #[Test]
+    public function testMethodExistsGuardsAgainstSmartyPhantomMethods(): void
+    {
+        $smartyDescendant = new class extends \Controller {
+        };
+
+        $dispatcher = new \Controller();
+
+        $methodExists = new \ReflectionMethod(\Controller::class, 'methodExists');
+
+        // Document the trap: is_callable() alone returns true for any method
+        // name on a Smarty descendant because Smarty's __call catches all calls.
+        // PHPStan can't model __call, so it concludes statically that
+        // is_callable() must be false — which is exactly the runtime trap
+        // this test documents and methodExists() guards against.
+        /** @phpstan-ignore-next-line function.impossibleType */
+        $isCallable = is_callable([$smartyDescendant, 'nonexistent_phantom_method']);
+        /** @phpstan-ignore-next-line method.impossibleType */
+        $this->assertTrue(
+            $isCallable,
+            'Expected is_callable() to return true due to Smarty __call ' .
+            '(this assertion documents the trap that methodExists() guards against).'
+        );
+
+        // The guard must return false for phantom methods that only __call catches.
+        $this->assertFalse(
+            $methodExists->invoke($dispatcher, $smartyDescendant, 'nonexistent_phantom_method'),
+            'methodExists() must return false for phantom methods caught only by __call.'
+        );
+
+        // Positive case: a genuinely-defined method should return true.
+        $this->assertTrue(
+            $methodExists->invoke($dispatcher, $smartyDescendant, 'process_action'),
+            'methodExists() must return true for genuinely-defined methods.'
+        );
+    }
 }

--- a/version.php
+++ b/version.php
@@ -39,7 +39,7 @@ $v_database = 538;
 // controls is (subsequently the acl_upgrade.php script then is used to
 // upgrade and track this value)
 //
-$v_acl = 12;
+$v_acl = 13;
 
 // Version for JavaScript and stylesheet includes. Increment whenever a .js or .css file changes.
 // Also whenever you change a .js or .css file, make sure that all URLs referencing it


### PR DESCRIPTION
Bundles all milestone 8.1.0 fixes that have not yet been backported into `rel-810`. One commit per source PR, cherry-picked with `-x` (provenance preserved), in master-merge chronological order.

## Backports (13 commits)

- #8087 — fix: clinicians can edit medications
- #11807 — fix(smarty): save admin practice settings
- #11866 — fix(db): Fix SQL upgrade syntax
- #11867 — chore(db): Fix typo
- #11618 — fix(bootstrap): replace die() with exception for missing session site_id
- #11864 — fix(db): Log all "helpfuldie" sql errors
- #11906 — fix(sql): Allow sql_upgrade to work on the cli
- #11937 — fix(clinical-notes): correct i18formatting asset name typo
- #11939 — fix: guard undefined keys and legacy PHP warnings flagged in production logs
- #11940 — fix(session): clean up callers that re-open read_and_close session
- #11958 — fix(portal): add CSRF protection to payment handler
- #11972 — fix(auth): remove unused redirect_token from OneTimeAuth
- #11999 — fix(ui): Fix crash from uncaught class in birthday popup

## Deferred from this batch

- **#11912** (MFA audit logging) — backporting this commit triggers Apache child segfaults under the Sentinel mTLS e2e variant, which corrupt Twig's compiled-template cache and break the login page. Tracked in #12012; will backport separately once root-caused.

## PHPStan baselines

`composer phpstan-baseline` was regenerated after every cherry-pick, so each commit's baseline matches its code state. Most regenerations produced no delta; #11940 picked up a small reduction in baselined errors and was amended.

## Conflict notes

- **#11999** modified `.phpstan/fatal-baseline-caps.php`, which does not exist on `rel-810`. Resolved by keeping `rel-810`'s deletion (the conflict was in a phpstan tracking file, not in runtime code).
- All other cherry-picks auto-merged cleanly (only baseline files and `version.php` ACL bump touched).

## Excluded from this batch

- 16 closed PRs in milestone are already in `rel-810` (merged before the rel-810 fork at #11772) — no action needed.
- 5 backport PRs in the milestone are already merged.
- 47 open milestone items (PRs in flight + issues without PRs) — not yet actionable.
- #11152 was closed without merging; not eligible for backport.
