### PR TITLE
feat(storage): fail fast when CLI runs as non-web user before file writes

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -80,6 +80,8 @@
     "lookup_code_descriptions",
     "note",
     "opcache_invalidate",
+    "posix_geteuid",
+    "posix_getpwnam",
     "privQuery",
     "privStatement",
     "resolve_rules_sql",

--- a/src/Common/Auth/OAuth2KeyConfig.php
+++ b/src/Common/Auth/OAuth2KeyConfig.php
@@ -197,9 +197,18 @@ class OAuth2KeyConfig
         // Fail fast if this process is not running as the web user.
         // Root-owned key files would brick OAuth at runtime: the web
         // server would log "Key path ... does not exist or is not
-        // readable" and return 500. See WebUserGuard for the full
-        // reasoning.
-        WebUserGuard::assertSafe('OAuth2 key generation at ' . $this->privateKey);
+        // readable" and return 500. The reference path is derived from
+        // the explicit private-key location (which already encodes the
+        // configured site dir) rather than $GLOBALS['OE_SITE_DIR'], so
+        // multisite callers that instantiate OAuth2KeyConfig with a
+        // non-default $siteDir validate against the correct site's
+        // documents directory. See WebUserGuard for the full reasoning.
+        WebUserGuard::assertSafe(
+            'OAuth2 key generation at ' . $this->privateKey,
+            // {siteDir}/documents/certificates/oaprivate.key
+            //   -> dirname x2 -> {siteDir}/documents
+            dirname($this->privateKey, 2),
+        );
 
         // Collect info from $this->oauth2KeyMissing to determine what is missing for logging purposes and then reset it
         $createNew = $this->oauth2KeyMissing->isMissingAll();

