### PR TITLE
fix(docker): add php-posix to the flex image apk install list

### DIFF
--- a/docker/flex/Dockerfile
+++ b/docker/flex/Dockerfile
@@ -129,6 +129,7 @@ RUN apk add --no-cache \
     php${PHP_VERSION_ABBR}-pecl-apcu \
     php${PHP_VERSION_ABBR}-pecl-imagick \
     php${PHP_VERSION_ABBR}-phar \
+    php${PHP_VERSION_ABBR}-posix \
     "$(if [ "${PHP_VERSION}" = "8.2" ] || [ "${PHP_VERSION}" = "8.3" ] || [ "${PHP_VERSION}" = "8.4" ]; then echo php${PHP_VERSION_ABBR}-redis; else echo php${PHP_VERSION_ABBR}-pecl-redis; fi)" \
     php${PHP_VERSION_ABBR}-session \
     php${PHP_VERSION_ABBR}-simplexml \


### PR DESCRIPTION
## Summary

#12539 (`feat(dx): Add REPL tool for dev envs`) added `psy/psysh` and `ext-posix` to root `composer.json`'s `require-dev` block, which in turn added `platform-dev: { ext-posix: "*" }` to `composer.lock`. The flex image (`openemr/openemr:flex`) backs every dev-stack variant (`docker/development-{easy,easy-light,easy-redis,insane}`) and does **not** install `php${PHP_VERSION_ABBR}-posix`. So the post-#12539 first-boot of any fresh stack hangs at `composer install` (the easy-dev stack runs it in dev mode because `DEVELOPER_TOOLS: "yes"`):

```
Your lock file does not contain a compatible set of packages. Please run composer update.

  Problem 1
    - Root composer.json requires PHP extension ext-posix * but it is missing
      from your system. Install or enable PHP's posix extension.
```

The openemr container restart-loops with exit code 2 until the `vendordir` volume is wiped. Existing stacks whose `vendordir` volume is already populated don't re-break on restart (composer install is skipped on the fast path), which is why this didn't surface immediately — the bite hits when contributors spin up fresh worktrees or wipe volumes for any reason.

## Why this image specifically

- `docker/flex/Dockerfile` — used by every `docker/development-*/` compose, runs `composer install` (with dev deps) on boot. **This is the fix.**
- `docker/release/Dockerfile` + `docker/binary/Dockerfile` — production images, run `composer install --no-dev` and never consult `platform-dev`. Deliberately not touched. Adding posix there gains nothing and quietly licenses future contributors to assume posix is always present (which is the chain that produced this bug).

## What changes

One line, alphabetical position in the existing `apk add --no-cache` list:

```
+    php${PHP_VERSION_ABBR}-posix \
```

The package exists in every Alpine version the flex matrix targets (3.22 / 3.23 / edge), across every PHP version (8.2 / 8.3 / 8.4 / 8.5).

## What happens after this lands

1. Next flex-publish run (manual dispatch, or 02:00 UTC cron) rebuilds `openemr/openemr:flex-3.22`, `flex-3.23`, `flex-edge`, plus the bare `flex` alias. Note: requires #12547 to also be in to actually publish — that PR fixes the broken flex publish path (modules submodule clone failure), and is the reason flex tags aren't currently refreshing under the new pipeline.
2. The `openemr-images` dependabot group auto-opens a PR within ~24h bumping the `openemr/openemr:flex@sha256:…` pin in:
   - `docker/development-easy/docker-compose.yml`
   - `docker/development-easy-light/docker-compose.yml`
   - `docker/development-easy-redis/docker-compose.yml`
   - `docker/development-insane/docker-compose.yml`
3. Fresh stacks pull the new image and come up cleanly. Existing populated `vendordir` volumes are unaffected throughout.

## Test plan

- [ ] CI green on this PR (Dockerfile linting / hadolint covers the apk install list change locally pre-commit was skipped on)
- [ ] After merge + #12547 merge, fire one manual flex publish to validate the build still works with the new package:
  - `gh workflow run docker-build-edge.yml --repo openemr/openemr`
- [ ] Pull the freshly-published image and confirm posix is present:
  - `docker run --rm openemr/openemr:flex-edge php -m | grep -i posix`
- [ ] Spin up a fresh stack against the new image SHA and verify the openemr container reaches healthy state instead of restart-looping at composer install

## Windows-native contributors

Out of scope here. Windows PHP has no posix build at all and this image fix doesn't help (or hurt) them. The previously-documented workaround stays valid:

```
composer config --global platform.ext-posix 1
```

Nothing in openemr's own code calls `posix_*` unconditionally, and the vendor packages that do (`symfony/process`, `symfony/console`, `react/socket`) all guard with `function_exists()` and degrade gracefully. The only intentional runtime caller is PsySH (`./cli shell` from #12539), and PsySH has Windows fallbacks. A follow-up could drop the explicit `ext-posix` line from `require-dev` (PsySH declares posix as `suggest`, not `require`) for Windows-friendliness — but that's an orthogonal scope decision and shouldn't gate fixing the broken dev images.

## Context

This is the second of two flex-image PRs unblocking the openemr-devops → openemr-core docker migration (tracked in openemr/openemr-devops#790). The first is #12547 (broken flex publish path). Both are dev/CI infra fixes — no production-image or production-runtime impact.