### PR TITLE
fix(insurance): clear phone_numbers before re-insert in legacy persist + cleanup migration

### DIFF
--- a/library/classes/InsuranceCompany.class.php
+++ b/library/classes/InsuranceCompany.class.php
@@ -337,33 +337,41 @@ class InsuranceCompany extends ORDataObject
 
     public function persist()
     {
-        parent::persist();
-        $this->address->persist($this->id);
-        $phoneService = new PhoneNumberService();
-        // Reset phone_numbers rows for this company before inserting so the
-        // table mirrors $this->phone_numbers after each save. Without the
-        // clear, persist() accumulates a fresh row on every save (since
-        // PhoneNumberService::insert is a plain INSERT, contrary to the
-        // earlier "handles upsert logic" comment) and the list-view LEFT
-        // JOINs on phone_numbers multiply each company across
-        // (work_count * fax_count) result rows.
-        QueryUtils::sqlStatementThrowException(
-            "DELETE FROM phone_numbers WHERE foreign_id = ?",
-            [$this->id]
-        );
-        foreach ($this->phone_numbers as $phone) {
-            $nationalDigits = $phone->phoneNumber->getNationalDigits();
-            if ($nationalDigits === null) {
-                // The legacy phone_numbers table stores 10-digit NANP parts
-                // (area_code / prefix / number). Skip numbers we can't
-                // represent in that schema rather than throwing a TypeError
-                // from PhoneNumberService::getPhoneParts().
-                continue;
+        // Wrap the whole logical save (parent row, address row, phone_numbers
+        // delete + re-insert) in a single transaction. The delete-then-insert
+        // below is what stops the duplicate-phone-row accumulation that PR
+        // #10326 introduced; without the transaction, a connection drop
+        // between the DELETE and the final INSERT would leave the record
+        // with partial or no phone data instead of just the buggy duplicates.
+        QueryUtils::inTransaction(function (): void {
+            parent::persist();
+            $this->address->persist($this->id);
+            $phoneService = new PhoneNumberService();
+            // Reset phone_numbers rows for this company so the table mirrors
+            // $this->phone_numbers after the loop. PhoneNumberService::insert
+            // is a plain INSERT (contrary to the earlier "handles upsert
+            // logic" comment), so without the clear persist() accumulates a
+            // fresh WORK + FAX row on every save and the list-view LEFT JOINs
+            // on phone_numbers multiply each company across
+            // (work_count * fax_count) result rows.
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM phone_numbers WHERE foreign_id = ?",
+                [$this->id]
+            );
+            foreach ($this->phone_numbers as $phone) {
+                $nationalDigits = $phone->phoneNumber->getNationalDigits();
+                if ($nationalDigits === null) {
+                    // The legacy phone_numbers table stores 10-digit NANP parts
+                    // (area_code / prefix / number). Skip numbers we can't
+                    // represent in that schema rather than throwing a TypeError
+                    // from PhoneNumberService::getPhoneParts().
+                    continue;
+                }
+                $phoneData = ['phone' => $nationalDigits];
+                $phoneService->type = $phone->type->value;
+                $phoneService->insert($phoneData, $this->id);
             }
-            $phoneData = ['phone' => $nationalDigits];
-            $phoneService->type = $phone->type->value;
-            $phoneService->insert($phoneData, $this->id);
-        }
+        });
     }
 
     public function insurance_companies_factory()

--- a/library/classes/InsuranceCompany.class.php
+++ b/library/classes/InsuranceCompany.class.php
@@ -16,6 +16,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\ORDataObject\Address;
 use OpenEMR\Common\ORDataObject\ORDataObject;
 use OpenEMR\Common\ValueObjects\TypedPhoneNumber;
@@ -339,6 +340,17 @@ class InsuranceCompany extends ORDataObject
         parent::persist();
         $this->address->persist($this->id);
         $phoneService = new PhoneNumberService();
