### PR TITLE
ci: retry Docker image pulls with backoff to survive registry timeouts

### DIFF
--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -83,8 +83,21 @@ with_retry() {
 # errors. Separated from `up` so a Docker Hub timeout retries just the pull
 # rather than failing the bring-up. --ignore-buildable skips services that
 # build locally (e.g. inferno's terminology_builder).
+#
+# Pulls at most once per job: dockers_env_start runs in several workflow
+# steps (initial bring-up, again after restarts in setup_e2e_bookends and
+# build_test_e2e), each in a fresh shell, so the guard is a marker file in
+# RUNNER_TEMP rather than a shell variable. Repeat calls skip the pull and
+# rely on `dc up --quiet-pull` to fetch anything still missing (e.g. a
+# profile-gated image the first pull's COMPOSE_PROFILES did not include).
 pull_images() {
+    local marker="${RUNNER_TEMP:-/tmp}/openemr-ci-images-pulled"
+    if [[ -f "${marker}" ]]; then
+        echo 'Images already pulled this job; skipping pull (up will fetch anything missing).'
+        return 0
+    fi
     with_retry 4 5 dc pull --quiet --ignore-buildable
+    touch "${marker}"
 }
 
 _exec() {

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -53,6 +53,40 @@ dc() {
     docker compose "$@"
 }
 
+##
+# Retry a command with exponential backoff. Docker Hub registry pulls time
+# out transiently in CI (issue #12423); without a retry a single hiccup
+# fails the whole matrix job. Usage: with_retry MAX_ATTEMPTS DELAY cmd args...
+with_retry() {
+    local max_attempts=$1
+    local delay=$2
+    shift 2
+    local attempt=1
+    while true; do
+        # shellcheck disable=SC2310  # the command's failure drives the retry, not errexit
+        if "$@"; then
+            return 0
+        fi
+        if (( attempt >= max_attempts )); then
+            echo "Command failed after ${attempt} attempts: $*" >&2
+            return 1
+        fi
+        echo "Attempt ${attempt}/${max_attempts} failed: $* — retrying in ${delay}s" >&2
+        sleep "${delay}"
+        (( ++attempt ))
+        (( delay *= 2 ))
+    done
+}
+
+##
+# Pull every image the compose stack needs, retrying on transient registry
+# errors. Separated from `up` so a Docker Hub timeout retries just the pull
+# rather than failing the bring-up. --ignore-buildable skips services that
+# build locally (e.g. inferno's terminology_builder).
+pull_images() {
+    with_retry 4 5 dc pull --quiet --ignore-buildable
+}
+
 _exec() {
     if [[ ${ENABLE_COVERAGE:-false} = true ]]; then
         # Set XDEBUG_MODE env var for xdebug coverage (ignored if using pcov).
@@ -95,6 +129,12 @@ convert_coverage() {
 }
 
 dockers_env_start() {
+    # Pull first, with retry, so a transient Docker Hub timeout retries the
+    # pull instead of failing the whole bring-up (issue #12423). `up` then
+    # finds the images already present; its own --quiet-pull is left as a
+    # harmless fallback for anything pull_images skipped (e.g. buildable
+    # services in the inferno stack).
+    pull_images
     dc up --detach --quiet-pull --wait --wait-timeout 300
 }
 

--- a/ci/inferno/run.sh
+++ b/ci/inferno/run.sh
@@ -178,6 +178,12 @@ main() {
     # The classic Docker builder does not.
     # We need platform arguments.
     export DOCKER_BUILDKIT=1
+    # Source the CI library for with_retry. run.sh runs from ci/inferno, so
+    # resolve the repo root to find it.
+    local repo_root
+    repo_root="$(git rev-parse --show-toplevel)"
+    # shellcheck source-path=SCRIPTDIR/..
+    . "${repo_root}/ci/ciLibrary.source"
     local use_cloned_files
     # shellcheck disable=SC2310
     if clone_files; then
@@ -186,7 +192,11 @@ main() {
       use_cloned_files=0
     fi
     echo 'Pulling Docker images...'
-    if ! docker compose pull; then
+    # Retry transient registry timeouts (issue #12423). --ignore-buildable
+    # skips locally built services (inferno, worker, terminology_builder),
+    # which the build step below handles.
+    # shellcheck disable=SC2310  # with_retry's own exit status drives the error path here
+    if ! with_retry 4 5 docker compose pull --ignore-buildable; then
         echo 'ERROR: Failed to pull Docker images'
         exit 1
     fi


### PR DESCRIPTION
## Summary

The `Test All Configurations` workflow has been failing on `master` and across open PRs because the compose bring-up pulls images exactly once, with no retry. A single transient Docker Hub timeout (`registry-1.docker.io`) fails the whole matrix job.

This adds retry/backoff around image pulls — the predominant failure mode in #12423.

## Changes

- `ci/ciLibrary.source`:
  - `with_retry` — generic exponential-backoff helper (4 attempts, 5s → 10s → 20s).
  - `pull_images` — `docker compose pull --quiet --ignore-buildable`, wrapped in `with_retry`.
  - `dockers_env_start` now pulls (with retry) before `docker compose up`, so a registry timeout retries just the pull instead of failing the bring-up. The existing `--quiet-pull` on `up` stays as a harmless fallback.
- `ci/inferno/run.sh`: the inferno certification pull is wrapped in the same `with_retry`. `--ignore-buildable` skips locally built services (handled by the existing `build` step).

`--ignore-buildable` is strictly safer than the previous plain `docker compose pull`: pure-image services still pull (now with retry), buildable services are left to the build step.

## Not in scope (follow-ups)

Per the issue's other suggested directions, two larger items are deferred to separate issues:

- Authenticating to Docker Hub to lift anonymous rate limits (needs an org secret).
- A pull-through registry cache / image cache shared across matrix jobs.

The e2e/Selenium flakes noted in the issue are a separate failure mode from the registry timeouts addressed here.

Refs #12423