### PR TITLE
fix(release): scope App token to dispatch target repos

### DIFF
--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -43,6 +43,11 @@ jobs:
       with:
         app-id: ${{ secrets.RELEASE_APP_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        # Scope the installation token to this repo plus the dispatch
+        # targets, otherwise repository_dispatch to the consumer repos
+        # returns 403 "Resource not accessible by integration".
+        owner: ${{ github.repository_owner }}
+        repositories: openemr,openemr-devops,website-openemr
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -69,6 +69,11 @@ jobs:
       with:
         app-id: ${{ secrets.RELEASE_APP_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        # Scope the installation token to this repo plus the dispatch
+        # targets, otherwise repository_dispatch to the consumer repos
+        # returns 403 "Resource not accessible by integration".
+        owner: ${{ github.repository_owner }}
+        repositories: openemr,openemr-devops,website-openemr
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer
@@ -188,6 +193,11 @@ jobs:
       with:
         app-id: ${{ secrets.RELEASE_APP_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        # Scope the installation token to this repo plus the dispatch
+        # targets, otherwise repository_dispatch to the consumer repos
+        # returns 403 "Resource not accessible by integration".
+        owner: ${{ github.repository_owner }}
+        repositories: openemr,openemr-devops,website-openemr
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer


### PR DESCRIPTION
After #12051 the release CLI runs cleanly, but the next failure surfaced: cross-repo `repository_dispatch` to the consumer repos returns:

```
HTTP 403: Resource not accessible by integration
```

`actions/create-github-app-token` mints an installation token scoped to just the calling repo by default. Even when the App is installed on the target repo with the right permissions, the token in the calling workflow lacks access.

Sets `owner` + `repositories` on every `create-github-app-token` step so the minted token covers this repo plus the dispatch targets (`openemr-devops`, `website-openemr`):

- `release-permissions-check.yml` — the probe job.
- `release-prep.yml` — both the `prep`-job mint (used for `peter-evans/create-pull-request` + the `openemr-rel-cut/update` dispatch) and the `finalize`-job mint (used for `create-tag.php` + the `openemr-tag` dispatch).

Same fix already applied to website-openemr in #98.

Surfaced by [run 25495991421](https://github.com/openemr/openemr/actions/runs/25495991421).

Follow-up to #11896 / #12048 / #12051.