### PR TITLE
fix: bypass max_input_vars truncation in edit_layout and edit_payment

### DIFF
--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -26202,11 +26202,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/super/edit_layout.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset int\\<1, max\\> on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/edit_layout.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset mixed on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/super/edit_layout.php',

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -3353,7 +3353,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 64,
+    'count' => 63,
     'path' => __DIR__ . '/../../interface/super/edit_layout.php',
 ];
 $ignoreErrors[] = [

--- a/interface/billing/edit_payment.php
+++ b/interface/billing/edit_payment.php
@@ -54,6 +54,9 @@ $screen = 'edit_payment';
 
 $recorder = new Recorder();
 
+/** @var string|null $saveError User-visible error when the body could not be re-parsed. */
+$saveError = null;
+
 // Deletion of payment distribution code
 
 if (isset($_POST["mode"])) {
@@ -89,23 +92,35 @@ if (isset($_POST["mode"])) {
 //Modify Payment Code.
 //===============================================================================
 
-if (isset($_POST["mode"])) {
-    if ($_POST["mode"] == "ModifyPayments" || $_POST["mode"] == "FinishPayments") {
-        CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+// CSRF + raw-body re-parse for the two mutating modes. Done in a top
+// guard block so a parser failure can fail closed: $saveError is set, the
+// existing write block below short-circuits on it, and the page renders
+// the banner instead of silently committing a partial post.
+$paymentMode = filter_input(INPUT_POST, 'mode');
+if (in_array($paymentMode, ['ModifyPayments', 'FinishPayments'], true)) {
+    CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+    try {
         // ModifyPayments posts one Payment$CountRow, AdjAmount$CountRow,
-        // etc. set per encounter row. For patients with many encounters this
-        // exceeds PHP's max_input_vars, silently truncating $_POST and
-        // producing a blank page. Re-parse the raw body so all rows survive,
-        // then repopulate $_POST — the per-row code below reads via
-        // formData(), trimPost(), and DistributionInsert(), all of which
-        // pull from the superglobal directly.
-        try {
-            RawPostParser::fromGlobals()->applyToGlobals();
-        } catch (RawPostParserException $e) {
-            ServiceContainer::getLogger()->warning('edit_payment.php: raw POST parse failed', ['exception' => $e]);
-            // Fall through with PHP's truncated $_POST; behaviour matches
-            // the pre-fix state rather than crashing the request.
-        }
+        // etc. set per encounter row. For patients with many encounters
+        // this exceeds PHP's max_input_vars and silently truncates $_POST.
+        // applyToGlobals re-parses the raw body and also rebuilds $_REQUEST
+        // so loop-bound reads (CountIndexAbove/Below) see the full payload.
+        RawPostParser::fromGlobals()->applyToGlobals();
+    } catch (RawPostParserException $e) {
+        $saveError = xl('Save did not complete: the form data could not be re-parsed. Please contact your administrator. No payments were modified.');
+        ServiceContainer::getLogger()->error('raw POST parse failed', [
+            'component' => 'edit_payment',
+            'mode' => $paymentMode,
+            'payment_id' => filter_input(INPUT_POST, 'payment_id', FILTER_VALIDATE_INT),
+            'content_length' => filter_input(INPUT_SERVER, 'CONTENT_LENGTH', FILTER_VALIDATE_INT),
+            'max_input_vars' => filter_var(ini_get('max_input_vars'), FILTER_VALIDATE_INT),
+            'exception' => $e,
+        ]);
+    }
+}
+
+if ($saveError === null && isset($_POST["mode"])) {
+    if ($_POST["mode"] == "ModifyPayments" || $_POST["mode"] == "FinishPayments") {
         $payment_id = $_REQUEST['payment_id'];
         //ar_session Code
         //===============================================================================
@@ -604,6 +619,11 @@ $ResultSearchSub = sqlStatement(
 </head>
 <body class="body_top" onload="OnloadAction()">
     <div class="container-fluid">
+        <?php if ($saveError !== null) { ?>
+            <div class="alert alert-danger m-2" role="alert" id="payment-save-error">
+                <?php echo text($saveError); ?>
+            </div>
+        <?php } ?>
         <?php
         if (($_REQUEST['ParentPage'] ?? '') == 'new_payment') {
             ?>

--- a/interface/billing/edit_payment.php
+++ b/interface/billing/edit_payment.php
@@ -22,8 +22,12 @@
 
 require_once("../globals.php");
 require_once("../../custom/code_types.inc.php");
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Http\RawPostParser;
+use OpenEMR\Common\Http\RawPostParserException;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -54,6 +58,7 @@ $recorder = new Recorder();
 
 if (isset($_POST["mode"])) {
     if ($_POST["mode"] == "DeletePaymentDistribution") {
+        CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
         $DeletePaymentDistributionId = (isset($_POST['DeletePaymentDistributionId']) ? trim((string) $_POST['DeletePaymentDistributionId']) : '');
         $DeletePaymentDistributionIdArray = explode('_', $DeletePaymentDistributionId);
         $payment_id = $DeletePaymentDistributionIdArray[0];
@@ -86,6 +91,21 @@ if (isset($_POST["mode"])) {
 
 if (isset($_POST["mode"])) {
     if ($_POST["mode"] == "ModifyPayments" || $_POST["mode"] == "FinishPayments") {
+        CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+        // ModifyPayments posts one Payment$CountRow, AdjAmount$CountRow,
+        // etc. set per encounter row. For patients with many encounters this
+        // exceeds PHP's max_input_vars, silently truncating $_POST and
+        // producing a blank page. Re-parse the raw body so all rows survive,
+        // then repopulate $_POST — the per-row code below reads via
+        // formData(), trimPost(), and DistributionInsert(), all of which
+        // pull from the superglobal directly.
+        try {
+            RawPostParser::fromGlobals()->applyToGlobals();
+        } catch (RawPostParserException $e) {
+            ServiceContainer::getLogger()->warning('edit_payment.php: raw POST parse failed', ['exception' => $e]);
+            // Fall through with PHP's truncated $_POST; behaviour matches
+            // the pre-fix state rather than crashing the request.
+        }
         $payment_id = $_REQUEST['payment_id'];
         //ar_session Code
         //===============================================================================
@@ -619,6 +639,7 @@ $ResultSearchSub = sqlStatement(
         $onclick = empty($payment_id) ? "top.restoreSession();return SavePayment();" : "return false;";
         ?>
         <form class="form" name='new_payment' method='post' action="edit_payment.php" onsubmit='<?php echo $onclick; ?>'>
+            <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken(session: $session)); ?>" />
             <?php
             if (!empty($payment_id)) { ?>
             <fieldset>

--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -452,12 +452,21 @@ if (!empty($_POST['formaction']) && ($_POST['formaction'] == "save") && $layout_
         $parsedPost = RawPostParser::fromGlobals()->applyToGlobals();
     } catch (RawPostParserException $e) {
         $saveError = xl('Save did not complete: the form data could not be re-parsed. Please contact your administrator. Your edits in the browser have not been discarded.');
-        ServiceContainer::getLogger()->warning('edit_layout.php: raw POST parse failed', ['exception' => $e]);
+        ServiceContainer::getLogger()->warning('raw POST parse failed', [
+            'component' => 'edit_layout',
+            'layout_id' => $layout_id,
+            'content_length' => filter_input(INPUT_SERVER, 'CONTENT_LENGTH', FILTER_VALIDATE_INT),
+            'max_input_vars' => filter_var(ini_get('max_input_vars'), FILTER_VALIDATE_INT),
+            'exception' => $e,
+        ]);
     }
     $fldPayload = $parsedPost['fld'] ?? null;
     if ($saveError === null && (!is_array($fldPayload) || $fldPayload === [])) {
         $saveError = xl('Save did not complete: no field rows were submitted. Please contact your administrator.');
-        ServiceContainer::getLogger()->warning('edit_layout.php: save received no fld[] payload');
+        ServiceContainer::getLogger()->warning('save received no fld[] payload', [
+            'component' => 'edit_layout',
+            'layout_id' => $layout_id,
+        ]);
     }
     // If we are saving, then save.
     $fld = is_array($fldPayload) ? $fldPayload : [];

--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -21,9 +21,12 @@ require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/layout.i
 /** @var list<int> $typesUsingList */
 /** @var array<string,string> $sources */
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Http\RawPostParser;
+use OpenEMR\Common\Http\RawPostParserException;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
@@ -435,11 +438,30 @@ $lbfonly = str_starts_with(attr($layout_id), 'LBF') ? "" : "style='display:none;
 
 // Handle the Form actions
 
+$saveError = null;
 if (!empty($_POST['formaction']) && ($_POST['formaction'] == "save") && $layout_id) {
     CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+    // The save form serialises one fld[N][...] subarray per layout row. For
+    // large layouts this exceeds PHP's max_input_vars, silently truncating
+    // $_POST['fld'] and dropping the tail rows from the save. Re-parse the
+    // raw body so every row survives. On parser failure we keep the
+    // truncated $_POST (current pre-fix behaviour) and surface an error
+    // banner in the editor instead of die()ing on the user.
+    $parsedPost = [];
+    try {
+        $parsedPost = RawPostParser::fromGlobals()->applyToGlobals();
+    } catch (RawPostParserException $e) {
+        $saveError = xl('Save did not complete: the form data could not be re-parsed. Please contact your administrator. Your edits in the browser have not been discarded.');
+        ServiceContainer::getLogger()->warning('edit_layout.php: raw POST parse failed', ['exception' => $e]);
+    }
+    $fldPayload = $parsedPost['fld'] ?? null;
+    if ($saveError === null && (!is_array($fldPayload) || $fldPayload === [])) {
+        $saveError = xl('Save did not complete: no field rows were submitted. Please contact your administrator.');
+        ServiceContainer::getLogger()->warning('edit_layout.php: save received no fld[] payload');
+    }
     // If we are saving, then save.
-    $fld = $_POST['fld'];
-    for ($lino = 1; isset($fld[$lino]['id']); ++$lino) {
+    $fld = is_array($fldPayload) ? $fldPayload : [];
+    for ($lino = 1; $saveError === null && isset($fld[$lino]['id']); ++$lino) {
         $iter = $fld[$lino];
         $field_id = trim((string) $iter['id']);
         $field_id_original = trim((string) $iter['originalid']);
@@ -1480,6 +1502,11 @@ function myChangeCheck() {
 </head>
 
 <body class="body_top admin-layout">
+<?php if ($saveError !== null) { ?>
+<div class="alert alert-danger m-2" role="alert" id="layout-save-error">
+    <?php echo text($saveError); ?>
+</div>
+<?php } ?>
 <form method='post' name='theform' id='theform' action='edit_layout.php'>
 <input type="hidden" name="csrf_token_form" value="<?php echo CsrfUtils::collectCsrfToken(session: $session); ?>" />
 <input type="hidden" name="formaction" id="formaction" value="" />

--- a/src/Common/Http/RawPostParser.php
+++ b/src/Common/Http/RawPostParser.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * RawPostParser — re-parses the raw POST body, sidestepping the
+ * `max_input_vars` truncation that drops fields from `$_POST` when a form
+ * posts more variables than the PHP configured ceiling.
+ *
+ * The browser sends the full body for an `application/x-www-form-urlencoded`
+ * POST; PHP just refuses to expose more than `max_input_vars` of it through
+ * `$_POST`. `parse_str()` is bound by the same limit (PHP 7+), so the parser
+ * splits the body into chunks below the configured ceiling, parses each chunk
+ * with `parse_str()`, and merges the results. `post_max_size` still caps the
+ * body PHP populates `php://input` with, so memory remains bounded.
+ *
+ * Use only for `application/x-www-form-urlencoded` POSTs. Multipart bodies
+ * (file uploads) cannot be re-parsed this way: PHP consumes them before
+ * `php://input` is populated. The constructor enforces this.
+ *
+ * Designed as an instance class so each request gets its own cache and tests
+ * get fresh state per test method. Inject at the controller boundary; do not
+ * call from inside services.
+ *
+ * `$_SERVER['CONTENT_TYPE']` is read intentionally as a transitional pattern
+ * at the legacy-script boundary. Do not add further superglobal reads here.
+ *
+ * Limitation: the merge step uses `array_replace_recursive`, which does not
+ * append-merge auto-indexed arrays (`foo[]=1&foo[]=2`). Both target endpoints
+ * use explicit indices (`fld[1][id]`, `Payment3`), so this is not a concern
+ * in practice; callers that emit `foo[]=…` patterns over the chunk boundary
+ * should switch to explicit indices.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Andrew Alanis <progradedteam@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Http;
+
+class RawPostParser
+{
+    /**
+     * Fraction of `max_input_vars` used as the parse_str() chunk size. Leaves
+     * headroom for parser overhead and prevents the per-call limit from
+     * tripping at the exact boundary.
+     */
+    private const CHUNK_SAFETY_FACTOR = 0.5;
+
+    /**
+     * Floor for the per-call chunk size. Honoured even when
+     * `max_input_vars` is configured pathologically low; below this the
+     * parser would issue thousands of tiny parse_str() calls.
+     */
+    private const MIN_CHUNK_SIZE = 50;
+
+    /**
+     * Fallback chunk size when `ini_get('max_input_vars')` is empty/unset.
+     * Matches PHP's compiled-in default.
+     */
+    private const DEFAULT_MAX_INPUT_VARS = 1000;
+
+    /**
+     * Cached parsed result. `array-key` because `parse_str()` coerces numeric
+     * top-level keys to integers (e.g. a body containing `42=foo` yields
+     * `[42 => 'foo']`), matching the shape `$_POST` would have had.
+     *
+     * @var array<array-key, mixed>|null
+     */
+    private ?array $cache = null;
+
+    public function __construct(
+        private readonly RawRequestBodyReader $reader,
+        private readonly string $contentType,
+    ) {
+    }
+
+    /**
+     * Factory using the request's Content-Type header and the default
+     * php://input stream — the production path. Tests should construct
+     * directly.
+     */
+    public static function fromGlobals(): self
+    {
+        // filter_input(INPUT_SERVER, ...) is the project-blessed boundary
+        // pattern for reading $_SERVER without tripping the forbidden-
+        // globals PHPStan rule. Header is normalised by PHP to CONTENT_TYPE.
+        $contentType = filter_input(INPUT_SERVER, 'CONTENT_TYPE') ?? '';
+        return new self(new RawRequestBodyReader(), (string) $contentType);
+    }
+
+    /**
+     * Returns the POST body re-parsed without max_input_vars truncation.
+     * Result is cached per instance.
+     *
+     * @return array<array-key, mixed>
+     *
+     * @throws RawPostParserException if the request is multipart/form-data
+     *                                (php://input is not populated by PHP),
+     *                                or the raw body cannot be read.
+     */
+    public function parse(): array
+    {
+        if ($this->cache !== null) {
+            return $this->cache;
+        }
+
+        if (stripos($this->contentType, 'multipart/form-data') !== false) {
+            throw new RawPostParserException(
+                'RawPostParser cannot read multipart/form-data bodies; '
+                . 'PHP consumes them before php://input is available.',
+            );
+        }
+
+        $raw = $this->reader->read();
+        if ($raw === '') {
+            return $this->cache = [];
+        }
+        // Implementation note: chunked parse_str() below tolerates bodies past
+        // the runtime max_input_vars ceiling. See class docblock for the full
+        // rationale; the chunk size is computed at parse time so a runtime
+        // ini change is honoured.
+
+        $chunkSize = $this->chunkSize();
+        $pairs = explode('&', $raw);
+        $parsed = [];
+        foreach (array_chunk($pairs, $chunkSize) as $chunk) {
+            $chunkParsed = [];
+            parse_str(implode('&', $chunk), $chunkParsed);
+            $parsed = array_replace_recursive($parsed, $chunkParsed);
+        }
+        return $this->cache = $parsed;
+    }
+
+    /**
+     * Boundary helper for legacy scripts: parse the raw body and write the
+     * result into `$_POST` so the downstream code's existing reads
+     * (`$_POST[...]`, `formData()`, `trimPost()`) see the full body. Returns
+     * the parsed array so callers can also read it directly without making a
+     * second `$_POST` access at the call site. Concentrating the mutation
+     * inside this abstraction class is the project-sanctioned pattern for
+     * the `openemr.forbiddenRequestGlobals` rule.
+     *
+     * @return array<array-key, mixed>
+     *
+     * @throws RawPostParserException — see parse().
+     */
+    public function applyToGlobals(): array
+    {
+        $parsed = $this->parse();
+        $_POST = $parsed;
+        return $parsed;
+    }
+
+    /**
+     * Returns a chunk size for parse_str() that stays below the runtime
+     * `max_input_vars` ceiling. Reads ini at parse time so tests and
+     * production both see the live configuration.
+     *
+     * @return positive-int
+     */
+    private function chunkSize(): int
+    {
+        $configured = (int) ini_get('max_input_vars');
+        if ($configured <= 0) {
+            $configured = self::DEFAULT_MAX_INPUT_VARS;
+        }
+        $scaled = (int) ($configured * self::CHUNK_SAFETY_FACTOR);
+        return max(self::MIN_CHUNK_SIZE, $scaled);
+    }
+}

--- a/src/Common/Http/RawPostParser.php
+++ b/src/Common/Http/RawPostParser.php
@@ -9,8 +9,14 @@
  * POST; PHP just refuses to expose more than `max_input_vars` of it through
  * `$_POST`. `parse_str()` is bound by the same limit (PHP 7+), so the parser
  * splits the body into chunks below the configured ceiling, parses each chunk
- * with `parse_str()`, and merges the results. `post_max_size` still caps the
- * body PHP populates `php://input` with, so memory remains bounded.
+ * with `parse_str()`, and merges the results.
+ *
+ * `post_max_size` still caps how much of the body PHP ever exposes via
+ * `php://input`. If the body exceeds that ceiling PHP silently discards the
+ * tail and `parse_str()` would happily parse the truncated bytes; the parser
+ * compares the bytes it read against the request's `Content-Length` and
+ * throws when they diverge, so post_max_size truncation never reaches the
+ * caller as a quiet partial result.
  *
  * Use only for `application/x-www-form-urlencoded` POSTs. Multipart bodies
  * (file uploads) cannot be re-parsed this way: PHP consumes them before
@@ -20,14 +26,15 @@
  * get fresh state per test method. Inject at the controller boundary; do not
  * call from inside services.
  *
- * `$_SERVER['CONTENT_TYPE']` is read intentionally as a transitional pattern
- * at the legacy-script boundary. Do not add further superglobal reads here.
+ * `$_SERVER['CONTENT_TYPE']` and `$_SERVER['CONTENT_LENGTH']` are read
+ * intentionally as a transitional pattern at the legacy-script boundary. Do
+ * not add further superglobal reads here.
  *
  * Limitation: the merge step uses `array_replace_recursive`, which does not
- * append-merge auto-indexed arrays (`foo[]=1&foo[]=2`). Both target endpoints
- * use explicit indices (`fld[1][id]`, `Payment3`), so this is not a concern
- * in practice; callers that emit `foo[]=…` patterns over the chunk boundary
- * should switch to explicit indices.
+ * append-merge bracket-bare auto-indexed arrays (`foo[]=1&foo[]=2`). Rather
+ * than silently produce a different shape from native `$_POST` parsing for
+ * such inputs, the parser rejects them up front; callers must use explicit
+ * indices (`foo[0]`, `foo[1]`, ...) instead.
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
@@ -40,7 +47,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Common\Http;
 
-class RawPostParser
+final class RawPostParser
 {
     /**
      * Fraction of `max_input_vars` used as the parse_str() chunk size. Leaves
@@ -74,13 +81,14 @@ class RawPostParser
     public function __construct(
         private readonly RawRequestBodyReader $reader,
         private readonly string $contentType,
+        private readonly ?int $contentLength = null,
     ) {
     }
 
     /**
-     * Factory using the request's Content-Type header and the default
-     * php://input stream — the production path. Tests should construct
-     * directly.
+     * Factory using the request's Content-Type / Content-Length headers and
+     * the default php://input stream — the production path. Tests should
+     * construct directly.
      */
     public static function fromGlobals(): self
     {
@@ -88,7 +96,12 @@ class RawPostParser
         // pattern for reading $_SERVER without tripping the forbidden-
         // globals PHPStan rule. Header is normalised by PHP to CONTENT_TYPE.
         $contentType = filter_input(INPUT_SERVER, 'CONTENT_TYPE') ?? '';
-        return new self(new RawRequestBodyReader(), (string) $contentType);
+        $contentLength = filter_input(INPUT_SERVER, 'CONTENT_LENGTH', FILTER_VALIDATE_INT);
+        return new self(
+            new RawRequestBodyReader(),
+            (string) $contentType,
+            is_int($contentLength) ? $contentLength : null,
+        );
     }
 
     /**
@@ -99,7 +112,11 @@ class RawPostParser
      *
      * @throws RawPostParserException if the request is multipart/form-data
      *                                (php://input is not populated by PHP),
-     *                                or the raw body cannot be read.
+     *                                if the raw body cannot be read, if the
+     *                                bytes read are shorter than the request's
+     *                                Content-Length (post_max_size truncation),
+     *                                or if the body contains a bracket-bare
+     *                                auto-indexed key.
      */
     public function parse(): array
     {
@@ -109,22 +126,49 @@ class RawPostParser
 
         if (stripos($this->contentType, 'multipart/form-data') !== false) {
             throw new RawPostParserException(
-                'RawPostParser cannot read multipart/form-data bodies; '
-                . 'PHP consumes them before php://input is available.',
+                'RawPostParser cannot read multipart/form-data bodies; PHP consumes them before php://input is available.',
             );
         }
 
         $raw = $this->reader->read();
+
+        // post_max_size truncation guard. PHP silently discards body bytes
+        // past post_max_size before php://input is populated; parse_str
+        // would then happily parse the truncated bytes and we'd produce a
+        // partial-but-plausible $_POST. Compare bytes read against the
+        // request's advertised length so the failure surfaces loudly.
+        if ($this->contentLength !== null && strlen($raw) < $this->contentLength) {
+            throw new RawPostParserException(
+                sprintf(
+                    'Raw body truncated: read %d bytes, Content-Length %d (likely exceeds post_max_size)',
+                    strlen($raw),
+                    $this->contentLength,
+                ),
+            );
+        }
+
         if ($raw === '') {
             return $this->cache = [];
         }
-        // Implementation note: chunked parse_str() below tolerates bodies past
-        // the runtime max_input_vars ceiling. See class docblock for the full
-        // rationale; the chunk size is computed at parse time so a runtime
-        // ini change is honoured.
+
+        $pairs = explode('&', $raw);
+
+        // Reject bracket-bare auto-indexed keys (foo[]=1&foo[]=2) up front
+        // rather than silently produce a different shape from native $_POST
+        // via array_replace_recursive. Forces callers onto explicit indices.
+        foreach ($pairs as $pair) {
+            if ($pair === '') {
+                continue;
+            }
+            $keyPart = explode('=', $pair, 2)[0];
+            if (str_contains($keyPart, '[]')) {
+                throw new RawPostParserException(
+                    'RawPostParser does not support bracket-bare auto-indexed keys (e.g. foo[]=1). Use explicit indices (foo[0], foo[1], ...).',
+                );
+            }
+        }
 
         $chunkSize = $this->chunkSize();
-        $pairs = explode('&', $raw);
         $parsed = [];
         foreach (array_chunk($pairs, $chunkSize) as $chunk) {
             $chunkParsed = [];
@@ -137,11 +181,17 @@ class RawPostParser
     /**
      * Boundary helper for legacy scripts: parse the raw body and write the
      * result into `$_POST` so the downstream code's existing reads
-     * (`$_POST[...]`, `formData()`, `trimPost()`) see the full body. Returns
-     * the parsed array so callers can also read it directly without making a
-     * second `$_POST` access at the call site. Concentrating the mutation
-     * inside this abstraction class is the project-sanctioned pattern for
-     * the `openemr.forbiddenRequestGlobals` rule.
+     * (`$_POST[...]`, `formData()`, `trimPost()`) see the full body. Also
+     * rebuilds `$_REQUEST` from `$_GET`, the new `$_POST`, and `$_COOKIE`
+     * because PHP builds `$_REQUEST` once at request start from the
+     * (truncated) `$_POST` and never re-derives it; legacy handlers that
+     * read loop bounds or money-disposition fields out of `$_REQUEST` would
+     * otherwise still see the pre-truncation values.
+     *
+     * Refuses to overwrite a non-empty `$_POST` with an empty parsed array,
+     * which would happen if `php://input` was already consumed by another
+     * layer in the request lifecycle. That branch returns the existing
+     * `$_POST` unchanged rather than wiping the user's submission.
      *
      * @return array<array-key, mixed>
      *
@@ -150,7 +200,36 @@ class RawPostParser
     public function applyToGlobals(): array
     {
         $parsed = $this->parse();
+
+        if ($parsed === [] && $_POST !== []) {
+            // php://input was already consumed by some earlier layer and
+            // we'd be silently clobbering PHP's truncated $_POST with
+            // nothing. That is strictly worse than the truncation bug; bail.
+            return $_POST;
+        }
+
         $_POST = $parsed;
+
+        // Re-derive $_REQUEST from the new $_POST plus existing $_GET and
+        // $_COOKIE. PHP's request_order ini setting governs the order; the
+        // default "GP" is honoured by walking GET first, then POST. We
+        // intentionally do not include $_COOKIE here unless request_order
+        // mentions 'C', matching PHP's own builder.
+        $order = ini_get('request_order') ?: ini_get('variables_order') ?: 'GP';
+        $request = [];
+        for ($i = 0, $n = strlen($order); $i < $n; $i++) {
+            $source = match ($order[$i]) {
+                'G' => $_GET,
+                'P' => $_POST,
+                'C' => $_COOKIE,
+                default => null,
+            };
+            if (is_array($source)) {
+                $request = array_replace($request, $source);
+            }
+        }
+        $_REQUEST = $request;
+
         return $parsed;
     }
 

--- a/src/Common/Http/RawPostParserException.php
+++ b/src/Common/Http/RawPostParserException.php
@@ -17,6 +17,6 @@ declare(strict_types=1);
 
 namespace OpenEMR\Common\Http;
 
-class RawPostParserException extends \RuntimeException
+final class RawPostParserException extends \RuntimeException
 {
 }

--- a/src/Common/Http/RawPostParserException.php
+++ b/src/Common/Http/RawPostParserException.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * RawPostParserException — thrown by RawPostParser and RawRequestBodyReader
+ * when the raw POST body cannot be read or is incompatible with raw parsing
+ * (e.g. multipart/form-data bodies that PHP consumes before php://input is
+ * populated). Callers should catch this type rather than \RuntimeException.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Andrew Alanis <progradedteam@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Http;
+
+class RawPostParserException extends \RuntimeException
+{
+}

--- a/src/Common/Http/RawRequestBodyReader.php
+++ b/src/Common/Http/RawRequestBodyReader.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * RawRequestBodyReader — reads the raw HTTP request body once per instance
+ * and caches the result.
+ *
+ * PHP's `file_get_contents('php://input')` has a `string|false` return type;
+ * isolating that call here keeps the false-on-error API out of business code.
+ * The reader also caches the body because `php://input` cannot be read more
+ * than once in some SAPI configurations.
+ *
+ * Constructor accepts an optional stream identifier so tests can substitute a
+ * fixture stream (e.g. `data://text/plain,foo=1&bar=2`) without polluting the
+ * real request lifecycle.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Andrew Alanis <progradedteam@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Http;
+
+class RawRequestBodyReader
+{
+    private ?string $cache = null;
+
+    public function __construct(private readonly string $streamIdentifier = 'php://input')
+    {
+    }
+
+    /**
+     * Returns the raw request body. The stream is read once per instance.
+     *
+     * @throws RawPostParserException if the stream cannot be read.
+     */
+    public function read(): string
+    {
+        if ($this->cache !== null) {
+            return $this->cache;
+        }
+
+        $raw = @file_get_contents($this->streamIdentifier);
+        if ($raw === false) {
+            throw new RawPostParserException(
+                sprintf('Unable to read raw request body from %s', $this->streamIdentifier),
+            );
+        }
+
+        return $this->cache = $raw;
+    }
+}

--- a/src/Common/Http/RawRequestBodyReader.php
+++ b/src/Common/Http/RawRequestBodyReader.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Common\Http;
 
-class RawRequestBodyReader
+final class RawRequestBodyReader
 {
     private ?string $cache = null;
 
@@ -35,7 +35,11 @@ class RawRequestBodyReader
     /**
      * Returns the raw request body. The stream is read once per instance.
      *
-     * @throws RawPostParserException if the stream cannot be read.
+     * @throws RawPostParserException if the stream cannot be read. The
+     *         exception message includes the underlying PHP error message
+     *         (via error_get_last) so failures on tempfile / data:// /
+     *         open_basedir-restricted paths surface with a real reason
+     *         rather than just the path that couldn't be opened.
      */
     public function read(): string
     {
@@ -43,10 +47,11 @@ class RawRequestBodyReader
             return $this->cache;
         }
 
-        $raw = @file_get_contents($this->streamIdentifier);
+        $raw = file_get_contents($this->streamIdentifier);
         if ($raw === false) {
+            $reason = error_get_last()['message'] ?? 'unknown error';
             throw new RawPostParserException(
-                sprintf('Unable to read raw request body from %s', $this->streamIdentifier),
+                sprintf('Unable to read raw request body from %s: %s', $this->streamIdentifier, $reason),
             );
         }
 

--- a/tests/PHPStan/Rules/ForbiddenRequestGlobalsRule.php
+++ b/tests/PHPStan/Rules/ForbiddenRequestGlobalsRule.php
@@ -48,6 +48,7 @@ class ForbiddenRequestGlobalsRule implements Rule
      */
     private const ABSTRACTION_CLASSES = [
         \OpenEMR\Common\Http\HttpRestRequest::class,
+        \OpenEMR\Common\Http\RawPostParser::class,
         \OpenEMR\Core\OEEnvBag::class,
     ];
 

--- a/tests/Tests/Isolated/Common/Http/RawPostParserIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Http/RawPostParserIsolatedTest.php
@@ -183,4 +183,121 @@ class RawPostParserIsolatedTest extends TestCase
         parse_str($body, $expected);
         $this->assertSame($expected, $parsed);
     }
+
+    public function testThrowsWhenBodyShorterThanContentLength(): void
+    {
+        // Simulates post_max_size truncation: the request advertised 200
+        // bytes but only 50 reached php://input. Pre-fix the parser would
+        // happily produce a partial $_POST.
+        $body = 'foo=1&bar=2';
+        $parser = new RawPostParser(
+            $this->readerFor($body),
+            'application/x-www-form-urlencoded',
+            200,
+        );
+
+        $this->expectException(RawPostParserException::class);
+        $this->expectExceptionMessage('post_max_size');
+        $parser->parse();
+    }
+
+    public function testAcceptsBodyMatchingContentLength(): void
+    {
+        $body = 'foo=1&bar=2';
+        $parser = new RawPostParser(
+            $this->readerFor($body),
+            'application/x-www-form-urlencoded',
+            strlen($body),
+        );
+
+        $this->assertSame(['foo' => '1', 'bar' => '2'], $parser->parse());
+    }
+
+    public function testRejectsBracketBareAutoIndexedKeys(): void
+    {
+        // foo[]=1&foo[]=2 would produce a different shape after
+        // array_replace_recursive than native parse_str, so reject up front.
+        $parser = new RawPostParser(
+            $this->readerFor('foo[]=1&foo[]=2'),
+            'application/x-www-form-urlencoded',
+        );
+
+        $this->expectException(RawPostParserException::class);
+        $this->expectExceptionMessage('bracket-bare');
+        $parser->parse();
+    }
+
+    /**
+     * Build an array through a helper whose return type is
+     * `array<string, mixed>` so PHPStan can't narrow it to the literal shape
+     * of the values. Used when fixture-loading superglobals in tests where a
+     * literal `$_POST = [...]` would over-narrow downstream assertions.
+     *
+     * @param array<string, mixed> $values
+     * @return array<string, mixed>
+     */
+    private function makeWideArray(array $values): array
+    {
+        return $values;
+    }
+
+    public function testApplyToGlobalsWritesPostAndRequest(): void
+    {
+        $originalPost = $_POST;
+        $originalRequest = $_REQUEST;
+        $originalGet = $_GET;
+        try {
+            $_POST = $this->makeWideArray(['stale' => 'truncated']);
+            $_GET = $this->makeWideArray(['layout_id' => 'DEM']);
+            $_REQUEST = $this->makeWideArray(['stale' => 'truncated', 'layout_id' => 'DEM']);
+
+            $parser = new RawPostParser(
+                $this->readerFor('formaction=save&fld[1][id]=alpha'),
+                'application/x-www-form-urlencoded',
+            );
+            $parser->applyToGlobals();
+
+            // $_POST replaced with parsed body.
+            $this->assertArrayHasKey('formaction', $_POST);
+            $this->assertSame('save', $_POST['formaction']);
+            $this->assertArrayHasKey('fld', $_POST);
+            $this->assertArrayNotHasKey('stale', $_POST);
+
+            // $_REQUEST rebuilt from $_GET + new $_POST.
+            $this->assertArrayHasKey('formaction', $_REQUEST);
+            $this->assertSame('save', $_REQUEST['formaction']);
+            $this->assertArrayHasKey('layout_id', $_REQUEST);
+            $this->assertSame('DEM', $_REQUEST['layout_id']);
+            $this->assertArrayNotHasKey('stale', $_REQUEST);
+        } finally {
+            $_POST = $originalPost;
+            $_REQUEST = $originalRequest;
+            $_GET = $originalGet;
+        }
+    }
+
+    public function testApplyToGlobalsRefusesToClobberNonEmptyPostWithEmptyParse(): void
+    {
+        // If php://input was already consumed by some earlier layer, the
+        // parser would parse an empty body and return []. Wiping $_POST with
+        // that empty array is strictly worse than the truncation bug, so
+        // applyToGlobals returns the existing $_POST unchanged.
+        $originalPost = $_POST;
+        try {
+            $_POST = $this->makeWideArray(['preserved' => 'data']);
+
+            $parser = new RawPostParser(
+                $this->readerFor(''),
+                'application/x-www-form-urlencoded',
+            );
+            $result = $parser->applyToGlobals();
+
+            $this->assertArrayHasKey('preserved', $_POST);
+            $this->assertSame('data', $_POST['preserved']);
+            $this->assertArrayHasKey('preserved', $result);
+            $this->assertSame('data', $result['preserved']);
+        } finally {
+            $_POST = $originalPost;
+        }
+    }
 }

--- a/tests/Tests/Isolated/Common/Http/RawPostParserIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Http/RawPostParserIsolatedTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * Isolated RawPostParser tests
+ *
+ * Verifies that the parser bypasses PHP's max_input_vars truncation, rejects
+ * multipart bodies, caches results, and produces the same array shape PHP's
+ * own POST parser would have produced for the same input.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Andrew Alanis <progradedteam@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Http;
+
+use OpenEMR\Common\Http\RawPostParser;
+use OpenEMR\Common\Http\RawPostParserException;
+use OpenEMR\Common\Http\RawRequestBodyReader;
+use PHPUnit\Framework\TestCase;
+
+class RawPostParserIsolatedTest extends TestCase
+{
+    private function readerFor(string $body): RawRequestBodyReader
+    {
+        // data:// URIs let us feed a fixture body through the real
+        // file_get_contents path without touching php://input.
+        return new RawRequestBodyReader('data://text/plain;base64,' . base64_encode($body));
+    }
+
+    public function testParsesUrlEncodedBody(): void
+    {
+        $parser = new RawPostParser(
+            $this->readerFor('foo=1&bar=2&baz=hello+world'),
+            'application/x-www-form-urlencoded',
+        );
+
+        $this->assertSame(
+            ['foo' => '1', 'bar' => '2', 'baz' => 'hello world'],
+            $parser->parse(),
+        );
+    }
+
+    public function testParsesArrayNotation(): void
+    {
+        $parser = new RawPostParser(
+            $this->readerFor('fld[1][id]=a&fld[1][type]=text&fld[2][id]=b'),
+            'application/x-www-form-urlencoded',
+        );
+
+        $this->assertSame(
+            [
+                'fld' => [
+                    1 => ['id' => 'a', 'type' => 'text'],
+                    2 => ['id' => 'b'],
+                ],
+            ],
+            $parser->parse(),
+        );
+    }
+
+    public function testRecoversBodyLargerThanTypicalMaxInputVars(): void
+    {
+        // Build a body with 5000 fld[N][id]=... pairs — comfortably past any
+        // sane max_input_vars ceiling (default is 1000).
+        $pairs = [];
+        for ($i = 1; $i <= 5000; $i++) {
+            $pairs[] = sprintf('fld[%d][id]=row%d&fld[%d][type]=t', $i, $i, $i);
+        }
+        $body = implode('&', $pairs);
+
+        $parser = new RawPostParser(
+            $this->readerFor($body),
+            'application/x-www-form-urlencoded',
+        );
+        $parsed = $parser->parse();
+
+        $this->assertArrayHasKey('fld', $parsed);
+        $fld = $parsed['fld'];
+        $this->assertIsArray($fld);
+        $this->assertCount(5000, $fld);
+
+        $this->assertArrayHasKey(1, $fld);
+        $firstRow = $fld[1];
+        $this->assertIsArray($firstRow);
+        $this->assertSame('row1', $firstRow['id'] ?? null);
+
+        $this->assertArrayHasKey(5000, $fld);
+        $lastRow = $fld[5000];
+        $this->assertIsArray($lastRow);
+        $this->assertSame('row5000', $lastRow['id'] ?? null);
+    }
+
+    public function testCachesResultAcrossCalls(): void
+    {
+        $reader = $this->readerFor('foo=cached');
+        $parser = new RawPostParser($reader, 'application/x-www-form-urlencoded');
+
+        $first = $parser->parse();
+        $second = $parser->parse();
+
+        $this->assertSame($first, $second);
+        // Reader cache prevents a second underlying read; explicit identity
+        // check confirms the parser returns the same array object.
+        $this->assertSame($first, $second);
+    }
+
+    public function testRejectsMultipartFormData(): void
+    {
+        $parser = new RawPostParser(
+            $this->readerFor('--boundary--'),
+            'multipart/form-data; boundary=----WebKitFormBoundary',
+        );
+
+        $this->expectException(RawPostParserException::class);
+        $this->expectExceptionMessage('multipart/form-data');
+        $parser->parse();
+    }
+
+    public function testAcceptsContentTypeWithCharset(): void
+    {
+        $parser = new RawPostParser(
+            $this->readerFor('foo=bar'),
+            'application/x-www-form-urlencoded; charset=UTF-8',
+        );
+
+        $this->assertSame(['foo' => 'bar'], $parser->parse());
+    }
+
+    public function testEmptyBodyParsesToEmptyArray(): void
+    {
+        $parser = new RawPostParser(
+            $this->readerFor(''),
+            'application/x-www-form-urlencoded',
+        );
+
+        $this->assertSame([], $parser->parse());
+    }
+
+    public function testMergesNestedArraysAcrossChunkBoundary(): void
+    {
+        // Force a chunk boundary inside an `fld[N]` group by stuffing the
+        // body with > MIN_CHUNK_SIZE leading fields, then a nested group
+        // whose two pairs straddle the boundary. If the merge is wrong, one
+        // of the inner keys is lost.
+        $pairs = [];
+        for ($i = 0; $i < 60; $i++) {
+            $pairs[] = sprintf('lead%d=x', $i);
+        }
+        $pairs[] = 'fld[1][id]=alpha';
+        $pairs[] = 'fld[1][type]=text';
+        $body = implode('&', $pairs);
+
+        $parser = new RawPostParser(
+            $this->readerFor($body),
+            'application/x-www-form-urlencoded',
+        );
+        $parsed = $parser->parse();
+
+        $this->assertArrayHasKey('fld', $parsed);
+        $fld = $parsed['fld'];
+        $this->assertIsArray($fld);
+        $this->assertSame(['id' => 'alpha', 'type' => 'text'], $fld[1] ?? null);
+    }
+
+    public function testProducesSameShapeAsParseStrForRepresentativeFormBody(): void
+    {
+        // A body that mirrors the edit_layout.php save payload: an outer
+        // `fld[N][...]` per-row group plus a `formaction` scalar.
+        $body = 'formaction=save&fld[1][id]=field_a&fld[1][type]=text&fld[2][id]=field_b';
+
+        $parser = new RawPostParser(
+            $this->readerFor($body),
+            'application/x-www-form-urlencoded',
+        );
+        $parsed = $parser->parse();
+
+        $expected = [];
+        parse_str($body, $expected);
+        $this->assertSame($expected, $parsed);
+    }
+}

--- a/tests/Tests/Isolated/Common/Http/RawRequestBodyReaderIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Http/RawRequestBodyReaderIsolatedTest.php
@@ -54,8 +54,23 @@ class RawRequestBodyReaderIsolatedTest extends TestCase
     {
         $reader = new RawRequestBodyReader('/this/path/does/not/exist/openemr');
 
-        $this->expectException(RawPostParserException::class);
-        $this->expectExceptionMessage('Unable to read raw request body');
-        $reader->read();
+        // Use error_reporting() instead of set_error_handler() so the test
+        // still exercises the real error_get_last() path — set_error_handler
+        // would intercept the warning before PHP records it. With
+        // error_reporting(0) the warning is suppressed at the report
+        // boundary but still populates error_get_last().
+        $prior = error_reporting(0);
+        $caught = null;
+        try {
+            $reader->read();
+        } catch (RawPostParserException $e) {
+            $caught = $e;
+        } finally {
+            error_reporting($prior);
+        }
+
+        $this->assertNotNull($caught, 'expected RawPostParserException');
+        $this->assertStringContainsString('Unable to read raw request body', $caught->getMessage());
+        $this->assertStringContainsString('No such file or directory', $caught->getMessage());
     }
 }

--- a/tests/Tests/Isolated/Common/Http/RawRequestBodyReaderIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Http/RawRequestBodyReaderIsolatedTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Isolated RawRequestBodyReader tests
+ *
+ * Verifies the reader returns the stream contents as a typed string, caches
+ * subsequent reads, and throws a typed exception on stream-open failure.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Andrew Alanis <progradedteam@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Http;
+
+use OpenEMR\Common\Http\RawPostParserException;
+use OpenEMR\Common\Http\RawRequestBodyReader;
+use PHPUnit\Framework\TestCase;
+
+class RawRequestBodyReaderIsolatedTest extends TestCase
+{
+    public function testReadsStreamContents(): void
+    {
+        $reader = new RawRequestBodyReader(
+            'data://text/plain;base64,' . base64_encode('foo=bar&baz=qux'),
+        );
+
+        $this->assertSame('foo=bar&baz=qux', $reader->read());
+    }
+
+    public function testCachesAcrossReads(): void
+    {
+        // Use a single tempfile, read once, then truncate underneath: the
+        // cached value should not change.
+        $path = tempnam(sys_get_temp_dir(), 'oemr-raw-reader-');
+        $this->assertNotFalse($path);
+        try {
+            file_put_contents($path, 'first');
+            $reader = new RawRequestBodyReader($path);
+            $this->assertSame('first', $reader->read());
+
+            file_put_contents($path, 'second');
+            $this->assertSame('first', $reader->read());
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function testThrowsOnUnreadableStream(): void
+    {
+        $reader = new RawRequestBodyReader('/this/path/does/not/exist/openemr');
+
+        $this->expectException(RawPostParserException::class);
+        $this->expectExceptionMessage('Unable to read raw request body');
+        $reader->read();
+    }
+}


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Two legacy forms — `interface/super/edit_layout.php` (Layout editor save) and `interface/billing/edit_payment.php` (Batch Payments Modify/Finish Payments) — serialise one input subarray per row. Large layouts and patients with many encounters push the input count past PHP's `max_input_vars` ceiling, at which point PHP silently truncates `$_POST` and the trailing rows fall on the floor. The Layout editor saves with missing fields; the Batch Payments user sees a blank white screen.

Per the design-sketch discussion on #11933, this uses server-side raw-body parsing rather than a client-side JSON-blob transport (a11y/o11y concerns).

Closes #11933
Closes #11494
Closes #12165

#### Changes proposed in this pull request:

**New abstraction-layer pair under `OpenEMR\Common\Http`:**

- `RawRequestBodyReader` — wraps `php://input` behind a typed string-returning API; throws `RawPostParserException` on read failure.
- `RawPostParser` — re-parses the raw `application/x-www-form-urlencoded` body and writes the result back into `$_POST` so legacy downstream code (`formData()`, `trimPost()`, `DistributionInsert()`) keeps working without per-call-site changes. Multipart bodies are rejected up front because PHP consumes them before `php://input` is populated.
- `ABSTRACTION_CLASSES` allowlist in `tests/PHPStan/Rules/ForbiddenRequestGlobalsRule.php` is extended to recognise `RawPostParser` as the single sanctioned point of `$_POST` mutation.

**Implementation note worth flagging:** `parse_str()` itself respects `max_input_vars` in PHP 7+, so the naïve single-call parse sketched in the design discussion on #11933 would still truncate (would silently drop variables and emit a runtime warning). `RawPostParser` splits the body into chunks below the configured ceiling, parses each with `parse_str()`, and merges with `array_replace_recursive`. Chunk size is computed at parse time so a runtime ini change is honoured. Documented caveat: `array_replace_recursive` does not append-merge bracket-bare auto-indexed arrays (`foo[]=1&foo[]=2`); both target endpoints use explicit indices (`fld[1][id]`, `Payment3`), so this is not a concern in practice.

**CSRF gap closed (#12165):** `edit_payment.php` had no CSRF check on its `DeletePaymentDistribution`, `ModifyPayments`, or `FinishPayments` handlers. A hidden `csrf_token_form` is now rendered in the shared form, and `CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true)` gates each handler. Bare/invalid tokens get HTTP 400.

**UX polish per review:** Kojiromike's review note that the original sketch's `die()` on a parse-failed save was poor UX is addressed — `edit_layout.php` now sets a `$saveError` variable, the save loop short-circuits when it is set, and the editor body renders a Bootstrap `alert-danger` banner explaining the failure. The user's browser-side edits are not discarded.

**Files changed:**

| File | Purpose |
|---|---|
| `src/Common/Http/RawPostParser.php` (new) | Chunked `parse_str` boundary helper |
| `src/Common/Http/RawRequestBodyReader.php` (new) | Typed `php://input` reader |
| `src/Common/Http/RawPostParserException.php` (new) | Typed exception |
| `tests/Tests/Isolated/Common/Http/RawPostParserIsolatedTest.php` (new) | 9 cases incl. 5000-vars body recovery + chunk-boundary correctness |
| `tests/Tests/Isolated/Common/Http/RawRequestBodyReaderIsolatedTest.php` (new) | 3 cases — read / cache / unreadable-stream |
| `interface/billing/edit_payment.php` | CSRF check + token field + `applyToGlobals()` call |
| `interface/super/edit_layout.php` | `applyToGlobals()` call + in-editor error banner |
| `tests/PHPStan/Rules/ForbiddenRequestGlobalsRule.php` | Add `RawPostParser` to allowlist |
| `.phpstan/baseline/openemr.forbiddenRequestGlobals.php` | edit_layout `$_POST` count 64→63 |
| `.phpstan/baseline/offsetAccess.nonOffsetAccessible.php` | Removed an `int<1, max>` entry made obsolete by improved typing |

**Verification:**

| Check | Result |
|---|---|
| Isolated PHPUnit (`RawPostParser` + `RawRequestBodyReader`) | 12 tests / 27 assertions |
| Full-codebase PHPStan level 10 | clean |
| Rector | clean |
| phpcs / phpcbf | clean |
| Conventional Commits validator | clean |

End-to-end browser test against the Demographics layout: **127 layout rows × 3352 form inputs** with `max_input_vars=3000`. Without the fix, trailing rows are truncated. With the fix, a save of the last row (`related_persons`) persists to `layout_options` as expected. CSRF check verified for all three mutating modes — bare or wrong `csrf_token_form` returns HTTP 400.

**Suggested follow-up (not in this PR):** Per kojiromike's review note about an admin-side healthcheck — when an editor renders, it could compute its field count and compare against `ini_get('max_input_vars')`, surfacing a banner before the user clicks Save if their environment would have truncated under the pre-fix code. Worth a sibling issue.

#### Was an AI assistant used? No

cc @kojiromike @msummers42