### PR TITLE
refactor: replace raw assert() calls with real runtime checks

### DIFF
--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -53,7 +53,9 @@ require_once($srcDir . '/patient.inc.php');
 require_once($srcDir . '/appointments.inc.php');
 require_once(OEGlobalsBag::getInstance()->getString('OE_SITE_DIR') . '/statement.inc.php');
 // statement.inc.php sets $STMT_TEMP_FILE
-assert(isset($STMT_TEMP_FILE));
+if (!isset($STMT_TEMP_FILE)) {
+    throw new \RuntimeException('$STMT_TEMP_FILE must be set by statement.inc.php');
+}
 require_once($srcDir . '/api.inc.php');
 require_once($srcDir . '/forms.inc.php');
 require_once($srcDir . '/../controllers/C_Document.class.php');

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -237,12 +237,10 @@ $GLOBALS['vendor_dir'] = "$webserver_root/vendor";
 if (empty($restRequest)) {
     $restRequest = HttpRestRequest::createFromGlobals();
 }
-if (isset($globalsBag)) {
-    assert($globalsBag instanceof OEGlobalsBag);
-} else {
-    // Initially this was too early. We now reinit at bottom to ensure all values are collected.
-    $globalsBag = OEGlobalsBag::getInstance();
-}
+// OEGlobalsBag is a singleton; reassigning here is safe even if an earlier
+// include already populated it. Selected values are re-set onto the bag
+// throughout the rest of this file.
+$globalsBag = OEGlobalsBag::getInstance();
 $globalsBag->set('webserver_root', $webserver_root);
 $globalsBag->set('web_root', $web_root);
 // Absolute path to the location of documentroot directory for use with include statements:

--- a/interface/main/backup.php
+++ b/interface/main/backup.php
@@ -44,7 +44,9 @@ use OpenEMR\Core\OEGlobalsBag;
 
 set_time_limit(0);
 $globalsBag = require_once("../globals.php");
-assert($globalsBag instanceof OEGlobalsBag);
+if (!$globalsBag instanceof OEGlobalsBag) {
+    throw new \LogicException('globals.php must return an instance of ' . OEGlobalsBag::class);
+}
 
 require_once($globalsBag->getSrcDir() . "/layout.inc.php");
 require_once($globalsBag->getSrcDir() . "/patient.inc.php");

--- a/portal/patient/_global_config.php
+++ b/portal/patient/_global_config.php
@@ -212,7 +212,9 @@ class GlobalConfig
             }
 
             $engine = new $engine_class(self::$TEMPLATE_PATH, self::$TEMPLATE_CACHE_PATH);
-            assert($engine instanceof IRenderEngine);
+            if (!$engine instanceof IRenderEngine) {
+                throw new \LogicException(sprintf('Template engine %s must implement %s', $engine_class, IRenderEngine::class));
+            }
             $this->render_engine = $engine;
             $this->render_engine->assign("ROOT_URL", self::$ROOT_URL);
             $this->render_engine->assign("PHREEZE_VERSION", Phreezer::$Version);