+        // Reset phone_numbers rows for this company before inserting so the
+        // table mirrors $this->phone_numbers after each save. Without the
+        // clear, persist() accumulates a fresh row on every save (since
+        // PhoneNumberService::insert is a plain INSERT, contrary to the
+        // earlier "handles upsert logic" comment) and the list-view LEFT
+        // JOINs on phone_numbers multiply each company across
+        // (work_count * fax_count) result rows.
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM phone_numbers WHERE foreign_id = ?",
+            [$this->id]
+        );
         foreach ($this->phone_numbers as $phone) {
             $nationalDigits = $phone->phoneNumber->getNationalDigits();
             if ($nationalDigits === null) {
@@ -350,7 +362,6 @@ class InsuranceCompany extends ORDataObject
             }
             $phoneData = ['phone' => $nationalDigits];
             $phoneService->type = $phone->type->value;
-            // Always insert for now - PhoneNumberService handles upsert logic
             $phoneService->insert($phoneData, $this->id);
         }
     }

--- a/library/classes/Pharmacy.class.php
+++ b/library/classes/Pharmacy.class.php
@@ -220,6 +220,17 @@ class Pharmacy extends ORDataObject
         parent::persist();
         $this->address->persist($this->id);
         $phoneService = new PhoneNumberService();
+        // Reset phone_numbers rows for this pharmacy before inserting so the
+        // table mirrors $this->phone_numbers after each save. Without the
+        // clear, persist() accumulates a fresh row on every save (since
+        // PhoneNumberService::insert is a plain INSERT, contrary to the
+        // earlier "handles upsert logic" comment) and the list-view LEFT
+        // JOINs on phone_numbers multiply each pharmacy across
+        // (work_count * fax_count) result rows.
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM phone_numbers WHERE foreign_id = ?",
+            [$this->id]
+        );
         foreach ($this->phone_numbers as $phone) {
             $nationalDigits = $phone->phoneNumber->getNationalDigits();
             if ($nationalDigits === null) {
@@ -231,7 +242,6 @@ class Pharmacy extends ORDataObject
             }
             $phoneData = ['phone' => $nationalDigits];
             $phoneService->type = $phone->type->value;
-            // Always insert for now - PhoneNumberService handles upsert logic
             $phoneService->insert($phoneData, $this->id);
         }
     }

--- a/library/classes/Pharmacy.class.php
+++ b/library/classes/Pharmacy.class.php
@@ -217,33 +217,34 @@ class Pharmacy extends ORDataObject
 
     function persist()
     {
-        parent::persist();
-        $this->address->persist($this->id);
-        $phoneService = new PhoneNumberService();
-        // Reset phone_numbers rows for this pharmacy before inserting so the
-        // table mirrors $this->phone_numbers after each save. Without the
-        // clear, persist() accumulates a fresh row on every save (since
-        // PhoneNumberService::insert is a plain INSERT, contrary to the
-        // earlier "handles upsert logic" comment) and the list-view LEFT
-        // JOINs on phone_numbers multiply each pharmacy across
-        // (work_count * fax_count) result rows.
-        QueryUtils::sqlStatementThrowException(
-            "DELETE FROM phone_numbers WHERE foreign_id = ?",
-            [$this->id]
-        );
-        foreach ($this->phone_numbers as $phone) {
-            $nationalDigits = $phone->phoneNumber->getNationalDigits();
-            if ($nationalDigits === null) {
-                // The legacy phone_numbers table stores 10-digit NANP parts
-                // (area_code / prefix / number). Skip numbers we can't
-                // represent in that schema rather than throwing a TypeError
-                // from PhoneNumberService::getPhoneParts().
-                continue;
+        // Wrap the whole logical save (parent row, address row, phone_numbers
+        // delete + re-insert) in a single transaction. See the matching note
+        // in InsuranceCompany::persist() — the delete-then-insert pattern is
+        // what stops the duplicate-phone-row accumulation, and the
+        // transaction keeps a mid-loop failure from leaving the record with
+        // partial or no phone data instead of just the buggy duplicates.
+        QueryUtils::inTransaction(function (): void {
+            parent::persist();
+            $this->address->persist($this->id);
+            $phoneService = new PhoneNumberService();
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM phone_numbers WHERE foreign_id = ?",
+                [$this->id]
+            );
+            foreach ($this->phone_numbers as $phone) {
+                $nationalDigits = $phone->phoneNumber->getNationalDigits();
+                if ($nationalDigits === null) {
+                    // The legacy phone_numbers table stores 10-digit NANP parts
+                    // (area_code / prefix / number). Skip numbers we can't
+                    // represent in that schema rather than throwing a TypeError
+                    // from PhoneNumberService::getPhoneParts().
+                    continue;
+                }
+                $phoneData = ['phone' => $nationalDigits];
+                $phoneService->type = $phone->type->value;
+                $phoneService->insert($phoneData, $this->id);
             }
-            $phoneData = ['phone' => $nationalDigits];
-            $phoneService->type = $phone->type->value;
-            $phoneService->insert($phoneData, $this->id);
-        }
+        });
     }
 
     function utility_pharmacy_array()

