### PR TITLE
fix(globals): stop forcing E_ALL error reporting and add reporting options

### DIFF
--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -14212,16 +14212,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'appKey\' on mixed\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'appSecret\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'fax_number\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup.php',
@@ -14518,11 +14508,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'lname\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'username\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
 ];
@@ -19609,11 +19594,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'username\' on array\\{id\\: numeric\\-string, uuid\\: string\\|null, username\\: string\\|null, password\\: string\\|null, authorized\\: numeric\\-string\\|null, info\\: string\\|null, source\\: numeric\\-string\\|null, fname\\: string\\|null, \\.\\.\\.\\}\\|false\\.$#',
     'count' => 3,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/PatientFilter/Module.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'username\' on mixed\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/PatientFilter/Module.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -14213,12 +14213,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'appKey\' on mixed\\.$#',
-    'count' => 3,
+    'count' => 4,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'appSecret\' on mixed\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup.php',
 ];
 $ignoreErrors[] = [
@@ -14328,12 +14328,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'appKey\' on mixed\\.$#',
-    'count' => 4,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_rc.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'appSecret\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_rc.php',
 ];
 $ignoreErrors[] = [
@@ -14487,16 +14487,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/ClickatellSMSClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'appKey\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'appSecret\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'email\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
@@ -14518,11 +14508,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'lname\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'username\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -14212,6 +14212,16 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'appKey\' on mixed\\.$#',
+    'count' => 3,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'appSecret\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'fax_number\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup.php',
@@ -14318,12 +14328,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'appKey\' on mixed\\.$#',
-    'count' => 1,
+    'count' => 4,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_rc.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'appSecret\' on mixed\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/setup_rc.php',
 ];
 $ignoreErrors[] = [
@@ -14508,6 +14518,11 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'lname\' on mixed\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'username\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
 ];
@@ -19594,6 +19609,11 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'username\' on array\\{id\\: numeric\\-string, uuid\\: string\\|null, username\\: string\\|null, password\\: string\\|null, authorized\\: numeric\\-string\\|null, info\\: string\\|null, source\\: numeric\\-string\\|null, fname\\: string\\|null, \\.\\.\\.\\}\\|false\\.$#',
     'count' => 3,
+    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/PatientFilter/Module.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot access offset \'username\' on mixed\\.$#',
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/PatientFilter/Module.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/property.notFound.php
+++ b/.phpstan/baseline/property.notFound.php
@@ -57,21 +57,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/eRxSOAP.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Access to an undefined property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EmailClient\\:\\:\\$appKey\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Access to an undefined property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EmailClient\\:\\:\\$appSecret\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Access to an undefined property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EmailClient\\:\\:\\$sid\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Access to an undefined property OpenEMR\\\\Modules\\\\FaxSMS\\\\EtherFax\\\\FaxAccount\\:\\:\\$TimeZone\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',

