### PR TITLE
feat(faxsms): encrypt unassigned inbound faxes at rest

### DIFF
--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -858,7 +858,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 9,
+    'count' => 7,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1228,7 +1228,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 12,
+    'count' => 11,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/FaxDocumentService.php',
 ];
 $ignoreErrors[] = [
@@ -1238,7 +1238,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 33,
+    'count' => 31,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/FaxDocumentService.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/FaxDocumentService.php
@@ -15,6 +15,7 @@ namespace OpenEMR\Modules\FaxSMS\Controller;
 
 use Document;
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Crypto\CryptoGenException;
 use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -23,6 +24,8 @@ use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Exception\FaxDocumentException;
 use OpenEMR\Modules\FaxSMS\Exception\FaxNotFoundException;
 use OpenEMR\Services\PhoneNumberService;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
 
 class FaxDocumentService
 {
@@ -176,9 +179,13 @@ class FaxDocumentService
             // legacy plaintext files left on disk before this change.
             $raw = file_get_contents($mediaPath);
             if ($raw === false) {
-                throw new FaxDocumentException("Failed to read fax media file: {$mediaPath}");
+                throw new FaxDocumentException("Failed to read fax media file");
             }
-            $mediaContent = $this->crypto->decryptFromFilesystem($raw);
+            try {
+                $mediaContent = $this->crypto->decryptFromFilesystem($raw);
+            } catch (CryptoGenException $e) {
+                throw new FaxDocumentException("Failed to decrypt fax media file", 0, $e);
+            }
             $details = json_decode($fax['details_json'] ?? '{}', true);
             $fromNumber = $details['from'] ?? $fax['calling_number'] ?? 'Unknown';
 
@@ -200,9 +207,18 @@ class FaxDocumentService
                 [$patientId, $result['document_id'], $result['media_path'], $faxSid, $this->siteId]
             );
 
-            // Delete old unassigned file; existence was verified above and
-            // nothing on this branch touches the path between.
-            unlink($mediaPath);
+            // Delete old unassigned file. Symfony Filesystem swallows the
+            // benign race where another process unlinked it first; a real
+            // permission failure still surfaces as IOException, which we log
+            // and continue from since the patient document is already saved.
+            try {
+                (new Filesystem())->remove($mediaPath);
+            } catch (IOException $e) {
+                ServiceContainer::getLogger()->warning(
+                    'Failed to remove unassigned fax file after patient assignment',
+                    ['exception' => $e, 'media_path' => $mediaPath]
+                );
+            }
 
             error_log("FaxDocumentService: Assigned fax {$faxSid} to patient {$patientId}");
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/FaxDocumentService.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/FaxDocumentService.php
@@ -14,6 +14,8 @@
 namespace OpenEMR\Modules\FaxSMS\Controller;
 
 use Document;
+use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Utils\FileUtils;
@@ -27,6 +29,7 @@ class FaxDocumentService
     private readonly string $siteId;
     private readonly string $sitePath;
     private readonly string $receivedFaxesPath;
+    private readonly CryptoInterface $crypto;
 
     public function __construct(?string $siteId = null)
     {
@@ -35,6 +38,7 @@ class FaxDocumentService
         $this->siteId = $siteId ?? $session->get('site_id');
         $this->sitePath = $globals->get('OE_SITE_DIR') ?? ($globals->get('OE_SITES_BASE') . '/' . $this->siteId);
         $this->receivedFaxesPath = $this->sitePath . '/documents/received_faxes';
+        $this->crypto = ServiceContainer::getCrypto();
 
         // Ensure received faxes directory exists
         if (!file_exists($this->receivedFaxesPath)) {
@@ -113,9 +117,12 @@ class FaxDocumentService
                     'patient_id' => $patientId
                 ];
             } else {
-                // Store in unassigned directory
+                // Store in unassigned directory, honoring the drive_encryption
+                // global the same way Document::createDocument does for the
+                // patient-matched branch above. encryptForFilesystem is a
+                // no-op when drive_encryption is off.
                 $mediaPath = $this->receivedFaxesPath . '/unassigned/' . $filename;
-                file_put_contents($mediaPath, $mediaContent);
+                file_put_contents($mediaPath, $this->crypto->encryptForFilesystem($mediaContent));
 
                 error_log("FaxDocumentService: Stored unassigned fax {$faxSid} at {$mediaPath}");
 
@@ -159,19 +166,28 @@ class FaxDocumentService
             }
 
             // Read the file from unassigned directory
-            $mediaPath = $fax['media_path'];
-            if (empty($mediaPath) || !file_exists($mediaPath)) {
+            $mediaPath = $fax['media_path'] ?? '';
+            if (!is_string($mediaPath) || $mediaPath === '' || !file_exists($mediaPath)) {
                 throw new FaxDocumentException("Fax media file not found: {$mediaPath}");
             }
 
-            $mediaContent = file_get_contents($mediaPath);
+            // decryptFromFilesystem checks for an encryption-version prefix
+            // and returns the value unchanged if absent, so this is safe for
+            // legacy plaintext files left on disk before this change.
+            $raw = file_get_contents($mediaPath);
+            if ($raw === false) {
+                throw new FaxDocumentException("Failed to read fax media file: {$mediaPath}");
+            }
+            $mediaContent = $this->crypto->decryptFromFilesystem($raw);
             $details = json_decode($fax['details_json'] ?? '{}', true);
             $fromNumber = $details['from'] ?? $fax['calling_number'] ?? 'Unknown';
 
-            // Determine mime type from file
-            $finfo = finfo_open(FILEINFO_MIME_TYPE);
-            $mimeType = finfo_file($finfo, $mediaPath);
-            finfo_close($finfo);
+            // Determine mime type from the decrypted bytes — finfo on the
+            // file path would inspect the encrypted blob.
+            $mimeType = (new \finfo(FILEINFO_MIME_TYPE))->buffer($mediaContent);
+            if ($mimeType === false) {
+                throw new FaxDocumentException("Failed to detect MIME type for fax media");
+            }
 
             // Store as patient document
             $result = $this->storeFaxDocument($faxSid, $mediaContent, $fromNumber, $patientId, $mimeType);
@@ -184,10 +200,9 @@ class FaxDocumentService
                 [$patientId, $result['document_id'], $result['media_path'], $faxSid, $this->siteId]
             );
 
-            // Delete old unassigned file
-            if (file_exists($mediaPath)) {
-                unlink($mediaPath);
-            }
+            // Delete old unassigned file; existence was verified above and
+            // nothing on this branch touches the path between.
+            unlink($mediaPath);
 
             error_log("FaxDocumentService: Assigned fax {$faxSid} to patient {$patientId}");
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
@@ -502,19 +502,27 @@ class SignalWireClient extends AppDispatch
         }
 
         $mediaPath = $fax['media_path'] ?? '';