--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -136,7 +136,7 @@ SET sql_mode = '';
 UPDATE `openemr_postcalendar_events` SET `pc_endDate` = NULL WHERE `pc_endDate` = '0000-00-00';
 SET sql_mode = @currentSQLMode;
 
--- v_database 540: Remove duplicate phone_numbers rows left by InsuranceCompany /
+-- v_database 541: Remove duplicate phone_numbers rows left by InsuranceCompany /
 -- Pharmacy persist() unconditional-insert.
 --
 -- PR #10326 replaced the legacy PhoneNumber->persist($id) call in

--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -135,3 +135,29 @@ SET @currentSQLMode = (SELECT @@sql_mode);
 SET sql_mode = '';
 UPDATE `openemr_postcalendar_events` SET `pc_endDate` = NULL WHERE `pc_endDate` = '0000-00-00';
 SET sql_mode = @currentSQLMode;
+
+-- v_database 540: Remove duplicate phone_numbers rows left by InsuranceCompany /
+-- Pharmacy persist() unconditional-insert.
+--
+-- PR #10326 replaced the legacy PhoneNumber->persist($id) call in
+-- InsuranceCompany::persist() and Pharmacy::persist() with a direct
+-- PhoneNumberService::insert() — which is a plain INSERT, not an upsert,
+-- despite the "PhoneNumberService handles upsert logic" comment that
+-- accompanied it. Every save (create or edit) appended fresh rows to
+-- phone_numbers for each entry in $this->phone_numbers; the list view's
+-- two LEFT JOINs on phone_numbers (one for type=WORK, one for type=FAX)
+-- then multiplied each company / pharmacy across
+-- (work_row_count * fax_row_count) result rows in the list UI.
+--
+-- The class-side fix (persist() now clears phone_numbers for the foreign id
+-- before re-inserting) stops new duplicates from forming; this cleanup
+-- handles rows already accumulated on instances upgrading from a buggy
+-- version. Idempotent — a no-op on instances that never accumulated dupes.
+--
+
+-- Keep the most recent (highest id) row per (foreign_id, type); drop older.
+DELETE p1 FROM phone_numbers p1
+INNER JOIN phone_numbers p2
+    ON p1.foreign_id = p2.foreign_id
+    AND p1.type = p2.type
+    AND p1.id < p2.id;

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3,7 +3,7 @@
 --
 -- Keep v_database in sync with $v_database in version.php.
 -- CI will fail if they don't match.
--- v_database: 540
+-- v_database: 541
 --
 
 --

--- a/tests/Tests/Services/InsuranceCompanyServiceTest.php
+++ b/tests/Tests/Services/InsuranceCompanyServiceTest.php
@@ -20,6 +20,7 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Services\Address\AddressData;
 use OpenEMR\Services\AddressService;
 use OpenEMR\Services\InsuranceCompanyService;
+use OpenEMR\Services\PhoneType;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -451,19 +452,32 @@ class InsuranceCompanyServiceTest extends TestCase
         $this->assertCount(2, $afterResave);
 
         // Re-save with a changed phone. The clear-then-insert should leave
-        // exactly one row per type, and the WORK row should carry the new
-        // number rather than the original.
+        // exactly one row per type, the WORK row should carry the new number,
+        // and the FAX row should still carry the original (since set_phone
+        // touches only the WORK entry).
         $co->set_phone('5551112222');
         $co->persist();
         $afterEdit = QueryUtils::fetchRecordsNoLog(
             "SELECT area_code, prefix, number, type FROM phone_numbers"
-            . " WHERE foreign_id = ? ORDER BY type",
+            . " WHERE foreign_id = ?",
             [$insuranceId]
         );
         $this->assertCount(2, $afterEdit);
