### PR TITLE
feat(vitals): add input validation for numeric fields

### DIFF
--- a/.phpstan/baseline/echo.nonString.php
+++ b/.phpstan/baseline/echo.nonString.php
@@ -264,11 +264,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/vitals/save.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/vitals/view.php',
 ];
 $ignoreErrors[] = [

--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -22,6 +22,7 @@ use OpenEMR\Common\Forms\FormVitalDetails;
 use OpenEMR\Common\Forms\FormVitals;
 use OpenEMR\Common\Forms\ReasonStatusCodes;
 use OpenEMR\Common\Forms\VitalsFieldRanges;
+use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Common\Uuid\UuidRegistry;
@@ -31,10 +32,7 @@ use OpenEMR\Services\VitalsService;
 
 class C_FormVitals
 {
-    /**
-     * @var FormVitals
-     */
-    public $vitals;
+    public FormVitals $vitals;
 
     public $template_dir;
     public $form_id;
@@ -354,7 +352,7 @@ class C_FormVitals
 
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
         $validationErrors = $session->get('vitals_validation_errors', []);
-        $session->remove('vitals_validation_errors');
+        SessionUtil::unsetSession(['vitals_validation_errors']);
 
         $data = [
             'vitals' => $vitals
@@ -463,8 +461,7 @@ class C_FormVitals
 
         $validationResult = $this->vitals->validate();
         if ($validationResult['errors'] !== []) {
-            $session = SessionWrapperFactory::getInstance()->getActiveSession();
-            $session->set('vitals_validation_errors', $validationResult['errors']);
+            SessionUtil::setSession('vitals_validation_errors', $validationResult['errors']);
             return;
         }
 

--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -172,15 +172,15 @@ class C_FormVitals
             ]
             ,[
                 'type' => 'textbox'
-                , xl('Pulse') => 'title'
+                ,'title' => xl('Pulse')
                 // eventually we could just grab the raw values...
                 ,'vitalsValue' => "get_pulse"
                 ,'precision' => 0
                 ,'input' => 'pulse'
                 ,'unit' => 'per min'
-                , xl('per min') => 'unitLabel'
+                ,'unitLabel' => xl('per min')
                 ,'codes' => 'LOINC:8867-4'
-                ,'valiuguufdation' => VitalsFieldRanges::getRangeForField('pulse')
+                ,'validation' => VitalsFieldRanges::getRangeForField('pulse')
             ]
             ,[
                 'type' => 'textbox'
@@ -190,6 +190,7 @@ class C_FormVitals
                 ,'precision' => 0
                 ,'input' => 'respiration'
                 ,'unit' => 'per min'
+                ,'unitLabel' => xl('per min')
                 ,'codes' => 'LOINC:9279-1'
                 ,'validation' => VitalsFieldRanges::getRangeForField('respiration')
             ]
@@ -352,8 +353,12 @@ class C_FormVitals
         }
 
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
+        $validationErrors = $session->get('vitals_validation_errors', []);
+        $session->remove('vitals_validation_errors');
+
         $data = [
             'vitals' => $vitals
+            ,'validationErrors' => $validationErrors
             ,'vitalFields' => $vitalFields
             ,'FORM_ACTION' => OEGlobalsBag::getInstance()->getWebRoot()
             ,'DONT_SAVE_LINK' => OEGlobalsBag::getInstance()->get('form_exit_url')

--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -21,6 +21,7 @@ use OpenEMR\Common\Forms\BmiCategory;
 use OpenEMR\Common\Forms\FormVitalDetails;
 use OpenEMR\Common\Forms\FormVitals;
 use OpenEMR\Common\Forms\ReasonStatusCodes;
+use OpenEMR\Common\Forms\VitalsFieldRanges;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Common\Uuid\UuidRegistry;
@@ -130,6 +131,7 @@ class C_FormVitals
                 ,'precision' => 2
                 ,'vitalsValueUSAHelpTitle' => xl("Decimal pounds or pounds and ounces separated by #(e.g. 5#4)")
                 ,'codes' => 'LOINC:29463-7'
+                ,'validation' => VitalsFieldRanges::getRangeForField('weight')
             ]
             ,[
                 'type' => 'textbox_conversion'
@@ -144,6 +146,7 @@ class C_FormVitals
                 ,'unitMetricLabel' => xl('cm')
                 ,'precision' => 2
                 ,'codes' => 'LOINC:8302-2'
+                ,'validation' => VitalsFieldRanges::getRangeForField('height')
             ]
             ,[
                 'type' => 'textbox'
@@ -154,6 +157,7 @@ class C_FormVitals
                 ,'unit' => 'mmHg'
                 ,'unitLabel' => xl('mmHg')
                 ,'codes' => 'LOINC:8480-6'
+                ,'validation' => VitalsFieldRanges::getRangeForField('bps')
             ]
             ,[
                 'type' => 'textbox'
@@ -164,17 +168,19 @@ class C_FormVitals
                 ,'unit' => 'mmHg'
                 ,'unitLabel' => xl('mmHg')
                 ,'codes' => 'LOINC:8462-4'
+                ,'validation' => VitalsFieldRanges::getRangeForField('bpd')
             ]
             ,[
                 'type' => 'textbox'
-                ,'title' => xl('Pulse')
+                , xl('Pulse') => 'title'
                 // eventually we could just grab the raw values...
                 ,'vitalsValue' => "get_pulse"
                 ,'precision' => 0
                 ,'input' => 'pulse'
                 ,'unit' => 'per min'
-                ,'unitLabel' => xl('per min')
+                , xl('per min') => 'unitLabel'
                 ,'codes' => 'LOINC:8867-4'
+                ,'valiuguufdation' => VitalsFieldRanges::getRangeForField('pulse')
             ]
             ,[
                 'type' => 'textbox'
@@ -184,8 +190,8 @@ class C_FormVitals
                 ,'precision' => 0
                 ,'input' => 'respiration'
                 ,'unit' => 'per min'
-                ,'unitLabel' => xl('per min')
                 ,'codes' => 'LOINC:9279-1'
+                ,'validation' => VitalsFieldRanges::getRangeForField('respiration')
             ]
             ,[
                 'type' => 'textbox_conversion'
@@ -200,6 +206,7 @@ class C_FormVitals
                 ,'unitMetricLabel' => xl('C')
                 ,'precision' => 2
                 ,'codes' => 'LOINC:8310-5'
+                ,'validation' => VitalsFieldRanges::getRangeForField('temperature')
             ]
             ,[
                 'type' => 'template'
@@ -215,6 +222,7 @@ class C_FormVitals
                 ,'unit' => '%'
                 ,'unitLabel' => '%'
                 ,'codes' => 'LOINC:59408-5'
+                ,'validation' => VitalsFieldRanges::getRangeForField('oxygen_saturation')
             ]
             ,[
                 'type' => 'textbox'
@@ -226,6 +234,7 @@ class C_FormVitals
                 ,'unit' => 'l/min'
                 ,'unitLabel' => xl('l/min')
                 ,'codes' => 'LOINC:3151-8'
+                ,'validation' => VitalsFieldRanges::getRangeForField('oxygen_flow_rate')
             ]
             ,[
                 'type' => 'textbox'
@@ -237,6 +246,7 @@ class C_FormVitals
                 ,'unit' => '%'
                 ,'unitLabel' => '%'
                 ,'codes' => 'LOINC:3150-0'
+                ,'validation' => VitalsFieldRanges::getRangeForField('inhaled_oxygen_concentration')
             ]
             ,[
                 'type' => 'textbox_conversion'
@@ -253,6 +263,7 @@ class C_FormVitals
                 // hide_circumferences
                 ,'hide' => OEGlobalsBag::getInstance()->get('gbl_vitals_options') > 0
                 ,'codes' => "LOINC:9843-4"
+                ,'validation' => VitalsFieldRanges::getRangeForField('head_circ')
             ]
             ,[
                 'type' => 'textbox_conversion'
@@ -269,6 +280,7 @@ class C_FormVitals
                 // hide_circumferences
                 ,'hide' => OEGlobalsBag::getInstance()->get('gbl_vitals_options') > 0
                 ,'codes' => "LOINC:9843-4"
+                ,'validation' => VitalsFieldRanges::getRangeForField('waist_circ')
             ]
             ,[
                 'type' => 'template'
@@ -287,6 +299,7 @@ class C_FormVitals
                 ,'unit' => '%'
                 ,'unitLabel' => '%'
                 ,'codes' => 'LOINC:77606-2'
+                ,'validation' => VitalsFieldRanges::getRangeForField('ped_weight_height')
                 ,'hide' => !$show_pediatric_fields
             ]
             ,[
@@ -298,6 +311,7 @@ class C_FormVitals
                 ,'unit' => '%'
                 ,'unitLabel' => '%'
                 ,'codes' => 'LOINC:59576-9'
+                ,'validation' => VitalsFieldRanges::getRangeForField('ped_bmi')
                 ,'hide' => !$show_pediatric_fields
             ]
             ,[
@@ -309,6 +323,7 @@ class C_FormVitals
                 ,'unit' => '%'
                 ,'unitLabel' => '%'
                 ,'codes' => 'LOINC:8289-1'
+                ,'validation' => VitalsFieldRanges::getRangeForField('ped_head_circ')
                 ,'hide' => !$show_pediatric_fields
             ]
             ,[
@@ -440,6 +455,13 @@ class C_FormVitals
         $this->vitals = new FormVitals();
         $this->vitals->populate_array($vitalsArray);
         $this->populate_object($this->vitals);
+
+        $validationResult = $this->vitals->validate();
+        if ($validationResult['errors'] !== []) {
+            $session = SessionWrapperFactory::getInstance()->getActiveSession();
+            $session->set('vitals_validation_errors', $validationResult['errors']);
+            return;
+        }
 
         $vitalsService->saveVitalsForm($this->vitals);
         return;

--- a/interface/forms/vitals/save.php
+++ b/interface/forms/vitals/save.php
@@ -31,7 +31,7 @@ $c->default_action_process();
 $validationErrors = $session->get('vitals_validation_errors');
 if ($validationErrors !== null && $validationErrors !== []) {
     $formUrl = OEGlobalsBag::getInstance()->getWebRoot()
-        . '/interface/forms/vitals/new.php?id=' . urlencode($_POST['id'] ?? '');
+        . '/interface/forms/vitals/new.php?id=' . (int) filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
     formJump($formUrl);
 } else {
     formJump();

--- a/interface/forms/vitals/save.php
+++ b/interface/forms/vitals/save.php
@@ -29,7 +29,7 @@ $c = new C_FormVitals();
 $c->default_action_process();
 
 $validationErrors = $session->get('vitals_validation_errors');
-if (!empty($validationErrors)) {
+if ($validationErrors !== null && $validationErrors !== []) {
     $formUrl = OEGlobalsBag::getInstance()->getWebRoot()
         . '/interface/forms/vitals/new.php?id=' . urlencode($_POST['id'] ?? '');
     formJump($formUrl);

--- a/interface/forms/vitals/save.php
+++ b/interface/forms/vitals/save.php
@@ -26,5 +26,13 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 
 $c = new C_FormVitals();
-echo $c->default_action_process();
-@formJump();
+$c->default_action_process();
+
+$validationErrors = $session->get('vitals_validation_errors');
+if (!empty($validationErrors)) {
+    $formUrl = OEGlobalsBag::getInstance()->getWebRoot()
+        . '/interface/forms/vitals/new.php?id=' . urlencode($_POST['id'] ?? '');
+    formJump($formUrl);
+} else {
+    formJump();
+}

--- a/interface/forms/vitals/templates/vitals/vitals.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals.html.twig
@@ -22,6 +22,9 @@
         ,'bpd_input': window.xl("BP Diastolic")
         ,'validateFailed': window.xl("Please correct the value(s) before proceeding!")
         ,'invalidField': window.xl("The following field has an invalid value")
+        ,'outsideRange': window.xl("Value is outside typical clinical range")
+        ,'invalidNegative': window.xl("Value cannot be negative")
+        ,'invalidRange': window.xl("Value is outside acceptable range")
     };
     if (window.vitalsForm) {
         window.vitalsForm.init({{ FORM_ACTION|js_url }}, vitalsTranslations);

--- a/interface/forms/vitals/templates/vitals/vitals.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals.html.twig
@@ -37,6 +37,19 @@
 <body>
 
  <div class="container mt-3">
+    {% if validationErrors is defined and validationErrors is not empty %}
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        <strong>{{ "Validation errors"|xlt }}:</strong>
+        <ul class="mb-0">
+            {% for error in validationErrors %}
+                <li>{{ error|text }}</li>
+            {% endfor %}
+        </ul>
+        <button type="button" class="close" data-dismiss="alert" aria-label="{{ "Close"|xla }}">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+    {% endif %}
     <div class="row no-gutters">
         <div class="col-4">
             <h2 class="h2-responsive">

--- a/interface/forms/vitals/templates/vitals/vitals_textbox.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals_textbox.html.twig
@@ -9,14 +9,18 @@
     {% if is_edit %}
     <td class='currentvalues p-2'>
         {% if field.precision is defined %}
-        <input type="text" class="form-control skip-template-editor" size='5' name='{{ field.input|attr }}' id='{{ field.input|attr }}_input'
-               value="{% if attribute(vitals,field.vitalsValue) is numeric %}{{ attribute(vitals,field.vitalsValue)|number_format(field.precision)|attr }}{% endif %}"/>
+        <input type="text" inputmode="decimal" class="form-control skip-template-editor" size='5' name='{{ field.input|attr }}' id='{{ field.input|attr }}_input'
+               value="{% if attribute(vitals,field.vitalsValue) is numeric %}{{ attribute(vitals,field.vitalsValue)|number_format(field.precision)|attr }}{% endif %}"
+               {% if field.validation is defined and field.validation is not null %}data-min="{{ field.validation.min|attr }}" data-max="{{ field.validation.max|attr }}" data-warning-min="{{ field.validation.warningMin|attr }}" data-warning-max="{{ field.validation.warningMax|attr }}"{% endif %}/>
         {% else %}
             {# This seems odd that we still do an is numeric check, copied over from the vitals_textbox.tpl file, but it would seem we'd skip the is_numeric check here#}
-        <input type="text" class="form-control skip-template-editor" size='5' name='{{ field.input|attr }}' id='{{ field.input|attr }}_input'
-               value="{% if attribute(vitals,field.vitalsValue) is numeric %}{{ attribute(vitals, field.vitalsValue)|attr }}{% endif %}"/>
+        <input type="text" inputmode="decimal" class="form-control skip-template-editor" size='5' name='{{ field.input|attr }}' id='{{ field.input|attr }}_input'
+               value="{% if attribute(vitals,field.vitalsValue) is numeric %}{{ attribute(vitals, field.vitalsValue)|attr }}{% endif %}"
+               {% if field.validation is defined and field.validation is not null %}data-min="{{ field.validation.min|attr }}" data-max="{{ field.validation.max|attr }}" data-warning-min="{{ field.validation.warningMin|attr }}" data-warning-max="{{ field.validation.warningMax|attr }}"{% endif %}/>
         {% endif %}
-
+        {% if field.validation is defined and field.validation is not null %}
+        <span class="vitals-warning-message" id="{{ field.input|attr }}_input_warning"></span>
+        {% endif %}
     </td>
     <td class="editonly">
         {% include 'vitals_interpretation_selector.html.twig' with { input: field.input, vitalDetails:vitals.get_details_for_column(field.input) } %}

--- a/interface/forms/vitals/templates/vitals/vitals_textbox_conversion.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals_textbox_conversion.html.twig
@@ -38,11 +38,15 @@
             <td class='currentvalues p-2'>
         {% endif %}
 
-            <input type="text" class="form-control vitals-conv-unit skip-template-editor" size='5' id='{{ field.input|attr }}_input_usa'
+            <input type="text" inputmode="decimal" class="form-control vitals-conv-unit skip-template-editor" size='5' id='{{ field.input|attr }}_input_usa'
                    value="{% if attribute(vitals, field.vitalsValue) is numeric %} {{ attribute(vitals, field.vitalsValue)|number_format(field.precision)|attr }}{% endif %}"
                    data-system="usa" data-unit="{{ field.unit|attr }}" data-target-input="{{ field.input|attr }}_input"
                    data-target-input-conv="{{ field.input|attr }}_input_metric"
-                   title='{{ field.vitalsValueUSAHelpTitle|default('')|attr }}'/>
+                   title='{{ field.vitalsValueUSAHelpTitle|default('')|attr }}'
+                   {% if field.validation is defined and field.validation is not null %}data-min="{{ field.validation.min|attr }}" data-max="{{ field.validation.max|attr }}" data-warning-min="{{ field.validation.warningMin|attr }}" data-warning-max="{{ field.validation.warningMax|attr }}"{% endif %}/>
+            {% if field.validation is defined and field.validation is not null %}
+            <span class="vitals-warning-message" id="{{ field.input|attr }}_input_usa_warning"></span>
+            {% endif %}
         </td>
         <td class="editonly">
             {% include 'vitals_interpretation_selector.html.twig' with { input: field.input, vitalDetails:vitals.get_details_for_column(field.input) } %}
@@ -83,10 +87,14 @@
         {% endif %}
 
             <!-- Note we intentionally use vitalsValue not vitalValuesMetric because of how data is stored internally -->
-            <input type="text" class="form-control vitals-conv-unit skip-template-editor" size='5' id='{{ field.input|attr }}_input_metric'
+            <input type="text" inputmode="decimal" class="form-control vitals-conv-unit skip-template-editor" size='5' id='{{ field.input|attr }}_input_metric'
                    value="{% if attribute(vitals, field.vitalsValue) is numeric %}{{ attribute(vitals, field.vitalsValueMetric)|number_format(field.precision)|attr }}{% endif %}"
                    data-system="metric" data-unit="{{ field.unit|attr }}" data-target-input="{{ field.input|attr }}_input"
-                   data-target-input-conv="{{ field.input|attr }}_input_usa" />
+                   data-target-input-conv="{{ field.input|attr }}_input_usa"
+                   {% if field.validation is defined and field.validation is not null and field.validation.metricMin is defined %}data-min="{{ field.validation.metricMin|attr }}" data-max="{{ field.validation.metricMax|attr }}" data-warning-min="{{ field.validation.metricWarningMin|attr }}" data-warning-max="{{ field.validation.metricWarningMax|attr }}"{% endif %}/>
+            {% if field.validation is defined and field.validation is not null and field.validation.metricMin is defined %}
+            <span class="vitals-warning-message" id="{{ field.input|attr }}_input_metric_warning"></span>
+            {% endif %}
         </td>
         <td class="editonly">
             {% if units_of_measurement == MEASUREMENT_METRIC_ONLY %}

--- a/interface/forms/vitals/vitals.css
+++ b/interface/forms/vitals/vitals.css
@@ -82,3 +82,14 @@ select {
 .error {
   border: 2px solid var(--danger);
 }
+
+.warning {
+  border: 2px solid var(--warning);
+}
+
+.vitals-warning-message {
+  display: block;
+  color: var(--warning);
+  font-size: 0.8rem;
+  margin-top: 2px;
+}

--- a/interface/forms/vitals/vitals.js
+++ b/interface/forms/vitals/vitals.js
@@ -12,31 +12,87 @@
     let translations = {};
     let webroot = null;
 
-    function vitalsFormSubmitted() {
-        var invalid = "";
+    function validateVitalField(element) {
+        let value = element.value.trim();
+        let warningSpan = document.getElementById(element.id + '_warning');
 
-        var elementsToValidate = ['weight_input_usa', 'weight_input_metric', 'height_input_usa', 'height_input_metric', 'bps_input', 'bpd_input'];
-
-        for (var i = 0; i < elementsToValidate.length; i++) {
-            var current_elem_id = elementsToValidate[i];
-            var tag_name = vitalsTranslations[current_elem_id] || "<unknown_tag_name>";
-
-            document.getElementById(current_elem_id).classList.remove('error');
-
-            if (isNaN(document.getElementById(current_elem_id).value)) {
-                invalid += vitalsTranslations['invalidField'] + ":" + vitalsTranslations[current_elem_id] + "\n";
-                document.getElementById(current_elem_id).className = document.getElementById(current_elem_id).className + " error";
-                document.getElementById(current_elem_id).focus();
-            }
-
-            if (invalid.length > 0) {
-                invalid += "\n" + vitalsTranslations['validateFailed'];
-                alert(invalid);
-                return false;
-            } else {
-                return top.restoreSession();
-            }
+        element.classList.remove('error', 'warning');
+        if (warningSpan) {
+            warningSpan.textContent = '';
         }
+
+        if (value === '') {
+            return { valid: true, warning: false };
+        }
+
+        // Special case: weight USA input allows # separator (lbs/oz format e.g. "5#4")
+        if (element.id === 'weight_input_usa' && value.indexOf('#') >= 0) {
+            let parts = value.split('#');
+            let pounds = parseFloat(parts[0]) || 0;
+            let ounces = parseFloat(parts[1]) || 0;
+            value = String(pounds + ounces / 16);
+        }
+
+        let numValue = parseFloat(value);
+
+        if (isNaN(numValue)) {
+            element.classList.add('error');
+            return { valid: false, warning: false };
+        }
+
+        if (numValue < 0) {
+            element.classList.add('error');
+            if (warningSpan) {
+                warningSpan.textContent = vitalsTranslations['invalidNegative'] || '';
+            }
+            return { valid: false, warning: false };
+        }
+
+        let min = parseFloat(element.dataset.min);
+        let max = parseFloat(element.dataset.max);
+        if (!isNaN(min) && !isNaN(max) && (numValue < min || numValue > max)) {
+            element.classList.add('error');
+            if (warningSpan) {
+                warningSpan.textContent = vitalsTranslations['invalidRange'] || '';
+            }
+            return { valid: false, warning: false };
+        }
+
+        let warningMin = parseFloat(element.dataset.warningMin);
+        let warningMax = parseFloat(element.dataset.warningMax);
+        if (!isNaN(warningMin) && !isNaN(warningMax) && (numValue < warningMin || numValue > warningMax)) {
+            element.classList.add('warning');
+            if (warningSpan) {
+                warningSpan.textContent = vitalsTranslations['outsideRange'] || '';
+            }
+            return { valid: true, warning: true };
+        }
+
+        return { valid: true, warning: false };
+    }
+
+    function vitalsFormSubmitted() {
+        let vitalsForm = document.getElementById('vitalsForm');
+        if (!vitalsForm) {
+            return false;
+        }
+
+        let inputs = vitalsForm.querySelectorAll('input[data-min]');
+        let hasErrors = false;
+
+        inputs.forEach(function(input) {
+            let result = validateVitalField(input);
+            if (!result.valid) {
+                hasErrors = true;
+            }
+        });
+
+        if (hasErrors) {
+            alert(vitalsTranslations['validateFailed']);
+            return false;
+        }
+
+        return top.restoreSession();
     }
 
     function convInputElement(evt) {
@@ -117,6 +173,25 @@
         let vitalsConvInputs = vitalsForm.querySelectorAll(".vitals-conv-unit");
         vitalsConvInputs.forEach(function(node) {
             node.addEventListener('change', convInputElement);
+            node.addEventListener('change', function(evt) {
+                validateVitalField(evt.currentTarget);
+                // Also validate the counterpart conversion field
+                let targetConvId = evt.currentTarget.dataset.targetInputConv;
+                if (targetConvId) {
+                    let counterpart = document.getElementById(targetConvId);
+                    if (counterpart && counterpart.dataset.min) {
+                        validateVitalField(counterpart);
+                    }
+                }
+            });
+        });
+
+        // Real-time validation for non-conversion inputs
+        let vitalsValidatedInputs = vitalsForm.querySelectorAll('input[data-min]:not(.vitals-conv-unit)');
+        vitalsValidatedInputs.forEach(function(node) {
+            node.addEventListener('change', function(evt) {
+                validateVitalField(evt.currentTarget);
+            });
         });
     }
     function init(webRootParam, vitalsTranslations) {

--- a/src/Common/Forms/FormVitals.php
+++ b/src/Common/Forms/FormVitals.php
@@ -495,14 +495,34 @@ class FormVitals extends ORDataObject
             'ped_head_circ' => 'ped_head_circ',
         ];
 
+        $fieldLabels = [
+            'weight' => xl('Weight'),
+            'height' => xl('Height/Length'),
+            'bps' => xl('BP Systolic'),
+            'bpd' => xl('BP Diastolic'),
+            'pulse' => xl('Pulse'),
+            'respiration' => xl('Respiration'),
+            'temperature' => xl('Temperature'),
+            'oxygen_saturation' => xl('Oxygen Saturation'),
+            'oxygen_flow_rate' => xl('Oxygen Flow Rate'),
+            'inhaled_oxygen_concentration' => xl('Inhaled Oxygen Concentration'),
+            'head_circ' => xl('Head Circumference'),
+            'waist_circ' => xl('Waist Circumference'),
+            'ped_weight_height' => xl('Pediatric Weight Height Percentile'),
+            'ped_bmi' => xl('Pediatric BMI Percentile'),
+            'ped_head_circ' => xl('Pediatric Head Circumference Percentile'),
+        ];
+
         foreach ($fieldPropertyMap as $fieldName => $property) {
             $value = $this->$property;
-            if ($value === null || $value === '' || $value === 0 || $value === '0') {
+            if ($value === null || $value === '') {
                 continue;
             }
 
+            $label = $fieldLabels[$fieldName] ?? $fieldName;
+
             if (!is_numeric($value)) {
-                $errors[] = "Field '{$fieldName}' has a non-numeric value.";
+                $errors[] = xl('Field') . " '{$label}' " . xl('has a non-numeric value.');
                 continue;
             }
 
@@ -513,17 +533,17 @@ class FormVitals extends ORDataObject
             }
 
             if ($numericValue < 0) {
-                $errors[] = "Field '{$fieldName}' cannot be negative.";
+                $errors[] = xl('Field') . " '{$label}' " . xl('cannot be negative.');
                 continue;
             }
 
             if ($numericValue < $range['min'] || $numericValue > $range['max']) {
-                $errors[] = "Field '{$fieldName}' is outside acceptable range ({$range['min']}–{$range['max']}).";
+                $errors[] = xl('Field') . " '{$label}' " . xl('is outside acceptable range') . " ({$range['min']}–{$range['max']}).";
                 continue;
             }
 
             if ($numericValue < $range['warningMin'] || $numericValue > $range['warningMax']) {
-                $warnings[] = "Field '{$fieldName}' is outside typical clinical range ({$range['warningMin']}–{$range['warningMax']}).";
+                $warnings[] = xl('Field') . " '{$label}' " . xl('is outside typical clinical range') . " ({$range['warningMin']}–{$range['warningMax']}).";
             }
         }
 

--- a/src/Common/Forms/FormVitals.php
+++ b/src/Common/Forms/FormVitals.php
@@ -467,6 +467,69 @@ class FormVitals extends ORDataObject
         }
     }
 
+    /**
+     * Validates all numeric vital properties against VitalsFieldRanges.
+     *
+     * @return array{errors: list<string>, warnings: list<string>}
+     */
+    public function validate(): array
+    {
+        $errors = [];
+        $warnings = [];
+
+        $fieldPropertyMap = [
+            'weight' => 'weight',
+            'height' => 'height',
+            'bps' => 'bps',
+            'bpd' => 'bpd',
+            'pulse' => 'pulse',
+            'respiration' => 'respiration',
+            'temperature' => 'temperature',
+            'oxygen_saturation' => 'oxygen_saturation',
+            'oxygen_flow_rate' => 'oxygen_flow_rate',
+            'inhaled_oxygen_concentration' => 'inhaled_oxygen_concentration',
+            'head_circ' => 'head_circ',
+            'waist_circ' => 'waist_circ',
+            'ped_weight_height' => 'ped_weight_height',
+            'ped_bmi' => 'ped_bmi',
+            'ped_head_circ' => 'ped_head_circ',
+        ];
+
+        foreach ($fieldPropertyMap as $fieldName => $property) {
+            $value = $this->$property;
+            if ($value === null || $value === '' || $value === 0 || $value === '0') {
+                continue;
+            }
+
+            if (!is_numeric($value)) {
+                $errors[] = "Field '{$fieldName}' has a non-numeric value.";
+                continue;
+            }
+
+            $numericValue = (float) $value;
+            $range = VitalsFieldRanges::getRangeForField($fieldName);
+            if ($range === null) {
+                continue;
+            }
+
+            if ($numericValue < 0) {
+                $errors[] = "Field '{$fieldName}' cannot be negative.";
+                continue;
+            }
+
+            if ($numericValue < $range['min'] || $numericValue > $range['max']) {
+                $errors[] = "Field '{$fieldName}' is outside acceptable range ({$range['min']}–{$range['max']}).";
+                continue;
+            }
+
+            if ($numericValue < $range['warningMin'] || $numericValue > $range['warningMax']) {
+                $warnings[] = "Field '{$fieldName}' is outside typical clinical range ({$range['warningMin']}–{$range['warningMax']}).";
+            }
+        }
+
+        return ['errors' => $errors, 'warnings' => $warnings];
+    }
+
     public function persist()
     {
         if (empty($this->uuid)) {

--- a/src/Common/Forms/FormVitals.php
+++ b/src/Common/Forms/FormVitals.php
@@ -522,7 +522,7 @@ class FormVitals extends ORDataObject
             $label = $fieldLabels[$fieldName] ?? $fieldName;
 
             if (!is_numeric($value)) {
-                $errors[] = xl('Field') . " '{$label}' " . xl('has a non-numeric value.');
+                $errors[] = sprintf(xl('Field "%1$s" has a non-numeric value.'), $label);
                 continue;
             }
 
@@ -533,17 +533,17 @@ class FormVitals extends ORDataObject
             }
 
             if ($numericValue < 0) {
-                $errors[] = xl('Field') . " '{$label}' " . xl('cannot be negative.');
+                $errors[] = sprintf(xl('Field "%1$s" cannot be negative.'), $label);
                 continue;
             }
 
             if ($numericValue < $range['min'] || $numericValue > $range['max']) {
-                $errors[] = xl('Field') . " '{$label}' " . xl('is outside acceptable range') . " ({$range['min']}–{$range['max']}).";
+                $errors[] = sprintf(xl('Field "%1$s" is outside acceptable range (%2$s–%3$s).'), $label, $range['min'], $range['max']);
                 continue;
             }
 
             if ($numericValue < $range['warningMin'] || $numericValue > $range['warningMax']) {
-                $warnings[] = xl('Field') . " '{$label}' " . xl('is outside typical clinical range') . " ({$range['warningMin']}–{$range['warningMax']}).";
+                $warnings[] = sprintf(xl('Field "%1$s" is outside typical clinical range (%2$s–%3$s).'), $label, $range['warningMin'], $range['warningMax']);
             }
         }
 

--- a/src/Common/Forms/FormVitals.php
+++ b/src/Common/Forms/FormVitals.php
@@ -477,49 +477,13 @@ class FormVitals extends ORDataObject
         $errors = [];
         $warnings = [];
 
-        $fieldPropertyMap = [
-            'weight' => 'weight',
-            'height' => 'height',
-            'bps' => 'bps',
-            'bpd' => 'bpd',
-            'pulse' => 'pulse',
-            'respiration' => 'respiration',
-            'temperature' => 'temperature',
-            'oxygen_saturation' => 'oxygen_saturation',
-            'oxygen_flow_rate' => 'oxygen_flow_rate',
-            'inhaled_oxygen_concentration' => 'inhaled_oxygen_concentration',
-            'head_circ' => 'head_circ',
-            'waist_circ' => 'waist_circ',
-            'ped_weight_height' => 'ped_weight_height',
-            'ped_bmi' => 'ped_bmi',
-            'ped_head_circ' => 'ped_head_circ',
-        ];
-
-        $fieldLabels = [
-            'weight' => xl('Weight'),
-            'height' => xl('Height/Length'),
-            'bps' => xl('BP Systolic'),
-            'bpd' => xl('BP Diastolic'),
-            'pulse' => xl('Pulse'),
-            'respiration' => xl('Respiration'),
-            'temperature' => xl('Temperature'),
-            'oxygen_saturation' => xl('Oxygen Saturation'),
-            'oxygen_flow_rate' => xl('Oxygen Flow Rate'),
-            'inhaled_oxygen_concentration' => xl('Inhaled Oxygen Concentration'),
-            'head_circ' => xl('Head Circumference'),
-            'waist_circ' => xl('Waist Circumference'),
-            'ped_weight_height' => xl('Pediatric Weight Height Percentile'),
-            'ped_bmi' => xl('Pediatric BMI Percentile'),
-            'ped_head_circ' => xl('Pediatric Head Circumference Percentile'),
-        ];
-
-        foreach ($fieldPropertyMap as $fieldName => $property) {
-            $value = $this->$property;
+        foreach (VitalsFieldRanges::getRanges() as $fieldName => $field) {
+            $value = $this->$fieldName;
             if ($value === null || $value === '') {
                 continue;
             }
 
-            $label = $fieldLabels[$fieldName] ?? $fieldName;
+            $label = $field['label'];
 
             if (!is_numeric($value)) {
                 $errors[] = sprintf(xl('Field "%1$s" has a non-numeric value.'), $label);
@@ -527,23 +491,19 @@ class FormVitals extends ORDataObject
             }
 
             $numericValue = (float) $value;
-            $range = VitalsFieldRanges::getRangeForField($fieldName);
-            if ($range === null) {
-                continue;
-            }
 
             if ($numericValue < 0) {
                 $errors[] = sprintf(xl('Field "%1$s" cannot be negative.'), $label);
                 continue;
             }
 
-            if ($numericValue < $range['min'] || $numericValue > $range['max']) {
-                $errors[] = sprintf(xl('Field "%1$s" is outside acceptable range (%2$s–%3$s).'), $label, $range['min'], $range['max']);
+            if ($numericValue < $field['min'] || $numericValue > $field['max']) {
+                $errors[] = sprintf(xl('Field "%1$s" is outside acceptable range (%2$s–%3$s).'), $label, $field['min'], $field['max']);
                 continue;
             }
 
-            if ($numericValue < $range['warningMin'] || $numericValue > $range['warningMax']) {
-                $warnings[] = sprintf(xl('Field "%1$s" is outside typical clinical range (%2$s–%3$s).'), $label, $range['warningMin'], $range['warningMax']);
+            if ($numericValue < $field['warningMin'] || $numericValue > $field['warningMax']) {
+                $warnings[] = sprintf(xl('Field "%1$s" is outside typical clinical range (%2$s–%3$s).'), $label, $field['warningMin'], $field['warningMax']);
             }
         }
 

--- a/src/Common/Forms/VitalsFieldRanges.php
+++ b/src/Common/Forms/VitalsFieldRanges.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * VitalsFieldRanges provides clinically-informed validation ranges for vitals form fields.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Davit Mnatsakanyan
+ * @copyright Copyright (c) 2026 OpenEMR Foundation
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Forms;
+
+final class VitalsFieldRanges
+{
+    /**
+     * @return array<string, array{min: float, max: float, warningMin: float, warningMax: float, metricMin?: float, metricMax?: float, metricWarningMin?: float, metricWarningMax?: float}>
+     */
+    public static function getRanges(): array
+    {
+        return [
+            'weight' => [
+                'min' => 0, 'max' => 2000, 'warningMin' => 0.1, 'warningMax' => 1500,
+                'metricMin' => 0, 'metricMax' => 910, 'metricWarningMin' => 0.05, 'metricWarningMax' => 680,
+            ],
+            'height' => [
+                'min' => 0, 'max' => 150, 'warningMin' => 1, 'warningMax' => 108,
+                'metricMin' => 0, 'metricMax' => 381, 'metricWarningMin' => 2.5, 'metricWarningMax' => 274,
+            ],
+            'bps' => [
+                'min' => 0, 'max' => 400, 'warningMin' => 20, 'warningMax' => 300,
+            ],
+            'bpd' => [
+                'min' => 0, 'max' => 300, 'warningMin' => 10, 'warningMax' => 200,
+            ],
+            'pulse' => [
+                'min' => 0, 'max' => 500, 'warningMin' => 10, 'warningMax' => 350,
+            ],
+            'respiration' => [
+                'min' => 0, 'max' => 150, 'warningMin' => 2, 'warningMax' => 100,
+            ],
+            'temperature' => [
+                'min' => 0, 'max' => 120, 'warningMin' => 80, 'warningMax' => 115,
+                'metricMin' => 0, 'metricMax' => 48.9, 'metricWarningMin' => 26.7, 'metricWarningMax' => 46.1,
+            ],
+            'oxygen_saturation' => [
+                'min' => 0, 'max' => 100, 'warningMin' => 0, 'warningMax' => 100,
+            ],
+            'oxygen_flow_rate' => [
+                'min' => 0, 'max' => 200, 'warningMin' => 0, 'warningMax' => 100,
+            ],
+            'inhaled_oxygen_concentration' => [
+                'min' => 0, 'max' => 100, 'warningMin' => 0, 'warningMax' => 100,
+            ],
+            'head_circ' => [
+                'min' => 0, 'max' => 75, 'warningMin' => 0, 'warningMax' => 50,
+                'metricMin' => 0, 'metricMax' => 190, 'metricWarningMin' => 0, 'metricWarningMax' => 127,
+            ],
+            'waist_circ' => [
+                'min' => 0, 'max' => 150, 'warningMin' => 0, 'warningMax' => 100,
+                'metricMin' => 0, 'metricMax' => 381, 'metricWarningMin' => 0, 'metricWarningMax' => 254,
+            ],
+            'ped_weight_height' => [
+                'min' => 0, 'max' => 100, 'warningMin' => 0, 'warningMax' => 100,
+            ],
+            'ped_bmi' => [
+                'min' => 0, 'max' => 100, 'warningMin' => 0, 'warningMax' => 100,
+            ],
+            'ped_head_circ' => [
+                'min' => 0, 'max' => 100, 'warningMin' => 0, 'warningMax' => 100,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{min: float, max: float, warningMin: float, warningMax: float, metricMin?: float, metricMax?: float, metricWarningMin?: float, metricWarningMax?: float}|null
+     */
+    public static function getRangeForField(string $fieldName): ?array
+    {
+        return self::getRanges()[$fieldName] ?? null;
+    }
+}

--- a/src/Common/Forms/VitalsFieldRanges.php
+++ b/src/Common/Forms/VitalsFieldRanges.php
@@ -47,30 +47,30 @@ final class VitalsFieldRanges
                 'metricMin' => 0, 'metricMax' => 48.9, 'metricWarningMin' => 26.7, 'metricWarningMax' => 46.1,
             ],
             'oxygen_saturation' => [
-                'min' => 0, 'max' => 100, 'warningMin' => 0, 'warningMax' => 100,
+                'min' => 0, 'max' => 100, 'warningMin' => 70, 'warningMax' => 100,
             ],
             'oxygen_flow_rate' => [
-                'min' => 0, 'max' => 200, 'warningMin' => 0, 'warningMax' => 100,
+                'min' => 0, 'max' => 200, 'warningMin' => 0.1, 'warningMax' => 100,
             ],
             'inhaled_oxygen_concentration' => [
-                'min' => 0, 'max' => 100, 'warningMin' => 0, 'warningMax' => 100,
+                'min' => 0, 'max' => 100, 'warningMin' => 21, 'warningMax' => 100,
             ],
             'head_circ' => [
-                'min' => 0, 'max' => 75, 'warningMin' => 0, 'warningMax' => 50,
-                'metricMin' => 0, 'metricMax' => 190, 'metricWarningMin' => 0, 'metricWarningMax' => 127,
+                'min' => 0, 'max' => 75, 'warningMin' => 0.1, 'warningMax' => 50,
+                'metricMin' => 0, 'metricMax' => 190, 'metricWarningMin' => 0.25, 'metricWarningMax' => 127,
             ],
             'waist_circ' => [
-                'min' => 0, 'max' => 150, 'warningMin' => 0, 'warningMax' => 100,
-                'metricMin' => 0, 'metricMax' => 381, 'metricWarningMin' => 0, 'metricWarningMax' => 254,
+                'min' => 0, 'max' => 150, 'warningMin' => 0.1, 'warningMax' => 100,
+                'metricMin' => 0, 'metricMax' => 381, 'metricWarningMin' => 0.25, 'metricWarningMax' => 254,
             ],
             'ped_weight_height' => [
-                'min' => 0, 'max' => 100, 'warningMin' => 0, 'warningMax' => 100,
+                'min' => 0, 'max' => 100, 'warningMin' => 3, 'warningMax' => 97,
             ],
             'ped_bmi' => [
-                'min' => 0, 'max' => 100, 'warningMin' => 0, 'warningMax' => 100,
+                'min' => 0, 'max' => 100, 'warningMin' => 3, 'warningMax' => 97,
             ],
             'ped_head_circ' => [
-                'min' => 0, 'max' => 100, 'warningMin' => 0, 'warningMax' => 100,
+                'min' => 0, 'max' => 100, 'warningMin' => 3, 'warningMax' => 97,
             ],
         ];
     }

--- a/src/Common/Forms/VitalsFieldRanges.php
+++ b/src/Common/Forms/VitalsFieldRanges.php
@@ -17,66 +17,81 @@ namespace OpenEMR\Common\Forms;
 final class VitalsFieldRanges
 {
     /**
-     * @return array<string, array{min: float, max: float, warningMin: float, warningMax: float, metricMin?: float, metricMax?: float, metricWarningMin?: float, metricWarningMax?: float}>
+     * @return array<string, array{label: string, min: float, max: float, warningMin: float, warningMax: float, metricMin?: float, metricMax?: float, metricWarningMin?: float, metricWarningMax?: float}>
      */
     public static function getRanges(): array
     {
         return [
             'weight' => [
+                'label' => xl('Weight'),
                 'min' => 0, 'max' => 2000, 'warningMin' => 0.1, 'warningMax' => 1500,
                 'metricMin' => 0, 'metricMax' => 910, 'metricWarningMin' => 0.05, 'metricWarningMax' => 680,
             ],
             'height' => [
+                'label' => xl('Height/Length'),
                 'min' => 0, 'max' => 150, 'warningMin' => 1, 'warningMax' => 108,
                 'metricMin' => 0, 'metricMax' => 381, 'metricWarningMin' => 2.5, 'metricWarningMax' => 274,
             ],
             'bps' => [
+                'label' => xl('BP Systolic'),
                 'min' => 0, 'max' => 400, 'warningMin' => 20, 'warningMax' => 300,
             ],
             'bpd' => [
+                'label' => xl('BP Diastolic'),
                 'min' => 0, 'max' => 300, 'warningMin' => 10, 'warningMax' => 200,
             ],
             'pulse' => [
+                'label' => xl('Pulse'),
                 'min' => 0, 'max' => 500, 'warningMin' => 10, 'warningMax' => 350,
             ],
             'respiration' => [
+                'label' => xl('Respiration'),
                 'min' => 0, 'max' => 150, 'warningMin' => 2, 'warningMax' => 100,
             ],
             'temperature' => [
+                'label' => xl('Temperature'),
                 'min' => 0, 'max' => 120, 'warningMin' => 80, 'warningMax' => 115,
                 'metricMin' => 0, 'metricMax' => 48.9, 'metricWarningMin' => 26.7, 'metricWarningMax' => 46.1,
             ],
             'oxygen_saturation' => [
+                'label' => xl('Oxygen Saturation'),
                 'min' => 0, 'max' => 100, 'warningMin' => 70, 'warningMax' => 100,
             ],
             'oxygen_flow_rate' => [
+                'label' => xl('Oxygen Flow Rate'),
                 'min' => 0, 'max' => 200, 'warningMin' => 0.1, 'warningMax' => 100,
             ],
             'inhaled_oxygen_concentration' => [
+                'label' => xl('Inhaled Oxygen Concentration'),
                 'min' => 0, 'max' => 100, 'warningMin' => 21, 'warningMax' => 100,
             ],
             'head_circ' => [
+                'label' => xl('Head Circumference'),
                 'min' => 0, 'max' => 75, 'warningMin' => 0.1, 'warningMax' => 50,
                 'metricMin' => 0, 'metricMax' => 190, 'metricWarningMin' => 0.25, 'metricWarningMax' => 127,
             ],
             'waist_circ' => [
+                'label' => xl('Waist Circumference'),
                 'min' => 0, 'max' => 150, 'warningMin' => 0.1, 'warningMax' => 100,
                 'metricMin' => 0, 'metricMax' => 381, 'metricWarningMin' => 0.25, 'metricWarningMax' => 254,
             ],
             'ped_weight_height' => [
+                'label' => xl('Pediatric Weight Height Percentile'),
                 'min' => 0, 'max' => 100, 'warningMin' => 3, 'warningMax' => 97,
             ],
             'ped_bmi' => [
+                'label' => xl('Pediatric BMI Percentile'),
                 'min' => 0, 'max' => 100, 'warningMin' => 3, 'warningMax' => 97,
             ],
             'ped_head_circ' => [
+                'label' => xl('Pediatric Head Circumference Percentile'),
                 'min' => 0, 'max' => 100, 'warningMin' => 3, 'warningMax' => 97,
             ],
         ];
     }
 
     /**
-     * @return array{min: float, max: float, warningMin: float, warningMax: float, metricMin?: float, metricMax?: float, metricWarningMin?: float, metricWarningMax?: float}|null
+     * @return array{label: string, min: float, max: float, warningMin: float, warningMax: float, metricMin?: float, metricMax?: float, metricWarningMin?: float, metricWarningMax?: float}|null
      */
     public static function getRangeForField(string $fieldName): ?array
     {

--- a/tests/Tests/Isolated/Common/Forms/FormVitalsValidateTest.php
+++ b/tests/Tests/Isolated/Common/Forms/FormVitalsValidateTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * Isolated FormVitals Validation Test
+ *
+ * Tests the validate() method on FormVitals against VitalsFieldRanges.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Davit Mnatsakanyan
+ * @copyright Copyright (c) 2026 OpenEMR Foundation
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Forms;
+
+use OpenEMR\Common\Forms\FormVitals;
+use OpenEMR\Common\Forms\VitalsFieldRanges;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class FormVitalsValidateTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // FormVitals → ORDataObject constructor reads globals. Provide required values.
+        $GLOBALS['pid'] ??= 1;
+        $GLOBALS['adodb'] ??= ['db' => null];
+        // xl() needs translation disabled to work without database.
+        $GLOBALS['disable_translation'] = true;
+
+        // Load translation helpers so xl() is defined as a passthrough.
+        $translationFile = realpath(__DIR__ . '/../../../../../library/translation.inc.php');
+        if ($translationFile !== false && !function_exists('xl')) {
+            require_once $translationFile;
+        }
+    }
+
+    private function createVitals(): FormVitals
+    {
+        return new FormVitals();
+    }
+
+    /**
+     * @return array<string, array{string, float|int}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function validValueProvider(): array
+    {
+        return [
+            'weight mid-range' => ['weight', 150],
+            'height mid-range' => ['height', 66],
+            'bps mid-range' => ['bps', 120],
+            'bpd mid-range' => ['bpd', 80],
+            'pulse mid-range' => ['pulse', 72],
+            'respiration mid-range' => ['respiration', 16],
+            'temperature mid-range' => ['temperature', 98.6],
+            'oxygen_saturation mid-range' => ['oxygen_saturation', 97],
+            'oxygen_flow_rate mid-range' => ['oxygen_flow_rate', 2],
+            'inhaled_oxygen_concentration mid-range' => ['inhaled_oxygen_concentration', 40],
+            'head_circ mid-range' => ['head_circ', 14],
+            'waist_circ mid-range' => ['waist_circ', 32],
+            'ped_weight_height mid-range' => ['ped_weight_height', 50],
+            'ped_bmi mid-range' => ['ped_bmi', 50],
+            'ped_head_circ mid-range' => ['ped_head_circ', 50],
+        ];
+    }
+
+    #[DataProvider('validValueProvider')]
+    public function testValidValueProducesNoErrorsOrWarnings(string $field, float|int $value): void
+    {
+        $vitals = $this->createVitals();
+        $vitals->$field = $value;
+        $result = $vitals->validate();
+        $this->assertSame([], $result['errors'], "Expected no errors for {$field}={$value}");
+        $this->assertSame([], $result['warnings'], "Expected no warnings for {$field}={$value}");
+    }
+
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function allFieldsProvider(): array
+    {
+        return [
+            'weight' => ['weight'],
+            'height' => ['height'],
+            'bps' => ['bps'],
+            'bpd' => ['bpd'],
+            'pulse' => ['pulse'],
+            'respiration' => ['respiration'],
+            'temperature' => ['temperature'],
+            'oxygen_saturation' => ['oxygen_saturation'],
+            'oxygen_flow_rate' => ['oxygen_flow_rate'],
+            'inhaled_oxygen_concentration' => ['inhaled_oxygen_concentration'],
+            'head_circ' => ['head_circ'],
+            'waist_circ' => ['waist_circ'],
+            'ped_weight_height' => ['ped_weight_height'],
+            'ped_bmi' => ['ped_bmi'],
+            'ped_head_circ' => ['ped_head_circ'],
+        ];
+    }
+
+    #[DataProvider('allFieldsProvider')]
+    public function testNonNumericValueProducesError(string $field): void
+    {
+        $vitals = $this->createVitals();
+        $vitals->$field = 'abc';
+        $result = $vitals->validate();
+        $this->assertNotEmpty($result['errors'], "Expected error for non-numeric {$field}");
+    }
+
+    #[DataProvider('allFieldsProvider')]
+    public function testNegativeValueProducesError(string $field): void
+    {
+        $vitals = $this->createVitals();
+        $vitals->$field = -1;
+        $result = $vitals->validate();
+        $this->assertNotEmpty($result['errors'], "Expected error for negative {$field}");
+    }
+
+    #[DataProvider('allFieldsProvider')]
+    public function testValueAboveMaxProducesError(string $field): void
+    {
+        $range = VitalsFieldRanges::getRangeForField($field);
+        $this->assertNotNull($range);
+
+        $vitals = $this->createVitals();
+        $vitals->$field = $range['max'] + 1;
+        $result = $vitals->validate();
+        $this->assertNotEmpty($result['errors'], "Expected error for {$field} above max");
+    }
+
+    #[DataProvider('allFieldsProvider')]
+    public function testNullValueIsSkipped(string $field): void
+    {
+        $vitals = $this->createVitals();
+        $vitals->$field = null;
+        $result = $vitals->validate();
+        $this->assertSame([], $result['errors'], "Expected no errors for null {$field}");
+        $this->assertSame([], $result['warnings'], "Expected no warnings for null {$field}");
+    }
+
+    #[DataProvider('allFieldsProvider')]
+    public function testEmptyStringIsSkipped(string $field): void
+    {
+        $vitals = $this->createVitals();
+        $vitals->$field = '';
+        $result = $vitals->validate();
+        $this->assertSame([], $result['errors'], "Expected no errors for empty string {$field}");
+        $this->assertSame([], $result['warnings'], "Expected no warnings for empty string {$field}");
+    }
+
+    #[DataProvider('allFieldsProvider')]
+    public function testZeroValueIsValidated(string $field): void
+    {
+        $vitals = $this->createVitals();
+        $vitals->$field = 0;
+        $result = $vitals->validate();
+        // Zero should NOT be skipped — it should be validated.
+        // For all fields, zero is within hard bounds (min=0), so no error.
+        // But for fields with warningMin > 0, it should produce a warning.
+        $range = VitalsFieldRanges::getRangeForField($field);
+        $this->assertNotNull($range);
+        $this->assertSame([], $result['errors'], "Zero should not produce errors for {$field}");
+
+        if ($range['warningMin'] > 0) {
+            $this->assertNotEmpty($result['warnings'], "Zero should produce a warning for {$field} (warningMin={$range['warningMin']})");
+        }
+    }
+
+    public function testWarningBandTriggersWarningNotError(): void
+    {
+        // oxygen_saturation has warningMin=70, min=0
+        // A value of 50 is within hard bounds but outside warning range
+        $vitals = $this->createVitals();
+        $vitals->oxygen_saturation = 50;
+        $result = $vitals->validate();
+        $this->assertSame([], $result['errors'], 'Value within hard bounds should not error');
+        $this->assertNotEmpty($result['warnings'], 'Value outside warning range should warn');
+    }
+
+    public function testMultipleFieldsValidatedIndependently(): void
+    {
+        $vitals = $this->createVitals();
+        $vitals->bps = 120;
+        $vitals->bpd = 999; // above max of 300
+        $result = $vitals->validate();
+        $this->assertCount(1, $result['errors'], 'Only the out-of-range field should error');
+    }
+}

--- a/tests/Tests/Isolated/Common/Forms/VitalsFieldRangesTest.php
+++ b/tests/Tests/Isolated/Common/Forms/VitalsFieldRangesTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Isolated VitalsFieldRanges Test
+ *
+ * Tests validation range definitions for vitals form fields.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Davit Mnatsakanyan
+ * @copyright Copyright (c) 2026 OpenEMR Foundation
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Forms;
+
+use OpenEMR\Common\Forms\VitalsFieldRanges;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class VitalsFieldRangesTest extends TestCase
+{
+    private const EXPECTED_FIELDS = [
+        'weight',
+        'height',
+        'bps',
+        'bpd',
+        'pulse',
+        'respiration',
+        'temperature',
+        'oxygen_saturation',
+        'oxygen_flow_rate',
+        'inhaled_oxygen_concentration',
+        'head_circ',
+        'waist_circ',
+        'ped_weight_height',
+        'ped_bmi',
+        'ped_head_circ',
+    ];
+
+    private const METRIC_FIELDS = [
+        'weight',
+        'height',
+        'temperature',
+        'head_circ',
+        'waist_circ',
+    ];
+
+    public function testEveryExpectedFieldHasARangeEntry(): void
+    {
+        $ranges = VitalsFieldRanges::getRanges();
+        foreach (self::EXPECTED_FIELDS as $field) {
+            $this->assertArrayHasKey($field, $ranges, "Missing range entry for field '{$field}'");
+        }
+    }
+
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function fieldProvider(): array
+    {
+        $cases = [];
+        foreach (self::EXPECTED_FIELDS as $field) {
+            $cases[$field] = [$field];
+        }
+        return $cases;
+    }
+
+    #[DataProvider('fieldProvider')]
+    public function testRangesAreSelfConsistent(string $field): void
+    {
+        $range = VitalsFieldRanges::getRangeForField($field);
+        $this->assertNotNull($range);
+
+        // assertLessThanOrEqual($expected, $actual) asserts $actual <= $expected
+        // Verify min <= warningMin <= warningMax <= max
+        $this->assertLessThanOrEqual($range['warningMin'], $range['min'], "min <= warningMin for {$field}");
+        $this->assertLessThanOrEqual($range['warningMax'], $range['warningMin'], "warningMin <= warningMax for {$field}");
+        $this->assertLessThanOrEqual($range['max'], $range['warningMax'], "warningMax <= max for {$field}");
+    }
+
+    #[DataProvider('fieldProvider')]
+    public function testWarningBandsAreNotInert(string $field): void
+    {
+        $range = VitalsFieldRanges::getRangeForField($field);
+        $this->assertNotNull($range);
+
+        $hasDistinctMin = $range['warningMin'] > $range['min'];
+        $hasDistinctMax = $range['warningMax'] < $range['max'];
+
+        $this->assertTrue(
+            $hasDistinctMin || $hasDistinctMax,
+            "Warning band for '{$field}' is identical to hard bounds — warnings can never trigger"
+        );
+    }
+
+    public function testGetRangeForFieldReturnsNullForUnknownField(): void
+    {
+        $this->assertNull(VitalsFieldRanges::getRangeForField('nonexistent_field'));
+        $this->assertNull(VitalsFieldRanges::getRangeForField(''));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function metricFieldProvider(): array
+    {
+        $cases = [];
+        foreach (self::METRIC_FIELDS as $field) {
+            $cases[$field] = [$field];
+        }
+        return $cases;
+    }
+
+    #[DataProvider('metricFieldProvider')]
+    public function testMetricFieldsHaveMetricRanges(string $field): void
+    {
+        $range = VitalsFieldRanges::getRangeForField($field);
+        $this->assertNotNull($range);
+        $this->assertArrayHasKey('metricMin', $range, "Missing metricMin for '{$field}'");
+        $this->assertArrayHasKey('metricMax', $range, "Missing metricMax for '{$field}'");
+        $this->assertArrayHasKey('metricWarningMin', $range, "Missing metricWarningMin for '{$field}'");
+        $this->assertArrayHasKey('metricWarningMax', $range, "Missing metricWarningMax for '{$field}'");
+
+        $this->assertLessThanOrEqual($range['metricWarningMin'], $range['metricMin'], "metricMin <= metricWarningMin for {$field}");
+        $this->assertLessThanOrEqual($range['metricWarningMax'], $range['metricWarningMin'], "metricWarningMin <= metricWarningMax for {$field}");
+        $this->assertLessThanOrEqual($range['metricMax'], $range['metricWarningMax'], "metricWarningMax <= metricMax for {$field}");
+    }
+}


### PR DESCRIPTION
#10602 

Adds comprehensive client-side and server-side validation for the vitals form to prevent invalid data entry (non-numeric, negative, out-of-range values) and warn on clinically unusual values.          
                                                                                                                                                                                                           
  Changes proposed in this pull request:                                                                                                                                                                   
                                                                                                                                                                                                           
  - New VitalsFieldRanges class as single source of truth for hard bounds and clinical warning ranges across all 15 numeric vitals fields (including metric equivalents)
  - Extended JS validation from 6 hardcoded fields to all numeric inputs via data-* attributes                                                                                                           
  - Added validateVitalField() with real-time validation on change events — errors block submission, warnings allow it
  - Added inputmode="decimal" and data-min/max/warning-min/warning-max attributes to textbox and conversion Twig templates
  - Added FormVitals::validate() method for server-side range checking as a safety net
  - Added .warning CSS styles (amber border) and inline warning messages
  - Preserved support for weight # format (e.g. 5#4 for lbs/oz)

  Was an AI assistant used? Yes
