### PR TITLE
feat(faxsms): encrypt staged fax upload files at rest

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -4293,7 +4293,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 7,
+    'count' => 8,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -4438,7 +4438,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 12,
+    'count' => 13,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
@@ -4503,7 +4503,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 4,
+    'count' => 5,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -4252,11 +4252,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' UTC\' results in an error\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
@@ -4283,7 +4278,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 7,
+    'count' => 6,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -4373,7 +4368,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
@@ -4418,7 +4413,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 12,
+    'count' => 11,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
@@ -4443,7 +4438,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [
@@ -4473,7 +4468,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [
@@ -4550,6 +4545,16 @@ $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\-" between mixed and int results in an error\\.$#',

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -4262,16 +4262,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/send\' results in an error\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/send/\' results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'T00\\:00\\:01\' results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
@@ -4293,7 +4283,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 8,
+    'count' => 7,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -4388,22 +4378,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'/\'\\|\'\\\\\\\\\' results in an error\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'/documents/logs_and…\' results in an error\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/send\' results in an error\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/send/\' results in an error\\.$#',
-    'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
@@ -4438,12 +4418,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 13,
+    'count' => 12,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'SignalWireClient…\' and mixed results in an error\\.$#',
-    'count' => 6,
+    'count' => 5,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [
@@ -4477,16 +4457,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/received_faxes\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/send\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'T00\\:00\\:01\' results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
@@ -4503,7 +4473,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 5,
+    'count' => 4,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -818,7 +818,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 25,
+    'count' => 24,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -828,12 +828,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 24,
+    'count' => 23,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 9,
+    'count' => 8,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -818,7 +818,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 24,
+    'count' => 23,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -828,12 +828,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 23,
+    'count' => 24,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 8,
+    'count' => 6,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [
@@ -850,6 +850,11 @@ $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 6,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot cast mixed to string\\.$#',
+    'count' => 2,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -818,7 +818,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 23,
+    'count' => 25,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -833,7 +833,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 7,
+    'count' => 9,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1193,7 +1193,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 22,
+    'count' => 23,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -1208,7 +1208,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 31,
+    'count' => 32,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1193,7 +1193,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 23,
+    'count' => 22,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -1208,7 +1208,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 32,
+    'count' => 31,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1193,7 +1193,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 22,
+    'count' => 23,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -1203,12 +1203,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 23,
+    'count' => 22,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 31,
+    'count' => 32,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.variable.php
+++ b/.phpstan/baseline/empty.variable.php
@@ -107,11 +107,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$content in empty\\(\\) is never defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$responseMsgs in empty\\(\\) always exists and is not falsy\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php',

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -1157,11 +1157,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$faxStoreDir \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$documentId \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/FaxDocumentService.php',

--- a/.phpstan/baseline/loader.php
+++ b/.phpstan/baseline/loader.php
@@ -96,6 +96,7 @@ return ['includes' => [
     __DIR__ . '/notIdentical.alwaysFalse.php',
     __DIR__ . '/notIdentical.alwaysTrue.php',
     __DIR__ . '/nullCoalesce.expr.php',
+    __DIR__ . '/nullCoalesce.initializedProperty.php',
     __DIR__ . '/nullCoalesce.offset.php',
     __DIR__ . '/nullCoalesce.property.php',
     __DIR__ . '/nullCoalesce.variable.php',

--- a/.phpstan/baseline/method.nameCase.php
+++ b/.phpstan/baseline/method.nameCase.php
@@ -227,84 +227,34 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:addAddress\\(\\) with incorrect case\\: AddAddress$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:addAttachment\\(\\) with incorrect case\\: AddAttachment$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:addReplyTo\\(\\) with incorrect case\\: AddReplyTo$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:send\\(\\) with incorrect case\\: Send$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:setFrom\\(\\) with incorrect case\\: SetFrom$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:addAddress\\(\\) with incorrect case\\: AddAddress$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:addAttachment\\(\\) with incorrect case\\: AddAttachment$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:addReplyTo\\(\\) with incorrect case\\: AddReplyTo$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:send\\(\\) with incorrect case\\: Send$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:setFrom\\(\\) with incorrect case\\: SetFrom$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:addAddress\\(\\) with incorrect case\\: AddAddress$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:addAttachment\\(\\) with incorrect case\\: AddAttachment$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:addReplyTo\\(\\) with incorrect case\\: AddReplyTo$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:send\\(\\) with incorrect case\\: Send$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:setFrom\\(\\) with incorrect case\\: SetFrom$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:send\\(\\) with incorrect case\\: Send$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:addAddress\\(\\) with incorrect case\\: AddAddress$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:addAttachment\\(\\) with incorrect case\\: AddAttachment$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:addReplyTo\\(\\) with incorrect case\\: AddReplyTo$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:send\\(\\) with incorrect case\\: Send$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Call to method PHPMailer\\\\PHPMailer\\\\PHPMailer\\:\\:setFrom\\(\\) with incorrect case\\: SetFrom$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to method OpenEMR\\\\Modules\\\\WenoModule\\\\Services\\\\TransmitProperties\\:\\:getWenoProviderId\\(\\) with incorrect case\\: getWenoProviderID$#',

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -932,11 +932,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\:\\:emailDocument\\(\\) has parameter \\$user with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\:\\:fetchFaxQueue\\(\\) return type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
@@ -972,11 +967,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\:\\:emailDocument\\(\\) has parameter \\$user with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\:\\:generateActionLinks\\(\\) return type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
@@ -1008,11 +998,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\SignalWireClient\\:\\:authenticate\\(\\) has parameter \\$acl with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\SignalWireClient\\:\\:emailDocument\\(\\) has parameter \\$user with no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
@@ -1060,6 +1045,16 @@ $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Events\\\\NotificationEventListener\\:\\:getRCCredentials\\(\\) return type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Service\\\\FaxMailer\\:\\:mailUploadedDocument\\(\\) has parameter \\$user with no value type specified in iterable type array\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Service\\\\FaxMailer\\:\\:send\\(\\) has parameter \\$user with no value type specified in iterable type array\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^PHPDoc tag @var for variable \\$module has no value type specified in iterable type array\\.$#',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -8487,21 +8487,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\:\\:emailDocument\\(\\) has parameter \\$body with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\:\\:emailDocument\\(\\) has parameter \\$email with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\:\\:emailDocument\\(\\) has parameter \\$file with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\:\\:fetchFaxFromQueue\\(\\) has parameter \\$id with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
@@ -8663,21 +8648,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\:\\:chartFaxDocument\\(\\) has parameter \\$pid with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\:\\:emailDocument\\(\\) has parameter \\$body with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\:\\:emailDocument\\(\\) has parameter \\$email with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\:\\:emailDocument\\(\\) has parameter \\$file with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];

--- a/.phpstan/baseline/missingType.property.php
+++ b/.phpstan/baseline/missingType.property.php
@@ -1557,11 +1557,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\:\\:\\$baseDir has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\:\\:\\$credentials has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
@@ -1588,11 +1583,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\:\\:\\$apiService has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\:\\:\\$baseDir has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
@@ -1643,11 +1633,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\SignalWireClient\\:\\:\\$apiToken has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\SignalWireClient\\:\\:\\$baseDir has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];

--- a/.phpstan/baseline/nullCoalesce.initializedProperty.php
+++ b/.phpstan/baseline/nullCoalesce.initializedProperty.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+    'message' => '#^Property OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\SignalWireClient\\:\\:\\$baseDir on left side of \\?\\? is not nullable nor uninitialized\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -14157,11 +14157,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'error\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'facility\' on array\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
@@ -14188,11 +14183,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'message\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'name\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
@@ -14224,11 +14214,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'phone\' on mixed\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'tmp_name\' on mixed\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -14277,11 +14262,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'error\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'expire_time\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
@@ -14317,11 +14297,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'name\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'phone\' on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
@@ -14334,11 +14309,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'smsNumber\' on mixed\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'tmp_name\' on mixed\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
@@ -14362,17 +14332,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'error\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'fax_number\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'name\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
@@ -14393,11 +14353,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'status\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'tmp_name\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenErrorLog.php
+++ b/.phpstan/baseline/openemr.forbiddenErrorLog.php
@@ -73,7 +73,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 8,
+    'count' => 6,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -83,12 +83,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 6,
+    'count' => 4,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 54,
+    'count' => 52,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenErrorLog.php
+++ b/.phpstan/baseline/openemr.forbiddenErrorLog.php
@@ -73,7 +73,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 10,
+    'count' => 8,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -83,12 +83,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 8,
+    'count' => 6,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 56,
+    'count' => 54,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenErrorLog.php
+++ b/.phpstan/baseline/openemr.forbiddenErrorLog.php
@@ -73,7 +73,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 9,
+    'count' => 10,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -83,12 +83,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 7,
+    'count' => 8,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 55,
+    'count' => 56,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -1998,7 +1998,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_FILES is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -2008,7 +2008,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_FILES is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
@@ -2023,7 +2023,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_FILES is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
@@ -166,7 +166,10 @@ class EtherFaxActions extends AppDispatch
             default => null,
         };
         if ($ext === null) {
-            error_log('Error: unsupported fax upload content type.');
+            ServiceContainer::getLogger()->warning(
+                'Unsupported fax upload content type',
+                ['mime' => $mime]
+            );
             return '';
         }
 
@@ -193,11 +196,31 @@ class EtherFaxActions extends AppDispatch
             return '';
         }
         if (file_put_contents($filepath, $this->crypto->encryptForFilesystem($content)) === false) {
-            error_log('Error: Failed to store uploaded fax.');
+            ServiceContainer::getLogger()->error(
+                'Failed to store uploaded fax',
+                ['filepath' => $filepath]
+            );
             return '';
         }
 
         return $filepath;
+    }
+
+    /**
+     * True if a path matches the on-disk shape faxProcessUploads creates
+     * (sanitized basename, 8-char hex suffix, fax-safe extension). Used to
+     * scope cleanup to files this controller staged rather than files
+     * caller code wrote into the same directory.
+     *
+     * @param string $path
+     * @return bool
+     */
+    private static function isStagedUploadPath(string $path): bool
+    {
+        return preg_match(
+            '/^[A-Za-z0-9_.-]+_[a-f0-9]{8}\\.(pdf|tiff|jpg|png|txt)$/',
+            basename($path)
+        ) === 1;
     }
 
     /**
@@ -255,11 +278,20 @@ class EtherFaxActions extends AppDispatch
 
         // faxProcessUploads stores the staged file via encryptForFilesystem.
         // Read it once, decrypt to memory, and hand off content (not the
-        // encrypted path) to downstream consumers. decryptFromFilesystem
-        // returns legacy plaintext unchanged via its version-prefix check,
-        // so files staged before this change remain readable.
+        // encrypted path) to downstream consumers. The pattern guard
+        // scopes cleanup to files this PR's faxProcessUploads created so
+        // callers that manage their own temp files aren't disrupted.
+        // decryptFromFilesystem returns legacy plaintext unchanged via its
+        // version-prefix check, so files staged before this change remain
+        // readable.
         $stagedPath = null;
-        if (empty($isContent) && !$isDocuments && is_string($file) && is_file($file)) {
+        if (
+            empty($isContent)
+            && !$isDocuments
+            && is_string($file)
+            && is_file($file)
+            && self::isStagedUploadPath($file)
+        ) {
             $raw = file_get_contents($file);
             if ($raw === false) {
                 return xlt('Error: Failed to read fax content');

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
@@ -22,6 +22,8 @@ use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\EtherFax\EtherFaxClient;
 use OpenEMR\Modules\FaxSMS\EtherFax\FaxResult;
 use OpenEMR\Services\ImageUtilities\HandleImageService;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
 
 class EtherFaxActions extends AppDispatch
 {
@@ -145,19 +147,53 @@ class EtherFaxActions extends AppDispatch
             return '';
         }
 
-        $name = basename((string)$_FILES['fax']['name']);
-        $tmp_name = $_FILES['fax']['tmp_name'];
-        $targetDir = $this->baseDir . '/send';
-
-        if (!file_exists($targetDir) && !mkdir($targetDir, 0777, true)) {
-            error_log('Error: Failed to create directory.');
+        $tmpName = $_FILES['fax']['tmp_name'];
+        if (!is_string($tmpName)) {
             return '';
         }
 
-        $filepath = $targetDir . "/" . $name;
+        // MIME filter on the actual upload bytes — reject anything that
+        // isn't a fax-safe content type so an attacker-chosen extension
+        // (e.g. .php, .phtml, .htaccess) can never land on disk under
+        // the staged path.
+        $mime = mime_content_type($tmpName);
+        $ext = match ($mime) {
+            'application/pdf' => '.pdf',
+            'image/tiff' => '.tiff',
+            'image/jpeg' => '.jpg',
+            'image/png' => '.png',
+            'text/plain' => '.txt',
+            default => null,
+        };
+        if ($ext === null) {
+            error_log('Error: unsupported fax upload content type.');
+            return '';
+        }
 
-        if (!move_uploaded_file($tmp_name, $filepath)) {
-            error_log('Error: Failed to move uploaded file.');
+        $targetDir = $this->baseDir . '/send';
+        if (!is_dir($targetDir) && !mkdir($targetDir, 0700, true)) {
+            error_log('Error: Failed to create directory.');
+            return '';
+        }
+        chmod($targetDir, 0700);
+
+        // Sanitized basename + short random hex suffix + server-determined
+        // extension. Preserves the human-readable label for vendor metadata
+        // while guaranteeing the on-disk filename is unguessable and the
+        // extension matches the actual content type.
+        $origName = basename((string)($_FILES['fax']['name'] ?? 'fax'));
+        $base = convert_safe_file_dir_name(pathinfo($origName, PATHINFO_FILENAME)) ?: 'fax';
+        $filepath = $targetDir . '/' . $base . '_' . bin2hex(random_bytes(4)) . $ext;
+
+        // Encrypt at rest. encryptForFilesystem is a no-op when the
+        // drive_encryption global is off, matching the rest of the
+        // document store. The send path decrypts before consumption.
+        $content = file_get_contents($tmpName);
+        if ($content === false) {
+            return '';
+        }
+        if (file_put_contents($filepath, $this->crypto->encryptForFilesystem($content)) === false) {
+            error_log('Error: Failed to store uploaded fax.');
             return '';
         }
 
@@ -217,16 +253,43 @@ class EtherFaxActions extends AppDispatch
             }
         }
 
+        // faxProcessUploads stores the staged file via encryptForFilesystem.
+        // Read it once, decrypt to memory, and hand off content (not the
+        // encrypted path) to downstream consumers. decryptFromFilesystem
+        // returns legacy plaintext unchanged via its version-prefix check,
+        // so files staged before this change remain readable.
+        $stagedPath = null;
+        if (empty($isContent) && !$isDocuments && is_string($file) && is_file($file)) {
+            $raw = file_get_contents($file);
+            if ($raw === false) {
+                return xlt('Error: Failed to read fax content');
+            }
+            $stagedPath = $file;
+            $file = $this->crypto->decryptFromFilesystem($raw);
+            $isDocuments = true;
+        }
+
         // If document mode, load from Document table instead
-        if ($isDocuments) {
+        if ($isDocuments && $stagedPath === null) {
             $doc = new Document($docId);
             $file = $doc->get_data();
             $fileName = $doc->get_name() ?? 'document';
         }
 
-        // Optional email copy
-        if ($hasEmail && $smtpEnabled) {
-            self::emailDocument($email, '', $file, $user);
+        // Optional email copy. When we have content (not a real path), write
+        // a per-request plaintext scratch file so AddAttachment can read it.
+        $emailPath = null;
+        if ($hasEmail && $smtpEnabled && is_string($email)) {
+            if ($isDocuments) {
+                $tmp = tempnam(sys_get_temp_dir(), 'fax_');
+                if ($tmp !== false) {
+                    $emailPath = $tmp;
+                    file_put_contents($emailPath, (string)$file);
+                    self::emailDocument($email, '', $emailPath, $user);
+                }
+            } else {
+                self::emailDocument($email, '', (string)$file, $user);
+            }
         }
 
         try {
@@ -289,6 +352,24 @@ class EtherFaxActions extends AppDispatch
             }
         } catch (\Throwable $e) {
             return 'Error: ' . json_encode($e->getMessage());
+        } finally {
+            // Best-effort cleanup of the staged encrypted upload and the
+            // plaintext email-attachment scratch file. Filesystem::remove
+            // swallows the benign already-gone case; a real permission
+            // failure surfaces as IOException, which we log.
+            try {
+                if ($stagedPath !== null) {
+                    (new Filesystem())->remove($stagedPath);
+                }
+                if ($emailPath !== null) {
+                    (new Filesystem())->remove($emailPath);
+                }
+            } catch (IOException $cleanupError) {
+                ServiceContainer::getLogger()->warning(
+                    'Failed to remove staged fax upload artifacts after send',
+                    ['exception' => $cleanupError]
+                );
+            }
         }
         $resultName = FaxResult::getFaxResult($status->FaxResult ?? null);
         // Treat InProgress as non-error (queued for tracking)

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
@@ -14,13 +14,13 @@ namespace OpenEMR\Modules\FaxSMS\Controller;
 
 use Document;
 use Exception;
-use MyMailer;
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\EtherFax\EtherFaxClient;
 use OpenEMR\Modules\FaxSMS\EtherFax\FaxResult;
+use OpenEMR\Modules\FaxSMS\Service\FaxMailer;
 use OpenEMR\Modules\FaxSMS\Service\FaxUploadStaging;
 use OpenEMR\Services\ImageUtilities\HandleImageService;
 
@@ -75,31 +75,6 @@ class EtherFaxActions extends AppDispatch
         $this->uriDir = $this->serverUrl . $this->uriDir;
 
         return $credentials;
-    }
-
-    /**
-     * @param       $email
-     * @param       $body
-     * @param       $file
-     * @param array $user
-     * @return string
-     * @throws \PHPMailer\PHPMailer\Exception
-     */
-    public static function emailDocument($email, $body, $file, array $user = []): string
-    {
-        $from_name = ($user['fname'] ?? '') . ' ' . ($user['lname'] ?? '');
-        $desc = xlt("Comment") . ":\n" . text($body) . "\n" . xlt("This email has an attached fax document.");
-        $mail = new MyMailer();
-        $from_name = text($from_name);
-        $from = OEGlobalsBag::getInstance()->getString("practice_return_email_path");
-        $mail->AddReplyTo($from, $from_name);
-        $mail->SetFrom($from, $from);
-        $mail->AddAddress($email, $email);
-        $mail->Subject = xlt("Forwarded Fax Document");
-        $mail->Body = $desc;
-        $mail->AddAttachment($file);
-
-        return $mail->Send() ? xlt("Email successfully sent.") : xlt("Error: Email failed") . text($mail->ErrorInfo);
     }
 
     /**
@@ -231,23 +206,20 @@ class EtherFaxActions extends AppDispatch
             $fileName = $doc->get_name() ?? 'document';
         }
 
-        // Optional email copy. The patient-document branch above hands us
-        // raw bytes rather than a path, so write a per-request plaintext
-        // scratch file in that case so AddAttachment sees a real path.
-        // The staged-upload branch already left $file pointing at a
-        // plaintext tempnam.
+        // Optional email copy. When the patient-document branch above
+        // handed us raw bytes rather than a path, FaxMailer writes a
+        // per-request plaintext scratch file and returns it for cleanup.
+        // The staged-upload branch already left $file pointing at a real
+        // plaintext path, so the helper just sends it directly.
         $emailPath = null;
-        if ($hasEmail && $smtpEnabled && is_string($email)) {
-            if ($isDocuments) {
-                $tmp = tempnam(sys_get_temp_dir(), 'fax_');
-                if ($tmp !== false) {
-                    $emailPath = $tmp;
-                    file_put_contents($emailPath, (string)$file);
-                    self::emailDocument($email, '', $emailPath, $user);
-                }
-            } else {
-                self::emailDocument($email, '', (string)$file, $user);
-            }
+        if ($hasEmail && $smtpEnabled) {
+            $emailPath = FaxMailer::mailUploadedDocument(
+                $email,
+                '',
+                $file,
+                $user,
+                $isDocuments,
+            );
         }
 
         try {
@@ -395,8 +367,8 @@ class EtherFaxActions extends AppDispatch
 
         file_put_contents($filepath, base64_decode((string)$content));
 
-        if ($hasEmail && $smtpEnabled) {
-            $statusMsg .= self::emailDocument($email, $this->getRequest('comments'), $filepath, $user) . "<br />";
+        if ($hasEmail && $smtpEnabled && is_string($email)) {
+            $statusMsg .= FaxMailer::send($email, (string)$this->getRequest('comments'), $filepath, $user) . "<br />";
         }
 
         if ($faxNumber) {

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
@@ -206,19 +206,21 @@ class EtherFaxActions extends AppDispatch
             $fileName = $doc->get_name() ?? 'document';
         }
 
-        // Optional email copy. When the patient-document branch above
-        // handed us raw bytes rather than a path, FaxMailer writes a
-        // per-request plaintext scratch file and returns it for cleanup.
-        // The staged-upload branch already left $file pointing at a real
-        // plaintext path, so the helper just sends it directly.
+        // Optional email copy. $file is raw bytes when either the
+        // patient-document branch above set it from Document::get_data
+        // ($isDocuments) or the caller indicated the payload is already
+        // content ($isContent). The staged-upload branch left $file
+        // pointing at a plaintext path, so the else branch in
+        // mailUploadedDocument sends it directly.
         $emailPath = null;
         if ($hasEmail && $smtpEnabled) {
+            $payloadIsContent = $isDocuments || !empty($isContent);
             $emailPath = FaxMailer::mailUploadedDocument(
                 $email,
                 '',
                 $file,
                 $user,
-                $isDocuments,
+                $payloadIsContent,
             );
         }
 
@@ -359,11 +361,11 @@ class EtherFaxActions extends AppDispatch
         $content = $fax->FaxImage;
         $c_header = $fax->DocumentParams->Type;
         $ext = $c_header == 'application/pdf' ? '.pdf' : ($c_header == 'image/tiff' || $c_header == 'image/tif' ? '.tiff' : '.txt');
-        $filepath = $this->baseDir . "/send/" . ($jobId . $ext);
-
-        if (!file_exists($this->baseDir . '/send')) {
-            mkdir($this->baseDir . '/send', 0777, true);
+        $stagingDir = $this->uploadStaging->ensureStagingDir($this->baseDir);
+        if ($stagingDir === null) {
+            return js_escape('Error: ' . xlt('Failed to prepare fax staging directory'));
         }
+        $filepath = $stagingDir . '/' . ($jobId . $ext);
 
         file_put_contents($filepath, base64_decode((string)$content));
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
@@ -21,20 +21,20 @@ use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\EtherFax\EtherFaxClient;
 use OpenEMR\Modules\FaxSMS\EtherFax\FaxResult;
+use OpenEMR\Modules\FaxSMS\Service\FaxUploadStaging;
 use OpenEMR\Services\ImageUtilities\HandleImageService;
-use Symfony\Component\Filesystem\Exception\IOException;
-use Symfony\Component\Filesystem\Filesystem;
 
 class EtherFaxActions extends AppDispatch
 {
     public static $timeZone;
-    protected $baseDir;
+    protected string $baseDir = '';
     protected $uriDir;
     protected $serverUrl;
     protected $credentials;
     public string $portalUrl;
     protected CryptoInterface $crypto;
     private readonly EtherFaxClient $client;
+    private readonly FaxUploadStaging $uploadStaging;
     private mixed $appSecret;
     private mixed $sid;
     private mixed $appKey;
@@ -46,6 +46,7 @@ class EtherFaxActions extends AppDispatch
         }
 
         $this->crypto = ServiceContainer::getCrypto();
+        $this->uploadStaging = FaxUploadStaging::create();
         $this->baseDir = OEGlobalsBag::getInstance()->getString('temporary_files_dir');
         $this->uriDir = OEGlobalsBag::getInstance()->get('OE_SITE_WEBROOT');
         $this->credentials = $this->getCredentials();
@@ -142,85 +143,10 @@ class EtherFaxActions extends AppDispatch
      */
     public function faxProcessUploads(): string
     {
-        if (empty($_FILES['fax']) || $_FILES['fax']['error'] !== UPLOAD_ERR_OK) {
-            error_log('Error: No file uploaded or upload error.');
-            return '';
-        }
-
-        $tmpName = $_FILES['fax']['tmp_name'];
-        if (!is_string($tmpName)) {
-            return '';
-        }
-
-        // MIME filter on the actual upload bytes — reject anything that
-        // isn't a fax-safe content type so an attacker-chosen extension
-        // (e.g. .php, .phtml, .htaccess) can never land on disk under
-        // the staged path.
-        $mime = mime_content_type($tmpName);
-        $ext = match ($mime) {
-            'application/pdf' => '.pdf',
-            'image/tiff' => '.tiff',
-            'image/jpeg' => '.jpg',
-            'image/png' => '.png',
-            'text/plain' => '.txt',
-            default => null,
-        };
-        if ($ext === null) {
-            ServiceContainer::getLogger()->warning(
-                'Unsupported fax upload content type',
-                ['mime' => $mime]
-            );
-            return '';
-        }
-
-        $targetDir = $this->baseDir . '/send';
-        if (!is_dir($targetDir) && !mkdir($targetDir, 0700, true)) {
-            error_log('Error: Failed to create directory.');
-            return '';
-        }
-        chmod($targetDir, 0700);
-
-        // Sanitized basename + short random hex suffix + server-determined
-        // extension. Preserves the human-readable label for vendor metadata
-        // while guaranteeing the on-disk filename is unguessable and the
-        // extension matches the actual content type.
-        $origName = basename((string)($_FILES['fax']['name'] ?? 'fax'));
-        $base = convert_safe_file_dir_name(pathinfo($origName, PATHINFO_FILENAME)) ?: 'fax';
-        $filepath = $targetDir . '/' . $base . '_' . bin2hex(random_bytes(4)) . $ext;
-
-        // Encrypt at rest. encryptForFilesystem is a no-op when the
-        // drive_encryption global is off, matching the rest of the
-        // document store. The send path decrypts before consumption.
-        $content = file_get_contents($tmpName);
-        if ($content === false) {
-            return '';
-        }
-        if (file_put_contents($filepath, $this->crypto->encryptForFilesystem($content)) === false) {
-            ServiceContainer::getLogger()->error(
-                'Failed to store uploaded fax',
-                ['filepath' => $filepath]
-            );
-            return '';
-        }
-
-        return $filepath;
-    }
-
-    /**
-     * True if a path matches the on-disk shape faxProcessUploads creates
-     * (sanitized basename, 8-char hex suffix, fax-safe extension). Used to
-     * scope cleanup to files this controller staged rather than files
-     * caller code wrote into the same directory.
-     *
-     * @param string $path
-     * @return bool
-     */
-    private static function isStagedUploadPath(string $path): bool
-    {
-        return preg_match(
-            '/^[A-Za-z0-9_.-]+_[a-f0-9]{8}\\.(pdf|tiff|jpg|png|txt)$/',
-            basename($path)
-        ) === 1;
+        $upload = $_FILES['fax'] ?? null;
+        return is_array($upload)
+            ? $this->uploadStaging->processUpload($this->baseDir, $upload)
+            : '';
     }
 
     /**
@@ -276,40 +202,40 @@ class EtherFaxActions extends AppDispatch
             }
         }
 
-        // faxProcessUploads stores the staged file via encryptForFilesystem.
-        // Read it once, decrypt to memory, and hand off content (not the
-        // encrypted path) to downstream consumers. The pattern guard
-        // scopes cleanup to files this PR's faxProcessUploads created so
-        // callers that manage their own temp files aren't disrupted.
-        // decryptFromFilesystem returns legacy plaintext unchanged via its
-        // version-prefix check, so files staged before this change remain
-        // readable.
+        // Decrypt the staged upload to a per-request plaintext tempnam
+        // and continue with that as $file. Pattern guard scopes the
+        // cleanup we'll do below to files this controller staged via
+        // FaxUploadStaging, leaving caller-managed temp files alone.
         $stagedPath = null;
+        $plainStagePath = null;
         if (
             empty($isContent)
             && !$isDocuments
             && is_string($file)
             && is_file($file)
-            && self::isStagedUploadPath($file)
+            && $this->uploadStaging->isStagedUploadPath($file)
         ) {
-            $raw = file_get_contents($file);
-            if ($raw === false) {
+            $plainStagePath = $this->uploadStaging->decryptStagedToTemp($file);
+            if ($plainStagePath === null) {
                 return xlt('Error: Failed to read fax content');
             }
             $stagedPath = $file;
-            $file = $this->crypto->decryptFromFilesystem($raw);
-            $isDocuments = true;
+            $file = $plainStagePath;
+            $fileName = pathinfo($file, PATHINFO_BASENAME);
         }
 
         // If document mode, load from Document table instead
-        if ($isDocuments && $stagedPath === null) {
+        if ($isDocuments) {
             $doc = new Document($docId);
             $file = $doc->get_data();
             $fileName = $doc->get_name() ?? 'document';
         }
 
-        // Optional email copy. When we have content (not a real path), write
-        // a per-request plaintext scratch file so AddAttachment can read it.
+        // Optional email copy. The patient-document branch above hands us
+        // raw bytes rather than a path, so write a per-request plaintext
+        // scratch file in that case so AddAttachment sees a real path.
+        // The staged-upload branch already left $file pointing at a
+        // plaintext tempnam.
         $emailPath = null;
         if ($hasEmail && $smtpEnabled && is_string($email)) {
             if ($isDocuments) {
@@ -385,23 +311,11 @@ class EtherFaxActions extends AppDispatch
         } catch (\Throwable $e) {
             return 'Error: ' . json_encode($e->getMessage());
         } finally {
-            // Best-effort cleanup of the staged encrypted upload and the
-            // plaintext email-attachment scratch file. Filesystem::remove
-            // swallows the benign already-gone case; a real permission
-            // failure surfaces as IOException, which we log.
-            try {
-                if ($stagedPath !== null) {
-                    (new Filesystem())->remove($stagedPath);
-                }
-                if ($emailPath !== null) {
-                    (new Filesystem())->remove($emailPath);
-                }
-            } catch (IOException $cleanupError) {
-                ServiceContainer::getLogger()->warning(
-                    'Failed to remove staged fax upload artifacts after send',
-                    ['exception' => $cleanupError]
-                );
-            }
+            $this->uploadStaging->removeStagedArtifacts(
+                $stagedPath,
+                $plainStagePath,
+                $emailPath
+            );
         }
         $resultName = FaxResult::getFaxResult($status->FaxResult ?? null);
         // Treat InProgress as non-error (queued for tracking)

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
@@ -12,12 +12,12 @@ namespace OpenEMR\Modules\FaxSMS\Controller;
 
 use Document;
 use Exception;
-use MyMailer;
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Utils\FileUtils;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\RCVoice\VoiceFunctionsTrait;
+use OpenEMR\Modules\FaxSMS\Service\FaxMailer;
 use OpenEMR\Modules\FaxSMS\Service\FaxUploadStaging;
 use OpenEMR\Services\ImageUtilities\HandleImageService;
 use RingCentral\SDK\Http\ApiException;
@@ -195,8 +195,8 @@ class RCFaxClient extends AppDispatch
             }
             file_put_contents($filePath, $rawData);
 
-            if ($hasEmail && $smtpEnabled) {
-                $statusMsg .= self::emailDocument($email, $this->getRequest('comments'), $filePath, $user) . "<br />";
+            if ($hasEmail && $smtpEnabled && is_string($email)) {
+                $statusMsg .= FaxMailer::send($email, (string)$this->getRequest('comments'), $filePath, $user) . "<br />";
             }
             if ($faxNumber) {
                 try {
@@ -315,23 +315,22 @@ class RCFaxClient extends AppDispatch
             // covers any caller that supplied already-ciphertext content.
             $content = $this->crypto->decryptFromFilesystem($content);
 
-            // Email: when we have content rather than a real path (the
-            // isContent and isDocuments branches), write a per-request
-            // scratch file so AddAttachment sees a real path. The staged-
-            // upload branch already left $file pointing at plaintext.
+            // Email: hand the payload to FaxMailer. When we have a real
+            // plaintext path (the staged-upload branch), it's emailed as
+            // is; for the isContent / isDocuments branches we pass the
+            // decrypted bytes and FaxMailer writes a per-request scratch
+            // file, returning that path for finally cleanup.
             $error = false;
-            if ($hasEmail && $smtpEnabled && is_string($email)) {
+            if ($hasEmail && $smtpEnabled) {
                 try {
-                    if (is_string($file) && is_file($file)) {
-                        self::emailDocument($email, $comments, $file, $user);
-                    } else {
-                        $tmp = tempnam(sys_get_temp_dir(), 'fax_');
-                        if ($tmp !== false) {
-                            $emailPath = $tmp;
-                            file_put_contents($emailPath, $content);
-                            self::emailDocument($email, $comments, $emailPath, $user);
-                        }
-                    }
+                    $payloadIsContent = !(is_string($file) && is_file($file));
+                    $emailPath = FaxMailer::mailUploadedDocument(
+                        $email,
+                        $comments,
+                        $payloadIsContent ? $content : $file,
+                        $user,
+                        $payloadIsContent,
+                    );
                 } catch (\PHPMailer\PHPMailer\Exception) {
                     $error = true;
                 }
@@ -1180,28 +1179,4 @@ class RCFaxClient extends AppDispatch
         }
     }
 
-    /**
-     * @param       $email
-     * @param       $body
-     * @param       $file
-     * @param array $user
-     * @return string
-     * @throws \PHPMailer\PHPMailer\Exception
-     */
-    public static function emailDocument($email, $body, $file, array $user = []): string
-    {
-        $from_name = ($user['fname'] ?? '') . ' ' . ($user['lname'] ?? '');
-        $desc = xlt("Comment") . ":\n" . text($body) . "\n" . xlt("This email has an attached fax document.");
-        $mail = new MyMailer();
-        $from_name = text($from_name);
-        $from = OEGlobalsBag::getInstance()->getString("practice_return_email_path");
-        $mail->AddReplyTo($from, $from_name);
-        $mail->SetFrom($from, $from);
-        $mail->AddAddress($email, $email);
-        $mail->Subject = xlt("Forwarded Fax Document");
-        $mail->Body = $desc;
-        $mail->AddAttachment($file);
-
-        return $mail->Send() ? xlt("Email successfully sent.") : xlt("Error: Email failed") . text($mail->ErrorInfo);
-    }
 }

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
@@ -20,6 +20,8 @@ use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\RCVoice\VoiceFunctionsTrait;
 use OpenEMR\Services\ImageUtilities\HandleImageService;
 use RingCentral\SDK\Http\ApiException;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
 
 class RCFaxClient extends AppDispatch
 {
@@ -69,17 +71,53 @@ class RCFaxClient extends AppDispatch
             return '';
         }
 