-        if (empty($mediaPath) || !file_exists($mediaPath)) {
+        if (!is_string($mediaPath) || $mediaPath === '' || !file_exists($mediaPath)) {
             http_response_code(404);
             die(xlt('Fax file not found'));
         }
 
-        // Send file for inline viewing
-        $filename = basename((string) $mediaPath);
+        // Decrypt the staged unassigned fax. decryptFromFilesystem returns
+        // legacy plaintext files unchanged via its version-prefix check, so
+        // this is safe for files written before drive-encrypted staging.
+        $raw = file_get_contents($mediaPath);
+        if ($raw === false) {
+            http_response_code(500);
+            die(xlt('Failed to read fax file'));
+        }
+        $payload  = $this->crypto->decryptFromFilesystem($raw);
+        $filename = basename($mediaPath);
         header('Content-Type: application/pdf');
         header('Content-Disposition: inline; filename="' . $filename . '"');
-        header('Content-Length: ' . filesize($mediaPath));
+        header('Content-Length: ' . strlen($payload));
         header('Cache-Control: no-cache, must-revalidate');
         header('Pragma: public');
-        readfile($mediaPath);
+        echo $payload;
         exit;
     }
 
@@ -550,19 +558,27 @@ class SignalWireClient extends AppDispatch
         }
 
         $mediaPath = $fax['media_path'] ?? '';
