### PR TITLE
fix(patient): dispatch PatientCreatedEvent from legacy new_patient_save.php

### DIFF
--- a/interface/new/new_patient_save.php
+++ b/interface/new/new_patient_save.php
@@ -6,14 +6,20 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 require_once("../globals.php");
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Events\Patient\PatientCreatedEventNotifier;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
@@ -137,6 +143,20 @@ if ($_POST['form_create']) {
     if ($refsource = trim((string) $_POST["refsource"])) {
         sqlQuery("UPDATE patient_data SET referral_source = ? " .
         "WHERE pid = ?", [$refsource, $pid]);
+    }
+
+    // Dispatch the modern PatientCreatedEvent so listeners that subscribe to
+    // the canonical patient lifecycle event (e.g. those wired through
+    // PatientService::databaseInsert()) see chart-UI patient creates too.
+    if (is_int($pid)) {
+        $newPatientRow = QueryUtils::querySingleRow(
+            "SELECT * FROM patient_data WHERE pid = ?",
+            [$pid]
+        );
+        (new PatientCreatedEventNotifier(
+            OEGlobalsBag::getInstance()->getKernel()->getEventDispatcher(),
+            ServiceContainer::getLogger(),
+        ))->notify($pid, $newPatientRow);
     }
 }
 ?>

--- a/src/Events/Patient/PatientCreatedEventNotifier.php
+++ b/src/Events/Patient/PatientCreatedEventNotifier.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Dispatches PatientCreatedEvent for legacy create paths that bypass
+ * PatientService::databaseInsert().
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Events\Patient;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final readonly class PatientCreatedEventNotifier
+{
+    public function __construct(
+        private EventDispatcherInterface $dispatcher,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Dispatch PatientCreatedEvent for the freshly-created patient identified by $pid.
+     *
+     * $patientRow is the result of re-reading the patient_data row after the
+     * legacy insert (newPatientData()) returned. Pass `false` to indicate the
+     * row was not found — the canonical signal QueryUtils::querySingleRow()
+     * uses for "no row." A missing row means the just-completed insert
+     * vanished between write and re-read; we log it so the silently-skipped
+     * lifecycle event surfaces in operator dashboards.
+     *
+     * @param array<mixed>|false $patientRow
+     */
+    public function notify(int $pid, array|false $patientRow): void
+    {
+        if ($patientRow === false) {
+            $this->logger->error(
+                'PatientCreatedEvent skipped: patient_data row missing immediately after newPatientData()',
+                ['pid' => $pid]
+            );
+            return;
+        }
+
+        $this->dispatcher->dispatch(
+            new PatientCreatedEvent($patientRow),
+            PatientCreatedEvent::EVENT_HANDLE
+        );
+    }
+}

--- a/tests/Tests/Isolated/Events/Patient/PatientCreatedEventNotifierTest.php
+++ b/tests/Tests/Isolated/Events/Patient/PatientCreatedEventNotifierTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Events\Patient;
+
+use OpenEMR\Events\Patient\PatientCreatedEvent;
+use OpenEMR\Events\Patient\PatientCreatedEventNotifier;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class PatientCreatedEventNotifierTest extends TestCase
+{
+    public function testDispatchesPatientCreatedEventWithFetchedRow(): void
+    {
+        $row = ['pid' => 42, 'uuid' => 'abc', 'fname' => 'Test'];
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                $this->callback(static fn($event): bool => $event instanceof PatientCreatedEvent
+                    && $event->getPatientData() === $row),
+                PatientCreatedEvent::EVENT_HANDLE,
+            );
+        $logger->expects($this->never())->method('error');
+
+        (new PatientCreatedEventNotifier($dispatcher, $logger))->notify(42, $row);
+    }
+
+    public function testLogsErrorAndSkipsDispatchWhenRowMissing(): void
+    {
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $dispatcher->expects($this->never())->method('dispatch');
+        $logger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->stringContains('PatientCreatedEvent skipped'),
+                ['pid' => 99],
+            );
+
+        (new PatientCreatedEventNotifier($dispatcher, $logger))->notify(99, false);
+    }
+}


### PR DESCRIPTION
## Summary

The legacy chart UI new-patient save path bypasses the modern patient lifecycle event that `OpenEMR\Services\PatientService` dispatches:

- `interface/new/new_patient_save.php` calls `newPatientData()`, which writes via raw `QueryUtils::sqlInsert` (`REPLACE INTO patient_data ...`) and never reaches `PatientService`. No `PatientCreatedEvent` is dispatched.

Modules that subscribe to `PatientCreatedEvent` therefore miss any patient created through the chart UI, even though the same create made via `PatientService::databaseInsert()` (REST/FHIR/etc.) does fire the event.

## Approach

After `newPatientData()` returns, re-fetch the new `patient_data` row and dispatch `PatientCreatedEvent($row)` through a small DI-friendly notifier (`src/Events/Patient/PatientCreatedEventNotifier`) that takes a PSR-3 logger and a Symfony `EventDispatcherInterface`. The notifier also logs an `error`-level entry when the just-inserted row vanishes between write and re-read, so silently-skipped lifecycle events surface in operator dashboards. Listener exceptions propagate, matching `PatientService::databaseInsert()`'s dispatch.

The notifier is unit-tested in isolation (no DB or kernel) by mocking the dispatcher and logger.

## Scope note

The original draft also added a `PatientUpdatedEvent` dispatch to `demographics_save.php`, but that turned out to be unnecessary: `updatePatientData()` (called by demographics_save) already routes through `PatientService::databaseUpdate()`, which dispatches `PatientUpdatedEvent`. Adding another dispatch would double-fire listeners. That change has been reverted; this PR now covers only the create path.

Fixes #12081

## Test plan

- [x] Isolated unit tests for `PatientCreatedEventNotifier` (dispatch on present row, log on missing row).
- [ ] Create a patient through the chart UI; confirm a `PatientCreatedEvent` listener fires with the new patient row.
- [ ] Confirm REST/FHIR patient creates still fire `PatientCreatedEvent` exactly once (no regression).