### PR TITLE
fix(upgrade): normalize categories_seq instead of unsafe multi-row UP…

### DIFF
--- a/src/Services/Utils/SQLUpgradeService.php
+++ b/src/Services/Utils/SQLUpgradeService.php
@@ -743,8 +743,8 @@ class SQLUpgradeService implements ISQLUpgradeService
                     // so collapse to a single row holding the current max id. DELETE-then-INSERT
                     // is safe for 0, 1, or N starting rows and avoids the multi-row UPDATE that
                     // fatals on a duplicate PRIMARY KEY.
-                    sqlStatementNoLog("DELETE FROM `categories_seq`");
-                    sqlStatementNoLog("INSERT INTO `categories_seq` (`id`) SELECT COALESCE(MAX(`id`), 0) FROM `categories`");
+                    QueryUtils::fetchRecordsNoLog("DELETE FROM `categories_seq`");
+                    QueryUtils::fetchRecordsNoLog("INSERT INTO `categories_seq` (`id`) SELECT COALESCE(MAX(`id`), 0) FROM `categories`");
                     $this->echo("<p class='text-success'>Completed conversion of categories for eye form insertion.</p>\n");
                     $this->flush_echo();
                     $skipping = false;

--- a/src/Services/Utils/SQLUpgradeService.php
+++ b/src/Services/Utils/SQLUpgradeService.php
@@ -737,6 +737,14 @@ class SQLUpgradeService implements ISQLUpgradeService
                             $eyeFormCategoryParent['rght'] + 5
                         ]
                     );
+                    // Resynchronize categories_seq after manually assigning category ids above.
+                    // categories_seq is a single-row sequence table consumed by ADODB GenID()
+                    // (see Tree.class.php). Historical upgrade data may have left multiple rows,
+                    // so collapse to a single row holding the current max id. DELETE-then-INSERT
+                    // is safe for 0, 1, or N starting rows and avoids the multi-row UPDATE that
+                    // fatals on a duplicate PRIMARY KEY.
+                    sqlStatementNoLog("DELETE FROM `categories_seq`");
+                    sqlStatementNoLog("INSERT INTO `categories_seq` (`id`) SELECT COALESCE(MAX(`id`), 0) FROM `categories`");
                     $this->echo("<p class='text-success'>Completed conversion of categories for eye form insertion.</p>\n");
                     $this->flush_echo();
                     $skipping = false;


### PR DESCRIPTION
…DATE

<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->
fixes #11930 
#### Short description of what this changes or resolves:
The categories_seq UPDATE added in #12011  fatals on databases where
categories_seq has drifted to multiple rows (duplicate PRIMARY KEY →
sqlStatementNoLog HelpfulDie → upgrade aborts before later files run).
Demo data lineage produces this: the v5 demo seed loads categories_seq
with one row, and 2_6_0-to-2_6_1_upgrade.sql then inserts a second.

categories_seq is not removable — ADODB GenID() reads it when categories
are added through the Tree UI (Tree.class.php), so it must hold the
current max id or the next category insert hits a duplicate key.

Replace the UPDATE with DELETE + INSERT, which collapses any number of
rows back to the single-row sequence contract and sets it to the current
max. Safe for 0, 1, or N starting rows.


#### Was an AI assistant used? Yes
claude.ai
<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
