### PR TITLE
feat(release): add test mode to release-prep workflow

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -103,6 +103,17 @@ jobs:
             branch="${INPUT_BRANCH}"
             version="${INPUT_VERSION}"
             test_mode="${INPUT_TEST}"
+            # Production runs must dispatch against the same ref they target,
+            # otherwise the mutators run on the dispatched ref's tree but
+            # peter-evans opens the PR against base=inputs.branch, producing
+            # a confusing diff. Test runs intentionally diverge: they
+            # dispatch against a feature branch (to pick up new conductor
+            # logic) while targeting a real test branch.
+            ref_branch="${REF#refs/heads/}"
+            if [ "${test_mode}" != 'true' ] && [ "${ref_branch}" != "${branch}" ]; then
+              echo "::error::workflow dispatched with --ref '${ref_branch}' but --branch='${branch}'; production runs must dispatch against the target branch. Set test=true if you intentionally want a feature-branch ref."
+              exit 1
+            fi
             ;;
           *)
             branch="${REF#refs/heads/}"

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -100,18 +100,28 @@ jobs:
       run: |
         case "${EVENT_NAME}" in
           workflow_dispatch)
-            echo "branch=${INPUT_BRANCH}"
-            echo "version=${INPUT_VERSION}"
+            branch="${INPUT_BRANCH}"
+            version="${INPUT_VERSION}"
             test_mode="${INPUT_TEST}"
             ;;
           *)
             branch="${REF#refs/heads/}"
-            echo "branch=${branch}"
-            printf 'version='
-            php tools/release/bin/branch-to-version.php "${branch}"
+            # The push glob (rel-[0-9]*0) is broader than what
+            # branch-to-version.php accepts (^rel-(\d+)(\d)0$, i.e.
+            # >=3 digits ending in 0). Guard explicitly so an off-pattern
+            # match like rel-10 surfaces a workflow-level ::error:: rather
+            # than a bare PHP stderr buried in the step log.
+            if ! version="$(php tools/release/bin/branch-to-version.php "${branch}" 2>&1)"; then
+              echo "::error::push trigger matched branch '${branch}' but branch-to-version rejected it: ${version}"
+              exit 1
+            fi
             test_mode='false'
             ;;
-        esac >> "$GITHUB_OUTPUT"
+        esac
+        {
+          echo "branch=${branch}"
+          echo "version=${version}"
+        } >> "$GITHUB_OUTPUT"
         # Encode test mode in the prep PR's head branch name so the finalize
         # job can detect it from pull_request.head.ref alone (no API call).
         if [ "${test_mode}" = 'true' ]; then

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -29,6 +29,11 @@ on:
         description: 'Release branch (rel-NNN)'
         required: true
         type: string
+      test:
+        description: 'Test mode: open the prep PR under release-prep-test/<branch> so its merge produces a v{M}_{m}_{p}-test.{shortSha} tag instead of a real release tag. Use to exercise the conductor end-to-end without cutting a real release.'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -87,19 +92,31 @@ jobs:
         REF: ${{ github.ref }}
         INPUT_BRANCH: ${{ inputs.branch }}
         INPUT_VERSION: ${{ inputs.target-version }}
+        INPUT_TEST: ${{ inputs.test }}
       run: |
         case "${EVENT_NAME}" in
           workflow_dispatch)
             echo "branch=${INPUT_BRANCH}"
             echo "version=${INPUT_VERSION}"
+            test_mode="${INPUT_TEST}"
             ;;
           *)
             branch="${REF#refs/heads/}"
             echo "branch=${branch}"
             printf 'version='
             php tools/release/bin/branch-to-version.php "${branch}"
+            test_mode='false'
             ;;
         esac >> "$GITHUB_OUTPUT"
+        # Encode test mode in the prep PR's head branch name so the finalize
+        # job can detect it from pull_request.head.ref alone (no API call).
+        if [ "${test_mode}" = 'true' ]; then
+          echo "prep-prefix=release-prep-test"
+          echo "title-prefix=[TEST] "
+        else
+          echo "prep-prefix=release-prep"
+          echo "title-prefix="
+        fi >> "$GITHUB_OUTPUT"
 
     - name: Render PR body
       id: pr-body
@@ -129,11 +146,11 @@ jobs:
       uses: peter-evans/create-pull-request@v8
       with:
         token: ${{ steps.app-token.outputs.token }}
-        branch: release-prep/${{ steps.resolve.outputs.branch }}
+        branch: ${{ steps.resolve.outputs.prep-prefix }}/${{ steps.resolve.outputs.branch }}
         base: ${{ steps.resolve.outputs.branch }}