-        $name = basename((string)$_FILES['fax']['name']);
         $tmpName = $_FILES['fax']['tmp_name'];
-        $targetDir = $this->baseDir . '/send';
-        if (!file_exists($targetDir) && !mkdir($targetDir, 0777, true)) {
-            error_log('Error: Failed to create directory.');
+        if (!is_string($tmpName)) {
             return '';
         }
 
-        $filepath = $targetDir . "/" . $name;
-        if (!move_uploaded_file($tmpName, $filepath)) {
-            error_log('Error: Failed to move uploaded file.');
+        // MIME filter on the actual upload bytes — reject anything that
+        // isn't a fax-safe content type so an attacker-chosen extension
+        // (e.g. .php, .phtml, .htaccess) can never land on disk under
+        // the staged path.
+        $mime = mime_content_type($tmpName);
+        $ext = match ($mime) {
+            'application/pdf' => '.pdf',
+            'image/tiff' => '.tiff',
+            'image/jpeg' => '.jpg',
+            'image/png' => '.png',
+            'text/plain' => '.txt',
+            default => null,
+        };
+        if ($ext === null) {
+            error_log('Error: unsupported fax upload content type.');
+            return '';
+        }
+
+        $targetDir = $this->baseDir . '/send';
+        if (!is_dir($targetDir) && !mkdir($targetDir, 0700, true)) {
+            error_log('Error: Failed to create directory.');
+            return '';
+        }
+        chmod($targetDir, 0700);
+
+        // Sanitized basename + short random hex suffix + server-determined
+        // extension. Preserves the human-readable label for vendor metadata
+        // while guaranteeing the on-disk filename is unguessable and the
+        // extension matches the actual content type.
+        $origName = basename((string)($_FILES['fax']['name'] ?? 'fax'));
+        $base = convert_safe_file_dir_name(pathinfo($origName, PATHINFO_FILENAME)) ?: 'fax';
+        $filepath = $targetDir . '/' . $base . '_' . bin2hex(random_bytes(4)) . $ext;
+
+        // Encrypt at rest. encryptForFilesystem is a no-op when the
+        // drive_encryption global is off, matching the rest of the
+        // document store. The send path decrypts before consumption.
+        $content = file_get_contents($tmpName);
+        if ($content === false) {
+            return '';
+        }
+        if (file_put_contents($filepath, $this->crypto->encryptForFilesystem($content)) === false) {
+            error_log('Error: Failed to store uploaded fax.');
             return '';
         }
 
@@ -280,45 +318,82 @@ class RCFaxClient extends AppDispatch
                 return xlt('Error: No Fax content');
             }
         }