-        $workRow = $afterEdit[0];
+        $byType = [];
+        foreach ($afterEdit as $row) {
+            $rowType = $row['type'];
+            $this->assertIsInt($rowType);
+            $byType[$rowType] = $row;
+        }
+        $workRow = $byType[PhoneType::WORK->value] ?? null;
+        $this->assertNotNull($workRow);
         $this->assertSame('555', $workRow['area_code']);
         $this->assertSame('111', $workRow['prefix']);
         $this->assertSame('2222', $workRow['number']);
+        $faxRow = $byType[PhoneType::FAX->value] ?? null;
+        $this->assertNotNull($faxRow);
+        $this->assertSame('555', $faxRow['area_code']);
+        $this->assertSame('987', $faxRow['prefix']);
+        $this->assertSame('6543', $faxRow['number']);
     }
 }

--- a/tests/Tests/Services/InsuranceCompanyServiceTest.php
+++ b/tests/Tests/Services/InsuranceCompanyServiceTest.php
@@ -416,4 +416,54 @@ class InsuranceCompanyServiceTest extends TestCase
         );
         $this->assertSame([], $phoneRows);
     }
+
+    #[Test]
+    public function testLegacyPersistDoesNotDuplicatePhoneRowsOnResave(): void
+    {
+        // Regression for the duplicate phone_numbers rows that accumulated on
+        // every save before persist() learned to clear by foreign_id first.
+        // PR #10326 swapped the legacy upsert for a bare PhoneNumberService
+        // insert(), so each save added another WORK row + another FAX row;
+        // the list view's two LEFT JOINs on phone_numbers then multiplied the
+        // company across (work_count * fax_count) rows in the UI.
+        $co = new \InsuranceCompany();
+        $co->set_name('test-fixture-LegacyPersistDuplicate');
+        $co->set_phone('5551234567');
+        $co->set_fax('5559876543');
+        $co->persist();
+        $insuranceId = $co->id;
+        $this->assertTrue(is_int($insuranceId) || is_string($insuranceId));
+        $this->createdIds[] = $insuranceId;
+
+        // After first save: one WORK row + one FAX row.
+        $afterCreate = QueryUtils::fetchRecordsNoLog(
+            "SELECT id, type FROM phone_numbers WHERE foreign_id = ?",
+            [$insuranceId]
+        );
+        $this->assertCount(2, $afterCreate);
+
+        // Re-save unchanged. Without the fix this would double to four rows.
+        $co->persist();
+        $afterResave = QueryUtils::fetchRecordsNoLog(
+            "SELECT id, type FROM phone_numbers WHERE foreign_id = ?",
+            [$insuranceId]
+        );
+        $this->assertCount(2, $afterResave);
+
+        // Re-save with a changed phone. The clear-then-insert should leave
+        // exactly one row per type, and the WORK row should carry the new
+        // number rather than the original.
+        $co->set_phone('5551112222');
+        $co->persist();
+        $afterEdit = QueryUtils::fetchRecordsNoLog(
+            "SELECT area_code, prefix, number, type FROM phone_numbers"
+            . " WHERE foreign_id = ? ORDER BY type",
+            [$insuranceId]
+        );
+        $this->assertCount(2, $afterEdit);
+        $workRow = $afterEdit[0];
+        $this->assertSame('555', $workRow['area_code']);
+        $this->assertSame('111', $workRow['prefix']);
+        $this->assertSame('2222', $workRow['number']);
+    }
 }

--- a/tests/Tests/Services/PharmacyPersistTest.php
+++ b/tests/Tests/Services/PharmacyPersistTest.php
@@ -19,6 +19,7 @@
 namespace OpenEMR\Tests\Services;
 
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\PhoneType;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -94,13 +95,25 @@ class PharmacyPersistTest extends TestCase
         $pharmacy->persist();
         $afterEdit = QueryUtils::fetchRecordsNoLog(
             "SELECT area_code, prefix, number, type FROM phone_numbers"
-            . " WHERE foreign_id = ? ORDER BY type",
+            . " WHERE foreign_id = ?",
             [$pharmacyId]
         );
         $this->assertCount(2, $afterEdit);
