### PR TITLE
fix: use standard invalid_request oauth error code

### DIFF
--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -493,7 +493,7 @@ class AuthorizationController
                 throw new OAuthServerException('Invalid client', 0, 'invalid_request', Response::HTTP_FORBIDDEN);
             }
             if ($client['registration_access_token'] !== $token) {
-                throw new OAuthServerException('Invalid registration token', 0, 'invalid _request', Response::HTTP_FORBIDDEN);
+                throw new OAuthServerException('Invalid registration token', 0, 'invalid_request', Response::HTTP_FORBIDDEN);
             }
             $params['client_id'] = $client['client_id'];
             try {
@@ -1455,7 +1455,7 @@ class AuthorizationController
         try {
             $id_token = $request->query->get('id_token_hint', '');
             if (empty($id_token)) {
-                throw new OAuthServerException('Id token missing from request', 0, 'invalid _request', Response::HTTP_BAD_REQUEST);
+                throw new OAuthServerException('Id token missing from request', 0, 'invalid_request', Response::HTTP_BAD_REQUEST);
             }
             $post_logout_url = $request->query->get('post_logout_redirect_uri', '');
             $state = $request->query->get('state', '');
@@ -1481,7 +1481,7 @@ class AuthorizationController
             $session_nonce = (json_decode((string) $trustedUser['session_cache'], true)['nonce']) ?? '';
             // this should be enough to confirm valid id
             if ($session_nonce !== $id_nonce) {
-                throw new OAuthServerException('Id token not issued from this server', 0, 'invalid _request', Response::HTTP_BAD_REQUEST);
+                throw new OAuthServerException('Id token not issued from this server', 0, 'invalid_request', Response::HTTP_BAD_REQUEST);
             }
             // clear the users session
             $this->trustedUserService->deleteTrustedUserById($trustedUser['id']);


### PR DESCRIPTION
﻿## Summary
- replaces three non-standard OAuth error codes from invalid _request to invalid_request
- keeps the existing exception messages and HTTP status codes unchanged

Closes #12325.

## Validation
- rg check confirmed no invalid _request remains in AuthorizationController.php
- git diff --check passed for AuthorizationController.php

PHP syntax checks were not run locally because PHP is not installed in this Windows environment.
