### PR TITLE
fix: correct typo in OAuth error code invalid _request

### DIFF
--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -493,7 +493,7 @@ class AuthorizationController
                 throw new OAuthServerException('Invalid client', 0, 'invalid_request', Response::HTTP_FORBIDDEN);
             }
             if ($client['registration_access_token'] !== $token) {
-                throw new OAuthServerException('Invalid registration token', 0, 'invalid _request', Response::HTTP_FORBIDDEN);
+                throw new OAuthServerException('Invalid registration token', 0, 'invalid_request', Response::HTTP_FORBIDDEN);
             }
             $params['client_id'] = $client['client_id'];
             try {
@@ -1455,7 +1455,7 @@ class AuthorizationController
         try {
             $id_token = $request->query->get('id_token_hint', '');
             if (empty($id_token)) {
-                throw new OAuthServerException('Id token missing from request', 0, 'invalid _request', Response::HTTP_BAD_REQUEST);
+                throw new OAuthServerException('Id token missing from request', 0, 'invalid_request', Response::HTTP_BAD_REQUEST);
             }
             $post_logout_url = $request->query->get('post_logout_redirect_uri', '');
             $state = $request->query->get('state', '');
@@ -1481,7 +1481,7 @@ class AuthorizationController
             $session_nonce = (json_decode((string) $trustedUser['session_cache'], true)['nonce']) ?? '';
             // this should be enough to confirm valid id
             if ($session_nonce !== $id_nonce) {
-                throw new OAuthServerException('Id token not issued from this server', 0, 'invalid _request', Response::HTTP_BAD_REQUEST);
+                throw new OAuthServerException('Id token not issued from this server', 0, 'invalid_request', Response::HTTP_BAD_REQUEST);
             }
             // clear the users session
             $this->trustedUserService->deleteTrustedUserById($trustedUser['id']);


### PR DESCRIPTION
## Problem

`OAuthServerException` constructions in `AuthorizationController.php` pass the error code `invalid _request` (stray space) instead of the OAuth 2.0 spec value `invalid_request` (RFC 6749 section 5.2).

This causes non-standard OAuth error codes to be returned in JSON responses.

## Fix

Replace `invalid _request` with `invalid_request` at three locations:

- L496: Invalid registration token (RFC 7592 management endpoint)
- L1458: Id token missing from request
- L1484: Id token not issued from this server

## Testing

Verified that all three occurrences are fixed and the error code now matches the OAuth 2.0 specification.

Fixes #12326
