### PR TITLE
fix(release-prep): prepend release-notes section to CHANGELOG (rel-810)

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -163,14 +163,29 @@ jobs:
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"
 
+    - name: Collect release notes from milestone
+      id: release-notes
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        VERSION: ${{ steps.resolve.outputs.version }}
+      run: |
+        notes_path="${RUNNER_TEMP}/release-notes.json"
+        php tools/release/bin/collect-release-notes.php \
+          --target-version="${VERSION}" \
+          --repo="${GITHUB_REPOSITORY}" \
+          > "${notes_path}"
+        echo "path=${notes_path}" >> "$GITHUB_OUTPUT"
+
     - name: Run release-prep mutators
       env:
+        NOTES_PATH: ${{ steps.release-notes.outputs.path }}
         VERSION: ${{ steps.resolve.outputs.version }}
       run: |
         php bin/console openemr:release-prep \
           --skip-globals \
           --target-version="${VERSION}" \
-          --scope=rel
+          --scope=rel \
+          --release-notes-json="${NOTES_PATH}"
 
     # Open/update the long-lived release-prep PR via peter-evans/create-pull-request,
     # which handles the diff detection, branch force-push, and PR open-or-update

--- a/src/Common/Command/ReleasePrep/Mutator/ChangelogMutator.php
+++ b/src/Common/Command/ReleasePrep/Mutator/ChangelogMutator.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Prepend (or replace, on re-run) the top-of-file section for the
+ * target version in repo-root CHANGELOG.md. Drives a real diff in the
+ * release-prep PR even when version.php and the docker pin are already
+ * at target — without this, all-no-op mutator runs open a zero-diff PR
+ * which GitHub immediately closes and the conductor stalls without a
+ * tag (see openemr/openemr#12291).
+ *
+ * The mutator stays pure: the conductor workflow gathers PR data via
+ * `gh`, encodes it as a Manifest on the MutatorContext, and the
+ * mutator only renders. If no manifest is supplied, the mutator
+ * no-ops — the workflow opts in.
+ *
+ * Idempotence: the renderer emits byte-stable output, so re-running
+ * with the same manifest produces no diff. Re-running with a changed
+ * manifest (new PRs merged between conductor runs) replaces the
+ * existing top section in place rather than stacking duplicates.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Command\ReleasePrep\Mutator;
+
+use OpenEMR\Common\Command\ReleasePrep\MutatorContext;
+use OpenEMR\Common\Command\ReleasePrep\MutatorInterface;
+use OpenEMR\Common\Command\ReleasePrep\MutatorResult;
+use OpenEMR\Common\Command\ReleasePrep\ReleaseNotes\Renderer;
+
+final readonly class ChangelogMutator implements MutatorInterface
+{
+    private const RELATIVE_PATH = 'CHANGELOG.md';
+    private const HEADER_LINE = "# CHANGELOG.md\n";
+
+    public function __construct(private Renderer $renderer = new Renderer())
+    {
+    }
+
+    public function name(): string
+    {
+        return 'CHANGELOG.md (prepend release section)';
+    }
+
+    public function apply(MutatorContext $context): MutatorResult
+    {
+        $manifest = $context->releaseNotes;
+        if ($manifest === null) {
+            return new MutatorResult([], ['CHANGELOG.md: no release-notes manifest supplied; skipped']);
+        }
+        if ($manifest->version !== $context->versionString()) {
+            throw new \RuntimeException(sprintf(
+                'CHANGELOG.md: manifest version %s does not match target version %s',
+                $manifest->version,
+                $context->versionString(),
+            ));
+        }
+
+        $path = $context->projectDir . '/' . self::RELATIVE_PATH;
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            throw new \RuntimeException('Cannot read ' . $path);
+        }
+
+        $rendered = $this->renderer->render($manifest);
+        $updated = $this->replaceOrPrepend($contents, $manifest->version, $rendered);
+        if ($updated === $contents) {
+            return MutatorResult::noop();
+        }
+        if (file_put_contents($path, $updated) === false) {
+            throw new \RuntimeException('Cannot write ' . $path);
+        }
+        return new MutatorResult([self::RELATIVE_PATH]);
+    }
+
+    private function replaceOrPrepend(string $contents, string $version, string $rendered): string
+    {
+        $headerPos = strpos($contents, self::HEADER_LINE);
+        if ($headerPos !== 0) {
+            throw new \RuntimeException(
+                'CHANGELOG.md: expected to start with "# CHANGELOG.md" header line',
+            );
+        }
+        $afterHeader = strlen(self::HEADER_LINE);
+
+        // Skip any blank lines between the header and the first section so
+        // the rendered block lands flush against a single blank line.
+        $cursor = $afterHeader;
+        $length = strlen($contents);
+        while ($cursor < $length && $contents[$cursor] === "\n") {
+            $cursor++;
+        }
+
+        $tail = substr($contents, $cursor);
+        $expectedHeading = sprintf('## [%s]', $version);
+        if (str_starts_with($tail, $expectedHeading)) {
+            // Replace existing top section: trim from its heading up to the
+            // next `## ` heading (or EOF).
+            $nextHeadingPos = strpos($tail, "\n## ", strlen($expectedHeading));
+            $tail = $nextHeadingPos === false
+                ? ''
+                : substr($tail, $nextHeadingPos + 1);
+        }
+
+        return self::HEADER_LINE . "\n" . $rendered . ($tail === '' ? '' : "\n" . $tail);
+    }
+}

