### PR TITLE
test(api): add appointment endpoint tests

### DIFF
--- a/tests/Tests/Api/AppointmentApiTest.php
+++ b/tests/Tests/Api/AppointmentApiTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Api;
+
+use OpenEMR\Tests\Fixtures\AppointmentFixtureManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Appointment API Endpoint Test Cases.
+ *
+ * Covers the Standard REST API read endpoints:
+ *   GET /api/appointment        – list all appointments
+ *   GET /api/appointment/:eid   – retrieve a single appointment by event id
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Miguel Montano <miiguel2m@gmail.com>
+ * @copyright Copyright (c) 2026 Miguel Montano
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+class AppointmentApiTest extends TestCase
+{
+    const APPOINTMENT_API_ENDPOINT = "/apis/default/api/appointment";
+    const PATIENT_APPOINTMENT_API_ENDPOINT = "/apis/default/api/patient";
+
+    private ApiTestClient $testClient;
+    private AppointmentFixtureManager $fixtureManager;
+    private int $appointmentEid;
+
+    protected function setUp(): void
+    {
+        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
+        $this->testClient = new ApiTestClient($baseUrl, false);
+        $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+
+        $this->fixtureManager = new AppointmentFixtureManager();
+        $dependencies = $this->fixtureManager->installDependencies();
+
+        $pid = $dependencies['pid'];
+        $facilityId = $dependencies['facility_id'];
+        $appointmentData = $this->fixtureManager->getSingleAppointmentFixture($facilityId);
+
+        $postResponse = $this->testClient->post(
+            self::PATIENT_APPOINTMENT_API_ENDPOINT . "/{$pid}/appointment",
+            $appointmentData
+        );
+        $this->assertEquals(200, $postResponse->getStatusCode());
+
+        /** @var array<string, mixed> $responseBody */
+        $responseBody = json_decode((string) $postResponse->getBody(), true);
+        $this->appointmentEid = (int) $responseBody['id'];
+        $this->assertGreaterThan(0, $this->appointmentEid);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fixtureManager->removeFixtures();
+    }
+
+    #[Test]
+    public function testGetAppointmentList(): void
+    {
+        $actualResponse = $this->testClient->get(self::APPOINTMENT_API_ENDPOINT);
+
+        $this->assertEquals(200, $actualResponse->getStatusCode());
+
+        /** @var list<array<string, mixed>> $responseBody */
+        $responseBody = json_decode((string) $actualResponse->getBody(), true);
+        $this->assertIsArray($responseBody);
+        $this->assertNotEmpty($responseBody);
+
+        $eids = array_map(fn(array $record) => (int) $record['pc_eid'], $responseBody);
+        $this->assertContains($this->appointmentEid, $eids);
+    }
+
+    #[Test]
+    public function testGetAppointmentById(): void
+    {
+        $actualResponse = $this->testClient->getOne(
+            self::APPOINTMENT_API_ENDPOINT,
+            (string) $this->appointmentEid
+        );
+
+        $this->assertEquals(200, $actualResponse->getStatusCode());
+
+        /** @var list<array<string, mixed>> $responseBody */
+        $responseBody = json_decode((string) $actualResponse->getBody(), true);
+        $this->assertIsArray($responseBody);
+        $this->assertNotEmpty($responseBody);
+
+        $appointment = $responseBody[0];
+        $this->assertEquals($this->appointmentEid, (int) $appointment['pc_eid']);
+        $this->assertArrayHasKey('pc_title', $appointment);
+        $this->assertArrayHasKey('pc_eventDate', $appointment);
+        $this->assertArrayHasKey('pc_startTime', $appointment);
+        $this->assertArrayHasKey('pc_apptstatus', $appointment);
+        $this->assertArrayHasKey('pc_duration', $appointment);
+    }
+
+    #[Test]
+    public function testGetAppointmentByIdNotFound(): void
+    {
+        $actualResponse = $this->testClient->getOne(self::APPOINTMENT_API_ENDPOINT, "999999999");
+
+        $this->assertEquals(404, $actualResponse->getStatusCode());
+    }
+
+    #[Test]
+    public function testGetAppointmentUnauthorized(): void
+    {
+        $this->testClient->removeAuthToken();
+        $actualResponse = $this->testClient->get(self::APPOINTMENT_API_ENDPOINT);
+
+        $this->assertEquals(401, $actualResponse->getStatusCode());
+    }
+}

--- a/tests/Tests/Api/AppointmentApiTest.php
+++ b/tests/Tests/Api/AppointmentApiTest.php
@@ -71,7 +71,7 @@ class AppointmentApiTest extends TestCase
         $responseBody = json_decode((string) $actualResponse->getBody(), true);
         $this->assertNotEmpty($responseBody);
 
