### PR TITLE
fix(persist): skip phones the legacy parts schema cannot represent (insurance + pharmacy)

### DIFF
--- a/library/classes/InsuranceCompany.class.php
+++ b/library/classes/InsuranceCompany.class.php
@@ -340,7 +340,15 @@ class InsuranceCompany extends ORDataObject
         $this->address->persist($this->id);
         $phoneService = new PhoneNumberService();
         foreach ($this->phone_numbers as $phone) {
-            $phoneData = ['phone' => $phone->phoneNumber->getNationalDigits()];
+            $nationalDigits = $phone->phoneNumber->getNationalDigits();
+            if ($nationalDigits === null) {
+                // The legacy phone_numbers table stores 10-digit NANP parts
+                // (area_code / prefix / number). Skip numbers we can't
+                // represent in that schema rather than throwing a TypeError
+                // from PhoneNumberService::getPhoneParts().
+                continue;
+            }
+            $phoneData = ['phone' => $nationalDigits];
             $phoneService->type = $phone->type->value;
             // Always insert for now - PhoneNumberService handles upsert logic
             $phoneService->insert($phoneData, $this->id);

--- a/library/classes/Pharmacy.class.php
+++ b/library/classes/Pharmacy.class.php
@@ -221,7 +221,15 @@ class Pharmacy extends ORDataObject
         $this->address->persist($this->id);
         $phoneService = new PhoneNumberService();
         foreach ($this->phone_numbers as $phone) {
-            $phoneData = ['phone' => $phone->phoneNumber->getNationalDigits()];
+            $nationalDigits = $phone->phoneNumber->getNationalDigits();
+            if ($nationalDigits === null) {
+                // The legacy phone_numbers table stores 10-digit NANP parts
+                // (area_code / prefix / number). Skip numbers we can't
+                // represent in that schema rather than throwing a TypeError
+                // from PhoneNumberService::getPhoneParts().
+                continue;
+            }
+            $phoneData = ['phone' => $nationalDigits];
             $phoneService->type = $phone->type->value;
             // Always insert for now - PhoneNumberService handles upsert logic
             $phoneService->insert($phoneData, $this->id);

--- a/tests/Tests/Services/InsuranceCompanyServiceTest.php
+++ b/tests/Tests/Services/InsuranceCompanyServiceTest.php
@@ -390,4 +390,30 @@ class InsuranceCompanyServiceTest extends TestCase
             'form_country' => 'USA',
         ]);
     }
+
+    #[Test]
+    public function testLegacyPersistSkipsPhoneWithoutTenDigitNationalNumber(): void
+    {
+        // Regression for the TypeError on Practice Settings → Insurance Company
+        // edit when the phone field posts something PhoneNumber::tryParse will
+        // accept but that doesn't yield a 10-digit NANP national number
+        // (e.g. "555-1234"). The legacy InsuranceCompany::persist() forwarded
+        // a null from PhoneNumber::getNationalDigits() into
+        // PhoneNumberService::getPhoneParts(string), throwing:
+        //   TypeError: Argument #1 ($phone_number) must be of type string, null given
+        $co = new \InsuranceCompany();
+        $co->set_name('test-fixture-LegacyPersistShortPhone');
+        $co->set_phone('555-1234');
+
+        $co->persist();
+        $insuranceId = $co->id;
+        $this->assertTrue(is_int($insuranceId) || is_string($insuranceId));
+        $this->createdIds[] = $insuranceId;
+
+        $phoneRows = QueryUtils::fetchRecordsNoLog(
+            "SELECT id FROM phone_numbers WHERE foreign_id = ?",
+            [$insuranceId]
+        );
+        $this->assertSame([], $phoneRows);
+    }
 }

--- a/tests/Tests/Services/PharmacyPersistTest.php
+++ b/tests/Tests/Services/PharmacyPersistTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Pharmacy Persist Integration Test
+ *
+ * Exercises the legacy library/classes/Pharmacy.class.php persist() path
+ * against the phone_numbers table. Covers the same null-national-digits
+ * regression as InsuranceCompanyServiceTest::testLegacyPersistSkipsPhone...,
+ * since Pharmacy got the exact same buggy persist() code from PR #10326
+ * (the PhoneNumberService consolidation refactor) as InsuranceCompany did.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Claude Code
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services;
+
+use OpenEMR\Common\Database\QueryUtils;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class PharmacyPersistTest extends TestCase
+{
+    /** @var list<int|string> */
+    private array $createdIds = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdIds as $id) {
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `addresses` WHERE `foreign_id` = ?", [$id]);
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `phone_numbers` WHERE `foreign_id` = ?", [$id]);
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `pharmacies` WHERE `id` = ?", [$id]);
+        }
+    }
+
+    #[Test]
+    public function testLegacyPersistSkipsPhoneWithoutTenDigitNationalNumber(): void
+    {
+        // Regression for the same TypeError that fired on insurance company
+        // edits prior to InsuranceCompany::persist()'s null guard. Pharmacy
+        // got identical code from #10326 and crashes identically when a phone
+        // PhoneNumber::tryParse accepts doesn't yield a 10-digit NANP national
+        // number (e.g. "555-1234").
+        $pharmacy = new \Pharmacy();
+        $pharmacy->set_name('test-fixture-LegacyPersistShortPhone');
+        $pharmacy->set_phone('555-1234');
+
+        $pharmacy->persist();
+        $pharmacyId = $pharmacy->id;
+        $this->assertTrue(is_int($pharmacyId) || is_string($pharmacyId));
+        $this->createdIds[] = $pharmacyId;
+
+        $phoneRows = QueryUtils::fetchRecordsNoLog(
+            "SELECT id FROM phone_numbers WHERE foreign_id = ?",
+            [$pharmacyId]
+        );
+        $this->assertSame([], $phoneRows);
+    }
+}


