### PR TITLE
revert(faxsms): restore VoiceClient and in-browser RingCentral softphone

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -4652,6 +4652,16 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Binary operation "\\." between mixed and \'/\'\\|\'\\\\\\\\\' results in an error\\.$#',
+    'count' => 2,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Binary operation "\\." between mixed and \'/documents/logs_and…\' results in an error\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'/inbox\\?a\\=get&f\\=pdf…\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/EtherFaxClient.php',

--- a/.phpstan/baseline/cast.int.php
+++ b/.phpstan/baseline/cast.int.php
@@ -328,6 +328,11 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to int\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot cast mixed to int\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/EtherFaxClient.php',
 ];

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1203,7 +1203,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 13,
+    'count' => 15,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/library/setup_services.php',
 ];
 $ignoreErrors[] = [
@@ -1218,7 +1218,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 13,
+    'count' => 15,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/openemr.bootstrap.php',
 ];
 $ignoreErrors[] = [
@@ -1273,12 +1273,17 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+    'count' => 7,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 5,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/EtherFaxClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 9,
+    'count' => 10,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -1577,6 +1577,16 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_rc.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Cannot call method getCredentials\\(\\) on OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\ClickatellSMSClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EmailClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\SignalWireClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\TwilioSMSClient\\|null\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_voice.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method verifyAcl\\(\\) on OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\ClickatellSMSClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EmailClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\SignalWireClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\TwilioSMSClient\\|null\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_voice.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Cannot call method add\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
@@ -1715,6 +1725,36 @@ $ignoreErrors[] = [
     'message' => '#^Cannot call method format\\(\\) on DateTime\\|null\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method auth\\(\\) on mixed\\.$#',
+    'count' => 4,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method data\\(\\) on mixed\\.$#',
+    'count' => 3,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method loggedIn\\(\\) on mixed\\.$#',
+    'count' => 3,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method login\\(\\) on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method setData\\(\\) on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot call method getCredentials\\(\\) on OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\ClickatellSMSClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EmailClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\SignalWireClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\TwilioSMSClient\\|null\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method sendSMS\\(\\) on OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\ClickatellSMSClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EmailClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\SignalWireClient\\|OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\TwilioSMSClient\\|null\\.$#',

--- a/.phpstan/baseline/method.notFound.php
+++ b/.phpstan/baseline/method.notFound.php
@@ -73,7 +73,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to an undefined method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:addListener\\(\\)\\.$#',
-    'count' => 5,
+    'count' => 7,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -1082,6 +1082,21 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:getCachedAuth\\(\\) return type has no value type specified in iterable type array\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:getCredentials\\(\\) return type has no value type specified in iterable type array\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:isValidCachedAuth\\(\\) has parameter \\$authData with no value type specified in iterable type array\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\EtherFax\\\\EtherFaxClient\\:\\:clientHttpGet\\(\\) has parameter \\$get with no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/EtherFaxClient.php',
@@ -1090,6 +1105,11 @@ $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\EtherFax\\\\EtherFaxClient\\:\\:clientHttpPost\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/EtherFaxClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Events\\\\NotificationEventListener\\:\\:getRCCredentials\\(\\) return type has no value type specified in iterable type array\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^PHPDoc tag @var for variable \\$module has no value type specified in iterable type array\\.$#',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -9322,6 +9322,16 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:authenticate\\(\\) has parameter \\$acl with no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:cacheAuthData\\(\\) has parameter \\$platform with no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\EtherFax\\\\EtherFaxClient\\:\\:__construct\\(\\) has parameter \\$account with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/EtherFaxClient.php',
@@ -9458,6 +9468,11 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Events\\\\NotificationEventListener\\:\\:emailNotification\\(\\) has parameter \\$file with no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Events\\\\NotificationEventListener\\:\\:getRCCredentials\\(\\) has parameter \\$serviceType with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
 ];

--- a/.phpstan/baseline/missingType.property.php
+++ b/.phpstan/baseline/missingType.property.php
@@ -2157,6 +2157,61 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$apiBase has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$baseDir has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$cacheDir has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$credentials has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$platform has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$portalUrl has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$rcsdk has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$redirectUrl has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$serverUrl has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$timeZone has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$uriDir has no type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\EtherFax\\\\EtherFaxClient\\:\\:\\$auth has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/EtherFaxClient.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -5667,6 +5667,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Events\\\\NotificationEventListener\\:\\:renderPhoneButton\\(\\) has no return type specified\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Function oe_module_priorauth_add_menu_item\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-prior-authorizations/openemr.bootstrap.php',

--- a/.phpstan/baseline/nullCoalesce.expr.php
+++ b/.phpstan/baseline/nullCoalesce.expr.php
@@ -113,7 +113,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Expression on left side of \\?\\? is not nullable\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -14397,6 +14397,41 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_rc.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'appKey\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_voice.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'appSecret\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_voice.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'extension\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_voice.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'jwt\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_voice.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'phone\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_voice.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'production\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_voice.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'smsNumber\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_voice.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'allow_dialog\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/BootstrapService.php',
@@ -14423,6 +14458,11 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'sms_vendor\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/BootstrapService.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'voice_vendor\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/BootstrapService.php',
 ];
@@ -14830,6 +14870,26 @@ $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'username\' on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'appKey\' on mixed\\.$#',
+    'count' => 2,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'appSecret\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'expire_time\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'jwt\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'actions\' on mixed\\.$#',

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -2079,6 +2079,11 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
     'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-prior-authorizations/ModuleManagerListener.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenCatchType.php
+++ b/.phpstan/baseline/openemr.forbiddenCatchType.php
@@ -203,7 +203,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^catch \\(Throwable\\) would suppress Error, which is forbidden\\.$#',
-    'count' => 1,
+    'count' => 2,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^catch \\(Throwable\\) would suppress Error, which is forbidden\\.$#',
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -2012,6 +2012,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_rc.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_voice.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Direct access to \\$_COOKIE is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php',

--- a/.phpstan/baseline/property.unused.php
+++ b/.phpstan/baseline/property.unused.php
@@ -2,11 +2,6 @@
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$client is unused\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Modules\\\\WenoModule\\\\Services\\\\LogProperties\\:\\:\\$container is unused\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-weno/src/Services/LogProperties.php',

--- a/.phpstan/baseline/property.unused.php
+++ b/.phpstan/baseline/property.unused.php
@@ -2,6 +2,11 @@
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:\\$client is unused\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Modules\\\\WenoModule\\\\Services\\\\LogProperties\\:\\:\\$container is unused\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-weno/src/Services/LogProperties.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -832,6 +832,16 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:getCachedAuth\\(\\) should return array but returns mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\VoiceClient\\:\\:getCredentials\\(\\) should return array but returns mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\EtherFax\\\\FaxResult\\:\\:getFaxResult\\(\\) should return int\\|string\\|null but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/FaxResult.php',
@@ -840,6 +850,11 @@ $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\EtherFax\\\\FaxState\\:\\:getFaxState\\(\\) should return int\\|string\\|null but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/FaxState.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Events\\\\NotificationEventListener\\:\\:getRCCredentials\\(\\) should return array but returns mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method ModuleManagerListener\\:\\:moduleManagerAction\\(\\) should return string but returns mixed\\.$#',

