### PR TITLE
fix(cors): run preflight handler before Symfony RouterListener

### DIFF
--- a/src/RestControllers/Subscriber/CORSListener.php
+++ b/src/RestControllers/Subscriber/CORSListener.php
@@ -17,7 +17,11 @@ class CORSListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::REQUEST => [['onKernelRequest', 25]],
+            // Run before Symfony's RouterListener (default REQUEST priority 32)
+            // so OPTIONS preflights for routes that only declare GET/POST are
+            // short-circuited cleanly here, instead of being rejected by the
+            // router with 404/405 before this listener can produce a 200 reply.
+            KernelEvents::REQUEST => [['onKernelRequest', 256]],
             KernelEvents::RESPONSE => [['onKernelResponse', 0]]
         ];
     }


### PR DESCRIPTION
`CORSListener` is registered at REQUEST priority 25, below Symfony's default `RouterListener` priority of 32. For routes that only declare GET/POST (e.g. `/apis/default/fhir/Patient`), the router rejects an OPTIONS preflight with 404 *Route not found* before `CORSListener` gets a chance to short-circuit it with a 200 reply.

Bumping the priority to 256 puts `CORSListener` ahead of the router so preflights are handled by this listener as intended. No other behavior changes.

```diff
-            KernelEvents::REQUEST => [['onKernelRequest', 25]],
+            // Run before Symfony's RouterListener (default REQUEST priority 32)
+            // so OPTIONS preflights for routes that only declare GET/POST are
+            // short-circuited cleanly here, instead of being rejected by the
+            // router with 404/405 before this listener can produce a 200 reply.
+            KernelEvents::REQUEST => [['onKernelRequest', 256]],
```

Reproduces against vanilla `openemr/openemr:latest` with any browser-based SMART app: an OPTIONS preflight to `/apis/default/fhir/Patient` from a non-same-origin client returns 404 instead of 200/204. With this change it returns 200 with the headers from `getInitialResponse()`.

Companion fix: #12070 corrects a separate typo so the methods header in `getInitialResponse()` actually lands. The two are independent and either can merge first.