-        // Check if the content is from patient report
-        if ($isContent) {
-            $content = $file;
-            $file = 'report-' . attr(OEGlobalsBag::getInstance()->get('pid')) . '.pdf';
-        } else {
-            // Is it from patient documents
-            if ($isDocuments) {
-                $content = (new Document($docId))->get_data();
-            } else {
-                // Get the content of the file or the file path
-                $content = (is_file($file) && empty($content)) ? file_get_contents($file) : $file;
-            }
-            if (empty($content)) {
-                return xlt('Error: No content to send.');
-            }
-        }
-
-        // Decrypt content if needed
-        $content = $this->crypto->decryptFromFilesystem($content);
-
-        // Email the document if email is provided and SMTP is enabled.
-        // TODO: need check to ensure not from forward fax
-        $error = false;
-        if ($hasEmail && $smtpEnabled) {
-            try {
-                self::emailDocument($email, $comments, $file, $user);
-                $error = false;
-            } catch (\PHPMailer\PHPMailer\Exception) {
-                $error = true;
-            }
-        }
-        // Request to send the fax
+        // Build $content (plaintext bytes for the vendor). The staged
+        // upload path stores the file via encryptForFilesystem, so the
+        // read here is paired with a decryptFromFilesystem. The version
+        // -prefix short-circuit in decryptFromFilesystem makes that safe
+        // for legacy plaintext files staged before this change.
+        $stagedPath = null;
+        $emailPath = null;
         try {
-            $this->sendFaxRequest($phone, $content, $fileName, $comments, $name);
-            // debug error log
-            error_log($phone . ' ' . $fileName . ' ' . $comments . ' ' . $name);
-            return xlt('Fax Successfully Sent') . ($error === true ? ("<br />" . xlt("Email Failed")) : '');
-        } catch (\Throwable $e) {
-            return 'Error: ' . text(js_escape($e->getMessage()));
+            if ($isContent) {
+                $content = $file;
+                $file = 'report-' . attr(OEGlobalsBag::getInstance()->get('pid')) . '.pdf';
+            } else {
+                if ($isDocuments) {
+                    $content = (new Document($docId))->get_data();
+                } elseif (is_file($file)) {
+                    $raw = file_get_contents($file);
+                    if ($raw === false) {
+                        return xlt('Error: No content to send.');
+                    }
+                    $stagedPath = $file;
+                    $content = $this->crypto->decryptFromFilesystem($raw);
+                } else {
+                    $content = $file;
+                }
+                if (empty($content)) {
+                    return xlt('Error: No content to send.');
+                }
+            }
+
+            // Defensive decrypt: a no-op on plaintext via cryptCheckStandard,
+            // covers any caller that supplied already-ciphertext content.
+            $content = $this->crypto->decryptFromFilesystem($content);
+
+            // Email: write plaintext content to a per-request scratch file
+            // so AddAttachment can read it. Cleaned up in finally.
+            $error = false;
+            if ($hasEmail && $smtpEnabled && is_string($email)) {
+                try {
+                    $tmp = tempnam(sys_get_temp_dir(), 'fax_');
+                    if ($tmp !== false) {
+                        $emailPath = $tmp;
+                        file_put_contents($emailPath, $content);
+                        self::emailDocument($email, $comments, $emailPath, $user);
+                    }
+                } catch (\PHPMailer\PHPMailer\Exception) {
+                    $error = true;
+                }
+            }
+
+            // Request to send the fax
+            try {
+                $this->sendFaxRequest($phone, $content, $fileName, $comments, $name);
+                // debug error log
+                error_log($phone . ' ' . $fileName . ' ' . $comments . ' ' . $name);
+                return xlt('Fax Successfully Sent') . ($error === true ? ("<br />" . xlt("Email Failed")) : '');
+            } catch (\Throwable $e) {
+                return 'Error: ' . text(js_escape($e->getMessage()));
+            }
+        } finally {
+            // Best-effort cleanup of the staged encrypted upload and the
+            // plaintext email-attachment scratch file. Filesystem::remove
+            // swallows the benign already-gone case; a real permission
+            // failure surfaces as IOException, which we log.
+            try {
+                if ($stagedPath !== null) {
+                    (new Filesystem())->remove($stagedPath);
+                }
+                if ($emailPath !== null) {
+                    (new Filesystem())->remove($emailPath);
+                }
+            } catch (IOException $cleanupError) {
+                ServiceContainer::getLogger()->warning(
+                    'Failed to remove staged fax upload artifacts after send',
+                    ['exception' => $cleanupError]
+                );
+            }
         }
     }
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
@@ -90,7 +90,10 @@ class RCFaxClient extends AppDispatch
             default => null,
         };
         if ($ext === null) {
-            error_log('Error: unsupported fax upload content type.');
+            ServiceContainer::getLogger()->warning(
+                'Unsupported fax upload content type',
+                ['mime' => $mime]
+            );
             return '';
         }
 
