### PR TITLE
refactor(sphere): use session storage instead of encryption for payment data

### DIFF
--- a/.phpstan/baseline/cast.int.php
+++ b/.phpstan/baseline/cast.int.php
@@ -618,11 +618,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to int\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/lib/paylib.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to int\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../portal/messaging/messages.php',
 ];

--- a/.phpstan/baseline/cast.int.php
+++ b/.phpstan/baseline/cast.int.php
@@ -618,6 +618,11 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to int\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../portal/lib/paylib.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot cast mixed to int\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../portal/messaging/messages.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -35682,21 +35682,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/lib/paylib.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'authcode\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/lib/paylib.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'cc\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/lib/paylib.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ccBrand\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/lib/paylib.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'currency\' on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../portal/lib/paylib.php',
@@ -35707,18 +35692,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/lib/paylib.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'get\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/lib/paylib.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'id\' on mixed\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../portal/lib/paylib.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'name\' on mixed\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../portal/lib/paylib.php',
 ];
 $ignoreErrors[] = [
@@ -35732,27 +35707,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/lib/paylib.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'patient_id_cc\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/lib/paylib.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'post\' on mixed\\.$#',
-    'count' => 6,
-    'path' => __DIR__ . '/../../portal/lib/paylib.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'status_name\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/lib/paylib.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'token\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/lib/paylib.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'transid\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/lib/paylib.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -4238,7 +4238,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 32,
+    'count' => 30,
     'path' => __DIR__ . '/../../portal/lib/paylib.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.noGlobalNsFunctions.php
+++ b/.phpstan/baseline/openemr.noGlobalNsFunctions.php
@@ -7247,11 +7247,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/lib/paylib.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function handleSpherePayment may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/lib/paylib.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function addPortalMailboxMail may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/lib/portal_mail.inc.php',

--- a/.phpstan/baseline/openemr.noGlobalNsFunctions.php
+++ b/.phpstan/baseline/openemr.noGlobalNsFunctions.php
@@ -7247,6 +7247,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/lib/paylib.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Function handleSpherePayment may not be defined in the global namespace\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../portal/lib/paylib.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Function addPortalMailboxMail may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/lib/portal_mail.inc.php',

--- a/portal/lib/paylib.php
+++ b/portal/lib/paylib.php
@@ -55,25 +55,52 @@ if (filter_input(INPUT_SERVER, 'REQUEST_METHOD') === 'POST') {
     CsrfUtils::checkCsrfInput(INPUT_POST, subject: 'portal-payment', dieOnFail: true);
 }
 
-if ($_POST['mode'] == 'Sphere') {
-    $dataTrans = $session->get('sphere_payment_result');
-    SessionUtil::unsetSession('sphere_payment_result');
-    if ($dataTrans === null) {
+if ($_POST['mode'] === 'Sphere') {
+    // Sphere patient portal payments require an authenticated portal session
+    if (!isset($pid)) {
+        http_response_code(403);
+        echo 'Unauthorized';
+    } else {
+        handleSpherePayment($session, (int) $pid);
+    }
+}
+
+/**
+ * Handle Sphere payment completion.
+ *
+ * Retrieves payment result from session (keyed by ticket), validates patient
+ * authorization, and saves the audit record.
+ */
+function handleSpherePayment(Symfony\Component\HttpFoundation\Session\SessionInterface $session, int $sessionPid): void
+{
+    $ticket = filter_input(INPUT_POST, 'sphere_ticket') ?? '';
+    $sessionKey = 'sphere_payment_result_' . $ticket;
+
+    $paymentResult = $session->get($sessionKey);
+    SessionUtil::unsetSession($sessionKey);
+
+    if (!is_array($paymentResult)) {
         http_response_code(400);
-        echo 'Missing payment data';
-        exit();
+        echo 'Missing or invalid payment data';
+        return;
     }
 
-    $form_pid = $dataTrans['get']['patient_id_cc'];
+    $form_pid = $paymentResult['patient_id'] ?? 0;
+    if ($form_pid <= 0 || $form_pid !== $sessionPid) {
+        http_response_code(403);
+        echo 'Unauthorized';
+        return;
+    }
 
-    $cc = [];
-    $cc["cardHolderName"] = $dataTrans['post']['name'];
-    $cc['status'] = $dataTrans['post']['status_name'];
-    $cc['authCode'] = $dataTrans['post']['authcode'];
-    $cc['transId'] = $dataTrans['post']['transid'];
-    $cc['cardNumber'] = "******** " . $dataTrans['post']['cc'];
-    $cc['cc_type'] = $dataTrans['post']['ccBrand'];
-    $cc['zip'] = '';
+    $cc = [
+        'cardHolderName' => $paymentResult['name'] ?? '',
+        'status' => $paymentResult['status_name'] ?? '',
+        'authCode' => $paymentResult['authcode'] ?? '',
+        'transId' => $paymentResult['transid'] ?? '',
+        'cardNumber' => '******** ' . ($paymentResult['cc'] ?? ''),
+        'cc_type' => $paymentResult['ccBrand'] ?? '',
+        'zip' => '',
+    ];
     $ccaudit = json_encode($cc);
     $invoice = $_POST['invValues'] ?? '';
 

--- a/portal/lib/paylib.php
+++ b/portal/lib/paylib.php
@@ -60,9 +60,9 @@ if ($_POST['mode'] === 'Sphere') {
     if (!isset($pid)) {
         http_response_code(403);
         echo 'Unauthorized';
-    } else {
-        handleSpherePayment($session, (int) $pid);
+        exit;
     }
+    handleSpherePayment($session, (int) $pid);
 }
 
 /**

--- a/portal/lib/paylib.php
+++ b/portal/lib/paylib.php
@@ -56,9 +56,13 @@ if (filter_input(INPUT_SERVER, 'REQUEST_METHOD') === 'POST') {
 }
 
 if ($_POST['mode'] == 'Sphere') {
-    $cryptoGen = ServiceContainer::getCrypto();
-    $dataTrans = $cryptoGen->decryptStandard(is_string($_POST['enc_data']) ? $_POST['enc_data'] : null);
-    $dataTrans = json_decode($dataTrans, true);
+    $dataTrans = $session->get('sphere_payment_result');
+    SessionUtil::unsetSession('sphere_payment_result');
+    if ($dataTrans === null) {
+        http_response_code(400);
+        echo 'Missing payment data';
+        exit();
+    }
 
     $form_pid = $dataTrans['get']['patient_id_cc'];
 

--- a/portal/lib/paylib.php
+++ b/portal/lib/paylib.php
@@ -57,22 +57,12 @@ if (filter_input(INPUT_SERVER, 'REQUEST_METHOD') === 'POST') {
 
 if ($_POST['mode'] === 'Sphere') {
     // Sphere patient portal payments require an authenticated portal session
-    if (!isset($pid)) {
+    if (!isset($pid) || !is_int($pid)) {
         http_response_code(403);
         echo 'Unauthorized';
         exit;
     }
-    handleSpherePayment($session, (int) $pid);
-}
 
-/**
- * Handle Sphere payment completion.
- *
- * Retrieves payment result from session (keyed by ticket), validates patient
- * authorization, and saves the audit record.
- */
-function handleSpherePayment(Symfony\Component\HttpFoundation\Session\SessionInterface $session, int $sessionPid): void
-{
     $ticket = filter_input(INPUT_POST, 'sphere_ticket') ?? '';
     $sessionKey = 'sphere_payment_result_' . $ticket;
 
@@ -82,14 +72,14 @@ function handleSpherePayment(Symfony\Component\HttpFoundation\Session\SessionInt
     if (!is_array($paymentResult)) {
         http_response_code(400);
         echo 'Missing or invalid payment data';
-        return;
+        exit;
     }
 
     $form_pid = $paymentResult['patient_id'] ?? 0;
-    if ($form_pid <= 0 || $form_pid !== $sessionPid) {
+    if ($form_pid <= 0 || $form_pid !== $pid) {
         http_response_code(403);
         echo 'Unauthorized';
-        return;
+        exit;
     }
 
     $cc = [
@@ -109,6 +99,7 @@ function handleSpherePayment(Symfony\Component\HttpFoundation\Session\SessionInt
     SaveAudit($form_pid, $invoice, $ccaudit);
 
     echo 'ok';
+    exit;
 }
 
 if ($_POST['mode'] == 'AuthorizeNet') {

--- a/sphere/process_response.php
+++ b/sphere/process_response.php
@@ -73,8 +73,18 @@ if (OEGlobalsBag::getInstance()->get('payment_gateway') != 'Sphere') {
         // Success!
         PaymentProcessing::saveAudit('sphere', $_GET['patient_id_cc'], 1, $auditData, $_POST['ticket'], $_POST['transid'], $_POST['action_name'], $_POST['amount']);
         if ($_GET['front'] == 'patient') {
-            // Store audit data in session - paylib.php retrieves it
-            SessionUtil::setSession('sphere_payment_result', $auditData);
+            // Store payment result in session keyed by ticket - paylib.php retrieves it
+            $ticket = filter_input(INPUT_POST, 'ticket') ?? '';
+            $patientId = filter_input(INPUT_GET, 'patient_id_cc', FILTER_VALIDATE_INT) ?: 0;
+            SessionUtil::setSession('sphere_payment_result_' . $ticket, [
+                'patient_id' => $patientId,
+                'transid' => filter_input(INPUT_POST, 'transid') ?? '',
+                'authcode' => filter_input(INPUT_POST, 'authcode') ?? '',
+                'name' => filter_input(INPUT_POST, 'name') ?? '',
+                'status_name' => filter_input(INPUT_POST, 'status_name') ?? '',
+                'cc' => filter_input(INPUT_POST, 'cc') ?? '',
+                'ccBrand' => filter_input(INPUT_POST, 'ccBrand') ?? '',
+            ]);
             echo "<script>opener.sphereSuccess();dlgclose();</script>";
         } else { // $_GET['front'] == 'clinic-phone' || $_GET['front'] == 'clinic-retail'
             echo "<script>opener.sphereSuccess(" . js_escape($_POST['transid']) . ");dlgclose();</script>";

--- a/sphere/process_response.php
+++ b/sphere/process_response.php
@@ -14,8 +14,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -73,7 +73,9 @@ if (OEGlobalsBag::getInstance()->get('payment_gateway') != 'Sphere') {
         // Success!
         PaymentProcessing::saveAudit('sphere', $_GET['patient_id_cc'], 1, $auditData, $_POST['ticket'], $_POST['transid'], $_POST['action_name'], $_POST['amount']);
         if ($_GET['front'] == 'patient') {
-            echo "<script>opener.sphereSuccess(" . js_escape((ServiceContainer::getCrypto())->encryptStandard(json_encode($auditData) ?: null)) . ");dlgclose();</script>";
+            // Store audit data in session - paylib.php retrieves it
+            SessionUtil::setSession('sphere_payment_result', $auditData);
+            echo "<script>opener.sphereSuccess();dlgclose();</script>";
         } else { // $_GET['front'] == 'clinic-phone' || $_GET['front'] == 'clinic-retail'
             echo "<script>opener.sphereSuccess(" . js_escape($_POST['transid']) . ");dlgclose();</script>";
         }

--- a/src/PaymentProcessing/Sphere/SpherePayment.php
+++ b/src/PaymentProcessing/Sphere/SpherePayment.php
@@ -114,20 +114,14 @@ class SpherePayment
     private function renderSphereJsPatientFront(): string
     {
         return "
-            function sphereSuccess(encData) {
+            function sphereSuccess() {
                 let oForm = document.forms['payment-form'];
                 oForm.elements['mode'].value = 'Sphere';
 
                 let inv_values = JSON.stringify(getFormObj('invoiceForm'));
                 document.getElementById('invValues').value = inv_values;
 
-                let hiddenInput = document.createElement('input');
-                hiddenInput.setAttribute('type', 'hidden');
-                hiddenInput.setAttribute('name', 'enc_data');
-                hiddenInput.setAttribute('value', encData);
-                oForm.appendChild(hiddenInput);
-
-                // Submit payment to server
+                // Submit payment to server (payment data is in server session)
                 fetch('./lib/paylib.php', {
                     method: 'POST',
                     body: new FormData(oForm)

--- a/src/PaymentProcessing/Sphere/SpherePayment.php
+++ b/src/PaymentProcessing/Sphere/SpherePayment.php
@@ -121,10 +121,12 @@ class SpherePayment
                 let inv_values = JSON.stringify(getFormObj('invoiceForm'));
                 document.getElementById('invValues').value = inv_values;
 
-                // Submit payment to server (payment data is in server session)
+                // Submit payment to server (payment data is in server session, keyed by ticket)
+                let formData = new FormData(oForm);
+                formData.append('sphere_ticket', window.spherePaymentTicket || '');
                 fetch('./lib/paylib.php', {
                     method: 'POST',
-                    body: new FormData(oForm)
+                    body: formData
                 }).then(function(response) {
                     if (!response.ok) {
                         throw Error(response.statusText);
@@ -197,6 +199,8 @@ class SpherePayment
                     error.log('Dynamic javascript ticket creation failed, so using backup ticket.');
                     ticket = backupTicket;
                 }
+                // Store ticket for sphereSuccess() to retrieve
+                window.spherePaymentTicket = ticket;
 
                 let responseUrl = " . js_escape($this->serverSite) . " + '/sphere/initial_response.php';
                 let cancelUrl = " . js_escape($this->serverSite) . " + '/sphere/initial_response.php?cancel=cancel&ticket=' + encodeURIComponent(ticket) + '&front=' + encodeURIComponent(front) + '&patient_id_cc=' + " . js_escape($this->patientIdCc) . " + '&csrf_token=' + " . js_escape(CsrfUtils::collectCsrfToken($session, 'sphere')) .  ";


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Updates Sphere payment flow to use server-side session storage instead of passing encrypted data through browser JS. This completely removes an opportunity for a bad client to attempt to manipulate (or even view) the data.

Honestly, it's still a suboptimal pattern, but it's a net win IMO. See several open issues re: webhooks and handling data from third party vendors.

This also addresses several adjacent security concerns noted by the analysis bot. Mostly hardening of existing logic.

#### Changes proposed in this pull request:

**Before:** Payment response data was encrypted in `process_response.php`, passed to parent window via JS `opener.sphereSuccess(encryptedData)`, then decrypted in `paylib.php`.

**After:** Payment response data is stored in PHP session, parent window JS just signals completion, `paylib.php` retrieves from session and clears it.

- `sphere/process_response.php` - store audit data in session instead of encrypting
- `src/PaymentProcessing/Sphere/SpherePayment.php` - JS no longer receives/passes `enc_data`
- `portal/lib/paylib.php` - read from session instead of decrypting POST data

**Benefits:**
- Payment data never exposed to browser (even encrypted)
- Simpler code path
- Removes crypto dependency from this flow

**Note:** Only affects patient portal Sphere payments. Clinic front was already passing just the transaction ID.

#### Testing

Requires Sphere/TrustCommerce merchant credentials to test. The integration uses TrustCommerce endpoints which appear to still be active.

#### Was an AI assistant used? Yes

All commits include the `Assisted-by: Claude Code` trailer.

---
Generated with [Claude Code](https://claude.ai/code)
