### PR TITLE
fix(ci): don't run sql_upgrade as root in Inferno test

### DIFF
--- a/ci/inferno/run.sh
+++ b/ci/inferno/run.sh
@@ -84,7 +84,7 @@ initialize_openemr() {
     "${HOME}/bin/openemr-cmd" pc inferno-files/files/resources/openemr-snapshots/2025-06-25-inferno-baseline.tgz
     "${HOME}/bin/openemr-cmd" rs 2025-06-25-inferno-baseline
     #  Snapshot is from 7.0.3; run migrations to create any new tables
-    docker compose exec -T openemr php "${OPENEMR_DIR}/sql_upgrade.php" --from=7.0.3
+    docker compose exec -T openemr run_php_as_apache php "${OPENEMR_DIR}/sql_upgrade.php" --from=7.0.3
     # (may need to configure api globals here)
     # Prevent password expiration from blocking OAuth password grant
     docker compose exec -T openemr mysql -u openemr --password=openemr -h mysql openemr \

--- a/ci/inferno/run.sh
+++ b/ci/inferno/run.sh
@@ -84,7 +84,7 @@ initialize_openemr() {
     "${HOME}/bin/openemr-cmd" pc inferno-files/files/resources/openemr-snapshots/2025-06-25-inferno-baseline.tgz
     "${HOME}/bin/openemr-cmd" rs 2025-06-25-inferno-baseline
     #  Snapshot is from 7.0.3; run migrations to create any new tables
-    docker compose exec -T openemr run_php_as_apache php "${OPENEMR_DIR}/sql_upgrade.php" --from=7.0.3
+    docker compose exec -T openemr su-exec apache php "${OPENEMR_DIR}/sql_upgrade.php" --from=7.0.3
     # (may need to configure api globals here)
     # Prevent password expiration from blocking OAuth password grant
     docker compose exec -T openemr mysql -u openemr --password=openemr -h mysql openemr \


### PR DESCRIPTION
#### Short description of what this changes or resolves:
Inferno tests are failing because of the newly-added root CLI guard.

#### Changes proposed in this pull request:
Updates the inferno CI script to run the SQL upgrade script as apache - see https://github.com/openemr/openemr-devops/pull/743

Note: the proper fix is really to have the dockerfile have `USER apache` or similar, but that has a whole bunch of other CI implications. There's other docker stuff in flight that would quickly supersede it.

#### Was an AI assistant used? Yes / No
Yes, badly. I redid its work 🙃 