@@ -117,11 +120,31 @@ class RCFaxClient extends AppDispatch
             return '';
         }
         if (file_put_contents($filepath, $this->crypto->encryptForFilesystem($content)) === false) {
-            error_log('Error: Failed to store uploaded fax.');
+            ServiceContainer::getLogger()->error(
+                'Failed to store uploaded fax',
+                ['filepath' => $filepath]
+            );
             return '';
         }
 
         return $filepath;
+    }
+
+    /**
+     * True if a path matches the on-disk shape faxProcessUploads creates
+     * (sanitized basename, 8-char hex suffix, fax-safe extension). Used to
+     * scope cleanup to files this controller staged rather than files
+     * caller code wrote into the same directory.
+     *
+     * @param string $path
+     * @return bool
+     */
+    private static function isStagedUploadPath(string $path): bool
+    {
+        return preg_match(
+            '/^[A-Za-z0-9_.-]+_[a-f0-9]{8}\\.(pdf|tiff|jpg|png|txt)$/',
+            basename($path)
+        ) === 1;
     }
 
     /**
@@ -337,7 +360,13 @@ class RCFaxClient extends AppDispatch
                     if ($raw === false) {
                         return xlt('Error: No content to send.');
                     }
-                    $stagedPath = $file;
+                    // Only mark for cleanup when the path matches the on-disk
+                    // shape faxProcessUploads creates — callers that build
+                    // their own temp files (e.g. forwardFax) manage their
+                    // own lifecycle.
+                    if (self::isStagedUploadPath($file)) {
+                        $stagedPath = $file;
+                    }
                     $content = $this->crypto->decryptFromFilesystem($raw);
                 } else {
                     $content = $file;

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
@@ -18,17 +18,16 @@ use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Utils\FileUtils;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\RCVoice\VoiceFunctionsTrait;
+use OpenEMR\Modules\FaxSMS\Service\FaxUploadStaging;
 use OpenEMR\Services\ImageUtilities\HandleImageService;
 use RingCentral\SDK\Http\ApiException;
-use Symfony\Component\Filesystem\Exception\IOException;
-use Symfony\Component\Filesystem\Filesystem;
 
 class RCFaxClient extends AppDispatch
 {
     use AuthenticateTrait;
     use VoiceFunctionsTrait;
 
-    public $baseDir;
+    public string $baseDir = '';
     public $uriDir;
     public $serverUrl;
     public $redirectUrl;
@@ -40,12 +39,14 @@ class RCFaxClient extends AppDispatch
     protected $platform;
     protected $rcsdk;
     protected CryptoInterface $crypto;
+    private readonly FaxUploadStaging $uploadStaging;
 
     private const AUTH_RATE_LIMIT = 5; // Max attempts per minute
 
     public function __construct()
     {
         $this->crypto = ServiceContainer::getCrypto();
+        $this->uploadStaging = FaxUploadStaging::create();
         $this->baseDir = OEGlobalsBag::getInstance()->getString('temporary_files_dir');
         $this->uriDir = OEGlobalsBag::getInstance()->get('OE_SITE_WEBROOT');
         $this->cacheDir = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . '/documents/logs_and_misc/_cache';
@@ -66,85 +67,10 @@ class RCFaxClient extends AppDispatch
      */
     public function faxProcessUploads(): string
     {
-        if (empty($_FILES['fax']) || $_FILES['fax']['error'] !== UPLOAD_ERR_OK) {
-            error_log('Error: No file uploaded or upload error.');
-            return '';
-        }
-
-        $tmpName = $_FILES['fax']['tmp_name'];
-        if (!is_string($tmpName)) {
-            return '';
-        }
-
-        // MIME filter on the actual upload bytes — reject anything that
-        // isn't a fax-safe content type so an attacker-chosen extension
-        // (e.g. .php, .phtml, .htaccess) can never land on disk under
-        // the staged path.
-        $mime = mime_content_type($tmpName);
-        $ext = match ($mime) {
-            'application/pdf' => '.pdf',
-            'image/tiff' => '.tiff',
-            'image/jpeg' => '.jpg',
-            'image/png' => '.png',
-            'text/plain' => '.txt',
-            default => null,
-        };
-        if ($ext === null) {
-            ServiceContainer::getLogger()->warning(
-                'Unsupported fax upload content type',
-                ['mime' => $mime]
-            );
-            return '';
-        }
-
-        $targetDir = $this->baseDir . '/send';
-        if (!is_dir($targetDir) && !mkdir($targetDir, 0700, true)) {
-            error_log('Error: Failed to create directory.');
-            return '';
-        }
-        chmod($targetDir, 0700);
-
-        // Sanitized basename + short random hex suffix + server-determined
-        // extension. Preserves the human-readable label for vendor metadata
-        // while guaranteeing the on-disk filename is unguessable and the
-        // extension matches the actual content type.
-        $origName = basename((string)($_FILES['fax']['name'] ?? 'fax'));
-        $base = convert_safe_file_dir_name(pathinfo($origName, PATHINFO_FILENAME)) ?: 'fax';
-        $filepath = $targetDir . '/' . $base . '_' . bin2hex(random_bytes(4)) . $ext;
-
-        // Encrypt at rest. encryptForFilesystem is a no-op when the
-        // drive_encryption global is off, matching the rest of the
-        // document store. The send path decrypts before consumption.
-        $content = file_get_contents($tmpName);
-        if ($content === false) {
-            return '';
-        }
-        if (file_put_contents($filepath, $this->crypto->encryptForFilesystem($content)) === false) {
-            ServiceContainer::getLogger()->error(
-                'Failed to store uploaded fax',
-                ['filepath' => $filepath]
-            );
-            return '';
-        }
-
-        return $filepath;
-    }
-
-    /**
-     * True if a path matches the on-disk shape faxProcessUploads creates
-     * (sanitized basename, 8-char hex suffix, fax-safe extension). Used to
-     * scope cleanup to files this controller staged rather than files
-     * caller code wrote into the same directory.
-     *
-     * @param string $path
-     * @return bool
-     */
-    private static function isStagedUploadPath(string $path): bool
-    {
-        return preg_match(
-            '/^[A-Za-z0-9_.-]+_[a-f0-9]{8}\\.(pdf|tiff|jpg|png|txt)$/',
-            basename($path)
-        ) === 1;
+        $upload = $_FILES['fax'] ?? null;
+        return is_array($upload)
+            ? $this->uploadStaging->processUpload($this->baseDir, $upload)
+            : '';
     }
 
     /**
@@ -341,14 +267,31 @@ class RCFaxClient extends AppDispatch
                 return xlt('Error: No Fax content');
             }
         }
-        // Build $content (plaintext bytes for the vendor). The staged
-        // upload path stores the file via encryptForFilesystem, so the
-        // read here is paired with a decryptFromFilesystem. The version
-        // -prefix short-circuit in decryptFromFilesystem makes that safe
-        // for legacy plaintext files staged before this change.
+        // Decrypt a staged upload to a per-request plaintext tempnam and
+        // continue with that as $file. Pattern guard scopes the cleanup
+        // below to files this controller staged via FaxUploadStaging,
+        // leaving caller-managed temp files alone (e.g. forwardFax).
         $stagedPath = null;
+        $plainStagePath = null;
         $emailPath = null;
         try {
+            if (
+                empty($isContent)
+                && !$isDocuments
+                && is_string($file)
+                && is_file($file)
+                && $this->uploadStaging->isStagedUploadPath($file)
+            ) {
+                $plainStagePath = $this->uploadStaging->decryptStagedToTemp($file);
+                if ($plainStagePath === null) {
+                    return xlt('Error: No content to send.');
+                }
+                $stagedPath = $file;
+                $file = $plainStagePath;
+                $fileName = pathinfo($file, PATHINFO_BASENAME);
+            }
+
+            // Build $content (plaintext bytes for the vendor).
             if ($isContent) {
                 $content = $file;
                 $file = 'report-' . attr(OEGlobalsBag::getInstance()->get('pid')) . '.pdf';
@@ -356,18 +299,10 @@ class RCFaxClient extends AppDispatch
                 if ($isDocuments) {
                     $content = (new Document($docId))->get_data();
                 } elseif (is_file($file)) {
-                    $raw = file_get_contents($file);
-                    if ($raw === false) {
+                    $content = file_get_contents($file);
+                    if ($content === false) {
                         return xlt('Error: No content to send.');
                     }
-                    // Only mark for cleanup when the path matches the on-disk
-                    // shape faxProcessUploads creates — callers that build
-                    // their own temp files (e.g. forwardFax) manage their
-                    // own lifecycle.
-                    if (self::isStagedUploadPath($file)) {
-                        $stagedPath = $file;
-                    }
-                    $content = $this->crypto->decryptFromFilesystem($raw);
                 } else {
                     $content = $file;
                 }
@@ -380,16 +315,22 @@ class RCFaxClient extends AppDispatch
             // covers any caller that supplied already-ciphertext content.
             $content = $this->crypto->decryptFromFilesystem($content);
 
-            // Email: write plaintext content to a per-request scratch file
-            // so AddAttachment can read it. Cleaned up in finally.
+            // Email: when we have content rather than a real path (the
+            // isContent and isDocuments branches), write a per-request
+            // scratch file so AddAttachment sees a real path. The staged-
+            // upload branch already left $file pointing at plaintext.
             $error = false;
             if ($hasEmail && $smtpEnabled && is_string($email)) {
                 try {
-                    $tmp = tempnam(sys_get_temp_dir(), 'fax_');
-                    if ($tmp !== false) {
-                        $emailPath = $tmp;
-                        file_put_contents($emailPath, $content);
-                        self::emailDocument($email, $comments, $emailPath, $user);
+                    if (is_string($file) && is_file($file)) {
+                        self::emailDocument($email, $comments, $file, $user);
+                    } else {
+                        $tmp = tempnam(sys_get_temp_dir(), 'fax_');
+                        if ($tmp !== false) {
+                            $emailPath = $tmp;
+                            file_put_contents($emailPath, $content);
+                            self::emailDocument($email, $comments, $emailPath, $user);
+                        }
                     }
                 } catch (\PHPMailer\PHPMailer\Exception) {
                     $error = true;
@@ -406,23 +347,11 @@ class RCFaxClient extends AppDispatch
                 return 'Error: ' . text(js_escape($e->getMessage()));
             }
         } finally {
-            // Best-effort cleanup of the staged encrypted upload and the
-            // plaintext email-attachment scratch file. Filesystem::remove
-            // swallows the benign already-gone case; a real permission
-            // failure surfaces as IOException, which we log.
-            try {
-                if ($stagedPath !== null) {
-                    (new Filesystem())->remove($stagedPath);
-                }
-                if ($emailPath !== null) {
-                    (new Filesystem())->remove($emailPath);
-                }
-            } catch (IOException $cleanupError) {
-                ServiceContainer::getLogger()->warning(
-                    'Failed to remove staged fax upload artifacts after send',
-                    ['exception' => $cleanupError]
-                );
-            }
+            $this->uploadStaging->removeStagedArtifacts(
+                $stagedPath,
+                $plainStagePath,
+                $emailPath
+            );
         }
     }
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
@@ -188,11 +188,12 @@ class RCFaxClient extends AppDispatch
 
             $ext = $this->getExtensionFromContentType($contentType);
             $type = $this->getTypeFromContentType($contentType);
-            $filePath = $this->baseDir . "/send/" . ($jobId . $ext);
-
-            if (!file_exists($this->baseDir . '/send')) {
-                mkdir($this->baseDir . '/send', 0777, true);
+            $stagingDir = $this->uploadStaging->ensureStagingDir($this->baseDir);
+            if ($stagingDir === null) {
+                return js_escape('Error: ' . xlt('Failed to prepare fax staging directory'));
             }
+            $filePath = $stagingDir . '/' . ($jobId . $ext);
+
             file_put_contents($filePath, $rawData);
 
             if ($hasEmail && $smtpEnabled && is_string($email)) {

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
@@ -177,29 +177,46 @@ class SignalWireClient extends AppDispatch
         }
 
         // faxProcessUploads stores the staged file via encryptForFilesystem.
-        // Read it once, decrypt to memory, and hand off content (not the
-        // encrypted path) to downstream consumers. decryptFromFilesystem
+        // Read it once, decrypt to memory, and stage the plaintext bytes at
+        // a per-request scratch path so downstream consumers (email
+        // attachment, uploadFileForFax) get a real file path to work with.
+        // The cleanup pattern guard scopes the encrypted-stage removal to
+        // files this PR's faxProcessUploads created, so callers that manage
+        // their own temp files aren't disrupted. decryptFromFilesystem
         // returns legacy plaintext unchanged via its version-prefix check,
         // so files staged before this change remain readable.
         $stagedPath = null;
-        if (empty($isContent) && !$isDocuments && is_string($file) && is_file($file)) {
+        $plainStagePath = null;
+        if (
+            empty($isContent)
+            && !$isDocuments
+            && is_string($file)
+            && is_file($file)
+            && self::isStagedUploadPath($file)
+        ) {
             $raw = file_get_contents($file);
             if ($raw === false) {
                 return xlt('Error: Failed to read fax content');
             }
             $stagedPath = $file;
-            $file = $this->crypto->decryptFromFilesystem($raw);
-            $isDocuments = 1;
+            $decrypted = $this->crypto->decryptFromFilesystem($raw);
+            $tmp = tempnam(sys_get_temp_dir(), 'fax_');
+            if ($tmp === false) {
+                return xlt('Error: Failed to prepare fax content');
+            }
+            $plainStagePath = $tmp;
+            file_put_contents($plainStagePath, $decrypted);
+            $file = $plainStagePath;
         }
 
         // Handle document retrieval
-        if ($isDocuments && $stagedPath === null) {
+        if ($isDocuments) {
             $file = (new Document($docId))->get_data();
         }
 
-        // Send email if requested. When we have content (not a real path),
-        // write a per-request plaintext scratch file so AddAttachment can
-        // read it. Cleaned up in finally below.
+        // Send email if requested. When we're holding raw content rather
+        // than a path (isDocuments mode), write a per-request plaintext
+        // scratch file so AddAttachment can read it. Cleaned up in finally.
         $emailPath = null;
         if ($hasEmail && $smtpEnabled && is_string($email)) {
             if ($isDocuments) {
@@ -281,13 +298,17 @@ class SignalWireClient extends AppDispatch
                 'error' => xlt('Error sending fax') . ': ' . $e->getMessage()
             ]);
         } finally {
-            // Best-effort cleanup of the staged encrypted upload and the
-            // plaintext email-attachment scratch file. Filesystem::remove
+            // Best-effort cleanup of the staged encrypted upload, the
+            // plaintext-decrypted scratch handed to uploadFileForFax, and
+            // the plaintext email-attachment scratch. Filesystem::remove
             // swallows the benign already-gone case; a real permission
             // failure surfaces as IOException, which we log.
             try {
                 if ($stagedPath !== null) {
                     (new Filesystem())->remove($stagedPath);
+                }
+                if ($plainStagePath !== null) {
+                    (new Filesystem())->remove($plainStagePath);
                 }
                 if ($emailPath !== null) {
                     (new Filesystem())->remove($emailPath);
@@ -299,6 +320,23 @@ class SignalWireClient extends AppDispatch
                 );
             }
         }
+    }
+
+    /**
+     * True if a path matches the on-disk shape faxProcessUploads creates
+     * (sanitized basename, 8-char hex suffix, fax-safe extension). Used to
+     * scope cleanup to files this controller staged rather than files
+     * caller code wrote into the same directory.
+     *
+     * @param string $path
+     * @return bool
+     */
+    private static function isStagedUploadPath(string $path): bool
+    {
+        return preg_match(
+            '/^[A-Za-z0-9_.-]+_[a-f0-9]{8}\\.(pdf|tiff|jpg|png|txt)$/',
+            basename($path)
+        ) === 1;
     }
 
     /**
@@ -1110,7 +1148,10 @@ class SignalWireClient extends AppDispatch
             default => null,
         };
         if ($ext === null) {
-            error_log('Error: unsupported fax upload content type.');
+            ServiceContainer::getLogger()->warning(
+                'Unsupported fax upload content type',
+                ['mime' => $mime]
+            );
             return '';
         }
 
@@ -1137,7 +1178,10 @@ class SignalWireClient extends AppDispatch
             return '';
         }
         if (file_put_contents($filepath, $this->crypto->encryptForFilesystem($content)) === false) {
-            error_log('Error: Failed to store uploaded fax.');
+            ServiceContainer::getLogger()->error(
+                'Failed to store uploaded fax',
+                ['filepath' => $filepath]
+            );
             return '';
         }
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
@@ -22,19 +22,19 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Exception\FaxDocumentException;
+use OpenEMR\Modules\FaxSMS\Service\FaxUploadStaging;
 use SignalWire\Rest\Client;
-use Symfony\Component\Filesystem\Exception\IOException;
-use Symfony\Component\Filesystem\Filesystem;
 
 class SignalWireClient extends AppDispatch
 {
     public static $timeZone;
-    protected $baseDir;
+    protected string $baseDir = '';
     protected $uriDir;
     protected $serverUrl;
     protected $credentials;
     public string $portalUrl;
     protected CryptoInterface $crypto;
+    private readonly FaxUploadStaging $uploadStaging;
     private $client;
     private $spaceUrl;
     private $projectId;
@@ -49,6 +49,7 @@ class SignalWireClient extends AppDispatch
         // Initialize properties before calling parent (like other controllers)
         $globals = OEGlobalsBag::getInstance();
         $this->crypto = ServiceContainer::getCrypto();
+        $this->uploadStaging = FaxUploadStaging::create();
         $this->baseDir = $globals->getString('temporary_files_dir');
         $this->uriDir = $globals->getString('OE_SITE_WEBROOT');
 
@@ -176,15 +177,10 @@ class SignalWireClient extends AppDispatch
             }
         }
 
-        // faxProcessUploads stores the staged file via encryptForFilesystem.
-        // Read it once, decrypt to memory, and stage the plaintext bytes at
-        // a per-request scratch path so downstream consumers (email
-        // attachment, uploadFileForFax) get a real file path to work with.
-        // The cleanup pattern guard scopes the encrypted-stage removal to
-        // files this PR's faxProcessUploads created, so callers that manage
-        // their own temp files aren't disrupted. decryptFromFilesystem
-        // returns legacy plaintext unchanged via its version-prefix check,
-        // so files staged before this change remain readable.
+        // Decrypt the staged upload to a per-request plaintext tempnam
+        // and continue with that as $file. Pattern guard scopes the
+        // cleanup we'll do below to files this controller staged via
+        // FaxUploadStaging, leaving caller-managed temp files alone.
         $stagedPath = null;
         $plainStagePath = null;
         if (
@@ -192,20 +188,13 @@ class SignalWireClient extends AppDispatch
             && !$isDocuments
             && is_string($file)
             && is_file($file)
-            && self::isStagedUploadPath($file)
+            && $this->uploadStaging->isStagedUploadPath($file)
         ) {
-            $raw = file_get_contents($file);
-            if ($raw === false) {
+            $plainStagePath = $this->uploadStaging->decryptStagedToTemp($file);
+            if ($plainStagePath === null) {
                 return xlt('Error: Failed to read fax content');
             }
             $stagedPath = $file;
-            $decrypted = $this->crypto->decryptFromFilesystem($raw);
-            $tmp = tempnam(sys_get_temp_dir(), 'fax_');
-            if ($tmp === false) {
-                return xlt('Error: Failed to prepare fax content');
-            }
-            $plainStagePath = $tmp;
-            file_put_contents($plainStagePath, $decrypted);
             $file = $plainStagePath;
         }
 
@@ -298,45 +287,12 @@ class SignalWireClient extends AppDispatch
                 'error' => xlt('Error sending fax') . ': ' . $e->getMessage()
             ]);
         } finally {
-            // Best-effort cleanup of the staged encrypted upload, the
-            // plaintext-decrypted scratch handed to uploadFileForFax, and
-            // the plaintext email-attachment scratch. Filesystem::remove
-            // swallows the benign already-gone case; a real permission
-            // failure surfaces as IOException, which we log.
-            try {
-                if ($stagedPath !== null) {
-                    (new Filesystem())->remove($stagedPath);
-                }
-                if ($plainStagePath !== null) {
-                    (new Filesystem())->remove($plainStagePath);
-                }
-                if ($emailPath !== null) {
-                    (new Filesystem())->remove($emailPath);
-                }
-            } catch (IOException $cleanupError) {
-                ServiceContainer::getLogger()->warning(
-                    'Failed to remove staged fax upload artifacts after send',
-                    ['exception' => $cleanupError]
-                );
-            }
+            $this->uploadStaging->removeStagedArtifacts(
+                $stagedPath,
+                $plainStagePath,
+                $emailPath
+            );
         }
-    }
-
-    /**
-     * True if a path matches the on-disk shape faxProcessUploads creates
-     * (sanitized basename, 8-char hex suffix, fax-safe extension). Used to
-     * scope cleanup to files this controller staged rather than files
-     * caller code wrote into the same directory.
-     *
-     * @param string $path
-     * @return bool
-     */
-    private static function isStagedUploadPath(string $path): bool
-    {
-        return preg_match(
-            '/^[A-Za-z0-9_.-]+_[a-f0-9]{8}\\.(pdf|tiff|jpg|png|txt)$/',
-            basename($path)
-        ) === 1;
     }
 
     /**
@@ -1124,67 +1080,10 @@ class SignalWireClient extends AppDispatch
      */
     public function faxProcessUploads(): string
     {
-        if (empty($_FILES['fax']) || $_FILES['fax']['error'] !== UPLOAD_ERR_OK) {
-            error_log('Error: No file uploaded or upload error.');
-            return '';
-        }
-
-        $tmpName = $_FILES['fax']['tmp_name'];
-        if (!is_string($tmpName)) {
-            return '';
-        }
-
-        // MIME filter on the actual upload bytes — reject anything that
-        // isn't a fax-safe content type so an attacker-chosen extension
-        // (e.g. .php, .phtml, .htaccess) can never land on disk under
-        // the staged path.
-        $mime = mime_content_type($tmpName);
-        $ext = match ($mime) {
-            'application/pdf' => '.pdf',
-            'image/tiff' => '.tiff',
-            'image/jpeg' => '.jpg',
-            'image/png' => '.png',
-            'text/plain' => '.txt',
-            default => null,
-        };
-        if ($ext === null) {
-            ServiceContainer::getLogger()->warning(
-                'Unsupported fax upload content type',
-                ['mime' => $mime]
-            );
-            return '';
-        }
-
-        $targetDir = $this->baseDir . '/send';
-        if (!is_dir($targetDir) && !mkdir($targetDir, 0700, true)) {
-            error_log('Error: Failed to create directory.');
-            return '';
-        }
-        chmod($targetDir, 0700);
-
-        // Sanitized basename + short random hex suffix + server-determined
-        // extension. Preserves the human-readable label for vendor metadata
-        // while guaranteeing the on-disk filename is unguessable and the
-        // extension matches the actual content type.
-        $origName = basename((string)($_FILES['fax']['name'] ?? 'fax'));
-        $base = convert_safe_file_dir_name(pathinfo($origName, PATHINFO_FILENAME)) ?: 'fax';
-        $filepath = $targetDir . '/' . $base . '_' . bin2hex(random_bytes(4)) . $ext;
-
-        // Encrypt at rest. encryptForFilesystem is a no-op when the
-        // drive_encryption global is off, matching the rest of the
-        // document store. The send path decrypts before consumption.
-        $content = file_get_contents($tmpName);
-        if ($content === false) {
-            return '';
-        }
-        if (file_put_contents($filepath, $this->crypto->encryptForFilesystem($content)) === false) {
-            ServiceContainer::getLogger()->error(
-                'Failed to store uploaded fax',
-                ['filepath' => $filepath]
-            );
-            return '';
-        }
-
-        return $filepath;
+        $upload = $_FILES['fax'] ?? null;
+        return is_array($upload)
+            ? $this->uploadStaging->processUpload($this->baseDir, $upload)
+            : '';
     }