--- a/src/Common/Command/ReleasePrep/MutatorContext.php
+++ b/src/Common/Command/ReleasePrep/MutatorContext.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace OpenEMR\Common\Command\ReleasePrep;
 
+use OpenEMR\Common\Command\ReleasePrep\ReleaseNotes\Manifest;
+
 final readonly class MutatorContext
 {
     public function __construct(
@@ -24,6 +26,7 @@ final readonly class MutatorContext
         public int $minor,
         public int $patch,
         public ?string $imageDigest = null,
+        public ?Manifest $releaseNotes = null,
     ) {
         if ($imageDigest !== null && preg_match('/^sha256:[0-9a-f]{64}$/', $imageDigest) !== 1) {
             throw new \InvalidArgumentException(
@@ -32,14 +35,18 @@ final readonly class MutatorContext
         }
     }
 
-    public static function fromVersionString(string $projectDir, string $version, ?string $imageDigest = null): self
-    {
+    public static function fromVersionString(
+        string $projectDir,
+        string $version,
+        ?string $imageDigest = null,
+        ?Manifest $releaseNotes = null,
+    ): self {
         if (preg_match('/^(\d+)\.(\d+)\.(\d+)$/', $version, $m) !== 1) {
             throw new \InvalidArgumentException(
                 'Target version must be MAJOR.MINOR.PATCH; got: ' . $version,
             );
         }
-        return new self($projectDir, (int) $m[1], (int) $m[2], (int) $m[3], $imageDigest);
+        return new self($projectDir, (int) $m[1], (int) $m[2], (int) $m[3], $imageDigest, $releaseNotes);
     }
 
     public function versionString(): string

--- a/src/Common/Command/ReleasePrep/ReleaseNotes/Entry.php
+++ b/src/Common/Command/ReleasePrep/ReleaseNotes/Entry.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * One CHANGELOG bullet: a PR (or hand-authored entry) destined for a
+ * specific Section in the rendered release notes.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Command\ReleasePrep\ReleaseNotes;
+
+final readonly class Entry
+{
+    public function __construct(
+        public string $title,
+        public ?int $prNumber = null,
+        public ?string $prUrl = null,
+    ) {
+        if ($title === '') {
+            throw new \InvalidArgumentException('Entry title cannot be empty');
+        }
+        if ($prNumber !== null && $prNumber <= 0) {
+            throw new \InvalidArgumentException('Entry prNumber must be positive');
+        }
+        if (($prNumber === null) !== ($prUrl === null)) {
+            throw new \InvalidArgumentException('Entry prNumber and prUrl must both be set or both be null');
+        }
+    }
+}

--- a/src/Common/Command/ReleasePrep/ReleaseNotes/Manifest.php
+++ b/src/Common/Command/ReleasePrep/ReleaseNotes/Manifest.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * Typed payload the ChangelogMutator renders into CHANGELOG.md. The
+ * conductor workflow gathers PR data via `gh`, the collector script
+ * normalises it into the JSON shape consumed by fromJsonFile(), and the
+ * mutator never touches the network. Keeping gathering and rendering
+ * separate mirrors how DockerComposeProductionMutator handles the image
+ * digest input.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Command\ReleasePrep\ReleaseNotes;
+
+final readonly class Manifest
+{
+    /**
+     * @param array<value-of<Section>, list<Entry>> $sections
+     */
+    public function __construct(
+        public string $version,
+        public int $milestoneNumber,
+        public string $milestoneUrl,
+        public string $date,
+        public array $sections,
+    ) {
+        if (preg_match('/^\d+\.\d+\.\d+(?:\.\d+)?$/', $version) !== 1) {
+            throw new \InvalidArgumentException('Manifest version must be MAJOR.MINOR.PATCH[.N]; got: ' . $version);
+        }
+        if ($milestoneNumber <= 0) {
+            throw new \InvalidArgumentException('Manifest milestoneNumber must be positive');
+        }
+        if ($milestoneUrl === '') {
+            throw new \InvalidArgumentException('Manifest milestoneUrl cannot be empty');
+        }
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
+            throw new \InvalidArgumentException('Manifest date must be YYYY-MM-DD; got: ' . $date);
+        }
+    }
+
+    /**
+     * @return list<Entry>
+     */
+    public function entriesFor(Section $section): array
+    {
+        return $this->sections[$section->value] ?? [];
+    }
+
+    public function isEmpty(): bool
+    {
+        foreach ($this->sections as $entries) {
+            if ($entries !== []) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static function fromJsonFile(string $path): self
+    {
+        $raw = @file_get_contents($path);
+        if ($raw === false) {
+            throw new \RuntimeException('Cannot read release-notes JSON at ' . $path);
+        }
+        try {
+            $decoded = json_decode($raw, true, 32, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException('Invalid release-notes JSON at ' . $path, 0, $e);
+        }
+        if (!is_array($decoded)) {
+            throw new \RuntimeException('Release-notes JSON must decode to an object');
+        }
+        $normalised = [];
+        foreach ($decoded as $key => $value) {
+            if (!is_string($key)) {
+                throw new \RuntimeException('Release-notes JSON must decode to a string-keyed object');
+            }
+            $normalised[$key] = $value;
+        }
+        return self::fromArray($normalised);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $version = $data['version'] ?? null;
+        if (!is_string($version)) {
+            throw new \InvalidArgumentException('Release-notes manifest is missing "version" string');
+        }
+        $date = $data['date'] ?? null;
+        if (!is_string($date)) {
+            throw new \InvalidArgumentException('Release-notes manifest is missing "date" string');
+        }
+        $milestone = $data['milestone'] ?? null;
+        if (!is_array($milestone)) {
+            throw new \InvalidArgumentException('Release-notes manifest is missing "milestone" object');
+        }
+        $milestoneNumber = $milestone['number'] ?? null;
+        if (!is_int($milestoneNumber)) {
+            throw new \InvalidArgumentException('Release-notes manifest milestone.number must be an int');
+        }
+        $milestoneUrl = $milestone['url'] ?? null;
+        if (!is_string($milestoneUrl)) {
+            throw new \InvalidArgumentException('Release-notes manifest milestone.url must be a string');
+        }
+        $rawSections = $data['sections'] ?? [];
+        if (!is_array($rawSections)) {
+            throw new \InvalidArgumentException('Release-notes manifest "sections" must be an object');
+        }
+        $sections = [];
+        foreach ($rawSections as $key => $entries) {
+            if (!is_string($key)) {
+                throw new \InvalidArgumentException('Release-notes manifest section keys must be strings');
+            }
+            $section = Section::tryFrom($key);
+            if ($section === null) {
+                throw new \InvalidArgumentException('Release-notes manifest has unknown section: ' . $key);
+            }
+            if (!is_array($entries)) {
+                throw new \InvalidArgumentException('Release-notes manifest section "' . $key . '" must be a list');
+            }
+            $sections[$section->value] = self::parseEntries($key, $entries);
+        }
+        return new self($version, $milestoneNumber, $milestoneUrl, $date, $sections);
+    }
+
+    /**
+     * @param array<int|string, mixed> $entries
+     * @return list<Entry>
+     */
+    private static function parseEntries(string $sectionKey, array $entries): array
+    {
+        $parsed = [];
+        foreach ($entries as $row) {
+            if (!is_array($row)) {
+                throw new \InvalidArgumentException(
+                    'Release-notes section "' . $sectionKey . '" contains a non-object entry',
+                );
+            }
+            $title = $row['title'] ?? null;
+            if (!is_string($title) || $title === '') {
+                throw new \InvalidArgumentException(
+                    'Release-notes section "' . $sectionKey . '" entry is missing "title"',
+                );
+            }
+            $prNumber = $row['number'] ?? null;
+            $prUrl = $row['url'] ?? null;
+            if ($prNumber !== null && !is_int($prNumber)) {
+                throw new \InvalidArgumentException(
+                    'Release-notes section "' . $sectionKey . '" entry "number" must be int or omitted',
+                );
+            }
+            if ($prUrl !== null && !is_string($prUrl)) {
+                throw new \InvalidArgumentException(
+                    'Release-notes section "' . $sectionKey . '" entry "url" must be string or omitted',
+                );
+            }
+            $parsed[] = new Entry($title, $prNumber, $prUrl);
+        }
+        return $parsed;
+    }
+}

--- a/src/Common/Command/ReleasePrep/ReleaseNotes/Renderer.php
+++ b/src/Common/Command/ReleasePrep/ReleaseNotes/Renderer.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Render a Manifest into the Markdown shape expected at the top of
+ * repo-root CHANGELOG.md. Format is fixed by the existing 8.0.0.3
+ * entry: H2 with a milestone link and ISO date, H3 buckets (Fixed,
+ * Added, Changed), H4 sub-buckets for Fixed (Security, Bug Fixes).
+ *
+ * String assembly only — no Markdown library. The byte-for-byte output
+ * is what makes the mutator's idempotence check work.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Command\ReleasePrep\ReleaseNotes;
+
+final readonly class Renderer
+{
+    public function render(Manifest $manifest): string
+    {
+        $out = sprintf(
+            "## [%s](%s) - %s\n",
+            $manifest->version,
+            $manifest->milestoneUrl,
+            $manifest->date,
+        );
+
+        $security = $manifest->entriesFor(Section::Security);
+        $bugFixes = $manifest->entriesFor(Section::BugFixes);
+        $added = $manifest->entriesFor(Section::Added);
+        $changed = $manifest->entriesFor(Section::Changed);
+
+        if ($security !== [] || $bugFixes !== []) {
+            $out .= "\n### Fixed\n";
+            if ($security !== []) {
+                $out .= "\n#### Security\n\n";
+                $out .= $this->renderEntries($security);
+            }
+            if ($bugFixes !== []) {
+                $out .= "\n#### Bug Fixes\n\n";
+                $out .= $this->renderEntries($bugFixes);
+            }
+        }
+        if ($added !== []) {
+            $out .= "\n### Added\n\n";
+            $out .= $this->renderEntries($added);
+        }
+        if ($changed !== []) {
+            $out .= "\n### Changed\n\n";
+            $out .= $this->renderEntries($changed);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param list<Entry> $entries
+     */
+    private function renderEntries(array $entries): string
+    {
+        $out = '';
+        foreach ($entries as $entry) {
+            $out .= '- ' . $entry->title;
+            if ($entry->prNumber !== null && $entry->prUrl !== null) {
+                $out .= sprintf(' ([#%d](%s))', $entry->prNumber, $entry->prUrl);
+            }
+            $out .= "\n";
+        }
+        return $out;
+    }
+}

--- a/src/Common/Command/ReleasePrep/ReleaseNotes/Section.php
+++ b/src/Common/Command/ReleasePrep/ReleaseNotes/Section.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Section bucket for a single CHANGELOG entry. Mirrors the H3/H4
+ * structure of the existing 8.0.0.3 entry: Fixed/Security,
+ * Fixed/BugFixes, Added, Changed.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Command\ReleasePrep\ReleaseNotes;
+
+enum Section: string
+{
+    case Security = 'security';
+    case BugFixes = 'bug_fixes';
+    case Added = 'added';
+    case Changed = 'changed';
+}

--- a/src/Common/Command/ReleasePrepCommand.php
+++ b/src/Common/Command/ReleasePrepCommand.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Common\Command;
 
+use OpenEMR\Common\Command\ReleasePrep\Mutator\ChangelogMutator;
 use OpenEMR\Common\Command\ReleasePrep\Mutator\DockerComposeProductionMutator;
 use OpenEMR\Common\Command\ReleasePrep\Mutator\GlobalsIncMutator;
 use OpenEMR\Common\Command\ReleasePrep\Mutator\OpenApiVersionMutator;
@@ -37,6 +38,7 @@ use OpenEMR\Common\Command\ReleasePrep\Mutator\VersionPhpMasterMutator;
 use OpenEMR\Common\Command\ReleasePrep\Mutator\VersionPhpMutator;
 use OpenEMR\Common\Command\ReleasePrep\MutatorContext;
 use OpenEMR\Common\Command\ReleasePrep\MutatorInterface;
+use OpenEMR\Common\Command\ReleasePrep\ReleaseNotes\Manifest;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -84,6 +86,12 @@ final class ReleasePrepCommand extends Command
                 'Optional sha256: digest for the docker image pin',
             )
             ->addOption(
+                'release-notes-json',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Path to the JSON manifest emitted by tools/release/bin/collect-release-notes.php',
+            )
+            ->addOption(
                 'project-dir',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -108,8 +116,19 @@ final class ReleasePrepCommand extends Command
             ? $rawProjectDir
             : $this->defaultProjectDir();
 
+        $rawNotesPath = $input->getOption('release-notes-json');
+        $releaseNotes = null;
+        if (is_string($rawNotesPath) && $rawNotesPath !== '') {
+            try {
+                $releaseNotes = Manifest::fromJsonFile($rawNotesPath);
+            } catch (\InvalidArgumentException | \RuntimeException $e) {
+                $output->writeln('<error>' . $e->getMessage() . '</error>');
+                return Command::INVALID;
+            }
+        }
+
         try {
-            $context = MutatorContext::fromVersionString($projectDir, $target, $imageDigest);
+            $context = MutatorContext::fromVersionString($projectDir, $target, $imageDigest, $releaseNotes);
         } catch (\InvalidArgumentException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             return Command::INVALID;
@@ -156,6 +175,7 @@ final class ReleasePrepCommand extends Command
             new DockerComposeProductionMutator(),
             new OpenApiVersionMutator(),
             new SwaggerRegenMutator(),
+            new ChangelogMutator(),
         ];
     }
 

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Common\Command\ReleasePrep;
 
+use OpenEMR\Common\Command\ReleasePrep\Mutator\ChangelogMutator;
 use OpenEMR\Common\Command\ReleasePrep\Mutator\DockerComposeProductionMutator;
 use OpenEMR\Common\Command\ReleasePrep\Mutator\GlobalsIncMutator;
 use OpenEMR\Common\Command\ReleasePrep\Mutator\OpenApiVersionMutator;
@@ -28,6 +29,9 @@ use OpenEMR\Common\Command\ReleasePrep\Mutator\VersionPhpMasterMutator;
 use OpenEMR\Common\Command\ReleasePrep\Mutator\VersionPhpMutator;
 use OpenEMR\Common\Command\ReleasePrep\MutatorContext;
 use OpenEMR\Common\Command\ReleasePrep\MutatorInterface;
+use OpenEMR\Common\Command\ReleasePrep\ReleaseNotes\Entry;
+use OpenEMR\Common\Command\ReleasePrep\ReleaseNotes\Manifest;
+use OpenEMR\Common\Command\ReleasePrep\ReleaseNotes\Section;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
@@ -208,6 +212,102 @@ final class MutatorTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('/exited 7/');
         $mutator->apply(MutatorContext::fromVersionString($this->tmpDir, '8.1.0'));
+    }
+
+    public function testChangelogPrependsNewSection(): void
+    {
+        $initial = "# CHANGELOG.md\n\n## [8.0.0.3](https://github.com/openemr/openemr/milestone/28?closed=1) - 2026-03-25\n\n### Fixed\n\n- old entry\n";
+        $this->writeFile('CHANGELOG.md', $initial);
+
+        $manifest = new Manifest(
+            version: '8.1.0',
+            milestoneNumber: 25,
+            milestoneUrl: 'https://github.com/openemr/openemr/milestone/25?closed=1',
+            date: '2026-05-28',
+            sections: [
+                Section::BugFixes->value => [new Entry('something broken', 11111, 'https://github.com/openemr/openemr/pull/11111')],
+                Section::Added->value => [new Entry('a new thing', 22222, 'https://github.com/openemr/openemr/pull/22222')],
+            ],
+        );
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0', null, $manifest);
+
+        $first = (new ChangelogMutator())->apply($context);
+        self::assertTrue($first->changed());
+        self::assertSame(['CHANGELOG.md'], $first->changedFiles);
+
+        $expected = "# CHANGELOG.md\n\n"
+            . "## [8.1.0](https://github.com/openemr/openemr/milestone/25?closed=1) - 2026-05-28\n\n"
+            . "### Fixed\n\n"
+            . "#### Bug Fixes\n\n"
+            . "- something broken ([#11111](https://github.com/openemr/openemr/pull/11111))\n\n"
+            . "### Added\n\n"
+            . "- a new thing ([#22222](https://github.com/openemr/openemr/pull/22222))\n\n"
+            . "## [8.0.0.3](https://github.com/openemr/openemr/milestone/28?closed=1) - 2026-03-25\n\n"
+            . "### Fixed\n\n"
+            . "- old entry\n";
+        self::assertSame($expected, $this->readFile($this->tmpDir . '/CHANGELOG.md'));
+
+        $second = (new ChangelogMutator())->apply($context);
+        self::assertFalse($second->changed(), 'ChangelogMutator is not idempotent');
+    }
+
+    public function testChangelogReplacesExistingTopSectionForSameVersion(): void
+    {
+        $initial = "# CHANGELOG.md\n\n"
+            . "## [8.1.0](https://github.com/openemr/openemr/milestone/25?closed=1) - 2026-05-20\n\n"
+            . "### Changed\n\n"
+            . "- stale entry from a previous conductor run\n\n"
+            . "## [8.0.0.3](https://github.com/openemr/openemr/milestone/28?closed=1) - 2026-03-25\n\n"
+            . "### Fixed\n\n- previous release entry\n";
+        $this->writeFile('CHANGELOG.md', $initial);
+
+        $manifest = new Manifest(
+            version: '8.1.0',
+            milestoneNumber: 25,
+            milestoneUrl: 'https://github.com/openemr/openemr/milestone/25?closed=1',
+            date: '2026-05-28',
+            sections: [
+                Section::Changed->value => [new Entry('fresh entry from latest PR', 33333, 'https://github.com/openemr/openemr/pull/33333')],
+            ],
+        );
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0', null, $manifest);
+
+        $result = (new ChangelogMutator())->apply($context);
+        self::assertTrue($result->changed());
+
+        $expected = "# CHANGELOG.md\n\n"
+            . "## [8.1.0](https://github.com/openemr/openemr/milestone/25?closed=1) - 2026-05-28\n\n"
+            . "### Changed\n\n"
+            . "- fresh entry from latest PR ([#33333](https://github.com/openemr/openemr/pull/33333))\n\n"
+            . "## [8.0.0.3](https://github.com/openemr/openemr/milestone/28?closed=1) - 2026-03-25\n\n"
+            . "### Fixed\n\n- previous release entry\n";
+        self::assertSame($expected, $this->readFile($this->tmpDir . '/CHANGELOG.md'));
+    }
+
+    public function testChangelogIsNoOpWhenManifestAbsent(): void
+    {
+        $this->writeFile('CHANGELOG.md', "# CHANGELOG.md\n\n## [8.0.0.3] - 2026-03-25\n");
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0');
+
+        $result = (new ChangelogMutator())->apply($context);
+        self::assertFalse($result->changed());
+    }
+
+    public function testChangelogRejectsManifestVersionMismatch(): void
+    {
+        $this->writeFile('CHANGELOG.md', "# CHANGELOG.md\n");
+        $manifest = new Manifest(
+            version: '8.1.1',
+            milestoneNumber: 1,
+            milestoneUrl: 'https://example/1',
+            date: '2026-05-28',
+            sections: [],
+        );
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0', null, $manifest);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/manifest version 8\.1\.1 does not match target version 8\.1\.0/');
+        (new ChangelogMutator())->apply($context);
     }
 
     private function assertMutationProducesAndIdempotent(

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/ReleaseNotes/ManifestTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/ReleaseNotes/ManifestTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * Validation tests for the release-notes Manifest loader. The
+ * conductor workflow trusts the collector script to emit
+ * well-formed JSON, so the loader's job is to fail loudly when an
+ * upstream change breaks the contract rather than silently shipping
+ * a malformed changelog.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Command\ReleasePrep\ReleaseNotes;
+
+use OpenEMR\Common\Command\ReleasePrep\ReleaseNotes\Manifest;
+use OpenEMR\Common\Command\ReleasePrep\ReleaseNotes\Section;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+#[Group('release-prep')]
+final class ManifestTest extends TestCase
+{
+    private string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/openemr-manifest-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->tmpDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->tmpDir);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tmpDir . '/*') ?: [] as $file) {
+            unlink($file);
+        }
+        rmdir($this->tmpDir);
+    }
+
+    public function testFromArrayParsesValidPayload(): void
+    {
+        $manifest = Manifest::fromArray([
+            'version' => '8.1.0',
+            'milestone' => ['number' => 25, 'url' => 'https://github.com/openemr/openemr/milestone/25?closed=1'],
+            'date' => '2026-05-28',
+            'sections' => [
+                'security' => [['title' => 'fix XSS', 'number' => 1, 'url' => 'https://example/1']],
+                'bug_fixes' => [['title' => 'fix calendar', 'number' => 2, 'url' => 'https://example/2']],
+            ],
+        ]);
+
+        self::assertSame('8.1.0', $manifest->version);
+        self::assertSame(25, $manifest->milestoneNumber);
+        self::assertSame('2026-05-28', $manifest->date);
+        self::assertCount(1, $manifest->entriesFor(Section::Security));
+        self::assertCount(1, $manifest->entriesFor(Section::BugFixes));
+        self::assertSame([], $manifest->entriesFor(Section::Added));
+        self::assertFalse($manifest->isEmpty());
+    }
+
+    public function testIsEmptyWhenNoEntries(): void
+    {
+        $manifest = Manifest::fromArray([
+            'version' => '8.1.0',
+            'milestone' => ['number' => 1, 'url' => 'https://example/1'],
+            'date' => '2026-05-28',
+            'sections' => [],
+        ]);
+        self::assertTrue($manifest->isEmpty());
+    }
+
+    public function testFromJsonFileRejectsMalformedJson(): void
+    {
+        $path = $this->tmpDir . '/broken.json';
+        file_put_contents($path, '{ not valid json');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Invalid release-notes JSON/');
+        Manifest::fromJsonFile($path);
+    }
+
+    public function testFromJsonFileRejectsMissingFile(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Cannot read release-notes JSON/');
+        Manifest::fromJsonFile($this->tmpDir . '/does-not-exist.json');
+    }
+
+    public function testRejectsMissingVersion(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/missing "version"/');
+        Manifest::fromArray([
+            'milestone' => ['number' => 1, 'url' => 'https://example/1'],
+            'date' => '2026-05-28',
+            'sections' => [],
+        ]);
+    }
+
+    public function testRejectsBadDate(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/date must be YYYY-MM-DD/');
+        Manifest::fromArray([
+            'version' => '8.1.0',
+            'milestone' => ['number' => 1, 'url' => 'https://example/1'],
+            'date' => '5/28/2026',
+            'sections' => [],
+        ]);
+    }
+
+    public function testRejectsUnknownSectionKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/unknown section: removed/');
+        Manifest::fromArray([
+            'version' => '8.1.0',
+            'milestone' => ['number' => 1, 'url' => 'https://example/1'],
+            'date' => '2026-05-28',
+            'sections' => ['removed' => []],
+        ]);
+    }
+
+    public function testRejectsEntryMissingTitle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/is missing "title"/');
+        Manifest::fromArray([
+            'version' => '8.1.0',
+            'milestone' => ['number' => 1, 'url' => 'https://example/1'],
+            'date' => '2026-05-28',
+            'sections' => ['changed' => [['number' => 1, 'url' => 'https://example/1']]],
+        ]);
+    }
+}

