### PR TITLE
test: exclude NotificationCronEmailTest from e2e suite (it lives in email suite)

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -56,6 +56,7 @@ This file configures the kind that requires initialization.
       <exclude>tests/Tests/E2e/EmailSendTest.php</exclude>
       <exclude>tests/Tests/E2e/EmailTestServiceTest.php</exclude>
       <exclude>tests/Tests/E2e/FaxSmsEmailTest.php</exclude>
+      <exclude>tests/Tests/E2e/NotificationCronEmailTest.php</exclude>
     </testsuite>
     <testsuite name="api">
       <directory>tests/Tests/Api</directory>


### PR DESCRIPTION
## Summary

`tests/Tests/E2e/NotificationCronEmailTest.php` was added to the `email` testsuite in #11589 to keep it out of the default e2e CI runs. The matching `<exclude>` in the `e2e` suite was forgotten, so the file lives in two suites at once. PHPUnit warns on every run that loads `phpunit.xml`:

```
Cannot add file tests/Tests/E2e/NotificationCronEmailTest.php to test suite 'email' as it was already added to test suite 'e2e'
```

That warning causes PHPUnit to return a non-zero exit code on otherwise-clean runs. The most visible victim is `composer update-layout-field-fixtures` (`openemr-cmd ulff`): every fixture regenerates fine, every test is skipped successfully, but the script reports `Script ... returned with error code 1` purely because of this stray warning.

## Fix

One line added — matches the pattern of the other three email tests already excluded above:

```xml
    <testsuite name="e2e">
      <directory>tests/Tests/E2e</directory>
      <exclude>tests/Tests/E2e/EmailSendTest.php</exclude>
      <exclude>tests/Tests/E2e/EmailTestServiceTest.php</exclude>
      <exclude>tests/Tests/E2e/FaxSmsEmailTest.php</exclude>
+     <exclude>tests/Tests/E2e/NotificationCronEmailTest.php</exclude>
    </testsuite>
```

## Test plan

- [x] Locally re-ran `openemr-cmd ulff` after the fix: exit 0, no PHPUnit warning.
- [x] `phpunit --filter GroupExportFhirApiTest` (an unrelated single-test run) no longer prints the dual-suite warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)