### PR TITLE
fix(oauth2): guard scopeAuthorizeConfirm against missing client_id

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -59283,7 +59283,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$clientIdentifier of method OpenEMR\\\\Common\\\\Auth\\\\OpenIDConnect\\\\Repositories\\\\ClientRepository\\:\\:getClientEntity\\(\\) expects string, mixed given\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
 ];
 $ignoreErrors[] = [

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -1101,8 +1101,28 @@ class AuthorizationController implements LoggerAwareInterface
         $offline_access_date = (new DateTimeImmutable())->add(new DateInterval(self::GRANT_TYPE_REFRESH_TOKEN_TTL))->format("Y-m-d");
         $claims = $session->get('claims', []);
 
-        $clientRepository = $this->getClientRepository();
-        $client = $clientRepository->getClientEntity($session->get('client_id', []));
+        $clientId = $session->get('client_id', '');
+        if (!is_string($clientId) || $clientId === '') {
+            $this->logger->error('scopeAuthorizeConfirm() session client_id was missing when it should not have been');
+            return $this->renderTwigPage(
+                'oauth2/authorize/scopes-authorize',
+                'error/general_http_error.html.twig',
+                ['statusCode' => Response::HTTP_BAD_REQUEST]
+            );
+        }
+
+        $client = $this->getClientRepository()->getClientEntity($clientId);
+        if ($client === false) {
+            $this->logger->error(
+                'scopeAuthorizeConfirm() session client_id was not found in oauth_clients',
+                ['client_id' => $clientId]
+            );
+            return $this->renderTwigPage(
+                'oauth2/authorize/scopes-authorize',
+                'error/general_http_error.html.twig',
+                ['statusCode' => Response::HTTP_BAD_REQUEST]
+            );
+        }
 
         $uuidToUser = $this->getUuidUserAccount($session->get('user_id', ''));
         $userRole = $uuidToUser->getUserRole();

--- a/tests/Tests/Api/AuthorizationGrantFlowTest.php
+++ b/tests/Tests/Api/AuthorizationGrantFlowTest.php
@@ -65,22 +65,7 @@ class AuthorizationGrantFlowTest extends TestCase
         $scopesString = implode(" ", $scopes);
 //        $scopesString = ApiTestClient::ALL_SCOPES;
         $redirectUri = "http://localhost:8080/oauth2/callback";
-        $dispatcher = new EventDispatcher();
-        $controller = $this->createMock(ControllerResolverInterface::class);
-        $kernel = new OEHttpKernel($dispatcher, $controller);
-        // set the globals.php kernel which doesn't do much... need to reconicle these two
-        // set our site_addr_oath so we use it properly
-        $kernel->getGlobalsBag()->set('site_addr_oath', $this->getBaseUrlApi());
-        $projectDir = $GLOBALS['webserver_root'] ?? dirname(__DIR__, 3);
-        $webRoot = $GLOBALS['webroot'] ?? '';
-        if (!is_string($projectDir) || !is_string($webRoot)) {
-            $this->fail('Expected $GLOBALS[webserver_root] and $GLOBALS[webroot] to be strings');
-        }
-        $kernel->getGlobalsBag()->set('kernel', new Kernel(
-            $projectDir,
-            $webRoot,
-            $dispatcher,
-        ));
+        $kernel = $this->createTestKernel();
         [$clientIdentifier, $clientSecret] = $this->requestTestRegistrationEndpoint($kernel, $redirectUri, $scopesString);
 
         // now test the authorization flow
@@ -112,6 +97,99 @@ class AuthorizationGrantFlowTest extends TestCase
             $scopesString,
             $kernel
         );
