### PR TITLE
docs(release): correct credentials, automation gaps, and recovery framing

### DIFF
--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -149,7 +149,7 @@ This document describes the *process*. The *current* state lives in Git and the 
 
 - **Shipping.** `ship-release.yml` inputs are `version` (e.g. `8.1.0`), `rel_branch` (e.g. `rel-810`), `dry_run` (bool). Validate before merging: `gh workflow run ship-release.yml --repo openemr/openemr-devops -f version=X.Y.Z -f rel_branch=rel-XY0 -f dry_run=true`.
 
-- **When to escalate to a human / org owner.** An automated agent cannot: merge the conductor PR (cuts a public tag — a go/no-go decision), or set/rotate the release-App secrets (`RELEASE_APP_PRIVATE_KEY`) and their per-repo scoping. If a consumer's auth fails, run that repo's `release-permissions-check.yml`; if it reports a missing or unscoped secret, stop and escalate — only an org owner can fix it.
+- **When to escalate to a human / org owner.** An automated agent cannot: merge the conductor PR (cuts a public tag — a go/no-go decision), or set/rotate the release-App credentials (`vars.RELEASE_APP_CLIENT_ID` and `secrets.RELEASE_APP_PRIVATE_KEY`). If a consumer's auth fails, run that repo's `release-permissions-check.yml`; if it reports a missing credential or permission, stop and escalate — only an org owner can fix it.
 
 ## Release runbook
 
