### PR TITLE
fix(calendar): restore appointments hidden after 8.0→8.1 upgrade

### DIFF
--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -113,6 +113,7 @@
 --    desc: Add encounter to the form_misc_billing_options table
 --    arguments: none
 
+-- v_database 540: Fix calendar appointments (pc_endDate zero-date sentinels).
 --
 -- Fix calendar appointments disappearing after 8.0.0 → 8.1.0 upgrade.
 -- The 8.0.0→8.1.0 migration ran UPDATE pc_endDate=NULL before the column was

--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -113,4 +113,24 @@
 --    desc: Add encounter to the form_misc_billing_options table
 --    arguments: none
 
--- v_database 539: cosmetic schema edit; no migration. Marker only — remove on any future real upgrade.
+--
+-- Fix calendar appointments disappearing after 8.0.0 → 8.1.0 upgrade.
+-- The 8.0.0→8.1.0 migration ran UPDATE pc_endDate=NULL before the column was
+-- made nullable, so MySQL/MariaDB silently coerced each NULL back to '0000-00-00'.
+-- The calendar query in 8.1.0 matches open-ended events on pc_endDate IS NULL,
+-- so any row still holding '0000-00-00' is invisible in all calendar views.
+-- See: https://github.com/openemr/openemr/issues/12518
+--
+
+-- Ensure pc_endDate is nullable before converting sentinels (idempotent on
+-- instances where the column was already corrected by the earlier ALTER).
+#IfNotColumnTypeDefault openemr_postcalendar_events pc_endDate date NULL
+ALTER TABLE `openemr_postcalendar_events` MODIFY `pc_endDate` date DEFAULT NULL;
+#EndIf
+
+-- Convert any remaining zero-date sentinels to NULL so open-ended appointments
+-- reappear in calendar views.
+SET @currentSQLMode = (SELECT @@sql_mode);
+SET sql_mode = '';
+UPDATE `openemr_postcalendar_events` SET `pc_endDate` = NULL WHERE `pc_endDate` = '0000-00-00';
+SET sql_mode = @currentSQLMode;

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3,7 +3,7 @@
 --
 -- Keep v_database in sync with $v_database in version.php.
 -- CI will fail if they don't match.
--- v_database: 539
+-- v_database: 540
 --
 
 --

--- a/version.php
+++ b/version.php
@@ -31,7 +31,7 @@ $v_realpatch = '0';
 //
 // Keep in sync with the v_database comment in sql/database.sql.
 // CI will fail if they don't match.
-$v_database = 539;
+$v_database = 540;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
## Summary

The 8.0.0→8.1.0 migration silently failed to convert `pc_endDate = '0000-00-00'` to `NULL` for pre-existing appointments, causing every open-ended appointment created before the upgrade to disappear from all calendar views after upgrading to 8.1.0.

**Root cause (already filed as #12518):** The migration ran the `UPDATE pc_endDate = NULL` *before* the `ALTER TABLE ... MODIFY pc_endDate ... DEFAULT NULL`. While the column was still `NOT NULL`, MySQL/MariaDB under `sql_mode = ''` silently coerces `NULL` to the implicit default `'0000-00-00'`. The UPDATE matched rows and reported success, but no values changed on disk. The subsequent ALTER made the column nullable, but by then the data was already coerced.

**Why appointments disappear:** The 8.1.0 calendar query was updated to match open-ended events with `pc_endDate IS NULL`. A leftover `'0000-00-00'` value satisfies neither branch (`'0000-00-00' >= $start` is false, and it is not `NULL`), so the row is filtered out of every day/week/month view.

## Fix

Adds a remediation step to `8_1_0-to-8_1_1_upgrade.sql` that:

1. Ensures `pc_endDate` is nullable (guards against any edge case; already applied on affected instances by the prior migration's ALTER).
2. Converts any remaining `'0000-00-00'` sentinels to `NULL`, restoring calendar visibility for affected appointments.

The UPDATE is idempotent — instances without stale rows are unaffected.

Closes #12518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar issues where open-ended appointments could fail to display correctly when their end date contained placeholder values.
* **Chores**
  * Updated the database schema version to keep it in sync with the application’s expected version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->