### PR TITLE
refactor(audit): Remove redundant encryption from audit log writes

### DIFF
--- a/interface/logview/logview.php
+++ b/interface/logview/logview.php
@@ -321,6 +321,7 @@ if (!empty($_GET)) {
                                                 $patterns = ['/^success/', '/^failure/', '/ encounter/'];
                                                 $replace = [xl('success'), xl('failure'), sprintf(' %s', xl('encounter'))];
 
+                                                // Note: new data no longer written encrypted. Kept for compatibility. See #12118.
                                                 $commentEncrStatus = !empty($iter['encrypt']) ? $iter['encrypt'] : "No";
                                                 $encryptVersion = !empty($iter['version']) ? $iter['version'] : 0;
 

--- a/interface/logview/logview.php
+++ b/interface/logview/logview.php
@@ -321,7 +321,7 @@ if (!empty($_GET)) {
                                                 $patterns = ['/^success/', '/^failure/', '/ encounter/'];
                                                 $replace = [xl('success'), xl('failure'), sprintf(' %s', xl('encounter'))];
 
-                                                // Note: new data no longer written encrypted. Kept for compatibility. See #12118.
+                                                // Note: new data no longer written encrypted. Kept for compatibility. See #12118+12120.
                                                 $commentEncrStatus = !empty($iter['encrypt']) ? $iter['encrypt'] : "No";
                                                 $encryptVersion = !empty($iter['version']) ? $iter['version'] : 0;
 

--- a/interface/reports/audit_log_tamper_report.php
+++ b/interface/reports/audit_log_tamper_report.php
@@ -279,6 +279,7 @@ $check_sum = isset($_GET['check_sum']);
                 $logType = xl('API');
             }
 
+            // Note: new data no longer written encrypted. Kept for compatibility. See #12118.
             $commentEncrStatus = !empty($iter['encrypt']) ? $iter['encrypt'] : "No";
             $encryptVersion = !empty($iter['version']) ? $iter['version'] : 0;
 

--- a/interface/reports/audit_log_tamper_report.php
+++ b/interface/reports/audit_log_tamper_report.php
@@ -279,7 +279,7 @@ $check_sum = isset($_GET['check_sum']);
                 $logType = xl('API');
             }
 
-            // Note: new data no longer written encrypted. Kept for compatibility. See #12118.
+            // Note: new data no longer written encrypted. Kept for compatibility. See #12118+12120.
             $commentEncrStatus = !empty($iter['encrypt']) ? $iter['encrypt'] : "No";
             $encryptVersion = !empty($iter['version']) ? $iter['version'] : 0;
 

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2904,13 +2904,6 @@ $GLOBALS_METADATA = [
             xl('CA Certificate for verifying the RFC 5425 TLS syslog server.')
         ],
 
