### PR TITLE
test: exclude non-logic dirs from phpunit coverage

### DIFF
--- a/phpunit-isolated.xml
+++ b/phpunit-isolated.xml
@@ -42,8 +42,22 @@ This file configures the kind that does not require initialization.
       <directory>.</directory>
     </include>
     <exclude>
+      <directory>bin</directory>
+      <directory>ccdaservice</directory>
+      <directory>ccr</directory>
+      <directory>ci</directory>
       <directory>config</directory>
+      <directory>contrib</directory>
+      <directory>db</directory>
+      <directory>meta/health</directory>
+      <directory>public</directory>
+      <directory>sphere</directory>
+      <directory>templates/super/rules</directory>
+      <directory>tools/release</directory>
       <directory>vendor</directory>
+      <file>rector-bootstrap.php</file>
+      <file>rector-globals.php</file>
+      <file>rector.php</file>
     </exclude>
   </source>
 

--- a/phpunit.integration.xml
+++ b/phpunit.integration.xml
@@ -42,8 +42,22 @@
       <directory>.</directory>
     </include>
     <exclude>
+      <directory>bin</directory>
+      <directory>ccdaservice</directory>
+      <directory>ccr</directory>
+      <directory>ci</directory>
       <directory>config</directory>
+      <directory>contrib</directory>
+      <directory>db</directory>
+      <directory>meta/health</directory>
+      <directory>public</directory>
+      <directory>sphere</directory>
+      <directory>templates/super/rules</directory>
+      <directory>tools/release</directory>
       <directory>vendor</directory>
+      <file>rector-bootstrap.php</file>
+      <file>rector-globals.php</file>
+      <file>rector.php</file>
     </exclude>
   </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -96,8 +96,22 @@ This file configures the kind that requires initialization.
       <directory>.</directory>
     </include>
     <exclude>
+      <directory>bin</directory>
+      <directory>ccdaservice</directory>
+      <directory>ccr</directory>
+      <directory>ci</directory>
       <directory>config</directory>
+      <directory>contrib</directory>
+      <directory>db</directory>
+      <directory>meta/health</directory>
+      <directory>public</directory>
+      <directory>sphere</directory>
+      <directory>templates/super/rules</directory>
+      <directory>tools/release</directory>
       <directory>vendor</directory>
+      <file>rector-bootstrap.php</file>
+      <file>rector-globals.php</file>
+      <file>rector.php</file>
     </exclude>
   </source>
 </phpunit>


### PR DESCRIPTION
## Summary

Stop counting installer scripts, CI helpers, vendored-but-now-ours service shims, and tool config against the coverage report. These files are either entry points or non-PHP-logic artifacts, so their 0% rows just drag the number down without telling us anything actionable.

Excludes added to all three phpunit configs (`phpunit.xml`, `phpunit-isolated.xml`, `phpunit.integration.xml`):

- Directories: `bin`, `ccdaservice`, `ccr`, `ci`, `contrib`, `db`, `meta/health`, `public`, `sphere`, `templates/super/rules`, `tools/release`
- Files: `rector.php`, `rector-bootstrap.php`, `rector-globals.php`

Deliberately **kept** (real logic, runtime-exercised, or in-repo enough to count):

- `tests/` (per project policy — tests count toward their own coverage)
- `gacl/` — vendored long ago, but it's ours now
- `oauth2/`, `controllers/` — wiring, but exercised at runtime
- Root entry points (`acl_upgrade.php`, `admin.php`, `bootstrap.php`, `controller.php`, `index.php`, `ippf_upgrade.php`, `setup.php`, `sql_patch.php`, `sql_upgrade.php`, `version.php`, `_rest_routes.inc.php`)

## Test plan

- [ ] CI completes the test matrix
- [ ] Codecov report no longer lists the excluded paths
- [ ] Overall coverage percentage moves up (fewer untested files in the denominator)