### PR TITLE
ci(dependabot): track pre-commit hook revs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,6 +120,26 @@ updates:
     include: scope
   open-pull-requests-limit: 5
 
+  # Pre-commit hook revs in .pre-commit-config.yaml. Tooling pins -- same
+  # category as github-actions above. Majors are allowed (no ignore block):
+  # hook bumps are reviewed before merge, so a behavior change (new lint
+  # rule, CLI rename) surfaces as a Dependabot PR with a diff, not silent
+  # drift. Application-dep ecosystems (composer/npm) block majors because
+  # the blast radius is different; pre-commit doesn't have that risk.
+- package-ecosystem: pre-commit
+  directory: /
+  schedule:
+    interval: weekly
+    day: monday
+    time: "08:00"
+  labels:
+  - dependencies
+  - pre-commit
+  commit-message:
+    prefix: chore
+    include: scope
+  open-pull-requests-limit: 5
+
   # Docker selenium updates for CI (shared compose file)
   # Docker dev directories are covered by their own entries below,
   # which handle selenium alongside all other images.


### PR DESCRIPTION
## Summary

Wires `.pre-commit-config.yaml` hook revs into Dependabot so they get the same weekly auto-bump treatment composer/npm/github-actions already get. Today every rev in that file is a manual pin — maintainers have to remember to run `prek autoupdate` or hand-edit. History of the file confirms: no bot-authored bumps, just incidental edits when someone touches the file for another reason.

With this entry, Dependabot files weekly PRs for outdated hooks. Currently that's `pre-commit-hooks` (v4.5.0), `language-formatters-pre-commit-hooks` (v2.14.0), `codespell` (v2.4.1), `actionlint` (v1.7.10), and `hadolint-py` (v2.14.0, just added in #12552).

## Design decisions

- **Allow majors (no `ignore` block).** Mirrors the existing `github-actions` ecosystem entry — both are dev tooling, not application dependencies. A behavior-changing bump (new lint rule, CLI rename, hook ID rename) surfaces as a Dependabot PR for review rather than silent drift. The `composer` and `npm` ecosystems block majors because app-dep breakage has a different blast radius; that doesn't apply here. If a specific hook turns out to ship reckless majors, we can add a per-`dependency-name` ignore later.
- **Weekly Monday 08:00.** Matches the existing composer/npm cadence so all dep-bump PRs cluster on the same day instead of trickling in every weekday.
- **`labels: [dependencies, pre-commit]`, `commit-message: { prefix: chore, include: scope }`.** Same shape as the other ecosystem entries.
- **`open-pull-requests-limit: 5`.** Same as `github-actions`. Pre-commit only has 5 hook blocks right now, so this is enough headroom for the rare case where every one of them has an outstanding bump.

## What's NOT covered (potential follow-up)

Right now, only one pre-commit hook gets meaningful CI validation when its rev changes: `pre-commit-hooks` (via `.github/workflows/whitespace.yml`, which runs `trailing-whitespace`/`end-of-file-fixer`/`mixed-line-ending` on every PR). The others:

- `actionlint` — `.github/workflows/pre-commit.yml` runs `actionlint-docker --all-files`, but only on `paths: ['.github/workflows/*.yml']`. A Dependabot bump to actionlint touches `.pre-commit-config.yaml`, which doesn't match that filter, so the bump PR wouldn't trigger this workflow.
- `language-formatters-pre-commit-hooks`, `hadolint-py` — no CI workflow runs these. A bad bump would land without a green-checkmark signal.
- `codespell` — CI runs `composer codespell` against a host-installed codespell from `requirements-spellcheck.txt`, independent of the pre-commit hook's rev. A pre-commit bump doesn't touch CI lint findings.

A small follow-up PR adding `.pre-commit-config.yaml` to the `paths:` filter on `pre-commit.yml` (or adding a new job that runs `prek run --all-files` against CI-safe hooks on config changes) would close that gap. Not bundling here because it's orthogonal to enabling Dependabot.

## Test plan

- [x] `prek run --files .github/dependabot.yml` — all hooks pass against the new entry
- [ ] Once merged, the next Monday's Dependabot cycle should pick up the `pre-commit` ecosystem and file PRs for any outdated hook revs

🤖 Generated with [Claude Code](https://claude.com/claude-code)