+
 }

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
@@ -203,19 +203,21 @@ class SignalWireClient extends AppDispatch
             $file = (new Document($docId))->get_data();
         }
 
-        // Send email if requested. When the patient-document branch
-        // above handed us raw bytes rather than a path, FaxMailer writes
-        // a per-request plaintext scratch file and returns it for
-        // cleanup. The staged-upload branch already left $file pointing
-        // at a real plaintext path, so the helper just sends it directly.
+        // Send email if requested. $file is raw bytes when either the
+        // patient-document branch above set it from Document::get_data
+        // ($isDocuments) or the caller indicated the payload is already
+        // content ($isContent). The staged-upload branch left $file
+        // pointing at a plaintext path, so the else branch in
+        // mailUploadedDocument sends it directly.
         $emailPath = null;
         if ($hasEmail && $smtpEnabled) {
+            $payloadIsContent = (bool)$isDocuments || !empty($isContent);
             $emailPath = FaxMailer::mailUploadedDocument(
                 $email,
                 '',
                 $file,
                 $user,
-                (bool)$isDocuments,
+                $payloadIsContent,
             );
         }
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
@@ -14,7 +14,6 @@ namespace OpenEMR\Modules\FaxSMS\Controller;
 
 use Document;
 use Exception;
-use MyMailer;
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Crypto\CryptoGenException;
 use OpenEMR\Common\Crypto\CryptoInterface;
