### PR TITLE
chore(deps): pin express version range in ccdaservice lockfile

### DIFF
--- a/ccdaservice/package-lock.json
+++ b/ccdaservice/package-lock.json
@@ -4669,7 +4669,7 @@
                 "compression": "1.8.1",
                 "cqm-execution": "4.4.1",
                 "cqm-models": "4.3.1",
-                "express": "^4.22.2",
+                "express": "4.22.2",
                 "xpath": "0.0.34"
             },
             "devDependencies": {
@@ -4750,7 +4750,7 @@
                 "compression": "1.8.1",
                 "cqm-execution": "4.4.1",
                 "cqm-models": "4.3.1",
-                "express": "^4.22.2",
+                "express": "4.22.2",
                 "logform": "1.10.0",
                 "luxon": "1.28.1",
                 "oe-cqm-parsers": "openemr/oe-cqm-parsers#ecqm-v7.0.4",


### PR DESCRIPTION
## Summary

Remove the caret prefix from the two `express` entries in `ccdaservice/package-lock.json` so the lockfile pins to `4.22.2` exactly. Matches the devDependency-pinning convention reaffirmed in the gulp -> webpack migration (#11231).

The dev container's `npm postinstall` regenerates the lockfile in this form periodically; the committed file had drifted to `^4.22.2` and shows up as a noisy diff for anyone whose workflow spins up a dev container. Landing this once to resync.

## Diff

Two single-line edits in `ccdaservice/package-lock.json`:

```diff
-                "express": "^4.22.2",
+                "express": "4.22.2",
```

## Test plan

- [ ] CI green (ccdaservice tests still pass)