### PR TITLE
feat(crypto): add encryption status check methods and conditional database encryption

### DIFF
--- a/src/BC/Crypto/ContextualEncryptionTrait.php
+++ b/src/BC/Crypto/ContextualEncryptionTrait.php
@@ -11,6 +11,10 @@ use OpenEMR\Common\Crypto\{
 };
 use ValueError;
 
+/**
+ * This adds common methods related to CryptoInterface for contextual
+ * encryption and checking about status
+ */
 trait ContextualEncryptionTrait
 {
     public function encryptForDatabase(?string $value): string
@@ -89,6 +93,9 @@ trait ContextualEncryptionTrait
         }
     }
 
+    /**
+     * See isDatabaseValueLatest - same.
+     */
     public function isFilesystemValueLatest(string $value): bool
     {
         if ($value === '') {

--- a/src/BC/Crypto/ContextualEncryptionTrait.php
+++ b/src/BC/Crypto/ContextualEncryptionTrait.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\BC\Crypto;
+
+use OpenEMR\Common\Crypto\{
+    CryptoGenException,
+    KeySource,
+    KeyVersion,
+};
+use ValueError;
+
+trait ContextualEncryptionTrait
+{
+    public function encryptForDatabase(?string $value): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+        if (!$this->shouldEncryptForDatabase) {
+            return $value;
+        }
+        return $this->encryptStandard($value, keySource: KeySource::Drive);
+    }
+
+    public function encryptForFilesystem(?string $value): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+        if (!$this->shouldEncryptForFilesystem) {
+            return $value;
+        }
+        return $this->encryptStandard($value, keySource: KeySource::Database);
+    }
+
+    public function decryptFromDatabase(?string $value, ?int $minimumVersion = null): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+        if (!$this->cryptCheckStandard($value)) {
+            return $value;
+        }
+        $result = $this->decryptStandard($value, keySource: KeySource::Drive, minimumVersion: $minimumVersion);
+        if ($result === false) {
+            throw new CryptoGenException('Decryption failed');
+        }
+        return $result;
+    }
+
+    public function decryptFromFilesystem(?string $value): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+        if (!$this->cryptCheckStandard($value)) {
+            return $value;
+        }
+        $result = $this->decryptStandard($value, keySource: KeySource::Database);
+        if ($result === false) {
+            throw new CryptoGenException('Decryption failed');
+        }
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * Note: This uses the CryptoGen tooling even in BC\Crypto, intentionally.
+     * As its internals note, it _also_ takes this path to remain compatible
+     * with existing key management until we can fully cut over to new tooling.
+     */
+    public function isDatabaseValueLatest(string $value): bool
+    {
+        if ($value === '') {
+            // Empty never encrypted
+            return true;
+        }
+
+        try {
+            $version = KeyVersion::fromPrefix($value);
+            // Value IS encrypted
+            return $this->shouldEncryptForDatabase && $version === KeyVersion::CURRENT;
+        } catch (ValueError) { // @phpstan-ignore openemr.forbiddenCatchType
+            // Value is NOT encrypted.
+            return !$this->shouldEncryptForDatabase;
+        }
+    }
+
+    public function isFilesystemValueLatest(string $value): bool
+    {
+        if ($value === '') {
+            return true;
+        }
+
+        try {
+            $version = KeyVersion::fromPrefix($value);
+            // Value IS encrypted
+            return $this->shouldEncryptForFilesystem && $version === KeyVersion::CURRENT;
+        } catch (ValueError) { // @phpstan-ignore openemr.forbiddenCatchType
+            // Value is NOT encrypted.
+            return !$this->shouldEncryptForFilesystem;
+        }
+    }
+}

--- a/src/BC/Crypto/Crypto.php
+++ b/src/BC/Crypto/Crypto.php
@@ -62,6 +62,7 @@ final readonly class Crypto implements CryptoInterface
         return new Crypto(
             $keychain,
             $logger,
+            shouldEncryptForDatabase: true, // See #11973
             shouldEncryptForFilesystem: OEGlobalsBag::getInstance()->getBoolean('drive_encryption'),
         );
     }

