### PR TITLE
fix(release-prep): accept bare image tag in docker-compose mutator

### DIFF
--- a/src/Common/Command/ReleasePrep/Mutator/DockerComposeProductionMutator.php
+++ b/src/Common/Command/ReleasePrep/Mutator/DockerComposeProductionMutator.php
@@ -52,8 +52,8 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
         // `@sha256:<digest>` suffix. The tag may be `latest`, the target
         // version, or another version (idempotence + handles re-runs after
         // a digest update). The digest is optional because rel-* branches
-        // cut before the digest-pinning automation existed start with a
-        // bare tag (e.g. `openemr/openemr:8.1.0`).
+        // that were cut before the digest-pinning automation existed start
+        // with a bare tag (e.g. `openemr/openemr:8.1.0`).
         $pattern = '/(image:\s*openemr\/openemr:)([^@\s]+)(?:(@sha256:)([0-9a-f]{64}))?/';
         $updated = preg_replace_callback(
             $pattern,

--- a/src/Common/Command/ReleasePrep/Mutator/DockerComposeProductionMutator.php
+++ b/src/Common/Command/ReleasePrep/Mutator/DockerComposeProductionMutator.php
@@ -48,15 +48,22 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
             ? null
             : preg_replace('/^sha256:/', '', $context->imageDigest);
 
-        // Pattern matches `image: openemr/openemr:<tag>@sha256:<digest>`
-        // where <tag> may be `latest`, the target version, or another
-        // version (idempotence + handles re-runs after a digest update).
-        $pattern = '/(image:\s*openemr\/openemr:)([^@\s]+)(@sha256:)([0-9a-f]{64})/';
+        // Pattern matches `image: openemr/openemr:<tag>` with an optional
+        // `@sha256:<digest>` suffix. The tag may be `latest`, the target
+        // version, or another version (idempotence + handles re-runs after
+        // a digest update). The digest is optional because rel-* branches
+        // cut before the digest-pinning automation existed start with a
+        // bare tag (e.g. `openemr/openemr:8.1.0`).
+        $pattern = '/(image:\s*openemr\/openemr:)([^@\s]+)(?:(@sha256:)([0-9a-f]{64}))?/';
         $updated = preg_replace_callback(
             $pattern,
             static function (array $match) use ($version, $newDigestHex): string {
-                $digest = $newDigestHex ?? $match[4];
-                return $match[1] . $version . $match[3] . $digest;
+                $existingDigest = $match[4] ?? '';
+                $digest = $newDigestHex ?? ($existingDigest !== '' ? $existingDigest : null);
+                if ($digest === null) {
+                    return $match[1] . $version;
+                }
+                return $match[1] . $version . '@sha256:' . $digest;
             },
             $contents,
             1,
@@ -67,7 +74,7 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
         }
         if ($count === 0) {
             throw new \RuntimeException(
-                'Expected an `image: openemr/openemr:<tag>@sha256:<digest>` line in docker-compose.yml',
+                'Expected an `image: openemr/openemr:<tag>` line in docker-compose.yml',
             );
         }
         if ($updated === $contents) {
@@ -89,7 +96,9 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
             );
         }
         $expectedDigest = $newDigestHex ?? $this->extractDigest($contents);
-        $expectedImage = sprintf('openemr/openemr:%s@sha256:%s', $version, $expectedDigest);
+        $expectedImage = $expectedDigest === null
+            ? sprintf('openemr/openemr:%s', $version)
+            : sprintf('openemr/openemr:%s@sha256:%s', $version, $expectedDigest);
         $actualImage = is_array($parsed)
             && is_array($parsed['services'] ?? null)
             && is_array($parsed['services']['openemr'] ?? null)
@@ -105,18 +114,20 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
         if (file_put_contents($path, $updated) === false) {
             throw new \RuntimeException('Cannot write ' . $path);
         }
-        $messages = $newDigestHex === null
-            ? ['docker-compose.yml: tag pinned to ' . $version . '; digest preserved (no --image-digest provided)']
-            : [];
+        if ($newDigestHex !== null) {
+            $messages = [];
+        } elseif ($expectedDigest === null) {
+            $messages = ['docker-compose.yml: tag pinned to ' . $version . '; no digest (source had none, no --image-digest provided)'];
+        } else {
+            $messages = ['docker-compose.yml: tag pinned to ' . $version . '; digest preserved (no --image-digest provided)'];
+        }
         return new MutatorResult([self::RELATIVE_PATH], $messages);
     }
 