@@ -22,6 +21,7 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Exception\FaxDocumentException;
+use OpenEMR\Modules\FaxSMS\Service\FaxMailer;
 use OpenEMR\Modules\FaxSMS\Service\FaxUploadStaging;
 use SignalWire\Rest\Client;
 
@@ -203,21 +203,20 @@ class SignalWireClient extends AppDispatch
             $file = (new Document($docId))->get_data();
         }
 
-        // Send email if requested. When we're holding raw content rather
-        // than a path (isDocuments mode), write a per-request plaintext
-        // scratch file so AddAttachment can read it. Cleaned up in finally.
+        // Send email if requested. When the patient-document branch
+        // above handed us raw bytes rather than a path, FaxMailer writes
+        // a per-request plaintext scratch file and returns it for
+        // cleanup. The staged-upload branch already left $file pointing
+        // at a real plaintext path, so the helper just sends it directly.
         $emailPath = null;
-        if ($hasEmail && $smtpEnabled && is_string($email)) {
-            if ($isDocuments) {
-                $tmp = tempnam(sys_get_temp_dir(), 'fax_');
-                if ($tmp !== false) {
-                    $emailPath = $tmp;
-                    file_put_contents($emailPath, (string)$file);
-                    self::emailDocument($email, '', $emailPath, $user);
-                }
-            } else {
-                self::emailDocument($email, '', (string)$file, $user);
-            }
+        if ($hasEmail && $smtpEnabled) {
+            $emailPath = FaxMailer::mailUploadedDocument(
+                $email,
+                '',
+                $file,
+                $user,
+                (bool)$isDocuments,
+            );
         }
 
         // Validate phone number
@@ -472,34 +471,6 @@ class SignalWireClient extends AppDispatch
     public function sendEmail(): mixed
     {
         return xlt('Email not implemented for SignalWire Fax');
-    }
-
-    /**
-     * Email a document
-     *
-     * @param string $email
-     * @param string $body
-     * @param string $file
-     * @param array $user
-     * @return string
-     * @throws \PHPMailer\PHPMailer\Exception
-     */
-    public static function emailDocument(string $email, string $body, string $file, array $user = []): string
-    {
-        $globals = OEGlobalsBag::getInstance();
-        $from_name = ($user['fname'] ?? '') . ' ' . ($user['lname'] ?? '');
-        $desc = xlt("Comment") . ":\n" . text($body) . "\n" . xlt("This email has an attached fax document.");
-        $mail = new MyMailer();
-        $from_name = text($from_name);
-        $from = $globals->getString("practice_return_email_path");
-        $mail->AddReplyTo($from, $from_name);
-        $mail->SetFrom($from, $from);
-        $mail->AddAddress($email, $email);
-        $mail->Subject = xlt("Forwarded Fax Document");
-        $mail->Body = $desc;
-        $mail->AddAttachment($file);
-
-        return $mail->Send() ? xlt("Email successfully sent.") : xlt("Error: Email failed") . text($mail->ErrorInfo);
     }
 
     /**

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
@@ -23,6 +23,8 @@ use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Exception\FaxDocumentException;
 use SignalWire\Rest\Client;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
 
 class SignalWireClient extends AppDispatch
 {
@@ -174,14 +176,42 @@ class SignalWireClient extends AppDispatch
             }
         }
 
+        // faxProcessUploads stores the staged file via encryptForFilesystem.
+        // Read it once, decrypt to memory, and hand off content (not the
+        // encrypted path) to downstream consumers. decryptFromFilesystem
+        // returns legacy plaintext unchanged via its version-prefix check,
+        // so files staged before this change remain readable.
+        $stagedPath = null;
+        if (empty($isContent) && !$isDocuments && is_string($file) && is_file($file)) {
+            $raw = file_get_contents($file);
+            if ($raw === false) {
+                return xlt('Error: Failed to read fax content');
+            }
+            $stagedPath = $file;
+            $file = $this->crypto->decryptFromFilesystem($raw);
+            $isDocuments = 1;
+        }
+
         // Handle document retrieval
-        if ($isDocuments) {
+        if ($isDocuments && $stagedPath === null) {
             $file = (new Document($docId))->get_data();
         }
 
-        // Send email if requested
-        if ($hasEmail && $smtpEnabled) {
-            self::emailDocument($email, '', $file, $user);
+        // Send email if requested. When we have content (not a real path),
+        // write a per-request plaintext scratch file so AddAttachment can
+        // read it. Cleaned up in finally below.
+        $emailPath = null;
+        if ($hasEmail && $smtpEnabled && is_string($email)) {
+            if ($isDocuments) {
+                $tmp = tempnam(sys_get_temp_dir(), 'fax_');
+                if ($tmp !== false) {
+                    $emailPath = $tmp;
+                    file_put_contents($emailPath, (string)$file);
+                    self::emailDocument($email, '', $emailPath, $user);
+                }
+            } else {
+                self::emailDocument($email, '', (string)$file, $user);
+            }
         }
 
         // Validate phone number
@@ -250,6 +280,24 @@ class SignalWireClient extends AppDispatch
                 'success' => false,
                 'error' => xlt('Error sending fax') . ': ' . $e->getMessage()
             ]);
+        } finally {
+            // Best-effort cleanup of the staged encrypted upload and the
+            // plaintext email-attachment scratch file. Filesystem::remove
+            // swallows the benign already-gone case; a real permission
+            // failure surfaces as IOException, which we log.
+            try {
+                if ($stagedPath !== null) {
+                    (new Filesystem())->remove($stagedPath);
+                }
+                if ($emailPath !== null) {
+                    (new Filesystem())->remove($emailPath);
+                }
+            } catch (IOException $cleanupError) {
+                ServiceContainer::getLogger()->warning(
+                    'Failed to remove staged fax upload artifacts after send',
+                    ['exception' => $cleanupError]
+                );
+            }
         }
     }
 
@@ -1043,19 +1091,53 @@ class SignalWireClient extends AppDispatch
             return '';
         }
 
-        $name = basename((string) $_FILES['fax']['name']);
-        $tmp_name = $_FILES['fax']['tmp_name'];
-        $targetDir = $this->baseDir . '/send';
-
-        if (!file_exists($targetDir) && !mkdir($targetDir, 0777, true)) {
-            error_log('Error: Failed to create directory.');
+        $tmpName = $_FILES['fax']['tmp_name'];
+        if (!is_string($tmpName)) {
             return '';
         }
 
-        $filepath = $targetDir . "/" . $name;
+        // MIME filter on the actual upload bytes — reject anything that
+        // isn't a fax-safe content type so an attacker-chosen extension
+        // (e.g. .php, .phtml, .htaccess) can never land on disk under
+        // the staged path.
+        $mime = mime_content_type($tmpName);
+        $ext = match ($mime) {
+            'application/pdf' => '.pdf',
+            'image/tiff' => '.tiff',
+            'image/jpeg' => '.jpg',
+            'image/png' => '.png',
+            'text/plain' => '.txt',
+            default => null,
+        };
+        if ($ext === null) {
+            error_log('Error: unsupported fax upload content type.');
+            return '';
+        }
 
-        if (!move_uploaded_file($tmp_name, $filepath)) {
-            error_log('Error: Failed to move uploaded file.');
+        $targetDir = $this->baseDir . '/send';
+        if (!is_dir($targetDir) && !mkdir($targetDir, 0700, true)) {
+            error_log('Error: Failed to create directory.');
+            return '';
+        }
+        chmod($targetDir, 0700);
+
+        // Sanitized basename + short random hex suffix + server-determined
+        // extension. Preserves the human-readable label for vendor metadata
+        // while guaranteeing the on-disk filename is unguessable and the
+        // extension matches the actual content type.
+        $origName = basename((string)($_FILES['fax']['name'] ?? 'fax'));
+        $base = convert_safe_file_dir_name(pathinfo($origName, PATHINFO_FILENAME)) ?: 'fax';
+        $filepath = $targetDir . '/' . $base . '_' . bin2hex(random_bytes(4)) . $ext;
+
+        // Encrypt at rest. encryptForFilesystem is a no-op when the
+        // drive_encryption global is off, matching the rest of the
+        // document store. The send path decrypts before consumption.
+        $content = file_get_contents($tmpName);
+        if ($content === false) {
+            return '';
+        }
+        if (file_put_contents($filepath, $this->crypto->encryptForFilesystem($content)) === false) {
+            error_log('Error: Failed to store uploaded fax.');
             return '';
         }
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Send fax documents by email.
+ *
+ * Each fax provider client used to inline its own static emailDocument
+ * helper and (in two of them) its own copy of the tempnam-for-content
+ * dance for the email-attachment branch. This service collects both
+ * behaviors in one place.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\FaxSMS\Service;
+
+use MyMailer;
+use OpenEMR\Core\OEGlobalsBag;
+
+final readonly class FaxMailer
+{
+    /**
+     * Send a fax document by email with the file as an attachment.
+     */
+    public static function send(
+        string $email,
+        string $body,
+        string $file,
+        array $user = []
+    ): string {
+        $fromName = ($user['fname'] ?? '') . ' ' . ($user['lname'] ?? '');
+        $desc = xlt("Comment") . ":\n" . text($body) . "\n" . xlt("This email has an attached fax document.");
+
+        $mail = new MyMailer();
+        $fromName = text($fromName);
+        $from = OEGlobalsBag::getInstance()->getString("practice_return_email_path");
+
+        $mail->AddReplyTo($from, $fromName);
+        $mail->SetFrom($from, $from);
+        $mail->AddAddress($email, $email);
+        $mail->Subject = xlt("Forwarded Fax Document");
+        $mail->Body = $desc;
+        $mail->AddAttachment($file);
+
+        return $mail->Send()
+            ? xlt("Email successfully sent.")
+            : xlt("Error: Email failed") . text($mail->ErrorInfo);
+    }
+
+    /**
+     * Mail a fax payload that may be either an on-disk plaintext path or
+     * raw content bytes. When $payloadIsContent is true, write a per-
+     * request plaintext scratch file under sys_get_temp_dir() so the
+     * underlying AddAttachment call sees a real file. Returns the scratch
+     * path so the caller can add it to its cleanup list, or null if no
+     * scratch file was created.
+     *
+     * The $email parameter is mixed because controllers pull it straight
+     * from the request; this helper narrows it once and silently no-ops
+     * for non-string values so call sites don't have to repeat the guard.
+     */
+    public static function mailUploadedDocument(
+        mixed $email,
+        string $body,
+        mixed $payload,
+        array $user,
+        bool $payloadIsContent
+    ): ?string {
+        if (!is_string($email)) {
+            return null;
+        }
+        if (!$payloadIsContent) {
+            self::send($email, $body, (string)$payload, $user);
+            return null;
+        }
+        $tmp = tempnam(sys_get_temp_dir(), 'fax_');
+        if ($tmp === false) {
+            return null;
+        }
+        file_put_contents($tmp, (string)$payload);
+        self::send($email, $body, $tmp, $user);
+        return $tmp;
+    }
+}

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxMailer.php
@@ -80,7 +80,14 @@ final readonly class FaxMailer
         if ($tmp === false) {
             return null;
         }