--- a/src/BC/Crypto/Crypto.php
+++ b/src/BC/Crypto/Crypto.php
@@ -44,9 +44,12 @@ use Throwable;
  */
 final readonly class Crypto implements CryptoInterface
 {
+    use ContextualEncryptionTrait;
+
     public function __construct(
         private KeychainInterface $keychain,
         private LoggerInterface $logger,
+        private bool $shouldEncryptForDatabase,
         private bool $shouldEncryptForFilesystem,
     ) {
     }
@@ -133,54 +136,5 @@ final readonly class Crypto implements CryptoInterface
         } catch (Throwable) {
             return false;
         }
-    }
-
-    public function encryptForDatabase(?string $value): string
-    {
-        if ($value === null || $value === '') {
-            return '';
-        }
-        return $this->encryptStandard($value, keySource: KeySource::Drive);
-    }
-
-    public function encryptForFilesystem(?string $value): string
-    {
-        if ($value === null || $value === '') {
-            return '';
-        }
-        if (!$this->shouldEncryptForFilesystem) {
-            return $value;
-        }
-        return $this->encryptStandard($value, keySource: KeySource::Database);
-    }
-
-    public function decryptFromDatabase(?string $value, ?int $minimumVersion = null): string
-    {
-        if ($value === null || $value === '') {
-            return '';
-        }
-        if (!$this->cryptCheckStandard($value)) {
-            return $value;
-        }
-        $result = $this->decryptStandard($value, keySource: KeySource::Drive, minimumVersion: $minimumVersion);
-        if ($result === false) {
-            throw new CryptoGenException('Decryption failed');
-        }
-        return $result;
-    }
-
-    public function decryptFromFilesystem(?string $value): string
-    {
-        if ($value === null || $value === '') {
-            return '';
-        }
-        if (!$this->cryptCheckStandard($value)) {
-            return $value;
-        }
-        $result = $this->decryptStandard($value, keySource: KeySource::Database);
-        if ($result === false) {
-            throw new CryptoGenException('Decryption failed');
-        }
-        return $result;
     }
 }

--- a/src/Common/Crypto/CryptoGen.php
+++ b/src/Common/Crypto/CryptoGen.php
@@ -32,12 +32,17 @@
 
 namespace OpenEMR\Common\Crypto;
 
-use OpenEMR\BC\ServiceContainer;
+use OpenEMR\BC\{
+    Crypto\ContextualEncryptionTrait,
+    ServiceContainer,
+};
 use OpenEMR\Core\OEGlobalsBag;
 use Psr\Log\LoggerInterface;
 
 class CryptoGen implements CryptoInterface
 {
+    use ContextualEncryptionTrait;
+
     /**
      * Key cache to optimize key collection, which avoids numerous repeat
      * calls to collect the key sets (and repeat decryption of the key set
@@ -48,6 +53,10 @@ class CryptoGen implements CryptoInterface
     private readonly LoggerInterface $logger;
 
     private readonly string $siteDir;
+
+    // This is intentionally not settable from the outside yet. Will change
+    // once more testing is complete. Needed for trait.
+    private bool $shouldEncryptForDatabase = true;
 
     private readonly bool $shouldEncryptForFilesystem;
 

--- a/src/Common/Crypto/CryptoGen.php
+++ b/src/Common/Crypto/CryptoGen.php
@@ -55,7 +55,7 @@ class CryptoGen implements CryptoInterface
     private readonly string $siteDir;
 
     // This is intentionally not settable from the outside yet. Will change
-    // once more testing is complete. Needed for trait.
+    // once more testing is complete. Needed for trait. See #11973
     private bool $shouldEncryptForDatabase = true;
 
     private readonly bool $shouldEncryptForFilesystem;

--- a/src/Common/Crypto/CryptoInterface.php
+++ b/src/Common/Crypto/CryptoInterface.php
@@ -86,4 +86,12 @@ interface CryptoInterface
      * @throws CryptoGenException If decryption of encrypted data fails
      */
     public function decryptFromFilesystem(?string $value): string;
+
+    /**
+     * Indicates if the value reflects the current DB encryption state (on/off,
+     * key at latest version if on). This does not verify the value is usable,
+     * only that the prefix indicates the preferred state.
+     */
+    public function isDatabaseValueLatest(string $value): bool;
+    public function isFilesystemValueLatest(string $value): bool;
 }

