### PR TITLE
chore(deps): drop unused laminas-xmlrpc and confirm 8.5 resolution path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,6 @@
         "laminas/laminas-servicemanager": "^3.24.0",
         "laminas/laminas-soap": "^2.14.0",
         "laminas/laminas-stdlib": "^3.21.0",
-        "laminas/laminas-xmlrpc": "^2.22.0",
         "lcobucci/clock": "^2.3 || ^3.0",
         "lcobucci/jwt": "^4.3.0",
         "league/csv": "^9.28.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53a7022ca0a061323d26dc325aafa481",
+    "content-hash": "4aeb20672c221d27bff20a80c46a4898",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -4640,134 +4640,6 @@
                 }
             ],
             "time": "2025-10-13T13:07:56+00:00"
-        },
-        {
-            "name": "laminas/laminas-xml",
-            "version": "1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-xml.git",
-                "reference": "3a7850dec668a89807accfa4826a2ff11497fe74"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-xml/zipball/3a7850dec668a89807accfa4826a2ff11497fe74",
-                "reference": "3a7850dec668a89807accfa4826a2ff11497fe74",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-simplexml": "*",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "conflict": {
-                "zendframework/zendxml": "*"
-            },
-            "require-dev": {
-                "ext-iconv": "*",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "phpunit/phpunit": "^10.5.35 || ^11.4",
-                "squizlabs/php_codesniffer": "3.10.3 as 2.9999999.9999999"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Xml\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Utility library for XML usage, best practices, and security in PHP",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "security",
-                "xml"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-xml/issues",
-                "rss": "https://github.com/laminas/laminas-xml/releases.atom",
-                "source": "https://github.com/laminas/laminas-xml"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2024-10-11T08:45:59+00:00"
-        },
-        {
-            "name": "laminas/laminas-xmlrpc",
-            "version": "2.22.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-xmlrpc.git",
-                "reference": "f251670ce1b7add203a6cfd91d5e58a724cec27a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-xmlrpc/zipball/f251670ce1b7add203a6cfd91d5e58a724cec27a",
-                "reference": "f251670ce1b7add203a6cfd91d5e58a724cec27a",
-                "shasum": ""
-            },
-            "require": {
-                "brick/math": "^0.13.1",
-                "ext-simplexml": "*",
-                "laminas/laminas-code": "^4.4",
-                "laminas/laminas-http": "^2.15",
-                "laminas/laminas-server": "^2.11",
-                "laminas/laminas-stdlib": "^3.10.1",
-                "laminas/laminas-xml": "^1.4.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "conflict": {
-                "zendframework/zend-xmlrpc": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~3.1.0",
-                "phpunit/phpunit": "^10.5.36",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.26.1"
-            },
-            "suggest": {
-                "laminas/laminas-cache": "To support Laminas\\XmlRpc\\Server\\Cache usage"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\XmlRpc\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Fully-featured XML-RPC server and client implementations",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "xmlrpc"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-xmlrpc/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-xmlrpc/issues",
-                "rss": "https://github.com/laminas/laminas-xmlrpc/releases.atom",
-                "source": "https://github.com/laminas/laminas-xmlrpc"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-11-11T22:34:06+00:00"
         },
         {
             "name": "lcobucci/clock",


### PR DESCRIPTION
## Summary

- Removes the `laminas/laminas-xmlrpc` require — it has zero code usages across `src`, `library`, `interface`, and `modules`. Dropping it also removes its transitive `laminas/laminas-xml` from the lock.
- This clears every non-`laminas-mvc` blocker to installing on PHP 8.5. Under a temporary `config.platform.php` pin of `8.5`, the rest of the tree resolves cleanly: `lcobucci/clock` → `3.6.0` and `laminas/laminas-server` → `2.19.0` via the existing constraints, with no further `composer.json` changes.

## Compatibility

PHP 8.2 support is preserved. The committed `composer.json` keeps `config.platform.php` at `8.2` and the committed lock stays resolved at 8.2 (`lcobucci/clock` 3.3.1). The 8.5 platform pin used to verify resolution was local-only and reverted before committing.

After this change, the only true hard blockers to PHP 8.5 are `laminas-mvc` and `laminas-mvc-i18n`, which have no 8.5-compatible release and require an architecture change handled separately. (`laminas-router` and `lcobucci/clock` also appear in `why-not php 8.5.7` against the committed lock, but only because the 8.2-resolved lock pins them below their 8.5-compatible releases — both resolve forward under the 8.5 pin.)

Part of #11209 — resolves the four "resolved now" rows (drop `laminas-xmlrpc`, transitive `laminas-xml`, `laminas-router` forward-resolve, `lcobucci/clock` forward-resolve). The two upstream-blocked rows (`laminas-mvc`, `laminas-mvc-i18n`) are the EOL framework cluster that needs the `zend_modules` migration, so this PR does not close the issue.

## Test plan

- [x] `composer validate --strict` passes
- [x] `composer normalize --dry-run` reports already normalized
- [x] `composer require-checker` reports no unknown symbols (xmlrpc removal left no undeclared dependency)
- [x] `composer why-not php 8.2.0` clean (8.2 still installs)
- [x] Under a temporary 8.5 platform pin, the full non-mvc tree resolves (clock 3.6.0, server 2.19.0); pin reverted afterward
- [x] Committed artifacts remain at platform 8.2 (clock 3.3.1); `laminas-xmlrpc` and `laminas-xml` removed from the lock
