### PR TITLE
refactor(portal): extract PatientPortalLoginController, behavior-preserving

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -12654,56 +12654,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'Location\\: \' and mixed results in an error\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'\\: \' results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'\\:allow portal…\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'\\:invalid email\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'\\:invalid password\' results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'\\:invalid username\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'\\:not active patient\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'\\:not authorized\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'Location\\: \' and mixed results in an error\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../portal/home.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.int.php
+++ b/.phpstan/baseline/cast.int.php
@@ -593,11 +593,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to int\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to int\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../portal/home.php',
 ];

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -2598,11 +2598,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 5,
     'path' => __DIR__ . '/../../portal/home.php',
 ];

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -3253,11 +3253,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 17,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/get_pro.php',
 ];

--- a/.phpstan/baseline/empty.variable.php
+++ b/.phpstan/baseline/empty.variable.php
@@ -287,11 +287,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/smarty_legacy/smarty/plugins/function.popup.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$userData in empty\\(\\) always exists and is not falsy\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$owner in empty\\(\\) always exists and is not falsy\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/messaging/handle_note.php',

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -2857,11 +2857,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/find_appt_popup_user.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$srcdir \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$webserver_root \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/home.php',

--- a/.phpstan/baseline/function.deprecated.php
+++ b/.phpstan/baseline/function.deprecated.php
@@ -629,24 +629,6 @@ $ignoreErrors[] = [
     'message' => '#^Call to deprecated function getUserIDInfo\\(\\)\\:
 7\\.0\\.3 see UserSettingsService\\:\\:getUserIDInfo$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function privQuery\\(\\)\\:
-Use the standard DB connections instead\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function privStatement\\(\\)\\:
-Use the standard DB connections instead\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function getUserIDInfo\\(\\)\\:
-7\\.0\\.3 see UserSettingsService\\:\\:getUserIDInfo$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../portal/messaging/messages.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/function.nameCase.php
+++ b/.phpstan/baseline/function.nameCase.php
@@ -117,11 +117,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/account/index_reset.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to function define\\(\\) with incorrect case\\: DEFINE$#',
-    'count' => 8,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to function header\\(\\) with incorrect case\\: Header$#',
     'count' => 2,
     'path' => __DIR__ . '/../../portal/index.php',

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -5872,11 +5872,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/get_patient_documents.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/get_prescriptions.php',

--- a/.phpstan/baseline/openemr.forbiddenErrorLog.php
+++ b/.phpstan/baseline/openemr.forbiddenErrorLog.php
@@ -283,11 +283,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/lib/appsql.class.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -4128,12 +4128,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 30,
+    'count' => 1,
     'path' => __DIR__ . '/../../portal/get_patient_info.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 1,
     'path' => __DIR__ . '/../../portal/get_patient_info.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -4127,16 +4127,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/get_patient_info.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/home.php',

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -4124,11 +4124,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../portal/home.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -2017,11 +2017,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/get_patient_documents.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$srcdir might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/get_patient_info.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$pid might not be defined\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/get_prescriptions.php',

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -49,7 +49,7 @@ return [
         'return.missing.php' => 0,
         'staticMethod.notFound.php' => 0,
         'trait.notFound.php' => 0,
-        'variable.undefined.php' => 547,
+        'variable.undefined.php' => 546,
     ],
     'confidentNonObject' => [
         'classConstant.nonObject.php' => 0,

--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -35,6 +35,7 @@ use OpenEMR\Controllers\Portal\SqlPortalLoginCredentialsRepository;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\Globals\UserSettingsService;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 require_once(__DIR__ . '/../vendor/autoload.php');
 
@@ -83,10 +84,16 @@ $controller = new PatientPortalLoginController(
     $auditLogger
 );
 
+$symfonyRequest = Request::createFromGlobals();
 /** @var array<string, mixed> $post */
-$post = $_POST;
+$post = $symfonyRequest->request->all();
+// Controller only reads $request['redirect']; the legacy script sourced it from
+// $_REQUEST, which (with default request_order GP) is POST shadowing GET.
 /** @var array<string, mixed> $request */
-$request = $_REQUEST;
+$request = [
+    'redirect' => $symfonyRequest->request->get('redirect')
+        ?? $symfonyRequest->query->get('redirect'),
+];
 
 // Resolve the site id from the session, then $_GET, then the literal 'default'.
 // Inline narrowing (rather than `(string) (... ?? ... ?? 'default')`) so unexpected

--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -3,314 +3,132 @@
 /**
  * portal/get_patient_info.php
  *
+ * Patient portal login form POST target. Thin entry point: bootstraps the portal
+ * session/autoloader, wires the production dependencies, invokes
+ * PatientPortalLoginController, and applies the returned directive
+ * (portalLog + maybe destroy session + maybe emit no-cache headers + redirect).
+ *
+ * All login logic lives in OpenEMR\Controllers\Portal\PatientPortalLoginController so
+ * it can be unit-tested with an injected in-memory credentials repository. See
+ * tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php.
+ *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Cassian LUP <cassi.lup@gmail.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2011 Cassian LUP <cassi.lup@gmail.com>
  * @copyright Copyright (c) 2016-2017 Jerry Padgett <sjpadgett@gmail.com>
  * @copyright Copyright (c) 2019 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-use OpenEMR\Common\Auth\AuthHash;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Controllers\Portal\PatientPortalLoginController;
+use OpenEMR\Controllers\Portal\PortalAuditLogger;
+use OpenEMR\Controllers\Portal\SessionUtilPortalSessionAccessor;
+use OpenEMR\Controllers\Portal\SqlPortalLoginCredentialsRepository;
 use OpenEMR\Core\OEGlobalsBag;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
-// Will start the (patient) portal OpenEMR session/cookie.
-// Need access to classes, so run autoloader now instead of in globals.php.
-require_once(__DIR__ . "/../vendor/autoload.php");
+require_once(__DIR__ . '/../vendor/autoload.php');
+
 $globalsBag = OEGlobalsBag::getInstance();
-if (empty(SessionUtil::getAppCookie())) {
-    // Prevent error 500 in case of cleaning cookies and site data once when the login page is already loaded
+
+// Prevent error 500 in case of cleaning cookies and site data once when the login page is already loaded.
+if (SessionUtil::getAppCookie() === '') {
     $_COOKIE[SessionUtil::APP_COOKIE_NAME] = SessionUtil::PORTAL_SESSION_ID;
 }
-// Auth flow writes heavily to session and uses migrate()
+
+// Auth flow writes heavily to session and uses migrate(); explicitly opt out of the
+// portal's default read-only session mode before obtaining the active session.
 $sessionAllowWrite = true;
 SessionWrapperFactory::getInstance()->setSessionReadOnly(false);
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
-
-// regenerating the session id to avoid session fixation attacks
+// Regenerate the session id to avoid session fixation attacks.
 $session->migrate(true);
-//
 
-// landing page definition -- where to go if something goes wrong
-$landingpage = "index.php?site=" . urlencode((string) ($session->get('site_id', false) ?? $_GET['site'] ?? 'default'));
-//
-
-if (!empty($_REQUEST['redirect'])) {
-    // let's add the redirect back in case there are any errors or other problems.
-    $landingpage .= "&redirect=" . urlencode((string) $_REQUEST['redirect']);
-}
-
-// checking whether the request comes from index.php
-if (!$session->get('itsme', false)) {
-    SessionWrapperFactory::getInstance()->destroyPortalSession();
-    header('Location: ' . $landingpage . '&w');
-    exit();
-}
-
-// some validation
-if (!isset($_POST['uname']) || empty($_POST['uname'])) {
-    SessionWrapperFactory::getInstance()->destroyPortalSession();
-    header('Location: ' . $landingpage . '&w&c');
-    exit();
-}
-
-if (!isset($_POST['pass']) || empty($_POST['pass'])) {
-    SessionWrapperFactory::getInstance()->destroyPortalSession();
-    header('Location: ' . $landingpage . '&w&c');
-    exit();
-}
-
-// set the language
-if (!empty($_POST['languageChoice'])) {
-    SessionUtil::setSession('language_choice', (int)$_POST['languageChoice']);
-} elseif (empty($session->get('language_choice', null))) {
-    // just in case both are empty, then use english
-    SessionUtil::setSession('language_choice', 1);
-} else {
-    // keep the current session language token
-}
-
-// Settings that will override globals.php
+// OpenEMR globals + legacy procedural helpers needed by the SQL repository and the
+// controller (privQuery/privStatement/QueryUtils::querySingleRow/getUserIDInfo,
+// AuthHash, CsrfUtils, ApplicationTable).
 $ignoreAuth_onsite_portal = true;
-//
-
-// Authentication
 require_once('../interface/globals.php');
-
-if (
-    $globalsBag->getBoolean('enforce_signin_email')
-    && (!isset($_POST['passaddon']) || empty($_POST['passaddon']))
-) {
-    SessionWrapperFactory::getInstance()->destroyPortalSession();
-    header('Location: ' . $landingpage . '&w&c');
-    exit();
-}
-
-require_once(__DIR__ . "/lib/appsql.class.php");
+require_once(__DIR__ . '/lib/appsql.class.php');
 require_once("$srcdir/user.inc.php");
 
-
 $logit = new ApplicationTable();
-$password_update = $session->get('password_update', 0);
-SessionUtil::unsetSession('password_update');
 
-$authorizedPortal = false; // flag
-DEFINE("TBL_PAT_ACC_ON", "patient_access_onsite");
-DEFINE("COL_ID", "id");
-DEFINE("COL_PID", "pid");
-DEFINE("COL_POR_PWD", "portal_pwd");
-DEFINE("COL_POR_USER", "portal_username");
-DEFINE("COL_POR_LOGINUSER", "portal_login_username");
-DEFINE("COL_POR_PWD_STAT", "portal_pwd_status");
-DEFINE("COL_POR_ONETIME", "portal_onetime");
-
-// 2 is flag for one time credential reset else 1 = normal reset.
-// one time reset requires a PIN where normal uses a new temp pass sent to user.
-if ($password_update === 2 && !empty($session->get('pin', null))) {
-    $sql = "SELECT " . implode(",", [
-            COL_ID, COL_PID, COL_POR_PWD, COL_POR_USER, COL_POR_LOGINUSER, COL_POR_PWD_STAT, COL_POR_ONETIME]) . " FROM " . TBL_PAT_ACC_ON .
-        " WHERE BINARY " . COL_POR_ONETIME . "= ?";
-    $auth = privQuery($sql, [$session->get('forward')]);
-    if ($auth !== false) {
-        // remove the token from database
-        privStatement("UPDATE " . TBL_PAT_ACC_ON . " SET " . COL_POR_ONETIME . "=NULL WHERE BINARY " . COL_POR_ONETIME . " = ?", [$auth['portal_onetime']]);
-        // validation
-        $validate = substr((string) $auth[COL_POR_ONETIME], 32, 6);
-        if (!empty($validate) && !empty($_POST['token_pin'])) {
-            if ($session->get('pin') !== $_POST['token_pin']) {
-                $auth = false;
-            } elseif ($validate !== $_POST['token_pin']) {
-                $auth = false;
-            }
-        } else {
-            $auth = false;
-        }
-        SessionUtil::unsetSession(['forward', 'pin']);
-        unset($_POST['token_pin']);
+// PortalAuditLogger adapter that delegates to ApplicationTable::portalLog. Defined as an
+// anonymous class here (rather than as a typed class in src/) so the legacy non-PSR-4
+// reference to ApplicationTable stays out of the autoloaded surface.
+$auditLogger = new class ($logit) implements PortalAuditLogger {
+    public function __construct(private readonly ApplicationTable $delegate)
+    {
     }
+
+    public function portalLog(string $event, $patientId, string $comments, string $binds = '', string $success = '1'): void
+    {
+        $this->delegate->portalLog($event, $patientId, $comments, $binds, $success);
+    }
+};
+
+// Wire the legacy getUserIDInfo() lookup into the SQL repository so the repo itself does
+// not depend on a non-autoloaded global function.
+$controller = new PatientPortalLoginController(
+    new SqlPortalLoginCredentialsRepository('getUserIDInfo'),
+    $auditLogger
+);
+
+/** @var array<string, mixed> $post */
+$post = $_POST;
+/** @var array<string, mixed> $request */
+$request = $_REQUEST;
+
+// Resolve the site id from the session, then $_GET, then the literal 'default'.
+// Inline narrowing (rather than `(string) (... ?? ... ?? 'default')`) so unexpected
+// types from the session or query string fall through to the default.
+$siteId = 'default';
+$fromSession = $session->get('site_id');
+if (is_string($fromSession) && $fromSession !== '') {
+    $siteId = $fromSession;
 } else {
-    // normal login
-    $sql = "SELECT " . implode(",", [
-            COL_ID, COL_PID, COL_POR_PWD, COL_POR_USER, COL_POR_LOGINUSER, COL_POR_PWD_STAT]) . " FROM " . TBL_PAT_ACC_ON .
-        " WHERE " . COL_POR_LOGINUSER . "= ?";
-    if ($password_update === 1) {
-        $sql = "SELECT " . implode(",", [
-                COL_ID, COL_PID, COL_POR_PWD, COL_POR_USER, COL_POR_LOGINUSER, COL_POR_PWD_STAT]) . " FROM " . TBL_PAT_ACC_ON .
-            " WHERE " . COL_POR_USER . "= ?";
+    $fromGet = $_GET['site'] ?? null;
+    if (is_string($fromGet) && $fromGet !== '') {
+        $siteId = $fromGet;
     }
-
-    $auth = privQuery($sql, [$_POST['uname']]);
 }
-if ($auth === false) {
-    $logit->portalLog('login attempt', '', ($_POST['uname'] . ':invalid username'), '', '0');
+
+$result = $controller->login(
+    $siteId,
+    $post,
+    $request,
+    new SessionUtilPortalSessionAccessor($session),
+    $globalsBag
+);
+
+if ($result->establishCsrf) {
+    // Set up the CSRF private key (for the patient portal). Note: this key always
+    // remains private and never leaves server session; it is used to create the
+    // CSRF tokens.
+    CsrfUtils::setupCsrfKey($session);
+}
+
+if ($result->portalLogArgs !== null) {
+    $logit->portalLog(...$result->portalLogArgs);
+}
+
+if ($result->destroySessionCookie) {
     SessionWrapperFactory::getInstance()->destroyPortalSession();
-    header('Location: ' . $landingpage . '&w&u');
-    exit();
 }
 
-if ($password_update === 2) {
-    if ($_POST['pass'] != $auth[COL_POR_PWD]) {
-        $logit->portalLog('login attempt', '', ($_POST['uname'] . ':invalid password'), '', '0');
-        SessionWrapperFactory::getInstance()->destroyPortalSession();
-        header('Location: ' . $landingpage . '&w&p');
-        exit();
-    }
-} else {
-    if (AuthHash::passwordVerify($_POST['pass'], $auth[COL_POR_PWD])) {
-        $authHashPortal = new AuthHash();
-        if ($authHashPortal->passwordNeedsRehash($auth[COL_POR_PWD])) {
-            // If so, create a new hash, and replace the old one (this will ensure always using most modern hashing)
-            $reHash = $authHashPortal->passwordHash($_POST['pass']);
-            if (empty($reHash)) {
-                // Something is seriously wrong
-                error_log('OpenEMR Error : OpenEMR is not working because unable to create a hash.');
-                die("OpenEMR Error : OpenEMR is not working because unable to create a hash.");
-            }
-            privStatement(
-                "UPDATE " . TBL_PAT_ACC_ON . " SET " . COL_POR_PWD . " = ? WHERE " . COL_ID . " = ?",
-                [
-                    $reHash,
-                    $auth[COL_ID]
-                ]
-            );
-        }
-    } else {
-        $logit->portalLog('login attempt', '', ($_POST['uname'] . ':invalid password'), '', '0');
-        SessionWrapperFactory::getInstance()->destroyPortalSession();
-        header('Location: ' . $landingpage . '&w&p');
-        exit();
-    }
+$response = new RedirectResponse($result->redirectUrl);
+if ($result->sendNoCacheHeaders) {
+    $response->headers->set('Expires', 'Mon, 26 Jul 1997 05:00:00 GMT');
+    $response->headers->set('Cache-Control', 'no-cache');
+    $response->headers->set('Pragma', 'no-cache');
 }
-
-
-
-SessionUtil::setSession('portal_username', $auth[COL_POR_USER]);
-SessionUtil::setSession('portal_login_username', $auth[COL_POR_LOGINUSER]);
-
-$sql = "SELECT * FROM `patient_data` WHERE `pid` = ?";
-
-if ($userData = sqlQuery($sql, [$auth['pid']])) { // if query gets executed
-    if (empty($userData)) {
-        $logit->portalLog('login attempt', '', ($_POST['uname'] . ':not active patient'), '', '0');
-        SessionWrapperFactory::getInstance()->destroyPortalSession();
-        header('Location: ' . $landingpage . '&w');
-        exit();
-    }
-
-    if ($userData['email'] != ($_POST['passaddon'] ?? '') && $globalsBag->getBoolean('enforce_signin_email')) {
-        $logit->portalLog('login attempt', '', ($_POST['uname'] . ':invalid email'), '', '0');
-        SessionWrapperFactory::getInstance()->destroyPortalSession();
-        header('Location: ' . $landingpage . '&w');
-        exit();
-    }
-
-    if ($userData['allow_patient_portal'] != "YES") {
-        // Patient has not authorized portal, so escape
-        $logit->portalLog('login attempt', '', ($_POST['uname'] . ':allow portal turned off'), '', '0');
-        SessionWrapperFactory::getInstance()->destroyPortalSession();
-        header('Location: ' . $landingpage . '&w');
-        exit();
-    }
-
-    if ($auth['pid'] != $userData['pid']) {
-        // Not sure if this is even possible, but should escape if this happens
-        SessionWrapperFactory::getInstance()->destroyPortalSession();
-        header('Location: ' . $landingpage . '&w');
-        exit();
-    }
-
-    if ($password_update) {
-        $code_new = $_POST['pass_new'];
-        $code_new_confirm = $_POST['pass_new_confirm'];
-        if (!(empty($_POST['pass_new'])) && !(empty($_POST['pass_new_confirm'])) && ($code_new == $code_new_confirm)) {
-            $new_hash = (new AuthHash())->passwordHash($code_new);
-            if (empty($new_hash)) {
-                // Something is seriously wrong
-                error_log('OpenEMR Error : OpenEMR is not working because unable to create a hash.');
-                die("OpenEMR Error : OpenEMR is not working because unable to create a hash.");
-            }
-            // Update the password and continue (patient is authorized)
-            privStatement(
-                "UPDATE " . TBL_PAT_ACC_ON . "  SET " . COL_POR_LOGINUSER . "=?," . COL_POR_PWD . "=?," . COL_POR_PWD_STAT . "=1 WHERE id=?",
-                [
-                    $_POST['login_uname'],
-                    $new_hash,
-                    $auth['id']
-                ]
-            );
-            $authorizedPortal = true;
-            $logit->portalLog('password update', $auth['pid'], ($_POST['login_uname'] . ': ' . $session->get('ptName') . ':success'));
-        }
-    }
-
-    if ($auth['portal_pwd_status'] == 0) {
-        if (!$authorizedPortal) {
-            // Need to enter a new password in the index.php script
-            SessionUtil::setSession('password_update', 1);
-            header('Location: ' . $landingpage);
-            exit();
-        }
-    }
-
-    if ($auth['portal_pwd_status'] == 1) {
-        // continue (patient is authorized)
-        $authorizedPortal = true;
-    }
-
-    if ($authorizedPortal) {
-        // patient is authorized (prepare the session variables)
-        $tmp = getUserIDInfo($userData['providerID']);
-        SessionUtil::setUnsetSession(
-            [
-                'pid' => $auth['pid'],
-                'patient_portal_onsite_two' => 1,
-                'providerName' => ($tmp['fname'] ?? '') . ' ' . ($tmp['lname'] ?? ''),
-                'providerUName' => $tmp['username'] ?? null,
-                'sessionUser' => '-patient-', // $_POST['uname'];
-                'providerId' => $userData['providerID'] ?: 'undefined',
-                'ptName' => $userData['fname'] . ' ' . $userData['lname'],
-                // never set authUserID though authUser is used for ACL!
-                'authUser' => 'portal-user',
-            ],
-            ['password_update', 'itsme'] // just being safe
-        );
-        // Set up the csrf private_key (for the paient portal)
-        //  Note this key always remains private and never leaves server session. It is used to create
-        //  the csrf tokens.
-        CsrfUtils::setupCsrfKey($session);
-
-        $logit->portalLog('login', $session->get('pid'), ($session->get('portal_username') . ': ' . $session->get('ptName') . ':success'));
-    } else {
-        $logit->portalLog('login', '', ($_POST['uname'] . ':not authorized'), '', '0');
-        SessionWrapperFactory::getInstance()->destroyPortalSession();
-        header('Location: ' . $landingpage . '&w');
-        exit();
-    }
-} else { // problem with query
-    SessionWrapperFactory::getInstance()->destroyPortalSession();
-    header('Location: ' . $landingpage . '&w');
-    exit();
-}
-
-// now that we are authorized, we need to check for the redirect, sanitize it (or eliminate it if we can't), and then redirect
-
-if (!empty($_REQUEST['redirect'])) {
-    // for now we are only going to allow redirects to locations in the module directories, we can open this up more
-    // in future requests once we consider the threat vectors
-    $safeRedirect = \OpenEMR\Core\ModulesApplication::filterSafeLocalModuleFiles([$_REQUEST['redirect']]);
-    if (!empty($safeRedirect)) {
-        header('Location: ' . $safeRedirect[0]);
-        exit();
-    }
-}
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Cache-Control: no-cache");
-header("Pragma: no-cache");
-header('Location: ./home.php');
-exit();
+$response->send();

--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -101,18 +101,23 @@ $request = [
         ?? $symfonyRequest->query->get('redirect'),
 ];
 
-// Resolve the site id from the session, then the query string, then the literal 'default'.
-// Inline narrowing (rather than `(string) (... ?? ... ?? 'default')`) so unexpected
-// types from the session or query string fall through to the default.
-$siteId = 'default';
-$fromSession = $session->get('site_id');
-if (is_string($fromSession) && $fromSession !== '') {
+// Site id resolution preserves the legacy expression:
+//   (string) ($session->get('site_id', false) ?? $_GET['site'] ?? 'default')
+// SessionInterface::get returns the provided default (`false`) when the key is missing,
+// and `??` only short-circuits on null — so a missing session key produces literal `''`
+// rather than falling through to the query string. The query-string fallback only runs
+// when site_id is present and explicitly null. This is a quirk of the legacy code, kept
+// for bit-for-bit behavior preservation.
+$fromSession = $session->get('site_id', false);
+if ($fromSession === false) {
+    $siteId = '';
+} elseif ($fromSession === null) {
+    $fromGet = $symfonyRequest->query->get('site');
+    $siteId = is_string($fromGet) ? $fromGet : 'default';
+} elseif (is_string($fromSession)) {
     $siteId = $fromSession;
 } else {
-    $fromGet = $symfonyRequest->query->get('site');
-    if (is_string($fromGet) && $fromGet !== '') {
-        $siteId = $fromGet;
-    }
+    $siteId = '';
 }
 
 $result = $controller->login(

--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -95,7 +95,7 @@ $request = [
         ?? $symfonyRequest->query->get('redirect'),
 ];
 
-// Resolve the site id from the session, then $_GET, then the literal 'default'.
+// Resolve the site id from the session, then the query string, then the literal 'default'.
 // Inline narrowing (rather than `(string) (... ?? ... ?? 'default')`) so unexpected
 // types from the session or query string fall through to the default.
 $siteId = 'default';
@@ -103,7 +103,7 @@ $fromSession = $session->get('site_id');
 if (is_string($fromSession) && $fromSession !== '') {
     $siteId = $fromSession;
 } else {
-    $fromGet = $_GET['site'] ?? null;
+    $fromGet = $symfonyRequest->query->get('site');
     if (is_string($fromGet) && $fromGet !== '') {
         $siteId = $fromGet;
     }

--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -33,6 +33,7 @@ use OpenEMR\Controllers\Portal\PortalAuditLogger;
 use OpenEMR\Controllers\Portal\SessionUtilPortalSessionAccessor;
 use OpenEMR\Controllers\Portal\SqlPortalLoginCredentialsRepository;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Services\Globals\UserSettingsService;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 require_once(__DIR__ . '/../vendor/autoload.php');
@@ -52,13 +53,12 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 // Regenerate the session id to avoid session fixation attacks.
 $session->migrate(true);
 
-// OpenEMR globals + legacy procedural helpers needed by the SQL repository and the
-// controller (privQuery/privStatement/QueryUtils::querySingleRow/getUserIDInfo,
-// AuthHash, CsrfUtils, ApplicationTable).
+// OpenEMR globals + the legacy ApplicationTable class needed by the audit logger.
+// (QueryUtils, AuthHash, CsrfUtils, and UserSettingsService are all PSR-4 and load
+// via the composer autoloader.)
 $ignoreAuth_onsite_portal = true;
 require_once('../interface/globals.php');
 require_once(__DIR__ . '/lib/appsql.class.php');
-require_once("$srcdir/user.inc.php");
 
 $logit = new ApplicationTable();
 
@@ -76,10 +76,10 @@ $auditLogger = new class ($logit) implements PortalAuditLogger {
     }
 };
 
-// Wire the legacy getUserIDInfo() lookup into the SQL repository so the repo itself does
-// not depend on a non-autoloaded global function.
+// Wire the provider info lookup as a static-method callable so the repository itself
+// does not have to reference the legacy global function.
 $controller = new PatientPortalLoginController(
-    new SqlPortalLoginCredentialsRepository('getUserIDInfo'),
+    new SqlPortalLoginCredentialsRepository(UserSettingsService::getUserIDInfo(...)),
     $auditLogger
 );
 

--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -57,6 +57,12 @@ $session->migrate(true);
 // OpenEMR globals + the legacy ApplicationTable class needed by the audit logger.
 // (QueryUtils, AuthHash, CsrfUtils, and UserSettingsService are all PSR-4 and load
 // via the composer autoloader.)
+// `$landingpage` must be defined before including interface/globals.php — its
+// multisite site-mismatch handler treats a non-empty $landingpage as "this is a
+// portal request" and redirects there; without it the user is bounced to
+// interface/login/login.php instead of the portal login. The real landing page
+// is rebuilt inside the controller from the resolved site id.
+$landingpage = 'index.php?site=default';
 $ignoreAuth_onsite_portal = true;
 require_once('../interface/globals.php');
 require_once(__DIR__ . '/lib/appsql.class.php');

--- a/src/Controllers/Portal/AuthHashPortalPasswordHasher.php
+++ b/src/Controllers/Portal/AuthHashPortalPasswordHasher.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * AuthHashPortalPasswordHasher — production PortalPasswordHasher wrapping
+ * AuthHash::passwordHash. Narrows AuthHash's `mixed` return to string|false so
+ * the controller has a single, testable failure mode.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Controllers\Portal;
+
+use OpenEMR\Common\Auth\AuthHash;
+
+final class AuthHashPortalPasswordHasher implements PortalPasswordHasher
+{
+    public function hash(string $plain): string|false
+    {
+        $result = (new AuthHash())->passwordHash($plain);
+        return is_string($result) ? $result : false;
+    }
+}

--- a/src/Controllers/Portal/PatientPortalLoginController.php
+++ b/src/Controllers/Portal/PatientPortalLoginController.php
@@ -264,7 +264,12 @@ class PatientPortalLoginController
         $pin = $this->stringOrNull($session->get('pin'));
         if ($passwordUpdate === self::PASSWORD_UPDATE_ONE_TIME_RESET && $pin !== null) {
             // One-time PIN reset: the row is keyed by the one-time token, not by username.
-            $token = $this->stringOrNull($session->get('forward')) ?? '';
+            // Bail without touching the DB when forward is missing; an empty-string lookup
+            // could match a stale `portal_onetime=''` row and then clear it as a side effect.
+            $token = $this->stringOrNull($session->get('forward'));
+            if ($token === null) {
+                return null;
+            }
             $auth = $this->repository->fetchByOneTimeToken($token);
 
             if ($auth === null) {

--- a/src/Controllers/Portal/PatientPortalLoginController.php
+++ b/src/Controllers/Portal/PatientPortalLoginController.php
@@ -46,10 +46,14 @@ class PatientPortalLoginController
     private const PASSWORD_UPDATE_REQUIRED = 1;
     private const PASSWORD_UPDATE_ONE_TIME_RESET = 2;
 
+    private readonly PortalPasswordHasher $passwordHasher;
+
     public function __construct(
         private readonly PortalLoginCredentialsRepository $repository,
         private readonly PortalAuditLogger $logit,
+        ?PortalPasswordHasher $passwordHasher = null,
     ) {
+        $this->passwordHasher = $passwordHasher ?? new AuthHashPortalPasswordHasher();
     }
 
     /**
@@ -164,13 +168,9 @@ class PatientPortalLoginController
             $codeNew = $this->stringOrNull($post['pass_new'] ?? null);
             $codeNewConfirm = $this->stringOrNull($post['pass_new_confirm'] ?? null);
             if ($codeNew !== null && $codeNewConfirm !== null && hash_equals($codeNewConfirm, $codeNew)) {
-                $newHash = (new AuthHash())->passwordHash($codeNew);
-                if (!is_string($newHash) || $newHash === '') {
-                    // @codeCoverageIgnoreStart — AuthHash::passwordHash returns mixed but in
-                    // practice produces a bcrypt string; this defensive branch only fires on
-                    // a configuration breakage that would also break the rest of the system.
+                $newHash = $this->passwordHasher->hash($codeNew);
+                if ($newHash === false || $newHash === '') {
                     throw new \RuntimeException('OpenEMR is not working because unable to create a hash.');
-                    // @codeCoverageIgnoreEnd
                 }
                 // The legacy script reads $_POST['login_uname'] without an empty() check,
                 // so '0' is a valid login username here. Narrow with is_string only — no
@@ -306,17 +306,18 @@ class PatientPortalLoginController
             return hash_equals($auth['portal_pwd'], $pass);
         }
 
+        // Keep a typed copy: AuthHash::passwordVerify takes its first argument by reference,
+        // which widens $pass to mixed for PHPStan after the call.
+        $plain = $pass;
         if (!AuthHash::passwordVerify($pass, $auth['portal_pwd'])) {
             return false;
         }
 
         $authHashPortal = new AuthHash();
         if ($authHashPortal->passwordNeedsRehash($auth['portal_pwd'])) {
-            $reHash = $authHashPortal->passwordHash($pass);
-            if (!is_string($reHash) || $reHash === '') {
-                // @codeCoverageIgnoreStart — see the matching defensive branch in login().
+            $reHash = $this->passwordHasher->hash($plain);
+            if ($reHash === false || $reHash === '') {
                 throw new \RuntimeException('OpenEMR is not working because unable to create a hash.');
-                // @codeCoverageIgnoreEnd
             }
             $this->repository->updatePasswordHash($auth['id'], $reHash);
         }

--- a/src/Controllers/Portal/PatientPortalLoginController.php
+++ b/src/Controllers/Portal/PatientPortalLoginController.php
@@ -92,12 +92,23 @@ class PatientPortalLoginController
             return new PatientPortalLoginResult($landingpage . '&w&c', true);
         }
 
-        // Language selection (mutates session whatever the auth outcome).
-        $languageChoice = $post['languageChoice'] ?? null;
-        if (is_numeric($languageChoice)) {
+        // Language selection (mutates session whatever the auth outcome). Matches the
+        // legacy three-way logic exactly:
+        //   if (!empty($_POST['languageChoice'])) { set as int }
+        //   elseif (empty($session->get('language_choice'))) { default to 1 }
+        //   else { leave session value alone }
+        // `empty('0')` is true in PHP, so '0' here counts as unset for both branches.
+        $languageChoice = $this->stringOrNull($post['languageChoice'] ?? null);
+        if ($languageChoice !== null) {
             $session->set('language_choice', (int) $languageChoice);
-        } elseif (!is_numeric($session->get('language_choice'))) {
-            $session->set('language_choice', 1);
+        } else {
+            $existing = $session->get('language_choice');
+            // Mirror `empty()` truthiness across the types this slot can hold.
+            $isLegacyEmpty = in_array($existing, [null, false, 0, '', '0'], true);
+            if ($isLegacyEmpty) {
+                // just in case both are empty, then use english (preserved from original)
+                $session->set('language_choice', 1);
+            }
         }
 
         // Mode discriminator: 2 = one-time PIN reset, 1 = normal-reset (must-change), 0 = normal.
@@ -299,12 +310,19 @@ class PatientPortalLoginController
     }
 
     /**
-     * Narrow `mixed` to a non-empty string or null. Used at the input boundary so the
-     * rest of the controller deals only with honest strings.
+     * Narrow `mixed` to a non-empty string or null, matching PHP's `empty()` semantics
+     * so this refactor preserves the legacy script's behavior bit-for-bit. `empty('0')`
+     * is true in PHP — the legacy script's `if (empty($_POST['x']))` checks therefore
+     * treated the literal "0" the same as "" and null, and so does this helper.
+     *
+     * Symfony's typed Request accessors (e.g. `InputBag::getString`) would replace
+     * this if the controller were restructured to take a `ServerRequestInterface`
+     * instead of raw `$_POST`/`$_REQUEST` arrays. That restructure is out of scope
+     * for this behavior-preserving extraction.
      */
     private function stringOrNull(mixed $value): ?string
     {
-        if (is_string($value) && $value !== '') {
+        if (is_string($value) && $value !== '' && $value !== '0') {
             return $value;
         }
         return null;

--- a/src/Controllers/Portal/PatientPortalLoginController.php
+++ b/src/Controllers/Portal/PatientPortalLoginController.php
@@ -241,13 +241,9 @@ class PatientPortalLoginController
         if ($redirectParam !== null) {
             $safeRedirect = ModulesApplication::filterSafeLocalModuleFiles([$redirectParam]);
             $safeUrl = $safeRedirect[0] ?? null;
-            // @codeCoverageIgnoreStart — filterSafeLocalModuleFiles uses realpath() against
-            // the live modules directory, so an accepted redirect requires a real on-disk
-            // file under interface/modules/. Exercised by the E2E suite, not unit tests.
             if (is_string($safeUrl) && $safeUrl !== '') {
                 return new PatientPortalLoginResult($safeUrl, false, $successLogArgs, false, true);
             }
-            // @codeCoverageIgnoreEnd
         }
 
         return new PatientPortalLoginResult('./home.php', false, $successLogArgs, true, true);

--- a/src/Controllers/Portal/PatientPortalLoginController.php
+++ b/src/Controllers/Portal/PatientPortalLoginController.php
@@ -166,7 +166,11 @@ class PatientPortalLoginController
             if ($codeNew !== null && $codeNewConfirm !== null && hash_equals($codeNewConfirm, $codeNew)) {
                 $newHash = (new AuthHash())->passwordHash($codeNew);
                 if (!is_string($newHash) || $newHash === '') {
+                    // @codeCoverageIgnoreStart — AuthHash::passwordHash returns mixed but in
+                    // practice produces a bcrypt string; this defensive branch only fires on
+                    // a configuration breakage that would also break the rest of the system.
                     throw new \RuntimeException('OpenEMR is not working because unable to create a hash.');
+                    // @codeCoverageIgnoreEnd
                 }
                 // The legacy script reads $_POST['login_uname'] without an empty() check,
                 // so '0' is a valid login username here. Narrow with is_string only — no
@@ -237,9 +241,13 @@ class PatientPortalLoginController
         if ($redirectParam !== null) {
             $safeRedirect = ModulesApplication::filterSafeLocalModuleFiles([$redirectParam]);
             $safeUrl = $safeRedirect[0] ?? null;
+            // @codeCoverageIgnoreStart — filterSafeLocalModuleFiles uses realpath() against
+            // the live modules directory, so an accepted redirect requires a real on-disk
+            // file under interface/modules/. Exercised by the E2E suite, not unit tests.
             if (is_string($safeUrl) && $safeUrl !== '') {
                 return new PatientPortalLoginResult($safeUrl, false, $successLogArgs, false, true);
             }
+            // @codeCoverageIgnoreEnd
         }
 
         return new PatientPortalLoginResult('./home.php', false, $successLogArgs, true, true);
@@ -306,7 +314,9 @@ class PatientPortalLoginController
         if ($authHashPortal->passwordNeedsRehash($auth['portal_pwd'])) {
             $reHash = $authHashPortal->passwordHash($pass);
             if (!is_string($reHash) || $reHash === '') {
+                // @codeCoverageIgnoreStart — see the matching defensive branch in login().
                 throw new \RuntimeException('OpenEMR is not working because unable to create a hash.');
+                // @codeCoverageIgnoreEnd
             }
             $this->repository->updatePasswordHash($auth['id'], $reHash);
         }

--- a/src/Controllers/Portal/PatientPortalLoginController.php
+++ b/src/Controllers/Portal/PatientPortalLoginController.php
@@ -1,0 +1,312 @@
+<?php
+
+/**
+ * PatientPortalLoginController — orchestrates the patient portal login flow.
+ *
+ * Extracted from portal/get_patient_info.php so the procedural login logic can be
+ * unit-tested. The controller is intentionally a faithful port of the original script:
+ * the same SQL is issued (via PortalLoginCredentialsRepository), the same session keys
+ * are set in the same order, the same audit entries are emitted, and the same redirect
+ * URLs are produced.
+ *
+ * Behavior the controller owns (side effects during login):
+ * - DB writes for password rehash and password update (via the repository).
+ * - Session mutations for language choice, portal_username/portal_login_username,
+ *   pid/patient_portal_onsite_two/etc on successful authentication, password_update=1
+ *   when a password change is required (via the PortalSessionAccessor).
+ * - Mid-flow audit entries (password-update success, all login-attempt failures).
+ *
+ * Behavior the caller owns (after the controller returns):
+ * - The final-state portalLog entry for successful login (carried in result.portalLogArgs).
+ * - CsrfUtils::setupCsrfKey($session) when result.establishCsrf is true.
+ * - Destroying the portal session cookie when the result says to.
+ * - Setting cache-disable headers when the result says to.
+ * - Sending the HTTP redirect.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Controllers\Portal;
+
+use OpenEMR\Common\Auth\AuthHash;
+use OpenEMR\Core\ModulesApplication;
+use OpenEMR\Core\OEGlobalsBag;
+
+/**
+ * @phpstan-import-type PatientAccessOnsiteRow from PortalLoginCredentialsRepository
+ * @phpstan-import-type PatientDataRow from PortalLoginCredentialsRepository
+ */
+class PatientPortalLoginController
+{
+    private const PASSWORD_UPDATE_NORMAL = 0;
+    private const PASSWORD_UPDATE_REQUIRED = 1;
+    private const PASSWORD_UPDATE_ONE_TIME_RESET = 2;
+
+    public function __construct(
+        private readonly PortalLoginCredentialsRepository $repository,
+        private readonly PortalAuditLogger $logit,
+    ) {
+    }
+
+    /**
+     * Run the login attempt.
+     *
+     * @param string                $siteIdHint  Caller's resolution of `$_GET['site']`-or-default.
+     * @param array<string, mixed>  $post        The raw `$_POST` superglobal contents.
+     * @param array<string, mixed>  $request     The raw `$_REQUEST` superglobal contents.
+     * @param PortalSessionAccessor $session     Read/write accessor for the portal session.
+     * @param OEGlobalsBag          $globalsBag  Access to OpenEMR globals (e.g. enforce_signin_email).
+     */
+    public function login(
+        string $siteIdHint,
+        array $post,
+        array $request,
+        PortalSessionAccessor $session,
+        OEGlobalsBag $globalsBag
+    ): PatientPortalLoginResult {
+        $landingpage = 'index.php?site=' . urlencode($siteIdHint);
+        $redirectParam = $this->stringOrNull($request['redirect'] ?? null);
+        if ($redirectParam !== null) {
+            $landingpage .= '&redirect=' . urlencode($redirectParam);
+        }
+
+        // Anti-CSRF: must have come from portal/index.php which set 'itsme' before POSTing.
+        if (!$session->get('itsme', false)) {
+            return new PatientPortalLoginResult($landingpage . '&w', true);
+        }
+
+        // Input presence.
+        $uname = $this->stringOrNull($post['uname'] ?? null);
+        $pass = $this->stringOrNull($post['pass'] ?? null);
+        if ($uname === null || $pass === null) {
+            return new PatientPortalLoginResult($landingpage . '&w&c', true);
+        }
+
+        // Optional email-as-second-factor (the legacy "passaddon" feature, not MFA).
+        $passaddon = $this->stringOrNull($post['passaddon'] ?? null);
+        if ($globalsBag->getBoolean('enforce_signin_email') && $passaddon === null) {
+            return new PatientPortalLoginResult($landingpage . '&w&c', true);
+        }
+
+        // Language selection (mutates session whatever the auth outcome).
+        $languageChoice = $post['languageChoice'] ?? null;
+        if (is_numeric($languageChoice)) {
+            $session->set('language_choice', (int) $languageChoice);
+        } elseif (!is_numeric($session->get('language_choice'))) {
+            $session->set('language_choice', 1);
+        }
+
+        // Mode discriminator: 2 = one-time PIN reset, 1 = normal-reset (must-change), 0 = normal.
+        // Pulled and immediately cleared from the session because subsequent flows expect a fresh state.
+        $passwordUpdateRaw = $session->get('password_update', 0);
+        $passwordUpdate = is_int($passwordUpdateRaw) ? $passwordUpdateRaw : 0;
+        $session->remove('password_update');
+
+        // Authenticate: locate the patient_access_onsite row.
+        $auth = $this->lookupAuth($passwordUpdate, $uname, $post, $session);
+
+        if ($auth === null) {
+            $this->logit->portalLog('login attempt', '', ($uname . ':invalid username'), '', '0');
+            return new PatientPortalLoginResult($landingpage . '&w&u', true);
+        }
+
+        // Verify password.
+        if (!$this->verifyPassword($passwordUpdate, $pass, $auth)) {
+            $this->logit->portalLog('login attempt', '', ($uname . ':invalid password'), '', '0');
+            return new PatientPortalLoginResult($landingpage . '&w&p', true);
+        }
+
+        // Mirror the portal_username / portal_login_username into the session early
+        // (preserves original ordering — these are set before the patient_data lookup).
+        $session->set('portal_username', $auth['portal_username']);
+        $session->set('portal_login_username', $auth['portal_login_username']);
+
+        $userData = $this->repository->fetchPatientData($auth['pid']);
+        if ($userData === null) {
+            // Original "problem with query" path: silent destroy + &w redirect, no log.
+            return new PatientPortalLoginResult($landingpage . '&w', true);
+        }
+
+        if ($userData['email'] !== ($passaddon ?? '') && $globalsBag->getBoolean('enforce_signin_email')) {
+            $this->logit->portalLog('login attempt', '', ($uname . ':invalid email'), '', '0');
+            return new PatientPortalLoginResult($landingpage . '&w', true);
+        }
+
+        if ($userData['allow_patient_portal'] !== 'YES') {
+            $this->logit->portalLog('login attempt', '', ($uname . ':allow portal turned off'), '', '0');
+            return new PatientPortalLoginResult($landingpage . '&w', true);
+        }
+
+        if ($auth['pid'] !== $userData['pid']) {
+            // Defensive: should be impossible given the join, but the original code guards it.
+            return new PatientPortalLoginResult($landingpage . '&w', true);
+        }
+
+        // Handle in-flight password change (the patient was redirected here from the
+        // "you must change your password" form and is now POSTing pass_new + confirmation).
+        $authorizedPortal = false;
+        if ($passwordUpdate !== self::PASSWORD_UPDATE_NORMAL) {
+            $codeNew = $this->stringOrNull($post['pass_new'] ?? null);
+            $codeNewConfirm = $this->stringOrNull($post['pass_new_confirm'] ?? null);
+            if ($codeNew !== null && $codeNewConfirm !== null && hash_equals($codeNewConfirm, $codeNew)) {
+                $newHash = (new AuthHash())->passwordHash($codeNew);
+                if (!is_string($newHash) || $newHash === '') {
+                    throw new \RuntimeException('OpenEMR is not working because unable to create a hash.');
+                }
+                $newLoginUname = $this->stringOrNull($post['login_uname'] ?? null) ?? '';
+                $this->repository->updateLoginAndPassword($auth['id'], $newLoginUname, $newHash);
+                $authorizedPortal = true;
+                $ptName = $this->stringOrNull($session->get('ptName')) ?? '';
+                $this->logit->portalLog(
+                    'password update',
+                    $auth['pid'],
+                    ($newLoginUname . ': ' . $ptName . ':success')
+                );
+            }
+        }
+
+        // If portal_pwd_status is 0 and we haven't just successfully changed the password,
+        // bounce back to the change form (mode=1).
+        if ($auth['portal_pwd_status'] === 0 && !$authorizedPortal) {
+            $session->set('password_update', self::PASSWORD_UPDATE_REQUIRED);
+            return new PatientPortalLoginResult($landingpage, false);
+        }
+
+        // portal_pwd_status==1 means password is current and the patient is authorized.
+        if ($auth['portal_pwd_status'] === 1) {
+            $authorizedPortal = true;
+        }
+
+        if (!$authorizedPortal) {
+            $this->logit->portalLog('login', '', ($uname . ':not authorized'), '', '0');
+            return new PatientPortalLoginResult($landingpage . '&w', true);
+        }
+
+        // Establish the portal session in one bulk write (mirrors upstream's
+        // SessionUtil::setUnsetSession pattern used in the original script).
+        $providerInfo = $this->repository->fetchProviderInfo($userData['providerID']) ?? [
+            'fname' => '',
+            'lname' => '',
+            'username' => null,
+        ];
+        $session->setMany([
+            'pid' => $auth['pid'],
+            'patient_portal_onsite_two' => 1,
+            'providerName' => $providerInfo['fname'] . ' ' . $providerInfo['lname'],
+            'providerUName' => $providerInfo['username'],
+            'sessionUser' => '-patient-',
+            'providerId' => $userData['providerID'] !== 0 ? $userData['providerID'] : 'undefined',
+            'ptName' => $userData['fname'] . ' ' . $userData['lname'],
+            // authUser is consumed by ACL; authUserID is intentionally not set for portal sessions.
+            'authUser' => 'portal-user',
+        ]);
+        $session->removeMany(['password_update', 'itsme']);
+
+        $successPid = $session->get('pid');
+        $successPortalUsername = $this->stringOrNull($session->get('portal_username')) ?? '';
+        $successPtName = $this->stringOrNull($session->get('ptName')) ?? '';
+        $successLogArgs = [
+            'login',
+            $successPid,
+            ($successPortalUsername . ': ' . $successPtName . ':success'),
+        ];
+
+        // Honour a post-login redirect target if the caller supplied one AND the target
+        // is on the allowed-modules safelist; otherwise default to ./home.php with
+        // cache-disable headers (the original behaviour).
+        if ($redirectParam !== null) {
+            $safeRedirect = ModulesApplication::filterSafeLocalModuleFiles([$redirectParam]);
+            $safeUrl = $safeRedirect[0] ?? null;
+            if (is_string($safeUrl) && $safeUrl !== '') {
+                return new PatientPortalLoginResult($safeUrl, false, $successLogArgs, false, true);
+            }
+        }
+
+        return new PatientPortalLoginResult('./home.php', false, $successLogArgs, true, true);
+    }
+
+    /**
+     * Locate the patient_access_onsite row for the current login attempt.
+     *
+     * @param array<string, mixed> $post
+     * @return PatientAccessOnsiteRow|null
+     */
+    private function lookupAuth(int $passwordUpdate, string $uname, array $post, PortalSessionAccessor $session): ?array
+    {
+        $pin = $this->stringOrNull($session->get('pin'));
+        if ($passwordUpdate === self::PASSWORD_UPDATE_ONE_TIME_RESET && $pin !== null) {
+            // One-time PIN reset: the row is keyed by the one-time token, not by username.
+            $token = $this->stringOrNull($session->get('forward')) ?? '';
+            $auth = $this->repository->fetchByOneTimeToken($token);
+
+            if ($auth === null) {
+                return null;
+            }
+
+            // The token is single-use regardless of whether the PIN validates.
+            $oneTimeToken = $auth['portal_onetime'] ?? '';
+            $this->repository->clearOneTimeToken($oneTimeToken);
+
+            $validate = substr($oneTimeToken, 32, 6);
+            $tokenPin = $this->stringOrNull($post['token_pin'] ?? null);
+            $pinValid = $validate !== ''
+                && $tokenPin !== null
+                && hash_equals($pin, $tokenPin)
+                && hash_equals($validate, $tokenPin);
+
+            $session->removeMany(['forward', 'pin']);
+
+            return $pinValid ? $auth : null;
+        }
+
+        return $passwordUpdate === self::PASSWORD_UPDATE_REQUIRED
+            ? $this->repository->fetchByUsername($uname)
+            : $this->repository->fetchByLoginUsername($uname);
+    }
+
+    /**
+     * Verify the supplied password against the stored hash, rehashing on success if the
+     * stored hash uses an older algorithm. Returns true on success, false on failure.
+     *
+     * @param PatientAccessOnsiteRow $auth
+     */
+    private function verifyPassword(int $passwordUpdate, string $pass, array $auth): bool
+    {
+        if ($passwordUpdate === self::PASSWORD_UPDATE_ONE_TIME_RESET) {
+            // Mode 2 (one-time PIN) compares the password column directly (no hashing).
+            // Use hash_equals to avoid the timing side-channel of a plain != comparison.
+            return hash_equals($auth['portal_pwd'], $pass);
+        }
+
+        if (!AuthHash::passwordVerify($pass, $auth['portal_pwd'])) {
+            return false;
+        }
+
+        $authHashPortal = new AuthHash();
+        if ($authHashPortal->passwordNeedsRehash($auth['portal_pwd'])) {
+            $reHash = $authHashPortal->passwordHash($pass);
+            if (!is_string($reHash) || $reHash === '') {
+                throw new \RuntimeException('OpenEMR is not working because unable to create a hash.');
+            }
+            $this->repository->updatePasswordHash($auth['id'], $reHash);
+        }
+
+        return true;
+    }
+
+    /**
+     * Narrow `mixed` to a non-empty string or null. Used at the input boundary so the
+     * rest of the controller deals only with honest strings.
+     */
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (is_string($value) && $value !== '') {
+            return $value;
+        }
+        return null;
+    }
+}

--- a/src/Controllers/Portal/PatientPortalLoginController.php
+++ b/src/Controllers/Portal/PatientPortalLoginController.php
@@ -168,7 +168,12 @@ class PatientPortalLoginController
                 if (!is_string($newHash) || $newHash === '') {
                     throw new \RuntimeException('OpenEMR is not working because unable to create a hash.');
                 }
-                $newLoginUname = $this->stringOrNull($post['login_uname'] ?? null) ?? '';
+                // The legacy script reads $_POST['login_uname'] without an empty() check,
+                // so '0' is a valid login username here. Narrow with is_string only — no
+                // empty()-style filter — and fall back to '' only when truly absent or
+                // non-string, matching the original `[$_POST['login_uname'], ...]` bind.
+                $loginUnameRaw = $post['login_uname'] ?? null;
+                $newLoginUname = is_string($loginUnameRaw) ? $loginUnameRaw : '';
                 $this->repository->updateLoginAndPassword($auth['id'], $newLoginUname, $newHash);
                 $authorizedPortal = true;
                 $ptName = $this->stringOrNull($session->get('ptName')) ?? '';

--- a/src/Controllers/Portal/PatientPortalLoginResult.php
+++ b/src/Controllers/Portal/PatientPortalLoginResult.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * PatientPortalLoginResult — the terminal directive returned by PatientPortalLoginController.
+ *
+ * Every login attempt ends in a redirect, whether successful, password-change-required, or
+ * an error. The result tells the caller what URL to redirect to, whether to destroy the
+ * portal session cookie first, and (if a final-state audit entry should be emitted) what
+ * arguments to pass to ApplicationTable::portalLog().
+ *
+ * Side effects during the login attempt (session mutations, DB writes for password rehash
+ * or password update, the mid-flow "password update" audit entry) happen inside the
+ * controller — the result only describes what to do *after* the attempt completes.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Controllers\Portal;
+
+final readonly class PatientPortalLoginResult
+{
+    /**
+     * @param array<int, mixed>|null $portalLogArgs Positional args for ApplicationTable::portalLog,
+     *   or null when no final audit entry should be emitted (e.g. the password-change-required path
+     *   which redirects to the password-update form without logging the attempt as failure).
+     * @param bool $sendNoCacheHeaders Emit the legacy Expires/Cache-Control/Pragma no-cache headers
+     *   before redirecting. Only set on the default success path (home.php redirect); preserved from
+     *   the original script for behavior equivalence.
+     * @param bool $establishCsrf Caller should call CsrfUtils::setupCsrfKey($session) after applying
+     *   the result. Set on every successful-login path; cleared on every error/redirect path.
+     */
+    public function __construct(
+        public string $redirectUrl,
+        public bool $destroySessionCookie,
+        public ?array $portalLogArgs = null,
+        public bool $sendNoCacheHeaders = false,
+        public bool $establishCsrf = false,
+    ) {
+    }
+}

--- a/src/Controllers/Portal/PortalAuditLogger.php
+++ b/src/Controllers/Portal/PortalAuditLogger.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * PortalAuditLogger — thin abstraction over ApplicationTable::portalLog so
+ * PatientPortalLoginController doesn't depend on the legacy non-PSR-4 class directly.
+ *
+ * The portal login audit shape is positional and stable: event name, patient identifier
+ * (string or int — '' is used for failures before a pid is known), comment string,
+ * binds string, success flag ('0' or '1'). The remaining ApplicationTable::portalLog
+ * arguments (user_notes, ccda_doc_id) are unused by the login flow.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Controllers\Portal;
+
+interface PortalAuditLogger
+{
+    /**
+     * @param string|int|null $patientId
+     */
+    public function portalLog(string $event, $patientId, string $comments, string $binds = '', string $success = '1'): void;
+}

--- a/src/Controllers/Portal/PortalLoginCredentialsRepository.php
+++ b/src/Controllers/Portal/PortalLoginCredentialsRepository.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * PortalLoginCredentialsRepository — read/write surface the portal login flow uses
+ * against the patient credential and demographic tables.
+ *
+ * The interface exists to make PatientPortalLoginController unit-testable: tests inject
+ * an in-memory implementation; production uses the SQL-backed implementation.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Controllers\Portal;
+
+/**
+ * Typed shapes for rows produced by this repository. The SQL implementation normalises
+ * the raw DB-string columns to these types at the boundary so the controller can treat
+ * them as honest ints/strings without casting.
+ *
+ * @phpstan-type PatientAccessOnsiteRow array{
+ *   id: int,
+ *   pid: int,
+ *   portal_pwd: string,
+ *   portal_username: string,
+ *   portal_login_username: string,
+ *   portal_pwd_status: int,
+ *   portal_onetime?: string|null,
+ * }
+ * @phpstan-type PatientDataRow array{
+ *   pid: int,
+ *   fname: string,
+ *   lname: string,
+ *   email: string,
+ *   providerID: int,
+ *   allow_patient_portal: string,
+ * }
+ * @phpstan-type ProviderInfoRow array{
+ *   fname: string,
+ *   lname: string,
+ *   username: string|null,
+ * }
+ */
+interface PortalLoginCredentialsRepository
+{
+    /**
+     * Fetch the `patient_access_onsite` row matching the supplied one-time PIN-reset token.
+     *
+     * @return PatientAccessOnsiteRow|null Row, or null if not found.
+     */
+    public function fetchByOneTimeToken(string $token): ?array;
+
+    /**
+     * Fetch by portal_login_username (the user-entered login).
+     *
+     * @return PatientAccessOnsiteRow|null Row, or null if not found.
+     */
+    public function fetchByLoginUsername(string $loginUsername): ?array;
+
+    /**
+     * Fetch by portal_username (the canonical username; used when password_update mode 1
+     * is active because the patient may have changed login_username).
+     *
+     * @return PatientAccessOnsiteRow|null Row, or null if not found.
+     */
+    public function fetchByUsername(string $username): ?array;
+
+    /**
+     * Clear a consumed one-time PIN-reset token so it cannot be reused.
+     */
+    public function clearOneTimeToken(string $token): void;
+
+    /**
+     * Persist a rehashed password without changing the login username. Called when the
+     * existing hash uses an older algorithm and we want to upgrade transparently.
+     */
+    public function updatePasswordHash(int $id, string $newHash): void;
+
+    /**
+     * Persist a new login username, new password hash, and clear the must-change status
+     * — performed when the patient completes a password-change flow.
+     */
+    public function updateLoginAndPassword(int $id, string $loginUsername, string $newHash): void;
+
+    /**
+     * Fetch the `patient_data` row for the given pid.
+     *
+     * @return PatientDataRow|null Patient demographics row, or null if not found
+     *   (treated as "not active patient").
+     */
+    public function fetchPatientData(int $pid): ?array;
+
+    /**
+     * Resolve a provider user id to display info. Returns null if the provider id is zero
+     * or the user lookup fails.
+     *
+     * @return ProviderInfoRow|null
+     */
+    public function fetchProviderInfo(int $providerId): ?array;
+}

--- a/src/Controllers/Portal/PortalLoginRowNormalizer.php
+++ b/src/Controllers/Portal/PortalLoginRowNormalizer.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * PortalLoginRowNormalizer — pure functions that map raw rows produced by the legacy
+ * ADODB-backed SQL helpers (where every column comes back as a string regardless of
+ * its declared type) to the typed shapes declared on PortalLoginCredentialsRepository.
+ *
+ * Lives separately from SqlPortalLoginCredentialsRepository so the normalization
+ * logic is unit-testable without a database.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Controllers\Portal;
+
+/**
+ * @phpstan-import-type PatientAccessOnsiteRow from PortalLoginCredentialsRepository
+ * @phpstan-import-type PatientDataRow from PortalLoginCredentialsRepository
+ * @phpstan-import-type ProviderInfoRow from PortalLoginCredentialsRepository
+ */
+final class PortalLoginRowNormalizer
+{
+    /**
+     * @param array<int|string, mixed> $row Raw row from QueryUtils::querySingleRow.
+     * @return PatientAccessOnsiteRow
+     */
+    public static function authRow(array $row, bool $includeOneTime): array
+    {
+        $normalized = [
+            'id' => self::intColumn($row['id'] ?? null),
+            'pid' => self::intColumn($row['pid'] ?? null),
+            'portal_pwd' => self::stringColumn($row['portal_pwd'] ?? null),
+            'portal_username' => self::stringColumn($row['portal_username'] ?? null),
+            'portal_login_username' => self::stringColumn($row['portal_login_username'] ?? null),
+            'portal_pwd_status' => self::intColumn($row['portal_pwd_status'] ?? null),
+        ];
+        if ($includeOneTime) {
+            $oneTime = $row['portal_onetime'] ?? null;
+            $normalized['portal_onetime'] = $oneTime === null ? null : self::stringColumn($oneTime);
+        }
+        return $normalized;
+    }
+
+    /**
+     * @param array<int|string, mixed> $row Raw row from QueryUtils::querySingleRow.
+     * @return PatientDataRow
+     */
+    public static function patientDataRow(array $row): array
+    {
+        return [
+            'pid' => self::intColumn($row['pid'] ?? null),
+            'fname' => self::stringColumn($row['fname'] ?? null),
+            'lname' => self::stringColumn($row['lname'] ?? null),
+            'email' => self::stringColumn($row['email'] ?? null),
+            'providerID' => self::intColumn($row['providerID'] ?? null),
+            'allow_patient_portal' => self::stringColumn($row['allow_patient_portal'] ?? null),
+        ];
+    }
+
+    /**
+     * @param array<int|string, mixed> $row Result of getUserIDInfo() or equivalent.
+     * @return ProviderInfoRow
+     */
+    public static function providerInfoRow(array $row): array
+    {
+        $username = $row['username'] ?? null;
+        return [
+            'fname' => self::stringColumn($row['fname'] ?? null),
+            'lname' => self::stringColumn($row['lname'] ?? null),
+            'username' => $username === null ? null : self::stringColumn($username),
+        ];
+    }
+
+    /**
+     * Coerce a DB-or-input value to int when it's a sane integer-like value; default
+     * to 0 otherwise. ADODB returns numeric columns as strings — `is_numeric` covers
+     * the typical case, and the null-default handles missing keys.
+     */
+    private static function intColumn(mixed $value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_string($value) && is_numeric($value)) {
+            return (int) $value;
+        }
+        return 0;
+    }
+
+    /**
+     * Coerce a DB-or-input value to string when it's a sane string-like value; default
+     * to '' otherwise.
+     */
+    private static function stringColumn(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        return '';
+    }
+}

--- a/src/Controllers/Portal/PortalPasswordHasher.php
+++ b/src/Controllers/Portal/PortalPasswordHasher.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * PortalPasswordHasher — narrow seam over AuthHash::passwordHash for the portal
+ * login controller. Exists so tests can inject a hasher that returns false,
+ * exercising the defensive throw in the controller's password-change branch.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Controllers\Portal;
+
+interface PortalPasswordHasher
+{
+    public function hash(string $plain): string|false;
+}

--- a/src/Controllers/Portal/PortalSessionAccessor.php
+++ b/src/Controllers/Portal/PortalSessionAccessor.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * PortalSessionAccessor — narrow read/write surface over the patient portal session.
+ *
+ * Exists so PatientPortalLoginController doesn't have to call $session->set() / ->remove()
+ * directly, which the upstream phpstan rule `openemr.forbidDirectSessionWrite` rejects:
+ * those methods silently fail on read-and-close sessions, and the production code path
+ * has to route writes through SessionUtil::setSession/unsetSession to auto-reopen the
+ * session lock.
+ *
+ * The interface is testable: the in-memory implementation in
+ * tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php stores values in a
+ * plain array; the production SessionUtilPortalSessionAccessor delegates writes to
+ * SessionUtil and reads to a SessionInterface.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Controllers\Portal;
+
+interface PortalSessionAccessor
+{
+    public function get(string $key, mixed $default = null): mixed;
+
+    public function has(string $key): bool;
+
+    public function set(string $key, mixed $value): void;
+
+    /**
+     * @param array<string, mixed> $kvs
+     */
+    public function setMany(array $kvs): void;
+
+    public function remove(string $key): void;
+
+    /**
+     * @param list<string> $keys
+     */
+    public function removeMany(array $keys): void;
+}

--- a/src/Controllers/Portal/SessionUtilPortalSessionAccessor.php
+++ b/src/Controllers/Portal/SessionUtilPortalSessionAccessor.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * @codeCoverageIgnore — production session adapter; exercised by the e2e suite, not unit tests.
- *
  * SessionUtilPortalSessionAccessor — production PortalSessionAccessor that delegates
  * reads to the supplied SessionInterface and routes writes through SessionUtil, so the
  * portal's read-and-close session lock is reopened correctly on each write.

--- a/src/Controllers/Portal/SessionUtilPortalSessionAccessor.php
+++ b/src/Controllers/Portal/SessionUtilPortalSessionAccessor.php
@@ -1,6 +1,8 @@
 <?php
 
 /**
+ * @codeCoverageIgnore — production session adapter; exercised by the e2e suite, not unit tests.
+ *
  * SessionUtilPortalSessionAccessor — production PortalSessionAccessor that delegates
  * reads to the supplied SessionInterface and routes writes through SessionUtil, so the
  * portal's read-and-close session lock is reopened correctly on each write.

--- a/src/Controllers/Portal/SessionUtilPortalSessionAccessor.php
+++ b/src/Controllers/Portal/SessionUtilPortalSessionAccessor.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * SessionUtilPortalSessionAccessor — production PortalSessionAccessor that delegates
+ * reads to the supplied SessionInterface and routes writes through SessionUtil, so the
+ * portal's read-and-close session lock is reopened correctly on each write.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Controllers\Portal;
+
+use OpenEMR\Common\Session\SessionUtil;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class SessionUtilPortalSessionAccessor implements PortalSessionAccessor
+{
+    public function __construct(
+        private readonly SessionInterface $session,
+    ) {
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->session->get($key, $default);
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->session->has($key);
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        SessionUtil::setSession($key, $value);
+    }
+
+    public function setMany(array $kvs): void
+    {
+        SessionUtil::setSession($kvs);
+    }
+
+    public function remove(string $key): void
+    {
+        SessionUtil::unsetSession($key);
+    }
+
+    public function removeMany(array $keys): void
+    {
+        SessionUtil::unsetSession($keys);
+    }
+}

--- a/src/Controllers/Portal/SqlPortalLoginCredentialsRepository.php
+++ b/src/Controllers/Portal/SqlPortalLoginCredentialsRepository.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * SqlPortalLoginCredentialsRepository — production implementation against the
+ * patient_access_onsite and patient_data tables via QueryUtils.
+ *
+ * The SQL strings and parameter shapes are preserved verbatim from
+ * portal/get_patient_info.php prior to the extraction so the refactor is behavior-
+ * preserving — with one explicit deviation: the legacy script used the deprecated
+ * privQuery/privStatement helpers (which bypass the SQL log to avoid recording
+ * password-related queries). This repository routes those same statements through
+ * QueryUtils with the `noLog` flag set, preserving the audit-omission behavior while
+ * using the non-deprecated API surface.
+ *
+ * Raw DB rows (where the legacy ADODB layer returns every value as a string) are
+ * normalized to the typed shapes declared on PortalLoginCredentialsRepository via
+ * PortalLoginRowNormalizer.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Controllers\Portal;
+
+use OpenEMR\Common\Database\QueryUtils;
+
+class SqlPortalLoginCredentialsRepository implements PortalLoginCredentialsRepository
+{
+    private const FIELDS = 'id, pid, portal_pwd, portal_username, portal_login_username, portal_pwd_status';
+    private const FIELDS_WITH_ONETIME = self::FIELDS . ', portal_onetime';
+
+    /**
+     * @param (callable(int): (array<string, mixed>|false|null))|null $providerLookup
+     *   Resolves a provider user id to display info. The default null means provider info is not
+     *   available (returns null from fetchProviderInfo). The script wires this to the legacy
+     *   `getUserIDInfo` function so this class does not have to reference it directly.
+     */
+    public function __construct(
+        private $providerLookup = null,
+    ) {
+    }
+
+    public function fetchByOneTimeToken(string $token): ?array
+    {
+        $row = QueryUtils::querySingleRow(
+            'SELECT ' . self::FIELDS_WITH_ONETIME . ' FROM patient_access_onsite WHERE BINARY portal_onetime = ?',
+            [$token],
+            false
+        );
+        return is_array($row) ? PortalLoginRowNormalizer::authRow($row, true) : null;
+    }
+
+    public function fetchByLoginUsername(string $loginUsername): ?array
+    {
+        $row = QueryUtils::querySingleRow(
+            'SELECT ' . self::FIELDS . ' FROM patient_access_onsite WHERE portal_login_username = ?',
+            [$loginUsername],
+            false
+        );
+        return is_array($row) ? PortalLoginRowNormalizer::authRow($row, false) : null;
+    }
+
+    public function fetchByUsername(string $username): ?array
+    {
+        $row = QueryUtils::querySingleRow(
+            'SELECT ' . self::FIELDS . ' FROM patient_access_onsite WHERE portal_username = ?',
+            [$username],
+            false
+        );
+        return is_array($row) ? PortalLoginRowNormalizer::authRow($row, false) : null;
+    }
+
+    public function clearOneTimeToken(string $token): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE patient_access_onsite SET portal_onetime=NULL WHERE BINARY portal_onetime = ?',
+            [$token],
+            true
+        );
+    }
+
+    public function updatePasswordHash(int $id, string $newHash): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE patient_access_onsite SET portal_pwd = ? WHERE id = ?',
+            [$newHash, $id],
+            true
+        );
+    }
+
+    public function updateLoginAndPassword(int $id, string $loginUsername, string $newHash): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE patient_access_onsite  SET portal_login_username=?, portal_pwd=?, portal_pwd_status=1 WHERE id=?',
+            [$loginUsername, $newHash, $id],
+            true
+        );
+    }
+
+    public function fetchPatientData(int $pid): ?array
+    {
+        $row = QueryUtils::querySingleRow('SELECT * FROM `patient_data` WHERE `pid` = ?', [$pid]);
+        if (!is_array($row) || $row === []) {
+            return null;
+        }
+        return PortalLoginRowNormalizer::patientDataRow($row);
+    }
+
+    public function fetchProviderInfo(int $providerId): ?array
+    {
+        if ($providerId === 0 || $this->providerLookup === null) {
+            return null;
+        }
+        $row = ($this->providerLookup)($providerId);
+        if (!is_array($row) || $row === []) {
+            return null;
+        }
+        return PortalLoginRowNormalizer::providerInfoRow($row);
+    }
+}

--- a/src/Controllers/Portal/SqlPortalLoginCredentialsRepository.php
+++ b/src/Controllers/Portal/SqlPortalLoginCredentialsRepository.php
@@ -33,14 +33,14 @@ class SqlPortalLoginCredentialsRepository implements PortalLoginCredentialsRepos
     private const FIELDS_WITH_ONETIME = self::FIELDS . ', portal_onetime';
 
     /**
-     * @param (callable(int): mixed)|null $providerLookup
+     * @param \Closure(int): mixed|null $providerLookup
      *   Resolves a provider user id to display info. The default null means provider info is not
      *   available (returns null from fetchProviderInfo). The script wires this to
-     *   UserSettingsService::getUserIDInfo. Return is `mixed` because the underlying lookup is
+     *   UserSettingsService::getUserIDInfo(...). Return is `mixed` because the underlying lookup is
      *   untyped; fetchProviderInfo narrows with is_array() before passing through the normaliser.
      */
     public function __construct(
-        private $providerLookup = null,
+        private readonly ?\Closure $providerLookup = null,
     ) {
     }
 

--- a/src/Controllers/Portal/SqlPortalLoginCredentialsRepository.php
+++ b/src/Controllers/Portal/SqlPortalLoginCredentialsRepository.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * @codeCoverageIgnore — production SQL adapter; exercised by the e2e suite, not unit tests.
- *
  * SqlPortalLoginCredentialsRepository — production implementation against the
  * patient_access_onsite and patient_data tables via QueryUtils.
  *

--- a/src/Controllers/Portal/SqlPortalLoginCredentialsRepository.php
+++ b/src/Controllers/Portal/SqlPortalLoginCredentialsRepository.php
@@ -33,10 +33,11 @@ class SqlPortalLoginCredentialsRepository implements PortalLoginCredentialsRepos
     private const FIELDS_WITH_ONETIME = self::FIELDS . ', portal_onetime';
 
     /**
-     * @param (callable(int): (array<string, mixed>|false|null))|null $providerLookup
+     * @param (callable(int): mixed)|null $providerLookup
      *   Resolves a provider user id to display info. The default null means provider info is not
-     *   available (returns null from fetchProviderInfo). The script wires this to the legacy
-     *   `getUserIDInfo` function so this class does not have to reference it directly.
+     *   available (returns null from fetchProviderInfo). The script wires this to
+     *   UserSettingsService::getUserIDInfo. Return is `mixed` because the underlying lookup is
+     *   untyped; fetchProviderInfo narrows with is_array() before passing through the normaliser.
      */
     public function __construct(
         private $providerLookup = null,

--- a/src/Controllers/Portal/SqlPortalLoginCredentialsRepository.php
+++ b/src/Controllers/Portal/SqlPortalLoginCredentialsRepository.php
@@ -1,6 +1,8 @@
 <?php
 
 /**
+ * @codeCoverageIgnore — production SQL adapter; exercised by the e2e suite, not unit tests.
+ *
  * SqlPortalLoginCredentialsRepository — production implementation against the
  * patient_access_onsite and patient_data tables via QueryUtils.
  *

--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -245,10 +245,20 @@ class ModulesApplication
             $projectDir = $globalsBag->getProjectDir();
             $webRoot = $globalsBag->getWebRoot();
             $moduleRootLocation = self::getModuleRootRealpath();
+            // realpath() of the modules directory can fail (missing tree, permissions);
+            // without a module root, nothing can be on the safelist.
+            if ($moduleRootLocation === false) {
+                return [];
+            }
             $filteredFiles = array_filter(array_map(function ($scriptSrc) use ($projectDir, $webRoot, $moduleRootLocation) {
                 // scripts that have any kind of parameters in them such as a cache buster mess up finding the real path
                 // we need to strip that out and then check against the real path
                 $scriptSrcPath = parse_url($scriptSrc, PHP_URL_PATH);
+                // parse_url returns null/false for malformed inputs (e.g. an absolute URL
+                // with no path, or a non-string $scriptSrc); fail closed for those cases.
+                if (!is_string($scriptSrcPath) || $scriptSrcPath === '') {
+                    return null;
+                }
                 // need to remove the web root as that is included in the $scriptSrc and also in the fileroot
                 $pos = stripos($scriptSrcPath, $webRoot);
                 if ($pos !== false) {

--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -251,11 +251,16 @@ class ModulesApplication
                 return [];
             }
             $filteredFiles = array_filter(array_map(function ($scriptSrc) use ($projectDir, $webRoot, $moduleRootLocation) {
+                // Callers can pass arbitrary array elements; parse_url would raise TypeError
+                // on a non-string. Fail closed before touching anything else.
+                if (!is_string($scriptSrc)) {
+                    return null;
+                }
                 // scripts that have any kind of parameters in them such as a cache buster mess up finding the real path
                 // we need to strip that out and then check against the real path
                 $scriptSrcPath = parse_url($scriptSrc, PHP_URL_PATH);
                 // parse_url returns null/false for malformed inputs (e.g. an absolute URL
-                // with no path, or a non-string $scriptSrc); fail closed for those cases.
+                // with no path); fail closed for those too.
                 if (!is_string($scriptSrcPath) || $scriptSrcPath === '') {
                     return null;
                 }

--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -258,6 +258,13 @@ class ModulesApplication
                 }
                 $realPath = realpath($projectDir . $scriptSrcPathWithoutWebroot);
 
+                // realpath returns false for non-existent paths (e.g. an attacker-controlled
+                // redirect like /etc/passwd that doesn't resolve under the modules tree);
+                // bail before str_starts_with raises TypeError on the false argument.
+                if ($realPath === false) {
+                    return null;
+                }
+
                 // make sure we haven't left our root path ie interface folder
                 if (str_starts_with($realPath, $moduleRootLocation) && file_exists($realPath)) {
                     return $scriptSrc;

--- a/tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php
+++ b/tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php
@@ -385,7 +385,7 @@ class PatientPortalLoginControllerTest extends TestCase
         $this->assertStringContainsString(':success', $result->portalLogArgs[2]);
     }
 
-    public function testSuccessfulLoginHonorsSafeRedirectAndSkipsCacheHeaders(): void
+    public function testUnsafeRedirectFallsBackToHomeWithCacheHeaders(): void
     {
         $this->session->set('itsme', 1);
         $this->repo->stubByLoginUsername['alice_login'] = $this->seededAuth();
@@ -393,9 +393,10 @@ class PatientPortalLoginControllerTest extends TestCase
         $this->repo->stubProviderInfo[11] = ['fname' => 'Dr', 'lname' => 'Who', 'username' => 'drwho'];
 
         // ModulesApplication::filterSafeLocalModuleFiles will reject this unknown path and
-        // strip it; the success path then falls back to ./home.php. That's the safe behavior:
-        // a malicious redirect param can't escape the modules safelist, and the test asserts
-        // the safelist is consulted.
+        // strip it; the success path then falls back to ./home.php (which DOES set the
+        // legacy no-cache headers, matching the original script's behaviour). The test
+        // asserts the safelist is consulted: a malicious redirect param can't escape
+        // through to the user.
         $result = $this->controller->login(
             self::SITE,
             ['uname' => 'alice_login', 'pass' => 'goodpass'],

--- a/tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php
+++ b/tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php
@@ -68,7 +68,7 @@ class PatientPortalLoginControllerTest extends TestCase
     {
         $hash = (new AuthHash())->passwordHash($passwordPlain);
         if (!is_string($hash)) {
-            $this->fail('AuthHash::passwordHash unexpectedly returned non-string in test fixture');
+            $this->fail('AuthHash::passwordHash unexpectedly returned non-string in test fixture'); // @codeCoverageIgnore
         }
         return [
             'id' => 7,
@@ -383,6 +383,169 @@ class PatientPortalLoginControllerTest extends TestCase
         $this->assertSame(self::PID, $result->portalLogArgs[1]);
         $this->assertIsString($result->portalLogArgs[2]);
         $this->assertStringContainsString(':success', $result->portalLogArgs[2]);
+    }
+
+    // ---------------------------------------------------------------------
+    // Additional branch coverage
+    // ---------------------------------------------------------------------
+
+    public function testLanguageChoiceFromPostOverridesSession(): void
+    {
+        $this->session->set('itsme', 1);
+        $this->session->set('language_choice', 7);
+
+        $this->controller->login(
+            self::SITE,
+            ['languageChoice' => '3'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame(3, $this->session->get('language_choice'));
+    }
+
+    public function testRedirectsSilentlyWhenAuthPidMismatchesPatientDataPid(): void
+    {
+        $this->session->set('itsme', 1);
+        $auth = $this->seededAuth();
+        $auth['pid'] = 99; // mismatched
+        $this->repo->stubByLoginUsername['alice_login'] = $auth;
+        // patient_data fixture is keyed at pid=99 because that's the lookup pid the
+        // controller will use (it joins via $auth['pid']); set userData with the WRONG
+        // mirror pid 42 to trigger the defensive guard.
+        $this->repo->stubPatientData[99] = $this->seededPatientData();
+        $this->repo->stubPatientData[99]['pid'] = 42;
+
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'alice_login', 'pass' => 'goodpass'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('index.php?site=default&w', $result->redirectUrl);
+        $this->assertTrue($result->destroySessionCookie);
+        $this->assertSame([], $this->log->calls, 'pid-mismatch guard is silent (no audit)');
+    }
+
+    public function testMismatchedNewPasswordsLeavesAuthorisationFalseAndLogsNotAuthorized(): void
+    {
+        // pwd_status=1 + passwordUpdate mode set, but new passwords don't match -> the
+        // change-flow doesn't run, but pwd_status==1 makes $authorizedPortal true and the
+        // patient logs in normally. To exercise the "!authorizedPortal" terminal log, use
+        // pwd_status=0 with mismatched pass_new so neither branch sets $authorizedPortal=true.
+        // The earlier-line pwd_status==0 bounce-back is also gated by !$authorizedPortal,
+        // so we'd hit THAT — not the terminal log. The legacy behaviour for "mismatched
+        // pass_new under pwd_status=0" is therefore "go back to the password-change form,"
+        // and we cover the terminal-log path differently: with pwd_status set to neither
+        // 0 nor 1 (a forced "in-between" state that the password-change attempt fails to
+        // resolve).
+        $this->session->set('itsme', 1);
+        $this->session->set('password_update', 1);
+        $auth = $this->seededAuth();
+        $auth['portal_pwd_status'] = 2; // neither 0 nor 1 — exercises the terminal !authorizedPortal
+        $this->repo->stubByUsername['alice'] = $auth;
+        $this->repo->stubPatientData[self::PID] = $this->seededPatientData();
+
+        $result = $this->controller->login(
+            self::SITE,
+            [
+                'uname' => 'alice',
+                'pass' => 'goodpass',
+                'pass_new' => 'NewPass123!',
+                'pass_new_confirm' => 'Different!',
+                'login_uname' => 'alice_login',
+            ],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('index.php?site=default&w', $result->redirectUrl);
+        $this->assertTrue($result->destroySessionCookie);
+        $this->assertSame('login', $this->log->calls[0]['event']);
+        $this->assertSame('alice:not authorized', $this->log->calls[0]['comments']);
+    }
+
+    public function testSuccessfulLoginWithMissingProviderInfoFallsBackToBlanks(): void
+    {
+        $this->session->set('itsme', 1);
+        $this->repo->stubByLoginUsername['alice_login'] = $this->seededAuth();
+        $this->repo->stubPatientData[self::PID] = $this->seededPatientData();
+        // No provider info stub — fetchProviderInfo returns null; controller falls back.
+
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'alice_login', 'pass' => 'goodpass'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('./home.php', $result->redirectUrl);
+        $this->assertSame(' ', $this->session->get('providerName'), 'fname + space + lname; both empty');
+        $this->assertNull($this->session->get('providerUName'));
+    }
+
+    public function testOneTimePinResetHappyPath(): void
+    {
+        // Patient is in the one-time PIN reset flow: the session carries the PIN they
+        // received out-of-band plus the `forward` token; the row is keyed by portal_onetime.
+        $this->session->set('itsme', 1);
+        $this->session->set('password_update', 2);
+        $this->session->set('pin', '987654');
+        // portal_onetime is 32 chars of opaque + 6 chars of validate-PIN appended.
+        $oneTimeToken = str_repeat('a', 32) . '987654';
+        $this->session->set('forward', $oneTimeToken);
+
+        $auth = $this->seededAuth();
+        $auth['portal_pwd'] = 'plaintext-pin-mode-pwd'; // mode 2 compares column directly
+        $auth['portal_onetime'] = $oneTimeToken;
+        $this->repo->stubByOneTimeToken[$oneTimeToken] = $auth;
+        $this->repo->stubPatientData[self::PID] = $this->seededPatientData();
+        $this->repo->stubProviderInfo[11] = ['fname' => 'Dr', 'lname' => 'Who', 'username' => 'drwho'];
+
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'alice', 'pass' => 'plaintext-pin-mode-pwd', 'token_pin' => '987654'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('./home.php', $result->redirectUrl);
+        $this->assertSame(self::PID, $this->session->get('pid'), 'PIN-reset login establishes the session');
+        $this->assertSame([$oneTimeToken], $this->repo->clearedOneTimeTokens, 'PIN-reset token consumed');
+        $this->assertFalse($this->session->has('forward'), 'forward cleared post-PIN');
+        $this->assertFalse($this->session->has('pin'), 'pin cleared post-PIN');
+    }
+
+    public function testOneTimePinResetInvalidPinRejected(): void
+    {
+        $this->session->set('itsme', 1);
+        $this->session->set('password_update', 2);
+        $this->session->set('pin', '987654');
+        $oneTimeToken = str_repeat('a', 32) . '987654';
+        $this->session->set('forward', $oneTimeToken);
+
+        $auth = $this->seededAuth();
+        $auth['portal_pwd'] = 'pwd';
+        $auth['portal_onetime'] = $oneTimeToken;
+        $this->repo->stubByOneTimeToken[$oneTimeToken] = $auth;
+
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'alice', 'pass' => 'pwd', 'token_pin' => '111111'], // wrong PIN
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('index.php?site=default&w&u', $result->redirectUrl);
+        $this->assertSame([$oneTimeToken], $this->repo->clearedOneTimeTokens, 'token consumed regardless of PIN validity');
+        $this->assertSame('alice:invalid username', $this->log->calls[0]['comments']);
     }
 
     public function testUnsafeRedirectFallsBackToHomeWithCacheHeaders(): void

--- a/tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php
+++ b/tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php
@@ -38,6 +38,7 @@ class PatientPortalLoginControllerTest extends TestCase
     private RecordingPortalAuditLogger $log;
     private OEGlobalsBag $globalsBag;
     private PatientPortalLoginController $controller;
+    private bool $originalEnforceSigninEmail;
 
     private const PID = 42;
     private const SITE = 'default';
@@ -48,8 +49,10 @@ class PatientPortalLoginControllerTest extends TestCase
         $this->session = new InMemoryPortalSessionAccessor();
         $this->repo = new InMemoryPortalLoginCredentialsRepository();
         $this->log = new RecordingPortalAuditLogger();
-        // Reset OEGlobalsBag to a known-empty state for the test.
         $this->globalsBag = OEGlobalsBag::getInstance();
+        // Capture the singleton's prior value so tearDown can restore it instead of
+        // overwriting whatever the surrounding suite had configured.
+        $this->originalEnforceSigninEmail = $this->globalsBag->getBoolean('enforce_signin_email');
         $this->globalsBag->set('enforce_signin_email', null);
         $this->controller = new PatientPortalLoginController($this->repo, $this->log);
     }
@@ -57,7 +60,7 @@ class PatientPortalLoginControllerTest extends TestCase
     protected function tearDown(): void
     {
         unset($_SESSION['csrf_private_key']);
-        $this->globalsBag->set('enforce_signin_email', null);
+        $this->globalsBag->set('enforce_signin_email', $this->originalEnforceSigninEmail);
         parent::tearDown();
     }
 

--- a/tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php
+++ b/tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php
@@ -1,0 +1,543 @@
+<?php
+
+/**
+ * PatientPortalLoginControllerTest — characterization tests for every branch of the
+ * patient portal login flow, exercising the controller with an in-memory credentials
+ * repository and an in-memory session.
+ *
+ * These tests lock in the existing behavior of portal/get_patient_info.php so future
+ * changes can be verified against a baseline.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Unit\Portal;
+
+use OpenEMR\Common\Auth\AuthHash;
+use OpenEMR\Controllers\Portal\PatientPortalLoginController;
+use OpenEMR\Controllers\Portal\PortalAuditLogger;
+use OpenEMR\Controllers\Portal\PortalLoginCredentialsRepository;
+use OpenEMR\Controllers\Portal\PortalSessionAccessor;
+use OpenEMR\Core\OEGlobalsBag;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @phpstan-import-type PatientAccessOnsiteRow from PortalLoginCredentialsRepository
+ * @phpstan-import-type PatientDataRow from PortalLoginCredentialsRepository
+ * @phpstan-import-type ProviderInfoRow from PortalLoginCredentialsRepository
+ */
+
+class PatientPortalLoginControllerTest extends TestCase
+{
+    private InMemoryPortalSessionAccessor $session;
+    private InMemoryPortalLoginCredentialsRepository $repo;
+    private RecordingPortalAuditLogger $log;
+    private OEGlobalsBag $globalsBag;
+    private PatientPortalLoginController $controller;
+
+    private const PID = 42;
+    private const SITE = 'default';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->session = new InMemoryPortalSessionAccessor();
+        $this->repo = new InMemoryPortalLoginCredentialsRepository();
+        $this->log = new RecordingPortalAuditLogger();
+        // Reset OEGlobalsBag to a known-empty state for the test.
+        $this->globalsBag = OEGlobalsBag::getInstance();
+        $this->globalsBag->set('enforce_signin_email', null);
+        $this->controller = new PatientPortalLoginController($this->repo, $this->log);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SESSION['csrf_private_key']);
+        $this->globalsBag->set('enforce_signin_email', null);
+        parent::tearDown();
+    }
+
+    /**
+     * @return PatientAccessOnsiteRow
+     */
+    private function seededAuth(string $passwordPlain = 'goodpass'): array
+    {
+        $hash = (new AuthHash())->passwordHash($passwordPlain);
+        if (!is_string($hash)) {
+            $this->fail('AuthHash::passwordHash unexpectedly returned non-string in test fixture');
+        }
+        return [
+            'id' => 7,
+            'pid' => self::PID,
+            'portal_pwd' => $hash,
+            'portal_username' => 'alice',
+            'portal_login_username' => 'alice_login',
+            'portal_pwd_status' => 1,
+        ];
+    }
+
+    /**
+     * @return PatientDataRow
+     */
+    private function seededPatientData(string $email = 'alice@example.com', string $allowPortal = 'YES'): array
+    {
+        return [
+            'pid' => self::PID,
+            'fname' => 'Alice',
+            'lname' => 'Smith',
+            'email' => $email,
+            'providerID' => 11,
+            'allow_patient_portal' => $allowPortal,
+        ];
+    }
+
+    // ---------------------------------------------------------------------
+    // Pre-auth gates
+    // ---------------------------------------------------------------------
+
+    public function testRedirectsToErrorWhenItsmeSessionMarkerAbsent(): void
+    {
+        $result = $this->controller->login(self::SITE, [], [], $this->session, $this->globalsBag);
+
+        $this->assertStringEndsWith('&w', $result->redirectUrl);
+        $this->assertSame('index.php?site=default&w', $result->redirectUrl);
+        $this->assertTrue($result->destroySessionCookie);
+        $this->assertNull($result->portalLogArgs);
+        $this->assertSame([], $this->log->calls, 'No audit entry on anti-CSRF gate');
+    }
+
+    public function testRedirectsWithChangedWhenUsernameMissing(): void
+    {
+        $this->session->set('itsme', 1);
+        $result = $this->controller->login(self::SITE, ['pass' => 'x'], [], $this->session, $this->globalsBag);
+        $this->assertSame('index.php?site=default&w&c', $result->redirectUrl);
+        $this->assertTrue($result->destroySessionCookie);
+        $this->assertSame([], $this->log->calls);
+    }
+
+    public function testRedirectsWithChangedWhenPasswordMissing(): void
+    {
+        $this->session->set('itsme', 1);
+        $result = $this->controller->login(self::SITE, ['uname' => 'x'], [], $this->session, $this->globalsBag);
+        $this->assertSame('index.php?site=default&w&c', $result->redirectUrl);
+    }
+
+    public function testRedirectsWithChangedWhenEmailEnforcedButMissing(): void
+    {
+        $this->session->set('itsme', 1);
+        $this->globalsBag->set('enforce_signin_email', true);
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'x', 'pass' => 'y'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+        $this->assertSame('index.php?site=default&w&c', $result->redirectUrl);
+    }
+
+    public function testIncludesRedirectQueryStringInLandingPage(): void
+    {
+        $this->session->set('itsme', 1);
+        $result = $this->controller->login(
+            self::SITE,
+            [],
+            ['redirect' => 'foo/bar.php'],
+            $this->session,
+            $this->globalsBag
+        );
+        $this->assertStringContainsString('&redirect=foo%2Fbar.php', $result->redirectUrl);
+    }
+
+    // ---------------------------------------------------------------------
+    // Credential failures
+    // ---------------------------------------------------------------------
+
+    public function testRedirectsWithInvalidUsernameWhenLookupReturnsNothing(): void
+    {
+        $this->session->set('itsme', 1);
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'nope', 'pass' => 'x'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+        $this->assertSame('index.php?site=default&w&u', $result->redirectUrl);
+        $this->assertTrue($result->destroySessionCookie);
+        $this->assertCount(1, $this->log->calls);
+        $this->assertSame('login attempt', $this->log->calls[0]['event']);
+        $this->assertSame('nope:invalid username', $this->log->calls[0]['comments']);
+        $this->assertSame('0', $this->log->calls[0]['success']);
+    }
+
+    public function testRedirectsWithInvalidPasswordWhenHashFailsToVerify(): void
+    {
+        $this->session->set('itsme', 1);
+        $this->repo->stubByLoginUsername['alice_login'] = $this->seededAuth('goodpass');
+
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'alice_login', 'pass' => 'wrongpass'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('index.php?site=default&w&p', $result->redirectUrl);
+        $this->assertTrue($result->destroySessionCookie);
+        $this->assertSame('alice_login:invalid password', $this->log->calls[0]['comments']);
+    }
+
+    public function testRehashesPasswordWhenHashAlgorithmNeedsUpgrade(): void
+    {
+        $this->session->set('itsme', 1);
+        // A bcrypt cost-4 hash will be considered in need of rehash by modern AuthHash settings.
+        $weakHash = password_hash('goodpass', PASSWORD_BCRYPT, ['cost' => 4]);
+        $auth = $this->seededAuth();
+        $auth['portal_pwd'] = $weakHash;
+        $this->repo->stubByLoginUsername['alice_login'] = $auth;
+        $this->repo->stubPatientData[self::PID] = $this->seededPatientData();
+        $this->repo->stubProviderInfo[11] = ['fname' => 'Dr', 'lname' => 'Who', 'username' => 'drwho'];
+
+        $this->controller->login(
+            self::SITE,
+            ['uname' => 'alice_login', 'pass' => 'goodpass'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertCount(1, $this->repo->passwordHashUpdates, 'A rehash should be persisted');
+        $this->assertSame(7, $this->repo->passwordHashUpdates[0]['id']);
+        $this->assertNotSame($weakHash, $this->repo->passwordHashUpdates[0]['hash']);
+    }
+
+    // ---------------------------------------------------------------------
+    // Patient-data branch
+    // ---------------------------------------------------------------------
+
+    public function testRedirectsWhenPatientDataLookupReturnsNothing(): void
+    {
+        $this->session->set('itsme', 1);
+        $this->repo->stubByLoginUsername['alice_login'] = $this->seededAuth();
+        // No patient_data row seeded.
+
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'alice_login', 'pass' => 'goodpass'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('index.php?site=default&w', $result->redirectUrl);
+        $this->assertTrue($result->destroySessionCookie);
+        $this->assertSame([], $this->log->calls, 'No audit entry on patient_data-missing path');
+    }
+
+    public function testRedirectsWhenEmailDoesNotMatchAndEnforcementOn(): void
+    {
+        $this->session->set('itsme', 1);
+        $this->globalsBag->set('enforce_signin_email', true);
+        $this->repo->stubByLoginUsername['alice_login'] = $this->seededAuth();
+        $this->repo->stubPatientData[self::PID] = $this->seededPatientData('alice@example.com');
+
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'alice_login', 'pass' => 'goodpass', 'passaddon' => 'wrong@example.com'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('index.php?site=default&w', $result->redirectUrl);
+        $this->assertSame('alice_login:invalid email', $this->log->calls[0]['comments']);
+    }
+
+    public function testRedirectsWhenAllowPatientPortalIsDisabled(): void
+    {
+        $this->session->set('itsme', 1);
+        $this->repo->stubByLoginUsername['alice_login'] = $this->seededAuth();
+        $this->repo->stubPatientData[self::PID] = $this->seededPatientData('alice@example.com', 'NO');
+
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'alice_login', 'pass' => 'goodpass'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('index.php?site=default&w', $result->redirectUrl);
+        $this->assertSame('alice_login:allow portal turned off', $this->log->calls[0]['comments']);
+    }
+
+    // ---------------------------------------------------------------------
+    // Password-change-required flow
+    // ---------------------------------------------------------------------
+
+    public function testRedirectsToPasswordChangeFormWhenPwdStatusZeroAndNoChangeAttempt(): void
+    {
+        $this->session->set('itsme', 1);
+        $auth = $this->seededAuth();
+        $auth['portal_pwd_status'] = 0;
+        $this->repo->stubByLoginUsername['alice_login'] = $auth;
+        $this->repo->stubPatientData[self::PID] = $this->seededPatientData();
+
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'alice_login', 'pass' => 'goodpass'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('index.php?site=default', $result->redirectUrl, 'Bare landing, no &w');
+        $this->assertFalse($result->destroySessionCookie, 'Session preserved for the change-form round-trip');
+        $this->assertSame(1, $this->session->get('password_update'), 'Mode 1 set for the next POST');
+    }
+
+    public function testCompletesPasswordChangeWhenNewPasswordsMatch(): void
+    {
+        // Patient was previously bounced to the change form; now POSTing the new password.
+        $this->session->set('itsme', 1);
+        $this->session->set('password_update', 1);
+        $auth = $this->seededAuth();
+        $auth['portal_pwd_status'] = 0;
+        $this->repo->stubByUsername['alice'] = $auth;  // mode 1 looks up by portal_username
+        $this->repo->stubPatientData[self::PID] = $this->seededPatientData();
+        $this->repo->stubProviderInfo[11] = ['fname' => 'Dr', 'lname' => 'Who', 'username' => 'drwho'];
+
+        $result = $this->controller->login(
+            self::SITE,
+            [
+                'uname' => 'alice',
+                'pass' => 'goodpass',
+                'pass_new' => 'NewPass123!',
+                'pass_new_confirm' => 'NewPass123!',
+                'login_uname' => 'alice_login',
+            ],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('./home.php', $result->redirectUrl, 'Successful login after password change');
+        $this->assertCount(1, $this->repo->loginAndPasswordUpdates);
+        $this->assertSame('alice_login', $this->repo->loginAndPasswordUpdates[0]['login']);
+
+        // The mid-flow "password update" audit and the final-state "login success" audit both fire.
+        $eventNames = array_column($this->log->calls, 'event');
+        $this->assertContains('password update', $eventNames);
+        $this->assertNotNull($result->portalLogArgs);
+        $this->assertSame('login', $result->portalLogArgs[0]);
+    }
+
+    // ---------------------------------------------------------------------
+    // Successful login
+    // ---------------------------------------------------------------------
+
+    public function testSuccessfulLoginEstablishesSessionAndReturnsHomeRedirect(): void
+    {
+        $this->session->set('itsme', 1);
+        $this->repo->stubByLoginUsername['alice_login'] = $this->seededAuth();
+        $this->repo->stubPatientData[self::PID] = $this->seededPatientData();
+        $this->repo->stubProviderInfo[11] = ['fname' => 'Dr', 'lname' => 'Who', 'username' => 'drwho'];
+
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'alice_login', 'pass' => 'goodpass'],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('./home.php', $result->redirectUrl);
+        $this->assertFalse($result->destroySessionCookie);
+        $this->assertTrue($result->sendNoCacheHeaders, 'home.php redirect should set the cache-disable headers');
+        $this->assertTrue($result->establishCsrf, 'successful login result asks the caller to set up CSRF');
+
+        // Session keys established.
+        $this->assertSame(self::PID, $this->session->get('pid'));
+        $this->assertSame(1, $this->session->get('patient_portal_onsite_two'));
+        $this->assertSame('Dr Who', $this->session->get('providerName'));
+        $this->assertSame('drwho', $this->session->get('providerUName'));
+        $this->assertSame('-patient-', $this->session->get('sessionUser'));
+        $this->assertSame(11, $this->session->get('providerId'));
+        $this->assertSame('Alice Smith', $this->session->get('ptName'));
+        $this->assertSame('portal-user', $this->session->get('authUser'));
+        $this->assertSame('alice', $this->session->get('portal_username'));
+        $this->assertSame('alice_login', $this->session->get('portal_login_username'));
+
+        // itsme cleared post-establishment.
+        $this->assertFalse($this->session->has('itsme'));
+
+        // Final-state log carried in result, not yet emitted by the controller.
+        $this->assertNotNull($result->portalLogArgs);
+        $this->assertSame('login', $result->portalLogArgs[0]);
+        $this->assertSame(self::PID, $result->portalLogArgs[1]);
+        $this->assertIsString($result->portalLogArgs[2]);
+        $this->assertStringContainsString(':success', $result->portalLogArgs[2]);
+    }
+
+    public function testSuccessfulLoginHonorsSafeRedirectAndSkipsCacheHeaders(): void
+    {
+        $this->session->set('itsme', 1);
+        $this->repo->stubByLoginUsername['alice_login'] = $this->seededAuth();
+        $this->repo->stubPatientData[self::PID] = $this->seededPatientData();
+        $this->repo->stubProviderInfo[11] = ['fname' => 'Dr', 'lname' => 'Who', 'username' => 'drwho'];
+
+        // ModulesApplication::filterSafeLocalModuleFiles will reject this unknown path and
+        // strip it; the success path then falls back to ./home.php. That's the safe behavior:
+        // a malicious redirect param can't escape the modules safelist, and the test asserts
+        // the safelist is consulted.
+        $result = $this->controller->login(
+            self::SITE,
+            ['uname' => 'alice_login', 'pass' => 'goodpass'],
+            ['redirect' => '/etc/passwd'],
+            $this->session,
+            $this->globalsBag
+        );
+
+        $this->assertSame('./home.php', $result->redirectUrl);
+        $this->assertTrue($result->sendNoCacheHeaders);
+    }
+}
+
+/**
+ * In-memory PortalLoginCredentialsRepository for tests.
+ */
+/**
+ * @phpstan-import-type PatientAccessOnsiteRow from PortalLoginCredentialsRepository
+ * @phpstan-import-type PatientDataRow from PortalLoginCredentialsRepository
+ * @phpstan-import-type ProviderInfoRow from PortalLoginCredentialsRepository
+ */
+final class InMemoryPortalLoginCredentialsRepository implements PortalLoginCredentialsRepository
+{
+    /** @var array<string, PatientAccessOnsiteRow> */
+    public array $stubByOneTimeToken = [];
+    /** @var array<string, PatientAccessOnsiteRow> */
+    public array $stubByLoginUsername = [];
+    /** @var array<string, PatientAccessOnsiteRow> */
+    public array $stubByUsername = [];
+    /** @var array<int, PatientDataRow> */
+    public array $stubPatientData = [];
+    /** @var array<int, ProviderInfoRow> */
+    public array $stubProviderInfo = [];
+
+    /** @var list<string> */
+    public array $clearedOneTimeTokens = [];
+    /** @var list<array{id: int, hash: string}> */
+    public array $passwordHashUpdates = [];
+    /** @var list<array{id: int, login: string, hash: string}> */
+    public array $loginAndPasswordUpdates = [];
+
+    public function fetchByOneTimeToken(string $token): ?array
+    {
+        return $this->stubByOneTimeToken[$token] ?? null;
+    }
+
+    public function fetchByLoginUsername(string $loginUsername): ?array
+    {
+        return $this->stubByLoginUsername[$loginUsername] ?? null;
+    }
+
+    public function fetchByUsername(string $username): ?array
+    {
+        return $this->stubByUsername[$username] ?? null;
+    }
+
+    public function clearOneTimeToken(string $token): void
+    {
+        $this->clearedOneTimeTokens[] = $token;
+    }
+
+    public function updatePasswordHash(int $id, string $newHash): void
+    {
+        $this->passwordHashUpdates[] = ['id' => $id, 'hash' => $newHash];
+    }
+
+    public function updateLoginAndPassword(int $id, string $loginUsername, string $newHash): void
+    {
+        $this->loginAndPasswordUpdates[] = ['id' => $id, 'login' => $loginUsername, 'hash' => $newHash];
+    }
+
+    public function fetchPatientData(int $pid): ?array
+    {
+        return $this->stubPatientData[$pid] ?? null;
+    }
+
+    public function fetchProviderInfo(int $providerId): ?array
+    {
+        return $this->stubProviderInfo[$providerId] ?? null;
+    }
+}
+
+/**
+ * Recording PortalAuditLogger that captures every portalLog call for assertions.
+ */
+final class RecordingPortalAuditLogger implements PortalAuditLogger
+{
+    /** @var list<array{event: string, patientId: mixed, comments: string, binds: string, success: string}> */
+    public array $calls = [];
+
+    public function portalLog(string $event, $patientId, string $comments, string $binds = '', string $success = '1'): void
+    {
+        $this->calls[] = [
+            'event' => $event,
+            'patientId' => $patientId,
+            'comments' => $comments,
+            'binds' => $binds,
+            'success' => $success,
+        ];
+    }
+}
+
+/**
+ * In-memory PortalSessionAccessor for tests. Stores everything in a plain array and
+ * records mutations so tests can assert against the final state.
+ */
+final class InMemoryPortalSessionAccessor implements PortalSessionAccessor
+{
+    /** @var array<string, mixed> */
+    private array $data = [];
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->data[$key] ?? $default;
+    }
+
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->data);
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        $this->data[$key] = $value;
+    }
+
+    public function setMany(array $kvs): void
+    {
+        foreach ($kvs as $key => $value) {
+            $this->data[$key] = $value;
+        }
+    }
+
+    public function remove(string $key): void
+    {
+        unset($this->data[$key]);
+    }
+
+    public function removeMany(array $keys): void
+    {
+        foreach ($keys as $key) {
+            unset($this->data[$key]);
+        }
+    }
+}

--- a/tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php
+++ b/tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php
@@ -338,6 +338,45 @@ class PatientPortalLoginControllerTest extends TestCase
         $this->assertSame('login', $result->portalLogArgs[0]);
     }
 
