### PR TITLE
fix(core): prevent {headerTemplate} from rendering the page header twice

### DIFF
--- a/library/smarty/plugins/function.headerTemplate.php
+++ b/library/smarty/plugins/function.headerTemplate.php
@@ -33,5 +33,11 @@ function smarty_function_headerTemplate($params, &$smarty)
         $assets = explode('|', (string) $params['assets']);
     }
 
-    return Header::setupHeader($assets);
+    // Pass $echoOutput = false so setupHeader() only returns the markup. As a Smarty
+    // function plugin, the value returned here is printed at the {headerTemplate} tag.
+    // With the default $echoOutput = true, setupHeader() would also echo the markup,
+    // emitting the entire header (jQuery, Bootstrap, etc.) twice from a single tag --
+    // double-binding Bootstrap's data-api handlers (e.g. dropdowns open then instantly
+    // close). See OpenEMR\Core\Header::setupHeader().
+    return Header::setupHeader($assets, false);
 }

--- a/tests/Tests/Unit/Core/HeaderTest.php
+++ b/tests/Tests/Unit/Core/HeaderTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Tests for the {headerTemplate} Smarty plugin / OpenEMR\Core\Header.
+ *
+ * Regression guard for the bug where a single {headerTemplate} tag emitted the
+ * page header (jQuery, Bootstrap, etc.) twice: Header::setupHeader() defaults to
+ * $echoOutput = true (echo + return), and a Smarty function plugin's return value
+ * is printed at the tag, so the plugin must call setupHeader() in return-only mode.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Discover and Change AI Worker <ai-worker@discoverandchange.com>
+ * @copyright Copyright (c) 2026 Discover and Change, Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Unit\Core;
+
+use OpenEMR\Core\Header;
+use OpenEMR\Core\OEGlobalsBag;
+use PHPUnit\Framework\TestCase;
+use Smarty;
+
+class HeaderTest extends TestCase
+{
+    /** Assets requested in the tests; each maps to a script that must appear exactly once. */
+    private const ASSET_MARKERS = [
+        'jquery/dist/jquery.min.js',
+        'js/bootstrap.bundle.min.js',
+        'select2.full.min.js',
+    ];
+
+    private string $compileDir = '';
+
+    private string $fileRoot = '';
+
+    protected function setUp(): void
+    {
+        $this->fileRoot = OEGlobalsBag::getInstance()->getString('fileroot');
+        // Ensure the plugin function is defined for the direct-call tests.
+        require_once $this->fileRoot . '/library/smarty/plugins/function.headerTemplate.php';
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->compileDir !== '' && is_dir($this->compileDir)) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($this->compileDir, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
+
+            foreach ($iterator as $path) {
+                if (!$path instanceof \SplFileInfo) {
+                    continue;
+                }
+                if ($path->isDir()) {
+                    rmdir($path->getPathname());
+                    continue;
+                }
+                unlink($path->getPathname());
+            }
+
+            rmdir($this->compileDir);
+        }
+    }
+
+    /**
+     * The plugin must RETURN its markup and NOT echo it. This is the direct guard
+     * against the regression: if the plugin reverts to setupHeader($assets) (echo
+     * defaulting to true), $echoed becomes non-empty and this fails.
+     */
+    public function testHeaderTemplatePluginReturnsMarkupWithoutEchoing(): void
+    {
+        $smarty = new Smarty();
+
+        ob_start();
+        $returned = smarty_function_headerTemplate(['assets' => 'datetime-picker|select2'], $smarty);
+        $echoed = ob_get_clean();
+
+        $this->assertSame('', $echoed, 'The {headerTemplate} plugin must not echo; it must only return markup.');
+        $this->assertIsString($returned, 'The {headerTemplate} plugin must return a markup string.');
+        $this->assertStringContainsString('js/bootstrap.bundle.min.js', $returned);
+    }
+
+    /**
+     * Header::setupHeader($assets, false) is the contract the plugin relies on:
+     * return the markup, echo nothing.
+     */
+    public function testSetupHeaderReturnOnlyDoesNotEcho(): void
+    {
+        ob_start();
+        $returned = Header::setupHeader([], false);
+        $echoed = ob_get_clean();
+
+        $this->assertSame('', $echoed, 'setupHeader(..., false) must not echo.');
+        $this->assertStringContainsString('js/bootstrap.bundle.min.js', $returned);
+    }
+
+    /**
+     * With $echoOutput = true the markup is both echoed and returned (the default
+     * used by direct PHP callers). Documents why the Smarty plugin must pass false.
+     */
+    public function testSetupHeaderEchoesAndReturnsWhenRequested(): void
+    {
+        ob_start();
+        $returned = Header::setupHeader([], true);
+        $echoed = ob_get_clean();
+
+        $this->assertNotSame('', $echoed, 'setupHeader(..., true) must echo the markup.');
+        $this->assertSame($echoed, $returned, 'Echoed and returned markup must be identical.');
+    }
+
+    /**
+     * End-to-end: rendering a Smarty template that uses {headerTemplate} must emit
+     * each asset exactly once. Pre-fix this produced two copies of the whole header.
+     */
+    public function testHeaderTemplateRendersAssetsExactlyOnce(): void
+    {
+        $this->compileDir = sys_get_temp_dir() . '/oe-headertest-' . bin2hex(random_bytes(8));
+        $this->assertTrue(mkdir($this->compileDir), "Failed to create temp compile dir: {$this->compileDir}");
+
+        $smarty = new Smarty();
+        $smarty->setCompileDir($this->compileDir);
+        $smarty->setPluginsDir([
+            $this->fileRoot . '/library/smarty/plugins',
+            $this->fileRoot . '/vendor/smarty/smarty/libs/plugins',
+        ]);
+
+        $html = $smarty->fetch("eval:{headerTemplate assets='datetime-picker|select2'}");
+
+        foreach (self::ASSET_MARKERS as $marker) {
+            $this->assertSame(
+                1,
+                substr_count($html, $marker),
+                "Asset '$marker' must be included exactly once (duplicate header = the regression)."
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #12567

## What

The `{headerTemplate}` Smarty plugin (`library/smarty/plugins/function.headerTemplate.php`) did:

```php
return Header::setupHeader($assets);
```

`Header::setupHeader()` has `$echoOutput = true` by default, so it **echoes** the header markup *and* returns it. Because a Smarty function plugin's return value is printed at the tag location, a single `{headerTemplate}` tag emitted the entire `<head>` asset block (jQuery, Bootstrap, etc.) **twice**.

## Why it matters

The duplicate `jquery.min.js` + `bootstrap.bundle.min.js` load registers Bootstrap's dropdown `data-api` click handler on `document` twice. A single toggle click then runs Bootstrap's `toggle` twice — open, then immediately close — so the menu flickers and appears to do nothing.

This is visible on the patient **Documents** upload screen: the "Open Patient Template" dropdown opens and instantly closes. It affects every Smarty page that uses `{headerTemplate}` (documents, practice settings, insurance companies, prescription lookup, review of systems, prior auth, clickmap), which all double-load their assets.

This regressed when the `return` in `setupHeader()` was made unconditional (so it now both echoes and returns); direct PHP callers ignore the return value, so only the Smarty path doubled.

## Fix

Pass `$echoOutput = false` so the plugin only **returns** the markup and Smarty prints a single copy. One line + explanatory comment. The sibling `{assetsTemplate}` plugin already calls `setupAssets()` in return-only form and is unaffected.

## Testing

- Rendered `{headerTemplate assets='datetime-picker|select2'}` through OpenEMR's real Smarty stack: `bootstrap.bundle.min.js`, `jquery.min.js`, `select2.full.min.js` each appear **once** (were twice before).
- Authenticated HTTP fetch of the Documents and prescription-lookup pages: single header; the documents dropdown opens and stays open.
- `composer phpcs` / `php -l` clean; core PHPUnit unit suite green.