### PR TITLE
chore(backport): rel-810: fix(billing): cast 835 monetary fields to float for type-strict comparisons (#11868)

### DIFF
--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -3262,11 +3262,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/sl_eob_process.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'amount\' on mixed\\.$#',
-    'count' => 5,
-    'path' => __DIR__ . '/../../interface/billing/sl_eob_process.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'check_date\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_process.php',
@@ -3313,7 +3308,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'group_code\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_process.php',
 ];
 $ignoreErrors[] = [
@@ -3363,7 +3358,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'reason_code\' on mixed\\.$#',
-    'count' => 7,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_process.php',
 ];
 $ignoreErrors[] = [

--- a/interface/billing/sl_eob_process.php
+++ b/interface/billing/sl_eob_process.php
@@ -11,7 +11,7 @@
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2006-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
- * @copyright Copyright (c) 2019-2020 Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2019-2026 Stephen Waite <stephen.waite@cmsvt.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -592,9 +592,12 @@ function eob_process_era_callback(array &$out): void
 
             // Post and report adjustments from this ERA.  Posted adjustment reasons
             // must be 25 characters or less in order to fit on patient statements.
+            /** @var array<string, mixed> $adj */
             foreach ($svc['adj'] as $adj) {
                 $description = ($adj['reason_code'] ?? '') . ': ' .
                     BillingUtilities::CLAIM_ADJUSTMENT_REASON_CODES[$adj['reason_code'] ?? ''];
+                $isContractualWriteoff = $adj['group_code'] === 'CO'
+                    && in_array($adj['reason_code'], ['45', '59'], true);
                 if ($adj['group_code'] === 'PR' || !$primary) {
                     // Group code PR is Patient Responsibility.  Enter these as zero
                     // adjustments to retain the note without crediting the claim.
@@ -628,17 +631,11 @@ function eob_process_era_callback(array &$out): void
                         );
                     }
 
-                    echo getMessageLine($bgcolor, $class, $description . ' ' .
-                    sprintf("%.2f", $adj['amount']));
+                    $amount = is_numeric($adj['amount']) ? (float)$adj['amount'] : 0.0;
+                    echo getMessageLine($bgcolor, $class, $description . ' ' . sprintf("%.2f", $amount));
                 } elseif (
-                    $svc['paid'] === 0
-                    && !(
-                        $adj['group_code'] === "CO"
-                        && (
-                            $adj['reason_code'] === '45'
-                            || $adj['reason_code'] === '59'
-                        )
-                    )
+                    $svc['paid'] === 0.0
+                    && !$isContractualWriteoff
                 ) {
                     $class = 'errdetail';
                     $error = true;

--- a/src/Billing/ParseERA.php
+++ b/src/Billing/ParseERA.php
@@ -7,7 +7,7 @@
  * @author Rod Roark <rod@sunsetsystems.com>
  * @author Stephen Waite <stephen.waite@cmsvt.com>
  * @copyright Copyright (c) 2006 Rod Roark <rod@sunsetsystems.com>
- * @copyright Copyright (c) 2019 Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2019-2026 Stephen Waite <stephen.waite@cmsvt.com>
  * @link https://www.open-emr.org
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -55,8 +55,8 @@ class ParseERA
                         array_unshift($out['svc'], []);
                         $out['svc'][0]['code'] = 'Claim';
                         $out['svc'][0]['mod'] = '';
-                        $out['svc'][0]['chg'] = '0';
-                        $out['svc'][0]['paid'] = '0';
+                        $out['svc'][0]['chg'] = 0.0;
+                        $out['svc'][0]['paid'] = 0.0;
                         $out['svc'][0]['adj'] = [];
                         $out['warnings'] .= "Procedure 'Claim' is inserted artificially to " .
                             "force claim balancing.\n";
@@ -277,8 +277,8 @@ class ParseERA
                     $out['svc'][$i] = [];
                     $out['svc'][$i]['code'] = 'Claim';
                     $out['svc'][$i]['mod'] = '';
-                    $out['svc'][$i]['chg'] = '0';
-                    $out['svc'][$i]['paid'] = '0';
+                    $out['svc'][$i]['chg'] = 0.0;
+                    $out['svc'][$i]['paid'] = 0.0;
                     $out['svc'][$i]['adj'] = [];
                 }
 