+    public function testPasswordChangeThrowsWhenHasherReturnsFalse(): void
+    {
+        // Inject a hasher that fails so the defensive throw in the password-change branch fires.
+        $controller = new PatientPortalLoginController(
+            $this->repo,
+            $this->log,
+            new class implements \OpenEMR\Controllers\Portal\PortalPasswordHasher {
+                public function hash(string $plain): string|false
+                {
+                    return false;
+                }
+            },
+        );
+
+        $this->session->set('itsme', 1);
+        $this->session->set('password_update', 1);
+        $auth = $this->seededAuth();
+        $auth['portal_pwd_status'] = 0;
+        $this->repo->stubByUsername['alice'] = $auth;
+        $this->repo->stubPatientData[self::PID] = $this->seededPatientData();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('OpenEMR is not working because unable to create a hash.');
+
+        $controller->login(
+            self::SITE,
+            [
+                'uname' => 'alice',
+                'pass' => 'goodpass',
+                'pass_new' => 'NewPass123!',
+                'pass_new_confirm' => 'NewPass123!',
+                'login_uname' => 'alice_login',
+            ],
+            [],
+            $this->session,
+            $this->globalsBag
+        );
+    }
+
     // ---------------------------------------------------------------------
     // Successful login
     // ---------------------------------------------------------------------

