### PR TITLE
ci: capture openemr log and apache coredump in e2e failure artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -587,6 +587,17 @@ jobs:
         . ci/ciLibrary.source
         setup_e2e_bookends ${{ needs.setup.outputs.webserver }}
 
+    ##
+    # Enable coredumps for the apache e2e cell so a segfaulting worker
+    # (#12438) leaves a core the failure-diagnostics step can backtrace
+    # (#12439). Apache-only: the nginx stack runs php-fpm, which logs
+    # crashes to the container log instead.
+    - name: Enable coredumps
+      if: ${{ matrix.suite == 'e2e' && needs.setup.outputs.webserver == 'apache' }}
+      run: |
+        . ci/ciLibrary.source
+        enable_coredumps
+
     - name: Run ${{ matrix.suite }} tests
       run: |
         . ci/ciLibrary.source
@@ -698,6 +709,35 @@ jobs:
       with:
         name: selenium-diagnostics-${{ needs.setup.outputs.docker_dir }}
         path: ${{ runner.temp }}/selenium-diagnostics/
+        if-no-files-found: ignore
+
+    ##
+    # Crash diagnostics for the apache worker segfault (#12438/#12439). The
+    # `E2e container logs`/`E2e error logs` steps below only echo to the job
+    # log, which is truncated to the summary tail — so the openemr PHP/Apache
+    # log and any coredump are not recoverable from a failed run. Capture them
+    # into a downloadable artifact, with a gdb backtrace naming the faulting
+    # shared object. junit is already uploaded separately (see above).
+    - name: Capture crash diagnostics on failure
+      if: ${{ failure() && matrix.suite == 'e2e' && needs.setup.outputs.webserver == 'apache' }}
+      env:
+        CRASH_DIAG_DIR: ${{ runner.temp }}/crash-diagnostics
+      run: |
+        . ci/ciLibrary.source
+        mkdir -p "${CRASH_DIAG_DIR}"
+        # openemr container log (Apache core + AH00051 segfault lines).
+        dc logs --no-color openemr > "${CRASH_DIAG_DIR}/openemr.container.log" 2>&1 || true
+        # In-container Apache/PHP error log.
+        dump_error_log apache > "${CRASH_DIAG_DIR}/openemr.error.log" 2>&1 || true
+        # Backtrace + gzip'd core for each coredump produced this run.
+        capture_coredumps "${CRASH_DIAG_DIR}"
+
+    - name: Upload crash diagnostics
+      if: ${{ failure() && matrix.suite == 'e2e' && needs.setup.outputs.webserver == 'apache' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: crash-diagnostics-${{ needs.setup.outputs.docker_dir }}
+        path: ${{ runner.temp }}/crash-diagnostics/
         if-no-files-found: ignore
 
     ##

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -693,10 +693,10 @@ capture_coredumps() {
 
     # gdb + binutils give us `bt` and `info sharedlibrary`. Install inside the
     # container so symbol resolution uses the container's own libraries.
-    # shellcheck disable=SC2310  # install failure is non-fatal; we still upload raw cores
+    # shellcheck disable=SC2310  # install failure is non-fatal; backtrace is just skipped
     dc exec -T openemr sh -c \
         'command -v gdb >/dev/null 2>&1 || { (apk add --no-cache gdb 2>/dev/null) || { apt-get update -qq && apt-get install -y -qq gdb; }; }' \
-        || echo 'WARNING: gdb install failed; raw cores will still be uploaded.' >&2
+        || echo 'WARNING: gdb install failed; no backtrace will be produced. The raw core is retained in the container; set COREDUMP_MAX_MB > 0 to upload it for offline analysis.' >&2
 
     # The faulting process is an Apache worker (AH00051 in the job log).
     local exe

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -639,6 +639,100 @@ dump_error_log() {
 }
 
 ##
+# Directory inside the openemr container where coredumps are collected. The
+# kernel core_pattern (set by enable_coredumps) is interpreted within the
+# crashing process's mount namespace, so this is a container path. It is not
+# on the bind mount; cores are streamed out with `dc exec` in
+# capture_coredumps, so they never touch the repo working tree.
+readonly COREDUMP_DIR='/var/www/coredumps'
+
+##
+# Enable coredumps so a segfaulting Apache worker leaves a usable core
+# (issue #12438/#12439). Three things must line up:
+#   1. The container's core ulimit must be non-zero — set in
+#      ci/compose-shared-apache.yml (ulimits.core).
+#   2. kernel.core_pattern must be a plain path, not a pipe. The GitHub
+#      runner ships `|/usr/share/apport/apport ...`, which the kernel runs
+#      in the host namespace; the core never reaches the container. An
+#      absolute path pattern is instead resolved inside the crashing
+#      process's mount namespace, landing the core in the container.
+#   3. fs.suid_dumpable=2 — Apache children drop privileges from root to
+#      the web user, which clears the dumpable flag; mode 2 restores it
+#      (core owned by root, readable by root).
+# core_pattern is a kernel global shared with the container.
+enable_coredumps() {
+    # Create the in-container target up front so the kernel has somewhere to
+    # write the core. World-writable + sticky: Apache workers run as the
+    # unprivileged web user once privileges are dropped.
+    dc exec -T openemr sh -c "mkdir -p '${COREDUMP_DIR}' && chmod 1777 '${COREDUMP_DIR}'"
+    sudo sysctl -w "kernel.core_pattern=${COREDUMP_DIR}/core.%e.%p.%t"
+    sudo sysctl -w 'fs.suid_dumpable=2'
+}
+
+##
+# Backtrace every coredump collected in the openemr container and write the
+# results into the diagnostics directory passed as $1 (a host path). For each
+# core: a gdb text backtrace (naming the faulting shared object — the whole
+# point of #12439) plus the gzip'd raw core, capped so a multi-hundred-MB
+# core does not blow the artifact budget. No-op when no core was produced.
+capture_coredumps() {
+    local dest_dir=$1
+    local max_core_mb=${COREDUMP_MAX_MB:-300}
+    mkdir -p "${dest_dir}"
+
+    local cores
+    # shellcheck disable=SC2310  # missing-core is expected; || true drives the no-op branch
+    cores=$(dc exec -T openemr sh -c "ls -1 '${COREDUMP_DIR}'/core.* 2>/dev/null") || true
+    if [[ -z "${cores}" ]]; then
+        echo "No coredumps found in ${COREDUMP_DIR}." > "${dest_dir}/coredumps.none.txt"
+        return 0
+    fi
+
+    # gdb + binutils give us `bt` and `info sharedlibrary`. Install inside the
+    # container so symbol resolution uses the container's own libraries.
+    # shellcheck disable=SC2310  # install failure is non-fatal; we still upload raw cores
+    dc exec -T openemr sh -c \
+        'command -v gdb >/dev/null 2>&1 || { (apk add --no-cache gdb 2>/dev/null) || { apt-get update -qq && apt-get install -y -qq gdb; }; }' \
+        || echo 'WARNING: gdb install failed; raw cores will still be uploaded.' >&2
+
+    # The faulting process is an Apache worker (AH00051 in the job log).
+    local exe
+    # shellcheck disable=SC2310  # missing binary is tolerated; gdb auto-detects from the core
+    exe=$(dc exec -T openemr sh -c 'command -v apache2 httpd 2>/dev/null | head -n1') || true
+    exe=${exe%$'\r'}
+
+    local core base
+    while IFS= read -r core; do
+        [[ -n "${core}" ]] || continue
+        base=$(basename "${core}")
+        echo "Backtracing ${base} (exe=${exe:-auto})..."
+        local -a gdb_args=(
+            exec -T openemr gdb --batch --nx
+            -ex 'set pagination off'
+            -ex 'thread apply all bt full'
+            -ex 'info sharedlibrary'
+        )
+        [[ -n "${exe}" ]] && gdb_args+=("${exe}")
+        gdb_args+=("${core}")
+        # shellcheck disable=SC2310  # a gdb failure is logged, not fatal — keep processing cores
+        dc "${gdb_args[@]}" \
+            > "${dest_dir}/${base}.backtrace.txt" 2>&1 \
+            || echo "gdb failed for ${base}; see ${base}.backtrace.txt" >&2
+        # Stream the core out as gzip, but only if it is under the cap.
+        local size_mb
+        # shellcheck disable=SC2310  # du failure falls back to 0 (treat as under cap)
+        size_mb=$(dc exec -T openemr sh -c "du -m '${core}' | cut -f1") || size_mb=0
+        size_mb=${size_mb%$'\r'}
+        if (( size_mb <= max_core_mb )); then
+            dc exec -T openemr gzip -c "${core}" > "${dest_dir}/${base}.gz"
+        else
+            echo "Core ${base} is ${size_mb}MB (> ${max_core_mb}MB cap); raw core omitted, backtrace retained." \
+                > "${dest_dir}/${base}.gz.skipped.txt"
+        fi
+    done <<< "${cores}"
+}
+
+##
 # Use the testsuite to figure out which junit filename to use.
 # This could get ugly if there's a long comma-delimited list of testsuites,
 # but we usually have only one.

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -713,10 +713,14 @@ capture_coredumps() {
         [[ -n "${core}" ]] || continue
         base=$(basename "${core}")
         echo "Backtracing ${base} (exe=${exe:-auto})..."
+        # `bt` (not `bt full`): a stack-only trace names the faulting frames
+        # and `info sharedlibrary` the faulting .so without printing locals or
+        # function arguments, which can hold request data / credentials. This
+        # keeps the backtrace safe to publish in a public artifact.
         local -a gdb_args=(
             exec -T openemr gdb --batch --nx
             -ex 'set pagination off'
-            -ex 'thread apply all bt full'
+            -ex 'thread apply all bt'
             -ex 'info sharedlibrary'
         )
         [[ -n "${exe}" ]] && gdb_args+=("${exe}")
@@ -733,10 +737,17 @@ capture_coredumps() {
                 > "${dest_dir}/${base}.gz.skipped.txt"
             continue
         fi
-        local size_mb
-        # shellcheck disable=SC2310  # du failure falls back to 0 (treat as under cap)
-        size_mb=$(dc exec -T openemr sh -c "du -m '${core}' | cut -f1") || size_mb=0
+        # If size can't be determined, skip the raw-core upload rather than
+        # risk streaming an oversized core past the cap; backtrace is retained.
+        local size_mb=''
+        # shellcheck disable=SC2310  # du failure handled explicitly below
+        size_mb=$(dc exec -T openemr sh -c "du -m '${core}' | cut -f1") || size_mb=''
         size_mb=${size_mb%$'\r'}
+        if [[ -z "${size_mb}" ]]; then
+            echo "Could not determine size of ${base}; raw core omitted (cap cannot be enforced), backtrace retained." \
+                > "${dest_dir}/${base}.gz.skipped.txt"
+            continue
+        fi
         if (( size_mb > max_core_mb )); then
             echo "Core ${base} is ${size_mb}MB (> ${max_core_mb}MB cap); raw core omitted, backtrace retained." \
                 > "${dest_dir}/${base}.gz.skipped.txt"

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -644,7 +644,11 @@ dump_error_log() {
 # crashing process's mount namespace, so this is a container path. It is not
 # on the bind mount; cores are streamed out with `dc exec` in
 # capture_coredumps, so they never touch the repo working tree.
-readonly COREDUMP_DIR='/var/www/coredumps'
+# Assign-if-unset before marking readonly: ci/inferno/run.sh sources this
+# library several times in one shell, and a bare `readonly VAR=...` errors on
+# the second source.
+: "${COREDUMP_DIR:=/var/www/coredumps}"
+readonly COREDUMP_DIR
 
 ##
 # Enable coredumps so a segfaulting Apache worker leaves a usable core
@@ -733,10 +737,18 @@ capture_coredumps() {
         # shellcheck disable=SC2310  # du failure falls back to 0 (treat as under cap)
         size_mb=$(dc exec -T openemr sh -c "du -m '${core}' | cut -f1") || size_mb=0
         size_mb=${size_mb%$'\r'}
-        if (( size_mb <= max_core_mb )); then
-            dc exec -T openemr gzip -c "${core}" > "${dest_dir}/${base}.gz"
-        else
+        if (( size_mb > max_core_mb )); then
             echo "Core ${base} is ${size_mb}MB (> ${max_core_mb}MB cap); raw core omitted, backtrace retained." \
+                > "${dest_dir}/${base}.gz.skipped.txt"
+            continue
+        fi
+        # Best-effort like the gdb/du calls: a gzip/stream failure (missing
+        # gzip, permissions, disk) must not abort the loop and skip the
+        # remaining cores' backtraces.
+        # shellcheck disable=SC2310  # gzip failure is logged, not fatal — keep processing cores
+        if ! dc exec -T openemr gzip -c "${core}" > "${dest_dir}/${base}.gz"; then
+            rm -f "${dest_dir}/${base}.gz"
+            echo "gzip stream failed for ${base}; raw core omitted, backtrace retained." \
                 > "${dest_dir}/${base}.gz.skipped.txt"
         fi
     done <<< "${cores}"

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -691,8 +691,8 @@ capture_coredumps() {
         return 0
     fi
 
-    # gdb + binutils give us `bt` and `info sharedlibrary`. Install inside the
-    # container so symbol resolution uses the container's own libraries.
+    # gdb gives us `bt` and `info sharedlibrary`. Install inside the container
+    # so symbol resolution uses the container's own libraries.
     # shellcheck disable=SC2310  # install failure is non-fatal; backtrace is just skipped
     dc exec -T openemr sh -c \
         'command -v gdb >/dev/null 2>&1 || { (apk add --no-cache gdb 2>/dev/null) || { apt-get update -qq && apt-get install -y -qq gdb; }; }' \

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -672,12 +672,15 @@ enable_coredumps() {
 ##
 # Backtrace every coredump collected in the openemr container and write the
 # results into the diagnostics directory passed as $1 (a host path). For each
-# core: a gdb text backtrace (naming the faulting shared object — the whole
-# point of #12439) plus the gzip'd raw core, capped so a multi-hundred-MB
-# core does not blow the artifact budget. No-op when no core was produced.
+# core we always write a gdb text backtrace (naming the faulting shared
+# object — the whole point of #12439). The raw core is NOT uploaded by
+# default: it can hold in-memory secrets (session tokens, the sqlconf.php DB
+# password) and the artifact is downloadable on a public PR. Set
+# COREDUMP_MAX_MB > 0 to also stream out the gzip'd core when it is under that
+# size. No-op when no core was produced.
 capture_coredumps() {
     local dest_dir=$1
-    local max_core_mb=${COREDUMP_MAX_MB:-300}
+    local max_core_mb=${COREDUMP_MAX_MB:-0}
     mkdir -p "${dest_dir}"
 
     local cores
@@ -718,7 +721,14 @@ capture_coredumps() {
         dc "${gdb_args[@]}" \
             > "${dest_dir}/${base}.backtrace.txt" 2>&1 \
             || echo "gdb failed for ${base}; see ${base}.backtrace.txt" >&2
-        # Stream the core out as gzip, but only if it is under the cap.
+        # Raw core upload is opt-in (COREDUMP_MAX_MB > 0) and size-gated, since
+        # a core can contain in-memory secrets. The backtrace above is the
+        # default deliverable and is safe to publish.
+        if (( max_core_mb <= 0 )); then
+            echo "Raw core retained in the container only (COREDUMP_MAX_MB=0); backtrace uploaded. Set COREDUMP_MAX_MB > 0 to include the gzip'd core." \
+                > "${dest_dir}/${base}.gz.skipped.txt"
+            continue
+        fi
         local size_mb
         # shellcheck disable=SC2310  # du failure falls back to 0 (treat as under cap)
         size_mb=$(dc exec -T openemr sh -c "du -m '${core}' | cut -f1") || size_mb=0

--- a/ci/compose-shared-apache.yml
+++ b/ci/compose-shared-apache.yml
@@ -5,6 +5,14 @@ services:
     - 443:443
     volumes:
     - ../:/var/www/localhost/htdocs/openemr
+    # Allow the container to write coredumps when an Apache worker segfaults
+    # (issue #12438/#12439): the kernel will not dump a process whose core
+    # ulimit is 0. The on-failure CI diagnostics step extracts and backtraces
+    # any core found here to identify the faulting native extension.
+    ulimits:
+      core:
+        soft: -1
+        hard: -1
     environment:
       EMPTY: yes
       FORCE_NO_BUILD_MODE: yes


### PR DESCRIPTION
## Summary

When an apache e2e cell fails, the failure-diagnostics path uploaded the selenium log, `dmesg`, and `docker stats` — but not the openemr container's PHP/Apache log or any coredump. Root-causing the apache-worker segfault on the patient re-open path (#12438) meant watching the recorded session video frame by frame, because neither the openemr log nor a core was reachable from the downloadable artifact.

This adds coredump capture and log collection so the next segfault can be diagnosed from the artifact alone.

## Changes

- **`ci/compose-shared-apache.yml`** — set `ulimits.core` so the container is allowed to write a coredump when a worker crashes (the kernel will not dump a process whose core ulimit is 0).
- **`ci/ciLibrary.source`**
  - `enable_coredumps()` — sets a container-path `kernel.core_pattern` (the runner's default `|/usr/share/apport/...` pipe runs in the host namespace and never reaches the container) and `fs.suid_dumpable=2` (an Apache worker drops privileges from root to the web user, which otherwise clears the dumpable flag).
  - `capture_coredumps()` — installs `gdb` in the container, writes a `thread apply all bt full` + `info sharedlibrary` backtrace (naming the faulting shared object), and streams out the gzip'd core under a size cap. No-op when no core was produced.
- **`.github/workflows/test.yml`** — apache-e2e-only "Enable coredumps" step before the test run, plus a `failure()`-gated step that captures the openemr container log, the Apache/PHP error log, and the coredump backtrace/core into a new `crash-diagnostics-<docker_dir>` artifact. junit is already uploaded separately.

## Testing

Dispatched `apache_82_118` e2e three times on a fork; all passed, confirming the "Enable coredumps" step runs cleanly on the green path and the `failure()`-gated capture stays dormant when there is no crash. The capture path itself fires only on a failing e2e cell, which is the intermittent segfault this is meant to instrument.

Closes #12439. Unblocks root-causing #12438.
