### PR TITLE
fix(sql): backtick bare `system` in ContactTelecomService for MySQL 8+ compat

### DIFF
--- a/src/Services/ContactTelecomService.php
+++ b/src/Services/ContactTelecomService.php
@@ -230,7 +230,7 @@ class ContactTelecomService extends BaseService
     {
         $sql = "SELECT * FROM contact_telecom
                 WHERE contact_id = ?
-                AND system = ?
+                AND `system` = ?
                 AND is_primary = 'Y'
                 AND status = 'A'
                 LIMIT 1";
@@ -254,7 +254,7 @@ class ContactTelecomService extends BaseService
             // Unset all other primary telecoms for this contact and system
             $sql = "UPDATE contact_telecom SET is_primary = 'N'
                     WHERE contact_id = ?
-                    AND system = ?";
+                    AND `system` = ?";
             QueryUtils::sqlStatementThrowException($sql, [$contactId, $system]);
 
             // Set the specified telecom as primary
@@ -329,7 +329,7 @@ class ContactTelecomService extends BaseService
     public function getTelecomsBySystem(int $contactId, string $system, bool $includeInactive = false): array
     {
         $sql = "SELECT * FROM contact_telecom
-                WHERE contact_id = ? AND system = ?";
+                WHERE contact_id = ? AND `system` = ?";
 
         if (!$includeInactive) {
             $sql .= " AND status = 'A'";


### PR DESCRIPTION
## Summary

\`SYSTEM\` became reserved in **MySQL 8.0** and stayed reserved through 8.4 and 9.x. Bare use as a column identifier fails to parse on those versions. The \`contact_telecom\` table has a \`system\` column and three methods in \`ContactTelecomService\` reference it without backticking.

Same failure pattern as the \`rank\` bug fixed in #12329 — passes every MariaDB CI leg and MySQL 5.7, fails MySQL 8.0 / 8.4 / 9.3 the moment a test path exercises the code.

## Empirical version matrix

Probed via \`SELECT system\` against fresh containers:

| Engine | Result | Reserved? |
|---|---|---|
| MySQL 5.7 | ERROR 1054 (resolver) | no |
| **MySQL 8.0** | **ERROR 1064 (parser)** | **YES** |
| **MySQL 8.4** | **ERROR 1064** | **YES** |
| **MySQL 9.3** | **ERROR 1064** | **YES** |
| MariaDB 10.6 | ERROR 1054 | no |
| MariaDB 10.11 | ERROR 1054 | no |
| MariaDB 11.4 | ERROR 1054 | no |
| MariaDB 11.8 | ERROR 1054 | no |
| MariaDB 12.0 | ERROR 1054 | no |

## Call sites fixed

All in \`src/Services/ContactTelecomService.php\`:

| Method | Position |
|---|---|
| \`getPrimaryTelecomForContact\` | \`WHERE ... AND \\\`system\\\` = ?\` |
| \`setPrimaryTelecomForContact\` | \`WHERE ... AND \\\`system\\\` = ?\` (inside transaction) |
| \`getTelecomsBySystem\` | \`WHERE ... AND \\\`system\\\` = ?\` |

Three lines changed total. No behavior change on MariaDB or MySQL 5.7; restores correct behavior on MySQL 8.0+.

## Provenance

Discovered by an in-progress PHPStan rule under development in **#12335**. That PR's broader server-derived reserved-word supplement caught these bugs that previous hand-maintained lists missed. Submitting the fix separately so it can be **backported to rel-* maintenance branches** independent of the rule infrastructure work.

## Test plan

- [x] All three sites backticked; verified via grep
- [x] Empirical version matrix verified against fresh \`mysql:5.7|8.0|8.4|9.3\` and \`mariadb:10.6|10.11|11.4|11.8|12.0\` containers
- [x] Pre-commit hook suite (phpstan, rector, phpcs, codespell, conventional-commits) passes
- [ ] Confirm CI matrix turns green across all MySQL legs on this PR