--- a/tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php
+++ b/tests/Tests/Unit/Portal/PatientPortalLoginControllerTest.php
@@ -394,9 +394,11 @@ class PatientPortalLoginControllerTest extends TestCase
         $this->session->set('itsme', 1);
         $this->session->set('language_choice', 7);
 
+        // uname/pass are required to get past the presence-check bail; the
+        // credentials don't have to validate — language is set before lookupAuth runs.
         $this->controller->login(
             self::SITE,
-            ['languageChoice' => '3'],
+            ['uname' => 'whoever', 'pass' => 'whatever', 'languageChoice' => '3'],
             [],
             $this->session,
             $this->globalsBag

--- a/tests/Tests/Unit/Portal/PortalLoginRowNormalizerTest.php
+++ b/tests/Tests/Unit/Portal/PortalLoginRowNormalizerTest.php
@@ -191,4 +191,40 @@ class PortalLoginRowNormalizerTest extends TestCase
         $this->assertSame('', $normalized['lname']);
         $this->assertNull($normalized['username']);
     }
+
+    // ---------------------------------------------------------------------
+    // Column-coercion edge cases (non-string inputs)
+    // ---------------------------------------------------------------------
+
+    public function testIntColumnPassesThroughActualInts(): void
+    {
+        // ADODB returns numeric columns as strings, but some adapters or test fixtures
+        // hand back actual ints — the coercer should accept those too.
+        $normalized = PortalLoginRowNormalizer::patientDataRow([
+            'pid' => 99,
+            'fname' => 'Alice',
+            'lname' => 'Smith',
+            'email' => 'a@b',
+            'providerID' => 11,
+            'allow_patient_portal' => 'YES',
+        ]);
+
+        $this->assertSame(99, $normalized['pid']);
+        $this->assertSame(11, $normalized['providerID']);
+    }
+
+    public function testStringColumnCoercesIntAndFloatToString(): void
+    {
+        // If a fixture or adapter hands a numeric value where a string column is expected
+        // (legacy code does this for things like provider names that look numeric), the
+        // coercer should stringify rather than fall through to the default.
+        $normalized = PortalLoginRowNormalizer::providerInfoRow([
+            'fname' => 42,        // int
+            'lname' => 1.5,       // float
+            'username' => 'drwho',
+        ]);
+
+        $this->assertSame('42', $normalized['fname']);
+        $this->assertSame('1.5', $normalized['lname']);
+    }
 }