-        $workRow = $afterEdit[0];
+        $byType = [];
+        foreach ($afterEdit as $row) {
+            $rowType = $row['type'];
+            $this->assertIsInt($rowType);
+            $byType[$rowType] = $row;
+        }
+        $workRow = $byType[PhoneType::WORK->value] ?? null;
+        $this->assertNotNull($workRow);
         $this->assertSame('555', $workRow['area_code']);
         $this->assertSame('111', $workRow['prefix']);
         $this->assertSame('2222', $workRow['number']);
+        $faxRow = $byType[PhoneType::FAX->value] ?? null;
+        $this->assertNotNull($faxRow);
+        $this->assertSame('555', $faxRow['area_code']);
+        $this->assertSame('987', $faxRow['prefix']);
+        $this->assertSame('6543', $faxRow['number']);
     }
 }

--- a/tests/Tests/Services/PharmacyPersistTest.php
+++ b/tests/Tests/Services/PharmacyPersistTest.php
@@ -59,4 +59,48 @@ class PharmacyPersistTest extends TestCase
         );
         $this->assertSame([], $phoneRows);
     }
+
+    #[Test]
+    public function testLegacyPersistDoesNotDuplicatePhoneRowsOnResave(): void
+    {
+        // Same regression as the matching InsuranceCompany test — Pharmacy
+        // inherited the duplicate-on-save bug from PR #10326. Without the
+        // clear-then-insert in persist() every save added another WORK + FAX
+        // pair, and the list view's two LEFT JOINs on phone_numbers
+        // multiplied the pharmacy across (work_count * fax_count) result rows.
+        $pharmacy = new \Pharmacy();
+        $pharmacy->set_name('test-fixture-LegacyPersistDuplicate');
+        $pharmacy->set_phone('5551234567');
+        $pharmacy->set_fax('5559876543');
+        $pharmacy->persist();
+        $pharmacyId = $pharmacy->id;
+        $this->assertTrue(is_int($pharmacyId) || is_string($pharmacyId));
+        $this->createdIds[] = $pharmacyId;
+
+        $afterCreate = QueryUtils::fetchRecordsNoLog(
+            "SELECT id, type FROM phone_numbers WHERE foreign_id = ?",
+            [$pharmacyId]
+        );
+        $this->assertCount(2, $afterCreate);
+
+        $pharmacy->persist();
+        $afterResave = QueryUtils::fetchRecordsNoLog(
+            "SELECT id, type FROM phone_numbers WHERE foreign_id = ?",
+            [$pharmacyId]
+        );
+        $this->assertCount(2, $afterResave);
+
+        $pharmacy->set_phone('5551112222');
+        $pharmacy->persist();
+        $afterEdit = QueryUtils::fetchRecordsNoLog(
+            "SELECT area_code, prefix, number, type FROM phone_numbers"
+            . " WHERE foreign_id = ? ORDER BY type",
+            [$pharmacyId]
+        );
+        $this->assertCount(2, $afterEdit);
+        $workRow = $afterEdit[0];
+        $this->assertSame('555', $workRow['area_code']);
+        $this->assertSame('111', $workRow['prefix']);
+        $this->assertSame('2222', $workRow['number']);
+    }
 }

--- a/version.php
+++ b/version.php
@@ -31,7 +31,7 @@ $v_realpatch = '0';
 //
 // Keep in sync with the v_database comment in sql/database.sql.
 // CI will fail if they don't match.
-$v_database = 540;
+$v_database = 541;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
## Summary

Third follow-up to PR #10326 (the *PhoneNumberService consolidation* refactor from 2026-01-27). #12529 fixed the `TypeError` on non-NANP phones; #12534 added client-side validation. This PR fixes the third bug from the same source — `InsuranceCompany::persist()` and `Pharmacy::persist()` accumulating duplicate `phone_numbers` rows on every save — and ships a one-time cleanup of rows already in production.

## Symptom

On *Practice Settings → Insurance Companies* (and *Procedures → Pharmacies*), edit any company, click Save without changing anything. The list view now shows the same company name **four times**. Save again: nine. Again: sixteen.

