### PR TITLE
fix(release-prep): accept bare image tag in docker-compose mutator (rel-810 backport)

### DIFF
--- a/src/Common/Command/ReleasePrep/Mutator/DockerComposeProductionMutator.php
+++ b/src/Common/Command/ReleasePrep/Mutator/DockerComposeProductionMutator.php
@@ -52,8 +52,8 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
         // `@sha256:<digest>` suffix. The tag may be `latest`, the target
         // version, or another version (idempotence + handles re-runs after
         // a digest update). The digest is optional because rel-* branches
-        // cut before the digest-pinning automation existed start with a
-        // bare tag (e.g. `openemr/openemr:8.1.0`).
+        // that were cut before the digest-pinning automation existed start
+        // with a bare tag (e.g. `openemr/openemr:8.1.0`).
         $pattern = '/(image:\s*openemr\/openemr:)([^@\s]+)(?:(@sha256:)([0-9a-f]{64}))?/';
         $updated = preg_replace_callback(
             $pattern,

--- a/src/Common/Command/ReleasePrep/Mutator/DockerComposeProductionMutator.php
+++ b/src/Common/Command/ReleasePrep/Mutator/DockerComposeProductionMutator.php
@@ -48,15 +48,22 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
             ? null
             : preg_replace('/^sha256:/', '', $context->imageDigest);
 
-        // Pattern matches `image: openemr/openemr:<tag>@sha256:<digest>`
-        // where <tag> may be `latest`, the target version, or another
-        // version (idempotence + handles re-runs after a digest update).
-        $pattern = '/(image:\s*openemr\/openemr:)([^@\s]+)(@sha256:)([0-9a-f]{64})/';
+        // Pattern matches `image: openemr/openemr:<tag>` with an optional
+        // `@sha256:<digest>` suffix. The tag may be `latest`, the target
+        // version, or another version (idempotence + handles re-runs after
+        // a digest update). The digest is optional because rel-* branches
+        // cut before the digest-pinning automation existed start with a
+        // bare tag (e.g. `openemr/openemr:8.1.0`).
+        $pattern = '/(image:\s*openemr\/openemr:)([^@\s]+)(?:(@sha256:)([0-9a-f]{64}))?/';
         $updated = preg_replace_callback(
             $pattern,
             static function (array $match) use ($version, $newDigestHex): string {
-                $digest = $newDigestHex ?? $match[4];
-                return $match[1] . $version . $match[3] . $digest;
+                $existingDigest = $match[4] ?? '';
+                $digest = $newDigestHex ?? ($existingDigest !== '' ? $existingDigest : null);
+                if ($digest === null) {
+                    return $match[1] . $version;
+                }
+                return $match[1] . $version . '@sha256:' . $digest;
             },
             $contents,
             1,
@@ -67,7 +74,7 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
         }
         if ($count === 0) {
             throw new \RuntimeException(
-                'Expected an `image: openemr/openemr:<tag>@sha256:<digest>` line in docker-compose.yml',
+                'Expected an `image: openemr/openemr:<tag>` line in docker-compose.yml',
             );
         }
         if ($updated === $contents) {
@@ -89,7 +96,9 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
             );
         }
         $expectedDigest = $newDigestHex ?? $this->extractDigest($contents);
-        $expectedImage = sprintf('openemr/openemr:%s@sha256:%s', $version, $expectedDigest);
+        $expectedImage = $expectedDigest === null
+            ? sprintf('openemr/openemr:%s', $version)
+            : sprintf('openemr/openemr:%s@sha256:%s', $version, $expectedDigest);
         $actualImage = is_array($parsed)
             && is_array($parsed['services'] ?? null)
             && is_array($parsed['services']['openemr'] ?? null)
@@ -105,18 +114,20 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
         if (file_put_contents($path, $updated) === false) {
             throw new \RuntimeException('Cannot write ' . $path);
         }
-        $messages = $newDigestHex === null
-            ? ['docker-compose.yml: tag pinned to ' . $version . '; digest preserved (no --image-digest provided)']
-            : [];
+        if ($newDigestHex !== null) {
+            $messages = [];
+        } elseif ($expectedDigest === null) {
+            $messages = ['docker-compose.yml: tag pinned to ' . $version . '; no digest (source had none, no --image-digest provided)'];
+        } else {
+            $messages = ['docker-compose.yml: tag pinned to ' . $version . '; digest preserved (no --image-digest provided)'];
+        }
         return new MutatorResult([self::RELATIVE_PATH], $messages);
     }
 
