### PR TITLE
ci(deps): migrate dependabot-auto-merge to client-id / vars

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,41 +12,41 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.AUTO_MERGE_APP_ID }}
-          private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}
+    - name: Generate GitHub App token
+      id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ vars.AUTO_MERGE_APP_CLIENT_ID }}
+        private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}
 
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
+    - name: Fetch Dependabot metadata
+      id: metadata
+      uses: dependabot/fetch-metadata@v3
+      with:
+        github-token: ${{ steps.app-token.outputs.token }}
 
       # Auto-merge docker-compose updates from directories where CI exercises
       # every image. Prefix matching only for ci/apache_* and ci/nginx_* since
       # those version-matrix dirs are added/removed over time; everything else
       # is matched explicitly so new dirs require an intentional opt-in here.
-      - name: Auto-merge docker-compose updates
-        if: >-
-          steps.metadata.outputs.package-ecosystem == 'docker_compose' &&
-          (
-            startsWith(steps.metadata.outputs.directory, '/ci/apache_') ||
-            startsWith(steps.metadata.outputs.directory, '/ci/nginx_') ||
-            steps.metadata.outputs.directory == '/ci/compose-shared-mailpit' ||
-            steps.metadata.outputs.directory == '/ci/compose-shared-nginx' ||
-            steps.metadata.outputs.directory == '/ci/compose-shared-redis-sentinel' ||
-            steps.metadata.outputs.directory == '/ci/compose-shared-selenium' ||
-            steps.metadata.outputs.directory == '/ci/inferno' ||
-            steps.metadata.outputs.directory == '/docker/development-easy' ||
-            steps.metadata.outputs.directory == '/docker/development-easy-light' ||
-            steps.metadata.outputs.directory == '/docker/development-easy-redis' ||
-            steps.metadata.outputs.directory == '/docker/development-insane' ||
-            steps.metadata.outputs.directory == '/docker/production'
-          )
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+    - name: Auto-merge docker-compose updates
+      if: >-
+        steps.metadata.outputs.package-ecosystem == 'docker_compose' &&
+        (
+          startsWith(steps.metadata.outputs.directory, '/ci/apache_') ||
+          startsWith(steps.metadata.outputs.directory, '/ci/nginx_') ||
+          steps.metadata.outputs.directory == '/ci/compose-shared-mailpit' ||
+          steps.metadata.outputs.directory == '/ci/compose-shared-nginx' ||
+          steps.metadata.outputs.directory == '/ci/compose-shared-redis-sentinel' ||
+          steps.metadata.outputs.directory == '/ci/compose-shared-selenium' ||
+          steps.metadata.outputs.directory == '/ci/inferno' ||
+          steps.metadata.outputs.directory == '/docker/development-easy' ||
+          steps.metadata.outputs.directory == '/docker/development-easy-light' ||
+          steps.metadata.outputs.directory == '/docker/development-easy-redis' ||
+          steps.metadata.outputs.directory == '/docker/development-insane' ||
+          steps.metadata.outputs.directory == '/docker/production'
+        )
+      run: gh pr merge --auto --squash "$PR_URL"
+      env:
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- `actions/create-github-app-token@v3.1.0` (2026-04-11) deprecated the `app-id` input in favor of `client-id`. The `dependabot-auto-merge.yml` workflow emits a `Input 'app-id' has been deprecated` warning on every Dependabot PR run.
- Switch to the Client ID identifier (string of the form `Iv23li...`) and store it as a **repo variable** instead of a secret. The Client ID is a public value visible on the App's settings page and present in plain text in JWT headers — it isn't sensitive. Only the private key needs to stay a secret.
- This aligns with the convention already in use by `release-prep.yml`, `release-permissions-check.yml`, and (after #12371) `refresh-reserved-word-supplement.yml`, all of which store their App identifier in a `vars.*` entry.
- The pre-commit `pretty-format-yaml` hook also fixed the file's indentation (6 → 4 spaces) to match the rest of `.github/workflows/`. That's why the diff looks larger than a one-line semantic change — most of the lines are whitespace-only.

A companion PR (openemr/openemr-devops#773) applies the identical edit to that repo's auto-merge workflow.

## One-time setup required before merge

This PR is **inert until the new repo variable is configured**. The workflow currently uses `secrets.AUTO_MERGE_APP_ID`; after merge it expects `vars.AUTO_MERGE_APP_CLIENT_ID`. If the variable is missing, the next eligible Dependabot PR will fail at the token-mint step with `actions/create-github-app-token` reporting empty inputs.

Maintainer steps:

1. On the auto-merge GitHub App's settings page (`Org → Developer settings → GitHub Apps → <app-name> → General`), copy the **Client ID** (visible directly under the App ID).
2. Add a repo **variable** at `openemr/openemr → Settings → Secrets and variables → Actions → Variables tab → New repository variable`:
   - Name: `AUTO_MERGE_APP_CLIENT_ID`
   - Value: the Client ID string
3. Merge this PR (and the openemr-devops companion #773).
4. Optionally delete the now-unused `AUTO_MERGE_APP_ID` secret. (The `AUTO_MERGE_APP_PRIVATE_KEY` secret stays — still required for App auth.)

## Test plan

- [ ] Maintainer adds `AUTO_MERGE_APP_CLIENT_ID` repo variable per steps above
- [ ] Merge this PR
- [ ] Wait for next Dependabot PR that matches the docker-compose auto-merge criteria (or trigger one by re-running an existing eligible Dependabot run)
- [ ] Verify the `Input 'app-id' has been deprecated` warning no longer appears in the workflow log
- [ ] Verify Dependabot PR is still auto-merged as expected
- [ ] Optionally delete `AUTO_MERGE_APP_ID` secret