### PR TITLE
chore(ci): Instruct CodeRabbit to not edit the main PR body

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+reviews:
+  high_level_summary: false


### PR DESCRIPTION
Updates the repo's [CodeRabbit config](https://docs.coderabbit.ai/reference/configuration) to not _edit the PR body_ with a summary. Comments are fine (and still allowed per default), but editing the PR body itself should be left to the authors and/or maintainers.