--- a/interface/modules/custom_modules/oe-module-faxsms/library/setup_services.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/setup_services.php
@@ -82,7 +82,7 @@ if ($_POST['form_save_permissions'] ?? null) {
     $users_query = "SELECT id, username FROM users WHERE active = 1 AND username IS NOT NULL AND fname IS NOT NULL";
     $users_result = sqlStatement($users_query);
 
-    $services = ['fax', 'sms', 'email'];
+    $services = ['fax', 'sms', 'email', 'voice'];
     $primary_user_id = $_POST['primary_user'] ?? null;
 
     // Handle primary user reset (when value is "0" or empty)
@@ -201,11 +201,13 @@ $vendors = $boot->getVendorGlobals();
     }
     $isSmsEnabled = $vendors['oefax_enable_sms'] > 0 ? 'sms' : '';
     $isEmailEnable = $vendors['oe_enable_email'] > 0 ? 'email' : '';
+    $isVoiceEnable = $vendors['oe_enable_voice'] > 0 ? 'voice' : '';
     $services = [$isSmsEnabled, $isEmailEnable];
 
     $smsVendor = ServiceType::fromValue($vendors['oefax_enable_sms']);
     $faxVendor = ServiceType::fromValue($vendors['oefax_enable_fax']);
     $emailVendor = ServiceType::fromValue($vendors['oe_enable_email']);
+    $voiceVendor = ServiceType::fromValue($vendors['oe_enable_voice']);
 
     $setupUrl = ($faxVendor === ServiceType::RINGCENTRAL || $smsVendor === ServiceType::RINGCENTRAL)
         ? './../setup_rc.php' : './../setup.php';