-        $eids = array_map('strval', array_column($responseBody, 'pc_eid'));
+        $eids = array_map(strval(...), array_column($responseBody, 'pc_eid'));
         $this->assertContains((string) $this->appointmentEid, $eids);
     }
 

--- a/tests/Tests/Api/AppointmentApiTest.php
+++ b/tests/Tests/Api/AppointmentApiTest.php
@@ -71,7 +71,7 @@ class AppointmentApiTest extends TestCase
         $responseBody = json_decode((string) $actualResponse->getBody(), true);
         $this->assertNotEmpty($responseBody);
 
-        $eids = array_map(strval(...), array_column($responseBody, 'pc_eid'));
+        $eids = array_column($responseBody, 'pc_eid');
         $this->assertContains((string) $this->appointmentEid, $eids);
     }
 

--- a/tests/Tests/Api/AppointmentApiTest.php
+++ b/tests/Tests/Api/AppointmentApiTest.php
@@ -51,7 +51,9 @@ class AppointmentApiTest extends TestCase
 
         /** @var array<string, mixed> $responseBody */
         $responseBody = json_decode((string) $postResponse->getBody(), true);
-        $this->appointmentEid = (int) $responseBody['id'];
+        $appointmentId = $responseBody['id'];
+        $this->assertIsInt($appointmentId);
+        $this->appointmentEid = $appointmentId;
         $this->assertGreaterThan(0, $this->appointmentEid);
     }
 
@@ -69,10 +71,9 @@ class AppointmentApiTest extends TestCase
 
         /** @var list<array<string, mixed>> $responseBody */
         $responseBody = json_decode((string) $actualResponse->getBody(), true);
-        $this->assertIsArray($responseBody);
         $this->assertNotEmpty($responseBody);
 
-        $eids = array_map(fn(array $record) => (int) $record['pc_eid'], $responseBody);
+        $eids = array_column($responseBody, 'pc_eid');
         $this->assertContains($this->appointmentEid, $eids);
     }
 
@@ -88,11 +89,10 @@ class AppointmentApiTest extends TestCase
 
         /** @var list<array<string, mixed>> $responseBody */
         $responseBody = json_decode((string) $actualResponse->getBody(), true);
-        $this->assertIsArray($responseBody);
         $this->assertNotEmpty($responseBody);
 
         $appointment = $responseBody[0];
-        $this->assertEquals($this->appointmentEid, (int) $appointment['pc_eid']);
+        $this->assertEquals($this->appointmentEid, $appointment['pc_eid']);
         $this->assertArrayHasKey('pc_title', $appointment);
         $this->assertArrayHasKey('pc_eventDate', $appointment);
         $this->assertArrayHasKey('pc_startTime', $appointment);

--- a/tests/Tests/Api/AppointmentApiTest.php
+++ b/tests/Tests/Api/AppointmentApiTest.php
@@ -49,11 +49,9 @@ class AppointmentApiTest extends TestCase
         );
         $this->assertEquals(200, $postResponse->getStatusCode());
 
-        /** @var array<string, mixed> $responseBody */
+        /** @var array{id: int|string} $responseBody */
         $responseBody = json_decode((string) $postResponse->getBody(), true);
-        $appointmentId = $responseBody['id'];
-        $this->assertIsInt($appointmentId);
-        $this->appointmentEid = $appointmentId;
+        $this->appointmentEid = (int) $responseBody['id'];
         $this->assertGreaterThan(0, $this->appointmentEid);
     }
 
@@ -73,8 +71,8 @@ class AppointmentApiTest extends TestCase
         $responseBody = json_decode((string) $actualResponse->getBody(), true);
         $this->assertNotEmpty($responseBody);
 
-        $eids = array_column($responseBody, 'pc_eid');
-        $this->assertContains($this->appointmentEid, $eids);
+        $eids = array_map('strval', array_column($responseBody, 'pc_eid'));
+        $this->assertContains((string) $this->appointmentEid, $eids);
     }
 
     #[Test]


### PR DESCRIPTION
Assisted-By: Claude Code

<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:

Adds API test coverage for the Standard REST Appointment resource, addressing gaps in the API test suite. Currently only 30/172 route+method combinations have tests.

Contributes to #12343

#### Changes proposed in this pull request:

- Created `tests/Tests/Api/AppointmentApiTest.php` with tests for:
  - GET /api/appointment (list all appointments)
  - GET /api/appointment/:eid (get single appointment by ID)
  - Proper error handling (404 for missing ID, 401 for unauthorized)
  - Follows the FacilityApiTest pattern as suggested in the coverage gap issue

#### Coverage impact:
- Before: 30/172 route+method combinations tested (17%)
- After: 32/172 route+method combinations tested (18.6%)

#### Was an AI assistant used? Yes / No
Yes
<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->