-        title: 'release-prep: ${{ steps.resolve.outputs.version }}'
+        title: '${{ steps.resolve.outputs.title-prefix }}release-prep: ${{ steps.resolve.outputs.version }}'
         body: ${{ steps.pr-body.outputs.body }}
-        commit-message: 'release-prep: ${{ steps.resolve.outputs.version }}'
+        commit-message: '${{ steps.resolve.outputs.title-prefix }}release-prep: ${{ steps.resolve.outputs.version }}'
         author: 'openemr-release-bot <release-bot@openemr.invalid>'
         committer: 'openemr-release-bot <release-bot@openemr.invalid>'
         draft: true
@@ -172,7 +189,8 @@ jobs:
     if: |
       github.event_name == 'pull_request'
       && github.event.pull_request.merged == true
-      && startsWith(github.event.pull_request.head.ref, 'release-prep/')
+      && (startsWith(github.event.pull_request.head.ref, 'release-prep/')
+          || startsWith(github.event.pull_request.head.ref, 'release-prep-test/'))
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -205,41 +223,61 @@ jobs:
       with:
         php-version: ${{ matrix.php-version }}
 
-    - name: Resolve version from base branch
+    - name: Resolve version, test-mode, and branch from merged PR
       id: resolve
       env:
         BASE_REF: ${{ github.event.pull_request.base.ref }}
+        HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
       run: |
