### PR TITLE
fix(cors): use => instead of , so Access-Control-Allow-Methods is actually sent

### DIFF
--- a/src/RestControllers/Subscriber/CORSListener.php
+++ b/src/RestControllers/Subscriber/CORSListener.php
@@ -66,7 +66,7 @@ class CORSListener implements EventSubscriberInterface
         $response = new Response('', Response::HTTP_OK, [
             'Access-Control-Allow-Credentials' => 'true',
             "Access-Control-Allow-Headers" => "origin, authorization, accept, content-type, content-encoding, x-requested-with",
-            "Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, PATCH, TRACE, OPTIONS"
+            "Access-Control-Allow-Methods" => "GET, HEAD, POST, PUT, DELETE, PATCH, TRACE, OPTIONS"
         ]);
         $origins = $request->getHeader('Origin');
         // TODO: @adunsulag should we allow all origins or just the first one?

--- a/tests/Tests/Isolated/RestControllers/Subscriber/CORSListenerTest.php
+++ b/tests/Tests/Isolated/RestControllers/Subscriber/CORSListenerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace OpenEMR\Tests\Isolated\RestControllers\Subscriber;
+
+use OpenEMR\Common\Http\HttpRestRequest;
+use OpenEMR\RestControllers\Subscriber\CORSListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class CORSListenerTest extends TestCase
+{
+    public function testPreflightResponseIncludesAllowedMethods(): void
+    {
+        $request = HttpRestRequest::create(
+            '/apis/default/api/patient',
+            'OPTIONS',
+            server: ['HTTP_ORIGIN' => 'https://example.com']
+        );
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        (new CORSListener())->onKernelRequest($event);
+
+        $this->assertSame(
+            'GET, HEAD, POST, PUT, DELETE, PATCH, TRACE, OPTIONS',
+            $event->getResponse()->headers->get('Access-Control-Allow-Methods')
+        );
+    }
+}

--- a/tests/Tests/Isolated/RestControllers/Subscriber/CORSListenerTest.php
+++ b/tests/Tests/Isolated/RestControllers/Subscriber/CORSListenerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OpenEMR\Tests\Isolated\RestControllers\Subscriber;
 
 use OpenEMR\Common\Http\HttpRestRequest;


### PR DESCRIPTION
The associative-array entry on the methods line of `CORSListener::getInitialResponse()` is malformed: a comma between key and value instead of `=>`. PHP parses the result as two positional entries `["Access-Control-Allow-Methods", "GET, HEAD, ..."]`, which Symfony's `HeaderBag` silently drops because they have no string key.

Net effect: every CORS preflight response built by `getInitialResponse()` omits `Access-Control-Allow-Methods`, and any browser doing a non-simple cross-origin request (anything carrying `Authorization`, a `Content-Type` other than the simple subset, etc.) blocks the actual request after what looks server-side like a successful preflight.

One-character fix.

```diff
-            "Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, PATCH, TRACE, OPTIONS"
+            "Access-Control-Allow-Methods" => "GET, HEAD, POST, PUT, DELETE, PATCH, TRACE, OPTIONS"
```