### PR TITLE
chore: remove unused Laminas\Mvc import in FHIRSearchFieldFactory

### DIFF
--- a/src/Services/Search/FHIRSearchFieldFactory.php
+++ b/src/Services/Search/FHIRSearchFieldFactory.php
@@ -16,7 +16,6 @@
 
 namespace OpenEMR\Services\Search;
 
-use Laminas\Mvc\Exception\BadMethodCallException;
 use OpenEMR\Services\FHIR\FhirUrlResolver;
 use OpenEMR\Services\Search\SearchFieldType;
 
@@ -198,7 +197,7 @@ class FHIRSearchFieldFactory
     /**
      * Returns the relative url
      * @param $urlToResolve
-     * @throws BadMethodCallException if the FhirUrlResolver is not setup for this class
+     * @throws \BadMethodCallException if the FhirUrlResolver is not setup for this class
      * @throws \InvalidArgumentException if the URL does not match the server base URL
      * @return string
      */


### PR DESCRIPTION
## What

Remove the unused `use Laminas\Mvc\Exception\BadMethodCallException;` import from `src/Services/Search/FHIRSearchFieldFactory.php`, and correct the related docblock `@throws` to reference the global `\BadMethodCallException`.

## Why

The Laminas type was imported but never used — every `throw` in the file uses the global `\BadMethodCallException` (lines 156, 162, 208). One docblock (`@throws BadMethodCallException`) was using the bare short name, which currently resolves to the Laminas import; updating it to `\BadMethodCallException` keeps it accurate after the dead import is removed and matches what the method actually throws.

Pure cleanup — no behavior change.