### PR TITLE
docs: document openemr-cmd phpstan-generate-reset and update-layout-field-fixtures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,20 @@ Review the diff before committing. See the
 [fixtures README](tests/Tests/Isolated/Common/Twig/fixtures/render/README.md)
 for details on adding new test cases.
 
+### Layout field rendering tests
+
+`tests/Tests/Services/Common/Layouts/FieldRenderingSnapshotTest.php` is a
+**DB-backed** snapshot test (default suite, not isolated) that renders
+every layout field and compares the HTML to recorded fixtures. When
+intentionally changing the renderer, regenerate the fixtures:
+
+```bash
+openemr-cmd update-layout-field-fixtures    # in container (alias: ulff)
+composer update-layout-field-fixtures       # on host
+```
+
+Review the diff before committing.
+
 ## Code Quality
 
 The same composer scripts back every PHP code-quality check, whether
@@ -171,6 +185,7 @@ In container (only requires Docker on host):
 openemr-cmd code-quality                # alias: cq -- full code-quality suite
 openemr-cmd phpstan                     # alias: pst
 openemr-cmd phpstan-generate            # alias: psg -- regenerate baseline
+openemr-cmd phpstan-generate-reset      # alias: pgr -- wipe + regenerate baseline from scratch
 openemr-cmd psr12-report                # alias: pr  (composer phpcs)
 openemr-cmd psr12-fix                   # alias: pf  (composer phpcbf)
 openemr-cmd rector-dry-run              # alias: rd
@@ -193,6 +208,7 @@ On the host (requires local PHP / Composer with `vendor/` populated / Node):
 composer code-quality                # Run all PHP quality checks
 composer phpstan                     # Static analysis (level 10)
 composer phpstan-baseline            # Regenerate PHPStan baseline
+composer phpstan-baseline-reset      # Wipe + regenerate PHPStan baseline from scratch
 composer phpcs                       # PHP code style check
 composer phpcbf                      # PHP code style auto-fix
 composer rector-check                # Code modernization (dry-run)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,9 +161,10 @@ for details on adding new test cases.
 ### Layout field rendering tests
 
 `tests/Tests/Services/Common/Layouts/FieldRenderingSnapshotTest.php` is a
-**DB-backed** snapshot test (default suite, not isolated) that renders
-every layout field and compares the HTML to recorded fixtures. When
-intentionally changing the renderer, regenerate the fixtures:
+**DB-backed** snapshot test (default suite, not isolated) that exercises
+each layout-field renderer branch (one per `data_type`/mode in
+`library/options.inc.php`) and compares the HTML to recorded fixtures.
+When intentionally changing the renderer, regenerate the fixtures:
 
 ```bash
 openemr-cmd update-layout-field-fixtures    # in container (alias: ulff)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -465,6 +465,10 @@ The OpenEMR development docker environment has a very rich advanced feature set.
       ```sh
       openemr-cmd update-twig-fixtures
       ```
+    - **Mutating maintenance command** — not a test: regenerates the snapshot fixtures used by the layout field rendering tests (`FieldRenderingSnapshotTest`, DB-backed). Run when you've intentionally changed the layout field renderer; review the diff before committing:
+      ```sh
+      openemr-cmd update-layout-field-fixtures
+      ```
 7. <a name="dev_tools_suite"></a>Run the entire dev tool suite (PSR12 fix, lint themes fix, PHP parse error, unit/API/e2e/services/fixtures/validators/controllers/common tests) in one command, run
     ```sh
     openemr-cmd clean-sweep


### PR DESCRIPTION
## Summary

Documents two new openemr-cmd aliases (added in [openemr/openemr-devops#736](https://github.com/openemr/openemr-devops/pull/736)) that wrap composer scripts previously reachable only by running `composer <script>` inside the container manually:

- **`pgr` / `phpstan-generate-reset`** — wipes the PHPStan baseline then regenerates from scratch (companion to `psg` / `phpstan-generate`; wraps `composer phpstan-baseline-reset`).
- **`ulff` / `update-layout-field-fixtures`** — regenerates the snapshot fixtures for `tests/Tests/Services/Common/Layouts/FieldRenderingSnapshotTest.php` (DB-backed, default suite — companion to `utf` / `update-twig-fixtures` for the isolated Twig render tests).

## Changes

- **`CLAUDE.md`** — adds in-container and on-host invocations for `phpstan-generate-reset` to the Code Quality command lists, plus a new "Layout field rendering tests" subsection mirroring the existing "Twig template tests" structure for `update-layout-field-fixtures`.
- **`CONTRIBUTING.md`** — adds a parallel bullet for `update-layout-field-fixtures` right next to `update-twig-fixtures` in the openemr-cmd commands list.

## Dependency

This PR documents commands that don't exist in openemr-cmd until [openemr/openemr-devops#736](https://github.com/openemr/openemr-devops/pull/736) lands and a flex image rebuild ships. Hold merge until then.

## Test plan

- [x] Local pre-commit: codespell + actionlint + Conventional Commits all pass.
- [ ] CI clean (docs-only change, should be quick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)