### PR TITLE
fix(calendar): restore appointments hidden after 8.0→8.1 upgrade

### DIFF
--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -1,0 +1,136 @@
+--
+--  Comment Meta Language Constructs:
+--
+--  #IfNotTable
+--    argument: table_name
+--    behavior: if the table_name does not exist,  the block will be executed
+
+--  #IfTable
+--    argument: table_name
+--    behavior: if the table_name does exist, the block will be executed
+
+--  #IfColumn
+--    arguments: table_name colname
+--    behavior:  if the table and column exist,  the block will be executed
+
+--  #IfMissingColumn
+--    arguments: table_name colname
+--    behavior:  if the table exists but the column does not,  the block will be executed
+
+--  #IfNotColumnType
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does not have a column colname with a data type equal to value, then the block will be executed
+
+--  #IfNotColumnTypeDefault
+--    arguments: table_name colname value value2
+--    behavior:  If the table table_name does not have a column colname with a data type equal to value and a default equal to value2, then the block will be executed
+
+--  #IfNotRow
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does not have a row where colname = value, the block will be executed.
+
+--  #IfNotRow2D
+--    arguments: table_name colname value colname2 value2
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2, the block will be executed.
+
+--  #IfNotRow3D
+--    arguments: table_name colname value colname2 value2 colname3 value3
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2 AND colname3 = value3, the block will be executed.
+
+--  #IfNotRow4D
+--    arguments: table_name colname value colname2 value2 colname3 value3 colname4 value4
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2 AND colname3 = value3 AND colname4 = value4, the block will be executed.
+
+--  #IfNotRow2Dx2
+--    desc:      This is a very specialized function to allow adding items to the list_options table to avoid both redundant option_id and title in each element.
+--    arguments: table_name colname value colname2 value2 colname3 value3
+--    behavior:  The block will be executed if both statements below are true:
+--               1) The table table_name does not have a row where colname = value AND colname2 = value2.
+--               2) The table table_name does not have a row where colname = value AND colname3 = value3.
+
+--  #IfRow
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does have a row where colname = value, the block will be executed.
+
+--  #IfRow2D
+--    arguments: table_name colname value colname2 value2
+--    behavior:  If the table table_name does have a row where colname = value AND colname2 = value2, the block will be executed.
+
+--  #IfRow3D
+--        arguments: table_name colname value colname2 value2 colname3 value3
+--        behavior:  If the table table_name does have a row where colname = value AND colname2 = value2 AND colname3 = value3, the block will be executed.
+
+--  #IfRowIsNull
+--    arguments: table_name colname
+--    behavior:  If the table table_name does have a row where colname is null, the block will be executed.
+
+--  #IfIndex
+--    desc:      This function is most often used for dropping of indexes/keys.
+--    arguments: table_name colname
+--    behavior:  If the table and index exist the relevant statements are executed, otherwise not.
+
+--  #IfNotIndex
+--    desc:      This function will allow adding of indexes/keys.
+--    arguments: table_name colname
+--    behavior:  If the index does not exist, it will be created
+
+--  #EndIf
+--    all blocks are terminated with a #EndIf statement.
+
+--  #IfNotListReaction
+--    Custom function for creating Reaction List
+
+--  #IfNotListOccupation
+--    Custom function for creating Occupation List
+
+--  #IfTextNullFixNeeded
+--    desc: convert all text fields without default null to have default null.
+--    arguments: none
+
+--  #IfTableEngine
+--    desc:      Execute SQL if the table has been created with given engine specified.
+--    arguments: table_name engine
+--    behavior:  Use when engine conversion requires more than one ALTER TABLE
+
+--  #IfInnoDBMigrationNeeded
+--    desc: find all MyISAM tables and convert them to InnoDB.
+--    arguments: none
+--    behavior: can take a long time.
+
+--  #IfDocumentNamingNeeded
+--    desc: populate name field with document names.
+--    arguments: none
+
+--  #IfUpdateEditOptionsNeeded
+--    desc: Change Layout edit options.
+--    arguments: mode(add or remove) layout_form_id the_edit_option comma_separated_list_of_field_ids
+
+--  #IfVitalsDatesNeeded
+--    desc: Change date from zeroes to date of vitals form creation.
+--    arguments: none
+
+--  #IfMBOEncounterNeeded
+--    desc: Add encounter to the form_misc_billing_options table
+--    arguments: none
+
+--
+-- Fix calendar appointments disappearing after 8.0.0 → 8.1.0 upgrade.
+-- The 8.0.0→8.1.0 migration ran UPDATE pc_endDate=NULL before the column was
+-- made nullable, so MySQL/MariaDB silently coerced each NULL back to '0000-00-00'.
+-- The calendar query in 8.1.0 matches open-ended events on pc_endDate IS NULL,
+-- so any row still holding '0000-00-00' is invisible in all calendar views.
+-- See: https://github.com/openemr/openemr/issues/12518
+--
+
+-- Ensure pc_endDate is nullable before converting sentinels (idempotent on
+-- instances where the column was already corrected by the earlier ALTER).
+#IfNotColumnTypeDefault openemr_postcalendar_events pc_endDate date NULL
+ALTER TABLE `openemr_postcalendar_events` MODIFY `pc_endDate` date DEFAULT NULL;
+#EndIf
+
+-- Convert any remaining zero-date sentinels to NULL so open-ended appointments
+-- reappear in calendar views.
+SET @currentSQLMode = (SELECT @@sql_mode);
+SET sql_mode = '';
+UPDATE `openemr_postcalendar_events` SET `pc_endDate` = NULL WHERE `pc_endDate` = '0000-00-00';
+SET sql_mode = @currentSQLMode;