### PR DESCRIPTION
**Bug:** saving an insurance company at *Practice Settings → Insurance Company* — or a pharmacy at *Procedures → Pharmacies* — throws a `TypeError` when the **Phone** (or **Fax**) field holds a value that `PhoneNumber::tryParse()` accepts but that does not yield a 10-digit NANP national number — e.g. a 7-digit local entry like `555-1234` or an over-long entry like `555-123-45678`. The user-visible trace from the insurance flow:

```
TypeError: OpenEMR\Services\PhoneNumberService::getPhoneParts():
  Argument #1 ($phone_number) must be of type string, null given,
  called in src/Services/PhoneNumberService.php on line 61
#0 src/Services/PhoneNumberService.php(61): PhoneNumberService->getPhoneParts()
#1 library/classes/InsuranceCompany.class.php(346): PhoneNumberService->insert()
#2 controllers/C_InsuranceCompany.class.php(89): C_InsuranceCompany->edit_action_process()
```

**Why:** `library/classes/InsuranceCompany.class.php::persist()` and `library/classes/Pharmacy.class.php::persist()` both read each typed phone via `$phone->phoneNumber->getNationalDigits()` and feed the result straight into `PhoneNumberService::insert()`. `getNationalDigits()` returns `?string` — `null` whenever the parsed national number isn't exactly 10 digits — and `PhoneNumberService::getPhoneParts()` is type-hinted `string`, so passing `null` blows up before the row hits the database.

Both classes got the buggy persist body from the same change: PR #10326 *"refactor(validation): consolidate phone number handling using PhoneNumberService"* (merged 2026-01-27), which replaced the old per-`PhoneNumber`-object `$phone->persist($id)` call with the service-mediated insert and introduced `getNationalDigits()` simultaneously without a null-check between them.

**Fix:** guard both `persist()` loops and skip phones the legacy `phone_numbers` table (the `area_code` / `prefix` / `number` triple) cannot represent. That mirrors the existing pattern on the read side of both classes, which already drops entries where `TypedPhoneNumber::tryCreate()` returns `null`. The user's save then succeeds; the invalid phone is silently dropped rather than crashing the request — matching what `set_number()` already does for outright unparseable input.

**Behavior note.** Silent-drop is the established convention in both `InsuranceCompany::set_number()` and `Pharmacy::set_number()` (they already silently return when `TypedPhoneNumber::tryCreate()` returns `null`), so this fix doesn't introduce a new UX pattern. Surface-level: pre-#10326 the same input quietly wrote a row with empty `area_code`/`prefix`/`number` columns (silent data corruption); this fix doesn't write a junk row. A proper form-level *"Phone must be a 10-digit number"* validation error belongs in a separate UX-focused PR — the underlying `phone_numbers` schema is itself NANP-only and would need to grow to support international formats first.

**Tests:**
- `InsuranceCompanyServiceTest::testLegacyPersistSkipsPhoneWithoutTenDigitNationalNumber` — drives the legacy InsuranceCompany class with `'555-1234'` and asserts persist completes and writes no `phone_numbers` row.
- `PharmacyPersistTest::testLegacyPersistSkipsPhoneWithoutTenDigitNationalNumber` — parallel test for the Pharmacy class.

**Verified locally:**
- Pre-fix: direct repro of both flows reproduces the exact reported `TypeError` (matched against the user's stack at `InsuranceCompany.class.php:346`; identical shape at `Pharmacy.class.php:227`).
- Post-fix: same inputs persist cleanly; happy path `'555-123-4567'` still writes `{area_code: 555, prefix: 123, number: 4567}` to `phone_numbers` for both classes.
- Pre-commit hook chain (phpstan / phpcbf / phpcs / rector / codespell / conventional-commits / composer-require-checker / php-syntax) all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Phone persistence for insurance companies and pharmacies now safely skips phone values that can’t be represented in the legacy format, preventing persistence-time errors.
* **Tests**
  * Added regression integration coverage to confirm that short/invalid phone numbers (e.g., missing a 10-digit national number) do not result in stored phone entries for both insurance and pharmacy records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->