### PR TITLE
fix(edihistory): move use statement out of docblock

### DIFF
--- a/.phpstan/baseline/class.notFound.php
+++ b/.phpstan/baseline/class.notFound.php
@@ -163,11 +163,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to static method getInstance\\(\\) on an unknown class OEGlobalsBag\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to static method getInstance\\(\\) on an unknown class OEGlobalsBag\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/smarty/plugins/function.assetVersionNumber.php',
 ];

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -3447,16 +3447,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method get\\(\\) on mixed\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method has\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method edih_delimiters\\(\\) on mixed\\.$#',
     'count' => 9,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_parse.php',

--- a/library/edihistory/edih_csv_inc.php
+++ b/library/edihistory/edih_csv_inc.php
@@ -28,9 +28,6 @@
  * function (in ibr_uploads.php) ibr_upload_match_file($param_ar, $fidx, &$html_str)
  *   contains a regular expression that must be correct
  *
-
-use OpenEMR\Core\OEGlobalsBag;
-
  * Also, the constant IBR_HISTORY_DIR must be correct
  * **************************
  * </pre>
@@ -68,6 +65,8 @@ use OpenEMR\Core\OEGlobalsBag;
  *
  * TO_DO functions to zip old files, put them aside, and remove them from csv tables
  */
+
+use OpenEMR\Core\OEGlobalsBag;
 
 /**
  * Constant that is checked in included files to prevent direct access.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
typo with use statement

#### Changes proposed in this pull request:
move it to proper place

#### Was an AI assistant used? Yes, lazily pasted php error into claude.ai :)

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
