### PR TITLE
fix(contrib): repair trailing comma in Pain_Initial_Assessment.json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,14 @@ repos:
     - --autofix
     - --indent=2
     - --no-sort-keys
-    exclude: ^composer\.json$
+    # composer.json is excluded because composer-normalize (below) owns its
+    # formatting -- two formatters fighting over the same file. The
+    # Pain_Initial_Assessment.json exclude is temporary: that file uses
+    # 4-space indent (consistent with HL7 SDC IG convention) and the hook
+    # would rewrite all 13k lines to 2-space on any touch. A follow-up PR
+    # will split this hook into per-ecosystem 2-space / 4-space blocks so
+    # individual excludes like this are no longer needed.
+    exclude: ^(composer\.json|contrib/portal_templates/assessments/SDC FHIR/Pain_Initial_Assessment\.json)$
   - id: mixed-line-ending
     args:
     - --fix=lf

--- a/contrib/portal_templates/assessments/SDC FHIR/Pain_Initial_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/Pain_Initial_Assessment.json
@@ -3,7 +3,7 @@
     "meta": {
         "profile": [
             "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
-            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
         ],
         "tag": [
             {


### PR DESCRIPTION
## Summary

`contrib/portal_templates/assessments/SDC FHIR/Pain_Initial_Assessment.json` has been invalid JSON since it was added in #7973 (2025-02-05). A trailing comma sits on the last element of the `meta.profile` array (line 6), which strict JSON forbids before `]`.

```json
        "profile": [
            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
-            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
        ],
```

The breakage went unnoticed because (1) the file has not been touched in a way that triggers pre-commit's `check-json` since the hook landed in #9740, and (2) no CI workflow runs `check-json --all-files`. I found it doing a repo-wide audit of the pre-commit hook suite.

## Why two files in the diff

PR-1 ships two changes:

1. **Surgical comma removal** — one-character fix that makes the file parse cleanly.

2. **Add the file to the `pretty-format-json` exclude pattern** — preserves the file's 4-space indent.

The `pretty-format-json` hook is configured with `--indent=2`, but every file under `contrib/portal_templates/assessments/SDC FHIR/` is 4-space throughout. That's not random — 4-space is the JSON convention used by HL7 FHIR resources and the SDC implementation guide examples that these contrib templates are derived from. Without an exclude, the autofixer would have rewritten all 13,724 lines on this commit, ballooning a one-character bug fix into a ~27k-line diff and silently diverging the file from its upstream SDC convention.

The exclude is **intentionally temporary** — see the inline comment above it explaining the design. A follow-up PR will:

- Split `pretty-format-json` into per-ecosystem 2-space (JS / npm / JSON-schema files) and 4-space (PHP / healthcare-data files) hook blocks, mirroring the existing `check-yaml` split for compose-with-`!override` files
- Either subsume `Pain_Initial_Assessment.json` into the 4-space block, or exclude the entire SDC FHIR contrib directory as an upstream-derived corpus (along with `src/Cqm/*.json`, the FHIR Questionnaire IG examples in `tests/Tests/data/Services/FHIR/`, and similar)

At that point the per-file exclude can be removed.

## Test plan

- [x] `python3 -c 'json.load(open(file))'` against the fixed file — parses cleanly
- [x] `prek run check-json --files <file>` — passes
- [x] `prek run pretty-format-json --files <file>` — skipped (exclude honored)
- [x] `git commit` runs through the full pre-commit suite without auto-rewriting the 13k-line file

🤖 Generated with [Claude Code](https://claude.com/claude-code)