### PR TITLE
feat(dx): Add REPL tool for dev envs

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -26,6 +26,7 @@
     "OpenEMR\\Gacl\\Hashed_Cache_Lite",
     "Pdo\\Mysql",
     "PHPUnit\\Framework\\Attributes\\Test",
+    "Psy\\Shell",
     "SebastianBergmann\\CodeCoverage\\CodeCoverage",
     "SebastianBergmann\\CodeCoverage\\Driver\\Selector",
     "SebastianBergmann\\CodeCoverage\\Filter",

--- a/cli
+++ b/cli
@@ -11,6 +11,7 @@ use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Firehed\Container\TypedContainerInterface;
 use OpenEMR\Console\Command\{
     InstallCommand,
+    ShellCommand,
 };
 use Symfony\Component\Console\Application;
 
@@ -29,6 +30,7 @@ file_put_contents(
 
 $application = new Application();
 $application->addCommand($container->get(InstallCommand::class));
+$application->addCommand($container->get(ShellCommand::class));
 
 // Doctrine Migrations integration
 MigrationsConsoleRunner::addCommands($application, $container->get(DependencyFactory::class));

--- a/composer.json
+++ b/composer.json
@@ -137,6 +137,7 @@
         "zircote/swagger-php": "^6.0"
     },
     "require-dev": {
+        "ext-posix": "*",
         "ergebnis/composer-normalize": "^2.48",
         "iamcal/sql-parser": "^0.7.0",
         "justinrainbow/json-schema": "^6.8",

--- a/composer.json
+++ b/composer.json
@@ -150,6 +150,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/php-code-coverage": "^11.0",
         "phpunit/phpunit": "^11.0",
+        "psy/psysh": "^0.12.23",
         "ramsey/conventional-commits": "^1.5",
         "rector/rector": "^2.1",
         "roave/security-advisories": "dev-latest",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8a8f65efa52a03945dbc1b1415682478",
+    "content-hash": "e174604fb1f221481ffe90cad5e777ef",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -18567,7 +18567,9 @@
         "ext-zip": "*",
         "ext-zlib": "*"
     },
-    "platform-dev": {},
+    "platform-dev": {
+        "ext-posix": "*"
+    },
     "platform-overrides": {
         "ext-bcmath": "8.2",
         "ext-calendar": "8.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab9fd3b55305a91b37fb5962b108129f",
+    "content-hash": "8a8f65efa52a03945dbc1b1415682478",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -15598,6 +15598,85 @@
                 }
             ],
             "time": "2026-02-18T12:37:06+00:00"
+        },
+        {
+            "name": "psy/psysh",
+            "version": "v0.12.23",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bobthecow/psysh.git",
+                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4dcc0f08047d52bbde475eda481146fd8e27e1a4",
+                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "nikic/php-parser": "^5.0 || ^4.0",
+                "php": "^8.0 || ^7.4",
+                "symfony/console": "^8.0 || ^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4",
+                "symfony/var-dumper": "^8.0 || ^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4"
+            },
+            "conflict": {
+                "symfony/console": "4.4.37 || 5.3.14 || 5.3.15 || 5.4.3 || 5.4.4 || 6.0.3 || 6.0.4"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
+                "composer/class-map-generator": "^1.6"
+            },
+            "suggest": {
+                "composer/class-map-generator": "Improved tab completion performance with better class discovery.",
+                "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",
+                "ext-posix": "If you have PCNTL, you'll want the POSIX extension as well."
+            },
+            "bin": [
+                "bin/psysh"
+            ],
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-main": "0.12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Psy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Justin Hileman",
+                    "email": "justin@justinhileman.info"
+                }
+            ],
+            "description": "An interactive shell for modern PHP.",
+            "homepage": "https://psysh.org",
+            "keywords": [
+                "REPL",
+                "console",
+                "interactive",
+                "shell"
+            ],
+            "support": {
+                "issues": "https://github.com/bobthecow/psysh/issues",
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.23"
+            },
+            "time": "2026-05-23T13:41:31+00:00"
         },
         {
             "name": "ramsey/conventional-commits",

--- a/config/cli.php
+++ b/config/cli.php
@@ -16,4 +16,5 @@ namespace OpenEMR\Console\Command;
 
 return [
     InstallCommand::class,
+    ShellCommand::class,
 ];

--- a/src/Console/Command/ShellCommand.php
+++ b/src/Console/Command/ShellCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Wrap PsySH in a console command with some pre-configured variables.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <eric@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ * @see       https://physh.org
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Console\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Psy\Shell;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+
+#[AsCommand(
+    name: 'shell',
+    description: 'Run a REPL in the bootstrapped application',
+    aliases: ['repl'],
+)]
+class ShellCommand extends Command
+{
+    public function __construct(
+        readonly private EntityManagerInterface $em,
+    ) {
+        parent::__construct();
+    }
+
+    public function __invoke(): int
+    {
+        $shell = new Shell();
+        $shell->setScopeVariables([
+            'em' => $this->em,
+        ]);
+
+        return $shell->run();
+    }
+}