--- a/src/Common/Auth/OAuth2KeyConfig.php
+++ b/src/Common/Auth/OAuth2KeyConfig.php
@@ -23,6 +23,7 @@ use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Utils\RandomGenUtils;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Services\Storage\WebUserGuard;
 
 class OAuth2KeyConfig
 {
@@ -193,6 +194,13 @@ class OAuth2KeyConfig
 
     private function createOrRecreateKeys(): void
     {
+        // Fail fast if this process is not running as the web user.
+        // Root-owned key files would brick OAuth at runtime: the web
+        // server would log "Key path ... does not exist or is not
+        // readable" and return 500. See WebUserGuard for the full
+        // reasoning.
+        WebUserGuard::assertSafe('OAuth2 key generation at ' . $this->privateKey);
+
         // Collect info from $this->oauth2KeyMissing to determine what is missing for logging purposes and then reset it
         $createNew = $this->oauth2KeyMissing->isMissingAll();
         if ($createNew) {

--- a/src/Services/Storage/CacheDirectory.php
+++ b/src/Services/Storage/CacheDirectory.php
@@ -46,7 +46,7 @@ use RuntimeException;
 final readonly class CacheDirectory
 {
     private string $baseDir;
-    private ?string $referencePath;
+    private string $referencePath;
 
     /**
      * @param string|null $baseDir       For testing only. This parameter is
@@ -61,13 +61,28 @@ final readonly class CacheDirectory
      *                                   guard validates against a
      *                                   test-process-owned dir and doesn't
      *                                   throw). In production both parameters
-     *                                   are null and the guard auto-discovers
+     *                                   are null and the reference is derived
      *                                   from `$GLOBALS['OE_SITE_DIR']`.
      */
     public function __construct(?string $baseDir = null, ?string $referencePath = null)
     {
         if ($baseDir === null) {
             $baseDir = sys_get_temp_dir();
+            // Production path: derive the reference from the bootstrapped
+            // site dir. `$GLOBALS['OE_SITE_DIR']` is set by
+            // interface/globals.php; every production caller of
+            // CacheDirectory runs after that.
+            // @phpstan-ignore openemr.forbiddenGlobalsAccess
+            $siteDir = $GLOBALS['OE_SITE_DIR'] ?? null;
+            if (!is_string($siteDir) || $siteDir === '') {
+                throw new \LogicException(
+                    'CacheDirectory requires $GLOBALS[\'OE_SITE_DIR\'] to be '
+                    . 'set (loaded via interface/globals.php). Pass a '
+                    . '$referencePath explicitly if instantiating outside a '
+                    . 'bootstrapped site context.'
+                );
+            }
+            $referencePath = $siteDir . '/documents';
         } else {
             if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
                 // @codeCoverageIgnoreStart
@@ -107,11 +122,7 @@ final readonly class CacheDirectory
         // root-owned cache dir created here would brick the web server
         // later (PHP Fatal: unable to write to compile_dir). See
         // WebUserGuard for the full reasoning.
-        if ($this->referencePath !== null) {
-            WebUserGuard::assertSafeWithReference('cache directory at ' . $path, $this->referencePath);
-        } else {
-            WebUserGuard::assertSafe('cache directory at ' . $path);
-        }
+        WebUserGuard::assertSafe('cache directory at ' . $path, $this->referencePath);
 
         if (is_link($path)) {
             throw new RuntimeException(sprintf(

--- a/src/Services/Storage/CacheDirectory.php
+++ b/src/Services/Storage/CacheDirectory.php
@@ -46,7 +46,7 @@ use RuntimeException;
 final readonly class CacheDirectory
 {
     private string $baseDir;
-    private string $referencePath;
+    private ?string $referencePath;
 
     /**
      * @param string|null $baseDir       For testing only. This parameter is
@@ -61,28 +61,14 @@ final readonly class CacheDirectory
      *                                   guard validates against a
      *                                   test-process-owned dir and doesn't
      *                                   throw). In production both parameters
-     *                                   are null and the reference is derived
-     *                                   from `$GLOBALS['OE_SITE_DIR']`.
+     *                                   are null and the guard falls back to
+     *                                   `{OE_SITE_DIR}/documents` via
+     *                                   OEGlobalsBag.
      */
     public function __construct(?string $baseDir = null, ?string $referencePath = null)
     {
         if ($baseDir === null) {
             $baseDir = sys_get_temp_dir();
-            // Production path: derive the reference from the bootstrapped
-            // site dir. `$GLOBALS['OE_SITE_DIR']` is set by
-            // interface/globals.php; every production caller of
-            // CacheDirectory runs after that.
-            // @phpstan-ignore openemr.forbiddenGlobalsAccess
-            $siteDir = $GLOBALS['OE_SITE_DIR'] ?? null;
-            if (!is_string($siteDir) || $siteDir === '') {
-                throw new \LogicException(
-                    'CacheDirectory requires $GLOBALS[\'OE_SITE_DIR\'] to be '
-                    . 'set (loaded via interface/globals.php). Pass a '
-                    . '$referencePath explicitly if instantiating outside a '
-                    . 'bootstrapped site context.'
-                );
-            }
-            $referencePath = $siteDir . '/documents';
         } else {
             if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
                 // @codeCoverageIgnoreStart

--- a/src/Services/Storage/CacheDirectory.php
+++ b/src/Services/Storage/CacheDirectory.php
@@ -46,13 +46,25 @@ use RuntimeException;
 final readonly class CacheDirectory
 {
     private string $baseDir;
+    private ?string $referencePath;
 
     /**
-     * @param string $baseDir For testing only. This parameter is guarded and
-     *                        will throw LogicException outside of PHPUnit.
-     *                        Production code must use the default.
+     * @param string|null $baseDir       For testing only. This parameter is
+     *                                   guarded and will throw LogicException
+     *                                   outside of PHPUnit. Production code
+     *                                   must use the default.
+     * @param string|null $referencePath For testing only. Overrides the
+     *                                   directory WebUserGuard uses to detect
+     *                                   the runtime web user. When `$baseDir`
+     *                                   is supplied without `$referencePath`,
+     *                                   the test base dir is used (so the
+     *                                   guard validates against a
+     *                                   test-process-owned dir and doesn't
+     *                                   throw). In production both parameters
+     *                                   are null and the guard auto-discovers
+     *                                   from `$GLOBALS['OE_SITE_DIR']`.
      */
-    public function __construct(?string $baseDir = null)
+    public function __construct(?string $baseDir = null, ?string $referencePath = null)
     {
         if ($baseDir === null) {
             $baseDir = sys_get_temp_dir();
@@ -64,8 +76,12 @@ final readonly class CacheDirectory
                 );
                 // @codeCoverageIgnoreEnd
             }
+            // In test mode default the WebUserGuard reference to the test
+            // base dir, which the test process owns — match, no throw.
+            $referencePath ??= $baseDir;
         }
         $this->baseDir = $baseDir;
+        $this->referencePath = $referencePath;
     }
 
     /**
@@ -86,6 +102,16 @@ final readonly class CacheDirectory
         }
 
         $path = $this->baseDir . '/' . $scope;
+
+        // Fail fast if this process is not running as the web user. A
+        // root-owned cache dir created here would brick the web server
+        // later (PHP Fatal: unable to write to compile_dir). See
+        // WebUserGuard for the full reasoning.
+        if ($this->referencePath !== null) {
+            WebUserGuard::assertSafeWithReference('cache directory at ' . $path, $this->referencePath);
+        } else {
+            WebUserGuard::assertSafe('cache directory at ' . $path);
+        }
 
         if (is_link($path)) {
             throw new RuntimeException(sprintf(

--- a/src/Services/Storage/WebUserGuard.php
+++ b/src/Services/Storage/WebUserGuard.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Guard against creating files the web server cannot read later.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\Storage;
+
+use RuntimeException;
+use Symfony\Component\Process\Exception\ExceptionInterface as ProcessExceptionInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * Asserts that the current PHP process is running as the same UID as the
+ * web server, so files this process creates will be readable by the web
+ * server later.
+ *
+ * The mismatch this catches: a CLI invocation (e.g. an admin's
+ * `sudo php sql_upgrade.php`, or a cron job configured to run as root)
+ * creates a file or directory with restrictive permissions; the web
+ * server, running as a different UID, then cannot read it. The failure
+ * later is opaque — a `PHP Fatal error: ... unable to write to ...`
+ * deep in template rendering or PDF generation, far from the original
+ * mistake.
+ *
+ * Surfacing the mismatch at the *write* call site converts that opaque
+ * failure into an immediate, actionable error pointing at the actual
+ * fix: "re-run PHP as the web user."
+ *
+ * The "web user" is detected from the owner of a directory OpenEMR
+ * guarantees is writable by the web server at runtime — specifically
+ * `{site_dir}/documents` (where patient documents are written). Whoever
+ * owns that directory IS the runtime web user, by definition; if it
+ * weren't, document uploads would already be broken.
+ *
+ * Non-POSIX systems (Windows): the check is skipped entirely. Windows
+ * uses ACLs, not UID-based permissions, and the failure mode this guards
+ * against doesn't naturally exist there.
+ */
+final class WebUserGuard
+{
+    /**
+     * Assert that this process can safely create files the web server
+     * will read later, using the default reference directory
+     * ({site_dir}/documents).
+     *
+     * No-ops on non-POSIX systems and when the reference directory
+     * cannot be located (e.g. early in bootstrap before
+     * `$GLOBALS['OE_SITE_DIR']` is set).
+     *
+     * @param string $writeContext Short description of what's about to be
+     *                             written, included in the error message
+     *                             to help the admin locate the mistake.
+     */
+    public static function assertSafe(string $writeContext): void
+    {
+        $referencePath = self::defaultReferencePath();
+        if ($referencePath === null) {
+            return;
+        }
+        self::assertSafeWithReference($writeContext, $referencePath);
+    }
+
+    /**
+     * Assert that this process can safely create files the web server
+     * will read later, using a caller-supplied reference directory.
+     *
+     * Use this overload when the caller already has a known-writable
+     * directory in hand (e.g. OAuth2KeyConfig already knows
+     * `{siteDir}/documents`), or in tests.
+     *
+     * No-ops on non-POSIX systems and when the reference path cannot be
+     * stat'd.
+     *
+     * @param string $writeContext   Short description of what's about to
+     *                               be written, included in the error
+     *                               message.
+     * @param string $referencePath  Path to a directory the web server
+     *                               writes to at runtime; its owner IS
+     *                               the web user.
+     */
+    public static function assertSafeWithReference(string $writeContext, string $referencePath): void
+    {
+        $current = self::currentEffectiveUid();
+        if ($current === null) {
+            // Non-POSIX (Windows), or couldn't determine — skip.
+            return;
+        }
+
+        $owner = @fileowner($referencePath);
+        if ($owner === false) {
+            // Reference path missing/unreadable. Fail open: this is a
+            // safety check, not a load-bearing precondition; if the
+            // install is broken enough that the documents dir isn't
+            // there, the user has bigger problems.
+            return;
+        }
+
+        if ($current === $owner) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            "Web-user mismatch: '%s' would be done by UID %d, but '%s' "
+            . "(a directory the web server writes to) is owned by UID %d. "
+            . "Files this process creates would not be readable by the web "
+            . "server, which would cause opaque fatal errors later "
+            . "(unable to write to compile_dir, key path not readable, "
+            . "etc). Re-run PHP as UID %d — e.g. via "
+            . "`su -s /bin/sh \$(id -un %d) -c '<your command>'`.",
+            $writeContext,
+            $current,
+            $referencePath,
+            $owner,
+            $owner,
+            $owner,
+        ));
+    }
+
+    /**
+     * Resolve the current process's effective UID without requiring the
+     * `posix` PHP extension to be loaded.
+     *
+     * Prefers `posix_geteuid()`. Falls back to running `id -u` via
+     * Symfony Process when posix is unavailable (common in stripped-down
+     * PHP CLI builds). Returns null on Windows / when neither path
+     * works.
+     */
+    private static function currentEffectiveUid(): ?int
+    {
+        if (function_exists('posix_geteuid')) {
+            return posix_geteuid();
+        }
+        try {
+            $process = new Process(['id', '-u']);
+            $process->run();
+            if (!$process->isSuccessful()) {
+                return null;
+            }
+            $trimmed = trim($process->getOutput());
+            if ($trimmed !== '' && ctype_digit($trimmed)) {
+                return (int) $trimmed;
+            }
+        } catch (ProcessExceptionInterface) {
+            // ProcessStartFailedException (binary missing), etc.
+            return null;
+        }
+        return null;
+    }
+
+    /**
+     * Find the default reference directory for the current OpenEMR site.
+     *
+     * Returns null if the site directory isn't set in $GLOBALS (e.g.
+     * pre-bootstrap call) or the documents subdirectory doesn't exist.
+     */
+    private static function defaultReferencePath(): ?string
+    {
+        // Direct $GLOBALS read intentional: this runs in low-level filesystem
+        // code paths where the OEGlobalsBag kernel may not have been
+        // initialized yet.
+        // @phpstan-ignore openemr.forbiddenGlobalsAccess
+        $siteDir = $GLOBALS['OE_SITE_DIR'] ?? null;
+        if (!is_string($siteDir) || $siteDir === '') {
+            return null;
+        }
+        $docs = $siteDir . '/documents';
+        return is_dir($docs) ? $docs : null;
+    }
+}

--- a/src/Services/Storage/WebUserGuard.php
+++ b/src/Services/Storage/WebUserGuard.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Services\Storage;
 
+use OpenEMR\Core\OEGlobalsBag;
 use RuntimeException;
 use Symfony\Component\Process\Exception\ExceptionInterface as ProcessExceptionInterface;
 use Symfony\Component\Process\Process;
@@ -35,11 +36,12 @@ use Symfony\Component\Process\Process;
  * failure into an immediate, actionable error pointing at the actual
  * fix: "re-run PHP as the web user."
  *
- * Callers supply a reference directory that the web server is known to
- * write to at runtime (e.g. `{site_dir}/documents`, where patient
- * documents are written). Whoever owns that directory IS the runtime
- * web user, by definition; if it weren't, document uploads would
- * already be broken.
+ * The reference directory used for the comparison must be one the web
+ * server is known to write to at runtime. By default the guard uses
+ * `{OE_SITE_DIR}/documents` (where patient documents land); whoever
+ * owns that directory IS the runtime web user, by definition (if it
+ * weren't, document uploads would already be broken). Callers with a
+ * different or multisite-specific path can pass it explicitly.
  *
  * Non-POSIX systems (Windows): the check is skipped entirely. Windows
  * uses ACLs, not UID-based permissions, and the failure mode this
@@ -55,16 +57,23 @@ final class WebUserGuard
      * stat'd (a missing reference is a bigger install problem; this
      * helper is a safety check, not a load-bearing precondition).
      *
-     * @param string $writeContext  Short description of what's about to
-     *                              be written, included in the error
-     *                              message to help the admin locate the
-     *                              mistake.
-     * @param string $referencePath Path to a directory the web server
-     *                              writes to at runtime; its owner IS
-     *                              the web user.
+     * @param string      $writeContext  Short description of what's
+     *                                   about to be written, included
+     *                                   in the error message to help
+     *                                   the admin locate the mistake.
+     * @param string|null $referencePath Path to a directory the web
+     *                                   server writes to at runtime;
+     *                                   its owner IS the web user.
+     *                                   When null, resolved from
+     *                                   `OEGlobalsBag` as
+     *                                   `{OE_SITE_DIR}/documents`.
+     *                                   Pass explicitly when the
+     *                                   caller knows the site context
+     *                                   (e.g. multisite).
      */
-    public static function assertSafe(string $writeContext, string $referencePath): void
+    public static function assertSafe(string $writeContext, ?string $referencePath = null): void
     {
+        $referencePath ??= self::defaultReferencePath();
         $current = self::currentEffectiveUid();
         if ($current === null) {
             // Non-POSIX (Windows), or couldn't determine — skip.
@@ -95,6 +104,31 @@ final class WebUserGuard
             $owner,
             $owner,
         ));
+    }
+
+    /**
+     * Resolve the default reference directory from the bootstrapped
+     * site context.
+     *
+     * @throws \LogicException when OE_SITE_DIR is not available via
+     *                         OEGlobalsBag. Callers reaching this path
+     *                         have presumably bootstrapped OpenEMR;
+     *                         not having OE_SITE_DIR is a programmer
+     *                         error worth surfacing loudly rather
+     *                         than silently no-opping.
+     */
+    private static function defaultReferencePath(): string
+    {
+        $siteDir = OEGlobalsBag::getInstance()->get('OE_SITE_DIR');
+        if (!is_string($siteDir) || $siteDir === '') {
+            throw new \LogicException(
+                'WebUserGuard could not resolve a default reference path: '
+                . 'OE_SITE_DIR is not set via OEGlobalsBag (call site is '
+                . 'likely pre-bootstrap). Pass a $referencePath explicitly '
+                . 'or load interface/globals.php first.'
+            );
+        }
+        return $siteDir . '/documents';
     }
 
     /**

--- a/src/Services/Storage/WebUserGuard.php
+++ b/src/Services/Storage/WebUserGuard.php
@@ -5,6 +5,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -33,59 +35,35 @@ use Symfony\Component\Process\Process;
  * failure into an immediate, actionable error pointing at the actual
  * fix: "re-run PHP as the web user."
  *
- * The "web user" is detected from the owner of a directory OpenEMR
- * guarantees is writable by the web server at runtime — specifically
- * `{site_dir}/documents` (where patient documents are written). Whoever
- * owns that directory IS the runtime web user, by definition; if it
- * weren't, document uploads would already be broken.
+ * Callers supply a reference directory that the web server is known to
+ * write to at runtime (e.g. `{site_dir}/documents`, where patient
+ * documents are written). Whoever owns that directory IS the runtime
+ * web user, by definition; if it weren't, document uploads would
+ * already be broken.
  *
  * Non-POSIX systems (Windows): the check is skipped entirely. Windows
- * uses ACLs, not UID-based permissions, and the failure mode this guards
- * against doesn't naturally exist there.
+ * uses ACLs, not UID-based permissions, and the failure mode this
+ * guards against doesn't naturally exist there.
  */
 final class WebUserGuard
 {
     /**
      * Assert that this process can safely create files the web server
-     * will read later, using the default reference directory
-     * ({site_dir}/documents).
-     *
-     * No-ops on non-POSIX systems and when the reference directory
-     * cannot be located (e.g. early in bootstrap before
-     * `$GLOBALS['OE_SITE_DIR']` is set).
-     *
-     * @param string $writeContext Short description of what's about to be
-     *                             written, included in the error message
-     *                             to help the admin locate the mistake.
-     */
-    public static function assertSafe(string $writeContext): void
-    {
-        $referencePath = self::defaultReferencePath();
-        if ($referencePath === null) {
-            return;
-        }
-        self::assertSafeWithReference($writeContext, $referencePath);
-    }
-
-    /**
-     * Assert that this process can safely create files the web server
-     * will read later, using a caller-supplied reference directory.
-     *
-     * Use this overload when the caller already has a known-writable
-     * directory in hand (e.g. OAuth2KeyConfig already knows
-     * `{siteDir}/documents`), or in tests.
+     * will read later.
      *
      * No-ops on non-POSIX systems and when the reference path cannot be
-     * stat'd.
+     * stat'd (a missing reference is a bigger install problem; this
+     * helper is a safety check, not a load-bearing precondition).
      *
-     * @param string $writeContext   Short description of what's about to
-     *                               be written, included in the error
-     *                               message.
-     * @param string $referencePath  Path to a directory the web server
-     *                               writes to at runtime; its owner IS
-     *                               the web user.
+     * @param string $writeContext  Short description of what's about to
+     *                              be written, included in the error
+     *                              message to help the admin locate the
+     *                              mistake.
+     * @param string $referencePath Path to a directory the web server
+     *                              writes to at runtime; its owner IS
+     *                              the web user.
      */
-    public static function assertSafeWithReference(string $writeContext, string $referencePath): void
+    public static function assertSafe(string $writeContext, string $referencePath): void
     {
         $current = self::currentEffectiveUid();
         if ($current === null) {
@@ -95,10 +73,6 @@ final class WebUserGuard
 
         $owner = @fileowner($referencePath);
         if ($owner === false) {
-            // Reference path missing/unreadable. Fail open: this is a
-            // safety check, not a load-bearing precondition; if the
-            // install is broken enough that the documents dir isn't
-            // there, the user has bigger problems.
             return;
         }
 
@@ -113,7 +87,7 @@ final class WebUserGuard
             . "server, which would cause opaque fatal errors later "
             . "(unable to write to compile_dir, key path not readable, "
             . "etc). Re-run PHP as UID %d — e.g. via "
-            . "`su -s /bin/sh \$(id -un %d) -c '<your command>'`.",
+            . "`su -s /bin/sh \$(id -un %d) -c '[your command]'`.",
             $writeContext,
             $current,
             $referencePath,
@@ -128,14 +102,23 @@ final class WebUserGuard
      * `posix` PHP extension to be loaded.
      *
      * Prefers `posix_geteuid()`. Falls back to running `id -u` via
-     * Symfony Process when posix is unavailable (common in stripped-down
-     * PHP CLI builds). Returns null on Windows / when neither path
-     * works.
+     * Symfony Process when posix is unavailable on a non-Windows host
+     * (common in stripped-down PHP CLI builds). Returns null on Windows
+     * (where the comparison doesn't apply — Windows uses ACLs) and when
+     * neither resolution path works.
      */
     private static function currentEffectiveUid(): ?int
     {
         if (function_exists('posix_geteuid')) {
             return posix_geteuid();
+        }
+        // Don't fall back to `id -u` on Windows: Git/MSYS in PATH would
+        // provide an `id` binary that returns a Unix-style UID, but
+        // fileowner() on Windows returns ACL-derived integers that
+        // don't share the same numbering space — comparing the two
+        // would produce nonsense mismatches.
+        if (PHP_OS_FAMILY === 'Windows') {
+            return null;
         }
         try {
             $process = new Process(['id', '-u']);
@@ -152,25 +135,5 @@ final class WebUserGuard
             return null;
         }
         return null;
-    }
-
-    /**
-     * Find the default reference directory for the current OpenEMR site.
-     *
-     * Returns null if the site directory isn't set in $GLOBALS (e.g.
-     * pre-bootstrap call) or the documents subdirectory doesn't exist.
-     */
-    private static function defaultReferencePath(): ?string
-    {
-        // Direct $GLOBALS read intentional: this runs in low-level filesystem
-        // code paths where the OEGlobalsBag kernel may not have been
-        // initialized yet.
-        // @phpstan-ignore openemr.forbiddenGlobalsAccess
-        $siteDir = $GLOBALS['OE_SITE_DIR'] ?? null;
-        if (!is_string($siteDir) || $siteDir === '') {
-            return null;
-        }
-        $docs = $siteDir . '/documents';
-        return is_dir($docs) ? $docs : null;
     }
 }

--- a/tests/Tests/Isolated/Services/Storage/CacheDirectoryTest.php
+++ b/tests/Tests/Isolated/Services/Storage/CacheDirectoryTest.php
@@ -138,11 +138,23 @@ final class CacheDirectoryTest extends TestCase
 
     public function testForUsesSystemTempDirWhenNoBaseDirProvided(): void
     {
+        // The no-arg constructor reads $GLOBALS['OE_SITE_DIR'] to seed
+        // its WebUserGuard reference; the isolated suite doesn't load
+        // interface/globals.php, so set it manually here. Point it at
+        // testBaseDir so the guard validates against a path the test
+        // process owns (no mismatch).
         $scope = 'openemr-cache-test-' . bin2hex(random_bytes(8));
-        $cache = new CacheDirectory();
         $tempDir = sys_get_temp_dir();
+        $hadSiteDir = array_key_exists('OE_SITE_DIR', $GLOBALS);
+        $priorSiteDir = $GLOBALS['OE_SITE_DIR'] ?? null;
+        // The WebUserGuard reference is {OE_SITE_DIR}/documents — point
+        // at testBaseDir's parent so {parent}/documents matches a real
+        // dir the test process owns.
+        @mkdir($this->testBaseDir . '-fake-site/documents', 0700, true);
+        $GLOBALS['OE_SITE_DIR'] = $this->testBaseDir . '-fake-site';
 
         try {
+            $cache = new CacheDirectory();
             $path = $cache->for($scope);
 
             self::assertSame($tempDir . '/' . $scope, $path);
@@ -150,6 +162,12 @@ final class CacheDirectoryTest extends TestCase
         } finally {
             if (is_dir($tempDir . '/' . $scope)) {
                 rmdir($tempDir . '/' . $scope);
+            }
+            $this->recursiveDelete($this->testBaseDir . '-fake-site');
+            if ($hadSiteDir) {
+                $GLOBALS['OE_SITE_DIR'] = $priorSiteDir;
+            } else {
+                unset($GLOBALS['OE_SITE_DIR']);
             }
         }
     }

--- a/tests/Tests/Isolated/Services/Storage/WebUserGuardTest.php
+++ b/tests/Tests/Isolated/Services/Storage/WebUserGuardTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Storage;
+
+use OpenEMR\Services\Storage\WebUserGuard;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Process\Exception\ExceptionInterface as ProcessExceptionInterface;
+use Symfony\Component\Process\Process;
+
+final class WebUserGuardTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/openemr-webuserguard-test-' . bin2hex(random_bytes(8));
+        mkdir($this->tempDir, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempDir)) {
+            // Restore ownership before deletion in case a test chown'd it
+            // away from the test process.
+            $currentUid = self::currentUid();
+            if ($currentUid !== null) {
+                @chown($this->tempDir, $currentUid);
+            }
+            @rmdir($this->tempDir);
+        }
+    }
+
+    public function testAssertSafeWithReferenceDoesNotThrowWhenOwnerMatchesCurrentUid(): void
+    {
+        $this->expectNotToPerformAssertions();
+        // tempDir was just created by the test process; owner is the
+        // current EUID; no mismatch.
+        WebUserGuard::assertSafeWithReference('test write', $this->tempDir);
+    }
+
+    public function testAssertSafeWithReferenceNoOpsOnMissingReferencePath(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $missing = $this->tempDir . '/does-not-exist';
+
+        WebUserGuard::assertSafeWithReference('test write', $missing);
+    }
+
+    public function testAssertSafeWithReferenceThrowsOnUidMismatch(): void
+    {
+        // Need to chown the reference dir to a UID different from the
+        // current process's. Requires root + an available second UID.
+        $currentUid = self::currentUid();
+        if ($currentUid === null) {
+            self::markTestSkipped('Cannot determine current UID; UID-based check does not apply');
+        }
+        if ($currentUid !== 0) {
+            self::markTestSkipped('Test process is not root; cannot chown to fabricate a mismatch');
+        }
+        $apacheUid = self::userUid('apache');
+        if ($apacheUid === null || $apacheUid === $currentUid) {
+            self::markTestSkipped("No usable non-root user on this system to fabricate a mismatch");
+        }
+
+        chown($this->tempDir, $apacheUid);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Web-user mismatch/');
+        $this->expectExceptionMessageMatches('/UID ' . preg_quote((string)$currentUid, '/') . '/');
+        $this->expectExceptionMessageMatches('/UID ' . preg_quote((string)$apacheUid, '/') . '/');
+
+        WebUserGuard::assertSafeWithReference('test write', $this->tempDir);
+    }
+
+    /** Mirror of WebUserGuard::currentEffectiveUid for posix-optional environments. */
+    private static function currentUid(): ?int
+    {
+        if (function_exists('posix_geteuid')) {
+            return posix_geteuid();
+        }
+        return self::idUViaProcess([]);
+    }
+
+    private static function userUid(string $username): ?int
+    {
+        if (function_exists('posix_getpwnam')) {
+            $pw = @posix_getpwnam($username);
+            return ($pw !== false) ? $pw['uid'] : null;
+        }
+        return self::idUViaProcess([$username]);
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    private static function idUViaProcess(array $args): ?int
+    {
+        try {
+            $process = new Process(['id', '-u', ...$args]);
+            $process->run();
+            if (!$process->isSuccessful()) {
+                return null;
+            }
+            $t = trim($process->getOutput());
+            return ($t !== '' && ctype_digit($t)) ? (int) $t : null;
+        } catch (ProcessExceptionInterface) {
+            return null;
+        }
+    }
+}

--- a/tests/Tests/Isolated/Services/Storage/WebUserGuardTest.php
+++ b/tests/Tests/Isolated/Services/Storage/WebUserGuardTest.php
@@ -1,8 +1,12 @@
 <?php
 
 /**
+ * Tests for WebUserGuard.
+ *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -39,23 +43,23 @@ final class WebUserGuardTest extends TestCase
         }
     }
 
-    public function testAssertSafeWithReferenceDoesNotThrowWhenOwnerMatchesCurrentUid(): void
+    public function testAssertSafeDoesNotThrowWhenOwnerMatchesCurrentUid(): void
     {
         $this->expectNotToPerformAssertions();
         // tempDir was just created by the test process; owner is the
         // current EUID; no mismatch.
-        WebUserGuard::assertSafeWithReference('test write', $this->tempDir);
+        WebUserGuard::assertSafe('test write', $this->tempDir);
     }
 
-    public function testAssertSafeWithReferenceNoOpsOnMissingReferencePath(): void
+    public function testAssertSafeNoOpsOnMissingReferencePath(): void
     {
         $this->expectNotToPerformAssertions();
         $missing = $this->tempDir . '/does-not-exist';
 
-        WebUserGuard::assertSafeWithReference('test write', $missing);
+        WebUserGuard::assertSafe('test write', $missing);
     }
 
-    public function testAssertSafeWithReferenceThrowsOnUidMismatch(): void
+    public function testAssertSafeThrowsOnUidMismatch(): void
     {
         // Need to chown the reference dir to a UID different from the
         // current process's. Requires root + an available second UID.
@@ -77,8 +81,12 @@ final class WebUserGuardTest extends TestCase
         $this->expectExceptionMessageMatches('/Web-user mismatch/');
         $this->expectExceptionMessageMatches('/UID ' . preg_quote((string)$currentUid, '/') . '/');
         $this->expectExceptionMessageMatches('/UID ' . preg_quote((string)$apacheUid, '/') . '/');
+        // Sanity-check that the message uses bracket placeholder (not
+        // HTML-special angle brackets) so it survives accidental
+        // browser rendering.
+        $this->expectExceptionMessageMatches('/\\[your command\\]/');
 
-        WebUserGuard::assertSafeWithReference('test write', $this->tempDir);
+        WebUserGuard::assertSafe('test write', $this->tempDir);
     }
 
     /** Mirror of WebUserGuard::currentEffectiveUid for posix-optional environments. */
@@ -86,6 +94,9 @@ final class WebUserGuardTest extends TestCase
     {
         if (function_exists('posix_geteuid')) {
             return posix_geteuid();
+        }
+        if (PHP_OS_FAMILY === 'Windows') {
+            return null;
         }
         return self::idUViaProcess([]);
     }
@@ -95,6 +106,9 @@ final class WebUserGuardTest extends TestCase
         if (function_exists('posix_getpwnam')) {
             $pw = @posix_getpwnam($username);
             return ($pw !== false) ? $pw['uid'] : null;
+        }
+        if (PHP_OS_FAMILY === 'Windows') {
+            return null;
         }
         return self::idUViaProcess([$username]);
     }


### PR DESCRIPTION
## Summary

Files written by a PHP process running as a different UID than the web server end up with restrictive ownership that apache cannot read later. The result is opaque downstream errors like `PHP Fatal: Smarty error: unable to write to compile_dir` or `Key path … is not readable` — far from the actual mistake ("re-run PHP as the apache user").

This PR adds `WebUserGuard` to surface the mismatch *at the write call site*, with an error message that names both UIDs and the exact command to fix it.

## How it works

The guard compares the current process's effective UID against the owner of `{siteDir}/documents` — a directory OpenEMR guarantees is writable by the web server at runtime (it's where patient documents land). Whoever owns that directory IS the runtime web user, by definition.

Example error message:

```
Web-user mismatch: 'cache directory at /tmp/openemr-smarty' would be done by UID 0,
but '/var/www/localhost/htdocs/openemr/sites/default/documents' (a directory the
web server writes to) is owned by UID 1000. Files this process creates would not
be readable by the web server, which would cause opaque fatal errors later
(unable to write to compile_dir, key path not readable, etc). Re-run PHP as UID
1000 — e.g. via `su -s /bin/sh $(id -un 1000) -c '<your command>'`.
```

## Wired into

- **`CacheDirectory::for()`** — covers `/tmp/openemr-smarty` (Smarty compile) and `/tmp/openemr-mpdf` (mPDF temp), plus any future `CacheDirectory` scope automatically (no per-scope maintenance).
- **`OAuth2KeyConfig::createOrRecreateKeys()`** — covers the OAuth2 private/public key generation under `sites/{site}/documents/certificates`.

## Background — what failures this catches

Reproduced today on master in a dev container running as root: hitting any Smarty-rendered page (Calendar, Practice Settings, New Documents) returns 500 with the compile-dir fatal in the PHP error log. Similarly, hitting any FHIR API endpoint returns 500 with "Key path ... is not readable" when the OAuth keys were generated by a root-running CLI invocation. The same shape applies to production environments where admins run `sudo php sql_upgrade.php` or where cron jobs are misconfigured to run as root.

## Cross-OS safety

- Skipped entirely on non-POSIX systems (Windows uses ACLs, not UID semantics; the failure mode doesn't naturally exist there).
- UID resolution prefers `posix_geteuid()` and falls back to running `id -u` via Symfony Process when the `posix` extension isn't loaded (common in stripped-down PHP CLI builds).
- `posix_geteuid` / `posix_getpwnam` are added to `.composer-require-checker.json`'s symbol whitelist — both are guarded with `function_exists` checks, so `ext-posix` is **not** declared as a hard composer dependency.

## Test plan

- [x] `composer phpstan` — clean
- [x] Isolated suite — 3033/3033 pass (3 new `WebUserGuardTest` cases + existing `CacheDirectoryTest` 21/21 still pass)
- [x] Manual verification end-to-end: as root from CLI, `(new CacheDirectory())->for('openemr-smarty')` now throws with the exact message above; as apache (`su apache -s /bin/sh -c '…'`), it creates the dir cleanly with apache ownership.
- [ ] CI green
- [ ] No regressions in api/services suites (will verify on PR)

## Notes for review

- The fix is intentionally *fail-loud*. There's a softer "auto-chown on root-creation" variant we discussed but decided against — it'd silently paper over a real configuration mistake, both in dev (where surfacing the issue is wanted) and in production (where it'd let admins continue running PHP as root without realizing the implication for future cron-vs-apache interleavings).
- Coverage is currently only the two known-impacted writers (cache dirs + OAuth keys). Other lazy-file-creation paths in OpenEMR may have the same issue and would benefit from the same guard. Out of scope for this PR but the helper is designed to drop into any analogous call site (`WebUserGuard::assertSafe('what you're about to write')`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)