### PR TITLE
[probe] investigate #12012 segfault — rel-810 + commits 1–11 of 8.1.0 backport

### DIFF
--- a/.phpstan/baseline/class.notFound.php
+++ b/.phpstan/baseline/class.notFound.php
@@ -167,6 +167,16 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Call to method dispatch\\(\\) on an unknown class EventDispatcher\\.$#',
+    'count' => 17,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^PHPDoc tag @var contains unknown class EventDispatcher\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Parameter \\$encounterId of method ESign\\\\Encounter_Log\\:\\:__construct\\(\\) has invalid type ESign\\\\unknown\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/ESign/Encounter/Log.php',

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -1243,7 +1243,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 4,
+    'count' => 6,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -3117,6 +3117,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_file/summary/dashboard_header.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Cannot call method addCard\\(\\) on mixed\\.$#',
+    'count' => 3,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Cannot call method canAdd\\(\\) on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
@@ -3137,13 +3142,28 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Cannot call method getAppendedInjection\\(\\) on mixed\\.$#',
+    'count' => 14,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Cannot call method getBackgroundColorClass\\(\\) on mixed\\.$#',
+    'count' => 2,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method getCards\\(\\) on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method getIdentifier\\(\\) on mixed\\.$#',
     'count' => 2,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method getPrependedInjection\\(\\) on mixed\\.$#',
