### PR TITLE
fix: blank charted document for portal LBF EncounterForm submissions

### DIFF
--- a/src/Services/DocumentTemplates/DocumentTemplateRender.php
+++ b/src/Services/DocumentTemplates/DocumentTemplateRender.php
@@ -228,6 +228,17 @@ class DocumentTemplateRender
                 $formname = $matches[2];
                 $this->keyLength = strlen($matches[0]);
                 $src = $formData['encounterForm'] ?? '';
+                // The portal captures this src URL with id=0 before the embedded form is
+                // first saved, and never rewrites it. If we know the saved form id, put it
+                // in the URL so the embedded form loads the patient's saved data; otherwise
+                // the form (and any chart/PDF made from it) renders blank. See encounterFormId
+                // stored alongside in template_data.
+                if (is_array($formData) && is_string($src) && $src !== '') {
+                    $encounterFormId = intval($formData['encounterFormId'] ?? 0);
+                    if ($encounterFormId > 0) {
+                        $src = preg_replace('/([?&]id=)\d+/', '${1}' . $encounterFormId, $src, 1) ?? $src;
+                    }
+                }
                 $sigfld = "<script>page.isFrameForm=1;page.encounterFormName=" . js_escape($formname) . "</script>";
                 $sigfld .= "<iframe id='encounterForm' class='lbfFrame' style='height:100vh;width:100%;border:0;' src='" . attr($src) . "'></iframe>";
                 $s = $this->keyReplace($s, $sigfld);


### PR DESCRIPTION
## Summary
Onsite patient-portal documents that embed an LBF encounter form via the `{EncounterForm:LBFxxxx}` directive are charted into the patient's Documents folder as **blank** documents — the patient's entered answers are not rendered. The data itself is saved (in `lbf_data`), but the charted artifact staff rely on is empty, so submissions appear lost.

Fixes #12319.

## Root cause
`onsite_documents.template_data` stores the embedded-form reference as two fields:
- `encounterForm` — the iframe URL, captured **before** the form is first saved, so it always contains `id=0`
- `encounterFormId` — the real saved form id

The `{EncounterForm:...}` branch of `DocumentTemplateRender::doSubs()` built the iframe `src` from `encounterForm` (the `id=0` URL) and never used `encounterFormId`. So every render (provider review, and the chart capture that follows) loaded a **new empty form**, and the blank form was charted.

## Fix
Substitute the known `encounterFormId` into the iframe `src`. Guarded: no effect when the id is unknown (`> 0` check) or for non-LBF documents, and the `[?&]id=` boundary avoids touching `formid=`/`docid=` params.

## Testing
Rendered a real affected submission through `DocumentTemplateRender::doRender()` with its saved `template_data`:
- **before:** `src=/interface/forms/LBF/new.php?...&id=0&isPortal=1`
- **after:**  `src=/interface/forms/LBF/new.php?...&id=41&isPortal=1`

With the corrected id, provider review shows the saved answers and the charted PDF is fully populated. Verified the regex leaves `formid=`/`docid=` untouched and handles both `?id=` and `&id=`.
