### PR TITLE
fix(oauth): use spec-compliant `invalid_request` error code (remove stray space)

### DIFF
--- a/src/RestControllers/Authorization/BearerTokenAuthorizationStrategy.php
+++ b/src/RestControllers/Authorization/BearerTokenAuthorizationStrategy.php
@@ -174,7 +174,7 @@ class BearerTokenAuthorizationStrategy implements IAuthorizationStrategy
                 "invalid Trusted User.  Refresh Token revoked or logged out",
                 ['clientId' => $clientId, 'userId' => $userId]
             );
-            throw new OAuthServerException('Refresh Token revoked or logged out', 0, 'invalid _request', 400);
+            throw new OAuthServerException('Refresh Token revoked or logged out', 0, 'invalid_request', 400);
         }
 
         // TODO: @adunsulag this seems redundant since the access token should already be verified on the expiration date

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -493,7 +493,7 @@ class AuthorizationController
                 throw new OAuthServerException('Invalid client', 0, 'invalid_request', Response::HTTP_FORBIDDEN);
             }
             if ($client['registration_access_token'] !== $token) {
-                throw new OAuthServerException('Invalid registration token', 0, 'invalid _request', Response::HTTP_FORBIDDEN);
+                throw new OAuthServerException('Invalid registration token', 0, 'invalid_request', Response::HTTP_FORBIDDEN);
             }
             $params['client_id'] = $client['client_id'];
             try {
@@ -1455,7 +1455,7 @@ class AuthorizationController
         try {
             $id_token = $request->query->get('id_token_hint', '');
             if (empty($id_token)) {
-                throw new OAuthServerException('Id token missing from request', 0, 'invalid _request', Response::HTTP_BAD_REQUEST);
+                throw new OAuthServerException('Id token missing from request', 0, 'invalid_request', Response::HTTP_BAD_REQUEST);
             }
             $post_logout_url = $request->query->get('post_logout_redirect_uri', '');
             $state = $request->query->get('state', '');
@@ -1481,7 +1481,7 @@ class AuthorizationController
             $session_nonce = (json_decode((string) $trustedUser['session_cache'], true)['nonce']) ?? '';
             // this should be enough to confirm valid id
             if ($session_nonce !== $id_nonce) {
-                throw new OAuthServerException('Id token not issued from this server', 0, 'invalid _request', Response::HTTP_BAD_REQUEST);
+                throw new OAuthServerException('Id token not issued from this server', 0, 'invalid_request', Response::HTTP_BAD_REQUEST);
             }
             // clear the users session
             $this->trustedUserService->deleteTrustedUserById($trustedUser['id']);


### PR DESCRIPTION
## Problem

Several `OAuthServerException` constructions pass the error code `'invalid _request'` — with a **stray space** — instead of the spec value `'invalid_request'`. That value is echoed verbatim to clients in the JSON error response's `error` field, so API consumers receive a non-standard OAuth2 error code:

```json
{"error":"invalid _request","error_description":"Invalid registration token"}
```

Per [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) the error code is `invalid_request` (no space).

## Fix

Replace `'invalid _request'` → `'invalid_request'` at all four occurrences:

- `src/RestControllers/AuthorizationController.php` — L496, L1458, L1484
- `src/RestControllers/Authorization/BearerTokenAuthorizationStrategy.php` — L177 (same typo; included for completeness)

No behavioural change other than the corrected, spec-compliant error code.

## Testing

Trigger any of the affected paths (e.g. an invalid dynamic-client-registration token, or a revoked refresh token) and confirm the JSON response now returns `"error":"invalid_request"` instead of `"error":"invalid _request"`.

Fixes #12326