### PR TITLE
fix(release): add empty-tree commit before opening probe PR

### DIFF
--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -68,7 +68,7 @@ jobs:
         fi
         echo "OK: release App is installed on ${REPO}"
 
-    - name: Probe contents:write (create throwaway branch)
+    - name: Probe contents:write (create throwaway branch + commit)
       id: probe-contents
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -78,12 +78,24 @@ jobs:
       run: |
         branch="release-permissions-check/${RUN_ID}"
         echo "branch=${branch}" >> "$GITHUB_OUTPUT"
-        sha=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
-        if ! gh api -X POST "repos/${REPO}/git/refs" -f "ref=refs/heads/${branch}" -f "sha=${sha}" >/dev/null; then
+        base_sha=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
+        if ! gh api -X POST "repos/${REPO}/git/refs" -f "ref=refs/heads/${branch}" -f "sha=${base_sha}" >/dev/null; then
           echo "FAIL: contents:write missing (cannot create branch)" >&2
           exit 1
         fi
-        echo "OK: created throwaway branch ${branch}"
+        # The PR probe needs at least one commit on the branch — a zero-diff
+        # PR is a 422 Validation Failed even when pull-requests:write is granted.
+        base_tree=$(gh api "repos/${REPO}/git/commits/${base_sha}" --jq '.tree.sha')
+        commit_sha=$(gh api -X POST "repos/${REPO}/git/commits" -f "message=release-permissions-check probe ${RUN_ID}" -f "tree=${base_tree}" -F "parents[]=${base_sha}" --jq '.sha')
+        if [[ -z "${commit_sha}" ]]; then
+          echo "FAIL: contents:write missing (cannot create commit)" >&2
+          exit 1
+        fi
+        if ! gh api -X PATCH "repos/${REPO}/git/refs/heads/${branch}" -f "sha=${commit_sha}" >/dev/null; then
+          echo "FAIL: contents:write missing (cannot fast-forward branch)" >&2
+          exit 1
+        fi
+        echo "OK: created throwaway branch ${branch} with empty-tree commit"
 
     - name: Probe pull-requests:write (open + close draft PR)
       id: probe-prs


### PR DESCRIPTION
The `pull-requests:write` probe in `release-permissions-check.yml` was creating a throwaway branch from the default-branch SHA and immediately opening a PR `head=branch` `base=master`. GitHub rejects that with **422 Validation Failed** because head and base point at the same commit — the diff is empty.

Adds an empty-tree commit on the throwaway branch via the git data API before the PR-open step, so the PR has a non-empty diff and the probe actually exercises `pull-requests:write` rather than crashing on input validation.

Surfaced by the first real run of the probe against `openemr/openemr` master after #11896 landed; everything before this step passed (App token mint OK, `contents:write` branch creation OK).

Follow-up to #11896.