### PR TITLE
fix(release): rename --version CLI option to --release-version

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -158,7 +158,7 @@ jobs:
           --sha="${PUSH_SHA}" \
           --actor='openemr-release-bot' \
           --branch="${REL_BRANCH}" \
-          --version="${VERSION}" \
+          --release-version="${VERSION}" \
           --prev-release="${prev_release}"
 
   finalize:
@@ -215,7 +215,7 @@ jobs:
       run: |
         php tools/release/bin/create-tag.php \
           --repo="${REPO}" \
-          --version="${VERSION}" \
+          --release-version="${VERSION}" \
           --commit-sha="${MERGE_SHA}" \
           --conductor-pr-url="${PR_URL}"
 
@@ -243,5 +243,5 @@ jobs:
           --sha="${MERGE_SHA}" \
           --actor='openemr-release-bot' \
           --branch="${REL_BRANCH}" \
-          --version="${VERSION}" \
+          --release-version="${VERSION}" \
           --tag="${tag_name}"

--- a/tests/Tests/Isolated/Release/DispatchDataBuilderTest.php
+++ b/tests/Tests/Isolated/Release/DispatchDataBuilderTest.php
@@ -26,7 +26,7 @@ final class DispatchDataBuilderTest extends TestCase
     {
         $builder = new DispatchDataBuilder($this->reader([
             '--branch' => 'rel-810',
-            '--version' => '8.1.0',
+            '--release-version' => '8.1.0',
             '--prev-release' => '8.0.0',
         ]));
         self::assertSame(
@@ -40,7 +40,7 @@ final class DispatchDataBuilderTest extends TestCase
         $builder = new DispatchDataBuilder($this->reader([
             '--tag' => 'v8_1_0',
             '--branch' => 'rel-810',
-            '--version' => '8.1.0',
+            '--release-version' => '8.1.0',
         ]));
         self::assertSame(
             ['tag' => 'v8_1_0', 'branch' => 'rel-810', 'version' => '8.1.0'],
@@ -63,7 +63,7 @@ final class DispatchDataBuilderTest extends TestCase
     {
         $definition = new InputDefinition([
             new InputOption('branch', null, InputOption::VALUE_REQUIRED),
-            new InputOption('version', null, InputOption::VALUE_REQUIRED),
+            new InputOption('release-version', null, InputOption::VALUE_REQUIRED),
             new InputOption('prev-release', null, InputOption::VALUE_REQUIRED),
             new InputOption('tag', null, InputOption::VALUE_REQUIRED),
         ]);

--- a/tools/release/bin/create-tag.php
+++ b/tools/release/bin/create-tag.php
@@ -40,7 +40,7 @@ use Symfony\Component\HttpClient\HttpClient;
     ->setName('create-tag')
     ->setDescription('Create an annotated release tag via the GitHub API')
     ->addOption('repo', null, InputOption::VALUE_REQUIRED, 'owner/name of the target repo')
-    ->addOption('version', null, InputOption::VALUE_REQUIRED, 'MAJOR.MINOR.PATCH release version')
+    ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'MAJOR.MINOR.PATCH release version')
     ->addOption('commit-sha', null, InputOption::VALUE_REQUIRED, '40-hex merge commit SHA')
     ->addOption('conductor-pr-url', null, InputOption::VALUE_REQUIRED, 'URL of the conductor release-prep PR')
     ->addOption(
@@ -65,7 +65,7 @@ use Symfony\Component\HttpClient\HttpClient;
         try {
             $request = new TagCreationRequest(
                 repo: $opts->string('repo'),
-                version: $opts->string('version'),
+                version: $opts->string('release-version'),
                 commitSha: $opts->string('commit-sha'),
                 conductorPrUrl: $opts->string('conductor-pr-url'),
                 appToken: $token,

--- a/tools/release/bin/dispatch.php
+++ b/tools/release/bin/dispatch.php
@@ -63,7 +63,7 @@ use Symfony\Component\HttpClient\HttpClient;
         'openemr/openemr-devops,openemr/website-openemr',
     )
     ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'rel-* branch name (rel-cut/update/tag events)')
-    ->addOption('version', null, InputOption::VALUE_REQUIRED, 'MAJOR.MINOR.PATCH release version')
+    ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'MAJOR.MINOR.PATCH release version')
     ->addOption('prev-release', null, InputOption::VALUE_REQUIRED, 'Previous release version (rel-cut/update)')
     ->addOption('tag', null, InputOption::VALUE_REQUIRED, 'Tag name (openemr-tag event)')
     ->addOption('probe', null, InputOption::VALUE_NONE, 'Bypass schema validation (permissions-check probe)')

--- a/tools/release/src/DispatchDataBuilder.php
+++ b/tools/release/src/DispatchDataBuilder.php
@@ -32,13 +32,13 @@ final readonly class DispatchDataBuilder
         return match ($event) {
             DispatchRequest::EVENT_REL_CUT, DispatchRequest::EVENT_REL_UPDATE => [
                 'branch' => $this->opts->string('branch'),
-                'version' => $this->opts->string('version'),
+                'version' => $this->opts->string('release-version'),
                 'prev_release' => $this->opts->string('prev-release'),
             ],
             DispatchRequest::EVENT_TAG => [
                 'tag' => $this->opts->string('tag'),
                 'branch' => $this->opts->string('branch'),
-                'version' => $this->opts->string('version'),
+                'version' => $this->opts->string('release-version'),
             ],
             DispatchRequest::EVENT_PROBE => [
                 'note' => 'release-permissions-probe; ignored by consumers',


### PR DESCRIPTION
Symfony Console's `SingleCommandApplication` automatically registers a built-in `--version` option (it prints the application version). The release CLI scripts were trying to declare their own `--version`, causing every invocation to crash with:

```
An option named "version" already exists.
```

The first run of `release-permissions-check.yml` against `openemr/openemr` master after #11896 + #12048 surfaced this — every prior code path stopped at earlier failures (App-token mint, PR-open) so the collision was never reached. See [run 25469321327](https://github.com/openemr/openemr/actions/runs/25469321327).

Renames the CLI option to `--release-version` in `dispatch.php` and `create-tag.php`, updates internal lookups in `DispatchDataBuilder` and `create-tag`, updates `release-prep.yml` to pass `--release-version`, and updates the `DispatchDataBuilder` test fixture. The JSON payload field stays `"version"` per the cross-repo contract in openemr-devops#664 — only the CLI flag changed.

Verified locally: `composer phpunit-isolated -- --filter Release` → 64 tests, 162 assertions, all green. `php tools/release/bin/dispatch.php --help` shows both `--release-version` (ours) and `-V, --version` (Symfony's) coexisting.

Follow-up to #11896 and #12048.