--- a/src/Console/Command/ShellCommand.php
+++ b/src/Console/Command/ShellCommand.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psy\Shell;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
     name: 'shell',
@@ -33,8 +34,13 @@ class ShellCommand extends Command
         parent::__construct();
     }
 
-    public function __invoke(): int
+    public function __invoke(OutputInterface $output): int
     {
+        // PhySH is installed as a dev dependency
+        if (!class_exists(Shell::class)) {
+            $output->writeln('Shell is only available in dev installations.');
+            return 1;
+        }
         $shell = new Shell();
         $shell->setScopeVariables([
             'em' => $this->em,

--- a/src/Console/Command/ShellCommand.php
+++ b/src/Console/Command/ShellCommand.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psy\Shell;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
@@ -34,7 +35,7 @@ class ShellCommand extends Command
         parent::__construct();
     }
 
-    public function __invoke(OutputInterface $output): int
+    public function __invoke(InputInterface $input, OutputInterface $output): int
     {
         if (!class_exists(Shell::class)) {
             // PhySH is installed as a dev dependency, so this condition is
@@ -49,6 +50,8 @@ class ShellCommand extends Command
             'em' => $this->em,
         ]);
 
-        return $shell->run();
+        // Input is only passed for unit tests, it's not needed for runtime.
+        // Passing output messes up formatting since it supplies its own tools
+        return $shell->run($input);
     }
 }

--- a/src/Console/Command/ShellCommand.php
+++ b/src/Console/Command/ShellCommand.php
@@ -36,10 +36,13 @@ class ShellCommand extends Command
 
     public function __invoke(OutputInterface $output): int
     {
-        // PhySH is installed as a dev dependency
         if (!class_exists(Shell::class)) {
+            // PhySH is installed as a dev dependency, so this condition is
+            // unreachable from test environments.
+            // @codeCoverageIgnoreStart
             $output->writeln('Shell is only available in dev installations.');
             return 1;
+            // @codeCoverageIgnoreEnd
         }
         $shell = new Shell();
         $shell->setScopeVariables([

--- a/tests/Tests/Isolated/Console/Command/ShellCommandTest.php
+++ b/tests/Tests/Isolated/Console/Command/ShellCommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Console\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use OpenEMR\Console\Command\ShellCommand;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+#[Group('isolated')]
+class ShellCommandTest extends TestCase
+{
+    public function testInvokeStartsShellAndExits(): void
+    {
+        if (posix_isatty(STDIN)) {
+            self::markTestSkipped('PsySH reads from STDIN; skipping in interactive mode. Run tests with `< /dev/null` at the end to test non-interactively.');
+        }
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $command = new ShellCommand($em);
+
+        $input = new ArrayInput([]);
+        $output = new NullOutput();
+
+        $result = $command($input, $output);
+
+        self::assertSame(0, $result, 'Shell should exit cleanly');
+    }
+}


### PR DESCRIPTION
#### Short description of what this changes or resolves:

During the course of expanding modernization (ORM/DBAL, DI, etc), it's helpful to be able to quickly validate integrations - particularly around the database. Instead of a slew of test scripts with repeated bootstrapping, this adds a REPL tool where the application is already bootstrapped, and exposes the Doctrine ORM EntityManagerInterface as `$em`. Other utilities/variables may get added in later based on their utility value.

#### Changes proposed in this pull request:

- Adds [PsySH](https://psysh.org) to the CLI, available at `./cli shell` (alias: `./cli repl`)
- Adds ext-posix to dev dependencies as a formality, though it's installed by default and must be explicitly disabled

#### Testing

Due to the nature of the package, it's not really possible to add any sort of *meaningful* unit tests as it's based around interactive inputs. Testing was manual:

- Ran `./cli repl` and `./cli shell`, saw it ran and behave as expected
- Ran `composer install --no-dev` to strip dev dependencies, saw it correctly detect the missing class and fail gracefully without disrupting other CLI commands

The test case included is mostly a smoke test.

#### Was an AI assistant used? Yes / No
No