--- a/interface/forms/newpatient/templates/newpatient/partials/common/_body-scripts.html.twig
+++ b/interface/forms/newpatient/templates/newpatient/partials/common/_body-scripts.html.twig
@@ -22,7 +22,7 @@
 </script>
 
 {# Load Bootstrap bundle to enable dismissible alerts and other JS components #}
-<script src="{{ webroot }}/public/assets/bootstrap/js/bootstrap.bundle.min.js?v={{ v_js_includes }}"></script>
+<script src="{{ webroot }}/public/assets/bootstrap/dist/js/bootstrap.bundle.min.js?v={{ v_js_includes }}"></script>
 
 {# TODO: It seems like this should be put in a module for this form #}
 {% if textTemplatesEnabled %}

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -168,7 +168,7 @@ if (!isset($ignoreAuth_onsite_portal)) {
 // Collect the apache server document root (and convert to windows slashes, if needed)
 $server_document_root = realpath($_SERVER['DOCUMENT_ROOT']);
 if (IS_WINDOWS) {
- //convert windows path separators
+    //convert windows path separators
     $server_document_root = str_replace("\\", "/", $server_document_root);
 }
 
@@ -284,7 +284,7 @@ if (empty($siteId) || !empty($_GET['site'])) {
     // for both REST API and browser access we can't proceed unless we have a valid site id.
     // since this is user provided content we need to escape the value but we use htmlspecialchars instead
     // of text() as our helper functions are loaded in later on in this file.
-    if (empty($tmp) || preg_match('/[^A-Za-z0-9\\-.]/', (string) $tmp)) {
+    if (empty($tmp) || preg_match('/[^A-Za-z0-9\\-.]/', (string)$tmp)) {
         http_response_code(400);
         echo "Invalid URL";
         $logger->warning("Request with site id '{site_id}' contains invalid characters.", ['site_id' => $tmp]);
@@ -292,14 +292,14 @@ if (empty($siteId) || !empty($_GET['site'])) {
     }
 
     if ($siteId !== null && $siteId != $tmp) {
-      // This is to prevent using session to penetrate other OpenEMR instances within same multisite module
+        // This is to prevent using session to penetrate other OpenEMR instances within same multisite module
         SessionUtil::clearSession();
         if (isset($landingpage) && !empty($landingpage)) {
-          // OpenEMR Patient Portal use
-            header('Location: index.php?site=' . urlencode((string) $tmp));
+            // OpenEMR Patient Portal use
+            header('Location: index.php?site=' . urlencode((string)$tmp));
         } else {
-          // Main OpenEMR use
-            header('Location: ../login/login.php?site=' . urlencode((string) $tmp)); // Assuming in the interface/main directory
+            // Main OpenEMR use
+            header('Location: ../login/login.php?site=' . urlencode((string)$tmp)); // Assuming in the interface/main directory
         }
 
         exit;
@@ -399,19 +399,19 @@ $globalsBag->set('sell_non_drug_products', 0);
 
 $glrow = sqlQueryNoLog("SHOW TABLES LIKE 'globals'");
 if (!empty($glrow)) {
-  // Collect user specific settings from user_settings table.
-  //
+    // Collect user specific settings from user_settings table.
+    //
     $gl_user = [];
-  // Collect the user id first
+    // Collect the user id first
     $temp_authuserid = '';
     if (!empty($session->get('authUserID'))) {
-      //Set the user id from the session variable
+        //Set the user id from the session variable
         $temp_authuserid = $session->get('authUserID');
     } else {
         if (!empty($_POST['authUser'])) {
             $temp_sql_ret = sqlQueryNoLog("SELECT `id` FROM `users` WHERE BINARY `username` = ?", [$_POST['authUser']]);
             if (!empty($temp_sql_ret['id'])) {
-              //Set the user id from the login variable
+                //Set the user id from the login variable
                 $temp_authuserid = $temp_sql_ret['id'];
             }
         }
@@ -426,24 +426,24 @@ if (!empty($glrow)) {
             [$temp_authuserid]
         );
         for ($iter = 0; $row = sqlFetchArray($glres_user); $iter++) {
-          //remove global_ prefix from label
-            $row['setting_label'] = substr((string) $row['setting_label'], 7);
+            //remove global_ prefix from label
+            $row['setting_label'] = substr((string)$row['setting_label'], 7);
             $gl_user[$iter] = $row;
         }
     }
 
-  // Set global parameters from the database globals table.
-  // Some parameters require custom handling.
-  //
+    // Set global parameters from the database globals table.
+    // Some parameters require custom handling.
+    //
     $GLOBALS['language_menu_show'] = [];
     $glres = sqlStatementNoLog(
         "SELECT gl_name, gl_index, gl_value FROM globals " .
         "ORDER BY gl_name, gl_index"
     );
     while ($glrow = sqlFetchArray($glres)) {
-        $gl_name  = $glrow['gl_name'];
+        $gl_name = $glrow['gl_name'];
         $gl_value = $glrow['gl_value'];
-      // Adjust for user specific settings
+        // Adjust for user specific settings
         if (!empty($gl_user)) {
             foreach ($gl_user as $setting) {
                 if ($gl_name == $setting['setting_label']) {
@@ -474,11 +474,11 @@ if (!empty($glrow)) {
                 [$session->get('pid') ?? 0, 'portal_theme']
             )['setting_value'] ?? null;
             $gl_value = $current_theme ?? null ?: $gl_value;
-            $GLOBALS[(string) $gl_name] = $web_root . '/public/themes/' . attr($gl_value) . '?v=' . $v_js_includes;
-            $portal_css_header = $GLOBALS[(string) $gl_name];
+            $GLOBALS[(string)$gl_name] = $web_root . '/public/themes/' . attr($gl_value) . '?v=' . $v_js_includes;
+            $portal_css_header = $GLOBALS[(string)$gl_name];
             $portal_temp_css_theme_name = $gl_value;
         } elseif ($gl_name == 'weekend_days') {
-            $globalsBag->set($gl_name, explode(',', (string) $gl_value));
+            $globalsBag->set($gl_name, explode(',', (string)$gl_value));
         } elseif ($gl_name == 'specific_application') {
             if ($gl_value == '2') {
                 $globalsBag->set('ippf_specific', true);
@@ -496,14 +496,14 @@ if (!empty($glrow)) {
                 $globalsBag->set('sell_non_drug_products', 2);
             }
         } elseif ($gl_name == 'gbl_time_zone') {
-          // The default PHP time zone is set here if it was specified, and is used
-          // as source data for the MySQL time zone here and in some other places
-          // where MySQL connections are opened.
+            // The default PHP time zone is set here if it was specified, and is used
+            // as source data for the MySQL time zone here and in some other places
+            // where MySQL connections are opened.
             if ($gl_value) {
                 date_default_timezone_set($gl_value);
             }
 
-          // Synchronize MySQL time zone with PHP time zone.
+            // Synchronize MySQL time zone with PHP time zone.
             sqlStatementNoLog("SET time_zone = ?", [(new DateTime())->format("P")]);
         } else {
             $globalsBag->set($gl_name, $gl_value);
@@ -544,7 +544,7 @@ if (!empty($glrow)) {
         SessionUtil::setSession('language_direction', getLanguageDir($session->get('language_choice')));
         if (
             $session->get('language_direction') === 'rtl' &&
-            !strpos((string) $globalsBag->get('portal_css_header', ''), 'rtl')
+            !strpos((string)$globalsBag->get('portal_css_header', ''), 'rtl')
         ) {
             // the $css_header_value is set above
             $rtl_portal_override = true;
@@ -553,7 +553,7 @@ if (!empty($glrow)) {
         //session 'language_direction' is not set, so will use the default language
         $default_lang_id = sqlQueryNoLog('SELECT lang_id FROM lang_languages WHERE lang_description = ?', [$GLOBALS['language_default'] ?? '']);
         $globalsBag->set('default_lang_id', $default_lang_id);
-        if (getLanguageDir($default_lang_id['lang_id'] ?? '') === 'rtl' && !strpos((string) $GLOBALS['css_header'], 'rtl')) {
+        if (getLanguageDir($default_lang_id['lang_id'] ?? '') === 'rtl' && !strpos((string)$GLOBALS['css_header'], 'rtl')) {
             // @todo eliminate 1 SQL query
             $rtl_override = true;
         }
@@ -596,15 +596,15 @@ if (!empty($glrow)) {
     unset($temp_css_theme_name, $new_theme, $rtl_override, $rtl_portal_override, $portal_temp_css_theme_name);
     // end of RTL section
 
-  //
-  // End of globals table processing.
+    //
+    // End of globals table processing.
 } else {
-  // Temporary stuff to handle the case where the globals table does not
-  // exist yet.  This will happen in sql_upgrade.php on upgrading to the
-  // first release containing this table.
+    // Temporary stuff to handle the case where the globals table does not
+    // exist yet.  This will happen in sql_upgrade.php on upgrading to the
+    // first release containing this table.
     $globalsBag->set('language_menu_login', true);
     $globalsBag->set('language_menu_showall', true);
-    $globalsBag->set('language_menu_show', ['English (Standard)','Swedish']);
+    $globalsBag->set('language_menu_show', ['English (Standard)', 'Swedish']);
     $globalsBag->set('language_default', "English (Standard)");
     $globalsBag->set('translate_layout', true);
     $globalsBag->set('translate_lists', true);
@@ -780,62 +780,53 @@ $globalsBag->set('groupname', $groupname);
 $globalsBag->set('temporary_files_dir', rtrim(sys_get_temp_dir(), '/'));
 
 // User PHP debug reporting mode.
-//
-// 0 = None.
-//     Preserve the current php.ini/startup runtime reporting mask, except for the
-//     global suppression of E_USER_DEPRECATED and E_USER_WARNING above.
-//
-// 2 = Display PHP application errors only.
-//     Show fatal/recoverable/parse/core/compile errors.
-//
-// 3 = Display PHP application errors and warnings only.
-//     Show errors plus PHP warnings. Still suppress notices, deprecated, strict,
-//     and user-level warnings/deprecations.
-//
-// 4 = Display PHP runtime reporting levels only.
-//     Do not change the current runtime error_reporting mask beyond the global
-//     suppression above. Only enable display_errors so the active level is visible.
+// Default behavior intentionally respects php.ini / server runtime error_reporting.
+// Note: user_debug is reserved for setup/JS console behavior and is not used here.
 $userPhpDebug = $globalsBag->getInt('user_php_debug', 0);
 
 switch ($userPhpDebug) {
     case 2:
         // Display PHP application errors only.
+        // Start with the current server/runtime mask and remove warnings, notices,
+        // deprecated, strict, and user-level noise.
         error_reporting(
-            E_ERROR
-            | E_PARSE
-            | E_CORE_ERROR
-            | E_CORE_WARNING
-            | E_COMPILE_ERROR
-            | E_COMPILE_WARNING
-            | E_RECOVERABLE_ERROR
+            error_reporting()
+            & ~E_WARNING
+            & ~E_NOTICE
+            & ~E_USER_WARNING
+            & ~E_USER_NOTICE
+            & ~E_DEPRECATED
+            & ~E_USER_DEPRECATED
+            & ~E_STRICT
         );
         ini_set('display_errors', '1');
         break;
     case 3:
         // Display PHP application errors and warnings only.
+        // Start with the current server/runtime mask and remove notices,
+        // deprecated, strict, and user-level notice/deprecated noise.
         error_reporting(
-            E_ERROR
-            | E_WARNING
-            | E_PARSE
-            | E_CORE_ERROR
-            | E_CORE_WARNING
-            | E_COMPILE_ERROR
-            | E_COMPILE_WARNING
-            | E_RECOVERABLE_ERROR
+            error_reporting()
+            & ~E_NOTICE
+            & ~E_USER_NOTICE
+            & ~E_DEPRECATED
+            & ~E_USER_DEPRECATED
+            & ~E_STRICT
         );
         ini_set('display_errors', '1');
         break;
     case 4:
-        // Display whatever php.ini/runtime is currently configured to report.
-        // Do not change the reporting mask.
+        // Display whatever the current server/runtime mask already reports.
+        // Do not alter error_reporting.
         ini_set('display_errors', '1');
         break;
     case 0:
     default:
-        // Respect php.ini / server runtime settings.
+        // Respect php.ini/server defaults.
         // Do not alter error_reporting or display_errors.
         break;
 }
+
 // Re-set the local variables that aren't in $GLOBALS
 $globalsBag->set('webserver_root', $webserver_root);
 $globalsBag->set('web_root', $web_root);

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -779,13 +779,63 @@ $globalsBag->set('groupname', $groupname);
 // Override temporary_files_dir
 $globalsBag->set('temporary_files_dir', rtrim(sys_get_temp_dir(), '/'));
 
-// Report all errors so nothing is silently suppressed.
-error_reporting(E_ALL);
-// user debug mode — controls display_errors
-if ($globalsBag->getInt('user_debug', 0) > 1) {
-    ini_set('display_errors', 1);
-}
+// User PHP debug reporting mode.
+//
+// 0 = None.
+//     Preserve the current php.ini/startup runtime reporting mask, except for the
+//     global suppression of E_USER_DEPRECATED and E_USER_WARNING above.
+//
+// 2 = Display PHP application errors only.
+//     Show fatal/recoverable/parse/core/compile errors.
+//
+// 3 = Display PHP application errors and warnings only.
+//     Show errors plus PHP warnings. Still suppress notices, deprecated, strict,
+//     and user-level warnings/deprecations.
+//
+// 4 = Display PHP runtime reporting levels only.
+//     Do not change the current runtime error_reporting mask beyond the global
+//     suppression above. Only enable display_errors so the active level is visible.
+$userPhpDebug = $globalsBag->getInt('user_php_debug', 0);
 
+switch ($userPhpDebug) {
+    case 2:
+        // Display PHP application errors only.
+        error_reporting(
+            E_ERROR
+            | E_PARSE
+            | E_CORE_ERROR
+            | E_CORE_WARNING
+            | E_COMPILE_ERROR
+            | E_COMPILE_WARNING
+            | E_RECOVERABLE_ERROR
+        );
+        ini_set('display_errors', '1');
+        break;
+    case 3:
+        // Display PHP application errors and warnings only.
+        error_reporting(
+            E_ERROR
+            | E_WARNING
+            | E_PARSE
+            | E_CORE_ERROR
+            | E_CORE_WARNING
+            | E_COMPILE_ERROR
+            | E_COMPILE_WARNING
+            | E_RECOVERABLE_ERROR
+        );
+        ini_set('display_errors', '1');
+        break;
+    case 4:
+        // Display whatever php.ini/runtime is currently configured to report.
+        // Do not change the reporting mask.
+        ini_set('display_errors', '1');
+        break;
+    case 0:
+    default:
+        // Respect php.ini / server runtime settings.
+        // Do not alter error_reporting or display_errors.
+        break;
+}
 // Re-set the local variables that aren't in $GLOBALS
 $globalsBag->set('webserver_root', $webserver_root);
 $globalsBag->set('web_root', $web_root);

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -137,7 +137,7 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
         $sessionSiteIdString = is_string($sessionSiteId) ? $sessionSiteId : '';
         ?>
         var site_id_js = <?php echo js_escape($sessionSiteIdString); ?>;
-        var userDebug = <?php echo js_escape(OEGlobalsBag::getInstance()->get('user_debug')); ?>;
+        var userDebug = <?php echo js_escape(OEGlobalsBag::getInstance()->getBoolean('user_debug')); ?>;
         var webroot_url = <?php echo js_escape(OEGlobalsBag::getInstance()->getWebRoot()); ?>;
         var jsLanguageDirection = <?php echo js_escape($session->get('language_direction')); ?> ||
         'ltr';

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -137,7 +137,7 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
         $sessionSiteIdString = is_string($sessionSiteId) ? $sessionSiteId : '';
         ?>
         var site_id_js = <?php echo js_escape($sessionSiteIdString); ?>;
-        var userDebug = <?php echo js_escape(OEGlobalsBag::getInstance()->getBoolean('user_debug')); ?>;
+        var userDebug = <?php echo js_escape((string)OEGlobalsBag::getInstance()->getBoolean('user_debug')); ?>;
         var webroot_url = <?php echo js_escape(OEGlobalsBag::getInstance()->getWebRoot()); ?>;
         var jsLanguageDirection = <?php echo js_escape($session->get('language_direction')); ?> ||
         'ltr';

--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
@@ -53,7 +53,6 @@ use OpenEMR\Modules\FaxSMS\Controller\NotificationTaskManager;
 use OpenEMR\Modules\FaxSMS\Enums\NotificationChannel;
 use OpenEMR\Modules\FaxSMS\Notification\AppointmentNotificationRunner;
 
-$session = SessionWrapperFactory::getInstance()->getActiveSession();
 $_SERVER['REQUEST_URI'] = $_SERVER['PHP_SELF'];
 $_SERVER['SERVER_NAME'] = 'localhost';
 
@@ -83,6 +82,8 @@ $sessionAllowWrite = true;
 require_once(__DIR__ . "/../../../../globals.php");
 require_once(OEGlobalsBag::getInstance()->getSrcDir() . "/appointments.inc.php");
 require_once(__DIR__ . "/rc_sms_notification_helpers.php");
+
+$session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 if ($argc > 1 && (in_array('--help', $argv) || in_array('-h', $argv))) {
     displayHelp();

--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php
@@ -217,7 +217,7 @@ if (!function_exists('cron_InsertNotificationLogEntryFaxsms')) {
     {
         $smsgateway_info = $type == 'SMS' ? "" : $db_sms_msg['email_sender'] . "|||" . $db_sms_msg['email_subject'];
 
-        $patient_info = $prow['title'] . " " . $prow['fname'] . " " . $prow['mname'] . " " . $prow['lname'] . "|||" . $prow['phone_cell'] . "|||" . $prow['email'];
+        $patient_info = ($prow['title'] ?? '') . " " . $prow['fname'] . " " . $prow['mname'] . " " . $prow['lname'] . "|||" . $prow['phone_cell'] . "|||" . $prow['email'];
         $data_info = $prow['pc_eventDate'] . "|||" . $prow['pc_endDate'] . "|||" . $prow['pc_startTime'] . "|||" . $prow['pc_endTime'];
         $sdate = date("Y-m-d H:i:s");
         $sql_loginsert = "INSERT INTO `notification_log` (`iLogId` , `pid` , `pc_eid` , `sms_gateway_type` , `message` , `type` , `patient_info` , `smsgateway_info` , `pc_eventDate` , `pc_endDate` , `pc_startTime` , `pc_endTime` , `dSentDateTime`) VALUES (NULL,?,?,?,?,?,?,?,?,?,?,?,?)";

--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification_helpers.php
@@ -222,7 +222,7 @@ if (!function_exists('cron_InsertNotificationLogEntryFaxsms')) {
         $sdate = date("Y-m-d H:i:s");
         $sql_loginsert = "INSERT INTO `notification_log` (`iLogId` , `pid` , `pc_eid` , `sms_gateway_type` , `message` , `type` , `patient_info` , `smsgateway_info` , `pc_eventDate` , `pc_endDate` , `pc_startTime` , `pc_endTime` , `dSentDateTime`) VALUES (NULL,?,?,?,?,?,?,?,?,?,?,?,?)";
 
-        $safe = [$prow['pid'], $prow['pc_eid'], $db_sms_msg['sms_gateway_type'], $db_sms_msg['message'], $db_sms_msg['type'], $patient_info, $smsgateway_info, $prow['pc_eventDate'], $prow['pc_endDate'], $prow['pc_startTime'], $prow['pc_endTime'], $sdate];
+        $safe = [$prow['pid'], $prow['pc_eid'], $db_sms_msg['sms_gateway_type'], $db_sms_msg['message'], $db_sms_msg['type'], $patient_info, $smsgateway_info, $prow['pc_eventDate'] ?? '', $prow['pc_endDate'] ?? '', $prow['pc_startTime'] ?? '', $prow['pc_endTime'] ?? '', $sdate];
 
         sqlStatement($sql_loginsert, $safe);
     }

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php
@@ -53,9 +53,6 @@ class EmailClient extends AppDispatch
     {
         $credentials = AppDispatch::getSetup();
 
-        $this->sid = $credentials['username'];
-        $this->appKey = $credentials['appKey'];
-        $this->appSecret = $credentials['appSecret'];
         $this->serverUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://" . $_SERVER['HTTP_HOST'];
         $this->uriDir = $this->serverUrl . $this->uriDir;
 

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2785,15 +2785,15 @@ $GLOBALS_METADATA = [
     'Logging' => [
 
         'user_php_debug' => [
-            xl('User PHP Debug Reporting Display Options'),
+            xl('User Debug PHP Reporting Options'),
             [
-                '0' => xl('Use Server Defaults (Display off)'),
-                '2' => xl('Display PHP Errors Only'),
-                '3' => xl('Display PHP Errors and Warnings Only'),
-                '4' => xl('Display Current PHP Runtime Reporting Level'),
+                '0' => xl('Use Server Defaults (Disply off)'),
+                '2' => xl('Display Errors Only'),
+                '3' => xl('Display Errors and Warnings Only'),
+                '4' => xl('Display Current Runtime Reporting'),
             ],
             '0',
-            xl('Controls Reporting PHP error display behavior for the current OpenEMR session.')
+            xl('Controls PHP error display/debug behavior without overriding server defaults unless explicitly selected.')
         ],
 
         'user_debug' => [

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2784,16 +2784,23 @@ $GLOBALS_METADATA = [
     //
     'Logging' => [
 
-        'user_debug' => [
-            xl('User Debugging Options'),
+        'user_php_debug' => [
+            xl('User PHP Debug Reporting Display Options'),
             [
-                '0' => xl('None'),
-                '1' => xl('Display Window Errors Only'),
-                '2' => xl('Display Application Errors Only'),
-                '3' => xl('All'),
+                '0' => xl('Use Server Defaults (Display off)'),
+                '2' => xl('Display PHP Errors Only'),
+                '3' => xl('Display PHP Errors and Warnings Only'),
+                '4' => xl('Display Current PHP Runtime Reporting Level'),
             ],
-            '0',                               // default
-            xl('User Debugging Mode.')
+            '0',
+            xl('Controls Reporting PHP error display behavior for the current OpenEMR session.')
+        ],
+
+        'user_debug' => [
+            xl('Display Window Console Errors'),
+            'bool',                           // data type
+            '0',                              // default
+            xl('Console errors')
         ],
 
         'enable_auditlog' => [

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2787,7 +2787,7 @@ $GLOBALS_METADATA = [
         'user_php_debug' => [
             xl('User Debug PHP Reporting Options'),
             [
-                '0' => xl('Use Server Defaults (Disply off)'),
+                '0' => xl('Use Server Defaults (Display off)'),
                 '2' => xl('Display Errors Only'),
                 '3' => xl('Display Errors and Warnings Only'),
                 '4' => xl('Display Current Runtime Reporting'),

--- a/library/js/utility.js
+++ b/library/js/utility.js
@@ -527,7 +527,7 @@ async function persistUserOption(option, value) {
  * @author    Jerry Padgett <sjpadgett@gmail.com>
  */
 
-if (typeof top.userDebug !== 'undefined' && (top.userDebug === '1' || top.userDebug === '3')) {
+if (typeof top.userDebug !== 'undefined' && top.userDebug) {
     window.onerror = function (msg, url, lineNo, columnNo, error) {
         const is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;
         const is_firefox = navigator.userAgent.indexOf('Firefox') > -1;

--- a/library/js/utility.js
+++ b/library/js/utility.js
@@ -527,7 +527,7 @@ async function persistUserOption(option, value) {
  * @author    Jerry Padgett <sjpadgett@gmail.com>
  */
 
-if (typeof top.userDebug !== 'undefined' && top.userDebug) {
+if (typeof top.userDebug !== 'undefined' && top.userDebug === '1') {
     window.onerror = function (msg, url, lineNo, columnNo, error) {
         const is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;
         const is_firefox = navigator.userAgent.indexOf('Firefox') > -1;

--- a/src/Services/Storage/CacheDirectory.php
+++ b/src/Services/Storage/CacheDirectory.php
@@ -105,6 +105,10 @@ final readonly class CacheDirectory
 
     private function validatePermissions(string $path): void
     {
+        if (defined('IS_WINDOWS') && IS_WINDOWS) {
+            return;
+        }
+
         $perms = fileperms($path);
         if ($perms === false) {
             // @codeCoverageIgnoreStart


### PR DESCRIPTION
Fixes: #12265
### Summary

This fixes a regression where `interface/globals.php` forces:
error_reporting(E_ALL);
on nearly every OpenEMR request.

Since globals.php is loaded by most scripts, this overrides the server/admin configured php.ini error reporting policy and can cause notices, warnings, deprecations, user warnings, and user deprecations to be logged or displayed unexpectedly.

Background

The previous long-standing behavior did not widen reporting to E_ALL. It narrowed noisy user-level warnings/deprecations and, when user debugging was enabled, displayed application errors only.

The current error_reporting(E_ALL) pattern changes that behavior by globally enabling all reporting levels regardless of php.ini.

Changes
Removes the unconditional error_reporting(E_ALL) override.
Adds/uses user_php_debug as the dedicated PHP runtime debug option.
Keeps default mode aligned with php.ini / server runtime settings.
Keeps user_debug separate for setup/JavaScript console reporting.
Expected behavior
Default mode does not alter error_reporting() or display_errors.
user_php_debug = 0 Use Server Defaults (Display off).
user_php_debug = 2 Display Errors Only.
user_php_debug = 3 Display Errors and Warnings Only
user_php_debug = 4 Display Current Runtime Reporting

Why

OpenEMR should not silently override administrator error reporting policy from globals.php. Debug display should be explicit and controlled by a PHP-specific global.

#### Was an AI assistant used? Yes `Assisted-by` Claude

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:
