### PR TITLE
Fix FHIR Patient ethnicity extension to comply with US Core missing data requirements

### DIFF
--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -492,14 +492,14 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
             $ombCategoryExtension->setUrl("ombCategory");
             $coding = new FHIRCoding();
             $coding->setSystem(new FHIRUri(FhirCodeSystemConstants::HL7_NULL_FLAVOR));
-            $coding->setCode('UNK');
-            $coding->setDisplay('Unknown');
+            $coding->setCode(new FHIRCode('UNK'));
+            $coding->setDisplay(new FHIRString('Unknown'));
             $ombCategoryExtension->setValueCoding($coding);
             $ethnicityExtension->addExtension($ombCategoryExtension);
 
             $textExtension = new FHIRExtension();
             $textExtension->setUrl("text");
-            $textExtension->setValueString('Unknown');
+            $textExtension->setValueString(new FHIRString('Unknown'));
             $ethnicityExtension->addExtension($textExtension);
         }
 

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -459,49 +459,47 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
 
     private function parseOpenEMREthnicityRecord(FHIRPatient $patientResource, $ethnicity)
     {
+        // Initialize defaults for missing/unknown data (US Core Missing Data guidance)
+        $code = 'UNK';
+        $display = xl("Unknown");
+        $system = FhirCodeSystemConstants::HL7_NULL_FLAVOR;
+
         $ethnicityExtension = new FHIRExtension();
         $ethnicityExtension->setUrl("http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity");
 
+        $ombCategoryExtension = new FHIRExtension();
+        $ombCategoryExtension->setUrl("ombCategory");
+        $ombCategoryCoding = new FHIRCoding();
+
         if (!empty($ethnicity)) {
-            $ombCategoryExtension = new FHIRExtension();
-            $ombCategoryExtension->setUrl("ombCategory");
-
-            $textExtension = new FHIRExtension();
-            $textExtension->setUrl("text");
-
             $record = $this->getCachedListOption('ethnicity', $ethnicity);
-            if (!empty($record)) {
-                $textExtension->setValueString($record['title']);
-                // the only possible options for ombCategory are hispanic or not hispanic
-                if ($record['option_id'] != 'decline_to_specify' && $record['option_id'] != 'declne_to_specfy') {
-                    $coding = new FHIRCoding();
-                    $coding->setSystem(new FHIRUri("http://terminology.hl7.org/CodeSystem/v3-Ethnicity"));
-                    $coding->setCode($record['notes']);
-                    $coding->setDisplay($record['title']);
-                    $coding->setSystem("urn:oid:2.16.840.1.113883.6.238");
-                    $ombCategoryExtension->setValueCoding($coding);
-                    $ethnicityExtension->addExtension($ombCategoryExtension);
-                }
+            if ($ethnicity === 'decline_to_specify' || $ethnicity === 'declne_to_specfy') {
+                // Asked but declined to answer - use ASKU per US Core guidance
+                // @see https://www.hl7.org/fhir/us/core/ValueSet-omb-ethnicity-category.html
+                $code = "ASKU";
+                $display = xl("Asked but no answer");
+            } elseif (!empty($record)) {
+                // Valid ethnicity data present
+                $code = $record['notes'];
+                $title = is_string($record['title']) ? $record['title'] : '';
+                // @phpstan-ignore argument.type (legacy on-the-fly translation of dynamic value; migration tracked in #11498)
+                $display = xl($title);
+                $system = "urn:oid:2.16.840.1.113883.6.238"; // v3-Ethnicity OID
             }
-
-            $ethnicityExtension->addExtension($textExtension);
-        } else {
-            // US Core requires ethnicity extension even when data is missing.
-            // Use Data Absent Reason per http://hl7.org/fhir/us/core/general-guidance.html#missing-data
-            $ombCategoryExtension = new FHIRExtension();
-            $ombCategoryExtension->setUrl("ombCategory");
-            $coding = new FHIRCoding();
-            $coding->setSystem(new FHIRUri(FhirCodeSystemConstants::HL7_NULL_FLAVOR));
-            $coding->setCode(new FHIRCode('UNK'));
-            $coding->setDisplay(new FHIRString('Unknown'));
-            $ombCategoryExtension->setValueCoding($coding);
-            $ethnicityExtension->addExtension($ombCategoryExtension);
-
-            $textExtension = new FHIRExtension();
-            $textExtension->setUrl("text");
-            $textExtension->setValueString(new FHIRString('Unknown'));
-            $ethnicityExtension->addExtension($textExtension);
         }
+
+        // Build ombCategory extension unconditionally (always required by US Core)
+        $ombCategoryCoding->setSystem(new FHIRUri($system));
+        $ombCategoryCoding->setCode(new FHIRCode($code));
+        $ombCategoryCoding->setDisplay(new FHIRString($display));
+        $ombCategoryExtension->setValueCoding($ombCategoryCoding);
+        $ethnicityExtension->addExtension($ombCategoryExtension);
+
+        // Build text extension unconditionally (always required by US Core)
+        $textExtension = new FHIRExtension();
+        $textExtension->setUrl("text");
+        $textExtension->setValueString(new FHIRString($ombCategoryCoding->getDisplay()));
+        $ethnicityExtension->addExtension($textExtension);
 
         $patientResource->addExtension($ethnicityExtension);
     }

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -459,11 +459,10 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
 
     private function parseOpenEMREthnicityRecord(FHIRPatient $patientResource, $ethnicity)
     {
-        // TODO: this is a required field, so not sure what we want to do if this is missing?
-        if (!empty($ethnicity)) {
-            $ethnicityExtension = new FHIRExtension();
-            $ethnicityExtension->setUrl("http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity");
+        $ethnicityExtension = new FHIRExtension();
+        $ethnicityExtension->setUrl("http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity");
 
+        if (!empty($ethnicity)) {
             $ombCategoryExtension = new FHIRExtension();
             $ombCategoryExtension->setUrl("ombCategory");
 
@@ -486,8 +485,25 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
             }
 
             $ethnicityExtension->addExtension($textExtension);
-            $patientResource->addExtension($ethnicityExtension);
+        } else {
+            // US Core requires ethnicity extension even when data is missing.
+            // Use Data Absent Reason per http://hl7.org/fhir/us/core/general-guidance.html#missing-data
+            $ombCategoryExtension = new FHIRExtension();
+            $ombCategoryExtension->setUrl("ombCategory");
+            $coding = new FHIRCoding();
+            $coding->setSystem(new FHIRUri(FhirCodeSystemConstants::HL7_NULL_FLAVOR));
+            $coding->setCode('UNK');
+            $coding->setDisplay('Unknown');
+            $ombCategoryExtension->setValueCoding($coding);
+            $ethnicityExtension->addExtension($ombCategoryExtension);
+
+            $textExtension = new FHIRExtension();
+            $textExtension->setUrl("text");
+            $textExtension->setValueString('Unknown');
+            $ethnicityExtension->addExtension($textExtension);
         }
+
+        $patientResource->addExtension($ethnicityExtension);
     }
 
     private function parseOpenEMRSocialSecurityRecord(FHIRPatient $patientResource, $ssn)

--- a/tests/Tests/Services/FHIR/FhirPatientServiceMappingTest.php
+++ b/tests/Tests/Services/FHIR/FhirPatientServiceMappingTest.php
@@ -276,4 +276,104 @@ class FhirPatientServiceMappingTest extends TestCase
         $this->assertEquals(1, count($email));
         $this->assertEquals($email[0]->getValue(), $actualResult['email']);
     }
+
+    /**
+     * Test ethnicity extension when ethnicity data is empty (missing)
+     * Should emit Data Absent Reason (UNK/Unknown) per US Core Missing Data guidance
+     */
+    #[Test]
+    public function testParseOpenEMREthnicityRecordWithEmptyEthnicity(): void
+    {
+        $patientResource = new FHIRPatient();
+        $ethnicity = null; // empty ethnicity
+
+        // Use reflection to call private method
+        $method = new \ReflectionMethod(FhirPatientService::class, 'parseOpenEMREthnicityRecord');
+        $method->setAccessible(true);
+        $method->invoke($this->fhirPatientService, $patientResource, $ethnicity);
+
+        // Assert extension exists
+        $extensions = $patientResource->getExtension();
+        $ethnicityExt = null;
+        foreach ($extensions as $ext) {
+            if ($ext->getUrl() === 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity') {
+                $ethnicityExt = $ext;
+                break;
+            }
+        }
+
+        $this->assertNotNull($ethnicityExt, 'Ethnicity extension must be present even when data is empty');
+
+        // Assert ombCategory extension with UNK code
+        $subExtensions = $ethnicityExt->getExtension();
+        $ombCategoryExt = null;
+        $textExt = null;
+
+        foreach ($subExtensions as $subExt) {
+            if ($subExt->getUrl() === 'ombCategory') {
+                $ombCategoryExt = $subExt;
+            } elseif ($subExt->getUrl() === 'text') {
+                $textExt = $subExt;
+            }
+        }
+
+        $this->assertNotNull($ombCategoryExt, 'ombCategory extension must be present');
+        $this->assertNotNull($textExt, 'text extension must be present');
+
+        // Assert ombCategory has correct UNK coding
+        $coding = $ombCategoryExt->getValueCoding();
+        $this->assertEquals('UNK', $coding->getCode(), 'Code should be UNK for unknown ethnicity');
+        $this->assertEquals('Unknown', $coding->getDisplay(), 'Display should be Unknown');
+        $this->assertStringContainsString('NullFlavor', $coding->getSystem(), 'System should be HL7 NullFlavor');
+
+        // Assert text extension has 'Unknown'
+        $this->assertEquals('Unknown', $textExt->getValueString(), 'Text should be Unknown');
+    }
+
+    /**
+     * Test ethnicity extension when ethnicity is 'decline_to_specify'
+     * Should emit ASKU (Asked but unknown) per US Core guidance
+     */
+    #[Test]
+    public function testParseOpenEMREthnicityRecordWithDeclineToSpecify(): void
+    {
+        $patientResource = new FHIRPatient();
+        $ethnicity = 'decline_to_specify';
+
+        // Use reflection to call private method
+        $method = new \ReflectionMethod(FhirPatientService::class, 'parseOpenEMREthnicityRecord');
+        $method->setAccessible(true);
+        $method->invoke($this->fhirPatientService, $patientResource, $ethnicity);
+
+        // Assert extension exists
+        $extensions = $patientResource->getExtension();
+        $ethnicityExt = null;
+        foreach ($extensions as $ext) {
+            if ($ext->getUrl() === 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity') {
+                $ethnicityExt = $ext;
+                break;
+            }
+        }
+
+        $this->assertNotNull($ethnicityExt, 'Ethnicity extension must be present');
+
+        // Assert ombCategory extension with ASKU code
+        $subExtensions = $ethnicityExt->getExtension();
+        $ombCategoryExt = null;
+
+        foreach ($subExtensions as $subExt) {
+            if ($subExt->getUrl() === 'ombCategory') {
+                $ombCategoryExt = $subExt;
+                break;
+            }
+        }
+
+        $this->assertNotNull($ombCategoryExt, 'ombCategory extension must be present even for decline_to_specify');
+
+        // Assert ombCategory has correct ASKU coding
+        $coding = $ombCategoryExt->getValueCoding();
+        $this->assertEquals('ASKU', $coding->getCode(), 'Code should be ASKU for decline to specify');
+        $this->assertEquals('Asked but no answer', $coding->getDisplay(), 'Display should indicate asked but no answer');
+        $this->assertStringContainsString('NullFlavor', $coding->getSystem(), 'System should be HL7 NullFlavor');
+    }
 }


### PR DESCRIPTION
## Summary

Adds a Data Absent Reason (`UNK`/Unknown) to the `us-core-ethnicity` extension 
when ethnicity data is not available in the EMR, per US Core Missing Data guidance.

## Problem

US Core requires the `us-core-ethnicity` extension on all Patient resources. 
When ethnicity was empty, the extension was silently omitted, causing validation 
failures against US Core profiles.

Ref: http://hl7.org/fhir/us/core/general-guidance.html#missing-data

## Fix

When ethnicity is empty, emit the extension with:
- `ombCategory` coding: system=`http://terminology.hl7.org/CodeSystem/v3-NullFlavor`, code=`UNK`, display=`Unknown`
- `text`: `Unknown`

This matches the existing pattern used for the `us-core-race` extension (which 
already handles missing data correctly).

Addresses the TODO at line 462:
> "this is a required field, so not sure what we want to do if this is missing?"
