### PR TITLE
fix(faxsms): lazy-init AppDispatch session to survive static factory path (rel-810 backport)

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
@@ -42,7 +42,7 @@ abstract class AppDispatch
     protected $_currentAction;
     protected $credentials;
     private $_request, $_response, $_query, $_post, $_server, $_cookies;
-    private readonly SessionInterface $_session;
+    private ?SessionInterface $_session = null;
     protected $authUser;
 
     /**
@@ -55,11 +55,11 @@ abstract class AppDispatch
         $this->_post = &$_POST;
         $this->_server = &$_SERVER;
         $this->_cookies = &$_COOKIE;
-        $this->_session = SessionWrapperFactory::getInstance()->getActiveSession();
+        $this->_session ??= SessionWrapperFactory::getInstance()->getActiveSession();
         $this->authErrorDefault = xlt('Error: Authentication Service Denies Access or Not Authorised. Lacking valid credentials or User permissions.');
         $this->authUser = (int)$this->getSession('authUserID');
         if (empty(self::$_apiModule)) {
-            self::$_apiModule = $_REQUEST['type'] ?? $this->_session->get('oefax_current_module_type') ?? null;
+            self::$_apiModule = $_REQUEST['type'] ?? $this->session()->get('oefax_current_module_type') ?? null;
         }
         $this->crypto = ServiceContainer::getCrypto();
         // Background-service workers (bin/console background:services run,
@@ -90,7 +90,7 @@ abstract class AppDispatch
             $action = $route[1] ?: $action;
         }
         if (empty($serviceType)) {
-            $serviceType = $_REQUEST['type'] ?? $this->_session->get('oefax_current_module_type') ?? null;
+            $serviceType = $_REQUEST['type'] ?? $this->session()->get('oefax_current_module_type') ?? null;
         }
         if (!empty($serviceType)) {
             self::setModuleType($serviceType);
@@ -155,11 +155,24 @@ abstract class AppDispatch
      */
     public function getSession(?string $param = null, mixed $default = null): mixed
     {
+        $session = $this->session();
         if ($param) {
-            return $this->_session->get($param) ?? $default;
+            return $session->get($param) ?? $default;
         }
 
-        return $this->_session;
+        return $session;
+    }
+
+    /**
+     * Lazily resolve the active session wrapper.
+     *
+     * Service clients reach this method via the static factory path
+     * (AppDispatch::getApiService → new RCFaxClient → getCredentials → getSession)
+     * *before* parent::__construct() has run, so the property is not yet set.
+     */
+    private function session(): SessionInterface
+    {
+        return $this->_session ??= SessionWrapperFactory::getInstance()->getActiveSession();
     }
 
     /**

--- a/tests/Tests/Isolated/Modules/FaxSMS/AppDispatchLazyInitTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/AppDispatchLazyInitTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Regression test for FaxSMS AppDispatch typed-session-property fatal.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Modules\FaxSMS;
+
+use Composer\Autoload\ClassLoader;
+use OpenEMR\Modules\FaxSMS\Controller\AppDispatch;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+/**
+ * The custom_modules/oe-module-faxsms module is not registered in the root
+ * composer.json autoload map. At runtime the module manager registers its
+ * PSR-4 prefix dynamically when the module is enabled in the database. The
+ * isolated test suite has no database, so we register the prefix ourselves
+ * before referencing any module class.
+ */
+final class AppDispatchLazyInitTest extends TestCase
+{
+    /**
+     * @codeCoverageIgnore Fixture wiring; runs before coverage attribution.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        $loaders = ClassLoader::getRegisteredLoaders();
+        $loader = reset($loaders);
+        if (!$loader instanceof ClassLoader) {
+            self::fail('Composer ClassLoader not available to register module autoload prefix.');
+        }
+        $loader->addPsr4(
+            'OpenEMR\\Modules\\FaxSMS\\',
+            dirname(__DIR__, 5) . '/interface/modules/custom_modules/oe-module-faxsms/src/'
+        );
+    }
+
+    /**
+     * Reproduces the issue #12208 call shape: a service-client constructor
+     * touches getSession() before parent::__construct() has run. Prior to
+     * the fix, $_session was a readonly typed property assigned only inside
+     * AppDispatch::__construct(), so this access fatalled with
+     * "Typed property AppDispatch::$_session must not be accessed before
+     * initialization".
+     */
+    public function testGetSessionBeforeParentConstructorDoesNotFatal(): void
+    {
+        $subject = new class extends AppDispatch {
+            public mixed $sessionResult = 'sentinel';
+
+            public function __construct()
+            {
+                // Touch the session before parent::__construct() — this is the
+                // bug path. Do not call parent::__construct() at all: it runs
+                // dispatchActions() and render(), which exit().
+                $this->sessionResult = $this->getSession('authUserID');
+            }
+
+            /** @codeCoverageIgnore Stub satisfies abstract contract. */
+            public function authenticate(): string|int|bool
+            {
+                return false;
+            }
+
+            /** @codeCoverageIgnore Stub satisfies abstract contract. */
+            public function sendFax(): string|bool
+            {
+                return false;
+            }
+
+            /** @codeCoverageIgnore Stub satisfies abstract contract. */
+            public function sendSMS(): mixed
+            {
+                return null;
+            }
+
+            /** @codeCoverageIgnore Stub satisfies abstract contract. */
+            public function sendEmail(): mixed
+            {
+                return null;
+            }
+
+            /** @codeCoverageIgnore Stub satisfies abstract contract. */
+            public function fetchReminderCount(): string|bool
+            {
+                return false;
+            }
+        };
+
+        // Reaching this line at all proves the fatal is gone.
+        self::assertNotSame('sentinel', $subject->sessionResult);
+    }
+
+    public function testGetSessionWithoutParamReturnsSessionInterface(): void
+    {
+        $subject = new class extends AppDispatch {
+            public mixed $session;
+
+            public function __construct()
+            {
+                $this->session = $this->getSession();
+            }
+
+            /** @codeCoverageIgnore Stub satisfies abstract contract. */
+            public function authenticate(): string|int|bool
+            {
+                return false;
+            }
+
+            /** @codeCoverageIgnore Stub satisfies abstract contract. */
+            public function sendFax(): string|bool
+            {
+                return false;
+            }
+
+            /** @codeCoverageIgnore Stub satisfies abstract contract. */
+            public function sendSMS(): mixed
+            {
+                return null;
+            }
+
+            /** @codeCoverageIgnore Stub satisfies abstract contract. */
+            public function sendEmail(): mixed
+            {
+                return null;
+            }
+
+            /** @codeCoverageIgnore Stub satisfies abstract contract. */
+            public function fetchReminderCount(): string|bool
+            {
+                return false;
+            }
+        };
+
+        self::assertInstanceOf(SessionInterface::class, $subject->session);
+    }
+}


