### PR TITLE
ci(release): add force-dispatch input to release-prep

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -38,6 +38,11 @@ on:
         required: false
         default: false
         type: boolean
+      force-dispatch:
+        description: 'Force the rel-update dispatch to consumers even when peter-evans reports pull-request-operation=none. Use to recover after a downstream workflow failed to consume the initial dispatch and the release-prep PR is already in its target state.'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -186,7 +191,7 @@ jobs:
         delete-branch: false
 
     - name: Dispatch rel-cut / rel-update to consumers
-      if: steps.prep-pr.outputs.pull-request-operation != 'none'
+      if: steps.prep-pr.outputs.pull-request-operation != 'none' || inputs.force-dispatch
       env:
         RELEASE_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         OPERATION: ${{ steps.prep-pr.outputs.pull-request-operation }}
@@ -201,6 +206,10 @@ jobs:
         # peter-evans action has already created the branch upstream, so a
         # post-hoc `gh api` existence check would always say "exists" and
         # dispatch the very first push as rel-update.
+        #
+        # When OPERATION is empty (force-dispatch on an unchanged PR),
+        # treat it as rel-update — rel-cut is only correct on the very
+        # first PR creation.
         case "${OPERATION}" in
           created) event='openemr-rel-cut' ;;
           *)       event='openemr-rel-update' ;;


### PR DESCRIPTION
Forward-port of #12286 from rel-810 to master so future release branches keep the recovery lever.

## Summary

The conductor's `Dispatch rel-cut / rel-update to consumers` step is gated on `steps.prep-pr.outputs.pull-request-operation != 'none'`. That's right for the steady-state path: an unchanged release-prep PR has nothing new to broadcast. But it strands recovery scenarios — if the initial dispatch fires correctly but a consumer workflow fails, the release-prep PR is already in its target state, so neither another push nor a workflow_dispatch will re-fire the dispatch.

Add a `force-dispatch` boolean workflow_dispatch input (default false) and OR it into the step's `if`, so a maintainer can manually re-fire `openemr-rel-update` from the Actions UI without touching the release branch's content.

When `force-dispatch=true` runs on an unchanged PR, `OPERATION` is empty and the existing case statement falls through to `openemr-rel-update`. `rel-cut` stays correct (only `created` selects it), which preserves the invariant that rel-cut fires exactly once per release.

## Context

See #12286 for the rel-810 landing and the incident that motivated it.

## Test plan

- [ ] CI green