### PR TITLE
chore(dbal): Groundwork for connecting to ORM and migration events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "doctrine/orm": "^3.6",
         "dompdf/dompdf": "^3.1.4",
         "ezyang/htmlpurifier": "^4.19.0",
-        "firehed/container": "^1.0",
+        "firehed/container": "^1.1",
         "giggsey/libphonenumber-for-php": "^9.0",
         "google/apiclient": "^2.18.4",
         "guzzlehttp/guzzle": "^7.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a77e5a6e80e3051cc64fc48a4d8cea97",
+    "content-hash": "0202b22cad659e0f70ef8e7c2b6053fb",
     "packages": [
         {
             "name": "academe/authorizenet-objects",

--- a/config/database.php
+++ b/config/database.php
@@ -114,6 +114,9 @@ return [
 
     EntityManager::class,
     EntityManagerInterface::class => EntityManager::class,
+
+    // Note: Doctrine EntityManager types EventManager not
+    // EventManagerInterface, so we use it as the key so it gets wired.
     EventManager::class => function (TC $c): EventManager {
         $manager = new EventManager();
         // Future: add ORM/DBAL lifecycle hooks in here

--- a/config/database.php
+++ b/config/database.php
@@ -12,6 +12,7 @@
 
 declare(strict_types=1);
 
+use Doctrine\Common\EventManager;
 use Doctrine\DBAL\{
     Connection,
     DriverManager,
@@ -111,4 +112,9 @@ return [
 
     EntityManager::class,
     EntityManagerInterface::class => EntityManager::class,
+    EventManager::class => function (TC $c): EventManager {
+        $manager = new EventManager();
+        // Future: add ORM/DBAL lifecycle hooks in here
+        return $manager;
+    },
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -130,7 +130,7 @@ return [
         // event's name which will be called upon event dispatching. E.g. an
         // event named `fooEvent` means the listener must have `public function
         // fooEvent(): void`. Some events emit additional data as an argument,
-        // see their defintions for more detail.
+        // see their definitions for more detail.
         //
         // This should NOT be used for application events; stick with the
         // Symfony EventDispatcher in the kernel.

--- a/config/database.php
+++ b/config/database.php
@@ -120,6 +120,14 @@ return [
     EventManager::class => function (TC $c): EventManager {
         $manager = new EventManager();
         // Future: add ORM/DBAL/Migrations lifecycle hooks in here
+        //
+        // Hookable events are defined in:
+        // - Doctrine\Migrations\Events
+        // - Doctrine\ORM\Events
+        // - Doctrine\ORM\Tools\ToolEvents
+        //
+        // This should NOT be used for application events; stick with the
+        // Symfony EventDispatcher in the kernel.
         return $manager;
     },
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -119,7 +119,7 @@ return [
     // EventManagerInterface, so we use it as the key so it gets wired.
     EventManager::class => function (TC $c): EventManager {
         $manager = new EventManager();
-        // Future: add ORM/DBAL lifecycle hooks in here
+        // Future: add ORM/DBAL/Migrations lifecycle hooks in here
         return $manager;
     },
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -18,8 +18,8 @@ use Doctrine\DBAL\{
     DriverManager,
 };
 use Doctrine\Migrations\Configuration\{
-    Connection\ConnectionLoader,
     Connection\ExistingConnection,
+    EntityManager\ExistingEntityManager,
     Migration\ConfigurationLoader,
     Migration\PhpFile,
 };
@@ -72,12 +72,14 @@ return [
 
     // Doctrine Migrations
     ConfigurationLoader::class => fn () => new PhpFile('db/migration-config.php'),
-    ConnectionLoader::class => fn (TC $c) => new ExistingConnection($c->get(Connection::class)),
-    DependencyFactory::class => fn (TC $c) => DependencyFactory::fromConnection(
+    // We use fromEntityManager instead of fromConnection to be able to leverage
+    // its EventManager. This is required to subscribe to migration events.
+    DependencyFactory::class => fn (TC $c) => DependencyFactory::fromEntityManager(
         $c->get(ConfigurationLoader::class),
-        $c->get(ConnectionLoader::class),
+        $c->get(ExistingEntityManager::class),
         $c->get(LoggerInterface::class),
     ),
+    ExistingEntityManager::class,
 
     // ORM
     Configuration::class => function (TC $c) {

--- a/config/database.php
+++ b/config/database.php
@@ -126,6 +126,12 @@ return [
         // - Doctrine\ORM\Events
         // - Doctrine\ORM\Tools\ToolEvents
         //
+        // Listeners are convention-based: they must have a public method of the
+        // event's name which will be called upon event dispatching. E.g. an
+        // event named `fooEvent` means the listener must have `public function
+        // fooEvent(): void`. Some events emit additional data as an argument,
+        // see their defintions for more detail.
+        //
         // This should NOT be used for application events; stick with the
         // Symfony EventDispatcher in the kernel.
         return $manager;


### PR DESCRIPTION
#### Short description of what this changes or resolves:
This exposes the tooling that will allow for hooking into `doctrine/migrations` lifecycle events, which is a necessary step towards switching to it from the home-rolled migration tooling (it exposes similar lifecycle events, which _are_ used, so those uses need equivalent hooks).

It also provides a jumping-off point for ORM lifecycle events, which I'll be using for things like timestamp updates and uuid generation.

#### Changes proposed in this pull request:

- Defines a Doctrine `EventManager` in the container (used by the migrations tooling)
- Updates the migrations toolset to fetch its connection from the ORM, ensuring it picks up that `EventManager`
- Comments what events are reachable, and that this shouldn't be repurposed for other application lifecycle work
- Bumps min container version to 1.1, which includes a fix that ensures the optional EventManager dependency is autowired

#### Was an AI assistant used? Yes / No
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated firehed/container dependency to version 1.1
  * Refined Doctrine database configuration and service initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->