### PR TITLE
fix(billing): define $ndc_applies for fee sheet edits on billed encounters

### DIFF
--- a/.phpstan/baseline/echo.nonString.php
+++ b/.phpstan/baseline/echo.nonString.php
@@ -143,7 +143,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 14,
+    'count' => 13,
     'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -537,11 +537,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$srcdir \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$usbillstyle \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 10,
     'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -567,46 +567,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/LBF/printable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$cleave_opt might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$code_types might not be defined\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$encounter might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$ndc_applies might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$pid might not be defined\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$rootdir might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$srcdir might not be defined\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$userauthorized might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$database might not be defined\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_ajax.php',

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -49,7 +49,7 @@ return [
         'return.missing.php' => 0,
         'staticMethod.notFound.php' => 0,
         'trait.notFound.php' => 0,
-        'variable.undefined.php' => 546,
+        'variable.undefined.php' => 538,
     ],
     'confidentNonObject' => [
         'classConstant.nonObject.php' => 0,

--- a/interface/forms/fee_sheet/new.php
+++ b/interface/forms/fee_sheet/new.php
@@ -9,24 +9,37 @@
  * @author    Terry Hill <terry@lillysystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2005-2022 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2017-2023 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 require_once(__DIR__ . "/../../globals.php");
-require_once("$srcdir/FeeSheetHtml.class.php");
-require_once("codes.php");
-require_once("$srcdir/options.inc.php");
 
 use OpenEMR\Billing\BillingUtilities;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Logging\EventAuditLogger;
+use OpenEMR\Common\Session\EncounterSessionUtil;
+use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\OeUI\OemrUI;
+
+// Hoist legacy `globals.php` locals so PHPStan can see them (#11792 Phase 5).
+$srcdir = OEGlobalsBag::getInstance()->getSrcDir();
+$rootdir = OEGlobalsBag::getInstance()->getString('rootdir');
+$pid = PatientSessionUtil::getPid();
+$encounter = EncounterSessionUtil::getEncounter();
+$userauthorized = PatientSessionUtil::getUserAuthorized();
+
+require_once("$srcdir/FeeSheetHtml.class.php");
+require_once("codes.php");
+require_once("$srcdir/options.inc.php");
+/** @var array<string, array<string, mixed>> $code_types defined transitively by options.inc.php */
 
 //acl check
 if (!AclMain::aclCheckForm('fee_sheet')) { ?>
@@ -1050,6 +1063,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             <?php
                                 $i = 0;
                                 $last_category = '';
+                                $cleave_opt = 1; // default; overwritten in the loop body for each new category
                                 // Create drop-lists based on the fee_sheet_options table.
                                 $res = sqlStatement("SELECT * FROM fee_sheet_options " .
                                 "ORDER BY fs_category, fs_option");
@@ -1137,8 +1151,6 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             if (!empty($_POST['search_type'])) {
                                 $search_type = $_POST['search_type'];
                             }
-
-                                $ndc_applies = true; // Assume all payers require NDC info.
 
                                 echo $i ? "  <td></td>\n </tr>\n" : "";
                             ?>
@@ -1620,8 +1632,8 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                                     $modifier = '';
                                                 }
                                                 $ndc_info = '';
-                                                // If HCPCS, find last NDC string used for this code.
-                                                if ($newtype == 'HCPCS' && $ndc_applies) {
+                                                // NDC info currently applies to all HCPCS line items; if HCPCS, find last NDC string used for this code.
+                                                if ($newtype == 'HCPCS') {
                                                     $tmp = sqlQuery("SELECT ndc_info FROM billing WHERE " .
                                                     "code_type = ? AND code = ? AND ndc_info LIKE 'N4%' " .
                                                     "ORDER BY date DESC LIMIT 1", [$newtype, $code]);


### PR DESCRIPTION
## Summary

- Fixes an `$ndc_applies` undefined-variable bug in the fee sheet. The flag's only assignment lived inside the `else { // the encounter is not yet billed }` branch, but the NDC-lookup check that read it runs outside that branch. When a user opened the fee sheet on an already-billed encounter and added line items, `$ndc_applies` was undefined and the HCPCS NDC lookup silently coerced it to falsy and was skipped.
- The flag was an unconditional `true` ("Assume all payers require NDC info"), so rather than reintroduce the dead flag it is removed and the lookup is gated on `$newtype == 'HCPCS'` directly — same intended behavior, no undefined read.
- Hoists the legacy `globals.php` locals (`$srcdir`, `$rootdir`, `$pid`, `$encounter`, `$userauthorized`, `$code_types`) and adds a top-of-loop default for `$cleave_opt` so PHPStan can resolve them. This drains 8 `variable.undefined` baseline entries (plus a few dependent `mixed`-cast entries) for `interface/forms/fee_sheet/new.php` and lowers the fatal cap accordingly.

No SQL, JS, or calculation-path changes. The five canonical hoists read from the same authoritative sources `globals.php` already populates the locals from, so runtime values are identical.

Closes #11968. Refs #11792.

## Test plan

- [ ] PHPStan level 10 passes with no new baseline entries (drained 8 from `variable.undefined.php`).
- [ ] New encounter (not yet billed): Fee Sheet category drop-lists render (`$cleave_opt`), no PHP warnings.
- [ ] Existing encounter with billing items: line items render with correct prices/modifiers (`$code_types`); add a new HCPCS code and Save.
- [ ] Billed encounter: re-open via "Add More Items", add an HCPCS line, confirm the NDC lookup runs and Save writes correctly.
- [ ] Rendering-provider default still resolves when `$fs->provider_id` is empty (`$userauthorized`).
