### PR TITLE
fix(fhir): make generated Observation value[x] PHPDoc nullable

### DIFF
--- a/.phpstan/baseline/booleanAnd.alwaysFalse.php
+++ b/.phpstan/baseline/booleanAnd.alwaysFalse.php
@@ -104,52 +104,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Result of && is always false\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationAdvanceDirectiveService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of && is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationCareExperiencePreferenceService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of && is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationEmployerService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of && is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationHistorySdohService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of && is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationLaboratoryService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of && is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationObservationFormService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of && is always false\\.$#',
-    'count' => 4,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationPatientService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of && is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationQuestionnaireItemService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of && is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of && is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationTreatmentInterventionPreferenceService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Result of && is always false\\.$#',

--- a/.phpstan/baseline/booleanNot.alwaysFalse.php
+++ b/.phpstan/baseline/booleanNot.alwaysFalse.php
@@ -188,56 +188,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Negated boolean expression is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationAdvanceDirectiveService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Negated boolean expression is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationCareExperiencePreferenceService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Negated boolean expression is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationEmployerService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Negated boolean expression is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationHistorySdohService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Negated boolean expression is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationLaboratoryService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Negated boolean expression is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationObservationFormService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Negated boolean expression is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationPatientService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Negated boolean expression is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationQuestionnaireItemService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Negated boolean expression is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Negated boolean expression is always false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationTreatmentInterventionPreferenceService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Negated boolean expression is always false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FacilityService.php',
 ];

--- a/.phpstan/baseline/booleanOr.alwaysTrue.php
+++ b/.phpstan/baseline/booleanOr.alwaysTrue.php
@@ -23,56 +23,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Result of \\|\\| is always true\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationAdvanceDirectiveService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of \\|\\| is always true\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationCareExperiencePreferenceService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of \\|\\| is always true\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationEmployerService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of \\|\\| is always true\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationHistorySdohService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of \\|\\| is always true\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationLaboratoryService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of \\|\\| is always true\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationObservationFormService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of \\|\\| is always true\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationPatientService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of \\|\\| is always true\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationQuestionnaireItemService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of \\|\\| is always true\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of \\|\\| is always true\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationTreatmentInterventionPreferenceService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of \\|\\| is always true\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/Search/FhirSearchWhereClauseBuilder.php',
 ];
@@ -95,11 +45,6 @@ $ignoreErrors[] = [
     'message' => '#^Result of \\|\\| is always true\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/FhirPatientServiceUSCore8Test.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Result of \\|\\| is always true\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/Observation/FhirObservationHistorySdohServiceTest.php',
 ];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/empty.expr.php
+++ b/.phpstan/baseline/empty.expr.php
@@ -38,53 +38,8 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
-    'count' => 5,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationAdvanceDirectiveService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationCareExperiencePreferenceService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationEmployerService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationHistorySdohService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationLaboratoryService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationObservationFormService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationPatientService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationQuestionnaireItemService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../src/Services/FHIR/Observation/FhirObservationTreatmentInterventionPreferenceService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
@@ -115,11 +70,6 @@ $ignoreErrors[] = [
     'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/FhirPatientServiceUSCore8Test.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/Observation/FhirObservationHistorySdohServiceTest.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Expression in empty\\(\\) is not falsy\\.$#',

--- a/.phpstan/baseline/isset.property.php
+++ b/.phpstan/baseline/isset.property.php
@@ -5147,11 +5147,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$dataAbsentReason \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRCodeableConcept\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$device \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRReference\\) in isset\\(\\) is not nullable\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
@@ -5203,61 +5198,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$subject \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRReference\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$valueBoolean \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRBoolean\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$valueCodeableConcept \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRCodeableConcept\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$valueDateTime \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRDateTime\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$valueInteger \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRInteger\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$valuePeriod \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRPeriod\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$valueQuantity \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRQuantity\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$valueRange \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRRange\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$valueRatio \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRRatio\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$valueSampledData \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRSampledData\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$valueString \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRString\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRDomainResource\\\\FHIRObservation\\:\\:\\$valueTime \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRTime\\) in isset\\(\\) is not nullable\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
 ];