The `insurance_companies` table isn't actually getting duplicate rows — it's still one. What's happening:

- `InsuranceCompany::persist()` and `Pharmacy::persist()` call `PhoneNumberService::insert()` once per entry in `$this->phone_numbers`. The accompanying comment says *"PhoneNumberService handles upsert logic"* — but the service's `insert()` is a plain INSERT. Each save appends a fresh WORK row + FAX row to `phone_numbers` for the same foreign id.
- `InsuranceCompanyService::search()` (the list query) LEFT JOINs `phone_numbers` twice on `i.id` — once filtered to `type=WORK`, once to `type=FAX`. With N work rows × M fax rows for one company, the join produces N×M list rows.

Both `set_number()` methods in the legacy classes already enforce *"replace existing phone of same type, or add new"* at the object layer, so multi-row-per-`(foreign_id, type)` is always a persist-bug artifact, never intentional state.

## Fix

Three pieces:

**1. `library/classes/InsuranceCompany.class.php` and `library/classes/Pharmacy.class.php` — `persist()`:** clear `phone_numbers` for the foreign id before the insert loop so the table mirrors `$this->phone_numbers` after every save.

```php
QueryUtils::sqlStatementThrowException(
    "DELETE FROM phone_numbers WHERE foreign_id = ?",
    [$this->id]
);
foreach ($this->phone_numbers as $phone) {
    // ... existing null-digits guard from #12529, then insert ...
}
```

**2. `sql/8_1_0-to-8_1_1_upgrade.sql` — one-time cleanup of duplicates already in production:**

```sql
DELETE p1 FROM phone_numbers p1
INNER JOIN phone_numbers p2
    ON p1.foreign_id = p2.foreign_id
    AND p1.type = p2.type
    AND p1.id < p2.id;
```

Self-join DELETE keeps the highest `id` per `(foreign_id, type)` and drops older duplicates. *Highest id* is right because if the user ever changed the phone, the latest save carries the corrected value. Idempotent — no-op on instances that never accumulated dupes, so re-running the upgrade is safe.

**3. Regression tests** — `InsuranceCompanyServiceTest::testLegacyPersistDoesNotDuplicatePhoneRowsOnResave` and the matching `PharmacyPersistTest`. Each covers: create, resave-unchanged, resave-with-changed-phone — asserts exactly one row per type each time, and that the row that survives carries the most recent number.

## Verification

- Direct PHP repro through `InsuranceCompany::persist()` and `Pharmacy::persist()` shows the new clear-then-insert leaves exactly one row per `(foreign_id, type)` across all three of the test scenarios.
- Selenium repro through the actual *Insurance Company* edit form: create → 3 resaves → list count stays at 1 each time (versus 1 → 4 → 9 → 16 without the fix).
- Manual sanity check of the cleanup SQL against fake duplicates in `phone_numbers` — 5 rows (3 WORK + 2 FAX) collapse to 2 (one row per type, both holding the highest-id record's values).
- Pre-commit chain green (phpstan, phpcbf, phpcs, rector, codespell, conventional-commits, composer-require-checker).

## Scope notes

- Affects only the legacy `library/classes/{InsuranceCompany,Pharmacy}.class.php::persist()` paths. The modern `InsuranceCompanyService::update()` already calls `phoneNumberService->update()` (true UPDATE WHERE foreign_id AND type), so the modern API path doesn't have this bug and isn't touched here.
- The cleanup query DELETEs across all `foreign_id` values, not just insurance / pharmacy ones — `phone_numbers` is shared, but the single-row-per-`(foreign_id, type)` invariant should hold across every writer anyway. If a non-shared writer somewhere depends on multiple rows per type for the same foreign id, this would be incorrect — I couldn't find such a writer in the codebase.

## Test plan

- [ ] Edit an existing insurance company, click Save, return to list — name should appear once, not multiple times.
- [ ] Repeat for a pharmacy.
- [ ] On a database with existing duplicates (e.g., a long-running instance), run the upgrade — list view stops multiplying, no data lost (highest-id row per type kept).
- [ ] On a clean database, run the upgrade — no-op (idempotent).