--- a/src/Common/Crypto/CryptoInterface.php
+++ b/src/Common/Crypto/CryptoInterface.php
@@ -93,5 +93,11 @@ interface CryptoInterface
      * only that the prefix indicates the preferred state.
      */
     public function isDatabaseValueLatest(string $value): bool;
+
+    /**
+     * Indicates if the value reflects the current FS encryption state (on/off,
+     * key at latest version if on). This does not verify the value is usable,
+     * only that the prefix indicates the preferred state.
+     */
     public function isFilesystemValueLatest(string $value): bool;
 }

--- a/tests/Tests/Isolated/BC/Crypto/CryptoTest.php
+++ b/tests/Tests/Isolated/BC/Crypto/CryptoTest.php
@@ -412,4 +412,153 @@ final class CryptoTest extends TestCase
 
         self::assertSame($plaintext, $decrypted);
     }
+
+    public function testEncryptForDatabasePassesThroughPlaintextWhenDisabled(): void
+    {
+        $crypto = new Crypto(
+            $this->keychain,
+            new NullLogger(),
+            shouldEncryptForDatabase: false,
+            shouldEncryptForFilesystem: true,
+        );
+        $plaintext = 'plaintext data that should not be encrypted';
+
+        $result = $crypto->encryptForDatabase($plaintext);
+
+        self::assertSame($plaintext, $result, 'Should pass through plaintext when database encryption is disabled');
+    }
+
+    public function testIsDatabaseValueLatestReturnsTrueForEmptyString(): void
+    {
+        self::assertTrue(
+            $this->crypto->isDatabaseValueLatest(''),
+            'Empty string is always considered latest',
+        );
+    }
+
+    public function testIsDatabaseValueLatestReturnsTrueForCurrentVersionEncrypted(): void
+    {
+        $ciphertext = $this->fixtures->getCiphertext(7);
+
+        self::assertTrue(
+            $this->crypto->isDatabaseValueLatest($ciphertext),
+            'Value encrypted with current version should be latest when encryption is enabled',
+        );
+    }
+
+    public function testIsDatabaseValueLatestReturnsFalseForOldVersionEncrypted(): void
+    {
+        $oldVersionCiphertext = $this->fixtures->getCiphertext(4);
+
+        self::assertFalse(
+            $this->crypto->isDatabaseValueLatest($oldVersionCiphertext),
+            'Value encrypted with old version should not be latest',
+        );
+    }
+
+    public function testIsDatabaseValueLatestReturnsFalseForPlaintextWhenEncryptionEnabled(): void
+    {
+        self::assertFalse(
+            $this->crypto->isDatabaseValueLatest('unencrypted plaintext'),
+            'Plaintext should not be latest when encryption is enabled',
+        );
+    }
+
+    public function testIsDatabaseValueLatestReturnsTrueForPlaintextWhenEncryptionDisabled(): void
+    {
+        $crypto = new Crypto(
+            $this->keychain,
+            new NullLogger(),
+            shouldEncryptForDatabase: false,
+            shouldEncryptForFilesystem: true,
+        );
+
+        self::assertTrue(
+            $crypto->isDatabaseValueLatest('unencrypted plaintext'),
+            'Plaintext should be latest when encryption is disabled',
+        );
+    }
+
+    public function testIsDatabaseValueLatestReturnsFalseForEncryptedWhenEncryptionDisabled(): void
+    {
+        $crypto = new Crypto(
+            $this->keychain,
+            new NullLogger(),
+            shouldEncryptForDatabase: false,
+            shouldEncryptForFilesystem: true,
+        );
+        $ciphertext = $this->fixtures->getCiphertext(7);
+
+        self::assertFalse(
+            $crypto->isDatabaseValueLatest($ciphertext),
+            'Encrypted value should not be latest when encryption is disabled',
+        );
+    }
+
+    public function testIsFilesystemValueLatestReturnsTrueForEmptyString(): void
+    {
+        self::assertTrue(
+            $this->crypto->isFilesystemValueLatest(''),
+            'Empty string is always considered latest',
+        );
+    }
+
+    public function testIsFilesystemValueLatestReturnsTrueForCurrentVersionEncrypted(): void
+    {
+        $ciphertext = $this->fixtures->getCiphertext(7);
+
+        self::assertTrue(
+            $this->crypto->isFilesystemValueLatest($ciphertext),
+            'Value encrypted with current version should be latest when encryption is enabled',
+        );
+    }
+
+    public function testIsFilesystemValueLatestReturnsFalseForOldVersionEncrypted(): void
+    {
+        $oldVersionCiphertext = $this->fixtures->getCiphertext(4);
+
+        self::assertFalse(
+            $this->crypto->isFilesystemValueLatest($oldVersionCiphertext),
+            'Value encrypted with old version should not be latest',
+        );
+    }
+
+    public function testIsFilesystemValueLatestReturnsFalseForPlaintextWhenEncryptionEnabled(): void
+    {
+        self::assertFalse(
+            $this->crypto->isFilesystemValueLatest('unencrypted plaintext'),
+            'Plaintext should not be latest when encryption is enabled',
+        );
+    }
+
+    public function testIsFilesystemValueLatestReturnsTrueForPlaintextWhenEncryptionDisabled(): void
+    {
+        $crypto = new Crypto(
+            $this->keychain,
+            new NullLogger(),
+            shouldEncryptForDatabase: true,
+            shouldEncryptForFilesystem: false,
+        );
+
+        self::assertTrue(
+            $crypto->isFilesystemValueLatest('unencrypted plaintext'),
+            'Plaintext should be latest when encryption is disabled',
+        );
+    }
+
+    public function testIsFilesystemValueLatestReturnsFalseForEncryptedWhenEncryptionDisabled(): void
+    {
+        $crypto = new Crypto(
+            $this->keychain,
+            new NullLogger(),
+            shouldEncryptForDatabase: true,
+            shouldEncryptForFilesystem: false,
+        );
+        $ciphertext = $this->fixtures->getCiphertext(7);
+
+        self::assertFalse(
+            $crypto->isFilesystemValueLatest($ciphertext),
+            'Encrypted value should not be latest when encryption is disabled',
+        );
+    }
 }

