### PR TITLE
fix(sql): handle table-qualified columns in escape_sql_column_name()

### DIFF
--- a/library/formdata.inc.php
+++ b/library/formdata.inc.php
@@ -138,14 +138,21 @@ function escape_sql_column_name($s, $tables, $long = false, $throwException = fa
     $columns_options = [];
     foreach ($tables_escaped as $table_escaped) {
         $res = sqlStatementNoLog("SHOW COLUMNS FROM " . $table_escaped);
+        // Strip backticks for whitelist comparison; input won't have them
+        $table_for_whitelist = trim($table_escaped, '`');
         while ($row = sqlFetchArray($res)) {
-            $columns_options[] = $long ? $table_escaped . "." . $row['Field'] : $row['Field'];
+            $columns_options[] = $long ? $table_for_whitelist . "." . $row['Field'] : $row['Field'];
         }
     }
 
     // Whitelist against actual columns, then backtick-quote to keep in identifier context
     $dieIfNoMatch = !$throwException;
     $column = escape_identifier($s, $columns_options, $dieIfNoMatch, true, $throwException);
+    // For table.column format, backtick each part separately
+    if ($long && str_contains($column, '.')) {
+        [$table, $col] = explode('.', $column, 2);
+        return sprintf('`%s`.`%s`', $table, $col);
+    }
     return sprintf('`%s`', $column);
 }
 


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes regression in `escape_sql_column_name()` when `$long=true` (table-qualified column names like `pnotes.date`), introduced in #11280.

#### Changes proposed in this pull request:

The `$long=true` path had two bugs after backtick-quoting was added:

1. **Whitelist mismatch**: `$columns_options` was built using backtick-quoted table names (e.g., `` `pnotes`.date ``), but input comes unquoted (`pnotes.date`), so validation always failed.

2. **Incorrect quoting**: Output wrapped the entire `table.column` string in backticks (`` `pnotes.date` ``), but MySQL interprets that as a column literally named "pnotes.date". Correct output is `` `pnotes`.`date` ``.

#### Was an AI assistant used? Yes

Assisted-by trailer included in commit.

🤖 Generated with [Claude Code](https://claude.ai/code)