-    private function extractDigest(string $original): string
+    private function extractDigest(string $original): ?string
     {
-        if (
-            preg_match('/image:\s*openemr\/openemr:[^@\s]+@sha256:([0-9a-f]{64})/', $original, $m) !== 1
-        ) {
-            throw new \RuntimeException('Cannot extract original digest from docker-compose.yml');
+        if (preg_match('/image:\s*openemr\/openemr:[^@\s]+@sha256:([0-9a-f]{64})/', $original, $m) !== 1) {
+            return null;
         }
         return $m[1];
     }

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorTest.php
@@ -1,0 +1,305 @@
+<?php
+
+/**
+ * Per-mutator tests for the openemr:release-prep conductor command.
+ * Each test copies a fixture into a tmp project root, applies the
+ * mutator, asserts the result matches the expected fixture exactly,
+ * then re-applies the mutator and asserts the second run is a no-op.
+ * Idempotence is the load-bearing property — the conductor workflow
+ * runs these mutators on every push to a rel-* branch.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Command\ReleasePrep;
+
+use OpenEMR\Common\Command\ReleasePrep\Mutator\DockerComposeProductionMutator;
+use OpenEMR\Common\Command\ReleasePrep\Mutator\DockerVersionFileMutator;
+use OpenEMR\Common\Command\ReleasePrep\Mutator\GlobalsIncMutator;
+use OpenEMR\Common\Command\ReleasePrep\Mutator\OpenApiVersionMutator;
+use OpenEMR\Common\Command\ReleasePrep\Mutator\SqlUpgradeSkeletonMutator;
+use OpenEMR\Common\Command\ReleasePrep\Mutator\SwaggerRegenMutator;
+use OpenEMR\Common\Command\ReleasePrep\Mutator\VersionPhpMasterMutator;
+use OpenEMR\Common\Command\ReleasePrep\Mutator\VersionPhpMutator;
+use OpenEMR\Common\Command\ReleasePrep\MutatorContext;
+use OpenEMR\Common\Command\ReleasePrep\MutatorInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+#[Group('isolated')]
+#[Group('release-prep')]
+final class MutatorTest extends TestCase
+{
+    private const FIXTURE_DIR = __DIR__ . '/fixtures';
+
+    private string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/openemr-release-prep-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->tmpDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->tmpDir);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursive($this->tmpDir);
+    }
+
+    public function testVersionPhpStripsDevTagOnRel(): void
+    {
+        $this->copyFixture('version_php/dev_input.php', 'version.php');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0');
+        $this->assertMutationProducesAndIdempotent(
+            new VersionPhpMutator(),
+            $context,
+            'version.php',
+            self::FIXTURE_DIR . '/version_php/rel_810_expected.php',
+        );
+    }
+
+    public function testVersionPhpMasterBumpsVersion(): void
+    {
+        $this->copyFixture('version_php/rel_810_expected.php', 'version.php');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1');
+        $this->assertMutationProducesAndIdempotent(
+            new VersionPhpMasterMutator(),
+            $context,
+            'version.php',
+            self::FIXTURE_DIR . '/version_php/master_post_810_expected.php',
+        );
+    }
+
+    public function testGlobalsIncSwitchesAllowDebugLanguageDefault(): void
+    {
+        $this->copyFixture('globals_inc/input.php', 'library/globals.inc.php');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0');
+        $this->assertMutationProducesAndIdempotent(
+            new GlobalsIncMutator(),
+            $context,
+            'library/globals.inc.php',
+            self::FIXTURE_DIR . '/globals_inc/expected.php',
+        );
+    }
+
+    public function testDockerComposePinsTagOnly(): void
+    {
+        $this->copyFixture('docker_compose/latest_input.yml', 'docker/production/docker-compose.yml');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0');
+        $this->assertMutationProducesAndIdempotent(
+            new DockerComposeProductionMutator(),
+            $context,
+            'docker/production/docker-compose.yml',
+            self::FIXTURE_DIR . '/docker_compose/pinned_no_digest_expected.yml',
+        );
+    }
+
+    public function testDockerComposePinsTagAndDigest(): void
+    {
+        $this->copyFixture('docker_compose/latest_input.yml', 'docker/production/docker-compose.yml');
+        $digest = 'sha256:' . str_repeat('a', 64);
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0', $digest);
+        $this->assertMutationProducesAndIdempotent(
+            new DockerComposeProductionMutator(),
+            $context,
+            'docker/production/docker-compose.yml',
+            self::FIXTURE_DIR . '/docker_compose/pinned_with_digest_expected.yml',
+        );
+    }
+
+    public function testDockerComposePinsBareTagWithoutDigest(): void
+    {
+        $this->copyFixture('docker_compose/bare_tag_input.yml', 'docker/production/docker-compose.yml');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0');
+        $this->assertMutationProducesAndIdempotent(
+            new DockerComposeProductionMutator(),
+            $context,
+            'docker/production/docker-compose.yml',
+            self::FIXTURE_DIR . '/docker_compose/bare_tag_pinned_expected.yml',
+        );
+    }
+
+    public function testDockerComposeAddsDigestToBareTag(): void
+    {
+        $this->copyFixture('docker_compose/bare_tag_input.yml', 'docker/production/docker-compose.yml');
+        $digest = 'sha256:' . str_repeat('a', 64);
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0', $digest);
+        $this->assertMutationProducesAndIdempotent(
+            new DockerComposeProductionMutator(),
+            $context,
+            'docker/production/docker-compose.yml',
+            self::FIXTURE_DIR . '/docker_compose/bare_tag_pinned_with_digest_expected.yml',
+        );
+    }
+
+    public function testOpenApiVersionBumpsAttribute(): void
+    {
+        $this->copyFixture('openapi/input.php', 'src/RestControllers/OpenApi/OpenApiDefinitions.php');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0');
+        $this->assertMutationProducesAndIdempotent(
+            new OpenApiVersionMutator(),
+            $context,
+            'src/RestControllers/OpenApi/OpenApiDefinitions.php',
+            self::FIXTURE_DIR . '/openapi/expected.php',
+        );
+    }
+
+    public function testDockerVersionSweepIncrementsAllFiles(): void
+    {
+        $this->writeFile('docker-version', "10\n");
+        $this->writeFile('sites/default/docker-version', "10\n");
+        // A nested location to prove the sweep, not a hardcoded list.
+        $this->writeFile('sites/other/docker-version', "5\n");
+        // Excluded dirs that shouldn't be picked up.
+        $this->writeFile('vendor/some/pkg/docker-version', "999\n");
+        $this->writeFile('node_modules/some/pkg/docker-version', "999\n");
+
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0');
+        $result = (new DockerVersionFileMutator())->apply($context);
+
+        self::assertCount(3, $result->changedFiles);
+        self::assertSame("11\n", file_get_contents($this->tmpDir . '/docker-version'));
+        self::assertSame("11\n", file_get_contents($this->tmpDir . '/sites/default/docker-version'));
+        self::assertSame("6\n", file_get_contents($this->tmpDir . '/sites/other/docker-version'));
+        self::assertSame("999\n", file_get_contents($this->tmpDir . '/vendor/some/pkg/docker-version'));
+        self::assertSame("999\n", file_get_contents($this->tmpDir . '/node_modules/some/pkg/docker-version'));
+    }
+
+    public function testSqlUpgradeSkeletonScaffoldsHeaderOnly(): void
+    {
+        // Project layout: a version.php at 8.1.1 (post-810 cut) and
+        // an existing 8_0_0-to-8_1_0_upgrade.sql to copy the header from.
+        $this->writeFile('version.php', "<?php\n\$v_major='8';\n\$v_minor='1';\n\$v_patch='1';\n");
+        $existing = "-- header line one\n-- header line two\n\n-- header line three\nINSERT INTO foo VALUES (1);\nINSERT INTO foo VALUES (2);\n";
+        $this->writeFile('sql/8_0_0-to-8_1_0_upgrade.sql', $existing);
+
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.2');
+        $result = (new SqlUpgradeSkeletonMutator())->apply($context);
+
+        self::assertSame(['sql/8_1_1-to-8_1_2_upgrade.sql'], $result->changedFiles);
+        self::assertSame(
+            "-- header line one\n-- header line two\n\n-- header line three\n",
+            file_get_contents($this->tmpDir . '/sql/8_1_1-to-8_1_2_upgrade.sql'),
+        );
+
+        // Idempotence: running twice doesn't overwrite the scaffold.
+        $secondResult = (new SqlUpgradeSkeletonMutator())->apply($context);
+        self::assertFalse($secondResult->changed());
+    }
+
+    public function testSwaggerRegenInvokesConsoleSubprocess(): void
+    {
+        $this->writeFile('swagger/openemr-api.yaml', "openapi: 3.0.0\ninfo:\n  version: 8.0.1\n");
+
+        $invocations = [];
+        $runner = function (Process $process) use (&$invocations): int {
+            $invocations[] = $process->getCommandLine();
+            // Simulate the subprocess writing a new YAML.
+            $target = $process->getWorkingDirectory() . '/swagger/openemr-api.yaml';
+            file_put_contents($target, "openapi: 3.0.0\ninfo:\n  version: 8.1.0\n");
+            return 0;
+        };
+
+        $mutator = new SwaggerRegenMutator($runner);
+        $result = $mutator->apply(MutatorContext::fromVersionString($this->tmpDir, '8.1.0'));
+
+        self::assertTrue($result->changed());
+        self::assertCount(1, $invocations);
+        self::assertStringContainsString('openemr:create-api-documentation', $invocations[0]);
+        self::assertStringContainsString('--skip-globals', $invocations[0]);
+
+        // Idempotence: running again with the same output is a no-op.
+        $secondResult = $mutator->apply(MutatorContext::fromVersionString($this->tmpDir, '8.1.0'));
+        self::assertFalse($secondResult->changed());
+    }
+
+    public function testSwaggerRegenFailsWhenSubprocessExitsNonZero(): void
+    {
+        $this->writeFile('swagger/openemr-api.yaml', "openapi: 3.0.0\n");
+        $runner = static fn (Process $process): int => 7;
+        $mutator = new SwaggerRegenMutator($runner);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/exited 7/');
+        $mutator->apply(MutatorContext::fromVersionString($this->tmpDir, '8.1.0'));
+    }
+
+    private function assertMutationProducesAndIdempotent(
+        MutatorInterface $mutator,
+        MutatorContext $context,
+        string $relativePath,
+        string $expectedFixturePath,
+    ): void {
+        $first = $mutator->apply($context);
+        self::assertTrue($first->changed(), $mutator->name() . ' should produce a diff on first run');
+        self::assertSame(
+            $this->readFile($expectedFixturePath),
+            $this->readFile($this->tmpDir . '/' . $relativePath),
+            $mutator->name() . ' produced unexpected output',
+        );
+
+        $second = $mutator->apply($context);
+        self::assertFalse(
+            $second->changed(),
+            $mutator->name() . ' is not idempotent — second run produced a diff',
+        );
+    }
+
+    private function copyFixture(string $fixturePath, string $relativeTarget): void
+    {
+        $this->writeFile($relativeTarget, $this->readFile(self::FIXTURE_DIR . '/' . $fixturePath));
+    }
+
+    private function writeFile(string $relativePath, string $contents): void
+    {
+        $absolute = $this->tmpDir . '/' . $relativePath;
+        $dir = dirname($absolute);
+        if (!is_dir($dir) && !mkdir($dir, 0700, true) && !is_dir($dir)) {
+            throw new \RuntimeException('Failed to create dir ' . $dir);
+        }
+        if (file_put_contents($absolute, $contents) === false) {
+            throw new \RuntimeException('Failed to write ' . $absolute);
+        }
+    }
+
+    private function readFile(string $path): string
+    {
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            throw new \RuntimeException('Cannot read ' . $path);
+        }
+        return $contents;
+    }
+
+    private function removeRecursive(string $path): void
+    {
+        if (!is_dir($path)) {
+            if (is_file($path) || is_link($path)) {
+                unlink($path);
+            }
+            return;
+        }
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        /** @var \SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $entryPath = $entry->getPathname();
+            if ($entry->isDir() && !$entry->isLink()) {
+                rmdir($entryPath);
+            } else {
+                unlink($entryPath);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_input.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_input.yml
@@ -1,0 +1,5 @@
+services:
+  openemr:
+    image: openemr/openemr:latest
+    ports:
+    - 80:80

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_pinned_expected.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_pinned_expected.yml
@@ -1,0 +1,5 @@
+services:
+  openemr:
+    image: openemr/openemr:8.1.0
+    ports:
+    - 80:80

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_pinned_with_digest_expected.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_pinned_with_digest_expected.yml
@@ -1,0 +1,5 @@
+services:
+  openemr:
+    image: openemr/openemr:8.1.0@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ports:
+    - 80:80

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/latest_input.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/latest_input.yml
@@ -1,0 +1,5 @@
+services:
+  openemr:
+    image: openemr/openemr:latest@sha256:1d8073d3acfc15b53e771f264b84c0be41a0f0c998f413af39811e1c2e5d8061
+    ports:
+    - 80:80

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/pinned_no_digest_expected.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/pinned_no_digest_expected.yml
@@ -1,0 +1,5 @@
+services:
+  openemr:
+    image: openemr/openemr:8.1.0@sha256:1d8073d3acfc15b53e771f264b84c0be41a0f0c998f413af39811e1c2e5d8061
+    ports:
+    - 80:80

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/pinned_with_digest_expected.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/pinned_with_digest_expected.yml
@@ -1,0 +1,5 @@
+services:
+  openemr:
+    image: openemr/openemr:8.1.0@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ports:
+    - 80:80

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/globals_inc/expected.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/globals_inc/expected.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'language_menu_other' => [
+        xl('Allowed Languages'),
+        'm_lang',
+        '',
+        xl('Select languages.'),
+    ],
+
+    'allow_debug_language' => [
+        xl('Allow Debugging Language'),
+        'bool',                           // data type
+        '0',                              // default = true during development and false for production releases
+        xl('This will allow selection of the debugging (\'dummy\') language.'),
+    ],
+
+    'translate_no_safe_apostrophe' => [
+        xl('Do Not Use Safe Apostrophe'),
+        'bool',
+        '0',
+        xl('Note.'),
+    ],
+];

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/globals_inc/input.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/globals_inc/input.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'language_menu_other' => [
+        xl('Allowed Languages'),
+        'm_lang',
+        '',
+        xl('Select languages.'),
+    ],
+
+    'allow_debug_language' => [
+        xl('Allow Debugging Language'),
+        'bool',                           // data type
+        '1',                              // default = true during development and false for production releases
+        xl('This will allow selection of the debugging (\'dummy\') language.'),
+    ],
+
+    'translate_no_safe_apostrophe' => [
+        xl('Do Not Use Safe Apostrophe'),
+        'bool',
+        '0',
+        xl('Note.'),
+    ],
+];

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/openapi/expected.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/openapi/expected.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OpenEMR\RestControllers\OpenApi;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Info(title: 'OpenEMR API', version: '8.1.0')]
+#[OA\Server(url: '/apis/default/')]
+
+class OpenApiDefinitions
+{
+}

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/openapi/input.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/openapi/input.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OpenEMR\RestControllers\OpenApi;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Info(title: 'OpenEMR API', version: '8.0.1')]
+#[OA\Server(url: '/apis/default/')]
+
+class OpenApiDefinitions
+{
+}

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/version_php/dev_input.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/version_php/dev_input.php
@@ -1,0 +1,8 @@
+<?php
+
+$v_major = '8';
+$v_minor = '1';
+$v_patch = '1';
+$v_tag   = '-dev';
+$v_realpatch = '0';
+$v_database = 538;

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/version_php/master_post_810_expected.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/version_php/master_post_810_expected.php
@@ -1,0 +1,8 @@
+<?php
+
+$v_major = '8';
+$v_minor = '1';
+$v_patch = '1';
+$v_tag   = '-dev';
+$v_realpatch = '0';
+$v_database = 538;

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/version_php/rel_810_expected.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/version_php/rel_810_expected.php
@@ -1,0 +1,8 @@
+<?php
+
+$v_major = '8';
+$v_minor = '1';
+$v_patch = '0';
+$v_tag   = '';
+$v_realpatch = '0';
+$v_database = 538;


### PR DESCRIPTION
Backport of #12283 onto `rel-810`.

## Summary

`DockerComposeProductionMutator` required `image: openemr/openemr:<tag>@sha256:<digest>` and threw when the digest was missing. `rel-810` was cut before the digest-pinning automation existed, so its `docker/production/docker-compose.yml` carries a bare `openemr/openemr:<version>` line, which blocks the release-prep conductor on every push.

This makes the `@sha256:<digest>` suffix optional. With no source digest and no `--image-digest`, the mutator writes a bare `<version>` tag. The other three cases are unchanged.

## Backport notes

- `tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorTest.php` did not yet exist on `rel-810`; the file is added wholesale here so the new `testDockerComposePinsBareTagWithoutDigest` / `testDockerComposeAddsDigestToBareTag` cases (plus the rest of the suite) run on this branch too. All referenced mutator classes already exist on `rel-810`.

## Test plan

- [x] `composer phpstan`, `composer phpcs`, rector, require-checker clean (pre-commit hooks)
- [ ] CI green on rel-810

## Context

Unblocks the in-progress 8.1.0 release: the conductor run on rel-810 failed at this mutator (https://github.com/openemr/openemr/actions/runs/26481755178).