### PR TITLE
docs: document new openemr-cmd worktree subcommands and AI-assistant rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,37 @@ docker compose up --detach --wait
 - **Login:** `admin` / `pass`
 - **phpMyAdmin:** http://localhost:8310/
 
+## Working in a git worktree
+
+OpenEMR supports concurrent development across branches via git worktrees
+managed by `openemr-cmd worktree` (see `CONTRIBUTING.md` for the full feature
+set). Skip this section if the working directory does not match
+`*/openemr-wt-<slug>/` — that path is the signal you are inside a managed
+worktree, where `<slug>` is the branch label. `openemr-cmd worktree list`
+confirms.
+
+**Never use raw `git worktree add`, `git worktree remove`, or
+`git worktree move` against this repo.** The `openemr-cmd worktree` script
+owns state that bare git does not: a JSON state file tracking each worktree,
+a per-worktree compose override with its assigned port offset, and a
+generated `.env`. Bypassing it leaves orphaned state files, port collisions
+between worktrees, and broken compose stacks that the script can no longer
+recover. Always use `openemr-cmd worktree` subcommands instead — `add`,
+`remove`, `up`, `down`, `start`, `stop`, `exec`, `set-env`, `list`, `regen`.
+
+When running commands against a worktree's containers, use
+`openemr-cmd worktree exec <branch> <cmd>` rather than
+`cd docker/development-easy && docker compose exec openemr ...`. The `exec`
+subcommand resolves the worktree's `openemr` container by compose project
+labels; the bare `docker compose` form will hit the wrong stack (or none)
+because each worktree has a distinct compose project name and port offset.
+Any standard `openemr-cmd` command works through `exec` — `ut`, `at`, `et`,
+`php-log`, `shell`, `drid`, etc.
+
+For short pauses, prefer `worktree stop` / `worktree start` over
+`worktree down` / `worktree up`. `stop`/`start` pause and resume existing
+containers (data preserved, much faster); `down`/`up` recreates them.
+
 ## Testing
 
 Tests run inside Docker via devtools. Run from `docker/development-easy/`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,13 +271,17 @@ The OpenEMR development docker environment has a very rich advanced feature set.
       ```
 
       ```
-      Usage: openemr-cmd worktree <add|remove|up|down|list|regen> [options]
+      Usage: openemr-cmd worktree <add|remove|up|down|start|stop|exec|list|regen|set-env> [options]
 
         add <branch> [-b] [--env easy|easy-light|easy-redis] [--start]
                                   Create worktree (-b creates new branch, default env: easy)
         remove <branch> [--keep-volumes] Remove worktree (volumes deleted by default)
         up <branch>               Start Docker stack for worktree
         down <branch> [--keep-volumes]  Stop Docker stack for worktree (volumes deleted by default)
+        start <branch>            Start stopped containers for worktree (preserves data)
+        stop <branch>             Stop running containers for worktree (preserves data)
+        set-env <branch> <env>    Switch a worktree's env (easy|easy-light|easy-redis); stack must be down first
+        exec <branch> <cmd> [args...]   Run an openemr-cmd command against the worktree's openemr container
         list                      List all worktrees and status
         regen <branch>            Regenerate override/env files
         wt                        Alias for worktree
