### PR TITLE
fix(upgrade): drop redundant categories_seq UPDATE in eye form laser migration

### DIFF
--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -7563,7 +7563,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecordsNoLog\\(\\) instead of sqlStatementNoLog\\(\\)\\.$#',
-    'count' => 24,
+    'count' => 23,
     'path' => __DIR__ . '/../../src/Services/Utils/SQLUpgradeService.php',
 ];
 $ignoreErrors[] = [

--- a/src/Services/Utils/SQLUpgradeService.php
+++ b/src/Services/Utils/SQLUpgradeService.php
@@ -737,8 +737,6 @@ class SQLUpgradeService implements ISQLUpgradeService
                             $eyeFormCategoryParent['rght'] + 5
                         ]
                     );
-                    // update root node
-                    sqlStatementNoLog("UPDATE `categories` SET `rght` = (SELECT MAX(`rght`) FROM `categories`) + 1 WHERE `id` = 1");
                     $this->echo("<p class='text-success'>Completed conversion of categories for eye form insertion.</p>\n");
                     $this->flush_echo();
                     $skipping = false;

--- a/src/Services/Utils/SQLUpgradeService.php
+++ b/src/Services/Utils/SQLUpgradeService.php
@@ -737,8 +737,8 @@ class SQLUpgradeService implements ISQLUpgradeService
                             $eyeFormCategoryParent['rght'] + 5
                         ]
                     );
-                    // update categories_seq
-                    sqlStatementNoLog("UPDATE `categories_seq` SET `id` = (SELECT MAX(`id`) FROM `categories`)");
+                    // update root node
+                    sqlStatementNoLog("UPDATE `categories` SET `rght` = (SELECT MAX(`rght`) FROM `categories`) + 1 WHERE `id` = 1");
                     $this->echo("<p class='text-success'>Completed conversion of categories for eye form insertion.</p>\n");
                     $this->flush_echo();
                     $skipping = false;


### PR DESCRIPTION
fixes #11930

<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
The categories_seq UPDATE fatals the demo data upgrade when
categories_seq has drifted from its single-row shape (duplicate
PRIMARY KEY → sqlStatementNoLog calls HelpfulDie → upgrade aborts).



#### Changes proposed in this pull request:
remove unnecessary sql to categories_seq

#### Was an AI assistant used? Yes

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
