### PR TITLE
feat(ci): auto-merge dependabot docker-compose updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     day: monday
     time: "08:00"
   rebase-strategy: disabled
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 15
   labels:
   - dependencies
   - php
@@ -53,7 +53,7 @@ updates:
     interval: weekly
     day: monday
     time: "08:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 15
   labels:
   - dependencies
   - javascript
@@ -128,6 +128,7 @@ updates:
   - ci/compose-shared-selenium/
   schedule:
     interval: daily
+  open-pull-requests-limit: 5
   allow:
   - dependency-name: selenium/standalone-chromium
   - dependency-name: selenium/video
@@ -173,6 +174,7 @@ updates:
   - ci/nginx_86/
   schedule:
     interval: daily
+  open-pull-requests-limit: 10
   ignore:
     # Block major/minor bumps for version-pinned images only — each CI
     # directory intentionally tests a specific database + PHP version.
@@ -222,6 +224,7 @@ updates:
   - docker/production/
   schedule:
     interval: daily
+  open-pull-requests-limit: 10
   ignore:
   - dependency-name: mariadb
     update-types: [version-update:semver-major]
@@ -259,6 +262,7 @@ updates:
   - docker/development-insane/
   schedule:
     interval: daily
+  open-pull-requests-limit: 10
   ignore:
   - dependency-name: mariadb
     update-types: [version-update:semver-major, version-update:semver-minor]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -203,6 +203,9 @@ updates:
     redis:
       patterns:
       - redis
+    infrastructure:
+      patterns:
+      - alpine
   labels:
   - dependencies
   - docker

--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -1,0 +1,19 @@
+name: All Checks Passed
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  all-checks:
+    name: All Checks Passed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lewagon/wait-on-check-action@v1.7.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          running-workflow-name: All Checks Passed
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30

--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -15,5 +15,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           running-workflow-name: All Checks Passed
+          ignore-checks: codecov/project
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,51 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.AUTO_MERGE_APP_ID }}
+          private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}
+
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      # Auto-merge docker-compose updates from directories where CI exercises
+      # every image. Prefix matching only for ci/apache_* and ci/nginx_* since
+      # those version-matrix dirs are added/removed over time; everything else
+      # is matched explicitly so new dirs require an intentional opt-in here.
+      - name: Auto-merge docker-compose updates
+        if: >-
+          steps.metadata.outputs.package-ecosystem == 'docker_compose' &&
+          (
+            startsWith(steps.metadata.outputs.directory, '/ci/apache_') ||
+            startsWith(steps.metadata.outputs.directory, '/ci/nginx_') ||
+            steps.metadata.outputs.directory == '/ci/compose-shared-mailpit' ||
+            steps.metadata.outputs.directory == '/ci/compose-shared-nginx' ||
+            steps.metadata.outputs.directory == '/ci/compose-shared-redis-sentinel' ||
+            steps.metadata.outputs.directory == '/ci/compose-shared-selenium' ||
+            steps.metadata.outputs.directory == '/ci/inferno' ||
+            steps.metadata.outputs.directory == '/docker/development-easy' ||
+            steps.metadata.outputs.directory == '/docker/development-easy-light' ||
+            steps.metadata.outputs.directory == '/docker/development-easy-redis' ||
+            steps.metadata.outputs.directory == '/docker/development-insane' ||
+            steps.metadata.outputs.directory == '/docker/production'
+          )
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,6 +2,7 @@ name: Dependabot Auto-Merge
 
 on:
   pull_request_target:
+    branches: [master]
 
 permissions:
   contents: read

--- a/ci/apache_82_118_redis_sentinel_mtls/docker-compose.yml
+++ b/ci/apache_82_118_redis_sentinel_mtls/docker-compose.yml
@@ -17,7 +17,7 @@ x-includes:
 services:
   # ---------- cert generation (identical to TLS variant) ----------
   redis-tls-init:
-    image: alpine:3.23
+    image: alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |

--- a/ci/apache_85_118_redis_sentinel_mtls/docker-compose.yml
+++ b/ci/apache_85_118_redis_sentinel_mtls/docker-compose.yml
@@ -17,7 +17,7 @@ x-includes:
 services:
   # ---------- cert generation (identical to TLS variant) ----------
   redis-tls-init:
-    image: alpine:3.23
+    image: alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |

--- a/ci/apache_85_118_redis_sentinel_tls/docker-compose.yml
+++ b/ci/apache_85_118_redis_sentinel_tls/docker-compose.yml
@@ -20,7 +20,7 @@ x-includes:
 services:
   # ---------- cert generation ----------
   redis-tls-init:
