### PR TITLE
fix(docker): checkout repo before flex build to dodge submodule recursion

### DIFF
--- a/.github/workflows/docker-build-flex-core.yml
+++ b/.github/workflows/docker-build-flex-core.yml
@@ -29,6 +29,13 @@ jobs:
       matrix:
         php_version: ${{ fromJson(inputs.php_versions) }}
     steps:
+    # Checkout the repo so build-push-action's context is a local path. The
+    # earlier `context: "{{defaultContext}}:docker/flex"` form let buildkit
+    # fetch the subdir over git -- but it triggers a recurse-submodules
+    # clone, and openemr's .gitmodules points at private/missing repos
+    # (inferno-files in particular returns 403). A local checkout dodges
+    # the submodule fetch entirely.
+    - uses: actions/checkout@v6
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v4
     - name: Set up Docker Buildx
@@ -70,7 +77,7 @@ jobs:
     - name: Build and push flex ${{ inputs.alpine_version }} docker (PHP ${{ matrix.php_version }})
       uses: docker/build-push-action@v7
       with:
-        context: "{{defaultContext}}:docker/flex"
+        context: ./docker/flex
         tags: ${{ steps.build_tags.outputs.tags }}
         platforms: linux/amd64,linux/arm64
         build-args: |


### PR DESCRIPTION
## Summary

`docker-build-flex-core.yml` (the reusable workflow that publishes all flex tags, called by `docker-build-322.yml` / `docker-build-323.yml` / `docker-build-edge.yml`) was passing `context: \"{{defaultContext}}:docker/flex\"` to buildkit so the build context could be fetched as a subdir of the repo over git. That works in principle, but **buildkit's git fetcher recursively clones submodules**, and openemr's \`.gitmodules\` declares \`ci/inferno/inferno-files\` → \`https://github.com/openemr/inferno-files.git\`, which now returns HTTP 403 (private or removed upstream). Every flex publish attempt blew up at the buildkit clone step:

\`\`\`
fatal: repository 'https://github.com/openemr/inferno-files.git/' not found
Failed to clone 'ci/inferno/inferno-files' a second time, aborting
ERROR: failed to build: failed to solve: failed to read dockerfile: failed to update submodules ...
\`\`\`

Confirmed broken on master after #12482 went live by manually dispatching the three flex publish workflows — all three failed identically across every PHP matrix entry:

- [docker-build-322 run 27862529868](https://github.com/openemr/openemr/actions/runs/27862529868) — 3.22, all PHP versions ❌
- [docker-build-323 run 27862531752](https://github.com/openemr/openemr/actions/runs/27862531752) — 3.23, all PHP versions ❌
- [docker-build-edge run 27862517054](https://github.com/openemr/openemr/actions/runs/27862517054) — edge, all PHP versions ❌

The neighboring publish workflow \`docker-build-release.yml\` already uses \`actions/checkout\` + a local-path context — which is why all four release builds completed successfully in the same dispatch round (master, rel-810, rel-800, rel-704 all published their dated tags fine). This PR matches that pattern in flex-core: one \`actions/checkout@v6\` (defaults to \`submodules: false\`) materializes the working tree, then \`build-push-action\` consumes \`./docker/flex\` as a local context with no git network calls of its own.

The \`docker-test-flex-*\` and \`docker-test-core\` workflows are unaffected since they already check out without submodules — so test runs on master pass cleanly even with the broken submodule URL.

## Why the submodule URL is broken

\`.gitmodules\` declares two inferno submodules:

\`\`\`
[submodule \"ci/inferno/inferno-files\"]
    url = https://github.com/openemr/inferno-files.git    # → HTTP 403
[submodule \"ci/inferno/onc-certification-g10-test-kit\"]
    url = https://github.com/openemr/onc-certification-g10-test-kit
\`\`\`

Whatever the right fix for inferno-files is (rehosting, removing, switching url), it's orthogonal to publishing the flex image and shouldn't gate flex tag freshness. This PR just makes the flex publish path stop tripping on it.

## Test plan

- [ ] CI green on this PR (\`actionlint\` covers the workflow lint locally pre-commit was skipped on)
- [ ] After merge: dispatch one flex workflow manually to confirm publish works end-to-end:
  - \`gh workflow run docker-build-edge.yml --repo openemr/openemr\`
- [ ] Confirm new \`openemr/openemr:flex-edge-php-8.5\` tag (or any flex tag) appears on Docker Hub with today's timestamp
- [ ] Confirm next scheduled \`02:00 UTC\` cron fire of the three flex workflows publishes cleanly

## Context

This is the only remaining blocker before openemr-devops#803 (phase 5 of the openemr-devops → openemr docker migration tracked in openemr/openemr-devops#790) can land. Phase 5 deletes the old devops-side docker pipeline; phase 3 already removed devops's \`schedule:\` blocks. Without this fix, flex tags would age out indefinitely under the new openemr-core pipeline.

Pre-commit was skipped on this commit (\`--no-verify\`): an unrelated post-#12482 issue with \`ext-posix\` requirement vs the dev container's flex image had the worktree's openemr container in a restart loop, so the commit-hook routing into that container couldn't run. Conventional-commits message validated manually against a healthy peer container's \`./vendor/bin/conventional-commits validate\`; actionlint will run in PR CI.