### PR TITLE
fix(release): derive patch version from tags off rel-NNN0 branches

### DIFF
--- a/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
+++ b/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
@@ -80,6 +80,17 @@ final class BranchVersionResolverTest extends TestCase
         self::assertSame('8.1.0', $resolver->branchToVersion('rel-810'));
     }
 
+    public function testBranchToVersionIgnoresLightweightReleaseShapedTags(): void
+    {
+        // A lightweight tag whose name matches the release pattern must
+        // not bump the patch: the spec requires annotated tags, so only
+        // an annotated v8_1_0 below counts toward the next version.
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 released 2026-05-01']);
+        $this->git(['tag', 'v8_1_5']);
+        $resolver = new BranchVersionResolver($this->tmpDir);
+        self::assertSame('8.1.1', $resolver->branchToVersion('rel-810'));
+    }
+
     public function testBranchToVersionRejectsBadInput(): void
     {
         $resolver = new BranchVersionResolver($this->tmpDir);

--- a/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
+++ b/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
@@ -35,20 +35,56 @@ final class BranchVersionResolverTest extends TestCase
         $this->removeRecursive($this->tmpDir);
     }
 
-    public function testBranchToVersionParsesRel810(): void
+    public function testBranchToVersionCutsDotZeroWhenMinorLineHasNoTag(): void
     {
-        self::assertSame('8.1.0', BranchVersionResolver::branchToVersion('rel-810'));
+        $resolver = new BranchVersionResolver($this->tmpDir);
+        self::assertSame('8.1.0', $resolver->branchToVersion('rel-810'));
     }
 
-    public function testBranchToVersionParsesRel700(): void
+    public function testBranchToVersionCutsDotZeroOnFreshRepoForRel700(): void
     {
-        self::assertSame('7.0.0', BranchVersionResolver::branchToVersion('rel-700'));
+        $resolver = new BranchVersionResolver($this->tmpDir);
+        self::assertSame('7.0.0', $resolver->branchToVersion('rel-700'));
+    }
+
+    public function testBranchToVersionCutsNextPatchAfterExistingRelease(): void
+    {
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 released 2026-05-01']);
+        $resolver = new BranchVersionResolver($this->tmpDir);
+        self::assertSame('8.1.1', $resolver->branchToVersion('rel-810'));
+    }
+
+    public function testBranchToVersionPicksHighestPatchOnMinorLine(): void
+    {
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 released 2026-05-01']);
+        $this->git(['tag', '-a', 'v8_1_1', '-m', 'OpenEMR 8.1.1 released 2026-05-15']);
+        $this->git(['tag', '-a', 'v8_1_2', '-m', 'OpenEMR 8.1.2 released 2026-06-01']);
+        $resolver = new BranchVersionResolver($this->tmpDir);
+        self::assertSame('8.1.3', $resolver->branchToVersion('rel-810'));
+    }
+
+    public function testBranchToVersionIgnoresTagsOnOtherMinorLines(): void
+    {
+        // Tags on 8.0.x and 8.2.x must not influence the patch chosen
+        // for the 8.1 line.
+        $this->git(['tag', '-a', 'v8_0_5', '-m', 'OpenEMR 8.0.5 released 2026-03-01']);
+        $this->git(['tag', '-a', 'v8_2_0', '-m', 'OpenEMR 8.2.0 released 2026-07-01']);
+        $resolver = new BranchVersionResolver($this->tmpDir);
+        self::assertSame('8.1.0', $resolver->branchToVersion('rel-810'));
+    }
+
+    public function testBranchToVersionIgnoresNonReleaseVTags(): void
+    {
+        $this->git(['tag', 'v8_1_x-nightly']);
+        $resolver = new BranchVersionResolver($this->tmpDir);
+        self::assertSame('8.1.0', $resolver->branchToVersion('rel-810'));
     }
 
     public function testBranchToVersionRejectsBadInput(): void
     {
+        $resolver = new BranchVersionResolver($this->tmpDir);
         $this->expectException(\InvalidArgumentException::class);
-        BranchVersionResolver::branchToVersion('main');
+        $resolver->branchToVersion('main');
     }
 
     public function testPreviousReleaseFallsBackWhenNoTagExists(): void

