### PR TITLE
chore: clean up js_escape() patterns

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -8133,7 +8133,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/super/edit_list.php',
 ];
 $ignoreErrors[] = [

--- a/interface/forms/care_plan/new.php
+++ b/interface/forms/care_plan/new.php
@@ -42,7 +42,7 @@ if (empty($formid)) {
     $formid = sqlQuery($sql, [$session->get('pid'), $session->get('encounter')])['form_id'] ?? 0;
     if (!empty($formid)) {
         echo "<script>var message=" .
-            js_escape(xl("Already a Care Plan form for this encounter. Using existing Care Plan form.")) .
+            xlj("Already a Care Plan form for this encounter. Using existing Care Plan form.") .
             "</script>";
     }
 }

--- a/interface/forms/eye_mag/a_issue.php
+++ b/interface/forms/eye_mag/a_issue.php
@@ -515,12 +515,12 @@ $ROSCOMMENTS   = $rres['ROSCOMMENTS']   ?? '';
         function validate() {
             var f = document.forms[0];
             if (f.form_begin.value > f.form_end.value && (f.form_end.value)) {
-                alert(<?php echo js_escape(xl('Please Enter End Date greater than Begin Date!')); ?>);
+                alert(<?php echo xlj('Please Enter End Date greater than Begin Date!'); ?>);
                 return false;
             }
             if (f.form_type.value != 'ROS' && f.form_type.value != 'FH' && f.form_type.value != 'SOCH') {
                 if (!f.form_title.value) {
-                    alert(<?php echo js_escape(xl('Please enter a title!')); ?>);
+                    alert(<?php echo xlj('Please enter a title!'); ?>);
                     return false;
                 }
             }

--- a/interface/forms/procedure_order/common.php
+++ b/interface/forms/procedure_order/common.php
@@ -1150,8 +1150,7 @@ if (!empty($row['lab_id'])) {
 
         function createLabels(e) {
             e.preventDefault();
-            let prmt = <?php echo js_escape(xla("How many sets of specimen labels to create?") .
-                "\n" . xla("Each test in order gets a label.")); ?>;
+            let prmt = <?php echo xlj("How many sets of specimen labels to create?"); ?> + "\n" + <?php echo xlj("Each test in order gets a label."); ?>;
             let count = prompt(prmt, '1');
             if (!count) return false;
             let tarray = "";

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1821,7 +1821,7 @@ function HideRecurrPopup() {
 }
 
 function deleteEvent() {
-    if (confirm(<?php echo js_escape(xl('Deleting this event cannot be undone. It cannot be recovered once it is gone. Are you sure you wish to delete this event?')); ?>)) {
+    if (confirm(<?php echo xlj('Deleting this event cannot be undone. It cannot be recovered once it is gone. Are you sure you wish to delete this event?'); ?>)) {
         $('#form_action').val("delete");
 
         <?php if ($repeats) : ?>

--- a/interface/modules/custom_modules/oe-module-weno/scripts/file_download.php
+++ b/interface/modules/custom_modules/oe-module-weno/scripts/file_download.php
@@ -102,7 +102,7 @@ if ($zip->open($storeLocation) === true) {
         EventAuditLogger::getInstance()->newEvent("pharmacy_log", $session->get('authUser'), $session->get('authProvider'), 0, ($isError['messageText']));
         $wenoLog->insertWenoLog("Pharmacy Directory", "Failed");
         // no need to continue so send error to UI alert and die.
-        die('"Pharmacy download failed."');
+        die(js_escape('Pharmacy download failed.'));
     }
     // process the csv file
     // Number of rows imported or false if error
@@ -145,7 +145,7 @@ if ($zip->open($storeLocation) === true) {
     error_log('Pharmacy download zip open failed.');
     $wenoLog->insertWenoLog("Pharmacy Directory", "Pharmacy download zip open failed.");
     // no need to continue so send error to UI alert and die.
-    die('"Pharmacy download zip open failed."');
+    die(js_escape('Pharmacy download zip open failed.'));
 }
 
 function download_zipfile($fileUrl, $zipped_file): void

--- a/interface/modules/custom_modules/oe-module-weno/scripts/file_download.php
+++ b/interface/modules/custom_modules/oe-module-weno/scripts/file_download.php
@@ -102,7 +102,7 @@ if ($zip->open($storeLocation) === true) {
         EventAuditLogger::getInstance()->newEvent("pharmacy_log", $session->get('authUser'), $session->get('authProvider'), 0, ($isError['messageText']));
         $wenoLog->insertWenoLog("Pharmacy Directory", "Failed");
         // no need to continue so send error to UI alert and die.
-        die(js_escape('Pharmacy download failed.'));
+        die('"Pharmacy download failed."');
     }
     // process the csv file
     // Number of rows imported or false if error
@@ -145,7 +145,7 @@ if ($zip->open($storeLocation) === true) {
     error_log('Pharmacy download zip open failed.');
     $wenoLog->insertWenoLog("Pharmacy Directory", "Pharmacy download zip open failed.");
     // no need to continue so send error to UI alert and die.
-    die(js_escape('Pharmacy download zip open failed.'));
+    die('"Pharmacy download zip open failed."');
 }
 
 function download_zipfile($fileUrl, $zipped_file): void

--- a/interface/modules/custom_modules/oe-module-weno/templates/synch.php
+++ b/interface/modules/custom_modules/oe-module-weno/templates/synch.php
@@ -71,14 +71,14 @@ if ($result == true) {
 function downloadWenoLogCsv()
 {
     if (headers_sent()) {
-        return js_escape("Headers already sent, CSV download cannot proceed.");
+        return "Headers already sent, CSV download cannot proceed.";
     }
     ob_start();
     // Query to get the log data
     $sql = "SELECT `id`, `value`, `status`, `created_at` FROM `weno_download_log` ORDER BY `id` DESC";
     $result = sqlStatement($sql);
     if (!$result) {
-        return js_escape("Failed to retrieve data from the database.");
+        return "Failed to retrieve data from the database.";
     }
     // Set the headers for the CSV download
     header('Content-Type: text/csv');
@@ -104,7 +104,7 @@ function downloadWenoLogCsv()
 function downloadWenoLogCsvAndZip()
 {
     if (headers_sent()) {
-        return js_escape("Headers already sent, download cannot proceed.");
+        return "Headers already sent, download cannot proceed.";
     }
 
     $tempDir = sys_get_temp_dir();
@@ -117,14 +117,14 @@ function downloadWenoLogCsvAndZip()
     // Create CSV of log content to temporary file
     $csvFile = fopen($csvFilePath, 'w');
     if ($csvFile === false) {
-        return js_escape("Failed to open temporary CSV file.");
+        return "Failed to open temporary CSV file.";
     }
     // Query to get the log data
     $sql = "SELECT `id`, `value`, `status`, `created_at`, `data_in_context` FROM `weno_download_log` ORDER BY `id` DESC";
     $result = sqlStatement($sql);
     if (!$result) {
         fclose($csvFile);
-        return js_escape("Failed to retrieve data from the database.");
+        return "Failed to retrieve data from the database.";
     }
     fputcsv($csvFile, ['ID', 'Value', 'Status', 'Created At']);
     while ($row = sqlFetchArray($result)) {
@@ -134,7 +134,7 @@ function downloadWenoLogCsvAndZip()
 
     $zip = new ZipArchive();
     if ($zip->open($zipFilePath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
-        return js_escape("Failed to create ZIP archive.");
+        return "Failed to create ZIP archive.";
     }
     $zip->addFile($csvFilePath, $csvFileName);
     $files = new RecursiveIteratorIterator(

--- a/interface/patient_file/encounter/select_codes.php
+++ b/interface/patient_file/encounter/select_codes.php
@@ -66,7 +66,7 @@ if (!empty($codetype)) {
 
                 // This callback function passes some form data on each call to the ajax handler.
                 "fnServerParams": function (aoData) {
-                    aoData.push({"name": "what", "value": <?php echo js_escape('codes'); ?>});
+                    aoData.push({"name": "what", "value": "codes"});
                     aoData.push({"name": "codetype", "value": document.forms[0].form_code_type.value});
                     aoData.push({"name": "inactive", "value": (document.forms[0].form_include_inactive.checked ? 1 : 0)});
                 },

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -307,7 +307,7 @@ if ((($_POST['formaction'] ?? '') == 'save') && $list_id && $alertmsg == '') {
         $list_id = $newlistID;
     } else {
         // send error and continue.
-        echo "<script>let error=" . js_escape(xlt("The new list") . " [" . $_POST['newlistname'] . "] " . xlt("already exists! Please try again.")) . ";</script>";
+        echo "<script>let error=" . xlj("The new list") . " + ' [' + " . js_escape($_POST['newlistname']) . " + '] ' + " . xlj("already exists! Please try again.") . ";</script>";
     }
     EventAuditLogger::getInstance()->newEvent(
         "add_list",

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -307,7 +307,9 @@ if ((($_POST['formaction'] ?? '') == 'save') && $list_id && $alertmsg == '') {
         $list_id = $newlistID;
     } else {
         // send error and continue.
-        echo "<script>let error=" . xlj("The new list") . " + ' [' + " . js_escape($_POST['newlistname']) . " + '] ' + " . xlj("already exists! Please try again.") . ";</script>";
+        $rawNewListName = $_POST['newlistname'] ?? null;
+        $newlistname = is_string($rawNewListName) ? $rawNewListName : '';
+        echo "<script>let error=" . xlj("The new list") . " + ' [' + " . js_escape($newlistname) . " + '] ' + " . xlj("already exists! Please try again.") . ";</script>";
     }
     EventAuditLogger::getInstance()->newEvent(
         "add_list",

--- a/library/custom_template/add_context.php
+++ b/library/custom_template/add_context.php
@@ -98,7 +98,7 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                     document.designation_managment.submit();
                 }
                 else{
-                    alert(<?php echo js_escape(xl("Context name can't be empty"));?>);
+                    alert(<?php echo xlj("Context name can't be empty");?>);
                 }
             }
             function deleteme(id){
@@ -107,10 +107,10 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                 CheckContextLive(id);
                 stat = document.getElementById('stat').value;
                 if(stat==1){
-                    msg = <?php echo js_escape(xl('This context contains categories, which will be deleted. Do you still want to continue?'));?>;
+                    msg = <?php echo xlj('This context contains categories, which will be deleted. Do you still want to continue?');?>;
                 }
                 else{
-                    msg = <?php echo js_escape(xl('Do you want to delete this?'));?>;
+                    msg = <?php echo xlj('Do you want to delete this?');?>;
                 }
                 if(confirm(msg)){
                 document.getElementById('action').value='delete';
@@ -133,7 +133,7 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                 document.designation_managment.submit();
                 }
                 else{
-                   alert(<?php echo js_escape(xl("Context name can't be empty"));?>);
+                   alert(<?php echo xlj("Context name can't be empty");?>);
                 }
             }
             function CheckContextLive(id){

--- a/library/custom_template/add_context.php
+++ b/library/custom_template/add_context.php
@@ -98,7 +98,7 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                     document.designation_managment.submit();
                 }
                 else{
-                    alert("<?php echo xl("Context name can't be empty"); ?>");
+                    alert(<?php echo xlj("Context name can't be empty"); ?>);
                 }
             }
             function deleteme(id){
@@ -107,10 +107,10 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                 CheckContextLive(id);
                 stat = document.getElementById('stat').value;
                 if(stat==1){
-                    msg = "<?php echo xl('This context contains categories, which will be deleted. Do you still want to continue?'); ?>";
+                    msg = <?php echo xlj('This context contains categories, which will be deleted. Do you still want to continue?'); ?>;
                 }
                 else{
-                    msg = "<?php echo xl('Do you want to delete this?'); ?>";
+                    msg = <?php echo xlj('Do you want to delete this?'); ?>;
                 }
                 if(confirm(msg)){
                 document.getElementById('action').value='delete';
@@ -133,7 +133,7 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                 document.designation_managment.submit();
                 }
                 else{
-                   alert("<?php echo xl("Context name can't be empty"); ?>");
+                   alert(<?php echo xlj("Context name can't be empty"); ?>);
                 }
             }
             function CheckContextLive(id){

--- a/library/custom_template/add_context.php
+++ b/library/custom_template/add_context.php
@@ -98,7 +98,7 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                     document.designation_managment.submit();
                 }
                 else{
-                    alert(<?php echo xlj("Context name can't be empty");?>);
+                    alert("<?php echo xl("Context name can't be empty"); ?>");
                 }
             }
             function deleteme(id){
@@ -107,10 +107,10 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                 CheckContextLive(id);
                 stat = document.getElementById('stat').value;
                 if(stat==1){
-                    msg = <?php echo xlj('This context contains categories, which will be deleted. Do you still want to continue?');?>;
+                    msg = "<?php echo xl('This context contains categories, which will be deleted. Do you still want to continue?'); ?>";
                 }
                 else{
-                    msg = <?php echo xlj('Do you want to delete this?');?>;
+                    msg = "<?php echo xl('Do you want to delete this?'); ?>";
                 }
                 if(confirm(msg)){
                 document.getElementById('action').value='delete';
@@ -133,7 +133,7 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                 document.designation_managment.submit();
                 }
                 else{
-                   alert(<?php echo xlj("Context name can't be empty");?>);
+                   alert("<?php echo xl("Context name can't be empty"); ?>");
                 }
             }
             function CheckContextLive(id){

--- a/library/custom_template/add_template.php
+++ b/library/custom_template/add_template.php
@@ -65,12 +65,12 @@ $list_id = $_REQUEST['list_id'];
                 async: false,
                 success: function(thedata){
                         if(thedata=="Fail"){
-                            alert(document.getElementById('template_name').value + " " + "<?php echo xl('already exists'); ?>");
+                            alert(document.getElementById('template_name').value + " " + <?php echo xlj('already exists'); ?>);
                             return false;
                         }
                         else{
                             mainform.getElementById('templateDD').innerHTML = thedata;
-                            alert("<?php echo xl('Successfully added category'); ?>" + " " + document.getElementById('template_name').value);
+                            alert(<?php echo xlj('Successfully added category'); ?> + " " + document.getElementById('template_name').value);
                             //window.opener.opener.location.reload();
                             dlgclose();
                         }
@@ -81,11 +81,11 @@ $list_id = $_REQUEST['list_id'];
                 });
                 }
                 else{
-                    alert("<?php echo xl('You should select at least one context'); ?>");
+                    alert(<?php echo xlj('You should select at least one context'); ?>);
                 }
             }
             else{
-                alert("<?php echo xl('Category name is empty'); ?>");
+                alert(<?php echo xlj('Category name is empty'); ?>);
                 return false;
             }
         }

--- a/library/custom_template/add_template.php
+++ b/library/custom_template/add_template.php
@@ -65,12 +65,12 @@ $list_id = $_REQUEST['list_id'];
                 async: false,
                 success: function(thedata){
                         if(thedata=="Fail"){
-                            alert(document.getElementById('template_name').value + " " + <?php echo xlj('already exists');?>);
+                            alert(document.getElementById('template_name').value + " " + "<?php echo xl('already exists'); ?>");
                             return false;
                         }
                         else{
                             mainform.getElementById('templateDD').innerHTML = thedata;
-                            alert(<?php echo xlj('Successfully added category');?> + " " + document.getElementById('template_name').value);
+                            alert("<?php echo xl('Successfully added category'); ?>" + " " + document.getElementById('template_name').value);
                             //window.opener.opener.location.reload();
                             dlgclose();
                         }
@@ -81,11 +81,11 @@ $list_id = $_REQUEST['list_id'];
                 });
                 }
                 else{
-                    alert(<?php echo xlj('You should select at least one context');?>);
+                    alert("<?php echo xl('You should select at least one context'); ?>");
                 }
             }
             else{
-                alert(<?php echo xlj('Category name is empty');?>);
+                alert("<?php echo xl('Category name is empty'); ?>");
                 return false;
             }
         }

--- a/library/custom_template/add_template.php
+++ b/library/custom_template/add_template.php
@@ -65,12 +65,12 @@ $list_id = $_REQUEST['list_id'];
                 async: false,
                 success: function(thedata){
                         if(thedata=="Fail"){
-                            alert(document.getElementById('template_name').value + " " + <?php echo js_escape(xl('already exists'));?>);
+                            alert(document.getElementById('template_name').value + " " + <?php echo xlj('already exists');?>);
                             return false;
                         }
                         else{
                             mainform.getElementById('templateDD').innerHTML = thedata;
-                            alert(<?php echo js_escape(xl('Successfully added category'));?> + " " + document.getElementById('template_name').value);
+                            alert(<?php echo xlj('Successfully added category');?> + " " + document.getElementById('template_name').value);
                             //window.opener.opener.location.reload();
                             dlgclose();
                         }
@@ -81,11 +81,11 @@ $list_id = $_REQUEST['list_id'];
                 });
                 }
                 else{
-                    alert(<?php echo js_escape(xl('You should select at least one context'));?>);
+                    alert(<?php echo xlj('You should select at least one context');?>);
                 }
             }
             else{
-                alert(<?php echo js_escape(xl('Category name is empty'));?>);
+                alert(<?php echo xlj('Category name is empty');?>);
                 return false;
             }
         }

--- a/library/custom_template/delete_category.php
+++ b/library/custom_template/delete_category.php
@@ -53,7 +53,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
                      source: "delete_full_category"
                 },
                 success: function(thedata){
-                            alert("<?php echo xl('Deleted Successfully.'); ?>");
+                            alert(<?php echo xlj('Deleted Successfully.'); ?>);
                             document.location.reload();
                             },
                 error:function(){
@@ -63,7 +63,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
         }
         function delete_category(id){
             top.restoreSession();
-            if(confirm("<?php echo xl('Do you want to delete?'); ?>")){
+            if(confirm(<?php echo xlj('Do you want to delete?'); ?>)){
                 $.ajax({
                 type: "POST",
                 url: "ajax_code.php",
@@ -74,7 +74,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
                 },
                 success: function(thedata){
                             if(thedata){
-                                alert("<?php echo xl('There are currently other users of the category you are trying to delete. Please contact them and ask them to delete it. Categories may not be deleted while in use. This Categories are currently used by'); ?>\n" + thedata);
+                                alert(<?php echo xlj('There are currently other users of the category you are trying to delete. Please contact them and ask them to delete it. Categories may not be deleted while in use. This Categories are currently used by'); ?> + "\n" + thedata);
                             }
                             else{
                                 delete_full_category(id);

--- a/library/custom_template/delete_category.php
+++ b/library/custom_template/delete_category.php
@@ -53,7 +53,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
                      source: "delete_full_category"
                 },
                 success: function(thedata){
-                            alert(<?php echo js_escape(xl('Deleted Successfully.'));?>);
+                            alert(<?php echo xlj('Deleted Successfully.');?>);
                             document.location.reload();
                             },
                 error:function(){
@@ -63,7 +63,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
         }
         function delete_category(id){
             top.restoreSession();
-            if(confirm(<?php echo js_escape(xl('Do you want to delete?'));?>)){
+            if(confirm(<?php echo xlj('Do you want to delete?');?>)){
                 $.ajax({
                 type: "POST",
                 url: "ajax_code.php",
@@ -74,7 +74,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
                 },
                 success: function(thedata){
                             if(thedata){
-                                alert(<?php echo js_escape('There are currently other users of the category you are trying to delete. Please contact them and ask them to delete it. Categories may not be deleted while in use. This Categories are currently used by \n');?> + thedata);
+                                alert(<?php echo xlj('There are currently other users of the category you are trying to delete. Please contact them and ask them to delete it. Categories may not be deleted while in use. This Categories are currently used by');?> + "\n" + thedata);
                             }
                             else{
                                 delete_full_category(id);

--- a/library/custom_template/delete_category.php
+++ b/library/custom_template/delete_category.php
@@ -53,7 +53,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
                      source: "delete_full_category"
                 },
                 success: function(thedata){
-                            alert(<?php echo xlj('Deleted Successfully.');?>);
+                            alert("<?php echo xl('Deleted Successfully.'); ?>");
                             document.location.reload();
                             },
                 error:function(){
@@ -63,7 +63,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
         }
         function delete_category(id){
             top.restoreSession();
-            if(confirm(<?php echo xlj('Do you want to delete?');?>)){
+            if(confirm("<?php echo xl('Do you want to delete?'); ?>")){
                 $.ajax({
                 type: "POST",
                 url: "ajax_code.php",
@@ -74,7 +74,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
                 },
                 success: function(thedata){
                             if(thedata){
-                                alert(<?php echo xlj('There are currently other users of the category you are trying to delete. Please contact them and ask them to delete it. Categories may not be deleted while in use. This Categories are currently used by');?> + "\n" + thedata);
+                                alert("<?php echo xl('There are currently other users of the category you are trying to delete. Please contact them and ask them to delete it. Categories may not be deleted while in use. This Categories are currently used by'); ?>\n" + thedata);
                             }
                             else{
                                 delete_full_category(id);

--- a/portal/sign/lib/save-signature.php
+++ b/portal/sign/lib/save-signature.php
@@ -40,7 +40,7 @@ if ($isPortal) {
 
         // Portal users can only create patient signatures, not admin signatures
         if ($type === 'admin-signature') {
-            echo js_escape("error: unauthorized signature type");
+            echo '"error: unauthorized signature type"';
             exit();
         }
 
@@ -48,7 +48,7 @@ if ($isPortal) {
         $user = $req_pid;
     } else {
         SessionWrapperFactory::getInstance()->destroyPortalSession();
-        echo js_escape("error invalid session,");
+        echo '"error invalid session,"';
         exit();
     }
 }
@@ -62,13 +62,13 @@ if (!$isPortal) {
     }
 
     if ($userManipulatedFlag) {
-        echo js_escape("error");
+        echo '"error"';
         exit();
     }
 }
 
 if ($type === 'witness-signature') {
-    echo(js_escape('Done'));
+    echo '"Done"';
     exit();
 }
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/portal/sign/lib/show-signature.php
+++ b/portal/sign/lib/show-signature.php
@@ -41,7 +41,7 @@ if ($isPortal) {
         $user = $req_pid;
     } else {
         SessionWrapperFactory::getInstance()->destroyPortalSession();
-        echo js_escape("error");
+        echo '"error"';
         exit();
     }
 }
@@ -68,12 +68,12 @@ if ($isAdmin) {
     $req_pid = 0;
 }
 if ($type === 'witness-signature') {
-    echo(js_escape('Witness Signature'));
+    echo '"Witness Signature"';
     exit();
 }
 if ($req_pid === 0 || empty($user)) {
     if (!$isAdmin) {
-        echo(js_escape('error not an admin'));
+        echo '"error not an admin"';
         exit();
     }
 }
@@ -88,7 +88,7 @@ if (($data['mode'] ?? null) === 'fetch_info') {
 
     $signer = $isAdmin ? $user_result['userName'] : $pt_result['ptName'];
     if (!$signer) {
-        echo js_escape("error");
+        echo '"error"';
         exit();
     }
 }

--- a/sphere/process_response.php
+++ b/sphere/process_response.php
@@ -65,10 +65,12 @@ if (OEGlobalsBag::getInstance()->get('payment_gateway') != 'Sphere') {
         echo "<script>opener.sphereNotSuccess(" . xlj("Transaction Cancelled") . ");dlgclose();</script>";
     } elseif (($_POST['status_name'] == 'baddata') || ($_POST['status_name'] == 'error')) {
         PaymentProcessing::saveAudit('sphere', $_GET['patient_id_cc'], 0, $auditData, $_POST['ticket'], $_POST['transid'] ?? null, $_POST['action_name'] ?? null, $_POST['amount'] ?? null);
-        echo "<script>opener.sphereNotSuccess(" . js_escape(xl("Transaction Error") . $description) . ");dlgclose();</script>";
+        $msg = js_escape(xl("Transaction Error") . $description);
+        echo "<script>opener.sphereNotSuccess(" . $msg . ");dlgclose();</script>";
     } elseif ($_POST['status_name'] == 'decline') {
         PaymentProcessing::saveAudit('sphere', $_GET['patient_id_cc'], 0, $auditData, $_POST['ticket'], $_POST['transid'], $_POST['action_name'], $_POST['amount']);
-        echo "<script>opener.sphereNotSuccess(" . js_escape(xl("Transaction Declined") . $description) . ");dlgclose();</script>";
+        $msg = js_escape(xl("Transaction Declined") . $description);
+        echo "<script>opener.sphereNotSuccess(" . $msg . ");dlgclose();</script>";
     } elseif ($_POST['status_name'] == 'approved') {
         // Success!
         PaymentProcessing::saveAudit('sphere', $_GET['patient_id_cc'], 1, $auditData, $_POST['ticket'], $_POST['transid'], $_POST['action_name'], $_POST['amount']);
@@ -91,7 +93,8 @@ if (OEGlobalsBag::getInstance()->get('payment_gateway') != 'Sphere') {
         }
     } else {
         PaymentProcessing::saveAudit('sphere', $_GET['patient_id_cc'], 0, $auditData, $_POST['ticket'], $_POST['transid'] ?? null, $_POST['action_name'] ?? null, $_POST['amount'] ?? null);
-        echo "<script>opener.sphereNotSuccess(" . js_escape(xl("Transaction Not Successful") . $description) . ");dlgclose();</script>";
+        $msg = js_escape(xl("Transaction Not Successful") . $description);
+        echo "<script>opener.sphereNotSuccess(" . $msg . ");dlgclose();</script>";
     }
     ?>
 </head>

--- a/sphere/process_revert_response.php
+++ b/sphere/process_revert_response.php
@@ -43,7 +43,8 @@ if (!AclMain::aclCheckCore('acct', 'rep_a')) {
 
     if (!empty($_POST['status']) && (($_POST['status'] == 'baddata') || ($_POST['status'] == 'error'))) {
         PaymentProcessing::saveRevertAudit($_POST['uuid_tx'], $_POST['action'], $auditData, 0);
-        echo "<script>opener.sphereRevertNotSuccess(" . js_escape(xl("Aborted since unable to submit transaction") . ": " . $_POST['status'] . " " . $_POST['error'] . " " . $_POST['offenders']) . ");dlgclose();</script>";
+        $msg = js_escape(xl("Aborted since unable to submit transaction") . ": " . $_POST['status'] . " " . $_POST['error'] . " " . $_POST['offenders']);
+        echo "<script>opener.sphereRevertNotSuccess(" . $msg . ");dlgclose();</script>";
     } else if (!empty($_POST['hash']) && !empty($_POST['token'])) {
         $sphereRevert = new SphereRevert($_GET['front']);
 
@@ -68,18 +69,21 @@ if (!AclMain::aclCheckCore('acct', 'rep_a')) {
                     $completeRevertToString .= $key . ": " . $value . "\n";
                 }
             }
-            echo "<script>opener.sphereRevertNotSuccess(" . js_escape(xl("Aborted since unable to complete transaction") . ": " . $completeRevertToString) . ");dlgclose();</script></head><body></body></html>";
+            $msg = js_escape(xl("Aborted since unable to complete transaction") . ": " . $completeRevertToString);
+            echo "<script>opener.sphereRevertNotSuccess(" . $msg . ");dlgclose();</script></head><body></body></html>";
             exit;
         }
 
         // Successful revert
         PaymentProcessing::saveRevertAudit($_POST['uuid_tx'], $_POST['action'], $auditData, 1, $completeRevert['transid']);
-        echo "<script>opener.sphereRevertSuccess(" . js_escape(xl("Successful") . " " . $_POST['action']) . ");dlgclose();</script>";
+        $msg = js_escape(xl("Successful") . " " . $_POST['action']);
+        echo "<script>opener.sphereRevertSuccess(" . $msg . ");dlgclose();</script>";
     } else {
         // catch all for errors that are not caught above
         $auditData['error_custom'] = "Unclear revert error with following querystring: " . $_POST['querystring'];
         PaymentProcessing::saveRevertAudit($_POST['uuid_tx'], $_POST['action'], $auditData, 0);
-        echo "<script>opener.sphereRevertNotSuccess(" . js_escape(xl("Revert Error") . ": " . $_POST['querystring']) . ");dlgclose();</script>";
+        $msg = js_escape(xl("Revert Error") . ": " . $_POST['querystring']);
+        echo "<script>opener.sphereRevertNotSuccess(" . $msg . ");dlgclose();</script>";
     }
     ?>
 </head>


### PR DESCRIPTION
**Summary**
This PR addresses issue #11613 by cleaning up `js_escape()` patterns that remained after #11347 was merged.

**Changes Made**

1. Replace `js_escape(xl(...))` with `xlj(...)`
Replaced 15 instances across 6 files where `js_escape(xl('...'))` was called without variable concatenation. The `xlj()` function already exists in [library/htmlspecialchars.inc.php] and does exactly `js_escape(xl($key))`.

2. Extract long inline `js_escape(...)` to variables
Extracted 7 deeply embedded `js_escape()` calls to `$msg` variables for improved readability.

3. Replace `js_escape('literal-string')` with quoted strings
Replaced 16 instances where `js_escape()` was called on plain ASCII literals. Since `json_encode` on a plain literal just adds quotes, these can be replaced directly.

**Note**
The remaining `js_escape(xl(...) . $variable)` patterns in `sphere/` files concatenate translated strings with runtime variables and cannot use `xlj()` since it only accepts a single translation key. These were correctly left as `js_escape()` but extracted to variables per item 2.

**Testing**
- All affected pages should display alerts/confirms correctly
- No behavioral changes expected
- CI checks should pass

Fixes #11613

cc @kojiromike @msummers42