--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -113,6 +113,7 @@
 --    desc: Add encounter to the form_misc_billing_options table
 --    arguments: none
 
+-- v_database 539: Fix calendar appointments (pc_endDate zero-date sentinels).
 --
 -- Fix calendar appointments disappearing after 8.0.0 → 8.1.0 upgrade.
 -- The 8.0.0→8.1.0 migration ran UPDATE pc_endDate=NULL before the column was

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3,7 +3,7 @@
 --
 -- Keep v_database in sync with $v_database in version.php.
 -- CI will fail if they don't match.
--- v_database: 538
+-- v_database: 539
 --
 
 --

--- a/version.php
+++ b/version.php
@@ -31,7 +31,7 @@ $v_realpatch = '0';
 //
 // Keep in sync with the v_database comment in sql/database.sql.
 // CI will fail if they don't match.
-$v_database = 538;
+$v_database = 539;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Backport of #12519 to rel-810.

## Summary

The 8.0.0→8.1.0 migration silently failed to convert `pc_endDate = '0000-00-00'` to `NULL` for pre-existing appointments, causing every open-ended appointment created before the upgrade to disappear from all calendar views after upgrading to 8.1.0.

**Root cause (filed as #12518):** The migration ran `UPDATE pc_endDate = NULL` *before* the `ALTER TABLE ... MODIFY pc_endDate ... DEFAULT NULL`. While the column was still `NOT NULL`, MySQL/MariaDB under `sql_mode = ''` silently coerces `NULL` to the implicit default `'0000-00-00'`. The UPDATE matched rows and reported success, but no values changed on disk.

**Why appointments disappear:** The 8.1.0 calendar query matches open-ended events with `pc_endDate IS NULL`. A leftover `'0000-00-00'` value satisfies neither branch, so the row is filtered out of every calendar view.

## Fix

Adds `8_1_0-to-8_1_1_upgrade.sql` with a remediation step that:

1. Ensures `pc_endDate` is nullable (idempotent guard).
2. Converts any remaining `'0000-00-00'` sentinels to `NULL`, restoring calendar visibility.

Closes #12518