### PR TITLE
feat(cli): refuse to run OpenEMR CLI as root

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -80,7 +80,6 @@
     "lookup_code_descriptions",
     "note",
     "opcache_invalidate",
-    "posix_geteuid",
     "privQuery",
     "privStatement",
     "resolve_rules_sql",

--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -80,6 +80,7 @@
     "lookup_code_descriptions",
     "note",
     "opcache_invalidate",
+    "posix_geteuid",
     "privQuery",
     "privStatement",
     "resolve_rules_sql",

--- a/bin/command-runner
+++ b/bin/command-runner
@@ -15,11 +15,17 @@ require_once $rootPath . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 
 
 use OpenEMR\Common\Command\Runner\CommandRunner;
+use OpenEMR\Common\Command\RootCliGuard;
 
 if (php_sapi_name() !== 'cli') {
     echo "Only php cli can execute a command\n";
     die();
 }
+
+// Refuse to run as root. Commands dispatched here (CreateAPIDocumentation,
+// etc.) write files the web server reads later; root-owned outputs would
+// brick those flows. See RootCliGuard for details.
+RootCliGuard::assertNotRoot();
 
 $commandRunner = new CommandRunner($rootPath, pathinfo(__FILE__, PATHINFO_FILENAME));
 $commandRunner->run();