+    'count' => 14,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/varTag.nativeType.php
+++ b/.phpstan/baseline/varTag.nativeType.php
@@ -7,6 +7,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/procedure_order/templates/procedure_specimen_row.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^PHPDoc tag @var with type EventDispatcher is not subtype of native type Symfony\\\\Component\\\\EventDispatcher\\\\EventDispatcherInterface\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
+];
+$ignoreErrors[] = [
     'message' => '#^PHPDoc tag @var with type OpenEMR\\\\Services\\\\Qdm\\\\PopulationSet is not subtype of native type array\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/Qdm/ResultsCalculator.php',

--- a/acl_upgrade.php
+++ b/acl_upgrade.php
@@ -777,9 +777,43 @@ if ($acl_version < $upgrade_acl) {
     $acl_version = $upgrade_acl;
 }
 
-/* This is a template for a new revision, when needed
 // Upgrade for acl_version 13
 $upgrade_acl = 13;
+if ($acl_version < $upgrade_acl) {
+    echo "<B>UPGRADING ACCESS CONTROLS TO VERSION " . $upgrade_acl . ":</B></BR>";
+
+    //Collect the ACL ID numbers.
+    echo "<B>Checking to ensure all the proper ACL(access control list) are present:</B></BR>";
+    $clin_write = AclExtended::getAclIdNumber('Clinicians', 'write');
+    $clin_addonly = AclExtended::getAclIdNumber('Clinicians', 'addonly');
+
+    //Add new object Sections
+    echo "<BR/><B>Adding new object sections</B><BR/>";
+
+    //Add new Objects
+    echo "<BR/><B>Adding new objects</B><BR/>";
+
+    //Update already existing Objects
+    echo "<BR/><B>Upgrading objects</B><BR/>";
+
+    //Add new ACLs here (will return the ACL ID of newly created or already existing ACL)
+    // (will also place in the appropriate group and CREATE a new group if needed)
+    echo "<BR/><B>Adding ACLs(Access Control Lists) and groups</B><BR/>";
+
+    //Update the ACLs
+    echo "<BR/><B>Updating the ACLs(Access Control Lists)</B><BR/>";
+    AclExtended::shiftAcl($clin_addonly, 'Clinicians', 'patients', 'Patients', 'med', 'Medical/History (write,addonly optional)', 'addonly');
+    AclExtended::updateAcl($clin_write, 'Clinicians', 'patients', 'Patients', 'med', 'Medical/History (write,addonly optional)', 'write');
+
+    //DONE with upgrading to this version
+    $acl_version = $upgrade_acl;
+}
+
+
+
+/* This is a template for a new revision, when needed
+// Upgrade for acl_version 14
+$upgrade_acl = 14;
 if ($acl_version < $upgrade_acl) {
     echo "<B>UPGRADING ACCESS CONTROLS TO VERSION " . $upgrade_acl . ":</B></BR>";
 

--- a/interface/forms/clinical_notes/templates/new.html.twig
+++ b/interface/forms/clinical_notes/templates/new.html.twig
@@ -18,7 +18,7 @@ The Edit/Create template of the clinical note form.
 #}
 {% extends "core/base.html.twig" %}
 {% block head %}
-    {{ setupHeader(['i18next', 'il8formatting', 'datetime-picker','datetime-picker-translated']) }}
+    {{ setupHeader(['i18next', 'i18formatting', 'datetime-picker','datetime-picker-translated']) }}
     <script src="{{ webroot }}/interface/forms/clinical_notes/clinical-notes.js?v={{ assetVersion|url_encode }}"></script>
     <script>
         if (window.oeFormsClinicalNotes) {

--- a/interface/forms/newpatient/C_EncounterVisitForm.class.php
+++ b/interface/forms/newpatient/C_EncounterVisitForm.class.php
@@ -676,7 +676,7 @@ class C_EncounterVisitForm
         $posOptions = $this->getPosOptionsForTemplate($facilityPosCode);
 // END AI GENERATED CODE
 
-        if (Utilities::isDateEmpty($encounter['onset_date'])) {
+        if (Utilities::isDateEmpty($encounter['onset_date'] ?? null)) {
             $encounter['onset_date'] = null;
         }
 

--- a/interface/forms/newpatient/save.php
+++ b/interface/forms/newpatient/save.php
@@ -12,6 +12,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Set $sessionAllowWrite to true since the encounter is written to the session via setencounter() below.
+$sessionAllowWrite = true;
 require_once(__DIR__ . "/../../globals.php");
 require_once("$srcdir/forms.inc.php");
 require_once("$srcdir/encounter.inc.php");

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -269,8 +269,7 @@ if (empty($siteId) || !empty($_GET['site'])) {
                 $globalsBag->set('srcdir', $srcdir);
                 require_once("$srcdir/auth.inc.php");
             }
-            http_response_code(400);
-            die("Site ID is missing from session data!");
+            throw new \OpenEMR\Common\System\MissingSiteIdException();
         }
 
         $tmp = $_SERVER['HTTP_HOST'];

--- a/interface/main/calendar/index.php
+++ b/interface/main/calendar/index.php
@@ -16,6 +16,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Set $sessionAllowWrite to true since pc_facility, pc_username, and viewtype are written to the session below.
+$sessionAllowWrite = true;
 require_once("../../globals.php");
 require_once("$srcdir/calendar.inc.php");
 require_once("$srcdir/patient.inc.php");

--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -1288,7 +1288,8 @@ function &postcalendar_userapi_pcGetEvents($args)
     $event->setProviderID($providerID ?? $provider_id ?? null);
 
     $result = OEGlobalsBag::getInstance()->getKernel()->getEventDispatcher()->dispatch($event, CalendarUserGetEventsFilter::EVENT_NAME);
-    return $result->getEventsByDays();
+    $eventsByDays = $result->getEventsByDays();
+    return $eventsByDays;
 }
 
 //===========================

--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -21,10 +21,12 @@ $sessionAllowWrite = true;
 require_once('../globals.php');
 
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Auth\AuthEvent;
 use OpenEMR\Common\Auth\AuthUtils;
 use OpenEMR\Common\Crypto\KeyVersion;
 use OpenEMR\Common\Crypto\PasswordBasedCrypto;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionTracker;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Utils\RandomGenUtils;
@@ -234,6 +236,14 @@ if (isset($_POST['new_login_session_management'])) {
                         [$session->get('authUserID')]
                     );
                 } else {
+                    $mfaUsername = $session->get('authUser');
+                    $mfaAuthGroup = $session->get('authProvider');
+                    EventAuditLogger::getInstance()->logAuthFailure(
+                        AuthEvent::mfa(),
+                        is_string($mfaUsername) ? $mfaUsername : null,
+                        is_string($mfaAuthGroup) ? $mfaAuthGroup : '',
+                        'TOTP code incorrect'
+                    );
                     $errormsg = xl("The code you entered was not valid");
                     $errortype = "TOTP";
                 }
@@ -266,6 +276,14 @@ if (isset($_POST['new_login_session_management'])) {
                 } catch (\u2flib_server\Error $e) {
                     // Authentication failed so we will build the U2F form again.
                     $form_response = '';
+                    $mfaUsername = $session->get('authUser');
+                    $mfaAuthGroup = $session->get('authProvider');
+                    EventAuditLogger::getInstance()->logAuthFailure(
+                        AuthEvent::mfa(),
+                        is_string($mfaUsername) ? $mfaUsername : null,
+                        is_string($mfaAuthGroup) ? $mfaAuthGroup : '',
+                        'U2F authentication error: ' . $e->getMessage()
+                    );
                     $errormsg = xl('U2F Key Authentication error') . ": " . $e->getMessage();
                     $errortype = "U2F";
                 }

--- a/interface/new/new_comprehensive_save.php
+++ b/interface/new/new_comprehensive_save.php
@@ -12,6 +12,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Set $sessionAllowWrite to true since the new patient pid is written to the session via setpid() below.
+$sessionAllowWrite = true;
 require_once("../globals.php");
 
 use OpenEMR\BC\ServiceContainer;

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -27,6 +27,9 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Set $sessionAllowWrite to true since this script writes disablePreviousNameAdds to the session
+// on every load, alert_notify_pid whenever CDR is enabled, and pid + encounter when ?set_pid is provided.
+$sessionAllowWrite = true;
 require_once("../../globals.php");
 
 require_once("$srcdir/lists.inc.php");

--- a/library/ajax/dated_reminders_counter.php
+++ b/library/ajax/dated_reminders_counter.php
@@ -31,8 +31,6 @@ if (SessionTracker::isSessionExpired()) {
     echo json_encode(['timeoutMessage' => 'timeout']);
     exit;
 }
-// keep this below above time out check.
-OpenEMR\Common\Session\SessionUtil::setSession('keepAliveTime', time());
 
 $total_counts = [];
 $other_count = [];

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -68,6 +68,9 @@ class Controller extends Smarty implements ControllerInterface
          $this->setCompileDir(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . '/documents/smarty/main');
          $this->setCompileCheck(true);
          $this->setPluginsDir([__DIR__ . "/../smarty/plugins", OEGlobalsBag::getInstance()->getKernel()->getVendorDir() . "/smarty/smarty/libs/plugins"]);
+         // Register {$x|text} explicitly so Smarty does not fall back to the
+         // deprecated unregistered-function path when escaping for text nodes.
+         $this->registerPlugin('modifier', 'text', self::escapeForTextNode(...));
          $this->assign("PROCESS", "true");
          $this->assign("HEADER", "<html><head></head><body>");
          $this->assign("FOOTER", "</body></html>");
@@ -272,6 +275,14 @@ class Controller extends Smarty implements ControllerInterface
     {
         return method_exists($controllerObj, $method)
             && is_callable([$controllerObj, $method]);
+    }
+
+    private static function escapeForTextNode(mixed $value): string
+    {
+        if (is_string($value) || is_int($value) || is_float($value) || is_bool($value) || $value instanceof \Stringable) {
+            return \text((string) $value);
+        }
+        return '';
     }
 
     public function _link($action = "default", $inlining = false)

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -1,5 +1,19 @@
 <?php
 
+/**
+ * Controller Class.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    OpenEMR contributors
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @author    Stephen Waite <stephen.waite@open-emr.org>
+ * @copyright Copyright (c) OpenEMR contributors
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@open-emr.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\ControllerInterface;
@@ -232,20 +246,32 @@ class Controller extends Smarty implements ControllerInterface
 
         $isProcessing = ($_POST['process'] ?? '') === 'true';
 
-        if ($isProcessing && is_callable([$controllerObj, $processMethod])) {
+        if ($isProcessing && $this->methodExists($controllerObj, $processMethod)) {
             $output .= $callMethod($processMethod);
             if ($controllerObj->_state === false) {
                 return $output;
             }
         }
 
-        if ($isProcessing || is_callable([$controllerObj, $actionMethod])) {
+        if ($this->methodExists($controllerObj, $actionMethod)) {
             $output .= $callMethod($actionMethod);
         } else {
             throw new NotFoundHttpException("Action '$action' does not exist on controller: $className");
         }
 
         return $output;
+    }
+
+    /**
+     * Check whether a method genuinely exists on a controller object.
+     *
+     * Smarty 4's __call makes is_callable() always return true on
+     * Smarty-derived objects, so we must also check method_exists().
+     */
+    private function methodExists(object $controllerObj, string $method): bool
+    {
+        return method_exists($controllerObj, $method)
+            && is_callable([$controllerObj, $method]);
     }
 
     public function _link($action = "default", $inlining = false)

--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -1230,7 +1230,7 @@ $config = 1; /////////////
         $gacl->add_acl(
             [
                 'encounters' => ['notes', 'relaxed'],
-                'patients' => ['demo', 'med', 'docs', 'notes','trans', 'reminder', 'alert', 'disclosure', 'rx', 'amendment', 'lab'],
+                'patients' => ['demo', 'docs', 'notes','trans', 'reminder', 'alert', 'disclosure', 'rx', 'amendment', 'lab'],
                 'sensitivities' => ['normal']
             ],
             null,
@@ -1243,6 +1243,20 @@ $config = 1; /////////////
             'Things that clinicians can read and enter but not modify'
         );
         // xl('Things that clinicians can read and enter but not modify')
+        $gacl->add_acl(
+            [
+                'patients' => ['med']
+            ],
+            null,
+            [$clin],
+            null,
+            null,
+            1,
+            1,
+            'write',
+            'Things that clinicians can read and modify'
+        );
+        // xl('Things that clinicians can read and modify')
         $gacl->add_acl(
             [
                 'placeholder' => ['filler']

--- a/library/sql.inc.php
+++ b/library/sql.inc.php
@@ -98,6 +98,7 @@ function sqlStatement($statement, $binds = false)
     try {
         return QueryUtils::sqlStatementThrowException($statement, $binds, noLog: false);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }
@@ -159,6 +160,7 @@ function sqlStatementNoLog($statement, $binds = false, $throw_exception_on_error
         if ($throw_exception_on_error) {
             throw $e;
         }
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }
@@ -241,6 +243,7 @@ function sqlInsert($statement, $binds = false)
     try {
         return QueryUtils::sqlInsert($statement, $binds);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("insert failed: $statement", $e->sqlError);
     }
 }
@@ -261,6 +264,7 @@ function sqlQuery($statement, $binds = false)
     try {
         return QueryUtils::querySingleRow($statement, $binds ?: []);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }
@@ -291,6 +295,7 @@ function sqlQueryNoLog($statement, $binds = false, $throw_exception_on_error = f
         if ($throw_exception_on_error) {
             throw $e;
         }
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }
@@ -332,6 +337,7 @@ function sqlInsertClean_audit($statement, $binds = false): void
     try {
         QueryUtils::sqlStatementThrowException($statement, $binds, noLog: true);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("insert failed: $statement", $e->sqlError);
     }
 }
@@ -434,6 +440,7 @@ function sqlQ($statement, $binds = false)
     try {
         return QueryUtils::sqlStatementThrowException($statement, $binds);
     } catch (SqlQueryException $e) {
+        ServiceContainer::getLogger()->error('{func} error', ['func' => __FUNCTION__, 'exception' => $e]);
         HelpfulDie("query failed: $statement", $e->sqlError);
     }
 }

