### PR TITLE
ci(release): add force-dispatch input to release-prep workflow (rel-810)

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -38,6 +38,11 @@ on:
         required: false
         default: false
         type: boolean
+      force-dispatch:
+        description: 'Force the rel-update dispatch to consumers even when peter-evans reports pull-request-operation=none. Use to recover after a downstream workflow failed to consume the initial dispatch and the release-prep PR is already in its target state.'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -186,7 +191,7 @@ jobs:
         delete-branch: false
 
     - name: Dispatch rel-cut / rel-update to consumers
-      if: steps.prep-pr.outputs.pull-request-operation != 'none'
+      if: steps.prep-pr.outputs.pull-request-operation != 'none' || inputs.force-dispatch
       env:
         RELEASE_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         OPERATION: ${{ steps.prep-pr.outputs.pull-request-operation }}
@@ -201,6 +206,10 @@ jobs:
         # peter-evans action has already created the branch upstream, so a
         # post-hoc `gh api` existence check would always say "exists" and
         # dispatch the very first push as rel-update.
+        #
+        # When OPERATION is empty (force-dispatch on an unchanged PR),
+        # treat it as rel-update — rel-cut is only correct on the very
+        # first PR creation.
         case "${OPERATION}" in
           created) event='openemr-rel-cut' ;;
           *)       event='openemr-rel-update' ;;


### PR DESCRIPTION
## Summary

Adds a `force-dispatch` boolean input to the release-prep `workflow_dispatch` so a maintainer can manually re-fire `openemr-rel-update` to the consumer repos when peter-evans reports `pull-request-operation=none` (i.e., the prep PR is already in its target state).

## Why

The Dispatch step is currently gated on `pull-request-operation != 'none'`. That's correct for normal runs — an unchanged PR has nothing new to announce — but it makes recovery painful when the initial dispatch was emitted but the consumer workflow failed:

- The prep PR is already in its target state, so neither another push to the rel-branch nor a workflow_dispatch will retry the dispatch.
- Today's concrete incident: #12285 dispatched `openemr-rel-cut` on its first push, but both consumer runs failed at action resolution (`actions/create-github-app-token@v3.1` — nonexistent tag). website-openemr#127 and openemr-devops#744 fixed the pins, but the conductor can't redispatch on its own.

With `force-dispatch=true` set on a `workflow_dispatch` run, the Dispatch step runs even when the PR is unchanged. Empty `OPERATION` is treated as `rel-update` (rel-cut is only correct on first PR creation).

## Test plan

- [ ] Manually `workflow_dispatch` against `rel-810` with `force-dispatch=true` and confirm consumer workflows in website-openemr and openemr-devops receive the `openemr-rel-update` event.
- [ ] Regular push/merge runs (without the flag) behave identically to today — Dispatch is skipped when there's nothing new.

Forward-port to master: TBD (matching PR will be opened against master).