### PR TITLE
fix(calendar): allow save for timed In/Out of Office events

### DIFF
--- a/interface/main/calendar/add_edit_event.js
+++ b/interface/main/calendar/add_edit_event.js
@@ -17,6 +17,7 @@
 /* global addEditEventConfig */
 
 const IN_OFFICE_CAT_ID = '2';
+const OUT_OF_OFFICE_CAT_ID = '3';
 
 // This is for callback by the find-patient popup.
 function setpatient(pid, lname, fname, dob) {

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1692,6 +1692,9 @@ function are_days_checked(){
 var collectvalidation = <?php echo $collectthis; ?>;
 function validateform(event,value){
     let allDay = document.getElementById('rballday1').checked;
+    let catValue = document.forms[0].form_category.value;
+    let isInOffice = catValue == IN_OFFICE_CAT_ID;
+    let isOutOfOffice = catValue == OUT_OF_OFFICE_CAT_ID;
     collectvalidation.form_hour = {
         numericality: {
             onlyInteger: true,
@@ -1718,7 +1721,7 @@ function validateform(event,value){
         }
     };
 
-    if ( allDay == true) {
+    if (allDay == true || isInOffice == true || isOutOfOffice == true) {
         collectvalidation.form_duration ={};
     } else {
     collectvalidation.form_duration = {


### PR DESCRIPTION
## Summary

- Picking the **In Office** or **Out Of Office** category in the appointment add/edit modal, then switching from *All day event* to *Time*, made the **Save** button silently do nothing.
- Root cause: PR #8263 added a `form_duration > 0` validation rule whenever the event is not all-day. Both of these categories are provider availability markers — their seed `pc_duration` is `0` and the In Office UI even forces the duration field to `0` and disables it — so the validation rule rejected the form on submit. PR #8876's partial fix only covered the all-day case.
- This PR extends the existing all-day bypass in `validateform()` to also skip duration validation when the category is In Office (`pc_catid = 2`) or Out Of Office (`pc_catid = 3`), matching the original spirit of PR #8263.

## Test plan

- [x] Add appointment, category **In Office**, **All day event** → saves (regression check)
- [x] Add appointment, category **In Office**, **Time** with a specific time → saves
- [x] Add appointment, category **Out Of Office**, **All day event** → saves (regression check)
- [x] Add appointment, category **Out Of Office**, **Time** with a specific time → saves
- [x] Add appointment, any other category, **Time** with `duration = 0` → still rejected with the existing validation message (regression check)