--- a/sql/7_0_3-to-7_0_4_upgrade.sql
+++ b/sql/7_0_3-to-7_0_4_upgrade.sql
@@ -1314,7 +1314,7 @@ ALTER TABLE `procedure_order`
 ALTER TABLE `procedure_order` ADD INDEX `idx_scheduled_date` (`scheduled_date`);
 #EndIf
 #IfNotIndex procedure_order idx_order_intent
-ALTER TABLE `procedure_order` ADD INDEX `idx_order_intent` (`order_intent`),
+ALTER TABLE `procedure_order` ADD INDEX `idx_order_intent` (`order_intent`);
 #EndIf
 #IfNotIndex procedure_order idx_location_id
 ALTER TABLE `procedure_order` ADD INDEX `idx_location_id` (`location_id`);

--- a/sql/7_0_3-to-7_0_4_upgrade.sql
+++ b/sql/7_0_3-to-7_0_4_upgrade.sql
@@ -1309,10 +1309,15 @@ ALTER TABLE `procedure_order`
         COMMENT 'FHIR intent: order, plan, directive, proposal',
     ADD COLUMN `location_id` INT DEFAULT NULL
         COMMENT 'References facility.id for service location (FHIR locationReference)';
-ALTER TABLE `procedure_order`
-    ADD INDEX IF NOT EXISTS `idx_scheduled_date` (`scheduled_date`),
-    ADD INDEX IF NOT EXISTS `idx_order_intent` (`order_intent`),
-    ADD INDEX IF NOT EXISTS `idx_location_id` (`location_id`);
+#EndIf
+#IfNotIndex procedure_order idx_scheduled_date
+ALTER TABLE `procedure_order` ADD INDEX `idx_scheduled_date` (`scheduled_date`);
+#EndIf
+#IfNotIndex procedure_order idx_order_intent
+ALTER TABLE `procedure_order` ADD INDEX `idx_order_intent` (`order_intent`),
+#EndIf
+#IfNotIndex procedure_order idx_location_id
+ALTER TABLE `procedure_order` ADD INDEX `idx_location_id` (`location_id`);
 #EndIf
 
 #IfNotRow2D list_options list_id ord_priority option_id routine

