### PR TITLE
fix(release): widen dispatch branch pattern to allow rel-test

### DIFF
--- a/tools/release/contracts/dispatch.schema.json
+++ b/tools/release/contracts/dispatch.schema.json
@@ -97,9 +97,9 @@
       "pattern": "^\\d+\\.\\d+\\.\\d+$"
     },
     "branch": {
-      "description": "Release branch name. Per #664 spec: rel-<MAJOR><MINOR>0.",
+      "description": "Release branch name. Per #664 spec real releases use rel-<MAJOR><MINOR>0 (e.g. rel-810). Pattern is widened to rel-<alphanumeric> so test branches like rel-test can exercise the same workflow end-to-end without a real release-cut.",
       "type": "string",
-      "pattern": "^rel-\\d+\\d0$"
+      "pattern": "^rel-[A-Za-z0-9]+$"
     },
     "tag": {
       "description": "Release tag name. Per #664 spec: v<MAJOR>_<MINOR>_<PATCH>.",


### PR DESCRIPTION
After #12059 the release-prep mutator runs cleanly and `peter-evans/create-pull-request` opens the draft prep PR, but the dispatch step fails on schema validation:

```
Dispatch payload failed schema validation:
  data.branch: Does not match the regex pattern ^rel-\d+\d0$
```

The dispatch payload schema enforces the production branch convention (`rel-810`, `rel-700`, …) per the contract pinned in openemr-devops#664. That blocks end-to-end testing on a branch like `rel-test` — the conductor never gets to dispatch a real payload to the consumer repos, so we can't exercise the rest of the pipeline before a real release-cut.

Widens the pattern to `^rel-[A-Za-z0-9]+$`. Production names (`rel-810`, etc.) still match. Schema description updated to call out the test-branch use case.

Surfaced by [run 25506659601](https://github.com/openemr/openemr/actions/runs/25506659601). Follow-up to #11896 / #12048 / #12051 / #12057 / #12059.