--- a/bin/console
+++ b/bin/console
@@ -19,6 +19,11 @@ if (php_sapi_name() !== 'cli') {
 $fileRoot = dirname(__DIR__);
 require_once "{$fileRoot}/vendor/autoload.php";
 
+// Refuse to run as root. The `--skip-globals` path below would bypass the
+// guard in interface/globals.php; enforce here so all console commands are
+// covered regardless of bootstrap mode.
+OpenEMR\Common\Command\RootCliGuard::assertNotRoot();
+
 $skipGlobals = in_array('--skip-globals', $argv, true);
 // Don't pass --skip-globals to Symfony, and reindex array
 $argv = array_values(array_diff($argv, ['--skip-globals']));

--- a/bin/generate-phpstan-types.php
+++ b/bin/generate-phpstan-types.php
@@ -16,7 +16,11 @@ declare(strict_types=1);
 require_once __DIR__ . '/../vendor/autoload.php';
 
 use OpenEMR\Common\Command\GeneratePhpstanTypesCommand;
+use OpenEMR\Common\Command\RootCliGuard;
 use Symfony\Component\Console\Application;
+
+// Refuse to run as root — see RootCliGuard.
+RootCliGuard::assertNotRoot();
 
 $application = new Application('openemr-phpstan-types', '1.0.0');
 $application->add(new GeneratePhpstanTypesCommand());

--- a/bin/get-v-database.php
+++ b/bin/get-v-database.php
@@ -17,11 +17,17 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+use OpenEMR\Common\Command\RootCliGuard;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\ParserFactory;
+
+// Refuse to run as root — see RootCliGuard. Read-only today, but uniform
+// policy across bin/ scripts avoids the "is this one safe as root" question
+// for future contributors.
+RootCliGuard::assertNotRoot();
 
 $file = $argv[1] ?? __DIR__ . '/../version.php';
 

--- a/bin/refresh-reserved-word-supplement.php
+++ b/bin/refresh-reserved-word-supplement.php
@@ -43,8 +43,14 @@ if (PHP_SAPI !== 'cli') {
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+use OpenEMR\Common\Command\RootCliGuard;
 use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
+
+// Refuse to run as root — see RootCliGuard. Uniform policy across bin/
+// scripts; this one writes the registry + snapshot files in-tree which
+// apache later needs to read at PHPStan-analyze time.
+RootCliGuard::assertNotRoot();
 
 const SNAPSHOT_DIR = __DIR__ . '/../tests/PHPStan/Rules/Sql/snapshots';
 const REGISTRY_FILE = __DIR__ . '/../tests/PHPStan/Rules/Sql/ReservedWordRegistry.php';

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -218,7 +218,22 @@ post_install_upgrade() {
     # rather than the `VAR=val cmd` form — demoData also references
     # $MYSQL_HOST / $MYSQL_ROOT_PASS directly, and the inline form would
     # scope them only to the prepareVariables call.
-    _exec sh -c 'export MYSQL_HOST=mysql MYSQL_ROOT_PASS=root && . /root/devtoolsLibrary.source && prepareVariables && demoData'
+    #
+    # upgradeOpenEMR() is overridden locally so sql_upgrade.php runs as
+    # apache rather than root. RootCliGuard refuses root for OpenEMR CLI
+    # scripts (the failure it catches: a root-owned write here would
+    # brick apache later). The full fix lives in openemr-devops/devtools
+    # — once devtoolsLibrary.source itself drops privileges, this
+    # override can be removed.
+    _exec sh -c '
+        export MYSQL_HOST=mysql MYSQL_ROOT_PASS=root
+        . /root/devtoolsLibrary.source
+        prepareVariables
+        upgradeOpenEMR() {
+            su -p -s /bin/sh apache -c "php -f /var/www/localhost/htdocs/openemr/sql_upgrade.php -- --from=\"$1\""
+        }
+        demoData
+    '
 
     # demoData drops all tables and reseeds from the 5.0.0 dump (which
     # has its own globals values), so the CI-specific globals that

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -238,23 +238,7 @@ post_install_upgrade() {
     # rather than the `VAR=val cmd` form — demoData also references
     # $MYSQL_HOST / $MYSQL_ROOT_PASS directly, and the inline form would
     # scope them only to the prepareVariables call.
-    #
-    # upgradeOpenEMR() is overridden locally so sql_upgrade.php runs as
-    # apache rather than root. RootCliGuard refuses root for OpenEMR CLI
-    # scripts (the failure it catches: a root-owned write here would
-    # brick apache later). The full fix lives in openemr-devops/devtools
-    # — once devtoolsLibrary.source itself drops privileges, this
-    # override can be removed.
-    # shellcheck disable=SC2016  # $1 is intentionally unexpanded by the outer shell — it refers to the overridden upgradeOpenEMR()'s positional arg, evaluated inside the inner shell that sources devtoolsLibrary.
-    _exec sh -c '
-        export MYSQL_HOST=mysql MYSQL_ROOT_PASS=root
-        . /root/devtoolsLibrary.source
-        prepareVariables
-        upgradeOpenEMR() {
-            su -p -s /bin/sh apache -c "php -f /var/www/localhost/htdocs/openemr/sql_upgrade.php -- --from=\"$1\""
-        }
-        demoData
-    '
+    _exec sh -c 'export MYSQL_HOST=mysql MYSQL_ROOT_PASS=root && . /root/devtoolsLibrary.source && prepareVariables && demoData'
 
     # demoData drops all tables and reseeds from the 5.0.0 dump (which
     # has its own globals values), so the CI-specific globals that

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -182,7 +182,12 @@ install_configure() {
     # we need this to occur on the docker image of OpenEMR, on local systems this may be the same but in the ci engine its inside the docker container
     # until we get the devops repo setup we'll just grab the auto_configure.php script and use that
     _exec sh -c 'curl -v https://raw.githubusercontent.com/openemr/openemr-devops/refs/heads/master/docker/openemr/flex/auto_configure.php > /root/auto_configure.php'
-    _exec sh -c 'OPENEMR_ENABLE_INSTALLER_AUTO=1 php -f ./contrib/util/installScripts/InstallerAuto.php rootpass=root server=mysql loginhost=%'
+    # InstallerAuto goes through the Installer class, which RootCliGuard
+    # refuses to run as root (PR #12267, def8758). Drop to apache for the
+    # subprocess — same approach as the upgradeOpenEMR override below.
+    # The openemr-devops devtools change will eventually carry the same
+    # privilege drop; until that lands, the ci library wraps locally.
+    _exec sh -c 'OPENEMR_ENABLE_INSTALLER_AUTO=1 su -p -s /bin/sh apache -c "php -f ./contrib/util/installScripts/InstallerAuto.php rootpass=root server=mysql loginhost=%"'
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'INSERT INTO product_registration (opt_out) VALUES (1)' openemr
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_api"' openemr
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_fhir_api"' openemr

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -71,6 +71,7 @@ _exec() {
 # pattern works across the full CI matrix without needing per-stack
 # branching at every su call site.
 web_user_in_openemr() {
+    # shellcheck disable=SC2016  # $u is the inner for-loop variable, intentionally evaluated inside the container's shell.
     _exec sh -c 'for u in apache www-data; do if id "$u" >/dev/null 2>&1; then echo "$u"; exit 0; fi; done; exit 1'
 }
 

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -65,6 +65,16 @@ _exec() {
 }
 
 ##
+# Echo the first existing web-server user inside the openemr container.
+# OpenEMR ships two web stacks: the apache image uses `apache`, the
+# nginx + php-fpm image uses `www-data`. Probe both so the same wrap
+# pattern works across the full CI matrix without needing per-stack
+# branching at every su call site.
+web_user_in_openemr() {
+    _exec sh -c 'for u in apache www-data; do if id "$u" >/dev/null 2>&1; then echo "$u"; exit 0; fi; done; exit 1'
+}
+
+##
 # Run the convert-coverage script inside the Docker container with
 # the standard coverage filter directories. This ensures that
 # realpath() and is_file() resolve correctly for container paths.
@@ -183,11 +193,15 @@ install_configure() {
     # until we get the devops repo setup we'll just grab the auto_configure.php script and use that
     _exec sh -c 'curl -v https://raw.githubusercontent.com/openemr/openemr-devops/refs/heads/master/docker/openemr/flex/auto_configure.php > /root/auto_configure.php'
     # InstallerAuto goes through the Installer class, which RootCliGuard
-    # refuses to run as root (PR #12267, def8758). Drop to apache for the
-    # subprocess — same approach as the upgradeOpenEMR override below.
-    # The openemr-devops devtools change will eventually carry the same
-    # privilege drop; until that lands, the ci library wraps locally.
-    _exec sh -c 'OPENEMR_ENABLE_INSTALLER_AUTO=1 su -p -s /bin/sh apache -c "php -f ./contrib/util/installScripts/InstallerAuto.php rootpass=root server=mysql loginhost=%"'
+    # refuses to run as root (PR #12267, def8758). Drop to the web user
+    # for the subprocess — same approach as the upgradeOpenEMR override
+    # below. The openemr-devops devtools change will eventually carry the
+    # same privilege drop; until that lands, the ci library wraps locally.
+    # Web user differs between stacks (apache image: apache, nginx image:
+    # www-data); web_user_in_openemr probes both.
+    local web_user
+    web_user=$(web_user_in_openemr)
+    _exec sh -c "OPENEMR_ENABLE_INSTALLER_AUTO=1 su -p -s /bin/sh ${web_user} -c 'php -f ./contrib/util/installScripts/InstallerAuto.php rootpass=root server=mysql loginhost=%'"
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'INSERT INTO product_registration (opt_out) VALUES (1)' openemr
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_api"' openemr
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_fhir_api"' openemr

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -225,6 +225,7 @@ post_install_upgrade() {
     # brick apache later). The full fix lives in openemr-devops/devtools
     # — once devtoolsLibrary.source itself drops privileges, this
     # override can be removed.
+    # shellcheck disable=SC2016  # $1 is intentionally unexpanded by the outer shell — it refers to the overridden upgradeOpenEMR()'s positional arg, evaluated inside the inner shell that sources devtoolsLibrary.
     _exec sh -c '
         export MYSQL_HOST=mysql MYSQL_ROOT_PASS=root
         . /root/devtoolsLibrary.source

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -29,6 +29,11 @@ use OpenEMR\Core\OEGlobalsBag;
 // Set up autoloader as early as possible
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
+// Refuse to run as root from the CLI. No OpenEMR CLI script needs root,
+// and a root-owned write here would brick the web server later. See
+// RootCliGuard for details.
+OpenEMR\Common\Command\RootCliGuard::assertNotRoot();
+
 // Checks if the server's PHP version is compatible with OpenEMR:
 $response = OpenEMR\Common\Compatibility\Checker::checkPhpVersion();
 if ($response !== true) {

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -31,8 +31,12 @@ require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 // Refuse to run as root from the CLI. No OpenEMR CLI script needs root,
 // and a root-owned write here would brick the web server later. See
-// RootCliGuard for details.
-OpenEMR\Common\Command\RootCliGuard::assertNotRoot();
+// RootCliGuard for details. Skipped under PHPUnit so CI bootstraps that
+// load globals.php as root aren't tripped — RootCliGuard's own tests
+// invoke the guard directly and bypass this carveout.
+if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
+    OpenEMR\Common\Command\RootCliGuard::assertNotRoot();
+}
 
 // Checks if the server's PHP version is compatible with OpenEMR:
 $response = OpenEMR\Common\Compatibility\Checker::checkPhpVersion();

--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -18,6 +18,7 @@
 
 use OpenEMR\BC\DatabaseConnectionFactory;
 use OpenEMR\BC\DatabaseConnectionOptions;
+use OpenEMR\Common\Command\RootCliGuard;
 use OpenEMR\Common\Crypto\KeyVersion;
 use OpenEMR\Common\Crypto\PasswordBasedCrypto;
 use OpenEMR\Common\Installer\InstallerInterface;
@@ -1449,6 +1450,18 @@ $config = 1; /////////////
      */
     public function quick_install(): bool
     {
+        // Refuse to run the installer as root from the CLI. The Installer
+        // does substantial filesystem writes (site directory copy, key
+        // material, generated config) and root-owned outputs would brick
+        // the web server later. CLI entry points are InstallerAuto.php
+        // (this repo) and auto_configure.php (openemr-devops); the web
+        // setup.php is also a caller but RootCliGuard short-circuits for
+        // non-CLI SAPI so web installs are unaffected. Skipped under
+        // PHPUnit so InstallerTest can construct/exercise the class.
+        if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
+            RootCliGuard::assertNotRoot();
+        }
+
         // Validation of OpenEMR user settings
         //   (applicable if not cloning from another database)
         if (empty($this->clone_database)) {

--- a/src/Common/Command/RootCliGuard.php
+++ b/src/Common/Command/RootCliGuard.php
@@ -74,19 +74,20 @@ final class RootCliGuard
     }
 
     /**
-     * Resolve the current process's effective UID without requiring the
-     * `posix` PHP extension.
+     * Resolve the current process's effective UID by running `id -u`
+     * via Symfony Process. The `posix` PHP extension would give the
+     * same result via a direct syscall, but the openemr docker images
+     * don't ship it, so the entire production path goes through
+     * Symfony Process — keeping a single tested path here is simpler
+     * than carrying a posix branch that real environments never run.
      *
-     * Prefers `posix_geteuid()`. Falls back to running `id -u` via
-     * Symfony Process when posix is unavailable on a non-Windows host
-     * (common in stripped-down PHP CLI builds). Returns null when
-     * neither resolution path works.
+     * Returns null when the resolution fails (e.g. `id` is unavailable
+     * — essentially impossible on any POSIX-y host coreutils ships
+     * on, but the null path keeps the guard a safety check rather
+     * than a load-bearing precondition).
      */
     private static function currentEffectiveUid(): ?int
     {
-        if (function_exists('posix_geteuid')) {
-            return posix_geteuid();
-        }
         try {
             $process = new Process(['id', '-u']);
             $process->run();

--- a/src/Common/Command/RootCliGuard.php
+++ b/src/Common/Command/RootCliGuard.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Guard against running OpenEMR CLI scripts as root.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Command;
+
+use RuntimeException;
+use Symfony\Component\Process\Exception\ExceptionInterface as ProcessExceptionInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * Refuses to let an OpenEMR CLI process start when invoked as root.
+ *
+ * Running PHP as root from the command line produces files (cache
+ * directories, generated keys, Smarty compile output, etc.) owned by
+ * UID 0 with restrictive permissions. The web server, running as a
+ * non-root user, then cannot read or write them, and the resulting
+ * failure surfaces far from the cause — an opaque
+ * `PHP Fatal error: ... unable to write to compile_dir` deep in
+ * template rendering, or `Key path … is not readable` in OAuth.
+ *
+ * No OpenEMR CLI script needs root. Sites that run their web server
+ * as root have a configuration problem of their own — accommodating
+ * them here would only hide it.
+ *
+ * The check is intentionally narrow:
+ *
+ * - CLI only (PHP_SAPI === 'cli'). Web requests are unaffected.
+ * - POSIX only. Windows uses ACLs, not UID-based permissions, and the
+ *   failure mode this guards against does not naturally exist there.
+ * - UID 0 only. The "wrong non-root user" case is the domain of
+ *   WebUserGuard, which compares against the web user's UID at
+ *   per-write call sites.
+ */
+final class RootCliGuard
+{
+    /**
+     * Throw if the current process is a CLI invocation running as root.
+     *
+     * Safe to call from any bootstrap path: no-ops on web requests, on
+     * Windows, and when the current UID cannot be resolved.
+     */
+    public static function assertNotRoot(): void
+    {
+        if (PHP_SAPI !== 'cli') {
+            return;
+        }
+        if (PHP_OS_FAMILY === 'Windows') {
+            return;
+        }
+        $uid = self::currentEffectiveUid();
+        if ($uid !== 0) {
+            return;
+        }
+
+        throw new RuntimeException(
+            "OpenEMR CLI scripts must not be run as root (UID 0). Doing "
+            . "so creates files the web server cannot read, leading to "
+            . "opaque fatal errors later (unable to write to compile_dir, "
+            . "key path not readable, etc). Re-run as the web user "
+            . "(typically 'apache' or 'www-data') — e.g. "
+            . "`su -s /bin/sh apache -c '[your command]'`."
+        );
+    }
+
+    /**
+     * Resolve the current process's effective UID without requiring the
+     * `posix` PHP extension.
+     *
+     * Prefers `posix_geteuid()`. Falls back to running `id -u` via
+     * Symfony Process when posix is unavailable on a non-Windows host
+     * (common in stripped-down PHP CLI builds). Returns null when
+     * neither resolution path works.
+     */
+    private static function currentEffectiveUid(): ?int
+    {
+        if (function_exists('posix_geteuid')) {
+            return posix_geteuid();
+        }
+        try {
+            $process = new Process(['id', '-u']);
+            $process->run();
+            if (!$process->isSuccessful()) {
+                return null;
+            }
+            $trimmed = trim($process->getOutput());
+            if ($trimmed !== '' && ctype_digit($trimmed)) {
+                return (int) $trimmed;
+            }
+        } catch (ProcessExceptionInterface) {
+            return null;
+        }
+        return null;
+    }
+}

--- a/tests/Tests/Isolated/Common/Command/RootCliGuardTest.php
+++ b/tests/Tests/Isolated/Common/Command/RootCliGuardTest.php
@@ -95,24 +95,11 @@ final class RootCliGuardTest extends TestCase
 
     private static function currentUid(): ?int
     {
-        if (function_exists('posix_geteuid')) {
-            return posix_geteuid();
-        }
-        if (PHP_OS_FAMILY === 'Windows') {
-            return null;
-        }
         return self::idUViaProcess([]);
     }
 
     private static function userUid(string $username): ?int
     {
-        if (function_exists('posix_getpwnam')) {
-            $pw = @posix_getpwnam($username);
-            return ($pw !== false) ? $pw['uid'] : null;
-        }
-        if (PHP_OS_FAMILY === 'Windows') {
-            return null;
-        }
         return self::idUViaProcess([$username]);
     }
 

--- a/tests/Tests/Isolated/Common/Command/RootCliGuardTest.php
+++ b/tests/Tests/Isolated/Common/Command/RootCliGuardTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Tests for RootCliGuard.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Command;
+
+use OpenEMR\Common\Command\RootCliGuard;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Process\Exception\ExceptionInterface as ProcessExceptionInterface;
+use Symfony\Component\Process\Process;
+
+final class RootCliGuardTest extends TestCase
+{
+    public function testAssertNotRootDoesNotThrowAsNonRoot(): void
+    {
+        $uid = self::currentUid();
+        if ($uid === null) {
+            self::markTestSkipped('Cannot determine current UID');
+        }
+        if ($uid === 0) {
+            self::markTestSkipped('Test process is root; covered by the throws-as-root test');
+        }
+
+        $this->expectNotToPerformAssertions();
+        RootCliGuard::assertNotRoot();
+    }
+
+    public function testAssertNotRootThrowsAsRoot(): void
+    {
+        $uid = self::currentUid();
+        if ($uid !== 0) {
+            self::markTestSkipped('Test process is not root; covered by the passes-as-non-root test');
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/must not be run as root/');
+        // Sanity-check that the message uses bracket placeholder (not
+        // HTML-special angle brackets) so it survives accidental
+        // browser rendering.
+        $this->expectExceptionMessageMatches('/\\[your command\\]/');
+
+        RootCliGuard::assertNotRoot();
+    }
+
+    public function testAssertNotRootPassesInSubprocessDroppedToApache(): void
+    {
+        // Only meaningful when this process IS root and an apache user
+        // exists to drop into — covers the non-root code path even when
+        // the test runner itself is root (typical CI container case).
+        $uid = self::currentUid();
+        if ($uid !== 0) {
+            self::markTestSkipped('Test process is not root; cannot drop privileges');
+        }
+        $apacheUid = self::userUid('apache');
+        if ($apacheUid === null || $apacheUid === 0) {
+            self::markTestSkipped('No usable non-root user on this system');
+        }
+
+        $autoload = realpath(__DIR__ . '/../../../../../vendor/autoload.php');
+        self::assertNotFalse($autoload, 'vendor/autoload.php must exist for the subprocess');
+
+        $php = '<?php require ' . var_export($autoload, true) . ';'
+            . ' \\OpenEMR\\Common\\Command\\RootCliGuard::assertNotRoot();'
+            . ' echo "OK";';
+        $tmpScript = tempnam(sys_get_temp_dir(), 'rootcliguard-');
+        self::assertNotFalse($tmpScript);
+        file_put_contents($tmpScript, $php);
+        // Apache must be able to read it.
+        chmod($tmpScript, 0644);
+
+        try {
+            $process = new Process(['su', '-s', '/bin/sh', 'apache', '-c', 'php ' . escapeshellarg($tmpScript)]);
+            $process->run();
+            self::assertTrue(
+                $process->isSuccessful(),
+                "Subprocess as apache failed: stdout=" . $process->getOutput()
+                . " stderr=" . $process->getErrorOutput(),
+            );
+            self::assertSame('OK', trim($process->getOutput()));
+        } finally {
+            @unlink($tmpScript);
+        }
+    }
+
+    private static function currentUid(): ?int
+    {
+        if (function_exists('posix_geteuid')) {
+            return posix_geteuid();
+        }
+        if (PHP_OS_FAMILY === 'Windows') {
+            return null;
+        }
+        return self::idUViaProcess([]);
+    }
+
+    private static function userUid(string $username): ?int
+    {
+        if (function_exists('posix_getpwnam')) {
+            $pw = @posix_getpwnam($username);
+            return ($pw !== false) ? $pw['uid'] : null;
+        }
+        if (PHP_OS_FAMILY === 'Windows') {
+            return null;
+        }
+        return self::idUViaProcess([$username]);
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    private static function idUViaProcess(array $args): ?int
+    {
+        try {
+            $process = new Process(['id', '-u', ...$args]);
+            $process->run();
+            if (!$process->isSuccessful()) {
+                return null;
+            }
+            $t = trim($process->getOutput());
+            return ($t !== '' && ctype_digit($t)) ? (int) $t : null;
+        } catch (ProcessExceptionInterface) {
+            return null;
+        }
+    }
+}

--- a/tests/Tests/Services/Background/BackgroundServicesCliIntegrationTest.php
+++ b/tests/Tests/Services/Background/BackgroundServicesCliIntegrationTest.php
@@ -212,9 +212,10 @@ class BackgroundServicesCliIntegrationTest extends TestCase
 
     /**
      * Return the first username in `$candidates` that exists on this
-     * system, or null if none do. Uses `posix_getpwnam()` when
-     * available, falls back to `id <name>` via Symfony Process for
-     * posix-less PHP CLI builds.
+     * system, or null if none do. Existence is probed via `id <name>`
+     * (Symfony Process) — the same single-path approach RootCliGuard
+     * uses, since the openemr docker images don't ship the posix
+     * extension.
      *
      * @param list<string> $candidates
      */
@@ -230,12 +231,6 @@ class BackgroundServicesCliIntegrationTest extends TestCase
 
     private static function userExists(string $name): bool
     {
-        if (function_exists('posix_getpwnam')) {
-            return @posix_getpwnam($name) !== false;
-        }
-        if (PHP_OS_FAMILY === 'Windows') {
-            return false;
-        }
         try {
             $process = new Process(['id', $name]);
             $process->run();
@@ -246,20 +241,13 @@ class BackgroundServicesCliIntegrationTest extends TestCase
     }
 
     /**
-     * Resolve the current process's effective UID without requiring the
-     * `posix` PHP extension. Mirrors RootCliGuard's own resolver so this
-     * test correctly identifies a root parent even on PHP CLI builds
-     * without posix loaded (a common configuration the guard itself is
-     * designed to handle).
+     * Resolve the current process's effective UID via `id -u` (Symfony
+     * Process). Mirrors RootCliGuard's resolver, which uses the same
+     * single-path approach since posix isn't loaded in the openemr
+     * docker images.
      */
     private static function currentEffectiveUid(): ?int
     {
-        if (function_exists('posix_geteuid')) {
-            return posix_geteuid();
-        }
-        if (PHP_OS_FAMILY === 'Windows') {
-            return null;
-        }
         try {
             $process = new Process(['id', '-u']);
             $process->run();

--- a/tests/Tests/Services/Background/BackgroundServicesCliIntegrationTest.php
+++ b/tests/Tests/Services/Background/BackgroundServicesCliIntegrationTest.php
@@ -32,6 +32,7 @@ use OpenEMR\Services\Background\BackgroundServiceDefinition;
 use OpenEMR\Services\Background\BackgroundServiceRegistry;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Exception\ExceptionInterface as ProcessExceptionInterface;
 use Symfony\Component\Process\Process;
 
 use function OpenEMR\Tests\Services\Background\Probe\cliProbeSentinelPath;
@@ -157,8 +158,24 @@ class BackgroundServicesCliIntegrationTest extends TestCase
      */
     private function runConsole(array $args): array
     {
+        $command = [PHP_BINARY, $this->projectDir . '/bin/console', 'background:services', ...$args];
+
+        // bin/console refuses to run as root (see RootCliGuard). When the
+        // test process is root (typical of CI containers and the docker
+        // dev stack), drop privileges to apache for the subprocess. This
+        // mirrors the production invocation pattern (web user shelling
+        // out from cron) and keeps the guard honest; bypassing it would
+        // hide the same root-CLI failure mode the guard exists to catch.
+        // `-p` preserves the env the bootstrap needs (HOME, PATH, MYSQL_*).
+        if (self::currentEffectiveUid() === 0) {
+            $command = [
+                'su', '-p', '-s', '/bin/sh', 'apache', '-c',
+                implode(' ', array_map(escapeshellarg(...), $command)),
+            ];
+        }
+
         $process = new Process(
-            [PHP_BINARY, $this->projectDir . '/bin/console', 'background:services', ...$args],
+            $command,
             $this->projectDir,
             // Inherit the parent env rather than scrubbing it: the
             // console bootstrap needs HOME, PATH, and (in the services
@@ -180,6 +197,37 @@ class BackgroundServicesCliIntegrationTest extends TestCase
         if (is_file($this->sentinelPath)) {
             unlink($this->sentinelPath);
         }
+    }
+
+    /**
+     * Resolve the current process's effective UID without requiring the
+     * `posix` PHP extension. Mirrors RootCliGuard's own resolver so this
+     * test correctly identifies a root parent even on PHP CLI builds
+     * without posix loaded (a common configuration the guard itself is
+     * designed to handle).
+     */
+    private static function currentEffectiveUid(): ?int
+    {
+        if (function_exists('posix_geteuid')) {
+            return posix_geteuid();
+        }
+        if (PHP_OS_FAMILY === 'Windows') {
+            return null;
+        }
+        try {
+            $process = new Process(['id', '-u']);
+            $process->run();
+            if (!$process->isSuccessful()) {
+                return null;
+            }
+            $trimmed = trim($process->getOutput());
+            if ($trimmed !== '' && ctype_digit($trimmed)) {
+                return (int) $trimmed;
+            }
+        } catch (ProcessExceptionInterface) {
+            return null;
+        }
+        return null;
     }
 
     private function sentinelLineCount(): int

--- a/tests/Tests/Services/Background/BackgroundServicesCliIntegrationTest.php
+++ b/tests/Tests/Services/Background/BackgroundServicesCliIntegrationTest.php
@@ -162,16 +162,23 @@ class BackgroundServicesCliIntegrationTest extends TestCase
 
         // bin/console refuses to run as root (see RootCliGuard). When the
         // test process is root (typical of CI containers and the docker
-        // dev stack), drop privileges to apache for the subprocess. This
-        // mirrors the production invocation pattern (web user shelling
-        // out from cron) and keeps the guard honest; bypassing it would
-        // hide the same root-CLI failure mode the guard exists to catch.
-        // `-p` preserves the env the bootstrap needs (HOME, PATH, MYSQL_*).
+        // dev stack), drop privileges to the web-server user for the
+        // subprocess. This mirrors the production invocation pattern
+        // (web user shelling out from cron) and keeps the guard honest;
+        // bypassing it would hide the same root-CLI failure mode the
+        // guard exists to catch. `-p` preserves the env the bootstrap
+        // needs (HOME, PATH, MYSQL_*). The username is derived from the
+        // owner of `projectDir` rather than hardcoded so the same test
+        // works against any web stack — apache on the apache image,
+        // www-data on the nginx/php-fpm image, etc.
         if (self::currentEffectiveUid() === 0) {
-            $command = [
-                'su', '-p', '-s', '/bin/sh', 'apache', '-c',
-                implode(' ', array_map(escapeshellarg(...), $command)),
-            ];
+            $webUser = self::resolveOwnerUsername($this->projectDir);
+            if ($webUser !== null && $webUser !== 'root') {
+                $command = [
+                    'su', '-p', '-s', '/bin/sh', $webUser, '-c',
+                    implode(' ', array_map(escapeshellarg(...), $command)),
+                ];
+            }
         }
 
         $process = new Process(
@@ -196,6 +203,43 @@ class BackgroundServicesCliIntegrationTest extends TestCase
     {
         if (is_file($this->sentinelPath)) {
             unlink($this->sentinelPath);
+        }
+    }
+
+    /**
+     * Resolve the username that owns `$path`. Uses `posix_getpwuid()`
+     * when available, falling back to `stat -c %U` via Symfony Process
+     * for posix-less PHP CLI builds. Returns null if neither path works
+     * or if the underlying owner UID cannot be read.
+     *
+     * The web-stack docker images ensure the project directory is owned
+     * by the web server user (apache on the apache image, www-data on
+     * php-fpm). Reading that owner is more portable than hardcoding a
+     * username that varies across base images.
+     */
+    private static function resolveOwnerUsername(string $path): ?string
+    {
+        $uid = @fileowner($path);
+        if ($uid === false) {
+            return null;
+        }
+        if (function_exists('posix_getpwuid')) {
+            $pw = @posix_getpwuid($uid);
+            return ($pw !== false) ? $pw['name'] : null;
+        }
+        if (PHP_OS_FAMILY === 'Windows') {
+            return null;
+        }
+        try {
+            $process = new Process(['stat', '-c', '%U', $path]);
+            $process->run();
+            if (!$process->isSuccessful()) {
+                return null;
+            }
+            $trimmed = trim($process->getOutput());
+            return ($trimmed !== '' && $trimmed !== 'UNKNOWN') ? $trimmed : null;
+        } catch (ProcessExceptionInterface) {
+            return null;
         }
     }
 

--- a/tests/Tests/Services/Background/BackgroundServicesCliIntegrationTest.php
+++ b/tests/Tests/Services/Background/BackgroundServicesCliIntegrationTest.php
@@ -167,13 +167,17 @@ class BackgroundServicesCliIntegrationTest extends TestCase
         // (web user shelling out from cron) and keeps the guard honest;
         // bypassing it would hide the same root-CLI failure mode the
         // guard exists to catch. `-p` preserves the env the bootstrap
-        // needs (HOME, PATH, MYSQL_*). The username is derived from the
-        // owner of `projectDir` rather than hardcoded so the same test
-        // works against any web stack — apache on the apache image,
-        // www-data on the nginx/php-fpm image, etc.
+        // needs (HOME, PATH, MYSQL_*). Probe a small list of known
+        // web-user names so the same test works against any web stack
+        // — apache on the apache image, www-data on the nginx +
+        // php-fpm image. Owning-uid detection from the project
+        // directory is not reliable in CI: the source is bind-mounted
+        // from the host, so the in-container owner is whoever runs the
+        // GH Actions job (typically uid 1001 `runner`), which may or
+        // may not map to a named user inside the container.
         if (self::currentEffectiveUid() === 0) {
-            $webUser = self::resolveOwnerUsername($this->projectDir);
-            if ($webUser !== null && $webUser !== 'root') {
+            $webUser = self::firstExistingUser(['apache', 'www-data']);
+            if ($webUser !== null) {
                 $command = [
                     'su', '-p', '-s', '/bin/sh', $webUser, '-c',
                     implode(' ', array_map(escapeshellarg(...), $command)),
@@ -207,39 +211,37 @@ class BackgroundServicesCliIntegrationTest extends TestCase
     }
 
     /**
-     * Resolve the username that owns `$path`. Uses `posix_getpwuid()`
-     * when available, falling back to `stat -c %U` via Symfony Process
-     * for posix-less PHP CLI builds. Returns null if neither path works
-     * or if the underlying owner UID cannot be read.
+     * Return the first username in `$candidates` that exists on this
+     * system, or null if none do. Uses `posix_getpwnam()` when
+     * available, falls back to `id <name>` via Symfony Process for
+     * posix-less PHP CLI builds.
      *
-     * The web-stack docker images ensure the project directory is owned
-     * by the web server user (apache on the apache image, www-data on
-     * php-fpm). Reading that owner is more portable than hardcoding a
-     * username that varies across base images.
+     * @param list<string> $candidates
      */
-    private static function resolveOwnerUsername(string $path): ?string
+    private static function firstExistingUser(array $candidates): ?string
     {
-        $uid = @fileowner($path);
-        if ($uid === false) {
-            return null;
+        foreach ($candidates as $name) {
+            if (self::userExists($name)) {
+                return $name;
+            }
         }
-        if (function_exists('posix_getpwuid')) {
-            $pw = @posix_getpwuid($uid);
-            return ($pw !== false) ? $pw['name'] : null;
+        return null;
+    }
+
+    private static function userExists(string $name): bool
+    {
+        if (function_exists('posix_getpwnam')) {
+            return @posix_getpwnam($name) !== false;
         }
         if (PHP_OS_FAMILY === 'Windows') {
-            return null;
+            return false;
         }
         try {
-            $process = new Process(['stat', '-c', '%U', $path]);
+            $process = new Process(['id', $name]);
             $process->run();
-            if (!$process->isSuccessful()) {
-                return null;
-            }
-            $trimmed = trim($process->getOutput());
-            return ($trimmed !== '' && $trimmed !== 'UNKNOWN') ? $trimmed : null;
+            return $process->isSuccessful();
         } catch (ProcessExceptionInterface) {
-            return null;
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary

OpenEMR has no CLI script that legitimately needs root. Running PHP as root from the command line creates files (cache dirs, generated keys, Smarty compile output) owned by UID 0 with restrictive permissions; the web server, running as a non-root user, then cannot read them, and the failure surfaces far from the cause — opaque `PHP Fatal: ... unable to write to compile_dir` deep in template rendering, or `Key path … is not readable` in OAuth, etc.

Sites that run their web server as root have a configuration problem of their own; accommodating them here only hides it.

This PR adds a small `RootCliGuard::assertNotRoot()` and wires it into every CLI entry point that loads or instantiates OpenEMR runtime code. The check itself is intentionally narrow:

- **CLI only** — web requests short-circuit via `PHP_SAPI !== 'cli'`.
- **POSIX only** — Windows uses ACLs; this failure mode doesn't naturally exist there.
- **UID 0 only** — the broader "wrong non-root user" case was the domain of the (now-closed) WebUserGuard #12266; this gate refuses root, full stop.

The error message points at the actionable fix:

```
OpenEMR CLI scripts must not be run as root (UID 0). Doing so creates
files the web server cannot read, leading to opaque fatal errors later
(unable to write to compile_dir, key path not readable, etc). Re-run as
the web user (typically 'apache' or 'www-data') — e.g. `su -s /bin/sh
apache -c '[your command]'`.
```

## Gate sites

Seven entry points, each chosen to be the minimal hook that covers a distinct failure mode:

| Location | Covers |
|---|---|
| `interface/globals.php` (after autoload, behind `PHP_SAPI === 'cli'`) | Everything that bootstraps OpenEMR runtime — `sql_upgrade.php`, `acl_upgrade.php`, `sql_patch.php`, contrib utilities, etc. |
| `bin/console` | Symfony console commands, including the `--skip-globals` minimal-bootstrap path |
| `bin/command-runner` | Dispatched commands like `CreateAPIDocumentation` that write swagger yaml |
| `bin/generate-phpstan-types.php` | PHPStan type-alias generator |
| `bin/get-v-database.php` | DB version extractor (read-only today, gated for policy uniformity) |
| `bin/refresh-reserved-word-supplement.php` | Monthly cron in `.github/workflows/refresh-reserved-word-supplement.yml` |
| `library/classes/Installer.class.php::quick_install()` | Both CLI install entry points (`InstallerAuto.php` in this repo and `auto_configure.php` in openemr-devops) plus the web installer `setup.php` (no-ops via the SAPI check) |

Anything that goes through one of these eventually trips the same `RootCliGuard::assertNotRoot()`.

## PHPUnit carveout

CI runs PHPUnit as root inside the test container, and the non-isolated suite loads `interface/globals.php` for DB-backed tests. The globals.php and Installer gates are wrapped in `if (!defined('PHPUNIT_COMPOSER_INSTALL'))` so PHPUnit's bootstrap and `InstallerTest` exercise the rest of the class without the gate firing. The constant is defined only by PHPUnit's autoloader, never in production. The `RootCliGuardTest` itself calls `assertNotRoot()` directly (bypassing the carveout) so the throw-as-root path stays meaningful.

## Test infrastructure

- `tests/Tests/Services/Background/BackgroundServicesCliIntegrationTest.php` spawns `php bin/console background:services` as a subprocess. The PHPUNIT carveout doesn't reach the subprocess, so the integration test now resolves the web-server user (`apache` on the apache image, `www-data` on nginx + php-fpm) and `su`'s the subprocess into it. UID resolution is done via Symfony Process (`id -u`) — the dev container doesn't ship `ext-posix`.
- `tests/Tests/Isolated/Common/Command/RootCliGuardTest.php` — 3 isolated tests covering throw-as-root, non-root pass, and subprocess-dropped-to-apache.
- `tests/Tests/Isolated/Common/Command/RootCliGuardTest.php` and `BackgroundServicesCliIntegrationTest` both use a Symfony-Process-only UID/user resolution path; the `posix_geteuid()` branch was removed since alpine PHP CLI doesn't ship the extension (the symbol was also dropped from `.composer-require-checker.json`).
- `ci/ciLibrary.source::install_configure()` wraps the `InstallerAuto.php` call in `su -p -s /bin/sh <web user> -c …` because that step runs on both the apache and the nginx (`dev-php-fpm`) matrices and dev-php-fpm doesn't carry the openemr-devops devtools library. A `web_user_in_openemr` helper probes `apache` then `www-data` so the same wrap works across the full matrix.

## Companion PRs (both merged)

- **openemr/openemr-devops#743** (merged) — drops privileges to apache across `devtoolsLibrary.source`, all `fsupgrade-*.sh` upgrade scripts, and the `openemr.sh` entrypoint, using `su-exec` for argv-passthrough. Affects flex, 8.1.1, and binary images.
- **openemr/demo_farm_openemr#109** (merged) — same privilege-drop pattern applied to `demo_build.sh` (resolves apache vs www-data from the existing `$alpineOs` flag).

With #743 landed and the flex image SHA in `docker/development-easy/docker-compose.yml` already bumped via dependabot, this PR's earlier `upgradeOpenEMR()` override in `post_install_upgrade()` is no longer needed — `devtoolsLibrary.source` now drops privileges in `upgradeOpenEMR` directly via `run_php_as_apache` (su-exec under the hood). The override was removed in the latest commit on this branch.

## Audit

- No `composer.json` script transitively loads `interface/globals.php`, so running `composer install` as root in build/CI containers is unaffected.
- All discovered OpenEMR-shipped CLI scripts route through one of the gate sites above. The Installer-class gate also covers openemr-devops's `auto_configure.php`, which has its own entry script but reaches `Installer::quick_install()` the same way `InstallerAuto.php` does.

## Test plan

- [x] PHPStan clean at level 10 (full project, no new baseline entries).
- [x] Isolated suite green on PHP 8.2 / 8.3 / 8.4 / 8.5 / 8.6 (includes RootCliGuardTest + InstallerTest under the PHPUNIT carveout).
- [x] Full matrix green: api / services / e2e / email across apache + nginx + Redis Sentinel mTLS + Upgrade-from-5.0.0 (4 PHP × 4 DB versions × 4 stacks).
- [x] Integration test (`BackgroundServicesCliIntegrationTest`) green via `su -p -s /bin/sh apache -c …` subprocess on apache stacks and `… www-data …` on nginx stacks.
- [x] Manual repro inside the running container:
  - `php bin/console list` as root → throws with full message.
  - `su -s /bin/sh apache -c 'php bin/console list'` → runs successfully.
  - `php sql_upgrade.php --from=…` as root → throws (globals.php anchor).
  - `php contrib/util/installScripts/InstallerAuto.php` as root → throws (Installer-class anchor).
  - Web login page returns 200 with a clean error log (web SAPI unaffected).

## Related

- **openemr/openemr-devops#743** (merged) — devops companion: privilege drops in flex, 8.1.1, binary devtools + openemr.sh + fsupgrade chain via su-exec.
- **openemr/demo_farm_openemr#109** (merged) — demo farm `demo_build.sh` privilege drops.
- **WebUserGuard #12266** (closed) — was a defense-in-depth at write sites; closed in favor of the simpler upstream-only refusal in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)