-        'enable_auditlog_encryption' => [
-            xl('Enable Audit Log Encryption'),
-            'bool',                           // data type
-            '0',                              // default
-            xl('Enable Audit Log Encryption')
-        ],
-
         'api_log_option' => [
             xl('API Log Option'),
             [

--- a/src/Common/Logging/Audit/Event.php
+++ b/src/Common/Logging/Audit/Event.php
@@ -32,7 +32,6 @@ readonly class Event
      * @param ?ApiData $api
      */
     public function __construct(
-        public bool $isEncrypted,
         public string $current_datetime,
         public string $event,
         public ?string $category,

--- a/src/Common/Logging/Audit/LogTablesSink.php
+++ b/src/Common/Logging/Audit/LogTablesSink.php
@@ -84,7 +84,7 @@ readonly class LogTablesSink implements SinkInterface
         // 2. insert associated entry (in addition to calculating and storing applicable checksums) into log_comment_encrypt
         $logCommentData = [
             'log_id' => $lastLogId,
-            'encrypt' => $event->isEncrypted ? 'Yes' : 'No', // DB is a Yes/No enum instead of bool :(
+            'encrypt' => 'No', // DB is a Yes/No enum instead of bool :( (see #12118)
             'checksum' => $checksum,
             'checksum_api' => $checksumGenerateApi,
             'version' => '4',

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -829,13 +829,4 @@ class EventAuditLogger
 
         return $event;
     }
-
-    private function encrypt(#[SensitiveParameter] string $plaintext): string
-    {
-        if ($this->crypto instanceof CipherSuiteInterface) {
-            return $this->crypto->encrypt($plaintext);
-        } else {
-            return $this->crypto->encryptStandard($plaintext);
-        }
-    }
 }

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -684,7 +684,6 @@ class EventAuditLogger
         //  4. if atna server is on, then send entry to atna server
         //
         $auditEvent = new Audit\Event(
-            $this->shouldEncrypt,
             $current_datetime,
             $event,
             $category,

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -663,20 +663,11 @@ class EventAuditLogger
             $patientId = null;
         }
 
-        if ($this->shouldEncrypt) {
-            $comments = $this->encrypt($comments);
-            if ($api !== null) {
-                $api['request_url'] = ($api['request_url'] === '') ? '' : $this->encrypt($api['request_url']);
-                $api['request_body'] = ($api['request_body'] === '') ? '' : $this->encrypt($api['request_body']);
-                $api['response'] = ($api['response'] === '') ? '' : $this->encrypt($api['response']);
-            }
-        } else {
-            // Since storing binary elements (uuid), need to base64 to not jarble them and to ensure the auditing hashing works
-            $comments = base64_encode($comments);
+        // Note: this used to have an encryption path; it was removed as part
+        // of #12118.
 
-            // Should this blank out the api fields? Previous behavior was that
-            // it did not.
-        }
+        // Since storing binary elements (uuid), need to base64 to not jarble them and to ensure the auditing hashing works
+        $comments = base64_encode($comments);
 
         // Collect timestamp and if pertinent, collect client cert name
         $current_datetime = $this->clock->now()->format('Y-m-d H:i:s');

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -661,7 +661,7 @@ class EventAuditLogger
         }
 
         // Note: this used to have an encryption path; it was removed as part
-        // of #12118.
+        // of #12118+12120.
 
         // Since storing binary elements (uuid), need to base64 to not jarble them and to ensure the auditing hashing works
         $comments = base64_encode($comments);

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -20,13 +20,10 @@ use OpenEMR\BC\{
     ServiceContainer,
 };
 use OpenEMR\Common\Auth\AuthEvent;
-use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Core\Traits\SingletonTrait;
-use OpenEMR\Encryption\CipherSuiteInterface;
 use Psr\Clock\ClockInterface;
-use SensitiveParameter;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -87,7 +87,6 @@ class EventAuditLogger
         return new self(
             sinks: $sinks,
             crypto: ServiceContainer::getCrypto(),
-            shouldEncrypt: $bag->getBoolean('enable_auditlog_encryption'),
             session: SessionWrapperFactory::getInstance()->getActiveSession(),
             config: $auditConfig,
             breakglassChecker: new BreakglassChecker($auditConn),
@@ -101,7 +100,6 @@ class EventAuditLogger
     public function __construct(
         private readonly array $sinks,
         private readonly CipherSuiteInterface|CryptoInterface $crypto,
-        private readonly bool $shouldEncrypt,
         private readonly SessionInterface $session,
         private readonly AuditConfig $config,
         private readonly BreakglassCheckerInterface $breakglassChecker,

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -86,7 +86,6 @@ class EventAuditLogger
 
         return new self(
             sinks: $sinks,
-            crypto: ServiceContainer::getCrypto(),
             session: SessionWrapperFactory::getInstance()->getActiveSession(),
             config: $auditConfig,
             breakglassChecker: new BreakglassChecker($auditConn),
@@ -99,7 +98,6 @@ class EventAuditLogger
      */
     public function __construct(
         private readonly array $sinks,
-        private readonly CipherSuiteInterface|CryptoInterface $crypto,
         private readonly SessionInterface $session,
         private readonly AuditConfig $config,
         private readonly BreakglassCheckerInterface $breakglassChecker,

--- a/tests/Tests/Fixtures/EventAuditLoggerFixturesTest.php
+++ b/tests/Tests/Fixtures/EventAuditLoggerFixturesTest.php
@@ -37,7 +37,6 @@ final class EventAuditLoggerFixturesTest extends TestCase
      */
     private array $modifiedGlobalKeys = [
         'enable_auditlog',
-        'enable_auditlog_encryption',
         'enable_atna_audit'
     ];
 
@@ -55,7 +54,6 @@ final class EventAuditLoggerFixturesTest extends TestCase
 
         // Enable audit logging for comprehensive testing
         $GLOBALS['enable_auditlog'] = true;
-        $GLOBALS['enable_auditlog_encryption'] = false;
 
         $this->eventAuditLogger = EventAuditLogger::getInstance();
 

--- a/tests/Tests/Isolated/Common/Logging/Audit/AtnaSinkTest.php
+++ b/tests/Tests/Isolated/Common/Logging/Audit/AtnaSinkTest.php
@@ -43,7 +43,6 @@ class AtnaSinkTest extends TestCase
         string $comments = 'Test comment',
     ): Event {
         return new Event(
-            isEncrypted: false,
             current_datetime: '2026-03-10 12:00:00',
             event: $event,
             category: 'test',

--- a/tests/Tests/Isolated/Common/Logging/Audit/LogTablesSinkTest.php
+++ b/tests/Tests/Isolated/Common/Logging/Audit/LogTablesSinkTest.php
@@ -35,10 +35,9 @@ class LogTablesSinkTest extends TestCase
     /**
      * @param ?ApiData $api
      */
-    private function createEvent(bool $isEncrypted = false, ?array $api = null): Event
+    private function createEvent(?array $api = null): Event
     {
         return new Event(
-            isEncrypted: $isEncrypted,
             current_datetime: '2026-03-11 12:00:00',
             event: 'test-event',
             category: 'test-category',
@@ -125,33 +124,9 @@ class LogTablesSinkTest extends TestCase
         self::assertSame(128, strlen($capturedLogCommentData['checksum']));
     }
 
-    public function testRecordSetsEncryptFlagToYesWhenEventIsEncrypted(): void
+    public function testRecordSetsEncryptFlagToNo(): void
     {
-        $event = $this->createEvent(isEncrypted: true);
-
-        $capturedLogCommentData = null;
-        $this->connection->expects($this->exactly(2))
-            ->method('insert')
-            ->willReturnCallback(function (string $table, array $data) use (&$capturedLogCommentData): int {
-                if ($table === 'log_comment_encrypt') {
-                    $capturedLogCommentData = $data;
-                }
-                return 1;
-            });
-
-        $this->connection->method('lastInsertId')->willReturn('1');
-
-        $sink = new LogTablesSink(conn: $this->connection);
-
-        $sink->record($event);
-
-        self::assertIsArray($capturedLogCommentData);
-        self::assertSame('Yes', $capturedLogCommentData['encrypt']);
-    }
-
-    public function testRecordSetsEncryptFlagToNoWhenEventIsNotEncrypted(): void
-    {
-        $event = $this->createEvent(isEncrypted: false);
+        $event = $this->createEvent();
 
         $capturedLogCommentData = null;
         $this->connection->expects($this->exactly(2))
@@ -176,7 +151,6 @@ class LogTablesSinkTest extends TestCase
     public function testRecordHandlesNullUserAndGroup(): void
     {
         $event = new Event(
-            isEncrypted: false,
             current_datetime: '2026-03-11 12:00:00',
             event: 'test-event',
             category: 'test-category',
@@ -218,7 +192,6 @@ class LogTablesSinkTest extends TestCase
     public function testRecordHandlesNullPatientId(): void
     {
         $event = new Event(
-            isEncrypted: false,
             current_datetime: '2026-03-11 12:00:00',
             event: 'test-event',
             category: null,

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerAuthFailureTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerAuthFailureTest.php
@@ -16,7 +16,6 @@ namespace OpenEMR\Tests\Isolated\Common\Logging;
 
 use Lcobucci\Clock\FrozenClock;
 use OpenEMR\Common\Auth\AuthEvent;
-use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Logging\Audit\Event;
 use OpenEMR\Common\Logging\Audit\SinkInterface;
 use OpenEMR\Common\Logging\AuditConfig;
@@ -28,14 +27,12 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class EventAuditLoggerAuthFailureTest extends TestCase
 {
-    private CryptoInterface&MockObject $crypto;
     private SessionInterface&MockObject $session;
     private AuditConfig $config;
     private BreakglassCheckerInterface&MockObject $breakglassChecker;
 
     protected function setUp(): void
     {
-        $this->crypto = $this->createMock(CryptoInterface::class);
         $this->session = $this->createMock(SessionInterface::class);
         $this->config = new AuditConfig(
             enabled: true,
@@ -60,8 +57,6 @@ class EventAuditLoggerAuthFailureTest extends TestCase
     {
         return new EventAuditLogger(
             sinks: [$sink],
-            crypto: $this->crypto,
-            shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -15,13 +15,11 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Isolated\Common\Logging;
 
 use Lcobucci\Clock\FrozenClock;
-use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Logging\Audit\Event;
 use OpenEMR\Common\Logging\Audit\SinkInterface;
 use OpenEMR\Common\Logging\AuditConfig;
 use OpenEMR\Common\Logging\BreakglassCheckerInterface;
 use OpenEMR\Common\Logging\EventAuditLogger;
-use OpenEMR\Encryption\CipherSuiteInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
@@ -29,7 +27,6 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class EventAuditLoggerTest extends TestCase
 {
-    private CryptoInterface&MockObject $crypto;
     private SessionInterface&MockObject $session;
     private AuditConfig $config;
     private BreakglassCheckerInterface&MockObject $breakglassChecker;
@@ -37,7 +34,6 @@ class EventAuditLoggerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->crypto = $this->createMock(CryptoInterface::class);
         $this->session = $this->createMock(SessionInterface::class);
         $this->config = new AuditConfig(
             enabled: true,
@@ -66,8 +62,6 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$sink1, $sink2],
-            crypto: $this->crypto,
-            shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -101,8 +95,6 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$sink],
-            crypto: $this->crypto,
-            shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -120,42 +112,7 @@ class EventAuditLoggerTest extends TestCase
         );
     }
 
-    public function testRecordLogItemEncryptsCommentsWhenEnabled(): void
-    {
-        $this->crypto->expects($this->once())
-            ->method('encryptStandard')
-            ->with('Sensitive data')
-            ->willReturn('encrypted:Sensitive data');
-
-        $sink = $this->createMock(SinkInterface::class);
-        $sink->expects($this->once())
-            ->method('record')
-            ->with(self::callback(function (Event $event): bool {
-                self::assertSame('encrypted:Sensitive data', $event->comments);
-                return true;
-            }))
-            ->willReturn(true);
-
-        $logger = new EventAuditLogger(
-            sinks: [$sink],
-            crypto: $this->crypto,
-            shouldEncrypt: true,
-            session: $this->session,
-            config: $this->config,
-            breakglassChecker: $this->breakglassChecker,
-            clock: $this->clock,
-        );
-
-        $logger->recordLogItem(
-            success: 1,
-            event: 'login',
-            user: 'testuser',
-            group: 'testgroup',
-            comments: 'Sensitive data',
-        );
-    }
-
-    public function testRecordLogItemBase64EncodesCommentsWhenNotEncrypted(): void
+    public function testRecordLogItemBase64EncodesComments(): void
     {
         $sink = $this->createMock(SinkInterface::class);
         $sink->expects($this->once())
@@ -168,8 +125,6 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$sink],
-            crypto: $this->crypto,
-            shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -189,8 +144,6 @@ class EventAuditLoggerTest extends TestCase
     {
         $logger = new EventAuditLogger(
             sinks: [],
-            crypto: $this->crypto,
-            shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -223,8 +176,6 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$failingSink, $successSink],
-            crypto: $this->crypto,
-            shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -237,52 +188,6 @@ class EventAuditLoggerTest extends TestCase
             user: 'testuser',
             group: 'testgroup',
             comments: 'Test comments',
-        );
-    }
-
-    public function testRecordLogItemEncryptsApiDataWhenEnabled(): void
-    {
-        $this->crypto->expects($this->exactly(4))
-            ->method('encryptStandard')
-            ->willReturnCallback(fn(string $value): string => 'encrypted:' . $value);
-
-        $sink = $this->createMock(SinkInterface::class);
-        $sink->expects($this->once())
-            ->method('record')
-            ->with(self::callback(function (Event $event): bool {
-                self::assertNotNull($event->api);
-                self::assertSame('encrypted:https://api.example.com/patient', $event->api['request_url']);
-                self::assertSame('encrypted:{"id":123}', $event->api['request_body']);
-                self::assertSame('encrypted:{"status":"ok"}', $event->api['response']);
-                return true;
-            }))
-            ->willReturn(true);
-
-        $logger = new EventAuditLogger(
-            sinks: [$sink],
-            crypto: $this->crypto,
-            shouldEncrypt: true,
-            session: $this->session,
-            config: $this->config,
-            breakglassChecker: $this->breakglassChecker,
-            clock: $this->clock,
-        );
-
-        $logger->recordLogItem(
-            success: 1,
-            event: 'api-create',
-            user: 'apiuser',
-            group: 'api',
-            comments: 'API call',
-            api: [
-                'user_id' => 1,
-                'patient_id' => 123,
-                'method' => 'POST',
-                'request' => 'create patient',
-                'request_url' => 'https://api.example.com/patient',
-                'request_body' => '{"id":123}',
-                'response' => '{"status":"ok"}',
-            ],
         );
     }
 
@@ -299,8 +204,6 @@ class EventAuditLoggerTest extends TestCase
 
         $logger = new EventAuditLogger(
             sinks: [$sink],
-            crypto: $this->crypto,
-            shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -315,42 +218,6 @@ class EventAuditLoggerTest extends TestCase
             group: 'testgroup',
             comments: 'Test comments',
             patientId: 'NULL',
-        );
-    }
-
-    public function testRecordLogItemEncryptsCommentsViaCipherSuite(): void
-    {
-        $cipherSuite = $this->createMock(CipherSuiteInterface::class);
-        $cipherSuite->expects($this->once())
-            ->method('encrypt')
-            ->with('Sensitive data')
-            ->willReturn('ciphersuite-encrypted:Sensitive data');
-
-        $sink = $this->createMock(SinkInterface::class);
-        $sink->expects($this->once())
-            ->method('record')
-            ->with(self::callback(function (Event $event): bool {
-                self::assertSame('ciphersuite-encrypted:Sensitive data', $event->comments);
-                return true;
-            }))
-            ->willReturn(true);
-
-        $logger = new EventAuditLogger(
-            sinks: [$sink],
-            crypto: $cipherSuite,
-            shouldEncrypt: true,
-            session: $this->session,
-            config: $this->config,
-            breakglassChecker: $this->breakglassChecker,
-            clock: $this->clock,
-        );
-
-        $logger->recordLogItem(
-            success: 1,
-            event: 'login',
-            user: 'testuser',
-            group: 'testgroup',
-            comments: 'Sensitive data',
         );
     }
 }

--- a/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Unit\Common\Logging;
 
 use Lcobucci\Clock\FrozenClock;
-use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Logging\AuditConfig;
 use OpenEMR\Common\Logging\BreakglassCheckerInterface;
 use OpenEMR\Common\Logging\EventAuditLogger;
@@ -83,7 +82,6 @@ final class EventAuditLoggerTest extends TestCase
      */
     private array $modifiedGlobalKeys = [
         'enable_auditlog',
-        'enable_auditlog_encryption',
         'audit_events_patient-record',
         'audit_events_security-administration',
         'audit_events_query',
@@ -186,7 +184,6 @@ final class EventAuditLoggerTest extends TestCase
 
         // Setup default $GLOBALS values - disable audit logging for unit tests to prevent SQL escaping errors
         $GLOBALS['enable_auditlog'] = false;
-        $GLOBALS['enable_auditlog_encryption'] = false;
         $GLOBALS['audit_events_patient-record'] = true;
         $GLOBALS['audit_events_security-administration'] = true;
         $GLOBALS['audit_events_query'] = true;
@@ -257,11 +254,9 @@ final class EventAuditLoggerTest extends TestCase
             ->willReturnCallback(fn(string $key) => $sessionValues[$key] ?? null);
 
         // Return positional array matching constructor parameter order:
-        // sinks, cryptoGen, shouldEncrypt, session, config, breakglassChecker, clock
+        // sinks, cryptoGen,  session, config, breakglassChecker, clock
         return [
             [],                                         // sinks
-            $this->createMock(CryptoGen::class),        // cryptoGen
-            false,                                      // shouldEncrypt
             $sessionMock,                               // session
             $config ?? $this->config,                   // config
             $this->breakglassChecker,                   // breakglassChecker
@@ -505,13 +500,12 @@ final class EventAuditLoggerTest extends TestCase
     }
 
     /**
-     * Test recordLogItem method without encryption
+     * Test recordLogItem method
      */
     public function testRecordLogItem(): void
     {
         // Keep audit logging disabled to prevent SQL escaping errors
         $GLOBALS['enable_auditlog'] = false;
-        $GLOBALS['enable_auditlog_encryption'] = false;
 
         $eventAuditLogger = new EventAuditLogger(
             sinks: [],
@@ -1185,7 +1179,6 @@ final class EventAuditLoggerTest extends TestCase
     {
         // Enable audit logging for this specific test
         $GLOBALS['enable_auditlog'] = true;
-        $GLOBALS['enable_auditlog_encryption'] = false;
 
         // Setup database mock for this test
         $mockAdodb = $this->createMockAdodb();

--- a/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Unit\Common\Logging;
 
 use Lcobucci\Clock\FrozenClock;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Logging\AuditConfig;
 use OpenEMR\Common\Logging\BreakglassCheckerInterface;
@@ -136,8 +135,6 @@ final class EventAuditLoggerTest extends TestCase
         // Get EventAuditLogger instance (works with existing singleton)
         $this->eventAuditLogger = new EventAuditLogger(
             sinks: [],
-            crypto: ServiceContainer::getCrypto(),
-            shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -510,7 +507,7 @@ final class EventAuditLoggerTest extends TestCase
     /**
      * Test recordLogItem method without encryption
      */
-    public function testRecordLogItemWithoutEncryption(): void
+    public function testRecordLogItem(): void
     {
         // Keep audit logging disabled to prevent SQL escaping errors
         $GLOBALS['enable_auditlog'] = false;
@@ -518,8 +515,6 @@ final class EventAuditLoggerTest extends TestCase
 
         $eventAuditLogger = new EventAuditLogger(
             sinks: [],
-            crypto: $this->createMock(CryptoGen::class),
-            shouldEncrypt: false,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -539,61 +534,6 @@ final class EventAuditLoggerTest extends TestCase
 
         // Test passes if no exceptions are thrown
         $this->addToAssertionCount(1);
-    }
-
-    /**
-     * Test recordLogItem method with encryption enabled (integration-style test)
-     */
-    public function testRecordLogItemWithEncryption(): void
-    {
-        // Enable audit logging and encryption for this specific test
-        $GLOBALS['enable_auditlog'] = true;
-        $GLOBALS['enable_auditlog_encryption'] = true;
-
-        // Setup database mock for this test
-        $mockAdodb = $this->createMockAdodb();
-        $this->setGlobalAdodbMock($mockAdodb);
-
-        // Create a mock CryptoGen to verify encryption calls
-        $cryptoMock = $this->getMockBuilder(CryptoGen::class)
-            ->onlyMethods(['encryptStandard'])
-            ->getMock();
-
-        $cryptoMock->expects($this->exactly(1))
-            ->method('encryptStandard')
-            ->willReturnCallback(
-                fn(string $value): string => 'encrypted_' . $value
-            );
-
-        $eventAuditLogger = new EventAuditLogger(
-            sinks: [],
-            crypto: $cryptoMock,
-            shouldEncrypt: true,
-            session: $this->session,
-            config: $this->config,
-            breakglassChecker: $this->breakglassChecker,
-            clock: $this->clock,
-        );
-
-        try {
-            // This should execute the full recordLogItem flow including encryption
-            $eventAuditLogger->recordLogItem(
-                1,
-                'patient-record-select',
-                'testuser',
-                'testgroup',
-                'SELECT * FROM patient_data',
-                123,
-                'patient-record'
-            );
-
-            // Test passes if no exceptions are thrown
-            $this->addToAssertionCount(1);
-        } finally {
-            // Restore audit logging state
-            $GLOBALS['enable_auditlog'] = false;
-            $GLOBALS['enable_auditlog_encryption'] = false;
-        }
     }
 
     /**
@@ -631,76 +571,6 @@ final class EventAuditLoggerTest extends TestCase
         );
 
         // Test passes if no exceptions are thrown
-        $this->addToAssertionCount(1);
-    }
-
-    /**
-     * Test recordLogItem with encryption enabled and API data
-     */
-    public function testRecordLogItemWithEncryptionAndApiData(): void
-    {
-        // Enable audit logging and encryption
-        $GLOBALS['enable_auditlog'] = true;
-        $GLOBALS['enable_auditlog_encryption'] = true;
-
-        // Setup database mock
-        $mockAdodb = $this->createMockAdodb();
-        $this->setGlobalAdodbMock($mockAdodb);
-
-        // Create API data with all the fields that get encrypted
-        $apiData = [
-            'user_id' => 1,
-            'patient_id' => 123,
-            'method' => 'POST',
-            'request' => '/api/patient/123',
-            'request_url' => 'https://example.com/api/patient/123',  // Line 767: This will be encrypted
-            'request_body' => '{"name": "John Doe"}',               // Line 768: This will be encrypted
-            'response' => '{"status": "success", "id": 123}'        // Line 769: This will be encrypted
-        ];
-
-        // Create a mock CryptoGen to verify encryption calls
-        $cryptoMock = $this->getMockBuilder(CryptoGen::class)
-            ->onlyMethods(['encryptStandard'])
-            ->getMock();
-
-        // Expect encryptStandard to be called 4 times:
-        // 1 time for comments, 3 times for API fields (request_url, request_body, response)
-        $cryptoMock->expects($this->exactly(4))
-            ->method('encryptStandard')
-            ->willReturnCallback(
-                fn(string $value): string => 'encrypted_' . $value
-            );
-
-        $eventAuditLogger = new EventAuditLogger(
-            sinks: [],
-            crypto: $cryptoMock,
-            shouldEncrypt: true,
-            session: $this->session,
-            config: $this->config,
-            breakglassChecker: $this->breakglassChecker,
-            clock: $this->clock,
-        );
-
-        // Call recordLogItem with API data - this should execute the encryption code:
-        // Line 767: $api['request_url'] = (!empty($api['request_url'])) ? $this->cryptoGen->encryptStandard($api['request_url']) : '';
-        // Line 768: $api['request_body'] = (!empty($api['request_body'])) ? $this->cryptoGen->encryptStandard($api['request_body']) : '';
-        // Line 769: $api['response'] = (!empty($api['response'])) ? $this->cryptoGen->encryptStandard($api['response']) : '';
-        $eventAuditLogger->recordLogItem(
-            1,
-            'api-create',
-            'apiuser',
-            'api',
-            'API call to create patient',
-            123,
-            'patient-record',
-            'api',
-            null,
-            null,
-            '',
-            $apiData
-        );
-
-        // Test passes if the encryption methods were called as expected
         $this->addToAssertionCount(1);
     }
 


### PR DESCRIPTION
#### Short description of what this changes or resolves:
Removes support for writing encrypted data to the audit logs. Existing data reads will continue to support decrypting existing data, and have been marked with a reference to this task for added context.

This is the first step towards #12118, though it doesn't complete it. Fixes #12120.

tl;dr: the Audit Log, per ONC (see linked issue), needs to be append-only and tamper-resistant+tamper-evident, but encryption is not part of the requirements. Encryption (which defaulted to off) does not enhance immutability on top of the existing checksumming system. Its presence is really just a liability, since it risks locking you out of critical audit data if there's an issue with key management.

> 170.315(d)(10) 
> (i) By default, be set to record actions related to electronic health information in accordance with the standard specified in [§ 170.210(e)(1)](https://www.ecfr.gov/current/title-45/section-170.210#p-170.210(e)(1)).
> (ii) If technology permits auditing to be disabled, the ability to do so must be restricted to a limited set of users.
> (iii) Actions recorded related to electronic health information must not be capable of being changed, overwritten, or deleted by the technology.
> (iv) Technology must be able to detect whether the audit log has been altered.

This change makes no regressions on certification requirements. There are follow-up issues linked from the parent to enhance the processes described in subsections iii and iv, independent of this change.

The encryption is also _uniquely_ problematic in the application setup, bootstrapping, and runtime: there's a patched-around circular dependency between the database and the audit logger. DB queries go through audit logging, audit logging could use encryption, and the encryption keys need to be obtained through a database connection (even when using the keys on the filesystem since they're encrypted with the db keys).

Through a combination of global state manipulation and careful routing through the "no log" query utilities, we've managed to work around it, but it's _extremely_ fragile and deeply incompatible with trying to move forward into a DI world. The fact that dropping audit log encryption fixes this is a huge bonus (I believe this means DBAL/ORM should be _relatively_ straightforward to progress on now, rather than requiring layers of indirection and complexity), but not directly a motivating factor.

#### Changes proposed in this pull request:

- Remove `enable_auditlog_encryption` config value
- Remove reading it from EAL
- Unthread both the preference and the cryptography tools from EAL, the Audit Event DTO, and the sinks
- Remove now-unreachable test paths

Testing:
- CI
- Verifying setting no longer in the admin>config menu
- Verifying audit log screen still works, including when display data that was previously encrypted
- Verifying audit log tamper report still works, including data ranges including encrypted data

#### Was an AI assistant used? Yes / No
Review only.