@@ -291,7 +291,7 @@ class ParseERA
                     $out['svc'][$i]['adj'][$j] = [];
                     $out['svc'][$i]['adj'][$j]['group_code'] = $seg[1];
                     $out['svc'][$i]['adj'][$j]['reason_code'] = $seg[$k];
-                    $out['svc'][$i]['adj'][$j]['amount'] = $seg[$k + 1];
+                    $out['svc'][$i]['adj'][$j]['amount'] = (float)($seg[$k + 1] ?? 0);
                 }
             } elseif ($segid == 'NM1' && $seg[1] == 'QC' && $out['loopid'] == '2100') { // QC = Patient
                 $out['patient_lname'] = trim($seg[3]);
@@ -380,8 +380,8 @@ class ParseERA
                     $out['svc'][$i]['mod'] = preg_replace('/:$/', '', $out['svc'][$i]['mod']);
                 }
 
-                $out['svc'][$i]['chg'] = $seg[2];
-                $out['svc'][$i]['paid'] = $seg[3];
+                $out['svc'][$i]['chg'] = (float)$seg[2];
+                $out['svc'][$i]['paid'] = (float)$seg[3];
                 $out['svc'][$i]['adj'] = [];
                 // Note: SVC05, if present, indicates the paid units of service.
                 // It defaults to 1.
@@ -409,7 +409,8 @@ class ParseERA
                     $out['svc'][$i]['adj'][$j] = [];
                     $out['svc'][$i]['adj'][$j]['group_code'] = $seg[1];
                     $out['svc'][$i]['adj'][$j]['reason_code'] = $seg[$k];
-                    $out['svc'][$i]['adj'][$j]['amount'] = $seg[$k + 1];
+                    $raw = $seg[$k + 1] ?? 0;
+                    $out['svc'][$i]['adj'][$j]['amount'] = is_numeric($raw) ? (float)$raw : 0.0;
                     // Note: $seg[$k+2] is "quantity".  A value here indicates a change to
                     // the number of units of service.  We're ignoring that for now.
                 }