--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -377,7 +377,7 @@ header('Content-type: text/html; charset=utf-8');
         <div id='processDetails' class='card card-body pb-2 h-50 overflow-auto collapse show'>
             <div class='col-md bg-light text-dark'>
                 <?php if (!empty($_POST['form_submit']) || $cliFromVersion !== null) {
-                    $form_old_version = $cliFromVersion ?? $_POST['form_old_version'];
+                    $form_old_version = $cliFromVersion ?? ($_POST['form_old_version'] ?? '');
 
                     foreach ($versions as $version => $filename) {
                         if (strcmp($version, (string) $form_old_version) < 0) {

--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -21,10 +21,24 @@
 // loads it later). The globals bag picks them up once globals.php runs.
 $GLOBALS['ongoing_sql_upgrade'] = true;
 
+$cliFromVersion = null;
 if (php_sapi_name() === 'cli') {
     // setting for when running as command line script
     // need this for output to be readable when running as command line
     $GLOBALS['force_simple_sql_upgrade'] = true;
+
+    // Set HTTP_HOST for CLI mode so globals.php can determine the site
+    // @phpstan-ignore openemr.forbiddenRequestGlobals (Required for write)
+    $_SERVER['HTTP_HOST'] = 'default';
+
+    assert(isset($argv));
+    // Parse --from=VERSION argument for CLI upgrades
+    foreach ($argv as $arg) {
+        if (str_starts_with($arg, '--from=')) {
+            $cliFromVersion = substr($arg, 7);
+            break;
+        }
+    }
 }
 
 // Checks if the server's PHP version is compatible with OpenEMR:
@@ -362,8 +376,8 @@ header('Content-type: text/html; charset=utf-8');
         </div>
         <div id='processDetails' class='card card-body pb-2 h-50 overflow-auto collapse show'>
             <div class='col-md bg-light text-dark'>
-                <?php if (!empty($_POST['form_submit'])) {
-                    $form_old_version = $_POST['form_old_version'];
+                <?php if (!empty($_POST['form_submit']) || $cliFromVersion !== null) {
+                    $form_old_version = $cliFromVersion ?? $_POST['form_old_version'];
 
                     foreach ($versions as $version => $filename) {
                         if (strcmp($version, (string) $form_old_version) < 0) {

--- a/src/Common/Auth/AuthEvent.php
+++ b/src/Common/Auth/AuthEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Value object representing an authentication audit event type.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Aanand Sreekumaran Nair Jayakumari
+ * @copyright Copyright (c) 2026 Aanand Sreekumaran Nair Jayakumari
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Auth;
+
+final readonly class AuthEvent
+{
+    public function __construct(public string $value)
+    {
+        if ($value === '') {
+            throw new \DomainException('AuthEvent value cannot be empty');
+        }
+    }
+
+    public static function login(): self
+    {
+        return new self('login');
+    }
+
+    public static function mfa(): self
+    {
+        return new self('mfa');
+    }
+
+    public static function password(): self
+    {
+        return new self('password');
+    }
+
+    public static function logout(): self
+    {
+        return new self('logout');
+    }
+
+    public static function auth(): self
+    {
+        return new self('auth');
+    }
+}

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -19,6 +19,7 @@ use OpenEMR\BC\{
     DatabaseConnectionOptions,
     ServiceContainer,
 };
+use OpenEMR\Common\Auth\AuthEvent;
 use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
@@ -225,6 +226,30 @@ class EventAuditLogger
         } else {
             $this->recordLogItem($success, $event, $user, $groupname, $comments, $patient_id, $category);
         }
+    }
+
+    /**
+     * Log a failed authentication event.
+     *
+     * Collects the client IP internally so callers do not need to repeat the
+     * collectIpAddresses() + comment-formatting boilerplate.
+     *
+     * @param AuthEvent                      $event      The auth event type (e.g. AuthEvent::mfa())
+     * @param string|null                    $username   Username, or null when not yet resolved
+     * @param string                         $authGroup  Auth group name, or '' when not resolved
+     * @param non-empty-string               $reason     Human-readable failure reason
+     * @param int|null                       $patientId  Patient ID for portal auth paths; null otherwise
+     */
+    public function logAuthFailure(
+        AuthEvent $event,
+        ?string $username,
+        string $authGroup,
+        string $reason,
+        ?int $patientId = null,
+    ): void {
+        $ip = collectIpAddresses();
+        $comments = "failure: " . $ip['ip_string'] . ". " . $reason;
+        $this->newEvent($event->value, $username ?? '', $authGroup, 0, $comments, $patientId);
     }
 
     /******************

--- a/src/Common/System/MissingSiteException.php
+++ b/src/Common/System/MissingSiteException.php
@@ -12,10 +12,12 @@
 
 namespace OpenEMR\Common\System;
 
-class MissingSiteException extends \RuntimeException
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class MissingSiteException extends BadRequestHttpException
 {
     public function __construct(string $message = "Site directory is not configured. OE_SITE_DIR must be set.", int $code = 0, ?\Throwable $previous = null)
     {
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, code: $code, previous: $previous);
     }
 }

--- a/src/Common/System/MissingSiteIdException.php
+++ b/src/Common/System/MissingSiteIdException.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MissingSiteIdException is thrown when the session does not contain a site ID.
+ *
+ * This extends MissingSiteException, which covers the broader case where the
+ * site directory is not configured. Catch MissingSiteException to handle both
+ * scenarios; catch MissingSiteIdException for the session-specific case only.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\System;
+
+class MissingSiteIdException extends MissingSiteException
+{
+    public function __construct(
+        string $message = 'Site ID is missing from session data.',
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -28,6 +28,7 @@ use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 use Nyholm\Psr7\Stream;
 use Nyholm\Psr7Server\ServerRequestCreator;
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Auth\AuthEvent;
 use OpenEMR\Common\Auth\AuthUtils;
 use OpenEMR\Common\Auth\MfaUtils;
 use OpenEMR\Common\Auth\OAuth2KeyConfig;
@@ -55,6 +56,7 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Common\Http\HttpSessionFactory;
 use OpenEMR\Common\Http\Psr17Factory;
+use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Logging\SystemLoggerAwareTrait;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -885,6 +887,20 @@ class AuthorizationController
             //Check the validity of the authentication token
             if ($request->request->get('user_role') === 'api'  && $mfa->isMfaRequired() && !is_null($mfaToken)) {
                 if (!$mfaToken || !$mfa->check($mfaToken, $request->request->get('mfa_type'))) {
+                    // Log failed MFA authentication attempt
+                    $rawMfaType = $request->request->getString('mfa_type');
+                    $mfaType = in_array($rawMfaType, [MfaUtils::TOTP, MfaUtils::U2F], true) ? $rawMfaType : 'unknown';
+                    $userService = new UserService();
+                    $userRow = $this->userId !== null ? $userService->getUser($this->userId) : false;
+                    $mfaUsername = ($userRow !== false && isset($userRow['username'])) ? $userRow['username'] : null;
+                    $mfaAuthGroup = '';
+                    if ($mfaUsername !== null) {
+                        $resolvedGroup = $userService->getAuthGroupForUser($mfaUsername);
+                        if (is_string($resolvedGroup)) {
+                            $mfaAuthGroup = $resolvedGroup;
+                        }
+                    }
+                    EventAuditLogger::getInstance()->logAuthFailure(AuthEvent::mfa(), $mfaUsername, $mfaAuthGroup, "OAuth2 MFA ($mfaType) code incorrect");
                     $invalid = xl("Sorry, Invalid code!");
                     $loginTwigVars['mfaRequired'] = true;
                     $loginTwigVars['invalid'] = $invalid;

--- a/tests/Tests/Isolated/Common/Auth/AuthEventTest.php
+++ b/tests/Tests/Isolated/Common/Auth/AuthEventTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Isolated tests for AuthEvent value object.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Aanand Sreekumaran Nair Jayakumari
+ * @copyright Copyright (c) 2026 Aanand Sreekumaran Nair Jayakumari
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Auth;
+
+use OpenEMR\Common\Auth\AuthEvent;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class AuthEventTest extends TestCase
+{
+    public function testConstructorStoresValue(): void
+    {
+        $event = new AuthEvent('login');
+        $this->assertSame('login', $event->value);
+    }
+
+    public function testConstructorThrowsOnEmptyString(): void
+    {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('AuthEvent value cannot be empty');
+        new AuthEvent('');
+    }
+
+    public function testLoginFactory(): void
+    {
+        $event = AuthEvent::login();
+        $this->assertSame('login', $event->value);
+    }
+
+    public function testMfaFactory(): void
+    {
+        $event = AuthEvent::mfa();
+        $this->assertSame('mfa', $event->value);
+    }
+
+    public function testPasswordFactory(): void
+    {
+        $event = AuthEvent::password();
+        $this->assertSame('password', $event->value);
+    }
+
+    public function testLogoutFactory(): void
+    {
+        $event = AuthEvent::logout();
+        $this->assertSame('logout', $event->value);
+    }
+
+    public function testAuthFactory(): void
+    {
+        $event = AuthEvent::auth();
+        $this->assertSame('auth', $event->value);
+    }
+
+    public function testEachFactoryReturnsDistinctValue(): void
+    {
+        $values = [
+            AuthEvent::login()->value,
+            AuthEvent::mfa()->value,
+            AuthEvent::password()->value,
+            AuthEvent::logout()->value,
+            AuthEvent::auth()->value,
+        ];
+        $this->assertCount(count($values), array_unique($values), 'Each factory must return a distinct value');
+    }
+
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function nonEmptyValueProvider(): array
+    {
+        return [
+            'arbitrary non-empty string' => ['some-event'],
+            'single character'           => ['x'],
+            'whitespace only'            => [' '],
+        ];
+    }
+
+    #[DataProvider('nonEmptyValueProvider')]
+    public function testConstructorAcceptsAnyNonEmptyString(string $value): void
+    {
+        $event = new AuthEvent($value);
+        $this->assertSame($value, $event->value);
+    }
+}

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerAuthFailureTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerAuthFailureTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * Isolated tests for EventAuditLogger::logAuthFailure().
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Aanand Sreekumaran Nair Jayakumari
+ * @copyright Copyright (c) 2026 Aanand Sreekumaran Nair Jayakumari
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Logging;
+
+use Lcobucci\Clock\FrozenClock;
+use OpenEMR\Common\Auth\AuthEvent;
+use OpenEMR\Common\Crypto\CryptoInterface;
+use OpenEMR\Common\Logging\Audit\Event;
+use OpenEMR\Common\Logging\Audit\SinkInterface;
+use OpenEMR\Common\Logging\AuditConfig;
+use OpenEMR\Common\Logging\BreakglassCheckerInterface;
+use OpenEMR\Common\Logging\EventAuditLogger;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class EventAuditLoggerAuthFailureTest extends TestCase
+{
+    private CryptoInterface&MockObject $crypto;
+    private SessionInterface&MockObject $session;
+    private AuditConfig $config;
+    private BreakglassCheckerInterface&MockObject $breakglassChecker;
+
+    protected function setUp(): void
+    {
+        $this->crypto = $this->createMock(CryptoInterface::class);
+        $this->session = $this->createMock(SessionInterface::class);
+        $this->config = new AuditConfig(
+            enabled: true,
+            forceBreakglass: false,
+            queryEvents: true,
+            httpRequestEvents: true,
+            eventTypeFlags: [],
+        );
+        $this->breakglassChecker = $this->createMock(BreakglassCheckerInterface::class);
+
+        // Set a known REMOTE_ADDR so comment assertions are deterministic.
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_X_FORWARDED_FOR']);
+    }
+
+    private function makeLogger(SinkInterface $sink): EventAuditLogger
+    {
+        return new EventAuditLogger(
+            sinks: [$sink],
+            crypto: $this->crypto,
+            shouldEncrypt: false,
+            session: $this->session,
+            config: $this->config,
+            breakglassChecker: $this->breakglassChecker,
+            clock: new FrozenClock(new \DateTimeImmutable('2026-01-15 10:30:00')),
+        );
+    }
+
+    public function testLogAuthFailurePassesEventValueToSink(): void
+    {
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->once())
+            ->method('record')
+            ->with(self::callback(function (Event $event): bool {
+                self::assertSame('mfa', $event->event);
+                return true;
+            }))
+            ->willReturn(true);
+
+        $this->makeLogger($sink)->logAuthFailure(
+            AuthEvent::mfa(),
+            'testuser',
+            'Administrators',
+            'TOTP code incorrect',
+        );
+    }
+
+    public function testLogAuthFailureAlwaysRecordsSuccess0(): void
+    {
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->once())
+            ->method('record')
+            ->with(self::callback(function (Event $event): bool {
+                self::assertSame(0, $event->success);
+                return true;
+            }))
+            ->willReturn(true);
+
+        $this->makeLogger($sink)->logAuthFailure(
+            AuthEvent::mfa(),
+            'testuser',
+            'Administrators',
+            'TOTP code incorrect',
+        );
+    }
+
+    public function testLogAuthFailureCommentsContainIpAndReason(): void
+    {
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->once())
+            ->method('record')
+            ->with(self::callback(function (Event $event): bool {
+                // Comments are base64-encoded by recordLogItem when encryption is off.
+                $decoded = base64_decode($event->comments);
+                self::assertStringContainsString('127.0.0.1', $decoded);
+                self::assertStringContainsString('TOTP code incorrect', $decoded);
+                self::assertStringStartsWith('failure:', $decoded);
+                return true;
+            }))
+            ->willReturn(true);
+
+        $this->makeLogger($sink)->logAuthFailure(
+            AuthEvent::mfa(),
+            'testuser',
+            'Administrators',
+            'TOTP code incorrect',
+        );
+    }
+
+    public function testLogAuthFailurePassesUsernameAndGroup(): void
+    {
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->once())
+            ->method('record')
+            ->with(self::callback(function (Event $event): bool {
+                self::assertSame('drsmith', $event->user);
+                self::assertSame('physicians', $event->group);
+                return true;
+            }))
+            ->willReturn(true);
+
+        $this->makeLogger($sink)->logAuthFailure(
+            AuthEvent::mfa(),
+            'drsmith',
+            'physicians',
+            'U2F authentication error',
+        );
+    }
+
+    public function testLogAuthFailureNullUsernameBecomesEmptyString(): void
+    {
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->once())
+            ->method('record')
+            ->with(self::callback(function (Event $event): bool {
+                self::assertSame('', $event->user);
+                return true;
+            }))
+            ->willReturn(true);
+
+        $this->makeLogger($sink)->logAuthFailure(
+            AuthEvent::mfa(),
+            null,
+            '',
+            'OAuth2 MFA (TOTP) code incorrect',
+        );
+    }
+
+    public function testLogAuthFailurePatientIdIsNullByDefault(): void
+    {
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->once())
+            ->method('record')
+            ->with(self::callback(function (Event $event): bool {
+                self::assertNull($event->patientId);
+                return true;
+            }))
+            ->willReturn(true);
+
+        $this->makeLogger($sink)->logAuthFailure(
+            AuthEvent::mfa(),
+            'testuser',
+            'Administrators',
+            'TOTP code incorrect',
+        );
+    }
+
+    public function testLogAuthFailurePatientIdForwardedToSink(): void
+    {
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->once())
+            ->method('record')
+            ->with(self::callback(function (Event $event): bool {
+                self::assertSame(42, $event->patientId);
+                return true;
+            }))
+            ->willReturn(true);
+
+        $this->makeLogger($sink)->logAuthFailure(
+            AuthEvent::mfa(),
+            'portaluser',
+            'portal',
+            'Portal MFA failure',
+            42,
+        );
+    }
+
+    public function testLogAuthFailureCommentsIncludeForwardedIp(): void
+    {
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '10.0.0.1';
+
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->once())
+            ->method('record')
+            ->with(self::callback(function (Event $event): bool {
+                $decoded = base64_decode($event->comments);
+                self::assertStringContainsString('10.0.0.1', $decoded);
+                return true;
+            }))
+            ->willReturn(true);
+
+        $this->makeLogger($sink)->logAuthFailure(
+            AuthEvent::mfa(),
+            'testuser',
+            'Administrators',
+            'TOTP code incorrect',
+        );
+    }
+}

--- a/tests/Tests/Isolated/Common/System/MissingSiteIdExceptionTest.php
+++ b/tests/Tests/Isolated/Common/System/MissingSiteIdExceptionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Isolated MissingSiteIdException Test
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\System;
+
+use OpenEMR\Common\System\MissingSiteException;
+use OpenEMR\Common\System\MissingSiteIdException;
+use PHPUnit\Framework\TestCase;
+
+class MissingSiteIdExceptionTest extends TestCase
+{
+    public function testDefaultMessage(): void
+    {
+        $exception = new MissingSiteIdException();
+        $this->assertSame('Site ID is missing from session data.', $exception->getMessage());
+    }
+
+    public function testCustomMessageAndPrevious(): void
+    {
+        $previous = new \RuntimeException('underlying');
+        $exception = new MissingSiteIdException('custom', 0, $previous);
+        $this->assertSame('custom', $exception->getMessage());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testCallersCanCatchAsMissingSiteException(): void
+    {
+        try {
+            throw new MissingSiteIdException();
+        } catch (MissingSiteException $caught) {
+            $this->assertSame('Site ID is missing from session data.', $caught->getMessage());
+        }
+    }
+
+    public function testProducesBadRequestHttpStatus(): void
+    {
+        $exception = new MissingSiteIdException();
+        $this->assertSame(400, $exception->getStatusCode());
+    }
+}

--- a/tests/Tests/RestControllers/ControllerRoutingTest.php
+++ b/tests/Tests/RestControllers/ControllerRoutingTest.php
@@ -185,4 +185,51 @@ class ControllerRoutingTest extends TestCase
         $this->assertArrayHasKey('sub_action', $dispatchParams);
         $this->assertSame('list', $dispatchParams['sub_action']);
     }
+
+    /**
+     * Controller extends Smarty, and Smarty's __call catches any undefined
+     * method call. This makes is_callable() return true for every method
+     * name on a Controller instance, even methods that don't actually exist.
+     *
+     * The methodExists() guard must combine is_callable() with method_exists()
+     * to distinguish genuinely-defined methods from phantom calls that would
+     * otherwise be dispatched into Smarty's extension handler (which throws
+     * "undefined extension class Smarty_Internal_Method_*" errors).
+     */
+    #[Test]
+    public function testMethodExistsGuardsAgainstSmartyPhantomMethods(): void
+    {
+        $smartyDescendant = new class extends \Controller {
+        };
+
+        $dispatcher = new \Controller();
+
+        $methodExists = new \ReflectionMethod(\Controller::class, 'methodExists');
+
+        // Document the trap: is_callable() alone returns true for any method
+        // name on a Smarty descendant because Smarty's __call catches all calls.
+        // PHPStan can't model __call, so it concludes statically that
+        // is_callable() must be false — which is exactly the runtime trap
+        // this test documents and methodExists() guards against.
+        /** @phpstan-ignore-next-line function.impossibleType */
+        $isCallable = is_callable([$smartyDescendant, 'nonexistent_phantom_method']);
+        /** @phpstan-ignore-next-line method.impossibleType */
+        $this->assertTrue(
+            $isCallable,
+            'Expected is_callable() to return true due to Smarty __call ' .
+            '(this assertion documents the trap that methodExists() guards against).'
+        );
+
+        // The guard must return false for phantom methods that only __call catches.
+        $this->assertFalse(
+            $methodExists->invoke($dispatcher, $smartyDescendant, 'nonexistent_phantom_method'),
+            'methodExists() must return false for phantom methods caught only by __call.'
+        );
+
+        // Positive case: a genuinely-defined method should return true.
+        $this->assertTrue(
+            $methodExists->invoke($dispatcher, $smartyDescendant, 'process_action'),
+            'methodExists() must return true for genuinely-defined methods.'
+        );
+    }
 }

--- a/version.php
+++ b/version.php
@@ -39,7 +39,7 @@ $v_database = 538;
 // controls is (subsequently the acl_upgrade.php script then is used to
 // upgrade and track this value)
 //
-$v_acl = 12;
+$v_acl = 13;
 
 // Version for JavaScript and stylesheet includes. Increment whenever a .js or .css file changes.
 // Also whenever you change a .js or .css file, make sure that all URLs referencing it


### PR DESCRIPTION
**Investigation workspace for #12012** — Apache segfault when #11912 (MFA audit logging) is backported to `rel-810` under the Sentinel mTLS e2e variant.

This branch is the bisect result that pinpointed #11912 as the trigger: it contains commits 1–11 of the 8.1.0 backport batch (cumulative state up to and including #11912's cherry-pick on top of `rel-810`). Re-running CI on this branch reproduces the segfault, so it's a useful starting point for testing fixes without dragging in the rest of the backport stack.

## How this differs from #12008

- #12008 — the actual backport PR (13 commits, #11912 deliberately excluded). Currently green and ready to merge.
- This PR (#12009) — `rel-810` + commits 1–11 (includes #11912). Reproduces the segfault. **Do not merge** — exists only as a CI test bed.

## Suggested probes

- Strip #11912 down to just the `AuthEvent` class (no callers, no `EventAuditLogger::logAuthFailure()`) and force-push here to see whether the class itself triggers the crash.
- Then add the `EventAuditLogger::logAuthFailure()` method without callers.
- Then add `main_screen.php` callers only.
- Then add `AuthorizationController.php` callers only.

Each probe is a force-push to this branch — the CI matrix runs automatically and the same Sentinel mTLS e2e job will tell us pass/fail.

## Reference

- Tracking issue: #12012
- Original bisect run (failing, includes #11912): https://github.com/openemr/openemr/actions/runs/25391506696