-        if (empty($mediaPath) || !file_exists($mediaPath)) {
+        if (!is_string($mediaPath) || $mediaPath === '' || !file_exists($mediaPath)) {
             http_response_code(404);
             die(xlt('Fax file not found'));
         }
 
-        // Send file as download
-        $filename = basename((string) $mediaPath);
+        // Decrypt the staged unassigned fax. decryptFromFilesystem returns
+        // legacy plaintext files unchanged via its version-prefix check, so
+        // this is safe for files written before drive-encrypted staging.
+        $raw = file_get_contents($mediaPath);
+        if ($raw === false) {
+            http_response_code(500);
+            die(xlt('Failed to read fax file'));
+        }
+        $payload  = $this->crypto->decryptFromFilesystem($raw);
+        $filename = basename($mediaPath);
         header('Content-Type: application/pdf');
         header('Content-Disposition: attachment; filename="' . $filename . '"');
-        header('Content-Length: ' . filesize($mediaPath));
+        header('Content-Length: ' . strlen($payload));
         header('Cache-Control: no-cache, must-revalidate');
         header('Pragma: public');
-        readfile($mediaPath);
+        echo $payload;
         exit;
     }
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
@@ -16,6 +16,7 @@ use Document;
 use Exception;
 use MyMailer;
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Crypto\CryptoGenException;
 use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -515,7 +516,19 @@ class SignalWireClient extends AppDispatch
             http_response_code(500);
             die(xlt('Failed to read fax file'));
         }
-        $payload  = $this->crypto->decryptFromFilesystem($raw);
+        $payload = null;
+        try {
+            $payload = $this->crypto->decryptFromFilesystem($raw);
+        } catch (CryptoGenException $e) {
+            ServiceContainer::getLogger()->error(
+                'SignalWire viewFaxPdf decrypt failed',
+                ['exception' => $e]
+            );
+        }
+        if ($payload === null) {
+            http_response_code(500);
+            die(xlt('Failed to decrypt fax file'));
+        }
         $filename = basename($mediaPath);
         header('Content-Type: application/pdf');
         header('Content-Disposition: inline; filename="' . $filename . '"');
@@ -571,7 +584,19 @@ class SignalWireClient extends AppDispatch
             http_response_code(500);
             die(xlt('Failed to read fax file'));
         }
-        $payload  = $this->crypto->decryptFromFilesystem($raw);
+        $payload = null;
+        try {
+            $payload = $this->crypto->decryptFromFilesystem($raw);
+        } catch (CryptoGenException $e) {
+            ServiceContainer::getLogger()->error(
+                'SignalWire download decrypt failed',
+                ['exception' => $e]
+            );
+        }
+        if ($payload === null) {
+            http_response_code(500);
+            die(xlt('Failed to decrypt fax file'));
+        }
         $filename = basename($mediaPath);
         header('Content-Type: application/pdf');
         header('Content-Disposition: attachment; filename="' . $filename . '"');


### PR DESCRIPTION
## Summary

When the SignalWire fax provider receives an inbound fax it cannot auto-match to a patient, the module currently stages the raw PDF under `sites/<site>/documents/received_faxes/unassigned/`. The patient-matched branch in the same `storeFaxDocument` method already routes through the `Document` class `createDocument` call, which honors the `drive_encryption` global; this PR extends the same encryption-at-rest behavior to the unassigned branch.

- The unassigned write in `FaxDocumentService::storeFaxDocument` wraps the bytes via `encryptForFilesystem` before writing the file.
- The read paths — `FaxDocumentService::assignFaxToPatient` and the SignalWire controller's `viewFaxPdf` / `download` endpoints — decrypt via `decryptFromFilesystem`.
- With `drive_encryption` off, `encryptForFilesystem` is a no-op, so behavior is unchanged.
- Legacy plaintext files left on disk from before this change are detected by `cryptCheckStandard` and returned unchanged, so no data migration is required.
- MIME detection in `assignFaxToPatient` now inspects the decrypted buffer rather than the file path (which would have read the encrypted blob after the write change).
- Stale entries cleaned up in `.phpstan/baseline/` for the two touched files (`$mediaPath` narrowed via `is_string()` at source, eliminating several `mixed` warnings; readfile entries removed since the streaming now goes through the crypto helper).

EtherFax and RingCentral inbound paths are unaffected — they don't go through this unassigned-on-disk staging.

## Test plan

- [ ] With `drive_encryption` on: send an unassigned inbound fax via SignalWire webhook, confirm the on-disk file under `sites/<site>/documents/received_faxes/unassigned/` is ciphertext (not a recognizable PDF header)
- [ ] With `drive_encryption` on: view the unassigned fax via the queue UI's "View" and "Download" buttons, confirm the PDF renders / downloads correctly
- [ ] Assign that unassigned fax to a patient, confirm the resulting patient document opens correctly through the standard Documents UI
- [ ] With `drive_encryption` off: confirm the same flows work and on-disk files remain plaintext
- [ ] Legacy compatibility: drop a known plaintext file into `sites/<site>/documents/received_faxes/unassigned/`, point an existing queue row at it, and confirm view/download/assign all still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)