### PR TITLE
feat(release): dispatch openemr-tag to openemr/demo_farm_openemr

### DIFF
--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -47,7 +47,7 @@ jobs:
         # targets, otherwise repository_dispatch to the consumer repos
         # returns 403 "Resource not accessible by integration".
         owner: ${{ github.repository_owner }}
-        repositories: openemr,openemr-devops,website-openemr
+        repositories: openemr,openemr-devops,website-openemr,demo_farm_openemr
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer
@@ -154,7 +154,7 @@ jobs:
         php tools/release/bin/dispatch.php \
           --probe \
           --event=release-permissions-probe \
-          --target-repos=openemr/openemr-devops,openemr/website-openemr \
+          --target-repos=openemr/openemr-devops,openemr/website-openemr,openemr/demo_farm_openemr \
           --sha='${{ github.sha }}' \
           --actor=openemr-release-bot
         echo "OK: dispatched release-permissions-probe to consumer repos"

--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -41,7 +41,7 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ secrets.RELEASE_APP_ID }}
+        client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
         # Scope the installation token to this repo plus the dispatch
         # targets, otherwise repository_dispatch to the consumer repos

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -82,7 +82,7 @@ jobs:
         # targets, otherwise repository_dispatch to the consumer repos
         # returns 403 "Resource not accessible by integration".
         owner: ${{ github.repository_owner }}
-        repositories: openemr,openemr-devops,website-openemr
+        repositories: openemr,openemr-devops,website-openemr,demo_farm_openemr
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer
@@ -245,7 +245,7 @@ jobs:
         # targets, otherwise repository_dispatch to the consumer repos
         # returns 403 "Resource not accessible by integration".
         owner: ${{ github.repository_owner }}
-        repositories: openemr,openemr-devops,website-openemr
+        repositories: openemr,openemr-devops,website-openemr,demo_farm_openemr
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -76,7 +76,7 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ secrets.RELEASE_APP_ID }}
+        client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
         # Scope the installation token to this repo plus the dispatch
         # targets, otherwise repository_dispatch to the consumer repos
@@ -239,7 +239,7 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ secrets.RELEASE_APP_ID }}
+        client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
         # Scope the installation token to this repo plus the dispatch
         # targets, otherwise repository_dispatch to the consumer repos

--- a/docs/release-automation-plan.md
+++ b/docs/release-automation-plan.md
@@ -120,7 +120,8 @@ In dependency order:
 ## Permissions self-check
 
 `.github/workflows/release-permissions-check.yml` (manual `workflow_dispatch`).
-Mints an App token from `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY` and
+Mints an App token from the org variable `RELEASE_APP_CLIENT_ID` (a
+`vars.*` entry, not a secret) plus the org secret `RELEASE_APP_PRIVATE_KEY` and
 probes everything the conductor workflow performs:
 
 - `GET /installation/repositories` — confirm this repo is in the install list.

--- a/tests/Tests/Isolated/Release/DispatcherTest.php
+++ b/tests/Tests/Isolated/Release/DispatcherTest.php
@@ -22,6 +22,13 @@ final class DispatcherTest extends TestCase
 {
     private const SCHEMA_PATH = __DIR__ . '/../../../../tools/release/contracts/dispatch.schema.json';
 
+    public function testDefaultTargetReposIncludesAllConsumers(): void
+    {
+        self::assertContains('openemr/openemr-devops', Dispatcher::DEFAULT_TARGET_REPOS);
+        self::assertContains('openemr/website-openemr', Dispatcher::DEFAULT_TARGET_REPOS);
+        self::assertContains('openemr/demo_farm_openemr', Dispatcher::DEFAULT_TARGET_REPOS);
+    }
+
     public function testValidRelCutDispatchesToBothConsumers(): void
     {
         /** @var list<array{url: string, body: string}> $captured */

--- a/tools/release/bin/dispatch.php
+++ b/tools/release/bin/dispatch.php
@@ -60,7 +60,7 @@ use Symfony\Component\HttpClient\HttpClient;
         null,
         InputOption::VALUE_REQUIRED,
         'Comma-separated owner/name list',
-        'openemr/openemr-devops,openemr/website-openemr,openemr/demo_farm_openemr',
+        implode(',', Dispatcher::DEFAULT_TARGET_REPOS),
     )
     ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'rel-* branch name (rel-cut/update/tag events)')
     ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'MAJOR.MINOR.PATCH release version')

--- a/tools/release/bin/dispatch.php
+++ b/tools/release/bin/dispatch.php
@@ -60,7 +60,7 @@ use Symfony\Component\HttpClient\HttpClient;
         null,
         InputOption::VALUE_REQUIRED,
         'Comma-separated owner/name list',
-        'openemr/openemr-devops,openemr/website-openemr',
+        'openemr/openemr-devops,openemr/website-openemr,openemr/demo_farm_openemr',
     )
     ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'rel-* branch name (rel-cut/update/tag events)')
     ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'MAJOR.MINOR.PATCH release version')

--- a/tools/release/src/Dispatcher.php
+++ b/tools/release/src/Dispatcher.php
@@ -21,6 +21,13 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final readonly class Dispatcher
 {
+    /** @var list<string> Default consumer repos when --target-repos is not supplied. */
+    public const DEFAULT_TARGET_REPOS = [
+        'openemr/openemr-devops',
+        'openemr/website-openemr',
+        'openemr/demo_farm_openemr',
+    ];
+
     public function __construct(
         private HttpClientInterface $httpClient,
         private string $schemaPath,


### PR DESCRIPTION
Refs openemr/openemr-devops#710. Sibling PR on consumer side: openemr/demo_farm_openemr#108.

## Summary

Adds `openemr/demo_farm_openemr` as a consumer of the conductor's `openemr-tag` repository_dispatch. With its sibling PR (openemr/demo_farm_openemr#108), this closes openemr/openemr-devops#710 — the demo-farm tag bump becomes hands-off.

## What this changes

- `release-prep.yml` and `release-permissions-check.yml`: extend the App's installation `repositories:` list to include `demo_farm_openemr`. Without this, the dispatch call gets a 403.
- `tools/release/bin/dispatch.php`: add `openemr/demo_farm_openemr` to the default `--target-repos` list so production runs include it. The existing `Tests\Isolated\Release\DispatcherTest` passes target lists explicitly, so this default change is invisible to tests.
- `release-permissions-check`'s probe step: extend its explicit `--target-repos` the same way so the probe exercises the new repo.

The schema's docstring still lists three consumers; updating it would trigger drift-checks on every other consumer's CI for a documentation-only change. Letting the docstring update ride along with the next real schema change.

## Maintainer setup required (one-time)

For end-to-end to work, two openemr-admin actions are needed:

1. **Expand the openemr release App's installation** to include `openemr/demo_farm_openemr`.
2. **Set `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY` repo secrets on `openemr/demo_farm_openemr`** (mirror the values from openemr/openemr-devops or website-openemr).

Until both are done, the dispatch will hit a 403 on the new target. The other targets are unaffected.

## Test plan

- All 66 isolated Release tests pass (`vendor/bin/phpunit -c phpunit-isolated.xml --filter Release`).
- `actionlint` clean on both modified workflows.
- Once the App scope is expanded, run `release-permissions-check` workflow manually — the probe step now exercises the dispatch path against `demo_farm_openemr` too, so a missing-permission failure shows up there before the next real release.