### PR TITLE
ci(release): drop single-entry matrix from release-permissions-check

### DIFF
--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -22,17 +22,10 @@ concurrency:
 
 jobs:
   probe:
-    name: Probe release-app permissions (${{ matrix.php-version }})
+    name: Probe release-app permissions
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    strategy:
-      matrix:
-        # Conductor tooling runs only on CI runners (no customer
-        # deployment), so per OCE conventions it tracks the latest
-        # stable PHP rather than the openemr application floor.
-        php-version:
-        - '8.5'
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -47,7 +40,10 @@ jobs:
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer
       with:
-        php-version: ${{ matrix.php-version }}
+        # Conductor tooling runs only on CI runners (no customer
+        # deployment), so per OCE conventions it tracks the latest
+        # stable PHP rather than the openemr application floor.
+        php-version: '8.5'
 
     - name: Resolve default branch
       id: repo


### PR DESCRIPTION
Manual one-shot probe; the single-entry `php-version` matrix added no value and made the job name harder to read. Inlines `php-version: '8.5'` into the setup-php-composer step.

Follow-up to #11896.