@@ -15633,66 +15573,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$code \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRCodeableConcept\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$dataAbsentReason \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRCodeableConcept\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$valueBoolean \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRBoolean\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$valueCodeableConcept \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRCodeableConcept\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$valueDateTime \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRDateTime\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$valueInteger \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRInteger\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$valuePeriod \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRPeriod\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$valueQuantity \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRQuantity\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$valueRange \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRRange\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$valueRatio \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRRatio\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$valueSampledData \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRSampledData\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$valueString \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRString\\) in isset\\(\\) is not nullable\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\FHIRResource\\\\FHIRObservation\\\\FHIRObservationComponent\\:\\:\\$valueTime \\(OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRTime\\) in isset\\(\\) is not nullable\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php',
 ];

--- a/.phpstan/baseline/method.alreadyNarrowedType.php
+++ b/.phpstan/baseline/method.alreadyNarrowedType.php
@@ -162,11 +162,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Isolated/Services/FHIR/Observation/FhirObservationQuestionnaireItemServiceTest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\) with OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRQuantity will always evaluate to true\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Isolated/Services/FHIR/Observation/FhirObservationQuestionnaireItemServiceTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\) with OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRReference will always evaluate to true\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Isolated/Services/FHIR/Observation/FhirObservationQuestionnaireItemServiceTest.php',
@@ -817,11 +812,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/Observation/FhirObservationAdvanceDirectiveServiceUSCore8Test.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\) with true and \'Observation should…\' will always evaluate to true\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/Observation/FhirObservationHistorySdohServiceTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with \'OpenEMR\\\\\\\\FHIR\\\\\\\\R4\\\\\\\\FHIRElement\\\\\\\\FHIRCodeableConcept\' and OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRCodeableConcept will always evaluate to true\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/Observation/FhirObservationObservationFormServiceTest.php',
@@ -848,11 +838,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\) with OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRObservationStatus will always evaluate to true\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/Observation/FhirObservationObservationFormServiceTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\) with OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRQuantity will always evaluate to true\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/Observation/FhirObservationObservationFormServiceTest.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -40439,11 +40439,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot access an offset on mixed\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIRObservation.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access an offset on mixed\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../src/FHIR/R4/FHIRDomainResource/FHIROperationDefinition.php',
 ];
 $ignoreErrors[] = [

--- a/src/FHIR/R4/FHIRDomainResource/FHIRObservation.php
+++ b/src/FHIR/R4/FHIRDomainResource/FHIRObservation.php
@@ -157,63 +157,63 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     public $performer = [];
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity|null
      */
     public $valueQuantity = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept|null
      */
     public $valueCodeableConcept = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRString
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRString|null
      */
     public $valueString = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean|null
      */
     public $valueBoolean = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger|null
      */
     public $valueInteger = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRRange
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRRange|null
      */
     public $valueRange = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRRatio
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRRatio|null
      */
     public $valueRatio = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRSampledData
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRSampledData|null
      */
     public $valueSampledData = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRTime
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRTime|null
      */
     public $valueTime = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime|null
      */
     public $valueDateTime = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod|null
      */
     public $valuePeriod = null;
 
     /**
      * Provides a reason why the expected value in the element Observation.value[x] is missing.
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept|null
      */
     public $dataAbsentReason = null;
 
@@ -575,7 +575,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity|null
      */
     public function getValueQuantity()
     {
@@ -583,7 +583,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity $valueQuantity
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity|null $valueQuantity
      * @return $this
      */
     public function setValueQuantity($valueQuantity)
@@ -593,7 +593,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept|null
      */
     public function getValueCodeableConcept()
     {
@@ -601,7 +601,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept $valueCodeableConcept
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept|null $valueCodeableConcept
      * @return $this
      */
     public function setValueCodeableConcept($valueCodeableConcept)
@@ -611,7 +611,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRString
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRString|null
      */
     public function getValueString()
     {
@@ -619,7 +619,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRString $valueString
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRString|null $valueString
      * @return $this
      */
     public function setValueString($valueString)
@@ -629,7 +629,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean|null
      */
     public function getValueBoolean()
     {
@@ -637,7 +637,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean $valueBoolean
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean|null $valueBoolean
      * @return $this
      */
     public function setValueBoolean($valueBoolean)
@@ -647,7 +647,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger|null
      */
     public function getValueInteger()
     {
@@ -655,7 +655,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger $valueInteger
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger|null $valueInteger
      * @return $this
      */
     public function setValueInteger($valueInteger)
@@ -665,7 +665,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRRange
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRRange|null
      */
     public function getValueRange()
     {
@@ -673,7 +673,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRRange $valueRange
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRRange|null $valueRange
      * @return $this
      */
     public function setValueRange($valueRange)
@@ -683,7 +683,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRRatio
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRRatio|null
      */
     public function getValueRatio()
     {
@@ -691,7 +691,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRRatio $valueRatio
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRRatio|null $valueRatio
      * @return $this
      */
     public function setValueRatio($valueRatio)
@@ -701,7 +701,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRSampledData
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRSampledData|null
      */
     public function getValueSampledData()
     {
@@ -709,7 +709,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRSampledData $valueSampledData
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRSampledData|null $valueSampledData
      * @return $this
      */
     public function setValueSampledData($valueSampledData)
@@ -719,7 +719,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRTime
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRTime|null
      */
     public function getValueTime()
     {
@@ -727,7 +727,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRTime $valueTime
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRTime|null $valueTime
      * @return $this
      */
     public function setValueTime($valueTime)
@@ -737,7 +737,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime|null
      */
     public function getValueDateTime()
     {
@@ -745,7 +745,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime $valueDateTime
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime|null $valueDateTime
      * @return $this
      */
     public function setValueDateTime($valueDateTime)
@@ -755,7 +755,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod|null
      */
     public function getValuePeriod()
     {
@@ -763,7 +763,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod $valuePeriod
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod|null $valuePeriod
      * @return $this
      */
     public function setValuePeriod($valuePeriod)
@@ -774,7 +774,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
 
     /**
      * Provides a reason why the expected value in the element Observation.value[x] is missing.
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept|null
      */
     public function getDataAbsentReason()
     {
@@ -783,7 +783,7 @@ class FHIRObservation extends FHIRDomainResource implements \JsonSerializable
 
     /**
      * Provides a reason why the expected value in the element Observation.value[x] is missing.
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept $dataAbsentReason
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept|null $dataAbsentReason
      * @return $this
      */
     public function setDataAbsentReason($dataAbsentReason)

--- a/src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php
+++ b/src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php
@@ -76,63 +76,63 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     public $code = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity|null
      */
     public $valueQuantity = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept|null
      */
     public $valueCodeableConcept = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRString
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRString|null
      */
     public $valueString = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean|null
      */
     public $valueBoolean = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger|null
      */
     public $valueInteger = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRRange
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRRange|null
      */
     public $valueRange = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRRatio
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRRatio|null
      */
     public $valueRatio = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRSampledData
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRSampledData|null
      */
     public $valueSampledData = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRTime
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRTime|null
      */
     public $valueTime = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime|null
      */
     public $valueDateTime = null;
 
     /**
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod|null
      */
     public $valuePeriod = null;
 
     /**
      * Provides a reason why the expected value in the element Observation.component.value[x] is missing.
-     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
+     * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept|null
      */
     public $dataAbsentReason = null;
 
@@ -174,7 +174,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity|null
      */
     public function getValueQuantity()
     {
@@ -182,7 +182,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity $valueQuantity
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity|null $valueQuantity
      * @return $this
      */
     public function setValueQuantity($valueQuantity)
@@ -192,7 +192,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept|null
      */
     public function getValueCodeableConcept()
     {
@@ -200,7 +200,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept $valueCodeableConcept
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept|null $valueCodeableConcept
      * @return $this
      */
     public function setValueCodeableConcept($valueCodeableConcept)
@@ -210,7 +210,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRString
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRString|null
      */
     public function getValueString()
     {
@@ -218,7 +218,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRString $valueString
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRString|null $valueString
      * @return $this
      */
     public function setValueString($valueString)
@@ -228,7 +228,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean|null
      */
     public function getValueBoolean()
     {
@@ -236,7 +236,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean $valueBoolean
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRBoolean|null $valueBoolean
      * @return $this
      */
     public function setValueBoolean($valueBoolean)
@@ -246,7 +246,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger|null
      */
     public function getValueInteger()
     {
@@ -254,7 +254,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger $valueInteger
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRInteger|null $valueInteger
      * @return $this
      */
     public function setValueInteger($valueInteger)
@@ -264,7 +264,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRRange
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRRange|null
      */
     public function getValueRange()
     {
@@ -272,7 +272,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRRange $valueRange
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRRange|null $valueRange
      * @return $this
      */
     public function setValueRange($valueRange)
@@ -282,7 +282,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRRatio
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRRatio|null
      */
     public function getValueRatio()
     {
@@ -290,7 +290,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRRatio $valueRatio
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRRatio|null $valueRatio
      * @return $this
      */
     public function setValueRatio($valueRatio)
@@ -300,7 +300,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRSampledData
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRSampledData|null
      */
     public function getValueSampledData()
     {
@@ -308,7 +308,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRSampledData $valueSampledData
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRSampledData|null $valueSampledData
      * @return $this
      */
     public function setValueSampledData($valueSampledData)
@@ -318,7 +318,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRTime
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRTime|null
      */
     public function getValueTime()
     {
@@ -326,7 +326,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRTime $valueTime
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRTime|null $valueTime
      * @return $this
      */
     public function setValueTime($valueTime)
@@ -336,7 +336,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime|null
      */
     public function getValueDateTime()
     {
@@ -344,7 +344,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime $valueDateTime
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime|null $valueDateTime
      * @return $this
      */
     public function setValueDateTime($valueDateTime)
@@ -354,7 +354,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod|null
      */
     public function getValuePeriod()
     {
@@ -362,7 +362,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
     }
 
     /**
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod $valuePeriod
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod|null $valuePeriod
      * @return $this
      */
     public function setValuePeriod($valuePeriod)
@@ -373,7 +373,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
 
     /**
      * Provides a reason why the expected value in the element Observation.component.value[x] is missing.
-     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept
+     * @return \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept|null
      */
     public function getDataAbsentReason()
     {
@@ -382,7 +382,7 @@ class FHIRObservationComponent extends FHIRBackboneElement implements \JsonSeria
 
     /**
      * Provides a reason why the expected value in the element Observation.component.value[x] is missing.
-     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept $dataAbsentReason
+     * @param \OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept|null $dataAbsentReason
      * @return $this
      */
     public function setDataAbsentReason($dataAbsentReason)


### PR DESCRIPTION
## What

Append `|null` to the `@var` / `@param` / `@return` PHPDoc of every `value[x]` choice-type member (and `dataAbsentReason`) in the generated FHIR `Observation` classes:

- `src/FHIR/R4/FHIRDomainResource/FHIRObservation.php`
- `src/FHIR/R4/FHIRResource/FHIRObservation/FHIRObservationComponent.php`

PHPDoc-only change. No runtime or behavioral change.

Also regenerates the per-identifier PHPStan baseline so the now-stale always-true/false entries are removed.

## Why

The php-fhir generator emits these properties as non-nullable in PHPDoc:

```php
/**
 * @var \OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity
 */
public $valueQuantity = null;
```

even though each defaults to `null` and an Observation has at most one of the `value[x]` members set at a time.

PHPStan trusts the non-nullable `@return` on the getter, infers `!empty($obs->getValueQuantity())` is always-true, then cascades into "always false" errors in code like `FhirObservationTrait::validateUSCore2Constraint()`. Today these are silenced by the per-identifier baseline; on PHPStan 2.2.x the same checks surface at locations the baseline doesn't cover, and the analysis fails.

Marking the PHPDoc nullable matches reality, eliminates the spurious always-true/false inferences, and unblocks the PHPStan 2.2.x bump.

## Verification

- `composer phpstan` — clean run with the regenerated baseline (`[OK] No errors`).
- Diff: 2 source files, 72 PHPDoc lines (12 members × 3 tags × 2 files). Baseline net `-340` entries (mostly Observation always-false/always-true and isset/empty noise).
- No edits to non-`value[x]` members; only `@var`/`@param`/`@return` PHPDoc changed.