### PR TITLE
chore(backport): rel-810 fix(upgrade) normalize categories_seq instead of unsafe multi-row

### DIFF
--- a/src/Services/Utils/SQLUpgradeService.php
+++ b/src/Services/Utils/SQLUpgradeService.php
@@ -737,8 +737,14 @@ class SQLUpgradeService implements ISQLUpgradeService
                             $eyeFormCategoryParent['rght'] + 5
                         ]
                     );
-                    // update categories_seq
-                    sqlStatementNoLog("UPDATE `categories_seq` SET `id` = (SELECT MAX(`id`) FROM `categories`)");
+                    // Resynchronize categories_seq after manually assigning category ids above.
+                    // categories_seq is a single-row sequence table consumed by ADODB GenID()
+                    // (see Tree.class.php). Historical upgrade data may have left multiple rows,
+                    // so collapse to a single row holding the current max id. DELETE-then-INSERT
+                    // is safe for 0, 1, or N starting rows and avoids the multi-row UPDATE that
+                    // fatals on a duplicate PRIMARY KEY.
+                    QueryUtils::fetchRecordsNoLog("DELETE FROM `categories_seq`");
+                    QueryUtils::fetchRecordsNoLog("INSERT INTO `categories_seq` (`id`) SELECT COALESCE(MAX(`id`), 0) FROM `categories`");
                     $this->echo("<p class='text-success'>Completed conversion of categories for eye form insertion.</p>\n");
                     $this->flush_echo();
                     $skipping = false;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:


#### Changes proposed in this pull request:


#### Was an AI assistant used? Yes / No

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
