### PR TITLE
chore(docker): wall off webpack cache in dev-easy compose envs

### DIFF
--- a/docker/development-easy-light/docker-compose.yml
+++ b/docker/development-easy-light/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     - nodemodules:/var/www/localhost/htdocs/openemr/node_modules:rw
     - vendordir:/var/www/localhost/htdocs/openemr/vendor:rw
     - phpstanvolume:/var/www/localhost/htdocs/openemr/tmp-phpstan:rw
+    - webpackcachevolume:/var/www/localhost/htdocs/openemr/.webpack-cache:rw
     - ccdanodemodules:/var/www/localhost/htdocs/openemr/ccdaservice/node_modules:rw
     - ccdanodemodules2:/var/www/localhost/htdocs/openemr/ccdaservice/packages/oe-cqm-service/node_modules:rw
     - logvolume:/var/log
@@ -108,6 +109,7 @@ volumes:
   nodemodules: {}
   vendordir: {}
   phpstanvolume: {}
+  webpackcachevolume: {}
   ccdanodemodules: {}
   ccdanodemodules2: {}
   logvolume: {}

--- a/docker/development-easy-redis/docker-compose.yml
+++ b/docker/development-easy-redis/docker-compose.yml
@@ -143,6 +143,7 @@ services:
     - nodemodules:/var/www/localhost/htdocs/openemr/node_modules:rw
     - vendordir:/var/www/localhost/htdocs/openemr/vendor:rw
     - phpstanvolume:/var/www/localhost/htdocs/openemr/tmp-phpstan:rw
+    - webpackcachevolume:/var/www/localhost/htdocs/openemr/.webpack-cache:rw
     - ccdanodemodules:/var/www/localhost/htdocs/openemr/ccdaservice/node_modules:rw
     - ccdanodemodules2:/var/www/localhost/htdocs/openemr/ccdaservice/packages/oe-cqm-service/node_modules:rw
     - logvolume:/var/log
@@ -304,6 +305,7 @@ volumes:
   nodemodules: {}
   vendordir: {}
   phpstanvolume: {}
+  webpackcachevolume: {}
   ccdanodemodules: {}
   ccdanodemodules2: {}
   logvolume: {}

--- a/docker/development-easy/docker-compose.yml
+++ b/docker/development-easy/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     - nodemodules:/var/www/localhost/htdocs/openemr/node_modules:rw
     - vendordir:/var/www/localhost/htdocs/openemr/vendor:rw
     - phpstanvolume:/var/www/localhost/htdocs/openemr/tmp-phpstan:rw
+    - webpackcachevolume:/var/www/localhost/htdocs/openemr/.webpack-cache:rw
     - ccdanodemodules:/var/www/localhost/htdocs/openemr/ccdaservice/node_modules:rw
     - ccdanodemodules2:/var/www/localhost/htdocs/openemr/ccdaservice/packages/oe-cqm-service/node_modules:rw
     - logvolume:/var/log
@@ -191,6 +192,7 @@ volumes:
   nodemodules: {}
   vendordir: {}
   phpstanvolume: {}
+  webpackcachevolume: {}
   ccdanodemodules: {}
   ccdanodemodules2: {}
   logvolume: {}


### PR DESCRIPTION
## Summary

Followup to #11231 (gulp -> webpack migration). Adds a named `webpackcachevolume` to the three dev-easy compose envs so the webpack filesystem cache (written to `.webpack-cache/` at the repo root) stays inside a Docker volume rather than polluting the host repo via the bind mount.

Mirrors the existing `phpstanvolume` pattern that solved the same problem for `tmp-phpstan/`.

## Background

`webpack.themes.js` configures `cacheDirectory: path.resolve(__dirname, ".webpack-cache")`. In the dev-easy envs the host repo is bind-mounted rw to `/var/www/localhost/htdocs/openemr`, so without a named-volume override webpack writes its cache to the host. That's the same hazard `phpstanvolume` was added to mitigate for `tmp-phpstan/`. `development-insane/` uses a different layout and is out of scope here.

## Diff

Six lines across three files — one named-volume mount on the openemr service plus one named-volume declaration, applied symmetrically to each env:

- `docker/development-easy/docker-compose.yml`
- `docker/development-easy-light/docker-compose.yml`
- `docker/development-easy-redis/docker-compose.yml`

## Verification

- `docker compose -f docker-compose.yml config -q` passes on all three
- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- Pre-commit hooks pass clean (no auto-formatting needed; #12464 normalized dev-easy-redis ahead of this PR)

## Test plan

- [ ] Bring up `docker/development-easy/` stack, run `npm run build` inside the openemr container
- [ ] Confirm `.webpack-cache/` is empty on the host but populated inside the container (i.e., the named volume swallowed the writes)
- [ ] Repeat for `development-easy-light/` and `development-easy-redis/`