+        # The prep job encodes test-mode into the PR head ref
+        # (release-prep-test/<rel-branch>) and the version into the PR
+        # title ('[TEST] release-prep: <version>'). Branch-to-version
+        # only handles production rel-NNN0 branches, so test-mode reads
+        # the version straight out of the title we authored.
+        if [[ "${HEAD_REF}" == release-prep-test/* ]]; then
+          test_mode='true'
+          version="${PR_TITLE##*release-prep: }"
+        else
+          test_mode='false'
+          version="$(php tools/release/bin/branch-to-version.php "${BASE_REF}")"
+        fi
         {
           echo "branch=${BASE_REF}"
-          printf 'version='
-          php tools/release/bin/branch-to-version.php "${BASE_REF}"
+          echo "version=${version}"
+          echo "test=${test_mode}"
         } >> "$GITHUB_OUTPUT"
 
     - name: Create annotated tag
+      id: tag
       env:
         RELEASE_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         REPO: ${{ github.repository }}
         VERSION: ${{ steps.resolve.outputs.version }}
         MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         PR_URL: ${{ github.event.pull_request.html_url }}
+        TEST_MODE: ${{ steps.resolve.outputs.test }}
       run: |
-        php tools/release/bin/create-tag.php \
-          --repo="${REPO}" \
-          --release-version="${VERSION}" \
-          --commit-sha="${MERGE_SHA}" \
+        args=(
+          --repo="${REPO}"
+          --release-version="${VERSION}"
+          --commit-sha="${MERGE_SHA}"
           --conductor-pr-url="${PR_URL}"
+        )
+        if [ "${TEST_MODE}" = 'true' ]; then
+          args+=(--test)
+        fi
+        php tools/release/bin/create-tag.php "${args[@]}"
 
     - name: Verify annotated tag
       env:
-        VERSION: ${{ steps.resolve.outputs.version }}
+        TAG_NAME: ${{ steps.tag.outputs.tag-name }}
       run: |
-        tag_name="v${VERSION//./_}"
         # The tag was just created via the API; the local checkout
         # doesn't have it yet. Fetch it before handing the local repo
         # to TagVerifier.
         git fetch --tags --quiet
-        php tools/release/bin/verify-tag.php "${tag_name}"
+        php tools/release/bin/verify-tag.php "${TAG_NAME}"
 
     - name: Dispatch openemr-tag to consumers
       env:
@@ -247,12 +285,12 @@ jobs:
         VERSION: ${{ steps.resolve.outputs.version }}
         REL_BRANCH: ${{ steps.resolve.outputs.branch }}
         MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        TAG_NAME: ${{ steps.tag.outputs.tag-name }}
       run: |
-        tag_name="v${VERSION//./_}"
         php tools/release/bin/dispatch.php \
           --event=openemr-tag \
           --sha="${MERGE_SHA}" \
           --actor='openemr-release-bot' \
           --branch="${REL_BRANCH}" \
           --release-version="${VERSION}" \
-          --tag="${tag_name}"
+          --tag="${TAG_NAME}"

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -10,8 +10,12 @@ name: Release Prep Conductor
 
 on:
   push:
+    # Production rel-* branches only. branch-to-version.php on the push
+    # path requires rel-<MAJOR><MINOR>0 and would crash on a stray push
+    # to a test branch like rel-test. Test runs come in via
+    # workflow_dispatch instead.
     branches:
-    - 'rel-*'
+    - 'rel-[0-9]*0'
     paths-ignore:
     - 'docs/**'
   pull_request:
@@ -237,7 +241,15 @@ jobs:
         # the version straight out of the title we authored.
         if [[ "${HEAD_REF}" == release-prep-test/* ]]; then
           test_mode='true'
-          version="${PR_TITLE##*release-prep: }"
+          # Extract MAJOR.MINOR.PATCH explicitly so an edited PR title
+          # surfaces a clear failure here instead of a downstream
+          # InvalidArgumentException from TagCreationRequest.
+          if [[ "${PR_TITLE}" =~ release-prep:[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            version="${BASH_REMATCH[1]}"
+          else
+            echo "::error::could not parse MAJOR.MINOR.PATCH from PR title: ${PR_TITLE}"
+            exit 1
+          fi
         else
           test_mode='false'
           version="$(php tools/release/bin/branch-to-version.php "${BASE_REF}")"

--- a/tests/Tests/Isolated/Release/Contracts/DispatchSchemaTest.php
+++ b/tests/Tests/Isolated/Release/Contracts/DispatchSchemaTest.php
@@ -34,6 +34,7 @@ final class DispatchSchemaTest extends TestCase
         yield 'openemr-rel-cut'       => ['good-rel-cut.json'];
         yield 'openemr-rel-update'    => ['good-rel-update.json'];
         yield 'openemr-tag'           => ['good-tag.json'];
+        yield 'openemr-tag (test)'    => ['good-tag-test.json'];
         yield 'openemr-docs-binaries' => ['good-docs-binaries.json'];
     }
 

--- a/tests/Tests/Isolated/Release/TagCreatorTest.php
+++ b/tests/Tests/Isolated/Release/TagCreatorTest.php
@@ -94,6 +94,22 @@ final class TagCreatorTest extends TestCase
         ));
     }
 
+    public function testTestModeTagAppendsShortShaSuffix(): void
+    {
+        $request = new TagCreationRequest(
+            repo: 'openemr/openemr',
+            version: '8.1.0',
+            commitSha: 'abcdef0' . str_repeat('1', 33),
+            conductorPrUrl: 'https://example.test',
+            appToken: 'token',
+            date: '2026-04-29',
+            test: true,
+        );
+
+        self::assertSame('v8_1_0-test.abcdef0', $request->tagName());
+        self::assertStringContainsString('test-release tag (not a real release)', $request->renderMessage());
+    }
+
     public function testRequestRejectsBadVersion(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag-test.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag-test.json
@@ -1,0 +1,12 @@
+{
+  "event": "openemr-tag",
+  "repo": "openemr/openemr",
+  "sha": "abcdef0123456789abcdef0123456789abcdef01",
+  "actor": "openemr-release-bot",
+  "dispatched_at": "2026-04-29T12:30:00Z",
+  "data": {
+    "tag": "v8_1_0-test.abcdef0",
+    "branch": "rel-test",
+    "version": "8.1.0"
+  }
+}

--- a/tools/release/bin/create-tag.php
+++ b/tools/release/bin/create-tag.php
@@ -50,6 +50,12 @@ use Symfony\Component\HttpClient\HttpClient;
         'GitHub App installation token (or set RELEASE_APP_TOKEN)',
     )
     ->addOption('date', null, InputOption::VALUE_REQUIRED, 'Release date (YYYY-MM-DD; defaults to today UTC)')
+    ->addOption(
+        'test',
+        null,
+        InputOption::VALUE_NONE,
+        'Format the tag as v{M}_{m}_{p}-test.{shortSha} so a test merge does not collide with a real release tag',
+    )
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
         $opts = new OptionReader($input);
         $token = $opts->string('app-token');
@@ -70,6 +76,7 @@ use Symfony\Component\HttpClient\HttpClient;
                 conductorPrUrl: $opts->string('conductor-pr-url'),
                 appToken: $token,
                 date: $date,
+                test: (bool) $input->getOption('test'),
             );
         } catch (\InvalidArgumentException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
@@ -85,6 +92,17 @@ use Symfony\Component\HttpClient\HttpClient;
         }
 
         $output->writeln(sprintf('<info>Created tag %s (sha: %s)</info>', $result->tagName, $result->tagSha));
+        // Emit GitHub Actions step outputs when running under Actions so the
+        // workflow's verify and dispatch steps consume the canonical tag name
+        // instead of recomputing it (which would diverge in test mode).
+        $githubOutput = getenv('GITHUB_OUTPUT');
+        if (is_string($githubOutput) && $githubOutput !== '') {
+            file_put_contents(
+                $githubOutput,
+                sprintf("tag-name=%s\ntag-sha=%s\n", $result->tagName, $result->tagSha),
+                FILE_APPEND,
+            );
+        }
         return 0;
     })
     ->run();

--- a/tools/release/contracts/dispatch.schema.json
+++ b/tools/release/contracts/dispatch.schema.json
@@ -102,9 +102,9 @@
       "pattern": "^rel-[A-Za-z0-9]+$"
     },
     "tag": {
-      "description": "Release tag name. Per #664 spec: v<MAJOR>_<MINOR>_<PATCH>.",
+      "description": "Release tag name. Per #664 spec real releases use v<MAJOR>_<MINOR>_<PATCH>. Test runs append -test.<shortSha> (7 hex chars) so a test merge does not collide with a real release tag.",
       "type": "string",
-      "pattern": "^v\\d+_\\d+_\\d+$"
+      "pattern": "^v\\d+_\\d+_\\d+(-test\\.[0-9a-f]{7})?$"
     },
     "relCutData": {
       "type": "object",

--- a/tools/release/src/TagCreationRequest.php
+++ b/tools/release/src/TagCreationRequest.php
@@ -26,6 +26,7 @@ final readonly class TagCreationRequest
         public string $conductorPrUrl,
         public string $appToken,
         public string $date,
+        public bool $test = false,
         public string $taggerName = 'openemr-release-bot',
         public string $taggerEmail = 'release-bot@openemr.invalid',
     ) {
@@ -48,13 +49,20 @@ final readonly class TagCreationRequest
 
     public function tagName(): string
     {
-        return 'v' . str_replace('.', '_', $this->version);
+        $base = 'v' . str_replace('.', '_', $this->version);
+        if (!$this->test) {
+            return $base;
+        }
+        return $base . '-test.' . substr($this->commitSha, 0, 7);
     }
 
     public function renderMessage(): string
     {
-        $template = <<<'TPL'
-        OpenEMR %s released %s
+        $headline = $this->test
+            ? 'OpenEMR %s test-release tag (not a real release) cut %s'
+            : 'OpenEMR %s released %s';
+        $template = <<<TPL
+        {$headline}
 
         Conductor PR: %s
         Merge commit: %s


### PR DESCRIPTION
Adds a `test` boolean input to `release-prep.yml`'s `workflow_dispatch`. Lets the conductor be exercised end-to-end against a `rel-test` (or any non-production) branch without producing a tag that collides with a real release.

## Behavior when `test=true`

- Prep job opens the long-lived prep PR under `release-prep-test/<rel-branch>` (vs `release-prep/<rel-branch>`) and prefixes the title with `[TEST] `. The branch-name encoding lets `finalize` detect test mode from `pull_request.head.ref` alone — no API lookup.
- Finalize job derives the version from the PR title (since `branch-to-version.php` only handles production `rel-NNN0` branches), passes `--test` to `create-tag.php`, and consumes the canonical `tag-name` step output for the verify and dispatch steps. Test tags can't be recomputed from version alone — they include the merge-commit short SHA.
- `create-tag.php` formats the tag as `v{M}_{m}_{p}-test.{shortSha}` (e.g. `v8_1_1-test.abcdef0`) and uses a `test-release tag (not a real release)` headline in the tag message so anyone running `git show <tag>` can immediately tell it's not a real release.
- Schema `tag` pattern widened to accept either shape: `^v\d+_\d+_\d+(-test\.[0-9a-f]{7})?$`.

The format intentionally keeps the `v{M}_{m}_{p}` root so when we eventually switch the production tag format to true semver (`{M}.{m}.{p}`), the test-mode formatter migrates with it without any separate work.

## Test plan

- Existing `DispatchSchemaTest` and `TagCreatorTest` cases still pass.
- New cases:
  - `DispatchSchemaTest` — `good-tag-test.json` fixture validates against the widened pattern.
  - `TagCreatorTest::testTestModeTagAppendsShortShaSuffix` — asserts `tagName()` produces `v8_1_0-test.abcdef0` and `renderMessage()` carries the test-release headline.
- End-to-end: dispatched against the branch ref with `test=true, branch=rel-test, target-version=8.1.1`. Verify the prep PR opens under `release-prep-test/rel-test`, the merge produces a `v8_1_1-test.{shortSha}` tag, and the openemr-tag dispatch payload validates.

Refs #11896, openemr/openemr-devops#664. Follow-up to #12061.