### PR TITLE
fix(password): expired password warning not displaying

### DIFF
--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -467,7 +467,7 @@ $_tabs = $listSvc->getOptionsByListName('default_open_tabs', ['activity' => 1]);
 if ($is_expired) {
     //display the php file containing the password expiration message.
     array_unshift($_tabs, [
-        'notes' => "pwd_expires_alert.php?csrf_token_form=" . CsrfUtils::collectCsrfToken(session: $session),
+        'notes' => "interface/main/pwd_expires_alert.php?csrf_token_form=" . CsrfUtils::collectCsrfToken(session: $session),
         'id' => "adm",
         "label" => xl("Password Reset"),
     ]);

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,13 +10,14 @@ parameters:
   # Set tmpDir explicitly so we know what it is
   tmpDir: tmp-phpstan
   excludePaths:
+  # excluding for easy dev setups since ccdaservice is a path below
+  - ccdaservice/node_modules/*
   # oe-module-claimrev-connect is a Composer dependency
   # (claimrevolution/oe-module-claimrev-connect), relocated into this path by the
   # oe-module-installer-plugin during `composer install`. It is third-party code,
   # not maintained in this repo, so exclude it from analysis the same way vendor/
   # is excluded.
   - interface/modules/custom_modules/oe-module-claimrev-connect/*
-  - ccdaservice/node_modules/*
   paths:
   - Documentation
   - _rest_routes.inc.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,6 +16,7 @@ parameters:
   # not maintained in this repo, so exclude it from analysis the same way vendor/
   # is excluded.
   - interface/modules/custom_modules/oe-module-claimrev-connect/*
+  - ccdaservice/node_modules/*
   paths:
   - Documentation
   - _rest_routes.inc.php

--- a/tests/Tests/Isolated/Tabs/DefaultTabsFilterTest.php
+++ b/tests/Tests/Isolated/Tabs/DefaultTabsFilterTest.php
@@ -168,4 +168,28 @@ class DefaultTabsFilterTest extends TestCase
             $filter->filter($tabs, self::projectRoot()),
         );
     }
+
+    public function testPasswordExpirationTabSurvivesFilter(): void
+    {
+        $notes = 'interface/main/pwd_expires_alert.php';
+
+        self::assertFileExists(
+            self::projectRoot() . DIRECTORY_SEPARATOR . $notes,
+            'pwd_expires_alert.php is not where main_screen.php points it.'
+        );
+
+        // Legacy key shape, exactly as main_screen.php prepends it, with query string.
+        $tabs = [[
+            'id'    => 'adm',
+            'label' => 'Password Reset',
+            'notes' => $notes . '?csrf_token_form=dummy',
+        ]];
+
+        $result = (new DefaultTabsFilter())->filter($tabs, self::projectRoot());
+
+        self::assertCount(1, $result, 'Expiration tab dropped — notes path does not resolve under root.');
+        self::assertSame('adm', $result[0]['option_id']);          // normalized from 'id'
+        self::assertSame('Password Reset', $result[0]['title']);   // normalized from 'label'
+        self::assertStringStartsWith($notes, $result[0]['notes']); // notes preserved incl. query
+    }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
Password expiration warnings were not displaying.

#### Changes proposed in this pull request:
Display them.

Also something weird with `phpstan` had to add `ccdaservice/node_modules` to the exclude path since using easy dev prek.

```
------ ----------------------------------------------------------------------- 
  Line   ccdaservice/node_modules/flatted/php/flatted.php                       
 ------ ----------------------------------------------------------------------- 
  22     Property FlattedString::$value has no type specified.                  
         🪪  missingType.property                                               
  23     Method FlattedString::__construct() has parameter $value with no type  
         specified.                                                             
         🪪  missingType.parameter                                              
  31     Method Flatted::parse() has no return type specified.                  
         🪪  missingType.return                                                 
  31     Method Flatted::parse() has parameter $assoc with no type specified.   
         🪪  missingType.parameter                                              
  31     Method Flatted::parse() has parameter $depth with no type specified.   
         🪪  missingType.parameter                                              
  31     Method Flatted::parse() has parameter $json with no type specified.    
         🪪  missingType.parameter                                              
  31     Method Flatted::parse() has parameter $options with no type            
         specified.                                                             
         🪪  missingType.parameter                                              
  36     Parameter #1 $json of function json_decode expects string, mixed       
         given.                                                                 
         🪪  argument.type                                                      
  36     Parameter #2 $array of function array_map expects array, mixed given.  
         🪪  argument.type                                                      
  36     Parameter #2 $associative of function json_decode expects bool|null,   
         mixed given.                                                           
         🪪  argument.type                                                      
  36     Parameter #3 $depth of function json_decode expects int<1, max>,       
         mixed given.                                                           
         🪪  argument.type                                                      
  36     Parameter #4 $flags of function json_decode expects int, mixed given.  
         🪪  argument.type                                                      
  49     Method Flatted::stringify() has no return type specified.              
         🪪  missingType.return                                                 
  49     Method Flatted::stringify() has parameter $depth with no type          
         specified.                                                             
         🪪  missingType.parameter                                              
  49     Method Flatted::stringify() has parameter $options with no type        
         specified.                                                             
         🪪  missingType.parameter                                              
  49     Method Flatted::stringify() has parameter $value with no type          
         specified.                                                             
         🪪  missingType.parameter                                              
  55     Parameter #1 $value of function intval expects                         
         array|bool|float|GMP|int|resource|SimpleXMLElement|string|null, mixed  
         given.                                                                 
         🪪  argument.type                                                      
  56     Parameter #1 $value of function count expects array|Countable, mixed   
         given.                                                                 
         🪪  argument.type                                                      
  57     Cannot access offset int on mixed.                                     
         🪪  offsetAccess.nonOffsetAccessible                                   
  60     Parameter #2 $flags of function json_encode expects int, mixed given.  
         🪪  argument.type                                                      
  60     Parameter #3 $depth of function json_encode expects int<1, max>,       
         mixed given.                                                           
         🪪  argument.type                                                      
  64     Method Flatted::asString() has no return type specified.               
         🪪  missingType.return                                                 
  64     Method Flatted::asString() has parameter $value with no type           
         specified.                                                             
         🪪  missingType.parameter                                              
  64     Static method Flatted::asString() is unused.                           
         🪪  method.unused                                                      
  68     Method Flatted::index() has no return type specified.                  
         🪪  missingType.return                                                 
  68     Method Flatted::index() has parameter $input with no type specified.   
         🪪  missingType.parameter                                              
  68     Method Flatted::index() has parameter $known with no type specified.   
         🪪  missingType.parameter                                              
  68     Method Flatted::index() has parameter $value with no type specified.   
         🪪  missingType.parameter                                              
  69     Cannot access an offset on mixed.                                      
         🪪  offsetAccess.nonOffsetAccessible                                   
  70     Parameter #1 $value of function count expects array|Countable, mixed   
         given.                                                                 
         🪪  argument.type                                                      
  71     Cannot access an offset on mixed.                                      
         🪪  offsetAccess.nonOffsetAccessible                                   
  71     Cannot access property $key on mixed.                                  
         🪪  property.nonObject                                                 
  72     Cannot access an offset on mixed.                                      
         🪪  offsetAccess.nonOffsetAccessible                                   
  72     Cannot access property $value on mixed.                                
         🪪  property.nonObject                                                 
  76     Method Flatted::keys() has no return type specified.                   
         🪪  missingType.return                                                 
  76     Method Flatted::keys() has parameter $value with no type specified.    
         🪪  missingType.parameter                                              
  77     Parameter #1 $object of class ReflectionObject constructor expects     
         object, mixed given.                                                   
         🪪  argument.type                                                      
  85     Method Flatted::loop() has no return type specified.                   
         🪪  missingType.return                                                 
  85     Method Flatted::loop() has parameter $input with no type specified.    
         🪪  missingType.parameter                                              
  85     Method Flatted::loop() has parameter $keys with no type specified.     
         🪪  missingType.parameter                                              
  85     Method Flatted::loop() has parameter $obj with no type specified.      
         🪪  missingType.parameter                                              
  85     Method Flatted::loop() has parameter $output with no type specified.   
         🪪  missingType.parameter                                              
  85     Method Flatted::loop() has parameter $set with no type specified.      
         🪪  missingType.parameter                                              
  86     Argument of an invalid type mixed supplied for foreach, only           
         iterables are supported.                                               
         🪪  foreach.nonIterable                                                
  87     Cannot access offset mixed on mixed.                                   
         🪪  offsetAccess.nonOffsetAccessible                                   
  89     Cannot access offset mixed on mixed.                                   
         🪪  offsetAccess.nonOffsetAccessible                                   
  94     Method Flatted::relate() has no return type specified.                 
         🪪  missingType.return                                                 
  94     Method Flatted::relate() has parameter $input with no type specified.  
         🪪  missingType.parameter                                              
  94     Method Flatted::relate() has parameter $known with no type specified.  
         🪪  missingType.parameter                                              
  94     Method Flatted::relate() has parameter $value with no type specified.  
         🪪  missingType.parameter                                              
  96     Cannot access property $key on mixed.                                  
         🪪  property.nonObject                                                 
  96     Parameter #2 $haystack of function array_search expects array, mixed   
         given.                                                                 
         🪪  argument.type                                                      
  98     Cannot access offset int|string on mixed.                              
         🪪  offsetAccess.nonOffsetAccessible                                   
  98     Cannot access property $value on mixed.                                
         🪪  property.nonObject                                                 
  104    Method Flatted::ref() has no return type specified.                    
         🪪  missingType.return                                                 
  104    Method Flatted::ref() has parameter $input with no type specified.     
         🪪  missingType.parameter                                              
  104    Method Flatted::ref() has parameter $key with no type specified.       
         🪪  missingType.parameter                                              
  104    Method Flatted::ref() has parameter $obj with no type specified.       
         🪪  missingType.parameter                                              
  104    Method Flatted::ref() has parameter $output with no type specified.    
         🪪  missingType.parameter                                              
  104    Method Flatted::ref() has parameter $set with no type specified.       
         🪪  missingType.parameter                                              
  104    Method Flatted::ref() has parameter $value with no type specified.     
         🪪  missingType.parameter                                              
  105    Parameter #2 $haystack of function in_array expects array, mixed       
         given.                                                                 
         🪪  argument.type                                                      
  106    Cannot access an offset on mixed.                                      
         🪪  offsetAccess.nonOffsetAccessible                                   
  109    Parameter #2 $haystack of function in_array expects array, mixed       
         given.                                                                 
         🪪  argument.type                                                      
  110    Cannot access an offset on mixed.                                      
         🪪  offsetAccess.nonOffsetAccessible                                   
  117    Cannot access offset mixed on mixed.                                   
         🪪  offsetAccess.nonOffsetAccessible                                   
  121    Method Flatted::transform() has no return type specified.              
         🪪  missingType.return                                                 
  121    Method Flatted::transform() has parameter $input with no type          
         specified.                                                             
         🪪  missingType.parameter                                              
  121    Method Flatted::transform() has parameter $known with no type          
         specified.                                                             
         🪪  missingType.parameter                                              
  121    Method Flatted::transform() has parameter $value with no type          
         specified.                                                             
         🪪  missingType.parameter                                              
  133    Argument of an invalid type mixed supplied for foreach, only           
         iterables are supported.                                               
         🪪  foreach.nonIterable                                                
  140    Method Flatted::wrap() has no return type specified.                   
         🪪  missingType.return                                                 
  140    Method Flatted::wrap() has parameter $value with no type specified.    
         🪪  missingType.parameter                                              
  140    Static method Flatted::wrap() is unused.                               
         🪪  method.unused                                                      
  149    Argument of an invalid type mixed supplied for foreach, only           
         iterables are supported.                                               
         🪪  foreach.nonIterable                                                
 ------ ----------------------------------------------------------------------- 


 [ERROR] Found 75 errors                                                        
```

#### Was an AI assistant used? Yes consulted with claude.ai.

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
