### PR TITLE
ci(phpstan): use GitHub App for reserved-word refresh PRs so CI runs

### DIFF
--- a/.github/workflows/refresh-reserved-word-supplement.yml
+++ b/.github/workflows/refresh-reserved-word-supplement.yml
@@ -85,6 +85,16 @@ jobs:
         MARIADB_PORT: 3307
       run: php bin/refresh-reserved-word-supplement.php --write
 
+    - name: Verify bot identity secrets are configured
+      env:
+        APP_ID: ${{ secrets.RESERVED_WORD_BOT_APP_ID }}
+        PRIVATE_KEY: ${{ secrets.RESERVED_WORD_BOT_PRIVATE_KEY }}
+      run: |
+        if [ -z "$APP_ID" ] || [ -z "$PRIVATE_KEY" ]; then
+          echo "::error::Required repo secrets RESERVED_WORD_BOT_APP_ID and RESERVED_WORD_BOT_PRIVATE_KEY are not set. See the setup steps in PR #12368 for how to create the GitHub App and add its credentials."
+          exit 1
+        fi
+
     - name: Generate GitHub App token
       id: app-token
       uses: actions/create-github-app-token@v3

--- a/.github/workflows/refresh-reserved-word-supplement.yml
+++ b/.github/workflows/refresh-reserved-word-supplement.yml
@@ -85,9 +85,17 @@ jobs:
         MARIADB_PORT: 3307
       run: php bin/refresh-reserved-word-supplement.php --write
 
-    - name: Open PR if anything changed
-      uses: peter-evans/create-pull-request@v7
+    - name: Generate GitHub App token
+      id: app-token
+      uses: actions/create-github-app-token@v3
       with:
+        app-id: ${{ secrets.RESERVED_WORD_BOT_APP_ID }}
+        private-key: ${{ secrets.RESERVED_WORD_BOT_PRIVATE_KEY }}
+
+    - name: Open PR if anything changed
+      uses: peter-evans/create-pull-request@v8
+      with:
+        token: ${{ steps.app-token.outputs.token }}
         commit-message: |
           chore(phpstan): refresh RESERVED_WORD_SUPPLEMENT
 


### PR DESCRIPTION
## Summary

- The drift-detection workflow at `.github/workflows/refresh-reserved-word-supplement.yml` opens its bot PR with the default `GITHUB_TOKEN`. GitHub deliberately suppresses `pull_request` workflow runs for PRs opened that way (anti-recursion safeguard), so the resulting bot PRs ship without any of the usual CI — see #12367 for an example with zero checks reported.
- Switch the workflow to mint an installation token from a dedicated GitHub App (`actions/create-github-app-token@v3`) and pass it to `peter-evans/create-pull-request`. Bot-opened PRs are now authored by the App's bot user, fire `pull_request` events normally, and get the full CI matrix — including the SqlReservedWordRule itself, which will flag any unbackticked call sites for newly reserved words in the same PR that adds them to the supplement.
- Same edit bumps `peter-evans/create-pull-request` v7 → v8. v8 supports Node 24 (Node 20 actions are deprecated on GitHub runners starting 2026-06-16). v8 only requires Actions Runner v2.327.1+ on self-hosted runners — GitHub-hosted runners are unaffected.

## One-time setup required before merge

This PR is **inert until two repo secrets are configured**. If merged without them, the workflow will fail at the new "Generate GitHub App token" step (rather than silently falling back to GITHUB_TOKEN).

Maintainer steps:

1. Create a GitHub App owned by the openemr org (`Settings → Developer settings → GitHub Apps → New GitHub App`):
   - Webhook: **Active = off** (not needed)
   - Repository permissions: **Contents = Read and write**, **Pull requests = Read and write** (nothing else)
   - Where can this App be installed: "Only on this account"
2. After creation, note the **App ID** and generate a **private key** (`.pem` download).
3. Install the App on `openemr/openemr` only (`Install App → Only select repositories`).
4. Add two repo secrets at `openemr/openemr → Settings → Secrets and variables → Actions`:
   - `RESERVED_WORD_BOT_APP_ID` — the App ID number
   - `RESERVED_WORD_BOT_PRIVATE_KEY` — the full `.pem` contents including `-----BEGIN/END-----` lines
5. Merge this PR.
6. Close #12367, manually re-dispatch the workflow from the Actions tab. The new bot PR should be authored by `<app-name>[bot]` and have the full CI matrix running.

## Test plan

- [ ] Maintainer creates the GitHub App and adds both repo secrets per steps above
- [ ] Merge this PR to master
- [ ] Close #12367 (CI-less drift PR)
- [ ] Dispatch `Refresh reserved-word supplement` workflow manually
- [ ] Verify the new drift PR's author is the App's bot user (not `github-actions[bot]`)
- [ ] Verify the Checks tab shows the standard PR CI matrix running
- [ ] Verify PR diff matches #12367 (`conversion` + `to_date` added to supplement; MariaDB snapshot version bumps 12.2.2 → 12.3.2)