### PR TITLE
chore(deps): add ext-redis to composer config.platform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -225,6 +225,7 @@
             "ext-pdo": "8.2",
             "ext-pdo_mysql": "8.2",
             "ext-phar": "8.2",
+            "ext-redis": "8.2",
             "ext-session": "8.2",
             "ext-simplexml": "8.2",
             "ext-soap": "8.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad50c57890120cd003d1bf6c13034a09",
+    "content-hash": "53a7022ca0a061323d26dc325aafa481",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -17441,6 +17441,7 @@
         "ext-pdo": "8.2",
         "ext-pdo_mysql": "8.2",
         "ext-phar": "8.2",
+        "ext-redis": "8.2",
         "ext-session": "8.2",
         "ext-simplexml": "8.2",
         "ext-soap": "8.2",


### PR DESCRIPTION
## Summary

- `composer.json` already requires `ext-redis` (line 35), but the entry was missing from the `config.platform` map that mirrors every other required extension.
- `composer.lock`'s platform-overrides block was correspondingly out of sync.
- Without `ext-redis` in `config.platform`, `composer install/update` on a machine that does not have the redis PECL extension installed cannot assume redis is present at PHP 8.2 level. For any transitively-required package that conditionally constrains on `ext-redis`, this can let resolution diverge from what the runtime environment actually loads.
- Aligning the two sections keeps resolution deterministic across machines and matches the pattern used for every other `ext-*` entry in the file.

The lockfile change is the standard one-line `content-hash` + platform-overrides refresh from `composer update --lock`. No package versions changed.

## Test plan

- [x] `composer-checks` (validate + normalize dry-run) passes
- [x] `composer update --lock` produces only the content-hash + platform-overrides diff (no resolved package changes)
- [ ] CI green