@@ -214,20 +214,29 @@ Standalone patch releases (`v<MAJOR>_<MINOR>_<PATCH>_<N>` tags with a `<M>-<m>-<
 
 ## Automation gaps
 
-The runbook above marks each currently-manual post-automation step **[Manual]**. None of them are irreducibly manual; they're tracked for follow-on automation:
+This section tracks every post-automation gap, not just the manual runbook steps: currently-manual steps (marked **[Manual]** in the runbook above), missing guards, and recovery tooling. None of them are irreducibly manual; they're tracked for follow-on automation. The "Step" column references the runbook step a gap relates to, or "Recovery" for gaps in the partial-merge recovery path:
 
 | Step | What | Tracking |
 | --- | --- | --- |
+| 2 / 15 | Seed `demo_farm_openemr` production-demo rows for a new minor line at branch cut, so the first tag on that line is not a no-op against the demo farm (today this is the manual step 2 prerequisite for step 15) | [openemr/demo_farm_openemr#110](https://github.com/openemr/demo_farm_openemr/issues/110) |
 | 9 | Auto-merge the `website-openemr` docs PR on `openemr-tag`; the page banner already flips to FINAL via the manifest, but the PR stays a GitHub draft that an operator marks ready and merges by hand | [openemr/openemr-devops#761](https://github.com/openemr/openemr-devops/issues/761) |
+| 10 | Verify the `openemr-tag` exists in `openemr/openemr` before the docs workflow flips pages DRAFT→FINAL — a guard so docs can never ship FINAL for a version that was never tagged | [openemr/website-openemr#132](https://github.com/openemr/website-openemr/issues/132) |
 | 16 | Automated post-release announcement fan-out (forums, chat, social, mailing list) | [openemr/openemr-devops#711](https://github.com/openemr/openemr-devops/issues/711) |
+| Recovery | Docs-first reconciliation workflow — re-render orphaned FINAL pages against the real tag after a docs-first partial merge (see [Docs-first recovery](#docs-first-recovery-manual-today)) | [openemr/website-openemr#133](https://github.com/openemr/website-openemr/issues/133) |
 
-Recently closed: step 10 (automated GitHub Release object creation + checksum/changelog upload on `openemr-tag`) shipped via [openemr/openemr-devops#757](https://github.com/openemr/openemr-devops/pull/757), closing [#756](https://github.com/openemr/openemr-devops/issues/756). The v8.1.0 release surfaced the gap — tag landed, no Release object did; `build-release-on-tag.yml` now creates the Release object automatically when the conductor emits `openemr-tag`.
+Recently closed: the Release-object creation for **runbook step 10** (automated GitHub Release object creation + checksum/changelog upload on `openemr-tag`) shipped via [openemr/openemr-devops#757](https://github.com/openemr/openemr-devops/pull/757), closing [#756](https://github.com/openemr/openemr-devops/issues/756). The v8.1.0 release surfaced the gap — tag landed, no Release object did; `build-release-on-tag.yml` now creates the Release object automatically when the conductor emits `openemr-tag`. The remaining open gap in the table's step-10 row, #132, is a different concern: the **docs DRAFT→FINAL tag-exists guard**, not the Release-object creation.
 
-Umbrella issue tracking the full gap closure: [openemr/openemr-devops#706](https://github.com/openemr/openemr-devops/issues/706).
+Umbrella issue tracking the full gap closure: [openemr/openemr-devops#706](https://github.com/openemr/openemr-devops/issues/706). Its open sub-issues are the five rows above: [openemr-devops#711](https://github.com/openemr/openemr-devops/issues/711), [openemr-devops#761](https://github.com/openemr/openemr-devops/issues/761), [website-openemr#132](https://github.com/openemr/website-openemr/issues/132), [website-openemr#133](https://github.com/openemr/website-openemr/issues/133), and [demo_farm_openemr#110](https://github.com/openemr/demo_farm_openemr/issues/110).
 
 ## Partial merges and recovery
 
 The three PRs are coupled only by `repository_dispatch`. Branch protection should block direct merges and require the [ship-release workflow](https://github.com/openemr/openemr-devops/blob/master/.github/workflows/ship-release.yml) as the only merge path (via the `release/ship-approved` commit status the workflow posts), but admin-overrides and misconfigurations happen — this section documents the recovery path when they do.
+
+**Re-running `ship-release.yml` is the normal recovery mechanism for partial *PR merges*, not a special bootstrap path.** Its idempotency is scoped to PR-merge state: it snapshots all three sibling PRs, skips any already merged, and merges the rest in order (infra → conductor → docs) after a readiness check. So re-triggering is safe when a subset of the PRs merged (by admin-override or a prior interrupted run) and the rest are still open and ready. Treat "re-run ship-release and let it reconcile" as the default response to a stuck *PR-merge* state.
+
+What it does **not** do today is inspect the annotated tag or the GitHub Release object — it never reads `refs/tags` or the Release API. The tag is created as a side effect of merging the conductor PR (`release-prep.yml` runs `create-tag.php` on merge), and the Release object follows from the `openemr-tag` dispatch. This matters for one state re-running ship-release cannot fix: a tag that already exists with the conductor PR still open (see the out-of-band-tag row below). The partial-merge table enumerates the states re-running recovers from and the two it does not (docs-first and out-of-band-tag).
+
+**Desired end state:** ship-release should be fully idempotent across the whole release, not just PR-merge state. It should read the tag and Release object up front, treat an already-existing correct tag as a completed step (rather than letting the conductor merge blindly re-attempt `create-tag.php` and fail), and fire the `openemr-tag` dispatch itself if it never ran. Reaching that retires the manual out-of-band-tag recovery below and makes "re-run ship-release and let it reconcile" the answer for *every* non-docs-first state. This is not yet built; until it is, the manual recovery applies.
 
 ### Partial-merge states
 
@@ -239,14 +248,17 @@ The three PRs are coupled only by `repository_dispatch`. Branch protection shoul
 | Conductor + infra (no docs) | Tag exists, CI green, but website still serves prior-version install/upgrade pages and no release notes. |
 | Conductor + docs (no infra) | Tag exists, docs FINAL, but CI matrices still build the prior `current`/`next` slots — release-CI signal lags until the rotation PR merges. |
 | Infra + docs (no conductor) | Both PRs reference a version whose tag does not exist. Docs stay DRAFT; CI builds for `current` fail. |
+| None merged, but tag + Release object already exist | The annotated tag and its GitHub Release object exist, yet all three sibling PRs are still open — the tag was cut out-of-band rather than by a conductor-PR merge. CI matrices and Docker pins still target the prior `current`; the website still advertises the prior version; docs are still DRAFT. **Re-running ship-release does not fix this**, and is in fact unsafe here: ship-release inspects only PR state, so it will try to merge the still-open conductor PR, whose merge runs `create-tag.php` — and that fails (HTTP 422 on `POST /git/refs`) because the tag already exists, aborting the conductor step. Recovery is manual today (see [Out-of-band tag recovery](#out-of-band-tag-recovery-manual)); the [desired end state](#partial-merges-and-recovery) is for ship-release to recognize the existing tag/Release and reconcile this automatically. This state has happened in practice: v8.1.0's Release object published while its conductor, infra, and docs PRs remained open — `release-docs.yml` carries dedicated retroactive-8.1.0 fallback logic because that tag's SHA predates `b10-tables.yml`, which is what let the tag land ahead of its PRs. (As always, discover the actual current state from Git and the GitHub API before acting; the v8.1.0 case is an example, not a standing assertion about today.) |
 
 ### Recovery
 
-For every case **except docs-first**: re-trigger the ship-release workflow. It detects already-merged PRs, skips them, and merges the rest in dependency order with the same preconditions check (mergeable + green + required approvals). The website may serve stale content and CI may be red against `current` until the workflow completes, but no manual intervention is needed.
+For partial *PR-merge* states (some sibling PRs merged, the rest still open and ready) **except docs-first and out-of-band-tag**: re-trigger the ship-release workflow. Its idempotency is scoped to PR-merge state (see the section intro) — it re-reads the PRs, detects already-merged ones, skips them, and merges the rest in dependency order with the same preconditions check (mergeable + green + required approvals). The website may serve stale content and CI may be red against `current` until the workflow completes, but no manual intervention is needed.
+
+Re-running ship-release does **not** cover the case where the tag (and Release object) already exist with the conductor PR still open — it inspects only PR state, so it would attempt the conductor merge and fail when `create-tag.php` hits the existing tag. See [Out-of-band tag recovery](#out-of-band-tag-recovery-manual) for that case.
 
 ### Docs-first recovery (manual, today)
 
-This is the worst case and recovery is currently manual. The ship-release workflow detects docs-first up front and **refuses to do anything** — it will not even merge the remaining PRs, because doing so would create a tag for a version whose docs have already shipped FINAL with no tag link. A future docs-side reconciliation workflow could automate the recovery; see the trailing note.
+This is the worst case and recovery is currently manual. The ship-release workflow detects docs-first up front and **refuses to do anything** — it will not even merge the remaining PRs, because doing so would create a tag for a version whose docs have already shipped FINAL with no tag link. A docs-side reconciliation workflow to automate the recovery is tracked in [openemr/website-openemr#133](https://github.com/openemr/website-openemr/issues/133); until it ships, follow the manual steps below.
 
 The docs PR has already shipped FINAL pages for a version that has no tag yet. After the operator manually merges the conductor (creating the tag) and infra, the existing FINAL-flip mechanism doesn't help — it fires on docs-PR updates, but the docs PR is already merged and closed. The published pages are orphaned: they reference a version that now exists, but with stale DRAFT-era SHAs and no tag link.
 
@@ -257,7 +269,23 @@ Manual steps:
 3. Verify the live website pages now show the FINAL banner with the correct tag link, not DRAFT.
 4. If anyone scraped or linked the DRAFT-stamped pages between merge and reconciliation, the URLs are stable — they now serve correct FINAL content.
 
-Folding this reconciliation into a workflow is a future follow-on; not yet filed. Scope it once docs-first has happened in practice (or the user-facing impact justifies preemptive automation).
+Folding this reconciliation into a workflow is tracked in [openemr/website-openemr#133](https://github.com/openemr/website-openemr/issues/133). Scope it once docs-first has happened in practice (or the user-facing impact justifies preemptive automation).
+
+### Out-of-band tag recovery (manual)
+
+This is the "tag + Release object exist, all PRs still open" row above — the tag was created outside the conductor-merge path. (This has happened in practice: it was v8.1.0's state. As always, discover the real current state before acting rather than assuming this is today's.) Recovery is manual because **re-running ship-release does not work here**: ship-release inspects only PR state, sees the conductor PR open, and tries to merge it; the conductor's post-merge tag step then fails with HTTP 422 because `refs/tags/<tag>` already exists. The squash-merge lands but the tag/dispatch step errors, leaving a half-finished conductor merge.
+
+The reason the conductor PR can't simply be merged: `release-prep.yml`'s `finalize` job runs `create-tag.php` on the merge of **any** PR whose head ref starts with `release-prep/` (or `release-prep-test/`) — there is no in-PR switch to skip it. So merging the existing conductor PR as-is always re-attempts the tag and fails on the existing ref.
+
+First discover the real state from Git and the GitHub API — which PRs are open, what SHA the existing tag points at, whether the `openemr-tag` dispatch already fired (i.e. whether the Release object and downstream consumers are up to date). Then reconcile by hand:
+
+1. **Conductor version bumps:** the conductor PR's two effects are the version-bump edits (still needed) and the tag (already done). Land the version-bump content via a branch **not** named `release-prep/*`, so the `finalize` tag job doesn't trigger: open a new PR from a plain branch (e.g. `release-reconcile/<version>`) carrying the same edits against the rel-branch, merge it, and close the original `release-prep/*` PR unmerged. Confirm the existing tag already points at the intended commit.
+2. **Dispatch:** if the `openemr-tag` dispatch never fired for the existing tag (Release object or downstream consumers not up to date), fire it manually so `build-release-on-tag.yml` and the consumer repos pick it up.
+3. **Infra:** once the tag and dispatch are settled and the `release-prep/*` PR is closed, merge the infra rotation PR — or re-run ship-release for the remaining PRs now that no `release-prep/*` PR is open to trip the tag step.
+4. **Docs:** merge/flip docs to FINAL against the now-confirmed tag.
+5. Verify CI matrices target the new `current`, the website advertises the new version, and docs show FINAL with the correct tag link.
+
+This whole manual path exists only because ship-release is PR-state-only today. The [desired end state](#partial-merges-and-recovery) — ship-release reading the tag/Release object and treating an already-correct tag as done — would let the operator just re-run the workflow here instead of hand-reconciling. Until that lands, the steps above are the path.
 
 ## Naming and tag conventions
 
@@ -287,9 +315,9 @@ Tags are unsigned; the trailer line records that automation produced them. Revis
 
 ## Bot identity and credentials
 
-A GitHub App (the "release app") performs all automated git/PR actions. Its credentials live as repo secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` on each of the four repos, and the App is installed on each.
+A GitHub App (the "release app") performs all automated git/PR actions. Every workflow mints a short-lived installation token via `actions/create-github-app-token`, authenticating with the App's client ID and private key — `client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}` and `private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}`. `RELEASE_APP_CLIENT_ID` is an **organization variable** (the App's public client ID, not a secret) and `RELEASE_APP_PRIVATE_KEY` is an **organization secret**. Because they're set once at the org level, they're available to the release workflows in all four repos automatically — there's no need to duplicate them repo-by-repo. The App is installed on each repo.
 
-Each repo carries a `release-permissions-check.yml` workflow (manual `workflow_dispatch`) that mints an App token and probes every permission the workflow needs — branch create/delete, PR open/close, tag create/delete, cross-repo `repository_dispatch`. Run it after installing the App or rotating the secrets; it fails loudly with the missing permission name.
+Each repo carries a `release-permissions-check.yml` workflow (manual `workflow_dispatch`) that mints an App token and probes every permission the workflow needs — branch create/delete, PR open/close, tag create/delete, cross-repo `repository_dispatch`. Run it after installing the App or rotating the credentials; it fails loudly with the missing permission name.
 
 This repo's check is at [`.github/workflows/release-permissions-check.yml`](../.github/workflows/release-permissions-check.yml).
 


### PR DESCRIPTION
## Summary

Aligns `docs/RELEASE_PROCESS.md` with the live cross-repo release automation. Docs-only change.

- **Credentials.** The release App authenticates with `client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}` + `private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}` via `actions/create-github-app-token`. `RELEASE_APP_CLIENT_ID` is an org-level variable (the App's public client ID); `RELEASE_APP_PRIVATE_KEY` is an org-level secret — both available to all four repos without per-repo duplication.
- **Automation gaps.** The section tracks every post-automation gap (manual steps, missing guards, recovery tooling), with rows for all five open sub-issues of umbrella [openemr-devops#706](https://github.com/openemr/openemr-devops/issues/706): [demo_farm_openemr#110](https://github.com/openemr/demo_farm_openemr/issues/110), [openemr-devops#761](https://github.com/openemr/openemr-devops/issues/761), [website-openemr#132](https://github.com/openemr/website-openemr/issues/132), [website-openemr#133](https://github.com/openemr/website-openemr/issues/133), and [openemr-devops#711](https://github.com/openemr/openemr-devops/issues/711). Disambiguates runbook step 10 (Release-object creation, closed via openemr-devops#757) from the docs DRAFT→FINAL tag-exists guard (#132).
- **Recovery framing.** Scopes `ship-release.yml` idempotency accurately: it inspects only PR state — not `refs/tags` or the Release object — so re-running it recovers partial PR merges but **not** the out-of-band-tag state (an existing tag aborts the conductor merge's `create-tag.php` with HTTP 422). Documents a feasible manual out-of-band-tag recovery, and the **desired end state** where ship-release becomes tag/Release-aware and fully idempotent, retiring that manual path.
- **Partial-merge table.** Adds the "tag + Release object exist, sibling PRs still open" row (framed as an example that has happened in practice, not a standing live-state claim), with the discover-current-state-before-acting caveat.

## Test plan

- [x] `codespell` and conventional-commits pre-commit hooks pass
- [ ] Markdown renders correctly on GitHub (anchor links, table)