--- a/tools/release/bin/collect-release-notes.php
+++ b/tools/release/bin/collect-release-notes.php
@@ -1,0 +1,79 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Emit the release-notes JSON manifest the release-prep conductor
+ * passes to openemr:release-prep --release-notes-json=. Shells out to
+ * `gh` for milestone lookup and PR enumeration; writes the result to
+ * stdout so the workflow can redirect it to a tmp file.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+if (!class_exists(\OpenEMR\Release\ReleaseNotesCollector::class)) {
+    fwrite(
+        STDERR,
+        "OpenEMR\\Release\\ classes are not autoloadable; rerun composer install with dev dependencies.\n",
+    );
+    exit(2);
+}
+
+use OpenEMR\Release\ReleaseNotesCollector;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('collect-release-notes')
+    ->setDescription('Emit the release-notes JSON manifest for openemr:release-prep')
+    ->addOption(
+        'target-version',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Target release version (MAJOR.MINOR.PATCH)',
+    )
+    ->addOption(
+        'repo',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'GitHub repo (owner/name)',
+        'openemr/openemr',
+    )
+    ->addOption(
+        'date',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Release date (YYYY-MM-DD). Defaults to today UTC.',
+    )
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $version = $input->getOption('target-version');
+        $repo = $input->getOption('repo');
+        $date = $input->getOption('date');
+        if (!is_string($version) || $version === '') {
+            $output->writeln('<error>--target-version is required</error>');
+            return 2;
+        }
+        if (!is_string($repo) || $repo === '') {
+            $output->writeln('<error>--repo is required</error>');
+            return 2;
+        }
+        if (!is_string($date) || $date === '') {
+            $date = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d');
+        }
+        $manifest = (new ReleaseNotesCollector($repo))->collect($version, $date);
+        $output->writeln(json_encode(
+            $manifest,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        ));
+        return 0;
+    })
+    ->run();