@@ -236,7 +238,7 @@ $vendors = $boot->getVendorGlobals();
         }
 
         function toggleUserAllServices(userId, checked) {
-            const services = ['fax', 'sms', 'email'];
+            const services = ['fax', 'sms', 'email', 'voice'];
             services.forEach(service => {
                 const checkbox = document.getElementById(`user_${userId}_${service}`);
                 if (checkbox) {
@@ -250,6 +252,7 @@ $vendors = $boot->getVendorGlobals();
         let ServiceFax = <?php echo js_escape($faxVendor->stringValue()); ?>;
         let ServiceSMS = <?php echo js_escape($smsVendor->stringValue()); ?>;
         let ServiceEmail = <?php echo js_escape($emailVendor->stringValue()); ?>;
+        let ServiceVoice = <?php echo js_escape($voiceVendor->stringValue()); ?>;
 
         function toggleHelpCard() {
             const helpCard = document.getElementById('helpCard');
@@ -258,6 +261,9 @@ $vendors = $boot->getVendorGlobals();
 
         function toggleSetup(id, type = 'single') {
             let url = ServiceFax === ServiceType.RINGCENTRAL ? '../setup_rc.php' : '../setup.php';
+            if (ServiceVoice === ServiceType.VOICE) {
+                url = '../setup_voice.php';
+            }
             let dialog = $("#dialog").is(':checked');
             if (!dialog || id === 'set-service') {
                 $(".frame").addClass("d-none");
@@ -301,6 +307,17 @@ $vendors = $boot->getVendorGlobals();
                 }
                 return dlgopen('', '', 'modal-lg', '', '', title, params);
             }
+            if (id === 'set-voice') {
+                let title = 'Voice Module Credentials';
+                let params = {
+                    buttons: [{text: 'Cancel', close: true, style: 'default btn-sm'}],
+                    sizeHeight: 'full',
+                    allowDrag: false,
+                    type: 'iframe',
+                    url: './../setup_voice.php?type=email&module_config=-1'
+                }
+                return dlgopen('', '', 'modal-lg', '', '', title, params);
+            }
         }
 
         $(function () {
@@ -332,6 +349,9 @@ $vendors = $boot->getVendorGlobals();
             <?php }
             if (!empty($vendors['oefax_enable_fax'])) { ?>
                 <button class="btn btn-outline-light" onclick="toggleSetup('set-fax')"><?php echo xlt("Setup Fax"); ?><span class="caret"></span></button>
+            <?php }
+            if (!empty($vendors['oe_enable_voice'])) { ?>
+                <button class="btn btn-outline-light" onclick="toggleSetup('set-voice')"><?php echo xlt("Setup Voice"); ?><span class="caret"></span></button>
             <?php }
             if (!empty($vendors['oe_enable_email'])) { ?>
                 <button class="btn btn-outline-light" onclick="toggleSetup('set-email')"><?php echo xlt("Setup Email"); ?><span class="caret"></span></button>
@@ -440,6 +460,14 @@ $vendors = $boot->getVendorGlobals();
                         </div>
                     </div>
                     <div class="row form-group">
+                        <label for="voice_vendor" class="col-sm-6"><?php echo xlt("Enable Voice Widgets") ?></label>
+                        <div class="col-sm-6" title="Enable Voice Widgets Support.">
+                            <select class="form-control persist" name="voice_vendor" id="voice_vendor">
+                                <?php echo ServiceType::renderSelectOptions('voice', $voiceVendor); ?>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row form-group">
                         <label for="allow_dialog" class="col-sm-6"><?php echo xlt("Enable Send SMS Dialog"); ?></label>
                         <div class="col-sm-6" title="Enable Send SMS Dialog Support. Various opportunities in UI.">
                             <input type="checkbox" class="checkbox persist" name="allow_dialog" id="allow_dialog" value="1" <?php echo $vendors['oesms_send'] == '1' ? 'checked' : ''; ?>>
@@ -535,6 +563,12 @@ $vendors = $boot->getVendorGlobals();
                 <iframe src="<?php echo attr('./../setup_email.php?type=email&module_config=1&mode=flat'); ?>" style="border:none;height:100vh;width:100%;"></iframe>
             </div>
         <?php } ?>
+        <?php if (!empty($vendors['oe_enable_voice'])) { ?>
+            <div id="set-voice" class="frame d-none">
+                <h3 class="text-center"><?php echo xlt("Setup Voice Account"); ?></h3>
+                <iframe src="<?php echo attr('./../setup_voice.php?type=voice&module_config=1&mode=flat'); ?>" style="border:none;height:100vh;width:100%;"></iframe>
+            </div>
+        <?php } ?>
         <?php if (($vendors['oeenable_users_permissions'] ?? '0') == '1') { ?>
             <div class="frame col-12 d-none" id="set-user-permissions">
                 <form id="user_permissions_form" name="user_permissions_form" class="form" role="form" method="post" action="">
@@ -542,7 +576,7 @@ $vendors = $boot->getVendorGlobals();
                     <div class="container-fluid">
                         <div class="title text-center"><?php echo xlt("User Service Permissions"); ?></div>
                         <div class="small text-center mb-2">
-                            <span><?php echo xlt("Set individual user permissions for Fax, SMS, and Email services."); ?></span>
+                            <span><?php echo xlt("Set individual user permissions for Fax, SMS, Email, and Voice services."); ?></span>
                         </div>
 
                         <?php if (isset($permissions_saved) && $permissions_saved) { ?>
@@ -575,6 +609,11 @@ $vendors = $boot->getVendorGlobals();
                                         <?php echo xlt("Email"); ?>
                                         <br>
                                         <input type="checkbox" onchange="toggleAllPermissions('email', this.checked)" title="<?php echo xla('Toggle all Email permissions'); ?>">
+                                    </th>
+                                    <th class="text-center">
+                                        <?php echo xlt("Voice"); ?>
+                                        <br>
+                                        <input type="checkbox" onchange="toggleAllPermissions('voice', this.checked)" title="<?php echo xla('Toggle all Voice permissions'); ?>">
                                     </th>
                                     <th class="text-center">
                                         <?php echo xlt("Use Primary"); ?>
@@ -632,6 +671,13 @@ $vendors = $boot->getVendorGlobals();
                                                 id="user_<?php echo attr($user_id); ?>_email"
                                                 value="1"
                                                 <?php echo BootstrapService::getUserPermission($user_id, 'email') == '1' ? 'checked' : ''; ?>>
+                                        </td>
+                                        <td class="text-center">
+                                            <input type="checkbox"
+                                                name="user_<?php echo attr($user_id); ?>_voice"
+                                                id="user_<?php echo attr($user_id); ?>_voice"
+                                                value="1"
+                                                <?php echo BootstrapService::getUserPermission($user_id, 'voice') == '1' ? 'checked' : ''; ?>>
                                         </td>
                                         <td class="text-center">
                                             <input type="checkbox"

--- a/interface/modules/custom_modules/oe-module-faxsms/library/setup_services.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/setup_services.php
@@ -201,7 +201,6 @@ $vendors = $boot->getVendorGlobals();
     }
     $isSmsEnabled = $vendors['oefax_enable_sms'] > 0 ? 'sms' : '';
     $isEmailEnable = $vendors['oe_enable_email'] > 0 ? 'email' : '';
-    $isVoiceEnable = $vendors['oe_enable_voice'] > 0 ? 'voice' : '';
     $services = [$isSmsEnabled, $isEmailEnable];
 
     $smsVendor = ServiceType::fromValue($vendors['oefax_enable_sms']);
@@ -314,7 +313,7 @@ $vendors = $boot->getVendorGlobals();
                     sizeHeight: 'full',
                     allowDrag: false,
                     type: 'iframe',
-                    url: './../setup_voice.php?type=email&module_config=-1'
+                    url: './../setup_voice.php?type=voice&module_config=-1'
                 }
                 return dlgopen('', '', 'modal-lg', '', '', title, params);
             }

--- a/interface/modules/custom_modules/oe-module-faxsms/openemr.bootstrap.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/openemr.bootstrap.php
@@ -23,6 +23,7 @@
  */
 
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Messaging\SendSmsEvent;
@@ -40,6 +41,7 @@ $allowFax = (OEGlobalsBag::getInstance()->get('oefax_enable_fax') ?? null);
 $allowSMS = (OEGlobalsBag::getInstance()->get('oefax_enable_sms') ?? null);
 $allowSMSButtons = (OEGlobalsBag::getInstance()->get('oesms_send') ?? null);
 $allowEmail = (OEGlobalsBag::getInstance()->get('oe_enable_email') ?? null);
+$allowVoice = (OEGlobalsBag::getInstance()->get('oe_enable_voice') ?? null);
 
 /**
  * @var \OpenEMR\Core\ModulesClassLoader $classLoader
@@ -69,18 +71,34 @@ if ($isUserPermissionOverride) {
     OEGlobalsBag::getInstance()->set('oefax_enable_fax', !empty(BootstrapService::getUserPermission('', 'fax')) ? OEGlobalsBag::getInstance()->get('oefax_enable_fax') ?? null : false);
     OEGlobalsBag::getInstance()->set('oefax_enable_sms', !empty(BootstrapService::getUserPermission('', 'sms')) ? OEGlobalsBag::getInstance()->get('oefax_enable_sms') ?? null : false);
     OEGlobalsBag::getInstance()->set('oe_enable_email', !empty(BootstrapService::getUserPermission('', 'email')) ? OEGlobalsBag::getInstance()->get('oe_enable_email') ?? null : false);
+    OEGlobalsBag::getInstance()->set('oe_enable_voice', !empty(BootstrapService::getUserPermission('', 'voice')) ? OEGlobalsBag::getInstance()->get('oe_enable_voice') ?? null : false);
 } else {
     // No user permission overrides, so just set to enabled/disabled based on module setup.
     OEGlobalsBag::getInstance()->set('oefax_enable_fax', !empty(OEGlobalsBag::getInstance()->get('oefax_enable_fax')) ? OEGlobalsBag::getInstance()->get('oefax_enable_fax') : false);
     OEGlobalsBag::getInstance()->set('oefax_enable_sms', !empty(OEGlobalsBag::getInstance()->get('oefax_enable_sms')) ? OEGlobalsBag::getInstance()->get('oefax_enable_sms') : false);
     OEGlobalsBag::getInstance()->set('oe_enable_email', !empty(OEGlobalsBag::getInstance()->get('oe_enable_email')) ? OEGlobalsBag::getInstance()->get('oe_enable_email') : false);
+    OEGlobalsBag::getInstance()->set('oe_enable_voice', !empty(OEGlobalsBag::getInstance()->get('oe_enable_voice')) ? OEGlobalsBag::getInstance()->get('oe_enable_voice') : false);
 }
 // Set local variables for use in this bootstrap.
 $allowFax = OEGlobalsBag::getInstance()->get('oefax_enable_fax');
 $allowSMS = OEGlobalsBag::getInstance()->get('oefax_enable_sms');
 $allowEmail = OEGlobalsBag::getInstance()->get('oe_enable_email');
+$allowVoice = OEGlobalsBag::getInstance()->get('oe_enable_voice');
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
+
+if ($allowVoice) {
+    $voiceVendorId = is_numeric($allowVoice) ? (int)$allowVoice : 0;
+    if (ServiceType::tryFrom($voiceVendorId) !== ServiceType::VOICE) {
+        ServiceContainer::getLogger()->error(
+            "FaxSMS: unknown voice vendor ID '" . var_export($allowVoice, true) . "'. "
+            . "Voice features disabled. To fix, run: "
+            . "UPDATE globals SET gl_value = '9' WHERE gl_name = 'oe_enable_voice';"
+        );
+        $allowVoice = false;
+        OEGlobalsBag::getInstance()->set('oe_enable_voice', false);
+    }
+}
 
 function getTwigNamespaces(): array
 {
@@ -326,6 +344,6 @@ if ($allowSMSButtons) {
     $eventDispatcher->addListener(SendSmsEvent::JAVASCRIPT_READY_SMS_POST, 'oe_module_faxsms_sms_render_javascript_post_load');
 }
 
-if (!(empty($session->get('authUserID')) && $session->get('pid')) && ($allowSMS || $allowEmail)) {
-    (new NotificationEventListener($eventDispatcher))->subscribeToEvents();
+if (!(empty($session->get('authUserID')) && $session->get('pid')) && ($allowSMS || $allowEmail || $allowVoice)) {
+    (new NotificationEventListener($eventDispatcher, OEGlobalsBag::getInstance()->getKernel()))->subscribeToEvents();
 }

--- a/interface/modules/custom_modules/oe-module-faxsms/setup_voice.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/setup_voice.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * Fax SMS Module Member
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2025 Jerry Padgett <sjpadgett@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Modules\FaxSMS\Controllers;
+
+require_once(__DIR__ . "/../../../globals.php");
+
+use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\Header;
+use OpenEMR\Modules\FaxSMS\Controller\AppDispatch;
+
+$serviceType = 'voice';
+AppDispatch::setModuleType($serviceType);
+// kick off app endpoints controller
+$clientApp = AppDispatch::getApiService($serviceType);
+if (!$clientApp->verifyAcl()) {
+    die("<h3>" . xlt("Not Authorised!") . "</h3>");
+}
+$c = $clientApp->getCredentials();
+$module_config = $_REQUEST['module_config'] ?? 1;
+$pid = SessionWrapperFactory::getInstance()->getActiveSession()->get('pid') ?? 0;
+echo "<script>var pid=" . js_escape($pid) . "</script>";
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>><?php echo xlt("Setup") ?></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <?php Header::setupHeader();
+    echo "<script>let Service=" . js_escape($serviceType) . "</script>";
+    ?>
+    <script>
+        $(function () {
+            $('#setup-form').on('submit', function (e) {
+                if (!e.isDefaultPrevented()) {
+                    $(window).scrollTop(0);
+                    let wait = '<i class="fa fa-cog fa-spin fa-4x"></i>';
+                    let url = 'saveSetup?type=voice';
+                    $.ajax({
+                        type: "POST",
+                        url: url,
+                        data: $(this).serialize(),
+                        success: function (data) {
+                            var err = (data.search(/Exception/) !== -1 ? 1 : 0);
+                            if (!err) {
+                                err = (data.search(/Error:/) !== -1 ? 1 : 0);
+                            }
+                            var messageAlert = 'alert-' + (err !== 0 ? 'danger' : 'success');
+                            var messageText = data;
+                            var alertBox = '<div class="alert ' + messageAlert + ' alert-dismissable"><button type="button" ' +
+                                'class="close" data-dismiss="alert" aria-hidden="true">&times;</button>' + messageText + '</div>';
+                            if (messageAlert && messageText) {
+                                // inject the alert to .messages div in our form
+                                $('#setup-form').find('.messages').html(alertBox);
+                                if (!err) {
+                                    // empty the form
+                                    $('#setup-form')[0].reset();
+                                    setTimeout(function () {
+                                        $('#setup-form').find('.messages').remove();
+                                        <?php if (!$module_config) { ?>
+                                        dlgclose();
+                                        location.reload();
+                                        <?php } else { ?>
+                                        location.reload();
+                                        <?php } ?>
+                                    }, 2000);
+                                }
+                            }
+                        }
+                    });
+                    return false;
+                }
+            });
+        });
+
+        function openJwtWindow() {
+            const clientId = document.getElementById('form_key').value;
+            if (clientId) {
+                const url = 'https://developers.ringcentral.com/console/my-credentials/create?client_id=' + encodeURIComponent(clientId);
+                window.open(url, '_blank', 'width=1200,height=800');
+            } else {
+                let message = xl("Please enter Client ID first.");
+                (async (message, time) => {
+                    await asyncAlertMsg(message, time, 'warning', 'lg');
+                })(message, 1500).then(res => {
+                    console.log(res);
+                });
+            }
+        }
+
+        function togglePasswordVisibility(id) {
+            var input = document.getElementById(id);
+            var icon = document.querySelector(`#${id} + .toggle-password i`);
+            if (input.type === "password") {
+                input.type = "text";
+                icon.classList.remove("fa-eye");
+                icon.classList.add("fa-eye-slash");
+            } else {
+                input.type = "password";
+                icon.classList.remove("fa-eye-slash");
+                icon.classList.add("fa-eye");
+            }
+        }
+    </script>
+</head>
+<body>
+    <div class="container-fluid">
+        <?php if ($module_config) { ?>
+            <h4><?php echo xlt("Setup Credentials") ?></h4>
+        <?php } ?>
+        <form class="form" id="setup-form" role="form">
+            <div class="messages"></div>
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="checkbox">
+                        <button type="submit" class="btn btn-success float-right m-2" value=""><?php echo xlt("Save Settings") ?></button>
+                        <label>
+                            <input id="form_production" type="checkbox" name="production" <?php echo attr($c['production']) ? ' checked' : '' ?>>
+                            <?php echo xlt("Production Check") ?>
+                        </label>
+                    </div>
+                    <div class="form-group">
+                        <label for="form_extension"><?php echo xlt("Extension") ?> *</label>
+                        <input id="form_extension" type="text" name="extension" class="form-control" value='<?php echo attr($c['extension']) ?>' required />
+                    </div>
+                    <div class="form-group">
+                        <label for="form_phone"><?php echo xlt("Phone Number") ?> *</label>
+                        <input type="tel" class="form-control" id="form_phone" name="phone" value='<?php echo attr($c['phone']) ?>' required />
+                    </div>
+                    <div class="form-group">
+                        <label for="form_smsnumber"><?php echo xlt("Opt Phone Number") ?></label>
+                        <input id="form_smsnumber" type="tel" name="smsnumber" class="form-control" value='<?php echo attr($c['smsNumber']) ?>' />
+                    </div>
+                </div>
+                <div class="col-md">
+                    <div class="form-group">
+                        <label for="form_key"><?php echo xlt("Client ID") ?> *</label>
+                        <div class="input-group">
+                            <input id="form_key" type="password" name="key" class="form-control" value='<?php echo attr($c['appKey']) ?>' required />
+                            <div class="input-group-append toggle-password" onclick="togglePasswordVisibility('form_key')">
+                                <span class="input-group-text"><i class="fa fa-eye"></i></span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="form_secret"><?php echo xlt("Client Secret") ?> *</label>
+                        <div class="input-group">
+                            <input id="form_secret" type="password" name="secret" class="form-control"
+                                value='<?php echo attr($c['appSecret']) ?>' required />
+                            <div class="input-group-append toggle-password" onclick="togglePasswordVisibility('form_secret')">
+                                <span class="input-group-text"><i class="fa fa-eye"></i></span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="form_jwt"><?php echo xlt("Copy and Paste JWT") ?> *</label>
+                        <span class="form-group">
+                                <button type="button" class="btn btn-primary btn-download btn-sm mb-1 p-0 px-1 float-right" onclick="openJwtWindow()"><?php echo xlt("Create JWT") ?></button>
+                            </span>
+                        <textarea id="form_jwt" type="text" rows="3" name="jwt" class="form-control small" required><?php echo attr($c['jwt']) ?></textarea>
+                    </div>
+                </div>
+            </div>
+            <p class="text-muted"><strong>*</strong> <?php echo xlt("These fields are required.") ?> </p>
+            <button type="submit" class="btn btn-success float-right m-2" value=""><?php echo xlt("Save Settings") ?></button>
+        </form>
+    </div>
+</body>
+</html>

--- a/interface/modules/custom_modules/oe-module-faxsms/setup_voice.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/setup_voice.php
@@ -33,7 +33,7 @@ echo "<script>var pid=" . js_escape($pid) . "</script>";
 <!DOCTYPE html>
 <html>
 <head>
-    <title>><?php echo xlt("Setup") ?></title>
+    <title><?php echo xlt("Setup") ?></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <?php Header::setupHeader();
     echo "<script>let Service=" . js_escape($serviceType) . "</script>";

--- a/interface/modules/custom_modules/oe-module-faxsms/src/BootstrapService.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/BootstrapService.php
@@ -50,11 +50,12 @@ class BootstrapService
         $vendors['oesms_send'] = '';
         $vendors['oerestrict_users'] = '';
         $vendors['oe_enable_email'] = '';
+        $vendors['oe_enable_voice'] = '';
         $vendors['oeenable_users_permissions'] = '';
 
         $gl = sqlStatementNoLog(
-            "SELECT gl_name, gl_value FROM `globals` WHERE `gl_name` IN(?, ?, ?, ?, ?, ?)",
-            ["oefax_enable_sms", "oefax_enable_fax", "oesms_send", "oerestrict_users", 'oe_enable_email', 'oeenable_users_permissions']
+            "SELECT gl_name, gl_value FROM `globals` WHERE `gl_name` IN(?, ?, ?, ?, ?, ?, ?)",
+            ["oefax_enable_sms", "oefax_enable_fax", "oesms_send", "oerestrict_users", 'oe_enable_email', 'oe_enable_voice', 'oeenable_users_permissions']
         );
         while ($row = sqlFetchArray($gl)) {
             $vendors[$row['gl_name']] = $row['gl_value'];
@@ -75,6 +76,7 @@ class BootstrapService
                        ('oerestrict_users', '0'),
                        ('oesms_send', '0'),
                        ('oe_enable_email', '0'),
+                       ('oe_enable_voice', '0'),
                        ('oeenable_users_permissions', '0')"
         );
     }
@@ -92,6 +94,7 @@ class BootstrapService
         $items['oesms_send'] = $vendors['allow_dialog'] ?? '';
         $items['oerestrict_users'] = $vendors['restrict'] ?? '';
         $items['oe_enable_email'] = $vendors['email_vendor'] ?? '';
+        $items['oe_enable_voice'] = $vendors['voice_vendor'] ?? '';
         $items['oeenable_users_permissions'] = $vendors['oeenable_users_permissions'] ?? '';
         foreach ($items as $key => $vendor) {
             sqlQuery(

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
@@ -295,6 +295,9 @@ abstract class AppDispatch
             'email' => [
                 ServiceType::EMAIL->value => fn(): EmailClient => new EmailClient(),
             ],
+            'voice' => [
+                ServiceType::VOICE->value => fn(): VoiceClient => new VoiceClient(),
+            ],
         ];
 
         $factory = $factoryMap[$type][$s] ?? null;
@@ -328,6 +331,9 @@ abstract class AppDispatch
         }
         if (self::$_apiModule === 'email') {
             return OEGlobalsBag::getInstance()->get('oe_enable_email') ?? null;
+        }
+        if (self::$_apiModule === 'voice') {
+            return OEGlobalsBag::getInstance()->get('oe_enable_voice') ?? null;
         }
 
         throw new \RuntimeException(

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace OpenEMR\Modules\FaxSMS\Controller;
+
+use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Crypto\CryptoInterface;
+use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Modules\FaxSMS\Controller\AppDispatch;
+
+class VoiceClient extends AppDispatch
+{
+    use AuthenticateTrait;
+
+    public static $timeZone;
+    public $baseDir;
+    public $uriDir;
+    public $serverUrl;
+    public $redirectUrl;
+    public $portalUrl;
+    public $credentials;
+    public $cacheDir;
+    public $apiBase;
+    protected $platform;
+    protected $rcsdk;
+    protected CryptoInterface $crypto;
+    private VoiceClient $client;
+    public function __construct()
+    {
+        if (empty(OEGlobalsBag::getInstance()->get('oe_enable_voice') ?? null)) {
+            throw new \RuntimeException(xlt("Access denied! Module not enabled"));
+        }
+        $this->crypto = ServiceContainer::getCrypto();
+        $this->baseDir = OEGlobalsBag::getInstance()->getString('temporary_files_dir');
+        $this->uriDir = OEGlobalsBag::getInstance()->get('OE_SITE_WEBROOT');
+        $this->cacheDir = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . '/documents/logs_and_misc/_cache';
+        $this->credentials = $this->getCredentials();
+        $this->portalUrl = $this->credentials['production'] ?? null ? "https://service.ringcentral.com/" : "https://service.devtest.ringcentral.com/";
+        $this->serverUrl = $this->credentials['production'] ?? null ? "https://platform.ringcentral.com" : "https://platform.devtest.ringcentral.com";
+        $this->redirectUrl = $this->credentials['redirect_url'] ?? null;
+        $this->initializeSDK();
+        //$this->initVoice($this->platform);
+        parent::__construct();
+    }
+
+    public function getVoiceCredentials(): mixed
+    {
+        $vendor = '_voice';
+        $this->authUser = (int)$this->getSession('authUserID');
+        if (!(OEGlobalsBag::getInstance()->get('oerestrict_users') ?? null)) {
+            $this->authUser = 0;
+        }
+        $credentials = sqlQuery("SELECT * FROM `module_faxsms_credentials` WHERE `auth_user` = ? AND `vendor` = ?", [$this->authUser, $vendor]);
+
+        if (empty($credentials)) {
+            return [
+                'extension' => '',
+                'phone' => '',
+                'smsNumber' => '',
+                'appKey' => '',
+                'appSecret' => '',
+                'server' => '',
+                'portal' => '',
+                'production' => '',
+                'jwt' => ''
+            ];
+        } else {
+            $credentials = $credentials['credentials'];
+        }
+
+        $decrypt = $this->crypto->decryptStandard(is_string($credentials) ? $credentials : null);
+        return json_decode($decrypt, true);
+    }
+
+    /**
+     * @return array
+     */
+    public function getCredentials(): array
+    {
+        if (!file_exists($this->cacheDir)) {
+            mkdir($this->cacheDir, 0777, true);
+        }
+        return $this->getSetup();
+    }
+
+    function sendFax(): string|bool
+    {
+        return '';
+        // TODO: Implement sendFax() method.
+    }
+
+    function sendSMS(): mixed
+    {
+        return '';
+        // TODO: Implement sendSMS() method.
+    }
+
+    function sendEmail(): mixed
+    {
+        return '';
+        // TODO: Implement sendEmail() method.
+    }
+
+    function fetchReminderCount(): string|bool
+    {
+        return '';
+        // TODO: Implement fetchReminderCount() method.
+    }
+}

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
@@ -51,7 +51,6 @@ class VoiceClient extends AppDispatch
     protected $platform;
     protected $rcsdk;
     protected CryptoInterface $crypto;
-    private VoiceClient $client;
     public function __construct()
     {
         if (empty(OEGlobalsBag::getInstance()->get('oe_enable_voice') ?? null)) {

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
@@ -7,6 +7,34 @@ use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Controller\AppDispatch;
 
+/**
+ * Server-side credential provider for the in-browser RingCentral softphone.
+ *
+ * **Do not remove this class because the `sendFax/sendSMS/sendEmail/fetchReminderCount`
+ * methods look like unimplemented stubs.** They are stubs, and they are not the
+ * execution path. Voice does not use them.
+ *
+ * The voice feature is a sponsored, production RingCentral integration. The
+ * server's only job is to mint credentials; the actual softphone runs entirely
+ * in the browser. The execution path is:
+ *
+ *   1. `VoiceClient::getCredentials()` / `getVoiceCredentials()` decrypt the
+ *      RingCentral appKey / appSecret / JWT from `module_faxsms_credentials`.
+ *   2. `NotificationEventListener::renderPhoneWidget()` injects those
+ *      credentials into `templates/phone_widget.html.twig` on every page.
+ *   3. The twig template loads RingCentral Embeddable
+ *      (apps.ringcentral.com/integration/ringcentral-embeddable/3.x/adapter.js)
+ *      and handles login, dialing, and call control client-side.
+ *
+ * Removing any of {this class, `setup_voice.php`, `phone_widget.html.twig`,
+ * `ServiceType::VOICE`, the voice subscriptions in `NotificationEventListener`}
+ * breaks the integration for every deployment that uses it. There is no CI
+ * coverage of this path yet — see #12230. Until that exists, treat removal as
+ * load-bearing and confirm with @sjpadgett.
+ *
+ * History: PR #12020 deleted this on the (incorrect) read that the stub
+ * methods meant the feature was unimplemented. PR #12229 reverted it.
+ */
 class VoiceClient extends AppDispatch
 {
     use AuthenticateTrait;

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Enums/ServiceType.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Enums/ServiceType.php
@@ -22,6 +22,12 @@ enum ServiceType: int
     case EMAIL = 4;
     case CLICKATELL_SMS = 5;
     case SIGNALWIRE = 6;
+    /**
+     * In-browser RingCentral softphone. Unlike the other cases, voice does
+     * NOT run server-side — see {@see \OpenEMR\Modules\FaxSMS\Controller\VoiceClient}
+     * for the full architecture. Removing this case breaks the sponsored
+     * voice integration; see #12230 before touching.
+     */
     case VOICE = 9;
 
     /**

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Enums/ServiceType.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Enums/ServiceType.php
@@ -22,6 +22,7 @@ enum ServiceType: int
     case EMAIL = 4;
     case CLICKATELL_SMS = 5;
     case SIGNALWIRE = 6;
+    case VOICE = 9;
 
     /**
      * Get the credential storage key for this service type
@@ -38,6 +39,7 @@ enum ServiceType: int
             self::EMAIL => '_email',
             self::CLICKATELL_SMS => '_clickatell',
             self::SIGNALWIRE => '_signalwire',
+            self::VOICE => '_voice',
         };
     }
 
@@ -73,6 +75,7 @@ enum ServiceType: int
             self::EMAIL => 'Email',
             self::CLICKATELL_SMS => 'Clickatell SMS',
             self::SIGNALWIRE => 'SignalWire Fax',
+            self::VOICE => 'Voice',
         };
     }
 
@@ -91,6 +94,7 @@ enum ServiceType: int
             self::EMAIL => xlt('Email'),
             self::CLICKATELL_SMS => xlt('Clickatell SMS'),
             self::SIGNALWIRE => xlt('SignalWire Fax'),
+            self::VOICE => xlt('Voice'),
         };
     }
 
@@ -143,6 +147,7 @@ enum ServiceType: int
             'sms' => [self::DISABLED, self::RINGCENTRAL, self::TWILIO_SMS, self::CLICKATELL_SMS],
             'fax' => [self::DISABLED, self::RINGCENTRAL, self::ETHERFAX, self::SIGNALWIRE],
             'email' => [self::DISABLED, self::EMAIL],
+            'voice' => [self::DISABLED, self::VOICE],
             default => [self::DISABLED],
         };
     }

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
@@ -105,7 +105,6 @@ class NotificationEventListener implements EventSubscriberInterface
     {
         $serviceType = 'voice';
         $loginCred = $this->getRCCredentials($serviceType);
-        $moduleBaseUrl = OEGlobalsBag::getInstance()->getWebRoot() . "/interface/modules/custom_modules/oe-module-faxsms";
         $context = [
             'clientId' => $loginCred['appKey'],
             'clientSecret' => $loginCred['appSecret'],

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
@@ -91,6 +91,16 @@ class NotificationEventListener implements EventSubscriberInterface
         }
     }
 
+    /**
+     * Inject the RingCentral Embeddable softphone into every page.
+     *
+     * This is the execution path for the voice feature — the server-side
+     * `VoiceClient::send*` methods are stubs and are not used. The twig
+     * template (`templates/phone_widget.html.twig`) loads RingCentral
+     * Embeddable and runs the entire softphone client-side using the
+     * credentials passed in here. See {@see VoiceClient} for full context
+     * and #12230 for the open work to make this path testable.
+     */
     public function renderPhoneWidget(RenderEvent $event): void
     {
         $serviceType = 'voice';

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
@@ -16,7 +16,10 @@ use MyMailer;
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Auth\OneTimeAuth;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Core\Kernel;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Events\Main\Tabs\RenderEvent;
 use OpenEMR\Events\Messaging\SendNotificationEvent;
 use OpenEMR\Modules\FaxSMS\Controller\AppDispatch;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -27,12 +30,24 @@ class NotificationEventListener implements EventSubscriberInterface
     private readonly bool $isSmsEnabled;
     private readonly bool $isEmailEnabled;
     private readonly bool $isFaxEnabled;
+    private readonly bool $isVoiceEnabled;
 
-    public function __construct(private readonly EventDispatcherInterface $eventDispatcher)
+    /**
+     * @var \Twig\Environment The twig rendering environment
+     */
+    private $twig;
+
+    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, ?Kernel $kernel = null)
     {
         $this->isSmsEnabled = !empty(OEGlobalsBag::getInstance()->get('oefax_enable_sms') ?? 0);
         $this->isFaxEnabled = !empty(OEGlobalsBag::getInstance()->get('oefax_enable_fax') ?? 0);
         $this->isEmailEnabled = !empty(OEGlobalsBag::getInstance()->get('oe_enable_email') ?? 0);
+        $this->isVoiceEnabled = !empty(OEGlobalsBag::getInstance()->get('oe_enable_voice') ?? 0);
+
+        $kernel ??= OEGlobalsBag::getInstance()->getKernel();
+        $twig = new TwigContainer($this->getTemplatePath(), $kernel);
+        $twigEnv = $twig->getTwig();
+        $this->twig = $twigEnv;
     }
 
     public function getTemplatePath(): string
@@ -59,6 +74,52 @@ class NotificationEventListener implements EventSubscriberInterface
         $this->eventDispatcher->addListener('sendNotification.service.universal.onetime', $this->onNotifyUniversalOneTime(...));
         $this->eventDispatcher->addListener(SendNotificationEvent::ACTIONS_RENDER_NOTIFICATION_POST, $this->notificationButton(...));
         $this->eventDispatcher->addListener(SendNotificationEvent::JAVASCRIPT_READY_NOTIFICATION_POST, $this->notificationDialogFunction(...));
+        if ($this->isVoiceEnabled) {
+            $this->eventDispatcher->addListener(RenderEvent::EVENT_BODY_RENDER_NAV, $this->renderPhoneButton(...));
+            $this->eventDispatcher->addListener(RenderEvent::EVENT_BODY_RENDER_POST, $this->renderPhoneWidget(...));
+        }
+    }
+
+    public function renderPhoneButton()
+    {
+        $loginCred = $this->getRCCredentials('voice');
+        if ($loginCred['appKey'] && $loginCred['appSecret'] && $loginCred['jwt'] && OEGlobalsBag::getInstance()->get('oe_enable_voice') ?? false) {
+            echo '
+            <button id="rc-toggle-exe" class="btn btn-outline-danger btn-sm" onclick="toggleRCWidget()">
+                <span id="btn-text"><i id="rc-toggle-btn" class="fa-solid fa-phone"></i></span>
+            </button>';
+        }
+    }
+
+    public function renderPhoneWidget(RenderEvent $event): void
+    {
+        $serviceType = 'voice';
+        $loginCred = $this->getRCCredentials($serviceType);
+        $moduleBaseUrl = OEGlobalsBag::getInstance()->getWebRoot() . "/interface/modules/custom_modules/oe-module-faxsms";
+        $context = [
+            'clientId' => $loginCred['appKey'],
+            'clientSecret' => $loginCred['appSecret'],
+            'jwt' => $loginCred['jwt'],
+        ];
+        // Render using Twig
+        if ($loginCred['appKey'] && $loginCred['appSecret'] && $loginCred['jwt']) {
+            echo $this->twig->render('phone_widget.html.twig', $context);
+        }
+    }
+
+    private function getRCCredentials($serviceType = 'voice'): array
+    {
+        AppDispatch::setModuleType($serviceType);
+        try {
+            $clientApp = AppDispatch::getApiService($serviceType);
+        } catch (\Throwable $e) {
+            ServiceContainer::getLogger()->warning(
+                "FaxSMS: failed to load service",
+                ['type' => $serviceType, 'message' => $e->getMessage()]
+            );
+            return ['appKey' => '', 'appSecret' => '', 'jwt' => ''];
+        }
+        return $clientApp->getCredentials();
     }
 
     /**

--- a/interface/modules/custom_modules/oe-module-faxsms/templates/phone_widget.html.twig
+++ b/interface/modules/custom_modules/oe-module-faxsms/templates/phone_widget.html.twig
@@ -1,0 +1,126 @@
+{# phone_widget.html.twig #}
+
+<div id="rc-container" class="d-flex flex-row align-items-center justify-content-between">
+    <div id="rc-header">
+        <script>
+            const RC_CLIENT_ID = {{ clientId|js_escape }};
+            const RC_CLIENT_SECRET = {{ clientSecret|js_escape }};
+            const RC_JWT = {{ jwt|js_escape }};
+            let isWidgetVisible = false;
+            let isRegistered = false;
+            let isLoggedIn = false;
+
+            const image = top.webroot_url + "/public/images/logos/core/menu/primary/logo.svg";
+
+            function loadRCAdapter() {
+                const rcScript = document.createElement("script");
+                rcScript.setAttribute("data-rc-adapter", "true");
+                rcScript.src = "https://apps.ringcentral.com/integration/ringcentral-embeddable/3.x/adapter.js" +
+                    `?enableSideWidget=1` +
+                    `&clientId=${encodeURIComponent(RC_CLIENT_ID)}` +
+                    `&clientSecret=${encodeURIComponent(RC_CLIENT_SECRET)}` +
+                    `&jwt=${encodeURIComponent(RC_JWT)}`;
+                document.body.appendChild(rcScript);
+                // Start a grace period to allow RC widget to initialize
+                setTimeout(() => {
+                    isLoggedIn = true;
+                }, 4000);
+                console.log("loaded RC adapter script");
+            }
+            // web phone event handling
+            window.addEventListener('message', function (e) {
+                const data = e.data;
+                if (!data) {
+                    return;
+                }
+                // Handle login status updates
+                if (data.type === 'rc-login-status-notify') {
+                    // replace logo image
+                    let imageLoad = document.querySelector('.Adapter_logo');
+                    imageLoad.src = image;
+                    // Register the adapter if not already done
+                    if (data.loggedIn && !isRegistered) {
+                        isRegistered = true;
+                        const frame = document.querySelector("#rc-widget-adapter-frame");
+                        frame?.contentWindow?.postMessage({
+                            type: 'rc-adapter-register-third-party-service',
+                            service: { name: 'oePhoneService' }
+                        }, '*');
+                    }
+                    // Handle login/logout status
+                    if (data.loggedIn === false && isLoggedIn) {
+                        // Remove the RingCentral iframe
+                        const rcFrame = document.getElementById("rc-widget");
+                        if (rcFrame) {
+                            rcFrame.remove();
+                            isLoggedIn = false;
+                        }
+                        // Remove existing RCAdapter object (cleanup)
+                        if (window.RCAdapter) {
+                            RCAdapter.dispose();
+                            delete window.RCAdapter;
+                        }
+                        console.warn('Detected logout. Reinitializing ...');
+                        // Reload the RC adapter, log back in
+                        loadRCAdapter();
+                    }
+                }
+                // Block popup login fallback
+                if (data.type === 'rc-adapter-login' || data.type === 'rc-login-popup-open') {
+                    console.warn('Blocked fallback login popup:', data.type);
+                    e.stopImmediatePropagation?.();
+                }
+            });
+            // Toggle visibility of the widget
+            function toggleRCWidget() {
+                const toggleBtn = document.getElementById('rc-toggle-btn');
+                const rcFrame = document.getElementById('rc-widget');
+                if (!rcFrame || typeof RCAdapter === 'undefined') {
+                    return;
+                }
+                // Check if the widget is currently visible
+                if (isWidgetVisible) {
+                    RCAdapter.setClosed(true);
+                    toggleBtn?.classList.remove('fa-phone-slash');
+                    toggleBtn?.classList.add('fa-phone');
+                    isWidgetVisible = false;
+                } else {
+                    RCAdapter.setClosed(false);
+                    toggleBtn?.classList.remove('fa-phone');
+                    toggleBtn?.classList.add('fa-phone-slash');
+                    isWidgetVisible = true;
+                }
+            }
+            // Start the adapter on page load
+            document.addEventListener('DOMContentLoaded', function () {
+                // Initial load
+                loadRCAdapter();
+                // Automatically hide the widget on page load.
+                // Give time for the adapter to initialize
+                setTimeout(function () {
+                    const rcFrame = document.querySelector('iframe[src*="ringcentral"]');
+                    if (rcFrame && typeof RCAdapter !== 'undefined') {
+                        RCAdapter.setClosed(false);
+                    }
+                }, 2000);
+                setTimeout(function () {
+                    const rcFrame = document.querySelector('iframe[src*="ringcentral"]');
+                    if (rcFrame && typeof RCAdapter !== 'undefined') {
+                        RCAdapter.setClosed(true);
+                    }
+                }, 6000);
+            });
+
+            window.addEventListener('beforeunload', function () {
+                const rcFrame = document.getElementById('rc-widget-adapter-frame');
+                if (rcFrame && rcFrame.contentWindow) {
+                    rcFrame.contentWindow.postMessage({
+                        type: 'rc-adapter-logout'
+                    }, '*');
+                    RCAdapter.dispose();
+                    console.log('Sent logout to RingCentral widget on unload');
+                }
+            });
+        </script>
+    </div>
+</div>


### PR DESCRIPTION
Reverts #12020.

## Why

#12020 was based on the (LLM-assisted) read that `VoiceClient`'s `sendFax/sendSMS/sendEmail/fetchReminderCount` were `return ''` TODO stubs, and concluded the voice feature was never implemented. The stubs are real, but they were never the execution path. The voice feature was a working, sponsored RingCentral integration whose architecture is:

- **Server side (`VoiceClient`)** — `getCredentials()` / `getVoiceCredentials()` retrieve the encrypted RingCentral `appKey` / `appSecret` / `jwt` from `module_faxsms_credentials`. Implemented and functional.
- **Client side (`phone_widget.html.twig`)** — loads RingCentral Embeddable (`apps.ringcentral.com/integration/ringcentral-embeddable/3.x/adapter.js`) with those credentials and runs an in-browser softphone. Handles login/logout via `postMessage`, registers `oePhoneService`. Implemented and functional.
- **Wiring (`NotificationEventListener::renderPhoneButton/renderPhoneWidget`)** — subscribes to `RenderEvent::EVENT_BODY_RENDER_NAV` / `EVENT_BODY_RENDER_POST`, gated on `oe_enable_voice` and credentials being present.
- **Setup (`setup_voice.php`, `ServiceType::VOICE`)** — credential entry UI and the dispatch enum/factory binding.

@sjpadgett (who maintains the module as a sponsored feature) confirmed in https://github.com/openemr/openemr/pull/12020#issuecomment-3257263935 that this has been working in production through 8.0.3 and posted a screenshot of the rendered phone button. The unimplemented `send*` methods look like an abandoned alternative server-side path; they aren't what voice actually used.

## What this restores

- `src/Controller/VoiceClient.php`
- `setup_voice.php`
- `templates/phone_widget.html.twig`
- `ServiceType::VOICE` (case 9) and the `'voice'` factory entry in `AppDispatch::$factoryMap`
- Voice subscriptions and `renderPhoneButton` / `renderPhoneWidget` in `NotificationEventListener`
- Voice toggles in `setup_services.php` (per-user permissions, vendor select, setup iframe)
- `oe_enable_voice` global, voice unknown-vendor logging in `openemr.bootstrap.php`
- `BootstrapService` row in `globals` and the vendors query

PHPStan baseline regenerated (one stale entry pruned).

## Follow-up (separate work)

The fact that this slipped through points to structural gaps worth addressing in a separate PR:

1. Drop the inherited `sendFax/sendSMS/sendEmail/fetchReminderCount` stubs from `VoiceClient` so future readers can't misread them as unimplemented. Split `AppDispatch` so voice implements only what it does (credential provider for a JS widget), not a messaging-client contract it can't satisfy.
2. Replace the `$factoryMap[$type][$s]` array lookup with typed service registration so PHPStan can see the link from `ServiceType::VOICE` to `VoiceClient`.
3. Reference `phone_widget.html.twig` via a class constant on `VoiceClient` so the template path is greppable from the class.
4. Add one end-to-end smoke test per channel — dispatch `RenderEvent::EVENT_BODY_RENDER_NAV` with `oe_enable_voice` on and seeded credentials, assert the button HTML renders. This single test would have failed #12020.

## Test plan

- [ ] PHPStan passes (baseline regenerated against current master)
- [ ] Voice UI renders when `oe_enable_voice` is set and credentials configured
- [ ] User permissions table shows fax/SMS/email/voice columns
- [ ] Setup page exposes the voice vendor select and "Setup Voice" button