@@ -301,6 +305,28 @@ The OpenEMR development docker environment has a very rich advanced feature set.
       - Can stop the docker testing stack on a worktree via:
       ```sh
       openemr-cmd worktree down worktree-branch-label
+      ```
+
+      - Can pause a worktree's running containers without recreating them (preserves data and is faster than `down`/`up`):
+      ```sh
+      openemr-cmd worktree stop worktree-branch-label
+      ```
+
+      - Can resume a worktree's stopped containers (counterpart to `stop`):
+      ```sh
+      openemr-cmd worktree start worktree-branch-label
+      ```
+
+      - Can run any standard `openemr-cmd` command against a specific worktree's `openemr` container without manually looking up the container id. Examples:
+      ```sh
+      openemr-cmd worktree exec worktree-branch-label drid
+      openemr-cmd worktree exec worktree-branch-label shell
+      openemr-cmd worktree exec worktree-branch-label pl
+      ```
+
+      - Can switch a worktree to a different docker dev environment (`easy`, `easy-light`, or `easy-redis`). The stack must be fully torn down first (use `worktree down` to discard the old volumes, or `worktree down --keep-volumes` to preserve them):
+      ```sh
+      openemr-cmd worktree set-env worktree-branch-label easy-redis
       ```
 
       - Can remove the worktree via:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,44 +302,44 @@ The OpenEMR development docker environment has a very rich advanced feature set.
       openemr-cmd worktree up worktree-branch-label
       ```
 
-      - Can stop the docker testing stack on a worktree via:
+    - Can stop the docker testing stack on a worktree via:
       ```sh
       openemr-cmd worktree down worktree-branch-label
       ```
 
-      - Can pause a worktree's running containers without recreating them (preserves data and is faster than `down`/`up`):
+    - Can pause a worktree's running containers without recreating them (preserves data and is faster than `down`/`up`):
       ```sh
       openemr-cmd worktree stop worktree-branch-label
       ```
 
-      - Can resume a worktree's stopped containers (counterpart to `stop`):
+    - Can resume a worktree's stopped containers (counterpart to `stop`):
       ```sh
       openemr-cmd worktree start worktree-branch-label
       ```
 
-      - Can run any standard `openemr-cmd` command against a specific worktree's `openemr` container without manually looking up the container id. Examples:
+    - Can run any standard `openemr-cmd` command against a specific worktree's `openemr` container without manually looking up the container id. Examples:
       ```sh
       openemr-cmd worktree exec worktree-branch-label drid
       openemr-cmd worktree exec worktree-branch-label shell
       openemr-cmd worktree exec worktree-branch-label pl
       ```
 
-      - Can switch a worktree to a different docker dev environment (`easy`, `easy-light`, or `easy-redis`). The stack must be fully torn down first (use `worktree down` to discard the old volumes, or `worktree down --keep-volumes` to preserve them):
+    - Can switch a worktree to a different docker dev environment (`easy`, `easy-light`, or `easy-redis`). The stack must be fully torn down first (use `worktree down` to discard the old volumes, or `worktree down --keep-volumes` to preserve them):
       ```sh
       openemr-cmd worktree set-env worktree-branch-label easy-redis
       ```
 
-      - Can remove the worktree via:
+    - Can remove the worktree via:
       ```sh
       openemr-cmd worktree remove worktree-branch-label
       ```
 
-      - Can view the list of worktrees via:
+    - Can view the list of worktrees via:
       ```sh
       openemr-cmd worktree list
       ```
 
-      - Lots of other cool stuff is listed in the usage description via `openemr-cmd worktree`
+    - Lots of other cool stuff is listed in the usage description via `openemr-cmd worktree`
 
 
 2. <a name="xdebug"></a>Xdebug and profiling is supported for PHPStorm, VSCode and VSCodium.


### PR DESCRIPTION
## Summary
- Updates `CONTRIBUTING.md` to cover the recently added `openemr-cmd worktree` subcommands (`start`, `stop`, `exec`, `set-env`): refreshes the usage block to match the script's current output and adds example invocations for each new action.
- Adds a new `## Working in a git worktree` section to `CLAUDE.md` so AI assistants invoked inside a worktree drive lifecycle exclusively through `openemr-cmd worktree` rather than raw `git worktree` commands. Bare git bypasses the script's state file, per-worktree compose override, port-offset assignment, and generated `.env` — the failure modes (orphaned state, port collisions, unrecoverable stacks) are spelled out so the rule is hard to miss.
- Also covers, for AI assistants: how to detect they are inside a worktree (cwd matches `*/openemr-wt-<slug>/`), the preference for `worktree exec <branch> <cmd>` over `cd docker/development-easy && docker compose exec ...`, and `stop`/`start` vs `down`/`up` for short pauses.

The new `openemr-cmd worktree` subcommands themselves landed in openemr-devops (commits openemr/openemr-devops@60f0e56 for `start`/`stop`/`exec` via openemr/openemr-devops#691, and openemr/openemr-devops@6245e8e for `set-env`) — this PR is purely documentation in the openemr repo to match.

## Test plan
- [ ] Render `CONTRIBUTING.md` and `CLAUDE.md` on GitHub and confirm the new sections render correctly.
- [ ] Confirm the `openemr-cmd worktree` usage block in `CONTRIBUTING.md` matches the actual `openemr-cmd worktree` (no args) output from the latest openemr-devops master.
- [ ] Spot-check that the example commands (`worktree stop`, `worktree start`, `worktree exec <branch> drid|shell|pl`, `worktree set-env <branch> easy-redis`) match the script's accepted invocations.