--- a/tools/release/src/ReleaseNotesCollector.php
+++ b/tools/release/src/ReleaseNotesCollector.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * Build the release-notes JSON manifest the conductor passes to the
+ * openemr:release-prep ChangelogMutator. Combines a milestone lookup
+ * with a `gh pr list --milestone:<version> is:merged` enumeration,
+ * categorises each PR, and emits the JSON shape Manifest::fromJsonFile
+ * expects.
+ *
+ * Categorisation is deliberately conservative:
+ *   - PRs labelled `Security` → Security
+ *   - PR title starts with `fix(...)` / `fix:` → Bug Fixes
+ *   - PR title starts with `feat(...)` / `feat:` → Added
+ *   - Everything else → Changed (catch-all)
+ * OpenEMR's label taxonomy is scope-based (Calendar, Authentication,
+ * etc.) rather than type-based, so the Conventional Commits prefix in
+ * the PR title is the primary signal.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * @phpstan-type GhPr array{number: int, title: string, url: string, labels: list<array{name: string}>}
+ * @phpstan-type GhMilestone array{number: int, title: string, html_url: string}
+ * @phpstan-type ProcessRunner callable(Process): string
+ */
+final readonly class ReleaseNotesCollector
+{
+    /**
+     * @param ProcessRunner|null $processRunner Override only in tests.
+     */
+    public function __construct(
+        private string $repo,
+        private mixed $processRunner = null,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *   version: string,
+     *   milestone: array{number: int, url: string},
+     *   date: string,
+     *   sections: array<string, list<array{title: string, number: int, url: string}>>,
+     * }
+     */
+    public function collect(string $version, string $date): array
+    {
+        $milestone = $this->lookupMilestone($version);
+        if ($milestone === null) {
+            throw new \RuntimeException(sprintf(
+                'No milestone titled "%s" found on %s; create the milestone before tagging',
+                $version,
+                $this->repo,
+            ));
+        }
+
+        $prs = $this->listMergedPrs($version);
+        $sections = $this->categorise($prs);
+
+        return [
+            'version' => $version,
+            'milestone' => [
+                'number' => $milestone['number'],
+                // Match the convention of prior CHANGELOG entries (e.g. 8.0.0.3),
+                // which link to the milestone's closed-issues view.
+                'url' => $milestone['html_url'] . '?closed=1',
+            ],
+            'date' => $date,
+            'sections' => $sections,
+        ];
+    }
+
+    /**
+     * @return GhMilestone|null
+     */
+    private function lookupMilestone(string $version): ?array
+    {
+        $stdout = $this->runGh([
+            'gh', 'api', '--paginate',
+            sprintf('repos/%s/milestones?state=all&per_page=100', $this->repo),
+            '--jq', sprintf('.[] | select(.title == "%s")', $version),
+        ]);
+        $stdout = trim($stdout);
+        if ($stdout === '') {
+            return null;
+        }
+        // --jq emits one matching object per line; take the first.
+        $firstLine = explode("\n", $stdout, 2)[0];
+        $decoded = json_decode($firstLine, true, 16, JSON_THROW_ON_ERROR);
+        if (
+            !is_array($decoded)
+            || !is_int($decoded['number'] ?? null)
+            || !is_string($decoded['title'] ?? null)
+            || !is_string($decoded['html_url'] ?? null)
+        ) {
+            throw new \RuntimeException('Malformed milestone payload from gh api');
+        }
+        return [
+            'number' => $decoded['number'],
+            'title' => $decoded['title'],
+            'html_url' => $decoded['html_url'],
+        ];
+    }
+
+    /**
+     * @return list<GhPr>
+     */
+    private function listMergedPrs(string $version): array
+    {
+        $stdout = $this->runGh([
+            'gh', 'pr', 'list',
+            '--repo', $this->repo,
+            '--state', 'merged',
+            '--search', sprintf('milestone:%s', $version),
+            '--limit', '500',
+            '--json', 'number,title,url,labels',
+        ]);
+        $stdout = trim($stdout);
+        if ($stdout === '') {
+            return [];
+        }
+        $decoded = json_decode($stdout, true, 32, JSON_THROW_ON_ERROR);
+        if (!is_array($decoded)) {
+            throw new \RuntimeException('gh pr list did not return a JSON array');
+        }
+        $rows = [];
+        foreach ($decoded as $row) {
+            if (
+                !is_array($row)
+                || !is_int($row['number'] ?? null)
+                || !is_string($row['title'] ?? null)
+                || !is_string($row['url'] ?? null)
+                || !is_array($row['labels'] ?? null)
+            ) {
+                throw new \RuntimeException('gh pr list returned a malformed row');
+            }
+            $labels = [];
+            foreach ($row['labels'] as $label) {
+                if (!is_array($label) || !is_string($label['name'] ?? null)) {
+                    throw new \RuntimeException('gh pr list returned a malformed label');
+                }
+                $labels[] = ['name' => $label['name']];
+            }
+            $rows[] = [
+                'number' => $row['number'],
+                'title' => $row['title'],
+                'url' => $row['url'],
+                'labels' => $labels,
+            ];
+        }
+        return $rows;
+    }
+
+    /**
+     * @param list<GhPr> $prs
+     * @return array<string, list<array{title: string, number: int, url: string}>>
+     */
+    private function categorise(array $prs): array
+    {
+        $buckets = [
+            'security' => [],
+            'bug_fixes' => [],
+            'added' => [],
+            'changed' => [],
+        ];
+        foreach ($prs as $pr) {
+            $section = $this->classify($pr);
+            $buckets[$section][] = [
+                'title' => $this->stripConventionalPrefix($pr['title']),
+                'number' => $pr['number'],
+                'url' => $pr['url'],
+            ];
+        }
+        return $buckets;
+    }
+
+    /**
+     * @param GhPr $pr
+     */
+    private function classify(array $pr): string
+    {
+        foreach ($pr['labels'] as $label) {
+            if (strcasecmp($label['name'], 'Security') === 0) {
+                return 'security';
+            }
+        }
+        if (preg_match('/^feat(?:\([^)]*\))?!?:/i', $pr['title']) === 1) {
+            return 'added';
+        }
+        if (preg_match('/^fix(?:\([^)]*\))?!?:/i', $pr['title']) === 1) {
+            return 'bug_fixes';
+        }
+        return 'changed';
+    }
+
+    private function stripConventionalPrefix(string $title): string
+    {
+        $stripped = preg_replace(
+            '/^(?:feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(?:\([^)]*\))?!?:\s*/i',
+            '',
+            $title,
+        );
+        return $stripped ?? $title;
+    }
+
+    /**
+     * @param list<string> $command
+     */
+    private function runGh(array $command): string
+    {
+        $process = new Process($command);
+        $process->setTimeout(120.0);
+        if ($this->processRunner !== null) {
+            $runner = $this->processRunner;
+            return $runner($process);
+        }
+        $process->mustRun();
+        return $process->getOutput();
+    }
+}

