### PR TITLE
fix(patient): dispatch PatientUpdatedEvent from legacy demographics_save.php

### DIFF
--- a/interface/patient_file/summary/demographics_save.php
+++ b/interface/patient_file/summary/demographics_save.php
@@ -26,6 +26,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Patient\PatientUpdatedEventAux;
+use OpenEMR\Events\Patient\PatientUpdatedEventNotifier;
 use OpenEMR\Services\ContactAddressService;
 use OpenEMR\Services\ContactRelationService;
 use OpenEMR\Services\ContactService;
@@ -187,6 +188,13 @@ while ($frow = sqlFetchArray($fres)) {
         $newdata[$table][$colname] = get_layout_form_value($frow);
     }
 }
+
+// Capture the pre-update patient_data row so the modern PatientUpdatedEvent
+// (dispatched after the save below) can carry both before and after snapshots,
+// matching what PatientService::databaseUpdate() emits. sqlQuery() returns
+// false when no row exists; PatientUpdatedEventNotifier handles that case.
+$pidInt = is_numeric($pid) ? (int) $pid : 0;
+$dataBeforeUpdate = $pidInt > 0 ? getPatientData($pidInt) : false;
 
 // Save patient and employer data
 try {
@@ -454,6 +462,18 @@ try {
     $logger->error("Error dispatching event", [
         'error' => $e->getMessage()
     ]);
+}
+
+// Dispatch the modern PatientUpdatedEvent so listeners that subscribe to
+// the canonical patient lifecycle event (e.g. those wired through
+// PatientService::databaseUpdate()) see chart-UI patient edits too. Done
+// alongside PatientUpdatedEventAux for backward compatibility with
+// existing aux subscribers.
+if ($pidInt > 0 && is_array($newdata['patient_data'] ?? null)) {
+    (new PatientUpdatedEventNotifier(
+        OEGlobalsBag::getInstance()->getKernel()->getEventDispatcher(),
+        $logger,
+    ))->notify($pidInt, $dataBeforeUpdate, $newdata['patient_data']);
 }
 
 include_once("demographics.php");

--- a/src/Events/Patient/PatientUpdatedEventNotifier.php
+++ b/src/Events/Patient/PatientUpdatedEventNotifier.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Dispatches PatientUpdatedEvent for legacy update paths that bypass
+ * PatientService::databaseUpdate().
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Events\Patient;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final readonly class PatientUpdatedEventNotifier
+{
+    public function __construct(
+        private EventDispatcherInterface $dispatcher,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Dispatch PatientUpdatedEvent for the patient identified by $pid.
+     *
+     * $dataBeforeUpdate is the result of getPatientData($pid) captured by
+     * the caller *before* the legacy update (updatePatientData()) ran. Pass
+     * `false` to indicate the row was not found — the canonical signal
+     * sqlQuery() uses for "no row." A missing pre-update row means the
+     * caller asked us to announce an update for a patient that did not
+     * exist; we log it so the silently-skipped lifecycle event surfaces in
+     * operator dashboards and skip dispatch (PatientUpdatedEvent's contract
+     * is that subscribers receive a real pre-update snapshot).
+     *
+     * @param array<mixed>|false $dataBeforeUpdate
+     * @param array<mixed> $newPatientData
+     */
+    public function notify(int $pid, array|false $dataBeforeUpdate, array $newPatientData): void
+    {
+        if ($dataBeforeUpdate === false) {
+            $this->logger->error(
+                'PatientUpdatedEvent skipped: pre-update patient_data row missing',
+                ['pid' => $pid]
+            );
+            return;
+        }
+
+        $this->dispatcher->dispatch(
+            new PatientUpdatedEvent($dataBeforeUpdate, $newPatientData),
+            PatientUpdatedEvent::EVENT_HANDLE
+        );
+    }
+}

--- a/tests/Tests/Isolated/Events/Patient/PatientUpdatedEventNotifierTest.php
+++ b/tests/Tests/Isolated/Events/Patient/PatientUpdatedEventNotifierTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Events\Patient;
+
+use OpenEMR\Events\Patient\PatientUpdatedEvent;
+use OpenEMR\Events\Patient\PatientUpdatedEventNotifier;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class PatientUpdatedEventNotifierTest extends TestCase
+{
+    public function testDispatchesPatientUpdatedEventWithBeforeAndAfter(): void
+    {
+        $before = ['pid' => 42, 'fname' => 'Test', 'hipaa_allowsms' => 'NO'];
+        $after = ['pid' => 42, 'fname' => 'Test', 'hipaa_allowsms' => 'YES'];
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                $this->callback(static fn($event): bool => $event instanceof PatientUpdatedEvent
+                    && $event->getDataBeforeUpdate() === $before
+                    && $event->getNewPatientData() === $after),
+                PatientUpdatedEvent::EVENT_HANDLE,
+            );
+        $logger->expects($this->never())->method('error');
+
+        (new PatientUpdatedEventNotifier($dispatcher, $logger))->notify(42, $before, $after);
+    }
+
+    public function testLogsErrorAndSkipsDispatchWhenPreUpdateRowMissing(): void
+    {
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $dispatcher->expects($this->never())->method('dispatch');
+        $logger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->stringContains('PatientUpdatedEvent skipped'),
+                ['pid' => 99],
+            );
+
+        (new PatientUpdatedEventNotifier($dispatcher, $logger))->notify(99, false, ['pid' => 99]);
+    }
+}


### PR DESCRIPTION
Companion to #12083, which closed the create-side gap (`new_patient_save.php` now dispatches `PatientCreatedEvent`). This closes the matching update-side gap in `interface/patient_file/summary/demographics_save.php`. Together they resolve the legacy chart save path coverage issue tracked in #12081.

## Summary

`demographics_save.php` calls `updatePatientData()` and dispatches only `PatientUpdatedEventAux`. The aux event carries `$_POST` with no pre-update snapshot, so subscribers to the canonical `PatientUpdatedEvent` (which carries both before and after data) miss every chart-UI edit. The same edit made via `PatientService::databaseUpdate()` (REST/FHIR/etc.) does fire the canonical event, so module behavior diverges based on which UI the staff member used.

Concrete example: detecting `hipaa_allowsms` `NO`→`YES` transitions for SMS opt-in welcome messages requires the pre-update snapshot to distinguish a real transition from an idempotent re-save. `PatientUpdatedEventAux` cannot carry that.

Capture `getPatientData($pid)` into `$dataBeforeUpdate` *before* `updatePatientData()` runs, then dispatch `PatientUpdatedEvent` through a small DI-friendly notifier (`src/Events/Patient/PatientUpdatedEventNotifier`) alongside the existing `PatientUpdatedEventAux` dispatch. The notifier takes a PSR-3 logger and a Symfony `EventDispatcherInterface` and logs an `error`-level entry when the pre-update row is missing (sqlQuery returns `false`), so silently-skipped lifecycle events surface in operator dashboards. `PatientUpdatedEventAux` is preserved for backward compatibility with existing aux subscribers (e.g. `oe-module-weno`).

The notifier is unit-tested in isolation (no DB or kernel) by mocking the dispatcher and logger.

## Refs

- Fixes the remaining half of #12081
- Companion to #12083
- Module-side tracker: openCoreEMR/oce-module-sinch-conversations#117

## Assisted-by

Assisted-by: Claude Code