+    }
+
+    public function testScopeAuthorizeConfirmWithMissingClientIdRendersErrorPage(): void
+    {
+        $session = $this->getMockSession();
+        $session->set('scopes', 'openid profile');
+        // intentionally do NOT set 'client_id' — this is the reproduction
+
+        $body = $this->requestScopeAuthorizeConfirm($session);
+
+        $this->assertErrorPageRendered($body);
+        $this->assertStringNotContainsStringIgnoringCase(
+            'bulkBind',
+            $body,
+            'Response must not surface the ADOdb bulkBind error from passing a non-string client_id'
+        );
+    }
+
+    public function testScopeAuthorizeConfirmWithUnknownClientIdRendersErrorPage(): void
+    {
+        $session = $this->getMockSession();
+        $session->set('scopes', 'openid profile');
+        // a well-formed client_id that has no row in oauth_clients
+        $session->set('client_id', 'no-such-client-' . bin2hex(random_bytes(8)));
+
+        $body = $this->requestScopeAuthorizeConfirm($session);
+
+        $this->assertErrorPageRendered($body);
+    }
+
+    /**
+     * Drive scopeAuthorizeConfirm() against the given session and return the rendered body.
+     */
+    private function requestScopeAuthorizeConfirm(Session $session): string
+    {
+        $authController = $this->getAuthorizationController($session, $this->createTestKernel());
+        $request = HttpRestRequest::create('/oauth2/default' . AuthorizationController::ENDPOINT_SCOPE_AUTHORIZE_CONFIRM);
+        $response = $authController->scopeAuthorizeConfirm($request);
+
+        $this->assertEquals(
+            Response::HTTP_OK,
+            $response->getStatusCode(),
+            'Error template is rendered with HTTP 200 by renderTwigPage; statusCode is conveyed via the page body'
+        );
+        return (string) $response->getBody();
+    }
+
+    /**
+     * Assert the general HTTP error page rendered with the 400 the guard passes, rather than the
+     * scope authorization form or renderTwigPage()'s 500 fallback for a template that threw.
+     */
+    private function assertErrorPageRendered(string $body): void
+    {
+        $this->assertStringContainsString(
+            '<body class="error">',
+            $body,
+            'error/general_http_error.html.twig should have rendered'
+        );
+        $this->assertStringContainsString(
+            (string) Response::HTTP_BAD_REQUEST,
+            $body,
+            'The error page should report the 400 passed by the guard, not the 500 renderTwigPage() falls back to'
+        );
+        $this->assertStringNotContainsString(
+            'id="userLogin"',
+            $body,
+            'The scope authorization form must not render when the client cannot be resolved'
+        );
+    }
+
+    private function createTestKernel(): OEHttpKernel
+    {
+        $dispatcher = new EventDispatcher();
+        $controller = $this->createMock(ControllerResolverInterface::class);
+        $kernel = new OEHttpKernel($dispatcher, $controller);
+        // set our site_addr_oath so we use it properly
+        $kernel->getGlobalsBag()->set('site_addr_oath', $this->getBaseUrlApi());
+        $projectDir = $GLOBALS['webserver_root'] ?? dirname(__DIR__, 3);
+        $webRoot = $GLOBALS['webroot'] ?? '';
+        if (!is_string($projectDir) || !is_string($webRoot)) {
+            // @codeCoverageIgnoreStart
+            // Defensive — these globals are strings once globals.php has bootstrapped,
+            // which is not a condition real CI exercises.
+            $this->fail('Expected $GLOBALS[webserver_root] and $GLOBALS[webroot] to be strings');
+            // @codeCoverageIgnoreEnd
+        }
+        // set the globals.php kernel which doesn't do much... need to reconicle these two
+        $kernel->getGlobalsBag()->set('kernel', new Kernel(
+            $projectDir,
+            $webRoot,
+            $dispatcher,
+        ));
+        return $kernel;
     }
 
     /**


### PR DESCRIPTION
## Summary

`scopeAuthorizeConfirm()` passes `$session->get('client_id', [])` directly into `ClientRepository::getClientEntity()`. When `client_id` is missing from the session the default `[]` is forwarded into `sqlQueryNoLog('Select * From oauth_clients Where client_id=?', [$clientIdentifier])`, which trips the ADOdb `bulkBind` guard with:

> 2D Array of values sent to execute and 'ADOdb_mysqli::bulkBind' not set

The error path then terminates the request, so the user gets a raw query-error dump instead of a page.

This change:

- narrows `$clientId` to a non-empty string before the lookup,
- handles the not-found case (`getClientEntity()` returns `false`), and
- renders the existing `error/general_http_error.html.twig` template in both cases, consistent with how this controller already surfaces fatal OAuth2 failures — and with the equivalent guard `userLogin()` already has.

## Tests

Two regression tests drive `scopeAuthorizeConfirm()` through both guards:

- `testScopeAuthorizeConfirmWithMissingClientIdRendersErrorPage` — no session `client_id`
- `testScopeAuthorizeConfirmWithUnknownClientIdRendersErrorPage` — a `client_id` with no row in `oauth_clients`

Both assert the error template rendered (`<body class="error">`), that it reports the **400** the guard passes rather than the 500 `renderTwigPage()` falls back to when a template throws, and that the scope authorization form did not render.

Verified the tests catch the regression: with the guard reverted, the first test aborts the PHPUnit process on the `bulkBind` query error.

## Test plan

- [x] `composer phpstan` — clean; baseline regenerates with no diff
- [x] `composer phpcs` — clean
- [x] Both new tests pass, and fail with the guard reverted
