### PR TITLE
test(api): align site_addr_oath with baseUrl in GroupExportFhirApiTest setUp

### DIFF
--- a/tests/Tests/Api/GroupExportFhirApiTest.php
+++ b/tests/Tests/Api/GroupExportFhirApiTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenEMR\Tests\Api;
 
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\RestControllers\FHIR\FhirPatientRestController;
 use OpenEMR\RestControllers\FHIR\Operations\FhirOperationExportRestController;
@@ -18,16 +19,35 @@ class GroupExportFhirApiTest extends TestCase
     private FixtureManager $fixtureManager;
     private array $fhirFixture;
     private FhirPatientRestController $fhirPatientController;
+    private ?string $savedSiteAddrOath = null;
+
     protected function setUp(): void
     {
         $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
         $this->testClient = new BulkAPITestClient($baseUrl, false);
+
+        // Align site_addr_oath with $baseUrl so the JWT client-assertion's
+        // 'aud' claim matches the server's expected audience. The dev
+        // compose sets site_addr_oath to an external host:port URL
+        // (e.g. https://localhost:9302) for browser access, but tests run
+        // inside the container where the OAuth server resolves to
+        // https://localhost. Without this, the JWT aud check fails and
+        // setAuthToken returns 401. CI's site_addr_oath happens to match
+        // the container's view already so this is a no-op there.
+        $row = QueryUtils::querySingleRow("SELECT gl_value FROM globals WHERE gl_name = 'site_addr_oath'");
+        $value = is_array($row) ? ($row['gl_value'] ?? null) : null;
+        $this->savedSiteAddrOath = is_string($value) ? $value : null;
+        QueryUtils::sqlStatementThrowException("UPDATE globals SET gl_value = ? WHERE gl_name = 'site_addr_oath'", [$baseUrl]);
     }
 
     public function tearDown(): void
     {
         $this->testClient->cleanupRevokeAuth();
         $this->testClient->cleanupClient();
+        if ($this->savedSiteAddrOath !== null) {
+            QueryUtils::sqlStatementThrowException("UPDATE globals SET gl_value = ? WHERE gl_name = 'site_addr_oath'", [$this->savedSiteAddrOath]);
+            $this->savedSiteAddrOath = null;
+        }
     }
 
     public function testGroupExportWithNonExistingGroupId(): void

--- a/tests/Tests/Api/GroupExportFhirApiTest.php
+++ b/tests/Tests/Api/GroupExportFhirApiTest.php
@@ -31,9 +31,14 @@ class GroupExportFhirApiTest extends TestCase
         // compose sets site_addr_oath to an external host:port URL
         // (e.g. https://localhost:9302) for browser access, but tests run
         // inside the container where the OAuth server resolves to
-        // https://localhost. Without this, the JWT aud check fails and
-        // setAuthToken returns 401. CI's site_addr_oath happens to match
-        // the container's view already so this is a no-op there.
+        // https://localhost. Without this, the token endpoint rejects
+        // the assertion as invalid_client (HTTP 400 from
+        // JWTClientAuthenticationService::validateJWTClientAssertion);
+        // setAuthToken's response is not 200 so $this->access_token stays
+        // null; the subsequent FHIR request goes out with an empty bearer
+        // and the resource server returns 401. CI's site_addr_oath
+        // happens to match the container's view already so this is a
+        // no-op there.
         $row = QueryUtils::querySingleRow("SELECT gl_value FROM globals WHERE gl_name = 'site_addr_oath'");
         $value = is_array($row) ? ($row['gl_value'] ?? null) : null;
         $this->savedSiteAddrOath = is_string($value) ? $value : null;
@@ -42,11 +47,18 @@ class GroupExportFhirApiTest extends TestCase
 
     public function tearDown(): void
     {
-        $this->testClient->cleanupRevokeAuth();
-        $this->testClient->cleanupClient();
-        if ($this->savedSiteAddrOath !== null) {
-            QueryUtils::sqlStatementThrowException("UPDATE globals SET gl_value = ? WHERE gl_name = 'site_addr_oath'", [$this->savedSiteAddrOath]);
-            $this->savedSiteAddrOath = null;
+        // try/finally so the site_addr_oath restore always runs even if a
+        // cleanup HTTP call throws (Guzzle can raise on connection errors).
+        // Otherwise the override would leak into later tests in the same
+        // PHPUnit process.
+        try {
+            $this->testClient->cleanupRevokeAuth();
+            $this->testClient->cleanupClient();
+        } finally {
+            if ($this->savedSiteAddrOath !== null) {
+                QueryUtils::sqlStatementThrowException("UPDATE globals SET gl_value = ? WHERE gl_name = 'site_addr_oath'", [$this->savedSiteAddrOath]);
+                $this->savedSiteAddrOath = null;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`GroupExportFhirApiTest::testGroupExportWithNonExistingGroupId` fails in dev with 401, but passes in CI. The test author already left a comment at line 36 foreshadowing this exact case:

> the audience and internal oauth server url need to match, if the internal oauth server is not the same as the external phpunit endpoint location we are going to have issues with the test client not being able to get an access token

…and almost marked the test incomplete because of it. Fixing instead of skipping.

## Root cause

`BulkAPITestClient::setAuthToken()` builds the JWT client-assertion's `aud` claim from `$this->baseUrl` (defaults to `https://localhost`). The OAuth server validates the JWT `aud` against `$globalsBag->get('site_addr_oath')`.

- In **CI**: `site_addr_oath` is implicitly `https://localhost` (no port — `InstallerAuto.php` doesn't set it and the dev compose's `setGlobalSettings` doesn't run). Audience matches → token issued → test passes.
- In **dev**: `auto_configure.php` calls `setGlobalSettings`, which sets `site_addr_oath` to `https://localhost:9302` (offset 2), `:9304` (offset 4), etc. for browser access. The in-container test client sees `https://localhost` (port 443 inside container), but the server expects `https://localhost:9302`. Mismatch → token issuance fails → `getAccessToken()` returns null → test sends an empty `Bearer ` header → FHIR endpoint returns 401.

## Fix

`setUp()` saves the current `site_addr_oath`, overrides it to match `$baseUrl` for the test's duration, and `tearDown()` restores. DB access goes through `QueryUtils::querySingleRow` / `sqlStatementThrowException` to satisfy the `openemr.deprecatedSqlFunction` PHPStan rule.

## Test plan

- [x] Verified locally on a fresh dev worktree (offset 4, `site_addr_oath` defaulting to `https://localhost:9304`): test passes (6 assertions), value correctly restored after `tearDown`.
- [x] `composer phpstan` clean.
- [ ] CI: api job continues to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)