--- a/portal/portal_payment.php
+++ b/portal/portal_payment.php
@@ -49,7 +49,10 @@ if (!empty($session->get('pid')) && !empty($session->get('patient_portal_onsite_
         exit();
     }
 }
-assert(isset($pid)); // Set by globals.php via session; PHPStan can't see through require_once
+// $pid is set by globals.php via session; PHPStan can't see through require_once
+if (!isset($pid)) {
+    throw new \RuntimeException('$pid must be set by globals.php before requiring this script');
+}
 $srcdir = $globalsBag->getString('srcdir');
 require_once(__DIR__ . "/lib/appsql.class.php");
 require_once("$srcdir/patient.inc.php");

--- a/public/index.php
+++ b/public/index.php
@@ -16,7 +16,9 @@ use OpenEMR\BC\FallbackRouter;
 use Psr\Log\LoggerInterface;
 
 $container = require_once __DIR__ . '/../bootstrap.php';
-assert($container instanceof TypedContainerInterface);
+if (!$container instanceof TypedContainerInterface) {
+    throw new \LogicException('bootstrap.php must return a ' . TypedContainerInterface::class);
+}
 
 $request = ServerRequest::fromGlobals();
 

--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -31,9 +31,8 @@ if (php_sapi_name() === 'cli') {
     // @phpstan-ignore openemr.forbiddenRequestGlobals (Required for write)
     $_SERVER['HTTP_HOST'] = 'default';
 
-    assert(isset($argv));
     // Parse --from=VERSION argument for CLI upgrades
-    foreach ($argv as $arg) {
+    foreach ($argv ?? [] as $arg) {
         if (str_starts_with($arg, '--from=')) {
             $cliFromVersion = substr($arg, 7);
             break;

--- a/src/BC/DatabaseConnectionFactory.php
+++ b/src/BC/DatabaseConnectionFactory.php
@@ -27,10 +27,9 @@ class DatabaseConnectionFactory
     ): ADODB_mysqli_log {
         self::loadAdodbClasses();
         $conn = ADONewConnection('mysqli_log');
-        if ($conn === false) {
-            throw new \Exception('SUPER BROKEN');
+        if (!$conn instanceof ADODB_mysqli_log) {
+            throw new RuntimeException('ADONewConnection did not return an ADODB_mysqli_log');
         }
-        assert($conn instanceof ADODB_mysqli_log);
 
         // These were settings applied throughout the app. Not 100% clear if
         // they're still required.
@@ -45,7 +44,9 @@ class DatabaseConnectionFactory
         }
 
         // Sockets? It's supported on paper but unclear now to configure.
-        assert($config->host !== null);
+        if ($config->host === null) {
+            throw new RuntimeException('ADODB driver does not yet support unix socket connections; configure host/port');
+        }
 
         $conn->port = $config->port;
         if ($persistent) {

--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -22,7 +22,6 @@ use Psr\Log\{LoggerInterface, LogLevel};
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
-use function assert;
 use function defined;
 use function error_reporting;
 use function header;
@@ -123,8 +122,7 @@ readonly class ErrorHandler
         if ($e instanceof HttpExceptionInterface) {
             $response = $this->rf->createResponse($e->getStatusCode());
             foreach ($e->getHeaders() as $header => $value) {
-                assert(is_string($value) || is_int($value));
-                $response = $response->withAddedHeader($header, (string)$value);
+                $response = $response->withAddedHeader($header, $this->normalizeHeaderValue($header, $value));
             }
             return $response;
         }
@@ -137,6 +135,35 @@ readonly class ErrorHandler
 
         return $this->rf->createResponse(500)
             ->withBody($this->sf->createStream($message));
+    }
+
+    /**
+     * @return string|list<string>
+     */
+    private function normalizeHeaderValue(string $header, mixed $value): string|array
+    {
+        if (is_array($value)) {
+            $normalized = [];
+            foreach ($value as $entry) {
+                if (!is_string($entry) && !is_int($entry)) {
+                    throw new \UnexpectedValueException(sprintf(
+                        'HttpExceptionInterface header "%s" array entry must be string or int; got %s',
+                        $header,
+                        get_debug_type($entry),
+                    ));
+                }
+                $normalized[] = (string)$entry;
+            }
+            return $normalized;
+        }
+        if (is_string($value) || is_int($value)) {
+            return (string)$value;
+        }
+        throw new \UnexpectedValueException(sprintf(
+            'HttpExceptionInterface header "%s" must be string, int, or array; got %s',
+            $header,
+            get_debug_type($value),
+        ));
     }
 
     private function logUncaughtException(Throwable $e): void

--- a/src/Encryption/Message.php
+++ b/src/Encryption/Message.php
@@ -51,7 +51,9 @@ final readonly class Message
      */
     private static function parseImplicitKey(string $encodedMessage): Message
     {
-        assert(strlen($encodedMessage) >= 3);
+        if (strlen($encodedMessage) < 3) {
+            throw new UnexpectedValueException('Encoded message is too short to contain an implicit key id');
+        }
 
         // `001`-`007`
         $numericKeyId = substr($encodedMessage, 0, 3);
@@ -80,7 +82,7 @@ final readonly class Message
 
     private function encodeImplicitKey(): string
     {
-        assert($this->format === MessageFormat::ImplicitKey);
+        // Called only from encode()'s match on $this->format === ImplicitKey.
         return sprintf('%s%s',
             $this->keyId->id,
             base64_encode($this->ciphertext->value),

--- a/src/PaymentProcessing/Rainforest/Webhooks/RecordPayment.php
+++ b/src/PaymentProcessing/Rainforest/Webhooks/RecordPayment.php
@@ -54,7 +54,13 @@ readonly class RecordPayment implements ProcessorInterface
 
     public function handle(Webhook $webhook): void
     {
-        assert($webhook->eventType === 'payin.authorized');
+        if ($webhook->eventType !== 'payin.authorized') {
+            throw new \DomainException(sprintf(
+                '%s cannot handle event type "%s"',
+                self::class,
+                $webhook->eventType,
+            ));
+        }
         // This transaction should be done in a general recording service, but
         // PaymentProcessing/Recorder isn't sophisticated enough yet.
         //

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -783,31 +783,27 @@ class PatientService extends BaseService
 
 
     /**
-     * @param string $dob
-     * @param ?string $date
      * @return array containing
      *      age - decimal age in years
      *      age_in_months - decimal age in months
      *      ageinYMD - formatted string #y #m #d
      */
-    public function getPatientAgeYMD($dob, $date = null)
+    public function getPatientAgeYMD(string $dob, ?string $date = null)
     {
-        if ($date == null) {
+        if ($date === null) {
             $daynow = date("d");
             $monthnow = date("m");
             $yearnow = date("Y");
             $datenow = $yearnow . $monthnow . $daynow;
         } else {
-            $datenow = preg_replace("/-/", "", $date);
-            assert(is_string($datenow));
+            $datenow = str_replace('-', '', $date);
             $yearnow = substr($datenow, 0, 4);
             $monthnow = substr($datenow, 4, 2);
             $daynow = substr($datenow, 6, 2);
             $datenow = $yearnow . $monthnow . $daynow;
         }
 
-        $dob = preg_replace("/-/", "", $dob);
-        assert(is_string($dob));
+        $dob = str_replace('-', '', $dob);
         $dobyear = substr($dob, 0, 4);
         $dobmonth = substr($dob, 4, 2);
         $dobday = substr($dob, 6, 2);

--- a/tests/Tests/Api/ApiTestClient.php
+++ b/tests/Tests/Api/ApiTestClient.php
@@ -285,7 +285,11 @@ class ApiTestClient
         $clientRepository = new ClientRepository();
         $clientRepository->setSystemLogger(new NullLogger());
         $clientEntity = $clientRepository->getClientEntity($this->client_id);
-        assert($clientEntity instanceof ClientEntity);
+        // @codeCoverageIgnoreStart Defensive guard against ClientRepository contract drift.
+        if (!$clientEntity instanceof ClientEntity) {
+            throw new \RuntimeException('Expected ' . ClientEntity::class . ' from ClientRepository::getClientEntity');
+        }
+        // @codeCoverageIgnoreEnd
         $clientRepository->saveIsEnabled($clientEntity, true);
     }
 

--- a/tests/Tests/Api/BulkAPITestClient.php
+++ b/tests/Tests/Api/BulkAPITestClient.php
@@ -50,7 +50,11 @@ class BulkAPITestClient extends ApiTestClient
     public function setAuthToken(string $authURL, array $credentials = [], string $client = 'private'): ResponseInterface
     {
         if (($credentials['client_id'] ?? '') !== '') {
-            assert(is_string($credentials['client_id']));
+            // @codeCoverageIgnoreStart Defensive guard against malformed credentials input.
+            if (!is_string($credentials['client_id'])) {
+                throw new \InvalidArgumentException('credentials[client_id] must be a string');
+            }
+            // @codeCoverageIgnoreEnd
             $this->client_id = $credentials['client_id'];
         }
         if (!(($credentials['jwks'] ?? null) === null && ($credentials['private_key'] ?? null) === null && ($credentials['public_key'] ?? null) === null)) {
@@ -141,7 +145,11 @@ class BulkAPITestClient extends ApiTestClient
         $clientRepository = new ClientRepository();
         $clientRepository->setSystemLogger(new NullLogger());
         $clientEntity = $clientRepository->getClientEntity($this->client_id);
-        assert($clientEntity instanceof ClientEntity);
+        // @codeCoverageIgnoreStart Defensive guard against ClientRepository contract drift.
+        if (!$clientEntity instanceof ClientEntity) {
+            throw new \RuntimeException('Expected ' . ClientEntity::class . ' from ClientRepository::getClientEntity');
+        }
+        // @codeCoverageIgnoreEnd
         $clientRepository->saveIsEnabled($clientEntity, true);
         return $clientEntity;
     }

--- a/tests/Tests/Api/FacilityApiTest.php
+++ b/tests/Tests/Api/FacilityApiTest.php
@@ -108,7 +108,7 @@ class FacilityApiTest extends TestCase
         $responseBody = json_decode((string) $actualResponse->getBody(), true);
 
         $facilityUuid = $responseBody["data"]["uuid"];
-        assert(is_string($facilityUuid));
+        self::assertIsString($facilityUuid);
 
         $this->facilityRecord["email"] = "help@pennfirm.com";
         $actualResponse = $this->testClient->put(self::FACILITY_API_ENDPOINT, $facilityUuid, $this->facilityRecord);
@@ -120,7 +120,7 @@ class FacilityApiTest extends TestCase
         $this->assertEquals(0, count($responseBody["internalErrors"]));
 
         $updatedResource = $responseBody["data"];
-        assert(is_array($updatedResource));
+        self::assertIsArray($updatedResource);
         $this->assertEquals($this->facilityRecord["email"], $updatedResource["email"]);
     }
 
@@ -146,7 +146,7 @@ class FacilityApiTest extends TestCase
         /** @var array<string, mixed> $responseBody */
         $responseBody = json_decode((string) $actualResponse->getBody(), true);
         $facilityUuid = $responseBody["data"]["uuid"];
-        assert(is_string($facilityUuid));
+        self::assertIsString($facilityUuid);
         $facilityId = $responseBody["data"]["id"];
 
         $actualResponse = $this->testClient->getOne(self::FACILITY_API_ENDPOINT, $facilityUuid);

--- a/tests/Tests/Api/HealthEndpointTest.php
+++ b/tests/Tests/Api/HealthEndpointTest.php
@@ -47,7 +47,7 @@ class HealthEndpointTest extends TestCase
         $this->assertStringContainsString('application/json', $contentType, 'livez should return JSON content type');
 
         $body = json_decode((string) $response->getBody(), true);
-        assert(is_array($body), 'livez response should be valid JSON');
+        self::assertIsArray($body, 'livez response should be valid JSON');
         $this->assertArrayHasKey('status', $body, 'livez response should have status key');
         $this->assertEquals('alive', $body['status'], 'livez status should be "alive"');
     }
@@ -78,7 +78,7 @@ class HealthEndpointTest extends TestCase
         $this->assertStringNotContainsString('login_screen.php', $bodyRaw, 'readyz should not redirect to login');
 
         $body = json_decode($bodyRaw, true);
-        assert(is_array($body), 'readyz response should be valid JSON');
+        self::assertIsArray($body, 'readyz response should be valid JSON');
         $this->assertArrayHasKey('status', $body, 'readyz response should have status key');
         $this->assertContains($body['status'], ['ready', 'setup_required', 'error'], 'readyz status should be valid');
     }
@@ -90,7 +90,7 @@ class HealthEndpointTest extends TestCase
     {
         $response = $this->client->get('/meta/health/readyz');
         $body = json_decode((string) $response->getBody(), true);
-        assert(is_array($body));
+        self::assertIsArray($body);
 
         // If status is 'ready', we should have checks
         if ($body['status'] === 'ready') {

--- a/tests/Tests/Api/PractitionerApiTest.php
+++ b/tests/Tests/Api/PractitionerApiTest.php
@@ -102,7 +102,7 @@ class PractitionerApiTest extends TestCase
         $responseBody = json_decode((string) $actualResponse->getBody(), true);
 
         $practitionerUuid = $responseBody["data"]["uuid"];
-        assert(is_string($practitionerUuid));
+        self::assertIsString($practitionerUuid);
 
         $this->practitionerRecord["email"] = "help@pennfirm.com";
         $actualResponse = $this->testClient->put(self::PRACTITIONER_API_ENDPOINT, $practitionerUuid, $this->practitionerRecord);
@@ -138,7 +138,7 @@ class PractitionerApiTest extends TestCase
         /** @var array<string, mixed> $responseBody */
         $responseBody = json_decode((string) $actualResponse->getBody(), true);
         $practitionerUuid = $responseBody["data"]["uuid"];
-        assert(is_string($practitionerUuid));
+        self::assertIsString($practitionerUuid);
         $practitionerId = $responseBody["data"]["id"];
 
         $actualResponse = $this->testClient->getOne(self::PRACTITIONER_API_ENDPOINT, $practitionerUuid);

--- a/tests/Tests/Fixtures/CryptoFixtureManager.php
+++ b/tests/Tests/Fixtures/CryptoFixtureManager.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Fixtures;
 
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Core\OEGlobalsBag;
 
 class CryptoFixtureManager
 {
@@ -147,10 +148,18 @@ class CryptoFixtureManager
 
     public function __construct(?string $siteDir = null)
     {
+        // @codeCoverageIgnoreStart Defensive config guards; the happy path passes $siteDir explicitly.
         if ($siteDir === null) {
-            $siteDir = $GLOBALS['OE_SITE_DIR'];
-            assert(is_string($siteDir));
+            $globalsBag = OEGlobalsBag::getInstance();
+            if (!$globalsBag->has('OE_SITE_DIR')) {
+                throw new \RuntimeException('OE_SITE_DIR must be configured to install crypto fixtures');
+            }
+            $siteDir = $globalsBag->getString('OE_SITE_DIR');
         }
+        if ($siteDir === '') {
+            throw new \RuntimeException('OE_SITE_DIR must not be empty');
+        }
+        // @codeCoverageIgnoreEnd
         $this->siteDir = $siteDir;
     }
 

--- a/tests/Tests/Isolated/Common/Session/Predis/LockingRedisSessionHandlerTest.php
+++ b/tests/Tests/Isolated/Common/Session/Predis/LockingRedisSessionHandlerTest.php
@@ -119,8 +119,7 @@ class LockingRedisSessionHandlerTest extends TestCase
     private static function argArray(array $call, int $index): array
     {
         $val = $call['args'][$index];
-        assert(is_array($val));
-        /** @var array<array-key, mixed> $val */
+        self::assertIsArray($val);
         return $val;
     }
 

--- a/tests/Tests/Isolated/Encryption/Keys/KeychainTest.php
+++ b/tests/Tests/Isolated/Encryption/Keys/KeychainTest.php
@@ -48,7 +48,7 @@ class KeychainTest extends TestCase
         $keychain->registerCipher($id2, $cipher2);
 
 
-        assert($cipher1 !== $cipher2);
+        self::assertNotSame($cipher1, $cipher2);
 
         $retr1 = $keychain->getCipher($id1);
         self::assertSame($cipher1, $retr1);

--- a/tests/Tests/Isolated/Encryption/MessageTest.php
+++ b/tests/Tests/Isolated/Encryption/MessageTest.php
@@ -65,7 +65,7 @@ class MessageTest extends TestCase
     {
         $data = $this->fixtures->getCiphertext(7);
         $message = Message::parse($data);
-        assert($message->format === MessageFormat::ImplicitKey);
+        self::assertSame(MessageFormat::ImplicitKey, $message->format);
         $reencoded = $message->encode();
         self::assertSame($data, $reencoded);
     }


### PR DESCRIPTION
## Summary

PHP's `assert()` is a no-op under the default production `zend.assertions=-1`, so every "guard" written as an `assert()` is unenforced where it matters most. It also gets used as a PHPStan band-aid that hides type problems the source can fix.

This PR removes every raw `assert()` from non-third-party PHP and replaces each with an appropriate alternative.

## Production code

- **Structural contract violations** → `LogicException`: `interface/main/backup.php` and `public/index.php` (depending on `require_once`'s return value); `portal/patient/_global_config.php` (dynamic class instantiation must implement `IRenderEngine`).
- **Environmental / config state** → `RuntimeException`: `sl_eob_search.php` (`$STMT_TEMP_FILE` from a site-customizable include), `portal/portal_payment.php` (`$pid` from session state), `DatabaseConnectionFactory` (ADODB connection class, unsupported unix-socket config).
- **Domain values outside a handler's acceptable set** → `DomainException`: `RecordPayment::handle` event-type guard.
- **External value doesn't match what we expected** → `UnexpectedValueException`: `Message::parseImplicitKey` length precondition (matches the existing file convention).
- **Dead/redundant guards deleted entirely**:
  - `interface/globals.php`: removed the `isset/assert` branch — `OEGlobalsBag` is a singleton, unconditional reassignment is safe; no caller pre-sets the bag.
  - `Message::encodeImplicitKey`: the only caller's `match` already enforces the precondition.
  - `DatabaseConnectionFactory`: collapsed `=== false` + `assert(... instanceof ADODB_mysqli_log)` into one `!instanceof` throw.
- **Narrow, don't cast**:
  - `ErrorHandler::buildResponse`: extracted a `normalizeHeaderValue` helper that handles scalar and `array<string>` header shapes (per `HttpExceptionInterface`) and throws `UnexpectedValueException` for anything else, instead of silently dropping non-scalar entries via assert + cast.
  - `PatientService::getPatientAgeYMD`: swapped `preg_replace('/-/', ...)` for `str_replace('-', ...)` (returns string for string input) and promoted the existing `@param string $dob` / `@param ?string $date` PHPDoc to native parameter types — narrow at the source instead of casting at the sink.
- **Replace superglobal narrowing with typed access**: `CryptoFixtureManager` now reads `OE_SITE_DIR` via `OEGlobalsBag::getInstance()->getString(...)`, guarded by `has()` and a non-empty check.

## Test code

- In test-support classes that **don't** extend `TestCase` (`ApiTestClient`, `BulkAPITestClient`, `CryptoFixtureManager`): raise an exception instead of asserting. The exception surfaces as a real test failure with a real message instead of silently no-opping. Defensive throw branches are wrapped with `@codeCoverageIgnoreStart/End` since the happy path doesn't exercise them.
- In PHPUnit `TestCase` subclasses (`FacilityApiTest`, `PractitionerApiTest`, `HealthEndpointTest`, `MessageTest`, `KeychainTest`, `InfernoSinglePatientAPITest`, `LockingRedisSessionHandlerTest`): replace raw `assert()` with the appropriate PHPUnit assertion (`assertIsString`, `assertIsArray`, `assertSame`, `assertNotSame`, `assertNotNull`) so failures surface as proper `AssertionFailedError`s.

## Out of scope

`Lcobucci\JWT\Configuration::validator()->assert()` in `JWTClientAuthenticationService` is the JWT library's assertion method (throws `RequiredConstraintsViolated`, already caught), not PHP's builtin. The `UniqueID::assert()` method definition is part of the Lcobucci `Constraint` interface. Both are unrelated to this refactor.

## Test plan

- [ ] CI green
- [ ] Sanity-check that `sql_upgrade.php --from=VERSION` still parses under CLI
- [ ] Confirm `Message::parseImplicitKey` length precondition still allows existing valid inputs