--- a/tools/release/src/ReleaseNotesCollector.php
+++ b/tools/release/src/ReleaseNotesCollector.php
@@ -3,9 +3,9 @@
 /**
  * Build the release-notes JSON manifest the conductor passes to the
  * openemr:release-prep ChangelogMutator. Combines a milestone lookup
- * with a `gh pr list --milestone:<version> is:merged` enumeration,
- * categorises each PR, and emits the JSON shape Manifest::fromJsonFile
- * expects.
+ * with a `gh pr list --state merged --search milestone:<version>`
+ * enumeration, categorises each PR, and emits the JSON shape
+ * Manifest::fromJsonFile expects.
  *
  * Categorisation is deliberately conservative:
  *   - PRs labelled `Security` → Security


### PR DESCRIPTION
## Summary

- Adds a `ChangelogMutator` that prepends (or replaces, on re-run) the target-version section in `CHANGELOG.md`, so the release-prep PR always carries a real diff. Fixes the auto-close behavior seen on #12291 where all-no-op mutator runs produced a zero-diff PR that GitHub immediately closed and the conductor stalled without a tag.
- Adds `tools/release/bin/collect-release-notes.php` — a `gh`-backed script that resolves the milestone for the target version and enumerates merged PRs into a JSON manifest. Workflow runs it before the mutator step and pipes the result via the new `--release-notes-json=<path>` option on `openemr:release-prep`.
- Categorisation: `Security` label → Security; PR title `^fix(…)?:` → Bug Fixes; `^feat(…)?:` → Added; everything else → Changed. (OpenEMR labels are scope-based, not type-based, so the Conventional Commits prefix in the PR title is the primary signal.)
- Mutator stays pure — all `gh` shell-outs live in the collector. Rendering is byte-stable, so re-running with an unchanged manifest is a true no-op and re-running with new PRs replaces the existing top section in place rather than stacking duplicates.

## Smoke test

Ran end-to-end against the live 8.1.0 milestone in this worktree:

```
$ php tools/release/bin/collect-release-notes.php --target-version=8.1.0 --repo=openemr/openemr > /tmp/notes.json
# 65 PRs: 5 security / 53 bug_fixes / 2 added / 5 changed
$ php bin/console openemr:release-prep --skip-globals --target-version=8.1.0 --scope=rel --release-notes-json=/tmp/notes.json
# 1 file changed: CHANGELOG.md (prepended the 8.1.0 section above 8.0.0.3)
$ php bin/console openemr:release-prep --skip-globals --target-version=8.1.0 --scope=rel --release-notes-json=/tmp/notes.json
# 0 file(s) changed (idempotent on re-run)
```

The rendered section matches the established 8.0.0.3 format (H2 with milestone+date, `### Fixed` / `#### Security` / `#### Bug Fixes`, `### Added`, `### Changed`).

## Test plan

- [x] `composer phpunit-isolated -- --group release-prep` — 23 tests, 63 assertions, all green (includes 4 new ChangelogMutator cases and 7 new Manifest validation cases)
- [x] `composer phpstan` — clean at level 10
- [x] `composer phpcs` — clean
- [x] Local smoke test against the 8.1.0 milestone (above)
- [ ] CI conductor run on rel-810 produces a release-prep PR with the new `## [8.1.0](…) - YYYY-MM-DD` section

## Forward port

After this lands on rel-810, the same change needs to forward-port to master so future release branches get it automatically.