-    private function extractDigest(string $original): string
+    private function extractDigest(string $original): ?string
     {
-        if (
-            preg_match('/image:\s*openemr\/openemr:[^@\s]+@sha256:([0-9a-f]{64})/', $original, $m) !== 1
-        ) {
-            throw new \RuntimeException('Cannot extract original digest from docker-compose.yml');
+        if (preg_match('/image:\s*openemr\/openemr:[^@\s]+@sha256:([0-9a-f]{64})/', $original, $m) !== 1) {
+            return null;
         }
         return $m[1];
     }

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorTest.php
@@ -115,6 +115,31 @@ final class MutatorTest extends TestCase
         );
     }
 
+    public function testDockerComposePinsBareTagWithoutDigest(): void
+    {
+        $this->copyFixture('docker_compose/bare_tag_input.yml', 'docker/production/docker-compose.yml');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0');
+        $this->assertMutationProducesAndIdempotent(
+            new DockerComposeProductionMutator(),
+            $context,
+            'docker/production/docker-compose.yml',
+            self::FIXTURE_DIR . '/docker_compose/bare_tag_pinned_expected.yml',
+        );
+    }
+
+    public function testDockerComposeAddsDigestToBareTag(): void
+    {
+        $this->copyFixture('docker_compose/bare_tag_input.yml', 'docker/production/docker-compose.yml');
+        $digest = 'sha256:' . str_repeat('a', 64);
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0', $digest);
+        $this->assertMutationProducesAndIdempotent(
+            new DockerComposeProductionMutator(),
+            $context,
+            'docker/production/docker-compose.yml',
+            self::FIXTURE_DIR . '/docker_compose/bare_tag_pinned_with_digest_expected.yml',
+        );
+    }
+
     public function testOpenApiVersionBumpsAttribute(): void
     {
         $this->copyFixture('openapi/input.php', 'src/RestControllers/OpenApi/OpenApiDefinitions.php');

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_input.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_input.yml
@@ -1,0 +1,5 @@
+services:
+  openemr:
+    image: openemr/openemr:latest
+    ports:
+    - 80:80

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_pinned_expected.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_pinned_expected.yml
@@ -1,0 +1,5 @@
+services:
+  openemr:
+    image: openemr/openemr:8.1.0
+    ports:
+    - 80:80

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_pinned_with_digest_expected.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_pinned_with_digest_expected.yml
@@ -1,0 +1,5 @@
+services:
+  openemr:
+    image: openemr/openemr:8.1.0@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ports:
+    - 80:80


### PR DESCRIPTION
## Summary

`DockerComposeProductionMutator` required `image: openemr/openemr:<tag>@sha256:<digest>` and threw when the digest was missing. rel-* branches cut before the digest-pinning automation existed (e.g. `rel-810`) carry a bare `openemr/openemr:<version>` line, which blocks the release-prep conductor on every push.

This makes the `@sha256:<digest>` suffix optional. With no source digest and no `--image-digest`, the mutator writes a bare `<version>` tag. The other three cases are unchanged:

| source has digest? | `--image-digest` given? | result                                |
|--------------------|-------------------------|---------------------------------------|
| no                 | no                      | bare `<version>` (new)                |
| no                 | yes                     | `<version>@sha256:<provided>` (new)   |
| yes                | no                      | preserve source digest (unchanged)    |
| yes                | yes                     | `<version>@sha256:<provided>` (unchanged) |

## Test plan

- [x] Two new isolated tests cover the bare-tag input paths and assert idempotence (`bare_tag_input.yml` → `bare_tag_pinned_expected.yml` and `bare_tag_pinned_with_digest_expected.yml`)
- [x] Existing `testDockerComposePinsTagOnly` / `testDockerComposePinsTagAndDigest` still pass
- [x] `composer phpstan`, `composer phpcs` clean

## Context

Blocks the in-progress 8.1.0 release: the conductor run on rel-810 failed at this mutator (https://github.com/openemr/openemr/actions/runs/26481755178). A backport PR to `rel-810` will follow once this merges.