--- a/tests/Tests/Isolated/BC/Crypto/CryptoTest.php
+++ b/tests/Tests/Isolated/BC/Crypto/CryptoTest.php
@@ -44,7 +44,12 @@ final class CryptoTest extends TestCase
     {
         $this->fixtures = new CryptoFixtureManager('/dev/null');
         $this->keychain = $this->buildKeychain();
-        $this->crypto = new Crypto($this->keychain, new NullLogger(), shouldEncryptForFilesystem: true);
+        $this->crypto = new Crypto(
+            keychain: $this->keychain,
+            logger: new NullLogger(),
+            shouldEncryptForFilesystem: true,
+            shouldEncryptForDatabase: true,
+        );
     }
 
     private function buildKeychain(): Keychain
@@ -340,7 +345,12 @@ final class CryptoTest extends TestCase
 
     public function testEncryptForFilesystemPassesThroughPlaintextWhenDisabled(): void
     {
-        $crypto = new Crypto($this->keychain, new NullLogger(), shouldEncryptForFilesystem: false);
+        $crypto = new Crypto(
+            $this->keychain,
+            new NullLogger(),
+            shouldEncryptForDatabase: false,
+            shouldEncryptForFilesystem: false,
+        );
         $plaintext = 'plaintext data that should not be encrypted';
 
         $result = $crypto->encryptForFilesystem($plaintext);

--- a/tests/Tests/Isolated/RestControllers/Authorization/EhrLaunchPatientContextTest.php
+++ b/tests/Tests/Isolated/RestControllers/Authorization/EhrLaunchPatientContextTest.php
@@ -21,7 +21,10 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\RestControllers\Authorization;
 
-use OpenEMR\BC\ServiceContainer;
+use OpenEMR\BC\{
+    Crypto\ContextualEncryptionTrait,
+    ServiceContainer,
+};
 use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Crypto\KeySource;
 use OpenEMR\FHIR\SMART\SMARTLaunchToken;
@@ -37,6 +40,9 @@ class EhrLaunchPatientContextTest extends TestCase
         // Provide a no-op crypto implementation so SMARTLaunchToken can
         // serialize/deserialize without database-backed encryption keys.
         $crypto = new class implements CryptoInterface {
+            use ContextualEncryptionTrait;
+            private bool $shouldEncryptForDatabase = true;
+            private bool $shouldEncryptForFilesystem = true;
             public function encryptStandard(?string $value, KeySource $keySource = KeySource::Drive): string
             {
                 // Use reversible encoding instead of real encryption
@@ -54,40 +60,6 @@ class EhrLaunchPatientContextTest extends TestCase
             public function cryptCheckStandard(?string $value): bool
             {
                 return $value !== null && str_starts_with($value, 'ENC:');
-            }
-
-            public function encryptForDatabase(?string $value): string
-            {
-                return $this->encryptStandard($value);
-            }
-
-            public function encryptForFilesystem(?string $value): string
-            {
-                return $this->encryptStandard($value);
-            }
-
-            public function decryptFromDatabase(?string $value, ?int $minimumVersion = null): string
-            {
-                if ($value === null || $value === '') {
-                    return '';
-                }
-                if (!$this->cryptCheckStandard($value)) {
-                    return $value;
-                }
-                $result = $this->decryptStandard($value, minimumVersion: $minimumVersion);
-                return $result === false ? '' : $result;
-            }
-
-            public function decryptFromFilesystem(?string $value): string
-            {
-                if ($value === null || $value === '') {
-                    return '';
-                }
-                if (!$this->cryptCheckStandard($value)) {
-                    return $value;
-                }
-                $result = $this->decryptStandard($value);
-                return $result === false ? '' : $result;
             }
         };
         ServiceContainer::override(CryptoInterface::class, $crypto);


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Adds `isDatabaseValueLatest()` and `isFilesystemValueLatest()` methods to `CryptoInterface` for checking whether encrypted values match the current encryption configuration (enabled/disabled, key version). This will be used for key rotation tooling - #12094.

Also adds conditional database encryption support via `shouldEncryptForDatabase` flag. Extracts repeated logic in CryptoInterface implementations into a shared trait.

Related to #11973, which will make the actual "for database" path togglable

#### Changes proposed in this pull request:

- Add `ContextualEncryptionTrait` with shared encryption/decryption logic and status check methods
- Add `isDatabaseValueLatest()` and `isFilesystemValueLatest()` to `CryptoInterface`
- Add `shouldEncryptForDatabase` constructor parameter to `BC\Crypto\Crypto`
- Migrate ~50 files from raw `CryptoGen` calls to contextual `encryptForDatabase`/`decryptFromDatabase` methods
- Add comprehensive test coverage for new status check methods
- Update PHPStan baselines for improved type safety

#### Was an AI assistant used? Yes