-    image: alpine:3.23
+    image: alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |

--- a/ci/compose-shared-redis-sentinel/docker-compose.yml
+++ b/ci/compose-shared-redis-sentinel/docker-compose.yml
@@ -19,7 +19,7 @@
 
 services:
   redis-master:
-    image: redis:8.6@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
+    image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
     container_name: redis-master
     # Config passed via command-line args instead of bind-mounted redis.conf.
     # Docker Compose resolves bind-mount paths relative to the first file in
@@ -48,7 +48,7 @@ services:
       start_period: 10s
 
   redis-replica-1:
-    image: redis:8.6@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
+    image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
     command:
       - redis-server
       - --bind
@@ -71,7 +71,7 @@ services:
         condition: service_healthy
 
   redis-replica-2:
-    image: redis:8.6@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
+    image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
     command:
       - redis-server
       - --bind
@@ -94,7 +94,7 @@ services:
         condition: service_healthy
 
   sentinel-1:
-    image: redis:8.6@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
+    image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
     # Config is written inline to avoid bind-mount directory pollution — see file header.
     entrypoint: ["/bin/sh", "-c"]
     command:
@@ -122,7 +122,7 @@ services:
       start_period: 15s
 
   sentinel-2:
-    image: redis:8.6@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
+    image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
     # Config is written inline to avoid bind-mount directory pollution — see file header.
     entrypoint: ["/bin/sh", "-c"]
     command:

--- a/docker/development-easy-light/docker-compose.yml
+++ b/docker/development-easy-light/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       retries: 3
   phpmyadmin:
     restart: always
-    image: phpmyadmin:latest@sha256:0480a7583f876944d10c112177309d1d7bd4f1bf76770c6e7cb04706d4e36375
+    image: phpmyadmin:5.2.3@sha256:0480a7583f876944d10c112177309d1d7bd4f1bf76770c6e7cb04706d4e36375
     ports:
     - "${WT_PMA_PORT:-8310}:80"
     environment:

--- a/docker/development-easy-redis/docker-compose.yml
+++ b/docker/development-easy-redis/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis-master:
-    image: redis:8.6@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
+    image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
     container_name: redis-master
     command:
       - redis-server
@@ -24,7 +24,7 @@ services:
       timeout: 3s
       retries: 5
   redis-replica-1:
-    image: redis:8.6@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
+    image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
     container_name: redis-replica-1
     command:
       - redis-server
@@ -44,7 +44,7 @@ services:
       - --replica-announce-ip
       - redis-replica-1
   redis-replica-2:
-    image: redis:8.6@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
+    image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
     container_name: redis-replica-2
     command:
       - redis-server
@@ -64,7 +64,7 @@ services:
       - --replica-announce-ip
       - redis-replica-2
   sentinel-1:
-    image: redis:8.6@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
+    image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
     container_name: sentinel-1
     entrypoint: ["/bin/sh", "-c"]
     command:
@@ -84,7 +84,7 @@ services:
       redis-master:
         condition: service_healthy
   sentinel-2:
-    image: redis:8.6@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
+    image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
     container_name: sentinel-2
     entrypoint: ["/bin/sh", "-c"]
     command:
@@ -245,7 +245,7 @@ services:
       retries: 3
   phpmyadmin:
     restart: always
-    image: phpmyadmin:latest@sha256:0480a7583f876944d10c112177309d1d7bd4f1bf76770c6e7cb04706d4e36375
+    image: phpmyadmin:5.2.3@sha256:0480a7583f876944d10c112177309d1d7bd4f1bf76770c6e7cb04706d4e36375
     ports:
     - "${WT_PMA_PORT:-8310}:80"
     environment:

--- a/docker/development-easy/docker-compose.yml
+++ b/docker/development-easy/docker-compose.yml
@@ -132,7 +132,7 @@ services:
       retries: 3
   phpmyadmin:
     restart: always
-    image: phpmyadmin:latest@sha256:0480a7583f876944d10c112177309d1d7bd4f1bf76770c6e7cb04706d4e36375
+    image: phpmyadmin:5.2.3@sha256:0480a7583f876944d10c112177309d1d7bd4f1bf76770c6e7cb04706d4e36375
     ports:
     - "${WT_PMA_PORT:-8310}:80"
     environment:

--- a/docker/development-insane/docker-compose.yml
+++ b/docker/development-insane/docker-compose.yml
@@ -619,7 +619,7 @@ services:
       retries: 3
   phpmyadmin:
     restart: always
