### PR TITLE
fix(release): skip globals bootstrap in release-prep mutator

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -117,6 +117,7 @@ jobs:
         VERSION: ${{ steps.resolve.outputs.version }}
       run: |
         php bin/console openemr:release-prep \
+          --skip-globals \
           --target-version="${VERSION}" \
           --scope=rel
 


### PR DESCRIPTION
After #12057 the release-prep workflow makes it past App-token scoping but the next failure is in the mutator step:

```
TypeError: mysqli_query(): Argument #1 ($mysql) must be of type mysqli, false given
  at vendor/adodb/adodb-php/drivers/adodb-mysqli.inc.php:1454
  #6 interface/globals.php(372): require_once(...)
  #7 bin/console(47): require_once(...)
```

`bin/console` bootstraps `interface/globals.php` (and therefore the database) by default. The CI job that runs the release-prep mutators has no database and shouldn't need one — the mutators rewrite files, they don't touch data.

Adds `--skip-globals` to the `php bin/console openemr:release-prep` invocation in `release-prep.yml`. Same flag already used by `openemr:create-api-documentation` in `api-docs.yml` for the same reason.

Surfaced by [run 25499577173](https://github.com/openemr/openemr/actions/runs/25499577173). Follow-up to #11896 / #12048 / #12051 / #12057.