-        file_put_contents($tmp, (string)$payload);
+        if (file_put_contents($tmp, (string)$payload) === false) {
+            // Scratch file was created by tempnam() but the payload didn't
+            // make it onto disk; bail rather than mail an empty attachment.
+            // The half-written tempnam gets unlinked best-effort here so it
+            // doesn't linger.
+            unlink($tmp);
+            return null;
+        }
         self::send($email, $body, $tmp, $user);
         return $tmp;
     }

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxUploadStaging.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxUploadStaging.php
@@ -98,15 +98,10 @@ final readonly class FaxUploadStaging
             return '';
         }
 
-        $targetDir = $baseDir . '/send';
-        if (!is_dir($targetDir) && !mkdir($targetDir, 0700, true)) {
-            $this->logger->error(
-                'Failed to create fax staging directory',
-                ['directory' => $targetDir]
-            );
+        $targetDir = $this->ensureStagingDir($baseDir);
+        if ($targetDir === null) {
             return '';
         }
-        chmod($targetDir, 0700);
 
         $rawName = $upload['name'] ?? null;
         $origName = is_string($rawName) ? basename($rawName) : 'fax';
@@ -176,23 +171,45 @@ final readonly class FaxUploadStaging
     /**
      * Best-effort removal of staging artifacts. Filesystem::remove
      * swallows the benign already-gone race; a real permission failure
-     * surfaces as IOException, which is logged at warning level so the
-     * caller's success path isn't interrupted.
+     * surfaces as IOException, which is logged at warning level for the
+     * individual path so the loop keeps cleaning up the remaining paths.
      */
     public function removeStagedArtifacts(?string ...$paths): void
     {
-        try {
-            $fs = new Filesystem();
-            foreach ($paths as $path) {
-                if ($path !== null) {
-                    $fs->remove($path);
-                }
+        $fs = new Filesystem();
+        foreach ($paths as $path) {
+            if ($path === null) {
+                continue;
             }
-        } catch (IOException $cleanupError) {
-            $this->logger->warning(
-                'Failed to remove staged fax upload artifacts after send',
-                ['exception' => $cleanupError]
-            );
+            try {
+                $fs->remove($path);
+            } catch (IOException $cleanupError) {
+                $this->logger->warning(
+                    'Failed to remove staged fax upload artifact',
+                    ['path' => $path, 'exception' => $cleanupError]
+                );
+            }
         }
+    }
+
+    /**
+     * Ensure the per-controller fax staging directory exists at
+     * `<baseDir>/send/` with 0700 permissions, and re-apply chmod on
+     * every call so installs that were created earlier with looser
+     * permissions get tightened on the next pass. Returns the directory
+     * path on success, or null if the directory could not be created.
+     */
+    public function ensureStagingDir(string $baseDir): ?string
+    {
+        $targetDir = $baseDir . '/send';
+        if (!is_dir($targetDir) && !mkdir($targetDir, 0700, true)) {
+            $this->logger->error(
+                'Failed to create fax staging directory',
+                ['directory' => $targetDir]
+            );
+            return null;
+        }
+        chmod($targetDir, 0700);
+        return $targetDir;
     }
 }

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxUploadStaging.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Service/FaxUploadStaging.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * Common staging behavior for outbound fax uploads.
+ *
+ * Each fax provider client used to inline its own copy of the upload-
+ * staging logic (MIME filter, sanitized random filename, encrypt at
+ * rest, decrypt-to-tempnam handoff, finally-cleanup). This service
+ * collects that behavior in one place so the controllers can focus on
+ * their per-vendor send semantics.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\FaxSMS\Service;
+
+use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Crypto\CryptoInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+final readonly class FaxUploadStaging
+{
+    /**
+     * On-disk shape produced by processUpload(): sanitized basename,
+     * underscore, 8-char random hex suffix, fax-safe extension.
+     */
+    private const STAGED_PATH_REGEX =
+        '/^[A-Za-z0-9_.-]+_[a-f0-9]{8}\\.(pdf|tiff|jpg|png|txt)$/';
+
+    /**
+     * MIME types accepted as fax payloads. Anything else is rejected at
+     * upload time so attacker-chosen extensions like .php or .htaccess
+     * can never reach the staging directory.
+     *
+     * @var array<string, string>
+     */
+    private const ACCEPTED_MIME = [
+        'application/pdf' => '.pdf',
+        'image/tiff' => '.tiff',
+        'image/jpeg' => '.jpg',
+        'image/png' => '.png',
+        'text/plain' => '.txt',
+    ];
+
+    public function __construct(
+        private CryptoInterface $crypto,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public static function create(): self
+    {
+        return new self(
+            ServiceContainer::getCrypto(),
+            ServiceContainer::getLogger(),
+        );
+    }
+
+    /**
+     * Process a single uploaded file entry (a slice of $_FILES). MIME-
+     * sniff the bytes, reject anything outside the whitelist, write the
+     * contents encrypted at rest (when drive_encryption is on) under a
+     * filename consisting of a sanitized basename, a short random hex
+     * suffix, and a server-determined extension. Returns the on-disk
+     * path, or an empty string on failure.
+     *
+     * Callers pass `$_FILES['fax']` directly; the service never reads
+     * superglobals so this stays testable and the openemr.forbiddenGlobals
+     * rule is honored at the boundary.
+     *
+     * @param array{name?: mixed, tmp_name?: mixed, error?: mixed} $upload
+     */
+    public function processUpload(string $baseDir, array $upload): string
+    {
+        if (($upload['error'] ?? null) !== UPLOAD_ERR_OK) {
+            $this->logger->warning('Fax upload missing or in error state');
+            return '';
+        }
+
+        $tmpName = $upload['tmp_name'] ?? null;
+        if (!is_string($tmpName)) {
+            return '';
+        }
+
+        $mime = mime_content_type($tmpName);
+        $ext = is_string($mime) ? (self::ACCEPTED_MIME[$mime] ?? null) : null;
+        if ($ext === null) {
+            $this->logger->warning(
+                'Unsupported fax upload content type',
+                ['mime' => $mime]
+            );
+            return '';
+        }
+
+        $targetDir = $baseDir . '/send';
+        if (!is_dir($targetDir) && !mkdir($targetDir, 0700, true)) {
+            $this->logger->error(
+                'Failed to create fax staging directory',
+                ['directory' => $targetDir]
+            );
+            return '';
+        }
+        chmod($targetDir, 0700);
+
+        $rawName = $upload['name'] ?? null;
+        $origName = is_string($rawName) ? basename($rawName) : 'fax';
+        $sanitized = convert_safe_file_dir_name(pathinfo($origName, PATHINFO_FILENAME));
+        $base = is_string($sanitized) && $sanitized !== '' ? $sanitized : 'fax';
+        $filepath = $targetDir . '/' . $base . '_' . bin2hex(random_bytes(4)) . $ext;
+
+        $content = file_get_contents($tmpName);
+        if ($content === false) {
+            return '';
+        }
+
+        $written = file_put_contents(
+            $filepath,
+            $this->crypto->encryptForFilesystem($content)
+        );
+        if ($written === false) {
+            $this->logger->error(
+                'Failed to store uploaded fax',
+                ['filepath' => $filepath]
+            );
+            return '';
+        }
+
+        return $filepath;
+    }
+
+    /**
+     * True if the path matches the on-disk shape processUpload() creates.
+     * Use this to scope cleanup to files this service staged, rather
+     * than to caller-managed temp files that happen to live in the same
+     * directory.
+     */
+    public function isStagedUploadPath(string $path): bool
+    {
+        return preg_match(self::STAGED_PATH_REGEX, basename($path)) === 1;
+    }
+
+    /**
+     * Read an encrypted staged upload, decrypt it, and write the
+     * plaintext to a per-request tempnam. Returns the tempnam path so
+     * callers can hand a real plaintext file to their vendor SDK or to
+     * email-attachment helpers. Returns null if any step fails.
+     *
+     * Legacy plaintext files (created before the at-rest encryption
+     * work landed) flow through unchanged because decryptFromFilesystem
+     * version-prefix-checks before decrypting.
+     */
+    public function decryptStagedToTemp(string $stagedPath): ?string
+    {
+        $raw = file_get_contents($stagedPath);
+        if ($raw === false) {
+            return null;
+        }
+        $plaintext = $this->crypto->decryptFromFilesystem($raw);
+
+        $tempPath = tempnam(sys_get_temp_dir(), 'fax_');
+        if ($tempPath === false) {
+            return null;
+        }
+        if (file_put_contents($tempPath, $plaintext) === false) {
+            return null;
+        }
+        return $tempPath;
+    }
+
+    /**
+     * Best-effort removal of staging artifacts. Filesystem::remove
+     * swallows the benign already-gone race; a real permission failure
+     * surfaces as IOException, which is logged at warning level so the
+     * caller's success path isn't interrupted.
+     */
+    public function removeStagedArtifacts(?string ...$paths): void
+    {
+        try {
+            $fs = new Filesystem();
+            foreach ($paths as $path) {
+                if ($path !== null) {
+                    $fs->remove($path);
+                }
+            }
+        } catch (IOException $cleanupError) {
+            $this->logger->warning(
+                'Failed to remove staged fax upload artifacts after send',
+                ['exception' => $cleanupError]
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Defense in depth for the staged-upload paths in the RingCentral, EtherFax, and SignalWire fax clients. Uploaded fax files are MIME-filtered against a fax-safe whitelist, renamed to a sanitized basename with a short random hex suffix and the server-determined extension, and encrypted at rest via `encryptForFilesystem`. The send path reads the bytes once, decrypts in memory, and hands content (not the encrypted path) to the vendor SDK, writing a per-request plaintext scratch file under `sys_get_temp_dir()` only when the email-attachment branch is requested. Both the staged encrypted file and the email scratch file are removed in a `finally` block via Symfony Filesystem.

Supersedes #12485 (broader scope; #12485 will be closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Security**
  * Fax file uploads are now encrypted during outbound upload staging to better protect stored temporary data.

* **Improvements**
  * Centralized fax email notifications via a dedicated mailer helper for more consistent delivery.
  * Upload staging now improves validation, supports staged/decrypted processing during sending, and strengthens filename handling.
  * Better cleanup of staged and temporary artifacts reduces disk usage and lowers the chance of leftover files.
  * Forwarding and email copy flows use the updated centralized mailer for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->