### PR TITLE
fix(sql): backtick `rank` column in ContactTelecomService for MySQL 8+ compat

### DIFF
--- a/src/Services/ContactTelecomService.php
+++ b/src/Services/ContactTelecomService.php
@@ -213,7 +213,7 @@ class ContactTelecomService extends BaseService
             $sql .= " AND status = 'A'";
         }
 
-        $sql .= " ORDER BY rank ASC, is_primary DESC";
+        $sql .= " ORDER BY `rank` ASC, is_primary DESC";
 
         return QueryUtils::fetchRecords($sql, [$contactId]) ?? [];
     }
@@ -335,7 +335,7 @@ class ContactTelecomService extends BaseService
             $sql .= " AND status = 'A'";
         }
 
-        $sql .= " ORDER BY rank ASC";
+        $sql .= " ORDER BY `rank` ASC";
 
         return QueryUtils::fetchRecords($sql, [$contactId, $system]) ?? [];
     }
@@ -357,7 +357,7 @@ class ContactTelecomService extends BaseService
             $sql .= " AND status = 'A'";
         }
 
-        $sql .= " ORDER BY rank ASC";
+        $sql .= " ORDER BY `rank` ASC";
 
         return QueryUtils::fetchRecords($sql, [$contactId, $use]) ?? [];
     }


### PR DESCRIPTION
## Summary

- `RANK` became a reserved word in MySQL 8.0 with the addition of window functions; unquoted use as a column identifier breaks queries against `contact_telecom` on MySQL 8.0/8.4/9.3.
- MariaDB does not reserve `RANK`, so the bug was latent until #12232 added `FieldRenderingSnapshotTest` with `telecom-list` data sets, which surfaced it on the MySQL CI legs.
- Three-line fix: backtick `` `rank` `` in the three `ORDER BY` clauses in `src/Services/ContactTelecomService.php`. Matches the existing pattern at line 354 where `` `use` `` is already backticked for the same reason. Bug present since #9333.

## Failing CI evidence (pre-fix)

From the most recent master run, only the MySQL `services` legs failed:

| Job | Status |
|---|---|
| `apache_85_57` services (MySQL 5.7) | pass |
| `apache_85_80` services (MySQL 8.0) | fail |
| `apache_85_84` services (MySQL 8.4) | fail |
| `apache_85_93` services (MySQL 9.3) | fail |
| `apache_85_106` / `_1011` / `_114` / `_118` / `_122` services (MariaDB) | pass |

JUnit error from each failing job:

```
SQLSTATE 42000: You have an error in your SQL syntax;
... near 'ASC, is_primary DESC' at line 1
Statement: SELECT * FROM contact_telecom WHERE contact_id = ? ORDER BY rank ASC, is_primary DESC
```

## Test plan

- [x] Confirmed root cause via JUnit artifact from failing CI run
- [x] Verified no other unbacked reserved-word column refs in the codebase via grep across `src/`, `library/`, `interface/`, `controllers/`, `modules/` (the only other relevant identifier — the `groups` table — is already backticked everywhere it's referenced)
- [x] Services suite green locally against MariaDB (no regression): 664 tests, 2624 assertions, 0 failures, 0 errors
- [ ] Confirm the four MySQL `services` legs in CI go green on this PR (`apache_85_80`, `apache_85_84`, `apache_85_93`)
- [ ] Confirm MariaDB legs stay green