### PR TITLE
chore(composer): ext-posix in `require-dev` breaks `composer install` on Windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,6 @@
         "zircote/swagger-php": "^6.0"
     },
     "require-dev": {
-        "ext-posix": "*",
         "ergebnis/composer-normalize": "^2.48",
         "iamcal/sql-parser": "^0.7.0",
         "justinrainbow/json-schema": "^6.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e174604fb1f221481ffe90cad5e777ef",
+    "content-hash": "8a8f65efa52a03945dbc1b1415682478",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -18567,9 +18567,7 @@
         "ext-zip": "*",
         "ext-zlib": "*"
     },
-    "platform-dev": {
-        "ext-posix": "*"
-    },
+    "platform-dev": {},
     "platform-overrides": {
         "ext-bcmath": "8.2",
         "ext-calendar": "8.2",
@@ -18606,5 +18604,5 @@
         "ext-zlib": "8.2",
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/Tests/Isolated/Console/Command/ShellCommandTest.php
+++ b/tests/Tests/Isolated/Console/Command/ShellCommandTest.php
@@ -1,11 +1,13 @@
 <?php
 
 /**
- * @package   OpenEMR
- * @link      https://www.open-emr.org
- * @author    Eric Stern <erics@opencoreemr.com>
- * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
- * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ * @package    OpenEMR
+ * @link       https://www.open-emr.org
+ * @author     Eric Stern <erics@opencoreemr.com>
+ * @author     Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright  Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @copyright  Copyright (c) 2026 Jerry Padgett <sjpadgett@gmail.com>
+ * @license    https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 declare(strict_types=1);
@@ -20,8 +22,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
-#[RequiresPhpExtension('posix')]
 #[Group('isolated')]
+#[RequiresPhpExtension('posix')]
 final class ShellCommandTest extends TestCase
 {
     public function testInvokeStartsShellAndExits(): void

--- a/tests/Tests/Isolated/Console/Command/ShellCommandTest.php
+++ b/tests/Tests/Isolated/Console/Command/ShellCommandTest.php
@@ -22,8 +22,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
-#[Group('isolated')]
 #[RequiresPhpExtension('posix')]
+#[Group('isolated')]
 final class ShellCommandTest extends TestCase
 {
     public function testInvokeStartsShellAndExits(): void

--- a/tests/Tests/Isolated/Console/Command/ShellCommandTest.php
+++ b/tests/Tests/Isolated/Console/Command/ShellCommandTest.php
@@ -15,12 +15,14 @@ namespace OpenEMR\Tests\Isolated\Console\Command;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenEMR\Console\Command\ShellCommand;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
+#[RequiresPhpExtension('posix')]
 #[Group('isolated')]
-class ShellCommandTest extends TestCase
+final class ShellCommandTest extends TestCase
 {
     public function testInvokeStartsShellAndExits(): void
     {


### PR DESCRIPTION

Windows PHP ships no posix extension, and a composer platform requirement is enforced at install time (and recorded in the lock's `platform-dev`), so every Windows contributor hits a hard failure. The only thing in the tree that actually touches posix is the `posix_isatty()` call in `ShellCommandTest` . We can let that test skip where posix isn't available — the standard cross-platform pattern — with `#[RequiresPhpExtension('posix')]`. PHPUnit evaluates it before the method runs

#### Was an AI assistant used? Yes

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
