### PR TITLE
build: exclude generated EHI schema docs from release archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -35,3 +35,16 @@ semgrep.yaml                   export-ignore
 CLAUDE.md                      export-ignore
 DOCKER_README.md               export-ignore
 README-Isolated-Testing.md     export-ignore
+
+# Exclude the very large generated EHI schema documentation (~140M of
+# SchemaSpy HTML, diagrams, jars) from release archives; it is published to
+# the website instead of shipped in the install package. The EHI exporter
+# only reads two descriptors at runtime, so keep just those via single-*
+# globs (which match immediate children only, leaving the parent dirs
+# walkable) plus -export-ignore carve-outs for the two files.
+Documentation/EHI_Export/docs/* export-ignore
+Documentation/EHI_Export/docs/openemr.openemr.xml -export-ignore
+Documentation/EHI_Export/schemaspy/* export-ignore
+Documentation/EHI_Export/schemaspy/schemas -export-ignore
+Documentation/EHI_Export/schemaspy/schemas/* export-ignore
+Documentation/EHI_Export/schemaspy/schemas/openemr.meta.xml -export-ignore


### PR DESCRIPTION
## Summary

- `Documentation/EHI_Export` is ~140M of SchemaSpy-generated HTML, diagrams, and tool jars — generated schema documentation, not application code.
- The EHI exporter reads only two descriptors from it at runtime (`docs/openemr.openemr.xml`, `schemaspy/schemas/openemr.meta.xml`); the rest is human-facing docs that belong on the website, not in the install package.
- Mark the generated output `export-ignore` so release archives and GitHub source downloads drop it, keeping the two runtime files via `-export-ignore` carve-outs. The bundled `Documentation/` tree drops from ~150M to ~10.5M.

The single-`*` globs match immediate children only, leaving the parent directories walkable so the carve-outs survive — a `/**` glob would prune the ancestor directories before `git archive` could re-include the two files.

## Verification

- `git archive` of `Documentation/EHI_Export` now yields exactly the two runtime XMLs.
- `EhiExporter` uses `xmlConfigPath` only to read those two files (constructor + `EhiExporter.php:358-359`); it does not copy the HTML tree into the patient export, so the ONC-certified EHI export feature is unaffected.

## Note

This targets `master`. The packaged release archives are built from the `rel-*` branches, so a backport (e.g. to `rel-810`) is needed for it to shrink a given release's package.