### PR TITLE
fix(billing): add CSRF check + tighten input on fee_sheet review/justify

### DIFF
--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -393,16 +393,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_ajax.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_justify.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_queries.php',
 ];

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -324,11 +324,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_justify.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/gad7/report.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -953,16 +953,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 16,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_ajax.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 12,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_justify.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_options_ajax.php',
 ];

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -612,52 +612,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_ajax.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$issues might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_ajax.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$req_encounter might not be defined\\.$#',
-    'count' => 5,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_ajax.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$req_pid might not be defined\\.$#',
-    'count' => 6,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_ajax.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$task might not be defined\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_ajax.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$billing_id might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_justify.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$database might not be defined\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_justify.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$json_diags might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_justify.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$req_encounter might not be defined\\.$#',
-    'count' => 5,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_justify.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$req_pid might not be defined\\.$#',
-    'count' => 5,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_justify.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$task might not be defined\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_justify.php',
 ];

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -49,7 +49,7 @@ return [
         'return.missing.php' => 0,
         'staticMethod.notFound.php' => 0,
         'trait.notFound.php' => 0,
-        'variable.undefined.php' => 559,
+        'variable.undefined.php' => 550,
     ],
     'confidentNonObject' => [
         'classConstant.nonObject.php' => 0,

--- a/interface/forms/fee_sheet/review/fee_sheet_ajax.php
+++ b/interface/forms/fee_sheet/review/fee_sheet_ajax.php
@@ -18,7 +18,6 @@ require_once("fee_sheet_queries.php");
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
-use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Forms\FeeSheet\Review\CodeInfo;
 use OpenEMR\Forms\FeeSheet\Review\Procedure;
 
@@ -26,87 +25,73 @@ if (!AclMain::aclCheckCore('acct', 'bill')) {
     AccessDeniedHelper::deny('Unauthorized access to fee sheet');
 }
 
-$session = SessionWrapperFactory::getInstance()->getActiveSession();
-if (!CsrfUtils::verifyCsrfToken($_REQUEST["csrf_token_form"], session: $session)) {
-    CsrfUtils::csrfNotVerified();
-}
+CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 
-if (isset($_REQUEST['pid'])) {
-    $req_pid = $_REQUEST['pid'];
-}
+$req_pid = filter_input(INPUT_POST, 'pid', FILTER_VALIDATE_INT) ?: 0;
+$req_encounter = filter_input(INPUT_POST, 'encounter', FILTER_VALIDATE_INT) ?: 0;
+$task = filter_input(INPUT_POST, 'task');
+$mode = filter_input(INPUT_POST, 'mode');
+$prev_encounter_param = filter_input(INPUT_POST, 'prev_encounter', FILTER_VALIDATE_INT) ?: null;
+$diags_raw = filter_input(INPUT_POST, 'diags');
+$procs_raw = filter_input(INPUT_POST, 'procs');
+$issues = [];
 
-if (isset($_REQUEST['encounter'])) {
-    $req_encounter = $_REQUEST['encounter'];
-}
-
-if (isset($_REQUEST['task'])) {
-    $task = $_REQUEST['task'];
-}
-
-if ($task == 'retrieve') {
-    $retval = [];
-    if ($_REQUEST['mode'] == 'encounters') {
-        $encounters = select_encounters($req_pid, $req_encounter);
-        if (isset($_REQUEST['prev_encounter'])) {
-            $prev_enc = $_REQUEST['prev_encounter'];
-        } else {
-            if (count($encounters) > 0) {
-                $prev_enc = $encounters[0]->getID();
-            }
+switch ($task) {
+    case 'retrieve':
+        $retval = [];
+        switch ($mode) {
+            case 'encounters':
+                $encounters = select_encounters($req_pid, $req_encounter);
+                $prev_enc = $prev_encounter_param ?? ($encounters[0] ?? null)?->getID();
+                $procedures = [];
+                if ($prev_enc !== null) {
+                    fee_sheet_items($req_pid, $prev_enc, $issues, $procedures);
+                }
+                $retval['prev_encounter'] = $prev_enc;
+                $retval['encounters'] = $encounters;
+                $retval['procedures'] = $procedures;
+                break;
+            case 'issues':
+                $issues = issue_diagnoses($req_pid, $req_encounter);
+                break;
+            case 'common':
+                $issues = common_diagnoses();
+                break;
         }
+        $retval['issues'] = $issues;
+        echo json_encode($retval);
+        return;
+    case 'add_diags':
+        $json_diags = is_string($diags_raw) ? json_decode($diags_raw) : [];
+        $json_diags = is_array($json_diags) ? $json_diags : [];
+        $diags = array_map(
+            fn($diag) => new CodeInfo($diag->code, $diag->code_type, $diag->description),
+            $json_diags
+        );
 
-        $issues = [];
-        $procedures = [];
-        fee_sheet_items($req_pid, ($prev_enc ?? null), $issues, $procedures);
-        $retval['prev_encounter'] = $prev_enc ?? null;
-        $retval['encounters'] = $encounters;
-        $retval['procedures'] = $procedures;
-    }
+        $json_procs = is_string($procs_raw) ? json_decode($procs_raw) : [];
+        $json_procs = is_array($json_procs) ? $json_procs : [];
+        $procs = array_map(
+            fn($proc) => new Procedure(
+                $proc->code,
+                $proc->code_type,
+                $proc->description,
+                $proc->fee,
+                $proc->justify,
+                $proc->modifiers,
+                $proc->units,
+                /** ai generated code by google-labs-jules starts */
+                $proc->mod_size, // mod_size
+                $proc->ndc_info ?? '' // ndc_info
+                /** ai generated code by google-labs-jules end */
+            ),
+            $json_procs
+        );
 
-    if ($_REQUEST['mode'] == 'issues') {
-        $issues = issue_diagnoses($req_pid, $req_encounter);
-    }
-
-    if ($_REQUEST['mode'] == 'common') {
-            $issues = common_diagnoses();
-    }
-
-    $retval['issues'] = $issues;
-    echo text(json_encode($retval));
-    return;
-}
-
-if ($task == 'add_diags') {
-    $json_diags = isset($_REQUEST['diags']) ? json_decode((string) $_REQUEST['diags']) : [];
-    $json_diags = is_array($json_diags) ? $json_diags : [];
-    $diags = array_map(
-        fn($diag) => new CodeInfo($diag->code, $diag->code_type, $diag->description),
-        $json_diags
-    );
-
-    $json_procs = isset($_REQUEST['procs']) ? json_decode((string) $_REQUEST['procs']) : [];
-    $json_procs = is_array($json_procs) ? $json_procs : [];
-    $procs = array_map(
-        fn($proc) => new Procedure(
-            $proc->code,
-            $proc->code_type,
-            $proc->description,
-            $proc->fee,
-            $proc->justify,
-            $proc->modifiers,
-            $proc->units,
-            /** ai generated code by google-labs-jules starts */
-            $proc->mod_size, // mod_size
-            $proc->ndc_info ?? '' // ndc_info
-            /** ai generated code by google-labs-jules end */
-        ),
-        $json_procs
-    );
-
-    $database->StartTrans();
-    create_diags($req_pid, $req_encounter, $diags);
-    update_issues($req_pid, $req_encounter, $diags);
-    create_procs($req_pid, $req_encounter, $procs);
-    $database->CompleteTrans();
-    return;
+        $database->StartTrans();
+        create_diags($req_pid, $req_encounter, $diags);
+        update_issues($req_pid, $req_encounter, $diags);
+        create_procs($req_pid, $req_encounter, $procs);
+        $database->CompleteTrans();
+        return;
 }

--- a/interface/forms/fee_sheet/review/fee_sheet_justify.php
+++ b/interface/forms/fee_sheet/review/fee_sheet_justify.php
@@ -17,72 +17,61 @@ require_once("fee_sheet_queries.php");
 
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Forms\FeeSheet\Review\CodeInfo;
 
 if (!AclMain::aclCheckCore('acct', 'bill')) {
     AccessDeniedHelper::deny('Unauthorized access to fee sheet justification');
 }
 
+CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 
-if (isset($_REQUEST['pid'])) {
-    $req_pid = $_REQUEST['pid'];
-}
+$req_pid = filter_input(INPUT_POST, 'pid', FILTER_VALIDATE_INT) ?: 0;
+$req_encounter = filter_input(INPUT_POST, 'encounter', FILTER_VALIDATE_INT) ?: 0;
+$task = filter_input(INPUT_POST, 'task');
+$billing_id = filter_input(INPUT_POST, 'billing_id', FILTER_VALIDATE_INT) ?: 0;
+$skip_issues = filter_input(INPUT_POST, 'skip_issues', FILTER_VALIDATE_BOOLEAN) ?: false;
+$diags_raw = filter_input(INPUT_POST, 'diags');
 
-if (isset($_REQUEST['encounter'])) {
-    $req_encounter = $_REQUEST['encounter'];
-}
-
-if (isset($_REQUEST['task'])) {
-    $task = $_REQUEST['task'];
-}
-
-if (isset($_REQUEST['billing_id'])) {
-    $billing_id = $_REQUEST['billing_id'];
-}
-
-if ($task == 'retrieve') {
-    $retval = [];
-    $patient = issue_diagnoses($req_pid, $req_encounter);
-    $common = common_diagnoses();
-    $retval['patient'] = $patient;
-    $retval['common'] = $common;
-    $fee_sheet_diags = [];
-    $fee_sheet_procs = [];
-    fee_sheet_items($req_pid, $req_encounter, $fee_sheet_diags, $fee_sheet_procs);
-    $retval['current'] = $fee_sheet_diags;
-    echo json_encode($retval);
-    return;
-}
-
-if ($task == 'update') {
-    $skip_issues = false;
-    if (isset($_REQUEST['skip_issues'])) {
-        $skip_issues = $_REQUEST['skip_issues'] == 'true';
-    }
-
-    $diags = [];
-    if (isset($_REQUEST['diags'])) {
-        $json_diags = json_decode((string) $_REQUEST['diags']);
-    }
-
-    foreach ($json_diags as $diag) {
-        $new_diag = new CodeInfo($diag->{'code'}, $diag->{'code_type'}, $diag->{'description'});
-        if (isset($diag->{'prob_id'})) {
-            $new_diag->db_id = $diag->{'prob_id'};
-        } else {
-            $new_diag->db_id = null;
-            $new_diag->create_problem = $diag->{'create_problem'};
+switch ($task) {
+    case 'retrieve':
+        $retval = [];
+        $patient = issue_diagnoses($req_pid, $req_encounter);
+        $common = common_diagnoses();
+        $retval['patient'] = $patient;
+        $retval['common'] = $common;
+        $fee_sheet_diags = [];
+        $fee_sheet_procs = [];
+        fee_sheet_items($req_pid, $req_encounter, $fee_sheet_diags, $fee_sheet_procs);
+        $retval['current'] = $fee_sheet_diags;
+        echo json_encode($retval);
+        return;
+    case 'update':
+        $diags = [];
+        $json_diags = [];
+        if (is_string($diags_raw)) {
+            $decoded = json_decode($diags_raw);
+            $json_diags = is_array($decoded) ? $decoded : [];
         }
 
-        $diags[] = $new_diag;
-    }
+        foreach ($json_diags as $diag) {
+            $new_diag = new CodeInfo($diag->{'code'}, $diag->{'code_type'}, $diag->{'description'});
+            if (isset($diag->{'prob_id'})) {
+                $new_diag->db_id = $diag->{'prob_id'};
+            } else {
+                $new_diag->db_id = null;
+                $new_diag->create_problem = $diag->{'create_problem'};
+            }
 
-    $database->StartTrans();
-    create_diags($req_pid, $req_encounter, $diags);
-    if (!$skip_issues) {
-        update_issues($req_pid, $req_encounter, $diags);
-    }
+            $diags[] = $new_diag;
+        }
 
-    update_justify($req_pid, $req_encounter, $diags, $billing_id);
-    $database->CompleteTrans();
+        $database->StartTrans();
+        create_diags($req_pid, $req_encounter, $diags);
+        if (!$skip_issues) {
+            update_issues($req_pid, $req_encounter, $diags);
+        }
+        update_justify($req_pid, $req_encounter, $diags, $billing_id);
+        $database->CompleteTrans();
+        break;
 }

--- a/interface/forms/fee_sheet/review/fee_sheet_justify_view_model.js
+++ b/interface/forms/fee_sheet/review/fee_sheet_justify_view_model.js
@@ -137,7 +137,8 @@ function update_justify(data, event) {
             encounter: data.encounter_id,
             task: 'update',
             billing_id: data.billing_id,
-            diags: JSON.stringify(justify)
+            diags: JSON.stringify(justify),
+            csrf_token_form: csrf_token_js
         },
         function (data) {
             refresh_codes();
@@ -338,11 +339,13 @@ function fee_sheet_justify_view_model(billing_id, enc_id, pat_id, current_justif
         search_change(data, vm)
     });
     var mode = 'common';
+    top.restoreSession();
     $.post(justify_ajax, {
             pid: pat_id,
             encounter: enc_id,
             mode: mode,
-            task: "retrieve"
+            task: "retrieve",
+            csrf_token_form: csrf_token_js
         }, function (data) {
             setup_justify(vm, data.current, data.patient, data.common);
 


### PR DESCRIPTION
Closes #11965. Tracks #11792.

## What this PR changes

**CSRF protection on `fee_sheet_justify.php`.** The file previously had no CSRF check at all, and `fee_sheet_justify_view_model.js` was not sending `csrf_token_form` on either of its `$.post` calls. Hoisted a CSRF check matching the pattern in `fee_sheet_ajax.php` and added the token to both POSTs.

**Restrict both endpoints to POST.** Replace `$_REQUEST` with `filter_input(INPUT_POST, ...)` throughout. The JS only POSTs to these endpoints, so this tightens reachability without changing behavior. Type filters (`FILTER_VALIDATE_INT`, `FILTER_VALIDATE_BOOLEAN`) narrow the values where appropriate, eliminating downstream `mixed`-given parameter mismatches.

**Add `top.restoreSession()` before the justify retrieve POST.** Matches the existing pattern at line 133 of `fee_sheet_justify_view_model.js` and `fee_sheet_review_view_model.js:212`, preventing session timeout on long-open dialogs.

**Restructure the controller flow as `switch ($task)` / `switch ($mode)`.** Cosmetic; came along with the explicit-initializer cleanup.

**No transaction-wrapper change.** The original `$database->StartTrans()` / `$database->CompleteTrans()` calls are preserved. See #11965 for why; #12032 tracks the eventual migration to `QueryUtils::inTransaction()`.

## PHPStan baseline impact

| File | Identifier | Δ |
|---|---|---:|
| `variable.undefined.php` | undefined-variable entries (cap: 559→550) | **−9** |
| `openemr.forbiddenRequestGlobals.php` | direct `$_REQUEST` (ajax + justify) | −2 entries (counts 13+9 → 0) |
| `cast.string.php` | `Cannot cast mixed to string` (the dropped `(string)` casts) | −2 entries |
| `foreach.nonIterable.php` | `$json_diags` | −1 |
| `argument.type.php` | `mixed`-given downstream of `$_REQUEST` | −24 entries |

The `variable.undefined.php` cap drops by 9 (not 11) because the `$database` entries for these two files remain. `method.nonObject.php` entries for `StartTrans`/`CompleteTrans` on `mixed` also remain.

## Verification

- `composer phpstan-baseline` — regenerates cleanly; no net new entries in any baseline file.
- `composer phpunit-isolated -- --filter FatalBaselineCapsIsolatedTest` — passes with the lowered cap.
- `composer phpunit-isolated` — full isolated suite passes.
- `git grep '\$_REQUEST' interface/forms/fee_sheet/review/fee_sheet_{ajax,justify}.php` — zero hits.
- Manual smoke: pending. Reviewer should open an encounter, click **Review** on the Fee Sheet, add a diagnosis + procedure, click Save (should still succeed). Then open the **justify** dialog on a billing line, choose diagnoses, click Update — should still populate the `justify` column, and the new CSRF token enforcement should not break the round-trip.