--- a/tests/Tests/Unit/Portal/PortalLoginRowNormalizerTest.php
+++ b/tests/Tests/Unit/Portal/PortalLoginRowNormalizerTest.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * PortalLoginRowNormalizerTest — verifies the row-shape normalisation that the SQL
+ * implementation of PortalLoginCredentialsRepository delegates to. ADODB returns every
+ * column as a string regardless of the underlying type; these tests lock in the boundary
+ * conversion to the typed shapes the controller expects.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Unit\Portal;
+
+use OpenEMR\Controllers\Portal\PortalLoginRowNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class PortalLoginRowNormalizerTest extends TestCase
+{
+    // ---------------------------------------------------------------------
+    // authRow
+    // ---------------------------------------------------------------------
+
+    public function testAuthRowConvertsStringColumnsToTypedShape(): void
+    {
+        $raw = [
+            'id' => '7',
+            'pid' => '42',
+            'portal_pwd' => '$2y$10$hash',
+            'portal_username' => 'alice',
+            'portal_login_username' => 'alice_login',
+            'portal_pwd_status' => '1',
+        ];
+
+        $normalized = PortalLoginRowNormalizer::authRow($raw, false);
+
+        $this->assertSame(7, $normalized['id']);
+        $this->assertSame(42, $normalized['pid']);
+        $this->assertSame('$2y$10$hash', $normalized['portal_pwd']);
+        $this->assertSame('alice', $normalized['portal_username']);
+        $this->assertSame('alice_login', $normalized['portal_login_username']);
+        $this->assertSame(1, $normalized['portal_pwd_status']);
+        $this->assertArrayNotHasKey('portal_onetime', $normalized, 'includeOneTime=false omits the key');
+    }
+
+    public function testAuthRowIncludesOneTimeWhenRequested(): void
+    {
+        $raw = [
+            'id' => '7',
+            'pid' => '42',
+            'portal_pwd' => 'x',
+            'portal_username' => 'alice',
+            'portal_login_username' => 'alice_login',
+            'portal_pwd_status' => '0',
+            'portal_onetime' => 'abc123' . str_repeat('x', 32),
+        ];
+
+        $normalized = PortalLoginRowNormalizer::authRow($raw, true);
+
+        $this->assertArrayHasKey('portal_onetime', $normalized);
+        $this->assertSame('abc123' . str_repeat('x', 32), $normalized['portal_onetime'] ?? null);
+    }
+
+    public function testAuthRowPreservesNullPortalOnetime(): void
+    {
+        $raw = [
+            'id' => '7',
+            'pid' => '42',
+            'portal_pwd' => 'x',
+            'portal_username' => 'alice',
+            'portal_login_username' => 'alice_login',
+            'portal_pwd_status' => '0',
+            'portal_onetime' => null,
+        ];
+
+        $normalized = PortalLoginRowNormalizer::authRow($raw, true);
+
+        $this->assertArrayHasKey('portal_onetime', $normalized);
+        $this->assertNull($normalized['portal_onetime']);
+    }
+
+    public function testAuthRowDefaultsMissingColumnsRatherThanThrowing(): void
+    {
+        $normalized = PortalLoginRowNormalizer::authRow([], false);
+
+        $this->assertSame(0, $normalized['id']);
+        $this->assertSame(0, $normalized['pid']);
+        $this->assertSame('', $normalized['portal_pwd']);
+        $this->assertSame('', $normalized['portal_username']);
+        $this->assertSame('', $normalized['portal_login_username']);
+        $this->assertSame(0, $normalized['portal_pwd_status']);
+    }
+
+    // ---------------------------------------------------------------------
+    // patientDataRow
+    // ---------------------------------------------------------------------
+
+    public function testPatientDataRowConvertsStringColumnsToTypedShape(): void
+    {
+        $raw = [
+            'pid' => '42',
+            'fname' => 'Alice',
+            'lname' => 'Smith',
+            'email' => 'alice@example.com',
+            'providerID' => '11',
+            'allow_patient_portal' => 'YES',
+        ];
+
+        $normalized = PortalLoginRowNormalizer::patientDataRow($raw);
+
+        $this->assertSame(42, $normalized['pid']);
+        $this->assertSame('Alice', $normalized['fname']);
+        $this->assertSame('Smith', $normalized['lname']);
+        $this->assertSame('alice@example.com', $normalized['email']);
+        $this->assertSame(11, $normalized['providerID']);
+        $this->assertSame('YES', $normalized['allow_patient_portal']);
+    }
+
+    public function testPatientDataRowDefaultsMissingProviderToZero(): void
+    {
+        $raw = [
+            'pid' => '42',
+            'fname' => 'Alice',
+            'lname' => 'Smith',
+            'email' => 'alice@example.com',
+            // providerID intentionally absent
+            'allow_patient_portal' => 'YES',
+        ];
+
+        $normalized = PortalLoginRowNormalizer::patientDataRow($raw);
+
+        $this->assertSame(0, $normalized['providerID']);
+    }
+
+    public function testPatientDataRowDefaultsEmptyEmailToEmptyString(): void
+    {
+        $raw = [
+            'pid' => '42',
+            'fname' => 'Alice',
+            'lname' => 'Smith',
+            'email' => null,
+            'providerID' => '11',
+            'allow_patient_portal' => 'YES',
+        ];
+
+        $normalized = PortalLoginRowNormalizer::patientDataRow($raw);
+
+        $this->assertSame('', $normalized['email']);
+    }
+
+    // ---------------------------------------------------------------------
+    // providerInfoRow
+    // ---------------------------------------------------------------------
+
+    public function testProviderInfoRowConvertsAllStringColumns(): void
+    {
+        $raw = [
+            'fname' => 'Dr',
+            'lname' => 'Who',
+            'username' => 'drwho',
+        ];
+
+        $normalized = PortalLoginRowNormalizer::providerInfoRow($raw);
+
+        $this->assertSame('Dr', $normalized['fname']);
+        $this->assertSame('Who', $normalized['lname']);
+        $this->assertSame('drwho', $normalized['username']);
+    }
+
+    public function testProviderInfoRowKeepsUsernameNullableWhenMissing(): void
+    {
+        $raw = [
+            'fname' => 'Dr',
+            'lname' => 'Who',
+            // username intentionally absent
+        ];
+
+        $normalized = PortalLoginRowNormalizer::providerInfoRow($raw);
+
+        $this->assertNull($normalized['username']);
+    }
+
+    public function testProviderInfoRowDefaultsMissingNamesToEmptyString(): void
+    {
+        $normalized = PortalLoginRowNormalizer::providerInfoRow([]);
+
+        $this->assertSame('', $normalized['fname']);
+        $this->assertSame('', $normalized['lname']);
+        $this->assertNull($normalized['username']);
+    }
+}


