### PR TITLE
ci(phpstan): migrate reserved-word bot to client-id / vars

### DIFF
--- a/.github/workflows/refresh-reserved-word-supplement.yml
+++ b/.github/workflows/refresh-reserved-word-supplement.yml
@@ -85,13 +85,13 @@ jobs:
         MARIADB_PORT: 3307
       run: php bin/refresh-reserved-word-supplement.php --write
 
-    - name: Verify bot identity secrets are configured
+    - name: Verify bot identity inputs are configured
       env:
-        APP_ID: ${{ secrets.RESERVED_WORD_BOT_APP_ID }}
+        CLIENT_ID: ${{ vars.RESERVED_WORD_BOT_CLIENT_ID }}
         PRIVATE_KEY: ${{ secrets.RESERVED_WORD_BOT_PRIVATE_KEY }}
       run: |
-        if [ -z "$APP_ID" ] || [ -z "$PRIVATE_KEY" ]; then
-          echo "::error::Required repo secrets RESERVED_WORD_BOT_APP_ID and RESERVED_WORD_BOT_PRIVATE_KEY are not set. See the setup steps in PR #12368 for how to create the GitHub App and add its credentials."
+        if [ -z "$CLIENT_ID" ] || [ -z "$PRIVATE_KEY" ]; then
+          echo "::error::Required GitHub App identifiers are not set. Need repo variable RESERVED_WORD_BOT_CLIENT_ID and repo secret RESERVED_WORD_BOT_PRIVATE_KEY. See the setup steps in PR #12368 for how to create the GitHub App and add its credentials."
           exit 1
         fi
 
@@ -99,7 +99,7 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ secrets.RESERVED_WORD_BOT_APP_ID }}
+        client-id: ${{ vars.RESERVED_WORD_BOT_CLIENT_ID }}
         private-key: ${{ secrets.RESERVED_WORD_BOT_PRIVATE_KEY }}
 
     - name: Open PR if anything changed


### PR DESCRIPTION
## Summary

- `actions/create-github-app-token@v3.1.0` (released 2026-04-11) deprecated the `app-id` input in favor of `client-id`. The reserved-word-supplement refresh workflow has been emitting this deprecation warning on every run since the App identity went live in #12368.
- Switch to the Client ID identifier (a string of the form `Iv23li...`) and store it as a **repo variable** instead of a secret. The Client ID, like the App ID, is a public identifier visible on the App's settings page — only the private key is genuinely sensitive. This also aligns with the existing convention in `release-prep.yml` and `release-permissions-check.yml`, which already use `vars.RELEASE_APP_CLIENT_ID`.
- No removal date is announced, but precedent from `create-github-app-token` v2.0.0 (which removed previously deprecated inputs in a single breaking-change release) suggests v4 will drop `app-id`. Migrating now means the eventual Dependabot bump to v4 won't break the workflow.

## One-time setup required before merge

This PR is **inert until the new repo variable is configured**. If merged without it, the workflow will fail at the preflight step with an explicit error (rather than silently failing inside the action with an opaque JWT error).

Maintainer steps:

1. On the GitHub App's settings page (`Org → Developer settings → GitHub Apps → openemr-reserved-word-bot → General`), copy the **Client ID** (string `Iv23li...`, right under the App ID).
2. Add a repo **variable** (not secret) at `openemr/openemr → Settings → Secrets and variables → Actions → Variables tab → New repository variable`:
   - Name: `RESERVED_WORD_BOT_CLIENT_ID`
   - Value: the Client ID string
3. Merge this PR.
4. Optionally delete the now-unused `RESERVED_WORD_BOT_APP_ID` secret. (The `RESERVED_WORD_BOT_PRIVATE_KEY` secret stays — it's still the App's auth material.)

## Test plan

- [ ] Maintainer adds `RESERVED_WORD_BOT_CLIENT_ID` repo variable per steps above
- [ ] Merge this PR
- [ ] Dispatch `Refresh reserved-word supplement` workflow manually from the Actions tab
- [ ] Verify the deprecation warning `Input 'app-id' has been deprecated` no longer appears in the workflow log
- [ ] Verify the workflow still authenticates as the App and either opens a drift PR or exits cleanly with "No drift"
- [ ] Optionally delete the `RESERVED_WORD_BOT_APP_ID` secret

## Out of scope

`dependabot-auto-merge.yml` also uses `app-id` (with `secrets.AUTO_MERGE_APP_ID`) and emits the same warning. Same migration applies there but is a separate workflow with its own App identity; not bundled here.