### PR TITLE
feat(encryption): Add DBAL-based key storage and extract loadWithEngines

### DIFF
--- a/src/BC/Crypto/LegacyKeychainLoader.php
+++ b/src/BC/Crypto/LegacyKeychainLoader.php
@@ -41,6 +41,9 @@ use Throwable;
  */
 final class LegacyKeychainLoader
 {
+    /**
+     * Loads the keychain using default legacy storage engines.
+     */
     public static function load(): KeychainInterface
     {
         $bag = OEGlobalsBag::getInstance();
@@ -52,6 +55,26 @@ final class LegacyKeychainLoader
         $pkod = new Storage\PlaintextKeyOnDisk($storageDir);
         $pkidb = new Storage\PlaintextKeyInDbKeysTableQueryUtils();
 
+        return self::loadWithEngines(
+            filesystemStorage: $pkod,
+            databaseStorage: $pkidb,
+            storageDir: $storageDir,
+        );
+    }
+
+    /**
+     * Loads the keychain using provided storage engines.
+     *
+     * This allows injecting alternative storage implementations for testing or
+     * when using different database connection strategies.
+     */
+    public static function loadWithEngines(
+        Storage\KeyStorageInterface $filesystemStorage,
+        Storage\KeyStorageInterface $databaseStorage,
+        string $storageDir,
+    ): KeychainInterface {
+        $pkod = $filesystemStorage;
+        $pkidb = $databaseStorage;
         $keychain = new EagerKeychain();
         // v1: broken crypto (no hmac)
         $one = self::tryLoadKey(new Storage\KeyMaterialId('one'), $pkod);

--- a/src/BC/Crypto/LegacyKeychainLoader.php
+++ b/src/BC/Crypto/LegacyKeychainLoader.php
@@ -42,7 +42,8 @@ use Throwable;
 final class LegacyKeychainLoader
 {
     /**
-     * Loads the keychain using default legacy storage engines.
+     * Loads the keychain using default legacy storage engines. This will
+     * create keys at the current version if they do not exist.
      */
     public static function load(): KeychainInterface
     {
@@ -63,10 +64,10 @@ final class LegacyKeychainLoader
     }
 
     /**
-     * Loads the keychain using provided storage engines.
+     * Loads the keychain using provided storage engines. This will create keys
+     * at the current version if they do not exist.
      *
-     * This allows injecting alternative storage implementations for testing or
-     * when using different database connection strategies.
+     * Important: this is still directly coupled to the filesystem
      */
     public static function loadWithEngines(
         Storage\KeyStorageInterface $filesystemStorage,

--- a/src/Encryption/Storage/PlaintextKeyInDbKeysTable.php
+++ b/src/Encryption/Storage/PlaintextKeyInDbKeysTable.php
@@ -25,6 +25,9 @@ use UnexpectedValueException;
  */
 readonly class PlaintextKeyInDbKeysTable implements KeyStorageInterface
 {
+    // Note: depending where we land on SQL logging, this may need
+    // a ConnectionManager instead of the raw Connection. Or ORM's
+    // EntityManager directly.
     public function __construct(
         private Connection $conn,
     ) {

--- a/src/Encryption/Storage/PlaintextKeyInDbKeysTable.php
+++ b/src/Encryption/Storage/PlaintextKeyInDbKeysTable.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Encryption\Storage;
+
+use Doctrine\DBAL\Connection;
+use OpenEMR\Encryption\Keys\KeyMaterial;
+use OutOfBoundsException;
+use UnexpectedValueException;
+
+/**
+ * Read key material from the `keys` table via DBAL.
+ *
+ * Important: this bypasses query audit logging, which is necessary to prevent
+ * recursion in the audit logger itself which can encrypt messages.
+ */
+readonly class PlaintextKeyInDbKeysTable implements KeyStorageInterface
+{
+    public function __construct(
+        private Connection $conn,
+    ) {
+    }
+
+    public function getKey(KeyMaterialId $identifier): KeyMaterial
+    {
+        $result = $this->conn->createQueryBuilder()
+            ->select('value')
+            ->from('`keys`')
+            ->where('name = :name')
+            ->setParameter('name', $identifier->id)
+            ->fetchOne();
+
+        if ($result === false) {
+            throw new OutOfBoundsException('No key found');
+        }
+
+        if (!is_string($result)) {
+            throw new UnexpectedValueException('Key found, invalid data format');
+        }
+
+        $key = base64_decode($result, strict: true);
+        if ($key === false) {
+            throw new UnexpectedValueException('Key found, malformed');
+        }
+
+        return new KeyMaterial($key);
+    }
+
+    public function storeKey(KeyMaterialId $identifier, KeyMaterial $key): void
+    {
+        $this->conn->insert('`keys`', [
+            'name' => $identifier->id,
+            'value' => base64_encode($key->key),
+        ]);
+    }
+}

--- a/tests/Tests/Isolated/Encryption/Storage/PlaintextKeyInDbKeysTableTest.php
+++ b/tests/Tests/Isolated/Encryption/Storage/PlaintextKeyInDbKeysTableTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Encryption\Storage;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use OpenEMR\Encryption\Keys\KeyMaterial;
+use OpenEMR\Encryption\Storage\KeyMaterialId;
+use OpenEMR\Encryption\Storage\PlaintextKeyInDbKeysTable;
+use OutOfBoundsException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+final class PlaintextKeyInDbKeysTableTest extends TestCase
+{
+    private Connection&MockObject $connection;
+    private QueryBuilder&MockObject $queryBuilder;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        $this->queryBuilder = $this->createMock(QueryBuilder::class);
+
+        $this->queryBuilder->method('select')->willReturnSelf();
+        $this->queryBuilder->method('from')->willReturnSelf();
+        $this->queryBuilder->method('where')->willReturnSelf();
+        $this->queryBuilder->method('setParameter')->willReturnSelf();
+    }
+
+    public function testGetKeyReturnsKeyMaterialWhenFound(): void
+    {
+        $rawKey = 'test_secret_key_________________';
+        $encodedValue = base64_encode($rawKey);
+
+        $this->queryBuilder->method('fetchOne')->willReturn($encodedValue);
+        $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
+
+        $storage = new PlaintextKeyInDbKeysTable($this->connection);
+        $result = $storage->getKey(new KeyMaterialId('test-key'));
+
+        self::assertSame($rawKey, $result->key, 'Retrieved key should match original');
+    }
+
+    public function testGetKeyThrowsOutOfBoundsWhenNotFound(): void
+    {
+        $this->queryBuilder->method('fetchOne')->willReturn(false);
+        $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
+
+        $storage = new PlaintextKeyInDbKeysTable($this->connection);
+
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('No key found');
+
+        $storage->getKey(new KeyMaterialId('nonexistent-key'));
+    }
+
+    public function testGetKeyThrowsUnexpectedValueWhenResultIsNotString(): void
+    {
+        $this->queryBuilder->method('fetchOne')->willReturn(123);
+        $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
+
+        $storage = new PlaintextKeyInDbKeysTable($this->connection);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Key found, invalid data format');
+
+        $storage->getKey(new KeyMaterialId('bad-type-key'));
+    }
+
+    public function testGetKeyThrowsUnexpectedValueWhenBase64Invalid(): void
+    {
+        $this->queryBuilder->method('fetchOne')->willReturn('not-valid-base64!!!');
+        $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
+
+        $storage = new PlaintextKeyInDbKeysTable($this->connection);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Key found, malformed');
+
+        $storage->getKey(new KeyMaterialId('malformed-key'));
+    }
+
+    public function testStoreKeyInsertsIntoDatabase(): void
+    {
+        $rawKey = 'test_secret_key_________________';
+        $keyMaterial = new KeyMaterial($rawKey);
+        $id = new KeyMaterialId('new-key');
+
+        $this->connection->expects($this->once())
+            ->method('insert')
+            ->with(
+                '`keys`',
+                [
+                    'name' => 'new-key',
+                    'value' => base64_encode($rawKey),
+                ],
+            );
+
+        $storage = new PlaintextKeyInDbKeysTable($this->connection);
+        $storage->storeKey($id, $keyMaterial);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `PlaintextKeyInDbKeysTable`, a DBAL-based implementation of `KeyStorageInterface` for reading/writing keys from the `keys` table
- Extracts `loadWithEngines()` from `LegacyKeychainLoader` to allow injecting storage engines (useful for testing and alternative connection strategies)
- Adds unit tests for the DBAL key storage implementation

This is going to be used as part of upcoming key rotation/syncing tooling without having to bootstrap ADODB on the DI path.

## Test plan

- Unit tests added
- Exercised heavily on the integration branch (including e2e verification that not only does this key loader work, but mixing the old and new cryptography APIs works AND it can handle plaintext and encrypted data simultaneously)