### PR DESCRIPTION
Backport of #12224 to `rel-810`.

## Summary

Fixes #12208 on the 8.1 release branch: `Typed property OpenEMR\Modules\FaxSMS\Controller\AppDispatch::\$_session must not be accessed before initialization` when reaching a fax/SMS service client through the static factory path.

Same change as master:
- Drop \`readonly\` from \`\$_session\`, make it nullable
- Route reads through a private \`session()\` accessor that lazy-initializes via \`SessionWrapperFactory\`
- Add regression test under \`tests/Tests/Isolated/Modules/FaxSMS/\`

## Backport notes

Cherry-picked from \`033f82b1fe\` with one drop: the \`.phpstan/fatal-baseline-caps.php\` count update in the master commit doesn't apply on rel-810 (the cap file doesn't exist on this branch). Everything else applies cleanly — the `crypto` method differences between branches (`encryptStandard`/`decryptStandard` on rel-810 vs `encryptForDatabase`/`decryptFromDatabase` on master) don't conflict because this fix doesn't touch those lines.

## Test plan

- [x] `composer phpunit-isolated -- --filter AppDispatchLazyInitTest` passes
- [x] PHPStan / PHPCS / Rector / Composer Require Checker (pre-commit) all green
- [ ] Manual smoke: enable a FaxSMS service in a clean 8.1 install, log out/in, hit the service from the Services menu — should no longer fatal