### PR TITLE
ci: authenticate to Docker Hub before image pulls to lift rate limits

### DIFF
--- a/.github/workflows/docker-compose-lint.yml
+++ b/.github/workflows/docker-compose-lint.yml
@@ -25,6 +25,21 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
+    - name: Login to Docker Hub
+      # The dclint steps below pull zavoloklom/dclint from Docker Hub.
+      # Authenticated pulls have a much higher rate limit than anonymous ones,
+      # reducing the registry failures tracked in #12423. The secrets context
+      # is unavailable in `if`, so map the secrets into env and gate on them;
+      # fork PRs without the secrets skip this and pull anonymously as before.
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      env:
+        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Get changed docker compose files
       id: changed-files
       continue-on-error: true

--- a/.github/workflows/inferno-test.yml
+++ b/.github/workflows/inferno-test.yml
@@ -308,6 +308,20 @@ jobs:
         chmod +x "$HOME/bin/openemr-cmd"
         # add the command to default path so will be found and run.sh can still be used locally
 
+    - name: Login to Docker Hub
+      # Authenticated pulls have a much higher rate limit than anonymous ones,
+      # reducing the registry failures tracked in #12423. The secrets context
+      # is unavailable in `if`, so map the secrets into env and gate on them;
+      # fork PRs without the secrets skip this and pull anonymously as before.
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      env:
+        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Run Inferno Certification Tests
       working-directory: ci/inferno
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -400,6 +400,20 @@ jobs:
         . ci/ciLibrary.source
         dc config
 
+    - name: Login to Docker Hub
+      # Authenticated pulls have a much higher rate limit than anonymous ones,
+      # reducing the registry failures tracked in #12423. The secrets context
+      # is unavailable in `if`, so map the secrets into env and gate on them;
+      # fork PRs without the secrets skip this and pull anonymously as before.
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      env:
+        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Dockers environment start
       run: |
         . ci/ciLibrary.source
@@ -528,6 +542,20 @@ jobs:
         # HACK Docker runs with a different uid/gid than the host.
         # See #9233
         sudo chmod -R 0777 .
+
+    - name: Login to Docker Hub
+      # Authenticated pulls have a much higher rate limit than anonymous ones,
+      # reducing the registry failures tracked in #12423. The secrets context
+      # is unavailable in `if`, so map the secrets into env and gate on them;
+      # fork PRs without the secrets skip this and pull anonymously as before.
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      env:
+        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Dockers environment start
       env:


### PR DESCRIPTION
## Summary

CI pulls Docker images from Docker Hub anonymously, which is subject to per-IP anonymous pull rate limits and contributes to the transient registry failures tracked in #12423. This authenticates to Docker Hub before each pull so CI uses the much higher logged-in quota.

This is the complementary fix to #12425 (retry/backoff): retry handles the *transient timeout* class of failures, authentication handles the *rate-limit* class.

## Changes

A `docker/login-action@v4` step is added before each Docker Hub pull point:

- `test.yml` — the reusable test workflow's `setup` and `test` jobs, before `dockers_env_start`.
- `inferno-test.yml` — before `run.sh` brings up the inferno stack.
- `docker-compose-lint.yml` — before the dclint steps, which pull `zavoloklom/dclint`.

`docker/login-action@v4` matches the version already used across the repo's build workflows (e.g. `build-dev-php-fpm-docker.yml`, `weekly-build-php-fpm-dockers.yml`).

## Fork safety

The `secrets` context is not available in `if` conditionals, so the token is mapped into the step's `env` and the step is gated on `env.DOCKERHUB_TOKEN != ''`. Fork PRs that don't have the `DOCKERHUB_TOKEN` secret simply skip the login step and pull anonymously, exactly as today.

`DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` already exist as repository secrets, so no maintainer secret-provisioning step is required.

Closes #12426
Refs #12423

## Test plan

- [ ] CI on this PR (fork, no secret) runs anonymously and is unaffected.
- [ ] After merge, runs on `master` perform an authenticated Docker Hub login before pulls.