### PR DESCRIPTION
## Summary

Behavior-preserving extraction of the entire patient portal login flow out of `portal/get_patient_info.php` into a unit-testable controller class. **No behavior change in the login flow** — same SQL is issued, same session keys are set in the same order, same audit entries are emitted, same redirect URLs are produced for every branch.

## Why

`portal/get_patient_info.php` was ~315 LOC of procedural PHP touching `\$_POST`, `\$_SESSION`, global SQL helpers, and emitting `header()` + `exit()` side effects mid-flow. Untestable. The MFA-enablement work I'm doing downstream (planned upstream contribution after this lands) needs an extension point in the login flow, and the surrounding paths have no characterisation coverage to catch regressions.

This PR is the foundation — it extracts the controller and adds 22 unit tests covering every branch, without touching observable behavior.

## What changed

**New (src/Controllers/Portal/):**
- `PatientPortalLoginController` — orchestrates the login flow.
- `PatientPortalLoginResult` — directive value object (redirect URL, destroy-session flag, optional audit args, cache-disable flag, CSRF-establish flag).
- `PortalLoginCredentialsRepository` — interface with typed-shape returns via `@phpstan-type`.
- `SqlPortalLoginCredentialsRepository` — production implementation. SQL preserved verbatim; calls migrated from the deprecated `privQuery` / `privStatement` helpers to `QueryUtils::querySingleRow` / `sqlStatementThrowException` with the `noLog` flag set, preserving the legacy audit-omission behaviour.
- `PortalLoginRowNormalizer` — pure helper that maps raw ADODB-string rows to the typed shapes. Lives separately so the conversion is unit-testable without a DB.
- `PortalAuditLogger` — interface for the `portalLog()` side effect.
- `PortalSessionAccessor` — interface for session read/write (required by phpstan's `openemr.forbidDirectSessionWrite` rule; routes writes through `SessionUtil::setSession`/`unsetSession`).
- `SessionUtilPortalSessionAccessor` — production accessor.

**Updated:**
- `portal/get_patient_info.php` — shrinks from 315 LOC to ~100 LOC of bootstrap + dependency wiring + controller invocation + result application (audit log, optional session destroy, CSRF setup, `RedirectResponse` send).

**New tests (tests/Tests/Unit/Portal/):**
- `PatientPortalLoginControllerTest` — 13 characterisation tests covering every branch: anti-CSRF gate, input validation, email-enforcement gate, invalid username, invalid password, password rehash on success, patient_data missing, email mismatch with enforcement on, `allow_patient_portal` disabled, password-change form bounce, successful password change completion, successful login with session establishment, safe-redirect fallback.
- `PortalLoginRowNormalizerTest` — 9 edge-case tests for the row normaliser (string-to-int conversion, `includeOneTime` branch, null `portal_onetime` preservation, missing-column defaults).

Uses hand-rolled in-memory implementations of the repository, audit logger, and session accessor so tests don't need a database.

## Behavior notes

- `new AuthHash('auth')` calls become `new AuthHash()`. The constructor accepts no parameters; the extra arg was silently ignored.
- `if (empty(\$userData))` dead branch (line 199 of the original) is dropped — `sqlQuery` returns false on missing rows, so the outer `if (\$userData = sqlQuery(...))` already collapses to the silent-redirect path; the inner `empty()` check was unreachable.
- Password equality in mode-2 (one-time PIN reset) and the password-confirm comparison now use `hash_equals()` for timing-safety.
- Magic ints 0/1/2 for the `password_update` mode are replaced with named class constants (`PASSWORD_UPDATE_NORMAL` / `REQUIRED` / `ONE_TIME_RESET`).
- `privQuery` / `privStatement` migrated to `QueryUtils::querySingleRow` / `sqlStatementThrowException` with the `noLog` flag. One behavioural difference: `QueryUtils` throws on SQL failure where the legacy `privStatement` called `exit()`. The throw propagates up; the script's outer context still produces a 500.

## .phpstan/baseline net effect

The refactor **removes ~103 lines of pre-existing baseline entries** (casts, `empty()` checks, deprecated function calls, etc. that the new code does not trigger) and **adds zero new entries** on the new files.

## Test plan

- [x] `composer phpstan` — clean (no new errors; baseline net reduction)
- [x] `composer rector-check` — clean
- [x] `composer require-checker` — clean (no new unknown symbols)
- [x] `composer phpcs` — clean
- [x] `php -l` clean on all changed files
- [ ] CI: phpcs, phpstan, rector, unit tests, codespell
- [ ] Smoke test in a dev tenant: log in as patient, verify session establishes correctly, verify failed login redirects to the right error variants