### PR TITLE
fix(contact): quote reserved word `rank` in telecom ORDER BY clauses

### DIFF
--- a/src/Services/ContactTelecomService.php
+++ b/src/Services/ContactTelecomService.php
@@ -213,7 +213,7 @@ class ContactTelecomService extends BaseService
             $sql .= " AND status = 'A'";
         }
 
-        $sql .= " ORDER BY rank ASC, is_primary DESC";
+        $sql .= " ORDER BY `rank` ASC, is_primary DESC";
 
         return QueryUtils::fetchRecords($sql, [$contactId]) ?? [];
     }
@@ -335,7 +335,7 @@ class ContactTelecomService extends BaseService
             $sql .= " AND status = 'A'";
         }
 
-        $sql .= " ORDER BY rank ASC";
+        $sql .= " ORDER BY `rank` ASC";
 
         return QueryUtils::fetchRecords($sql, [$contactId, $system]) ?? [];
     }
@@ -357,7 +357,7 @@ class ContactTelecomService extends BaseService
             $sql .= " AND status = 'A'";
         }
 
-        $sql .= " ORDER BY rank ASC";
+        $sql .= " ORDER BY `rank` ASC";
 
         return QueryUtils::fetchRecords($sql, [$contactId, $use]) ?? [];
     }


### PR DESCRIPTION
## Summary

`master` CI is currently red. `ContactTelecomService` builds three `ORDER BY rank` clauses with the column name unquoted. `rank` is a **reserved keyword** in MySQL 8.0+ (the `RANK()` window function), so these queries raise:

```
SQLSTATE syntax error ... near 'ASC, is_primary DESC'
Statement: SELECT * FROM contact_telecom WHERE contact_id = ? ORDER BY rank ASC, is_primary DESC
```

This backticks the column in all three clauses, matching the already-quoted `` `use` `` column in the same service.

## Why it surfaced now

The query has existed since #9333, but it had no test coverage exercising it. #12232 added the DB-backed `FieldRenderingSnapshotTest` whose `telecom-list` case renders through `getTelecomsForContact()`, which runs the failing query on the MySQL 8+ CI matrix.

## Test plan

- [ ] `FieldRenderingSnapshotTest::rendererProducesExpectedOutput` with data set `edit telecom-list` passes on the MySQL 8+ matrix
- [ ] Integration test matrix green across all MySQL/MariaDB versions