-    image: phpmyadmin:latest@sha256:0480a7583f876944d10c112177309d1d7bd4f1bf76770c6e7cb04706d4e36375
+    image: phpmyadmin:5.2.3@sha256:0480a7583f876944d10c112177309d1d7bd4f1bf76770c6e7cb04706d4e36375
     ports:
     - 8200:80
     environment:
@@ -641,7 +641,7 @@ services:
       COUCHDB_PASSWORD: password
   orthanc:
     restart: always
-    image: jodogne/orthanc-plugins:latest@sha256:d9b82d85ac61f9f19e2d66cc96341f79e34a97a5f1267cca54c4e4f098f98e60
+    image: jodogne/orthanc-plugins:1.12.11@sha256:8b028b7c286b14bd54b1db1af6982b6dfe6262de81aa0a793a70b43c4b1f8778
     ports:
     - 4242:4242
     - 8042:8042
@@ -789,7 +789,7 @@ services:
       OPENEMR_DOCKER_ENV_TAG: insane-dev-docker
   redis:
     restart: always
-    image: redis:latest@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
+    image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
   openldap:
     restart: always
     image: openemr/dev-ldap:insane@sha256:24b023a969e3a2e43bfab56e22474a036553c3d69687f8e0f9d8da968ed744a7
@@ -800,7 +800,7 @@ services:
       LDAP_TLS_KEY_FILENAME: server-key.pem
   fhir:
     restart: always
-    image: ibmcom/ibm-fhir-server:latest@sha256:27f39ef992c4925407e20137b4103ab717d208b4a67c835b499ed46b67cccdf9
+    image: ibmcom/ibm-fhir-server:4.11.1@sha256:27f39ef992c4925407e20137b4103ab717d208b4a67c835b499ed46b67cccdf9
     ports:
     - 9443:9443
   selenium:


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Enables automatic merging of routine dependabot docker-compose updates (digest, patch, minor, and major) once CI passes, mirroring the pattern in use in openemr-devops. Includes preparatory housekeeping to pin floating image tags so the version is visible in compose files. Manual review hasn't surfaced regressions for the past month and CI exercises every image that gets bumped.

#### Changes proposed in this pull request:

**Auto-merge automation**

- `.github/workflows/dependabot-auto-merge.yml` — on every PR opened by `dependabot[bot]` for the `docker_compose` ecosystem, queue an auto-merge with `--squash`. Directory filter covers `/ci/apache_*`, `/ci/nginx_*`, `/ci/compose-shared-*`, `/ci/inferno`, `/docker/development-*`, and `/docker/production`. Apache and nginx use prefix matching since those version-matrix dirs grow over time; the rest are matched explicitly so new dirs require an opt-in here.
- `.github/workflows/all-checks-passed.yml` — aggregate workflow using `lewagon/wait-on-check-action@v1.7.0` so branch protection can require a single status. The auto-merge fires once this passes.
- `.github/dependabot.yml` — adds an `infrastructure` group covering `alpine` so future bumps in the sentinel TLS dirs land as a single PR.

**Image-tag housekeeping** (no behavior change except orthanc, see below)

- `redis` — unify on `8.6.3` across `compose-shared-redis-sentinel`, `development-easy-redis`, and `development-insane` (was `8.6` in two places and `latest` in insane). Same digest as the existing `8.6` / `latest` pins.
- `phpmyadmin` — pin to `5.2.3` (was `latest`) in all four dev dirs. Same digest.
- `ibmcom/ibm-fhir-server` — pin to `4.11.1` (was `latest`) in `development-insane`. Same digest.
- `alpine` — pin to `3.23.4` with sha256 digest in the three sentinel TLS/mTLS CI dirs (was unpinned `3.23`). `3.23.4` is the current `3.23` patch.
- `jodogne/orthanc-plugins` — bump `latest` to `1.12.11` in `development-insane`. The previously pinned `latest` digest sits between `1.12.10` and `1.12.11` (a rebuilt-RC overwrite); `1.12.11` is the released build. **Digest does change.** Worth a smoke-test of the insane stack before merging.

**Activation prerequisites (deployment-side, not in this PR)**

- `AUTO_MERGE_APP_ID` / `AUTO_MERGE_APP_PRIVATE_KEY` repo or org secrets must be available — same App used by openemr-devops.
- Branch protection on `master` should require the `All Checks Passed` check (existing required checks become redundant once that one is in place).

#### Was an AI assistant used? Yes