@@ -417,7 +418,7 @@ class ParseERA
                 // ignore
             } elseif ($segid == 'AMT' && $seg[1] == 'B6' && $out['loopid'] == '2110') {
                 $i = count($out['svc']) - 1;
-                $out['svc'][$i]['allowed'] = $seg[2]; // report this amount as a note
+                $out['svc'][$i]['allowed'] = (float)$seg[2]; // report this amount as a note
             } elseif ($segid == 'AMT' && $out['loopid'] == '2110') {
                 $out['warnings'] .= "$inline at service level ignored.\n";
             } elseif ($segid == 'LQ' && $seg[1] == 'HE' && $out['loopid'] == '2110') {

--- a/tests/Tests/Isolated/Billing/ParseERATest.php
+++ b/tests/Tests/Isolated/Billing/ParseERATest.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Billing;
+
+use OpenEMR\Billing\ParseERA;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for ParseERA float type correctness.
+ *
+ * These tests specifically cover the fix where chg/paid values were stored as
+ * strings ('0') rather than floats (0.0), which caused the strict === 0.0
+ * comparison in sl_eob_process.php to be permanently dead code.
+ */
+class ParseERATest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    /**
+     * Minimal 835 with zero paid and a non-contractual adjustment (OA*96).
+     */
+    private function getZeroPaidNonContractualFixture(): string
+    {
+        return implode("\n", [
+            'ISA*00*          *00*          *ZZ*PAYER          *ZZ*RECEIVER       *260101*1200*^*00501*000000001*0*P*:~',
+            'GS*HP*PAYER*RECEIVER*20260101*1200*1*X*005010X221A1~',
+            'ST*835*0001~',
+            'BPR*I*0*C*NON************20260101~',
+            'TRN*1*12345*1234567890~',
+            'DTM*405*20260101~',
+            'N1*PR*TEST PAYER~',
+            'N1*PE*TEST PROVIDER*XX*1234567890~',
+            'LX*1~',
+            'CLP*CLAIM001*1*100.00*0*0*MC*12345~',
+            'NM1*QC*1*DOE*JOHN****MI*123456789~',
+            'SVC*HC:99213*100.00*0~',
+            'DTM*472*20260101~',
+            'CAS*OA*96*100.00~',
+            'SE*15*0001~',
+            'GE*1*1~',
+            'IEA*1*000000001~',
+        ]);
+    }
+
+    /**
+     * Minimal 835 with zero paid and a contractual writeoff (CO*45).
+     */
+    private function getZeroPaidContractualWriteoffFixture(): string
+    {
+        return implode("\n", [
+            'ISA*00*          *00*          *ZZ*PAYER          *ZZ*RECEIVER       *260101*1200*^*00501*000000001*0*P*:~',
+            'GS*HP*PAYER*RECEIVER*20260101*1200*1*X*005010X221A1~',
+            'ST*835*0001~',
+            'BPR*I*0*C*NON************20260101~',
+            'TRN*1*12345*1234567890~',
+            'DTM*405*20260101~',
+            'N1*PR*TEST PAYER~',
+            'N1*PE*TEST PROVIDER*XX*1234567890~',
+            'LX*1~',
+            'CLP*CLAIM001*1*100.00*0*0*MC*12345~',
+            'NM1*QC*1*DOE*JOHN****MI*123456789~',
+            'SVC*HC:99213*100.00*0~',
+            'DTM*472*20260101~',
+            'CAS*CO*45*100.00~',
+            'SE*15*0001~',
+            'GE*1*1~',
+            'IEA*1*000000001~',
+        ]);
+    }
+
+    /**
+     * Minimal 835 with a non-zero paid amount.
+     */
+    private function getNonZeroPaidFixture(): string
+    {
+        return implode("\n", [
+            'ISA*00*          *00*          *ZZ*PAYER          *ZZ*RECEIVER       *260101*1200*^*00501*000000001*0*P*:~',
+            'GS*HP*PAYER*RECEIVER*20260101*1200*1*X*005010X221A1~',
+            'ST*835*0001~',
+            'BPR*I*75.00*C*NON************20260101~',
+            'TRN*1*12345*1234567890~',
+            'DTM*405*20260101~',
+            'N1*PR*TEST PAYER~',
+            'N1*PE*TEST PROVIDER*XX*1234567890~',
+            'LX*1~',
+            'CLP*CLAIM001*1*100.00*75.00*0*MC*12345~',
+            'NM1*QC*1*DOE*JOHN****MI*123456789~',
+            'SVC*HC:99213*100.00*75.00~',
+            'DTM*472*20260101~',
+            'CAS*CO*45*25.00~',
+            'SE*15*0001~',
+            'GE*1*1~',
+            'IEA*1*000000001~',
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Write fixture to a temp file, parse it, clean up, return $out.
+     *
+     * @return array<int|string, mixed>
+     */
+    private function parseFixture(string $content): array
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'era_test_');
+        file_put_contents($tmp, $content);
+
+        /** @var array<int|string, mixed> $out */
+        $out = [];
+        $cb = function (array &$o) use (&$out): void {
+            $out = $o;
+        };
+
+        ParseERA::parseERA($tmp, $cb);
+        unlink($tmp);
+
+        return $out;
+    }
+
+    /**
+     * Extract first svc row from parsed output.
+     *
+     * @param array<int|string, mixed> $out
+     * @return array<string, mixed>
+     */
+    private function firstSvc(array $out): array
+    {
+        /** @var array<int, mixed> $svcs */
+        $svcs = $out['svc'];
+        /** @var array<string, mixed> $svc */
+        $svc = $svcs[0];
+        return $svc;
+    }
+
+    /**
+     * Extract first adj row from a svc row.
+     *
+     * @param array<string, mixed> $svc
+     * @return array<string, mixed>
+     */
+    private function firstAdj(array $svc): array
+    {
+        /** @var array<int, mixed> $adjs */
+        $adjs = $svc['adj'];
+        /** @var array<string, mixed> $adj */
+        $adj = $adjs[0];
+        return $adj;
+    }
+
+    // -------------------------------------------------------------------------
+    // Type tests — chg/paid are floats, not strings
+    // -------------------------------------------------------------------------
+
+    public function testPaidIsFloat(): void
+    {
+        $svc = $this->firstSvc($this->parseFixture($this->getNonZeroPaidFixture()));
+        $this->assertIsFloat($svc['paid'], 'paid should be float, not string');
+    }
+
+    public function testChgIsFloat(): void
+    {
+        $svc = $this->firstSvc($this->parseFixture($this->getNonZeroPaidFixture()));
+        $this->assertIsFloat($svc['chg'], 'chg should be float, not string');
+    }
+
+    public function testPaidValueParsedCorrectly(): void
+    {
+        $svc = $this->firstSvc($this->parseFixture($this->getNonZeroPaidFixture()));
+        $this->assertSame(75.0, $svc['paid']);
+    }
+
+    public function testChgValueParsedCorrectly(): void
+    {
+        $svc = $this->firstSvc($this->parseFixture($this->getNonZeroPaidFixture()));
+        $this->assertSame(100.0, $svc['chg']);
+    }
+
+    // -------------------------------------------------------------------------
+    // The quiet bug fix: '0' string vs 0.0 float strict comparison
+    // -------------------------------------------------------------------------
+
+    /**
+     * Core regression test.
+     *
+     * Old behavior: paid was stored as string '0', so ($svc['paid'] === 0.0)
+     * was always false — error detection in sl_eob_process was dead code.
+     *
+     * New behavior: paid is float 0.0, so the comparison is live.
+     */
+    public function testZeroPaidIsFloatNotString(): void
+    {
+        $svc = $this->firstSvc($this->parseFixture($this->getZeroPaidNonContractualFixture()));
+        $this->assertIsFloat($svc['paid'], 'zero paid should be float 0.0, not string "0"');
+        $this->assertSame(0.0, $svc['paid']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Contractual writeoff (CO*45) — paid 0.0 but should NOT be flagged
+    // -------------------------------------------------------------------------
+
+    public function testContractualWriteoffGroupCode(): void
+    {
+        $svc = $this->firstSvc($this->parseFixture($this->getZeroPaidContractualWriteoffFixture()));
+        $adj = $this->firstAdj($svc);
+
+        $this->assertSame(0.0, $svc['paid']);
+        $this->assertSame('CO', $adj['group_code']);
+        $this->assertSame('45', $adj['reason_code']);
+    }
+
+    public function testContractualWriteoffAmountIsFloat(): void
+    {
+        $svc = $this->firstSvc($this->parseFixture($this->getZeroPaidContractualWriteoffFixture()));
+        $adj = $this->firstAdj($svc);
+
+        $this->assertIsFloat($adj['amount']);
+        $this->assertSame(100.0, $adj['amount']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-contractual adjustment (OA*96) — zero paid, should be detectable
+    // -------------------------------------------------------------------------
+
+    public function testNonContractualAdjGroupCode(): void
+    {
+        $svc = $this->firstSvc($this->parseFixture($this->getZeroPaidNonContractualFixture()));
+        $adj = $this->firstAdj($svc);
+
+        $this->assertSame('OA', $adj['group_code']);
+        $this->assertSame('96', $adj['reason_code']);
+    }
+
+    public function testNonContractualAdjAmountIsFloat(): void
+    {
+        $svc = $this->firstSvc($this->parseFixture($this->getZeroPaidNonContractualFixture()));
+        $adj = $this->firstAdj($svc);
+
+        $this->assertIsFloat($adj['amount']);
+        $this->assertSame(100.0, $adj['amount']);
+    }
+}


### PR DESCRIPTION
Fixes #12204
Cherry-picked commits:

- e392a30ba0 - fix(billing): cast 835 monetary fields to float for type-strict comparisons (#11868)