### PR TITLE
fix(faxsms): use filesystem-targeted encryption for cached auth

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AuthenticateTrait.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AuthenticateTrait.php
@@ -99,14 +99,14 @@ trait AuthenticateTrait
             }
 
             $json = $this->crypto->decryptFromFilesystem($contents);
-            $data = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+            $data = json_decode((string) $json, true, flags: JSON_THROW_ON_ERROR);
 
             if (!$this->isValidCachedAuth($data)) {
                 $error = true;
                 return [];
             }
             return $data;
-        } catch (CryptoGenException $e) {
+        } catch (CryptoGenException) {
             $error = true;
             return [];
         } finally {

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AuthenticateTrait.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AuthenticateTrait.php
@@ -13,6 +13,7 @@
 namespace OpenEMR\Modules\FaxSMS\Controller;
 
 use Exception;
+use OpenEMR\Common\Crypto\CryptoGenException;
 use RingCentral\SDK\Http\ApiException;
 use RingCentral\SDK\SDK;
 
@@ -80,23 +81,40 @@ trait AuthenticateTrait
     }
 
     /**
-     * @param string $authBack
      * @return array
      */
-    private function getCachedAuth(string $authBack): array
+    private function getCachedAuth(string $file): array
     {
-        if (file_exists($authBack)) {
-            $cachedAuth = file_get_contents($authBack);
-            $cachedAuth = json_decode($this->crypto->decryptStandard($cachedAuth !== false ? $cachedAuth : null), true);
-
-            // Don't delete cache immediately - validate first
-            if ($this->isValidCachedAuth($cachedAuth)) {
-                return $cachedAuth;
-            }
-            // If cached auth is invalid, delete the file
-            unlink($authBack); // Only delete if invalid
+        if (!file_exists($file)) {
+            return [];
         }
-        return [];
+        try {
+            $error = false;
+
+            $contents = file_get_contents($file);
+            if ($contents === false) {
+                // exists but not readable
+                $error = true;
+                return [];
+            }
+
+            $json = $this->crypto->decryptFromFilesystem($contents);
+            $data = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+
+            if (!$this->isValidCachedAuth($data)) {
+                $error = true;
+                return [];
+            }
+            return $data;
+        } catch (CryptoGenException $e) {
+            $error = true;
+            return [];
+        } finally {
+            // If the cache file was invalid in any way, remove the temp file
+            if ($error) {
+                unlink($file);
+            }
+        }
     }
 
     private function isValidCachedAuth(array $authData): bool
@@ -148,8 +166,8 @@ trait AuthenticateTrait
     private function cacheAuthData($platform): void
     {
         $data = $platform->auth()->data();
-        $jsonData = json_encode($data);
-        $encryptedData = $this->crypto->encryptStandard($jsonData !== false ? $jsonData : null);
+        $jsonData = json_encode($data, flags: JSON_THROW_ON_ERROR);
+        $encryptedData = $this->crypto->encryptForFilesystem($jsonData);
         file_put_contents($this->cacheDir . DIRECTORY_SEPARATOR . 'platform.json', $encryptedData);
     }
 


### PR DESCRIPTION
I came across a cryptointerface touch-point during a refactor that seemed to be using the wrong keysource (and thus method). I pulled it out so it doesn't get swept up in an invalid change.

## Summary
- Switch from `encryptStandard`/`decryptStandard` to `encryptForFilesystem`/`decryptFromFilesystem` for cached RingCentral authentication data
- This results in using the correct key source (database key) for filesystem-stored data per CryptoGen conventions
- Adds explicit error handling for decryption failures with automatic cache cleanup
- Uses `JSON_THROW_ON_ERROR` for stricter JSON validation
