### PR TITLE
refactor(portal): remove unnecessary encryption from one-time tokens

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -12732,17 +12732,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/import_template_ui.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'One time reset\\:\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/index.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'/js/xl/jquery…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/index.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'\\:invalid one time\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/index.php',
 ];

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -12463,12 +12463,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'Patient credential…\' and mixed results in an error\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../portal/account/account.lib.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'Patient password…\' and mixed results in an error\\.$#',
-    'count' => 8,
+    'count' => 7,
     'path' => __DIR__ . '/../../portal/account/account.lib.php',
 ];
 $ignoreErrors[] = [
@@ -12503,7 +12503,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 19,
+    'count' => 17,
     'path' => __DIR__ . '/../../portal/account/account.lib.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -2618,7 +2618,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../portal/index.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -3208,7 +3208,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 28,
+    'count' => 26,
     'path' => __DIR__ . '/../../portal/account/account.lib.php',
 ];
 $ignoreErrors[] = [
@@ -3278,7 +3278,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 35,
+    'count' => 33,
     'path' => __DIR__ . '/../../portal/index.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -5932,11 +5932,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/index.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) instead of sqlQueryNoLog\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/index.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../portal/index.php',

--- a/.phpstan/baseline/openemr.forbiddenErrorLog.php
+++ b/.phpstan/baseline/openemr.forbiddenErrorLog.php
@@ -288,11 +288,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../portal/index.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/lib/appsql.class.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -4193,7 +4193,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 29,
+    'count' => 28,
     'path' => __DIR__ . '/../../portal/index.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -4193,7 +4193,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 28,
+    'count' => 26,
     'path' => __DIR__ . '/../../portal/index.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -1932,16 +1932,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/validation/validation_script.js.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$token_database might not be defined\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../portal/account/account.lib.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$token_encrypt might not be defined\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../portal/account/account.lib.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$srcdir might not be defined\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../portal/account/account.php',
@@ -2073,11 +2063,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Variable \\$defaultLangName might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/index.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$one_time might not be defined\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/index.php',
 ];

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -49,7 +49,7 @@ return [
         'return.missing.php' => 0,
         'staticMethod.notFound.php' => 0,
         'trait.notFound.php' => 0,
-        'variable.undefined.php' => 550,
+        'variable.undefined.php' => 547,
     ],
     'confidentNonObject' => [
         'classConstant.nonObject.php' => 0,

--- a/portal/account/account.lib.php
+++ b/portal/account/account.lib.php
@@ -133,25 +133,24 @@ function verifyEmail(string $languageChoice, string $fname, string $mname, strin
         ServiceContainer::getLogger()->debug("verifyEmail function: the email will be used to register the patient");
 
         // create token (1 hour expiry) and ensure the token is unique
-        $unique = false;
-        for ($i = 1; $i <= 10; $i++) {
-            $expiry = new DateTime('NOW');
-            $expiry->add(new DateInterval('PT01H'));
+        $expiry = new DateTime('NOW');
+        $expiry->add(new DateInterval('PT01H'));
+        $attempt = 0;
+        do {
+            $attempt++;
             $token = RandomGenUtils::createUniqueToken(32);
-            $token_database = $token . bin2hex($expiry->format('U'));
-
             $sqlVerify = sqlQueryNoLog("SELECT `id` FROM `verify_email` WHERE `token_onetime` LIKE BINARY ?", [$token . '%']);
-            if (empty($sqlVerify['id'])) {
-                $unique = true;
-                break;
-            } else {
+            $isUnique = empty($sqlVerify['id']);
+            if (!$isUnique) {
                 ServiceContainer::getLogger()->error("was unable to create a unique token in verifyEmail function, which is very odd, so will try again (will try up to 10 times)");
             }
-        }
-        if (!$unique) {
+        } while (!$isUnique && $attempt < 10);
+
+        if (!$isUnique) {
             ServiceContainer::getLogger()->error("was unable to create a unique token in verifyEmail function, so failed");
             return false;
         }
+        $token_database = $token . bin2hex($expiry->format('U'));
 
         // place/replace database entry
         $sql = sqlQuery("SELECT `id` FROM `verify_email` WHERE `email` = ?", [$email]);

--- a/portal/account/account.lib.php
+++ b/portal/account/account.lib.php
@@ -138,7 +138,7 @@ function verifyEmail(string $languageChoice, string $fname, string $mname, strin
         $attempt = 0;
         do {
             $attempt++;
-            $token = RandomGenUtils::createUniqueToken(32);
+            $token = RandomGenUtils::createUniqueToken(RandomGenUtils::DEFAULT_TOKEN_LENGTH);
             $sqlVerify = sqlQueryNoLog("SELECT `id` FROM `verify_email` WHERE `token_onetime` LIKE BINARY ?", [$token . '%']);
             $isUnique = empty($sqlVerify['id']);
             if (!$isUnique) {
@@ -377,7 +377,7 @@ function doCredentials($pid, $resetPass = false, $resetPassEmail = ''): bool
     $expiry = new DateTime('NOW');
     $expiry->add(new DateInterval('PT01H'));
 
-    $token = RandomGenUtils::createUniqueToken(32);
+    $token = RandomGenUtils::createUniqueToken(RandomGenUtils::DEFAULT_TOKEN_LENGTH);
     $pin = RandomGenUtils::createUniqueToken(6);
     if (!$resetPass) {
         $clear_pass = RandomGenUtils::generatePortalPassword();

--- a/portal/account/account.lib.php
+++ b/portal/account/account.lib.php
@@ -137,16 +137,10 @@ function verifyEmail(string $languageChoice, string $fname, string $mname, strin
         for ($i = 1; $i <= 10; $i++) {
             $expiry = new DateTime('NOW');
             $expiry->add(new DateInterval('PT01H'));
-            $token_raw = RandomGenUtils::createUniqueToken(32);
-            $token_encrypt = (ServiceContainer::getCrypto())->encryptStandard($token_raw);
-            if (empty($token_encrypt)) {
-                // Serious issue if this is case, so return that something bad happened.
-                ServiceContainer::getLogger()->error("OpenEMR Error : Portal email verification token encryption broken - exiting");
-                return false;
-            }
-            $token_database = $token_raw . bin2hex($expiry->format('U'));
+            $token = RandomGenUtils::createUniqueToken(32);
+            $token_database = $token . bin2hex($expiry->format('U'));
 
-            $sqlVerify = sqlQueryNoLog("SELECT `id` FROM `verify_email` WHERE `token_onetime` LIKE BINARY ?", [$token_raw . '%']);
+            $sqlVerify = sqlQueryNoLog("SELECT `id` FROM `verify_email` WHERE `token_onetime` LIKE BINARY ?", [$token . '%']);
             if (empty($sqlVerify['id'])) {
                 $unique = true;
                 break;
@@ -194,12 +188,12 @@ function verifyEmail(string $languageChoice, string $fname, string $mname, strin
         $site_id = $session->get('site_id');
         if (stripos($site_addr, (string) $site_id) === false) {
             $encoded_link = sprintf("%s?%s", attr($site_addr), http_build_query([
-                'forward_email_verify' => $token_encrypt,
+                'forward_email_verify' => $token,
                 'site' => $site_id
             ]));
         } else {
             $encoded_link = sprintf("%s&%s", attr($site_addr), http_build_query([
-                'forward_email_verify' => $token_encrypt
+                'forward_email_verify' => $token
             ]));
         }
         $template = 'verify-success';
@@ -384,26 +378,11 @@ function doCredentials($pid, $resetPass = false, $resetPassEmail = ''): bool
     $expiry = new DateTime('NOW');
     $expiry->add(new DateInterval('PT01H'));
 
-    $token_new = RandomGenUtils::createUniqueToken(32);
+    $token = RandomGenUtils::createUniqueToken(32);
     $pin = RandomGenUtils::createUniqueToken(6);
     if (!$resetPass) {
         $clear_pass = RandomGenUtils::generatePortalPassword();
         $uname = $newpd['fname'] . $newpd['id'];
-    }
-
-    // Will send a link to user with encrypted token
-    $token = (ServiceContainer::getCrypto())->encryptStandard($token_new);
-    if (empty($token)) {
-        // Serious issue if this is case, so exit.
-        if ($resetPass) {
-            EventAuditLogger::getInstance()->newEvent('patient-password-reset', '', '', 0, "Patient password reset failure secondary critical encryption error for email " . $newpd['email'] . " and pid: " . $pid);
-            ServiceContainer::getLogger()->error("Error : Token encryption failed during patient password reset - exiting");
-            return false;
-        } else { // !$resetPass
-            EventAuditLogger::getInstance()->newEvent('patient-registration', '', '', 0, "Patient credential creation registration failure secondary critical encryption error for email " . $newpd['email'] . " and pid: " . $pid);
-            ServiceContainer::getLogger()->error("Error : Token encryption failed during patient registration - exiting");
-            return false;
-        }
     }
     $site_addr = $globalsBag->getString('portal_onsite_two_address');
     $site_id = $session->get('site_id');
@@ -428,8 +407,8 @@ function doCredentials($pid, $resetPass = false, $resetPassEmail = ''): bool
         }
     }
 
-    // Will store unencrypted token in database with the pin and expiration date
-    $one_time = $token_new . $pin . bin2hex($expiry->format('U'));
+    // Store token in database with the pin and expiration date
+    $one_time = $token . $pin . bin2hex($expiry->format('U'));
     if ($resetPass) {
         // already confirmed there is an entry in patient_access_onsite in previously called resetPassword function
         // (note that portal_username, portal_pwd_status and portal_pwd are not touched here since password needs to remain valid until patient

--- a/portal/index.php
+++ b/portal/index.php
@@ -27,10 +27,12 @@ use OpenEMR\Common\Auth\Exception\OneTimeAuthException;
 use OpenEMR\Common\Auth\Exception\OneTimeAuthExpiredException;
 use OpenEMR\Common\Auth\OneTimeAuth;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Common\Utils\RandomGenUtils;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\LogoService;
@@ -167,7 +169,7 @@ if (!empty($_GET['forward_email_verify'])) {
     }
 
     $token_one_time = is_string($_GET['forward_email_verify']) ? $_GET['forward_email_verify'] : '';
-    if (strlen($token_one_time) !== 32 || !ctype_alnum($token_one_time)) {
+    if (strlen($token_one_time) !== RandomGenUtils::DEFAULT_TOKEN_LENGTH || !ctype_alnum($token_one_time)) {
         ServiceContainer::getLogger()->debug("invalid token format, so stopped attempt to use forward_email_verify token");
         SessionUtil::portalSessionCookieDestroy();
         header('Location: ' . $landingpage . '&w&u');
@@ -244,14 +246,33 @@ if (!empty($_GET['forward_email_verify'])) {
         header('Location: ' . $landingpage . '&w&u');
         exit();
     }
-    $auth = false;
     $one_time = is_string($_GET['forward']) ? $_GET['forward'] : '';
-    if (strlen($one_time) === 32 && ctype_alnum($one_time)) {
-        $auth = sqlQueryNoLog("Select * From patient_access_onsite Where portal_onetime Like BINARY ?", [$one_time . '%']);
-    }
-    if ($auth === false) {
-        error_log("PORTAL ERROR: " . errorLogEscape('One time reset: invalid token'), 0);
+    if (strlen($one_time) !== RandomGenUtils::DEFAULT_TOKEN_LENGTH || !ctype_alnum($one_time)) {
+        ServiceContainer::getLogger()->error('One time reset: invalid token format');
         $logit->portalLog('login attempt', '', 'invalid one time token', '', '0');
+        SessionUtil::portalSessionCookieDestroy();
+        header('Location: ' . $landingpage . '&w&u');
+        exit();
+    }
+    $records = QueryUtils::fetchRecordsNoLog("SELECT * FROM `patient_access_onsite` WHERE `portal_onetime` LIKE BINARY ?", [$one_time . '%']);
+    if (count($records) > 1) {
+        ServiceContainer::getLogger()->debug("token found more than once, so stopped attempt to use forward token");
+        EventAuditLogger::getInstance()->newEvent('patient-reset-credentials', '', '', 0, "token found more than once, so stopped attempt to use forward token");
+        SessionUtil::portalSessionCookieDestroy();
+        header('Location: ' . $landingpage . '&w&u');
+        exit();
+    }
+    if (count($records) === 0) {
+        ServiceContainer::getLogger()->error("One time reset: token not found");
+        $logit->portalLog('login attempt', '', 'invalid one time token', '', '0');
+        SessionUtil::portalSessionCookieDestroy();
+        header('Location: ' . $landingpage . '&w&u');
+        exit();
+    }
+    $auth = $records[0];
+    if (!array_key_exists('portal_onetime', $auth)) {
+        ServiceContainer::getLogger()->debug("token data not properly set up, so stopped attempt to use forward token");
+        EventAuditLogger::getInstance()->newEvent('patient-reset-credentials', '', '', 0, "token data not properly set up, so stopped attempt to use forward token");
         SessionUtil::portalSessionCookieDestroy();
         header('Location: ' . $landingpage . '&w&u');
         exit();
@@ -259,7 +280,7 @@ if (!empty($_GET['forward_email_verify'])) {
     $parse = str_replace($one_time, '', $auth['portal_onetime']);
     $validate = hex2bin(substr($parse, 6));
     if ($validate <= time()) {
-        error_log("PORTAL ERROR: " . errorLogEscape('One time reset link expired. Dying.'), 0);
+        ServiceContainer::getLogger()->error('One time reset link expired');
         $logit->portalLog('password reset attempt', '', ($_POST['uname'] . ':link expired'), '', '0');
         SessionUtil::portalSessionCookieDestroy();
         die(xlt("Your one time credential reset link has expired. Reset and try again.") . "time:$validate time:" . time());

--- a/portal/index.php
+++ b/portal/index.php
@@ -176,23 +176,23 @@ if (!empty($_GET['forward_email_verify'])) {
 
     $sqlResource = sqlStatementNoLog("SELECT `id`, `token_onetime`, `fname`, `mname`, `lname`, `dob`, `email`, `language` FROM `verify_email` WHERE `active` = 1 AND `token_onetime` LIKE BINARY ?", [$token_one_time . '%']);
     if (sqlNumRows($sqlResource) > 1) {
-        ServiceContainer::getLogger()->debug("active token (" . $token_one_time . ") found more than once, so stopped attempt to use forward_email_verify token");
-        EventAuditLogger::getInstance()->newEvent('patient-reg-email-verify', '', '', 0, "active token (" . $token_one_time . ") found more than once, so stopped attempt to use forward_email_verify token");
+        ServiceContainer::getLogger()->debug("active token found more than once, so stopped attempt to use forward_email_verify token");
+        EventAuditLogger::getInstance()->newEvent('patient-reg-email-verify', '', '', 0, "active token found more than once, so stopped attempt to use forward_email_verify token");
         SessionUtil::portalSessionCookieDestroy();
         header('Location: ' . $landingpage . '&w&u');
         exit();
     }
     if (!sqlNumRows($sqlResource)) {
-        ServiceContainer::getLogger()->debug("active token (" . $token_one_time . ") not found, so stopped attempt to use forward_email_verify token");
-        EventAuditLogger::getInstance()->newEvent('patient-reg-email-verify', '', '', 0, "active token (" . $token_one_time . ") not found, so stopped attempt to use forward_email_verify token");
+        ServiceContainer::getLogger()->debug("active token not found, so stopped attempt to use forward_email_verify token");
+        EventAuditLogger::getInstance()->newEvent('patient-reg-email-verify', '', '', 0, "active token not found, so stopped attempt to use forward_email_verify token");
         SessionUtil::portalSessionCookieDestroy();
         header('Location: ' . $landingpage . '&w&u');
         exit();
     }
     $sqlVerify = sqlFetchArray($sqlResource);
     if (empty($sqlVerify['id']) || empty($sqlVerify['token_onetime'])) {
-        ServiceContainer::getLogger()->debug("active token (" . $token_one_time . ") not properly set up, so stopped attempt to use forward_email_verify token");
-        EventAuditLogger::getInstance()->newEvent('patient-reg-email-verify', '', '', 0, "active token (" . $token_one_time . ") not properly set up, so stopped attempt to use forward_email_verify token");
+        ServiceContainer::getLogger()->debug("active token not properly set up, so stopped attempt to use forward_email_verify token");
+        EventAuditLogger::getInstance()->newEvent('patient-reg-email-verify', '', '', 0, "active token not properly set up, so stopped attempt to use forward_email_verify token");
         SessionUtil::portalSessionCookieDestroy();
         header('Location: ' . $landingpage . '&w&u');
         exit();
@@ -202,8 +202,8 @@ if (!empty($_GET['forward_email_verify'])) {
 
     $validateTime = hex2bin(str_replace($token_one_time, '', $sqlVerify['token_onetime']));
     if ($validateTime <= time()) {
-        ServiceContainer::getLogger()->debug("active token (" . $token_one_time . ") has expired, so stopped attempt to use forward_email_verify token");
-        EventAuditLogger::getInstance()->newEvent('patient-reg-email-verify', '', '', 0, "active token (" . $token_one_time . ") has expired, so stopped attempt to use forward_email_verify token");
+        ServiceContainer::getLogger()->debug("active token has expired, so stopped attempt to use forward_email_verify token");
+        EventAuditLogger::getInstance()->newEvent('patient-reg-email-verify', '', '', 0, "active token has expired, so stopped attempt to use forward_email_verify token");
         SessionUtil::portalSessionCookieDestroy();
         die(xlt("Your email verification link has expired. Reset and try again."));
     }
@@ -227,12 +227,12 @@ if (!empty($_GET['forward_email_verify'])) {
             'token_id_holder' => $sqlVerify['id'],
         ]);
         ServiceContainer::getLogger()->debug("token worked for forward_email_verify token, now on to registration");
-        EventAuditLogger::getInstance()->newEvent('patient-reg-email-verify', '', '', 1, "token (" . $token_one_time . ") was successful for forward_email_verify token");
+        EventAuditLogger::getInstance()->newEvent('patient-reg-email-verify', '', '', 1, "token was successful for forward_email_verify token");
         require_once(__DIR__ . "/account/register.php");
         exit();
     } else {
-        ServiceContainer::getLogger()->debug("active token (" . $token_one_time . ") did not have all required data, so stopped attempt to use forward_email_verify token");
-        EventAuditLogger::getInstance()->newEvent('patient-reg-email-verify', '', '', 0, "active token (" . $token_one_time . ") did not have all required data, so stopped attempt to use forward_email_verify token");
+        ServiceContainer::getLogger()->debug("active token did not have all required data, so stopped attempt to use forward_email_verify token");
+        EventAuditLogger::getInstance()->newEvent('patient-reg-email-verify', '', '', 0, "active token did not have all required data, so stopped attempt to use forward_email_verify token");
         SessionUtil::portalSessionCookieDestroy();
         header('Location: ' . $landingpage . '&w&u');
         exit();
@@ -250,8 +250,8 @@ if (!empty($_GET['forward_email_verify'])) {
         $auth = sqlQueryNoLog("Select * From patient_access_onsite Where portal_onetime Like BINARY ?", [$one_time . '%']);
     }
     if ($auth === false) {
-        error_log("PORTAL ERROR: " . errorLogEscape('One time reset:' . $_GET['forward']), 0);
-        $logit->portalLog('login attempt', '', ($_GET['forward'] . ':invalid one time'), '', '0');
+        error_log("PORTAL ERROR: " . errorLogEscape('One time reset: invalid token'), 0);
+        $logit->portalLog('login attempt', '', 'invalid one time token', '', '0');
         SessionUtil::portalSessionCookieDestroy();
         header('Location: ' . $landingpage . '&w&u');
         exit();

--- a/portal/index.php
+++ b/portal/index.php
@@ -166,18 +166,9 @@ if (!empty($_GET['forward_email_verify'])) {
         exit();
     }
 
-    $crypto = ServiceContainer::getCrypto();
-    $forwardEmailVerify = is_string($_GET['forward_email_verify']) ? $_GET['forward_email_verify'] : null;
-    if (!$crypto->cryptCheckStandard($forwardEmailVerify)) {
-        ServiceContainer::getLogger()->debug("illegal token, so stopped attempt to use forward_email_verify token");
-        SessionUtil::portalSessionCookieDestroy();
-        header('Location: ' . $landingpage . '&w&u');
-        exit();
-    }
-
-    $token_one_time = $crypto->decryptStandard($forwardEmailVerify, minimumVersion: 6);
-    if (empty($token_one_time)) {
-        ServiceContainer::getLogger()->debug("unable to decrypt token, so stopped attempt to use forward_email_verify token");
+    $token_one_time = is_string($_GET['forward_email_verify']) ? $_GET['forward_email_verify'] : '';
+    if (strlen($token_one_time) !== 32 || !ctype_alnum($token_one_time)) {
+        ServiceContainer::getLogger()->debug("invalid token format, so stopped attempt to use forward_email_verify token");
         SessionUtil::portalSessionCookieDestroy();
         header('Location: ' . $landingpage . '&w&u');
         exit();
@@ -254,15 +245,9 @@ if (!empty($_GET['forward_email_verify'])) {
         exit();
     }
     $auth = false;
-    if (strlen((string) $_GET['forward']) >= 64) {
-        $crypto = ServiceContainer::getCrypto();
-        $forwardToken = is_string($_GET['forward']) ? $_GET['forward'] : null;
-        if ($crypto->cryptCheckStandard($forwardToken)) {
-            $one_time = $crypto->decryptStandard($forwardToken, minimumVersion: 6);
-            if (!empty($one_time)) {
-                $auth = sqlQueryNoLog("Select * From patient_access_onsite Where portal_onetime Like BINARY ?", [$one_time . '%']);
-            }
-        }
+    $one_time = is_string($_GET['forward']) ? $_GET['forward'] : '';
+    if (strlen($one_time) === 32 && ctype_alnum($one_time)) {
+        $auth = sqlQueryNoLog("Select * From patient_access_onsite Where portal_onetime Like BINARY ?", [$one_time . '%']);
     }
     if ($auth === false) {
         error_log("PORTAL ERROR: " . errorLogEscape('One time reset:' . $_GET['forward']), 0);

--- a/src/Common/Utils/RandomGenUtils.php
+++ b/src/Common/Utils/RandomGenUtils.php
@@ -14,6 +14,7 @@ namespace OpenEMR\Common\Utils;
 
 class RandomGenUtils
 {
+    public const DEFAULT_TOKEN_LENGTH = 32;
     /**
      * @deprecated Use random_bytes() directly
      */


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Removes encryption/decryption overhead from portal one-time tokens (email verification and password reset links). The 32-character random tokens are already cryptographically unguessable — encryption added complexity without security benefit.

#### Changes proposed in this pull request:

- Remove `encryptStandard()` calls when generating tokens in `account.lib.php`
- Remove `decryptStandard()` and `cryptCheckStandard()` calls when validating tokens in `index.php`
- Replace crypto validation with simple format check (32 alphanumeric characters)
- Restructure token generation loop from `for` to `do/while` for clearer control flow
- Regenerate PHPStan baseline

**Security note:** The tokens use `RandomGenUtils::createUniqueToken(32)` which generates 32 characters from a 62-character alphabet, providing ~190 bits of entropy. This randomness is what prevents guessing — the encryption layer was security theater.

#### Was an AI assistant used? Yes

All commits include the `Assisted-by: Claude Code` trailer.

🤖 Generated with [Claude Code](https://claude.ai/code)