--- a/tools/release/bin/branch-to-version.php
+++ b/tools/release/bin/branch-to-version.php
@@ -30,6 +30,7 @@ if (!class_exists(\OpenEMR\Release\BranchVersionResolver::class)) {
 use OpenEMR\Release\BranchVersionResolver;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\SingleCommandApplication;
 
@@ -37,14 +38,22 @@ use Symfony\Component\Console\SingleCommandApplication;
     ->setName('branch-to-version')
     ->setDescription('Translate a rel-* branch name to MAJOR.MINOR.PATCH')
     ->addArgument('branch', InputArgument::REQUIRED, 'Branch name (e.g. rel-810)')
+    ->addOption(
+        'repo-dir',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Repo path (defaults to cwd)',
+        getcwd() === false ? '.' : getcwd(),
+    )
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
         $raw = $input->getArgument('branch');
-        if (!is_string($raw) || $raw === '') {
-            $output->writeln('<error>branch argument is required</error>');
+        $repoDir = $input->getOption('repo-dir');
+        if (!is_string($raw) || $raw === '' || !is_string($repoDir) || $repoDir === '') {
+            $output->writeln('<error>branch argument and --repo-dir are required</error>');
             return 2;
         }
         try {
-            $version = BranchVersionResolver::branchToVersion($raw);
+            $version = (new BranchVersionResolver($repoDir))->branchToVersion($raw);
         } catch (\InvalidArgumentException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             return 1;

--- a/tools/release/src/BranchVersionResolver.php
+++ b/tools/release/src/BranchVersionResolver.php
@@ -29,14 +29,26 @@ final readonly class BranchVersionResolver
     ) {
     }
 
-    public static function branchToVersion(string $branch): string
+    /**
+     * Translate a rel-<MAJOR><MINOR>0 branch to the version it should
+     * cut next. The trailing 0 is a structural marker — there is one
+     * release branch per minor line, so rel-810 is the home for all of
+     * 8.1.x — not the patch digit. The patch is derived from tags:
+     * the highest existing v<MAJOR>_<MINOR>_* patch plus one, or 0 when
+     * no release has been cut on that minor line yet.
+     */
+    public function branchToVersion(string $branch): string
     {
         if (preg_match('/^rel-(\d+)(\d)0$/', $branch, $m) !== 1) {
             throw new \InvalidArgumentException(
                 'branch must match rel-<MAJOR><MINOR>0; got: ' . $branch,
             );
         }
-        return sprintf('%s.%s.0', $m[1], $m[2]);
+        $major = (int) $m[1];
+        $minor = (int) $m[2];
+        $highestPatch = $this->highestPatchOnMinorLine($major, $minor);
+        $nextPatch = $highestPatch === null ? 0 : $highestPatch + 1;
+        return sprintf('%d.%d.%d', $major, $minor, $nextPatch);
     }
 
     /**
@@ -66,23 +78,57 @@ final readonly class BranchVersionResolver
 
     private function latestVersionTagBelow(string $targetVersion): ?string
     {
-        $process = new Process(['git', 'tag', '--list', 'v*', '--sort=-v:refname'], $this->repoDir);
-        $process->mustRun();
-        $output = trim($process->getOutput());
-        if ($output === '') {
-            return null;
-        }
-        $split = preg_split('/\R/', $output);
-        $lines = $split === false ? [] : $split;
-        foreach ($lines as $tag) {
-            if (preg_match('/^v(\d+)_(\d+)_(\d+)$/', $tag, $m) !== 1) {
-                continue;
-            }
-            $candidate = sprintf('%s.%s.%s', $m[1], $m[2], $m[3]);
+        foreach ($this->releaseTags() as [$major, $minor, $patch]) {
+            $candidate = sprintf('%d.%d.%d', $major, $minor, $patch);
             if (version_compare($candidate, $targetVersion, '<')) {
                 return $candidate;
             }
         }
         return null;
+    }
+
+    /**
+     * Highest PATCH among v<MAJOR>_<MINOR>_* tags on the given minor
+     * line, or null when no release has been cut on that line yet.
+     */
+    private function highestPatchOnMinorLine(int $major, int $minor): ?int
+    {
+        $highest = null;
+        foreach ($this->releaseTags() as [$tagMajor, $tagMinor, $tagPatch]) {
+            if ($tagMajor !== $major || $tagMinor !== $minor) {
+                continue;
+            }
+            if ($highest === null || $tagPatch > $highest) {
+                $highest = $tagPatch;
+            }
+        }
+        return $highest;
+    }
+
+    /**
+     * All v<MAJOR>_<MINOR>_<PATCH> release tags in the repo, parsed into
+     * [major, minor, patch] tuples and sorted descending by version
+     * (highest first). Non-release v* tags are skipped.
+     *
+     * @return list<array{int, int, int}>
+     */
+    private function releaseTags(): array
+    {
+        $process = new Process(['git', 'tag', '--list', 'v*', '--sort=-v:refname'], $this->repoDir);
+        $process->mustRun();
+        $output = trim($process->getOutput());
+        if ($output === '') {
+            return [];
+        }
+        $split = preg_split('/\R/', $output);
+        $lines = $split === false ? [] : $split;
+        $tags = [];
+        foreach ($lines as $tag) {
+            if (preg_match('/^v(\d+)_(\d+)_(\d+)$/', $tag, $m) !== 1) {
+                continue;
+            }
+            $tags[] = [(int) $m[1], (int) $m[2], (int) $m[3]];
+        }
+        return $tags;
     }
 }

--- a/tools/release/src/BranchVersionResolver.php
+++ b/tools/release/src/BranchVersionResolver.php
@@ -110,11 +110,18 @@ final readonly class BranchVersionResolver
      * [major, minor, patch] tuples and sorted descending by version
      * (highest first). Non-release v* tags are skipped.
      *
+     * Only annotated tags count: the release spec requires `git tag -a`
+     * (see TagVerifier), so a lightweight tag whose name happens to look
+     * like a release must not influence the derived version.
+     *
      * @return list<array{int, int, int}>
      */
     private function releaseTags(): array
     {
-        $process = new Process(['git', 'tag', '--list', 'v*', '--sort=-v:refname'], $this->repoDir);
+        $process = new Process(
+            ['git', 'tag', '--list', 'v*', '--sort=-v:refname', '--format=%(objecttype) %(refname:short)'],
+            $this->repoDir,
+        );
         $process->mustRun();
         $output = trim($process->getOutput());
         if ($output === '') {
@@ -123,7 +130,15 @@ final readonly class BranchVersionResolver
         $split = preg_split('/\R/', $output);
         $lines = $split === false ? [] : $split;
         $tags = [];
-        foreach ($lines as $tag) {
+        foreach ($lines as $line) {
+            $parts = explode(' ', $line, 2);
+            if (count($parts) !== 2) {
+                continue;
+            }
+            [$objectType, $tag] = $parts;
+            if ($objectType !== 'tag') {
+                continue;
+            }
             if (preg_match('/^v(\d+)_(\d+)_(\d+)$/', $tag, $m) !== 1) {
                 continue;
             }


### PR DESCRIPTION
## Summary

`OpenEMR\Release\BranchVersionResolver::branchToVersion()` hardcoded the patch component to `0`, so the release conductor could only ever cut a `.0` release off a `rel-<MAJOR><MINOR>0` branch. The trailing `0` in `rel-810` is a structural marker — there is one release branch per minor line (`rel-810` is the home for all of 8.1.x) — not the patch digit. After 8.1.0 shipped, every non-docs push to `rel-810` regenerated a "prep 8.1.0" PR, and merging it re-attempted to cut the existing `v8_1_0` tag (HTTP 422 in finalize).

This teaches `branchToVersion` to derive the patch from tags: read `v<MAJOR>_<MINOR>_*`, take the highest patch + 1, or `.0` when no release has been cut on that minor line yet.

- Converted `branchToVersion` from a static to an instance method, reusing the tag-reading machinery already present for `previousRelease()` (factored into a shared `releaseTags()` helper).
- Updated `branch-to-version.php` to instantiate the resolver, adding a `--repo-dir` option (defaulting to cwd) to match `derive-prev-release.php`.
- Both the prep and finalize workflow paths invoke `branch-to-version.php` from the repo root, so this single CLI change fixes both — no workflow edit needed.

### Why `tag + 1` is correct for both prep and finalize

Finalize computes the version *before* it creates its tag, so "highest `v<MAJOR>_<MINOR>_*` + 1" is consistent across both jobs: prep sees highest `v8_1_0` → preps 8.1.1; finalize on that merge still sees `v8_1_0` (it is the job that creates the next tag) → cuts `v8_1_1`. A fresh minor line with no tag → `.0`, matching today's behavior.

## Test plan

- [x] Extended `BranchVersionResolverTest` (isolated): `.0` on a fresh minor line, `.1` after one release, highest-patch selection, other minor lines ignored, non-release `v*` tags ignored, bad input rejected. 12/12 pass.
- [x] PHPStan level 10 clean on changed files; phpcs, rector, require-checker pass (pre-commit).
- [x] CLI smoke test against a checkout with real tags: `rel-810` → `8.1.1`.

Closes #12420