### PR TITLE
style(yaml): apply pretty-format-yaml across repo-owned configs

### DIFF
--- a/.github/actions/setup-php-composer/action.yml
+++ b/.github/actions/setup-php-composer/action.yml
@@ -25,31 +25,31 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ inputs.php-version }}
-        coverage: ${{ inputs.coverage }}
-        extensions: ${{ inputs.extensions }}
-        tools: ${{ inputs.tools }}
+  - name: Setup PHP
+    uses: shivammathur/setup-php@v2
+    with:
+      php-version: ${{ inputs.php-version }}
+      coverage: ${{ inputs.coverage }}
+      extensions: ${{ inputs.extensions }}
+      tools: ${{ inputs.tools }}
 
-    - name: Get composer cache directory
-      if: inputs.skip-composer-install != 'true'
-      id: composer-cache
-      shell: bash
-      run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+  - name: Get composer cache directory
+    if: inputs.skip-composer-install != 'true'
+    id: composer-cache
+    shell: bash
+    run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
-    - name: Cache Composer dependencies
-      if: inputs.skip-composer-install != 'true'
-      uses: actions/cache@v5
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-${{ inputs.php-version }}-
-          ${{ runner.os }}-composer-
+  - name: Cache Composer dependencies
+    if: inputs.skip-composer-install != 'true'
+    uses: actions/cache@v5
+    with:
+      path: ${{ steps.composer-cache.outputs.dir }}
+      key: ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles('**/composer.lock') }}
+      restore-keys: |
+        ${{ runner.os }}-composer-${{ inputs.php-version }}-
+        ${{ runner.os }}-composer-
 
-    - name: Install Composer dependencies
-      if: inputs.skip-composer-install != 'true'
-      shell: bash
-      run: composer install --prefer-dist --no-progress
+  - name: Install Composer dependencies
+    if: inputs.skip-composer-install != 'true'
+    shell: bash
+    run: composer install --prefer-dist --no-progress

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,14 +5,14 @@ daysUntilStale: 90
 daysUntilClose: 7
 # Only close triaged issues that lack reproduction / clear next steps
 onlyLabels:
-    - WaitingForInfo
+- WaitingForInfo
 # Set to true to ignore issues with an assignee (defaults to false)
 exemptAssignees: true
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - pinned
-  - Security
-  - stalebot-ignore
+- pinned
+- Security
+- stalebot-ignore
 # Label to use when marking an issue as stale
 staleLabel: Stale
 # Set to true to ignore issues in a milestone (defaults to false)

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,8 +5,8 @@ on:
     # All PRs
   push:
     branches:
-      - master
-      - rel-*
+    - master
+    - rel-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -26,37 +26,37 @@ jobs:
       fail-fast: false
       matrix:
         database:
-          - name: MySQL 5.7
-            image: mysql:5.7
-            health-cmd: "mysql -uroot -proot -e 'SELECT 1'"
-          - name: MySQL 8.4 (LTS)
-            image: mysql:8.4
-            health-cmd: "mysql -uroot -proot -e 'SELECT 1'"
-          - name: MySQL 9.7 (LTS)
-            image: mysql:9.7
-            health-cmd: "mysql -uroot -proot -e 'SELECT 1'"
-          - name: MariaDB 10.6 (LTS)
-            image: mariadb:10.6
-            health-cmd: "healthcheck.sh --connect --innodb_initialized"
-          - name: MariaDB 10.11 (LTS)
-            image: mariadb:10.11
-            health-cmd: "healthcheck.sh --connect --innodb_initialized"
-          - name: MariaDB 11.4 (LTS)
-            image: mariadb:11.4
-            health-cmd: "healthcheck.sh --connect --innodb_initialized"
-          - name: MariaDB 11.8 (LTS)
-            image: mariadb:11.8
-            health-cmd: "healthcheck.sh --connect --innodb_initialized"
-          - name: MariaDB 12
-            image: mariadb:12
-            health-cmd: "healthcheck.sh --connect --innodb_initialized"
-            coverage: true
+        - name: MySQL 5.7
+          image: mysql:5.7
+          health-cmd: "mysql -uroot -proot -e 'SELECT 1'"
+        - name: MySQL 8.4 (LTS)
+          image: mysql:8.4
+          health-cmd: "mysql -uroot -proot -e 'SELECT 1'"
+        - name: MySQL 9.7 (LTS)
+          image: mysql:9.7
+          health-cmd: "mysql -uroot -proot -e 'SELECT 1'"
+        - name: MariaDB 10.6 (LTS)
+          image: mariadb:10.6
+          health-cmd: "healthcheck.sh --connect --innodb_initialized"
+        - name: MariaDB 10.11 (LTS)
+          image: mariadb:10.11
+          health-cmd: "healthcheck.sh --connect --innodb_initialized"
+        - name: MariaDB 11.4 (LTS)
+          image: mariadb:11.4
+          health-cmd: "healthcheck.sh --connect --innodb_initialized"
+        - name: MariaDB 11.8 (LTS)
+          image: mariadb:11.8
+          health-cmd: "healthcheck.sh --connect --innodb_initialized"
+        - name: MariaDB 12
+          image: mariadb:12
+          health-cmd: "healthcheck.sh --connect --innodb_initialized"
+          coverage: true
         php:
-          - version: '8.2'
-          - version: '8.3'
-          - version: '8.4'
-          - version: '8.5'
-            coverage: true
+        - version: '8.2'
+        - version: '8.3'
+        - version: '8.4'
+        - version: '8.5'
+          coverage: true
     env:
       # Only collect coverage on one matrix arm to save time
       COLLECT_COVERAGE: ${{ matrix.php.coverage && matrix.database.coverage }}
@@ -75,53 +75,39 @@ jobs:
           --health-retries=20
 
         ports:
-          - 3306:3306
+        - 3306:3306
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+    - name: Checkout
+      uses: actions/checkout@v6
 
-      - name: Setup PHP and Composer
-        uses: ./.github/actions/setup-php-composer
-        with:
-          coverage: ${{ env.COLLECT_COVERAGE }}
-          php-version: ${{ matrix.php.version }}
+    - name: Setup PHP and Composer
+      uses: ./.github/actions/setup-php-composer
+      with:
+        coverage: ${{ env.COLLECT_COVERAGE }}
+        php-version: ${{ matrix.php.version }}
 
-      - name: Run CLI installer
-        run: ./cli install
-            --db-host=127.0.0.1
-            --db-port=3306
-            --db-root-user=root
-            --db-root-password=root
-            --db-user=ci
-            --db-password=topsecret
-            --db-name=openemr_test
-            --oe-admin-username=admin
-            --oe-admin-password=pass
-            --no-interaction
-            -vvv
+    - name: Run CLI installer
+      run: ./cli install --db-host=127.0.0.1 --db-port=3306 --db-root-user=root --db-root-password=root --db-user=ci --db-password=topsecret --db-name=openemr_test --oe-admin-username=admin --oe-admin-password=pass --no-interaction -vvv
 
-      - name: Verify installation
-        run: |
-          mysql -h 127.0.0.1 -u ci -ptopsecret openemr_test \
-            -e "SELECT COUNT(*) as user_count FROM users WHERE username='admin';" \
-            | grep -q "1"
+    - name: Verify installation
+      run: |
+        mysql -h 127.0.0.1 -u ci -ptopsecret openemr_test \
+          -e "SELECT COUNT(*) as user_count FROM users WHERE username='admin';" \
+          | grep -q "1"
 
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit
-          ${{ env.COLLECT_COVERAGE == 'true' && '--coverage-text --coverage-clover clover.xml' || '' }}
-          --log-junit junit.xml
-          --testsuite common,controllers,fixtures,validators,unit
+    - name: Run PHPUnit
+      run: vendor/bin/phpunit ${{ env.COLLECT_COVERAGE == 'true' && '--coverage-text --coverage-clover clover.xml' || '' }} --log-junit junit.xml --testsuite common,controllers,fixtures,validators,unit
 
-      - name: Upload coverage
-        if: ${{ !cancelled() && env.COLLECT_COVERAGE == 'true' }}
-        uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload coverage
+      if: ${{ !cancelled() && env.COLLECT_COVERAGE == 'true' }}
+      uses: codecov/codecov-action@v7
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v7
-        with:
-          report_type: test_results
-          token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload test results
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v7
+      with:
+        report_type: test_results
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-frontcontroller.yml
+++ b/.github/workflows/test-frontcontroller.yml
@@ -5,7 +5,7 @@ on:
     # All PRs
   push:
     branches:
-      - master
+    - master
 
 env:
   ENVIRONMENT: ci
@@ -21,12 +21,12 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - 8.2
-          - 8.3
-          - 8.4
-          - 8.5
+        - 8.2
+        - 8.3
+        - 8.4
+        - 8.5
         suite:
-          - api
+        - api
 
     services:
       # Future: Matrix here too?
@@ -38,79 +38,60 @@ jobs:
           MYSQL_PASSWORD: topsecret
           MYSQL_DATABASE: openemr_test
         ports:
-          - 3306:3306
+        - 3306:3306
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+    - name: Checkout
+      uses: actions/checkout@v6
 
-      - name: Setup PHP
-        uses: ./.github/actions/setup-php-composer
-        with:
-          php-version: ${{ matrix.php }}
+    - name: Setup PHP
+      uses: ./.github/actions/setup-php-composer
+      with:
+        php-version: ${{ matrix.php }}
 
-      - name: Run CLI installer
-        run: ./cli install
-            --db-root-user=root
-            --db-root-password=root
-            --db-host=127.0.0.1
-            --db-port=3306
-            --db-user=ci
-            --db-password=topsecret
-            --db-name=openemr_test
-            --oe-admin-username=admin
-            --oe-admin-password=pass
-            --enable-rest-api
-            --enable-fhir-api
-            --enable-portal-api
-            --enable-password-grant
-            --enable-system-scopes
-            --site-address=http://localhost:8080
-            --no-interaction
-            -vvv
+    - name: Run CLI installer
+      run: ./cli install --db-root-user=root --db-root-password=root --db-host=127.0.0.1 --db-port=3306 --db-user=ci --db-password=topsecret --db-name=openemr_test --oe-admin-username=admin --oe-admin-password=pass --enable-rest-api --enable-fhir-api --enable-portal-api --enable-password-grant --enable-system-scopes --site-address=http://localhost:8080 --no-interaction -vvv
 
-      - name: Suppress product registration prompt
-        run: |
-          mysql -h 127.0.0.1 -P 3306 -u root -proot openemr_test -e "
-            INSERT INTO product_registration (opt_out) VALUES (1);
-          "
+    - name: Suppress product registration prompt
+      run: |
+        mysql -h 127.0.0.1 -P 3306 -u root -proot openemr_test -e "
+          INSERT INTO product_registration (opt_out) VALUES (1);
+        "
 
-      - name: Start server (bg)
-        env:
-          PHP_CLI_SERVER_WORKERS: '8'
-        run: |
-          php -S 0.0.0.0:8080 -t . public/index.php \
-            > "${RUNNER_TEMP}/php-server.out.log" \
-            2> "${RUNNER_TEMP}/php-server.err.log" &
+    - name: Start server (bg)
+      env:
+        PHP_CLI_SERVER_WORKERS: '8'
+      run: |
+        php -S 0.0.0.0:8080 -t . public/index.php \
+          > "${RUNNER_TEMP}/php-server.out.log" \
+          2> "${RUNNER_TEMP}/php-server.err.log" &
 
-      - name: Wait for webserver
-        run: |
-          curl --retry-connrefused --retry 30 --retry-delay 1 \
-               --fail --silent --show-error \
-               -o /dev/null http://127.0.0.1:8080/
+    - name: Wait for webserver
+      run: |
+        curl --retry-connrefused --retry 30 --retry-delay 1 \
+             --fail --silent --show-error \
+             -o /dev/null http://127.0.0.1:8080/
 
-      - name: Run ${{ matrix.suite }} tests
-        working-directory: .
-        env:
-          OPENEMR_BASE_URL_API: http://localhost:8080
-        run: vendor/bin/phpunit
-            --testsuite ${{ matrix.suite }}
-            --log-junit junit-${{ matrix.suite }}.xml
+    - name: Run ${{ matrix.suite }} tests
+      working-directory: .
+      env:
+        OPENEMR_BASE_URL_API: http://localhost:8080
+      run: vendor/bin/phpunit --testsuite ${{ matrix.suite }} --log-junit junit-${{ matrix.suite }}.xml
 
-      - name: Show server stdout
-        if: ${{ !cancelled() }}
-        run: cat "${RUNNER_TEMP}/php-server.out.log"
+    - name: Show server stdout
+      if: ${{ !cancelled() }}
+      run: cat "${RUNNER_TEMP}/php-server.out.log"
 
-      - name: Show server stderr
-        if: ${{ !cancelled() }}
-        run: cat "${RUNNER_TEMP}/php-server.err.log"
+    - name: Show server stderr
+      if: ${{ !cancelled() }}
+      run: cat "${RUNNER_TEMP}/php-server.err.log"
 
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          report_type: test_results
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v7
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        report_type: test_results
 
   # Future jobs:
   # - apache (mod_php)

--- a/.github/workflows/weekly-build-php-fpm-dockers.yml
+++ b/.github/workflows/weekly-build-php-fpm-dockers.yml
@@ -3,7 +3,7 @@ name: Weekly Build php-fpm Dockers
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 2 * * 0' # (weekly) run at 2 AM UTC on Sundays
+  - cron: '0 2 * * 0'   # (weekly) run at 2 AM UTC on Sundays
 
 permissions:
   contents: read
@@ -15,297 +15,297 @@ jobs:
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:8.1 docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm-8-1
-          tags: openemr/dev-php-fpm:8.1
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push dev-php-fpm:8.1 docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm-8-1
+        tags: openemr/dev-php-fpm:8.1
+        platforms: linux/amd64
+        push: true
+        no-cache: true
 
   build_8_1_redis:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:8.1-redis docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm-8-1-redis
-          tags: openemr/dev-php-fpm:8.1-redis
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push dev-php-fpm:8.1-redis docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm-8-1-redis
+        tags: openemr/dev-php-fpm:8.1-redis
+        platforms: linux/amd64
+        push: true
+        no-cache: true
 
   build_8_2:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:8.2 docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm-8-2
-          tags: openemr/dev-php-fpm:8.2
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push dev-php-fpm:8.2 docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm-8-2
+        tags: openemr/dev-php-fpm:8.2
+        platforms: linux/amd64
+        push: true
+        no-cache: true
 
   build_8_2_redis:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:8.2-redis docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm-8-2-redis
-          tags: openemr/dev-php-fpm:8.2-redis
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push dev-php-fpm:8.2-redis docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm-8-2-redis
+        tags: openemr/dev-php-fpm:8.2-redis
+        platforms: linux/amd64
+        push: true
+        no-cache: true
 
   build_8_3:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:8.3 docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm-8-3
-          tags: openemr/dev-php-fpm:8.3
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push dev-php-fpm:8.3 docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm-8-3
+        tags: openemr/dev-php-fpm:8.3
+        platforms: linux/amd64
+        push: true
+        no-cache: true
 
   build_8_3_redis:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:8.3-redis docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm-8-3-redis
-          tags: openemr/dev-php-fpm:8.3-redis
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push dev-php-fpm:8.3-redis docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm-8-3-redis
+        tags: openemr/dev-php-fpm:8.3-redis
+        platforms: linux/amd64
+        push: true
+        no-cache: true
 
   build_8_4:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:8.4 docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm-8-4
-          tags: openemr/dev-php-fpm:8.4
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push dev-php-fpm:8.4 docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm-8-4
+        tags: openemr/dev-php-fpm:8.4
+        platforms: linux/amd64
+        push: true
+        no-cache: true
 
   build_8_4_redis:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:8.4-redis docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm-8-4-redis
-          tags: openemr/dev-php-fpm:8.4-redis
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push dev-php-fpm:8.4-redis docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm-8-4-redis
+        tags: openemr/dev-php-fpm:8.4-redis
+        platforms: linux/amd64
+        push: true
+        no-cache: true
 
   build_8_5:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:8.5 docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm-8-5
-          tags: openemr/dev-php-fpm:8.5
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push dev-php-fpm:8.5 docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm-8-5
+        tags: openemr/dev-php-fpm:8.5
+        platforms: linux/amd64
+        push: true
+        no-cache: true
 
   build_8_5_redis:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:8.5-redis docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm-8-5-redis
-          tags: openemr/dev-php-fpm:8.5-redis
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push dev-php-fpm:8.5-redis docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm-8-5-redis
+        tags: openemr/dev-php-fpm:8.5-redis
+        platforms: linux/amd64
+        push: true
+        no-cache: true
 
   build_8_6:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:8.6 docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm-8-6
-          tags: openemr/dev-php-fpm:8.6
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push dev-php-fpm:8.6 docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm-8-6
+        tags: openemr/dev-php-fpm:8.6
+        platforms: linux/amd64
+        push: true
+        no-cache: true
 
   build_8_6_redis:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push dev-php-fpm:8.6-redis docker
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/library/dockers/dev-php-fpm-8-6-redis
-          tags: openemr/dev-php-fpm:8.6-redis
-          platforms: linux/amd64
-          push: true
-          no-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push dev-php-fpm:8.6-redis docker
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/library/dockers/dev-php-fpm-8-6-redis
+        tags: openemr/dev-php-fpm:8.6-redis
+        platforms: linux/amd64
+        push: true
+        no-cache: true

--- a/ci/apache_82_118_redis_sentinel_mtls/docker-compose.yml
+++ b/ci/apache_82_118_redis_sentinel_mtls/docker-compose.yml
@@ -20,162 +20,160 @@ services:
     image: alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        set -ex
+    - |
+      set -ex
 
-        # Idempotent: skip if certs already exist.  docker compose up may
-        # restart this container on subsequent calls; regenerating would
-        # invalidate certs the running Redis/Sentinel containers already loaded.
-        if [ -f /certs/ca.crt ]; then
-            echo "Certs already present — skipping generation."
-            exit 0
-        fi
+      # Idempotent: skip if certs already exist.  docker compose up may
+      # restart this container on subsequent calls; regenerating would
+      # invalidate certs the running Redis/Sentinel containers already loaded.
+      if [ -f /certs/ca.crt ]; then
+          echo "Certs already present — skipping generation."
+          exit 0
+      fi
 
-        apk add --no-cache openssl
-        cd /certs
+      apk add --no-cache openssl
+      cd /certs
 
-        # --- CA ---
-        openssl genrsa -out ca.key 2048
-        openssl req -x509 -new -key ca.key -days 1 -out ca.crt -subj "/CN=test-ca"
+      # --- CA ---
+      openssl genrsa -out ca.key 2048
+      openssl req -x509 -new -key ca.key -days 1 -out ca.crt -subj "/CN=test-ca"
 
-        # --- Server cert (covers every Redis/Sentinel hostname) ---
-        echo "subjectAltName=DNS:redis-master,DNS:redis-replica-1,DNS:redis-replica-2,DNS:sentinel-1,DNS:sentinel-2,DNS:localhost" > /tmp/san.ext
-        openssl genrsa -out server.key 2048
-        openssl req -new -key server.key -subj "/CN=redis" \
-          | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
-              -extfile /tmp/san.ext -days 1 -out server.crt
+      # --- Server cert (covers every Redis/Sentinel hostname) ---
+      echo "subjectAltName=DNS:redis-master,DNS:redis-replica-1,DNS:redis-replica-2,DNS:sentinel-1,DNS:sentinel-2,DNS:localhost" > /tmp/san.ext
+      openssl genrsa -out server.key 2048
+      openssl req -new -key server.key -subj "/CN=redis" \
+        | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
+            -extfile /tmp/san.ext -days 1 -out server.crt
 
-        # --- Client cert (required for mTLS) ---
-        openssl genrsa -out client.key 2048
-        openssl req -new -key client.key -subj "/CN=openemr-client" \
-          | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
-              -days 1 -out client.crt
+      # --- Client cert (required for mTLS) ---
+      openssl genrsa -out client.key 2048
+      openssl req -new -key client.key -subj "/CN=openemr-client" \
+        | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
+            -days 1 -out client.crt
 
-        # --- Symlinks matching SentinelUtil's expected filenames ---
-        ln -sf ca.crt redis-sentinel-ca
-        ln -sf client.crt redis-sentinel-cert
-        ln -sf client.key redis-sentinel-key
-        ln -sf ca.crt redis-master-ca
-        ln -sf client.crt redis-master-cert
-        ln -sf client.key redis-master-key
+      # --- Symlinks matching SentinelUtil's expected filenames ---
+      ln -sf ca.crt redis-sentinel-ca
+      ln -sf client.crt redis-sentinel-cert
+      ln -sf client.key redis-sentinel-key
+      ln -sf ca.crt redis-master-ca
+      ln -sf client.crt redis-master-cert
+      ln -sf client.key redis-master-key
 
-        chmod 644 *.crt *.key ca.key
-        ls -la /certs/
+      chmod 644 *.crt *.key ca.key
+      ls -la /certs/
     volumes:
-      - redis-certs:/certs
+    - redis-certs:/certs
 
   # ---------- Redis overrides: TLS + require client certs ----------
   redis-master:
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --tls-port
-      - "6379"
-      - --port
-      - "0"
-      - --tls-cert-file
-      - /certs/server.crt
-      - --tls-key-file
-      - /certs/server.key
-      - --tls-ca-cert-file
-      - /certs/ca.crt
-      - --tls-auth-clients
-      - "yes"
-      - --tls-replication
-      - "yes"
-      - --replica-announce-ip
-      - redis-master
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --tls-port
+    - "6379"
+    - --port
+    - "0"
+    - --tls-cert-file
+    - /certs/server.crt
+    - --tls-key-file
+    - /certs/server.key
+    - --tls-ca-cert-file
+    - /certs/ca.crt
+    - --tls-auth-clients
+    - "yes"
+    - --tls-replication
+    - "yes"
+    - --replica-announce-ip
+    - redis-master
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt",
-             "--cert", "/certs/client.crt", "--key", "/certs/client.key",
-             "-a", "strongpassword", "ping"]
+      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "--cert", "/certs/client.crt", "--key", "/certs/client.key", "-a", "strongpassword", "ping"]
 
   redis-replica-1:
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --replicaof
-      - redis-master
-      - "6379"
-      - --tls-port
-      - "6379"
-      - --port
-      - "0"
-      - --tls-cert-file
-      - /certs/server.crt
-      - --tls-key-file
-      - /certs/server.key
-      - --tls-ca-cert-file
-      - /certs/ca.crt
-      - --tls-auth-clients
-      - "yes"
-      - --tls-replication
-      - "yes"
-      - --replica-announce-ip
-      - redis-replica-1
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --replicaof
+    - redis-master
+    - "6379"
+    - --tls-port
+    - "6379"
+    - --port
+    - "0"
+    - --tls-cert-file
+    - /certs/server.crt
+    - --tls-key-file
+    - /certs/server.key
+    - --tls-ca-cert-file
+    - /certs/ca.crt
+    - --tls-auth-clients
+    - "yes"
+    - --tls-replication
+    - "yes"
+    - --replica-announce-ip
+    - redis-replica-1
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
 
   redis-replica-2:
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --replicaof
-      - redis-master
-      - "6379"
-      - --tls-port
-      - "6379"
-      - --port
-      - "0"
-      - --tls-cert-file
-      - /certs/server.crt
-      - --tls-key-file
-      - /certs/server.key
-      - --tls-ca-cert-file
-      - /certs/ca.crt
-      - --tls-auth-clients
-      - "yes"
-      - --tls-replication
-      - "yes"
-      - --replica-announce-ip
-      - redis-replica-2
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --replicaof
+    - redis-master
+    - "6379"
+    - --tls-port
+    - "6379"
+    - --port
+    - "0"
+    - --tls-cert-file
+    - /certs/server.crt
+    - --tls-key-file
+    - /certs/server.key
+    - --tls-ca-cert-file
+    - /certs/ca.crt
+    - --tls-auth-clients
+    - "yes"
+    - --tls-replication
+    - "yes"
+    - --replica-announce-ip
+    - redis-replica-2
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
@@ -184,64 +182,60 @@ services:
   sentinel-1:
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        printf '%s\n' \
-          'port 0' \
-          'tls-port 26379' \
-          'tls-cert-file /certs/server.crt' \
-          'tls-key-file /certs/server.key' \
-          'tls-ca-cert-file /certs/ca.crt' \
-          'tls-auth-clients yes' \
-          'tls-replication yes' \
-          'daemonize no' \
-          'sentinel resolve-hostnames yes' \
-          'sentinel announce-hostnames yes' \
-          'sentinel monitor redis-master redis-master 6379 2' \
-          'sentinel auth-pass redis-master strongpassword' \
-          'sentinel down-after-milliseconds redis-master 5000' \
-          'sentinel failover-timeout redis-master 60000' \
-          'sentinel parallel-syncs redis-master 1' \
-          > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+    - |
+      printf '%s\n' \
+        'port 0' \
+        'tls-port 26379' \
+        'tls-cert-file /certs/server.crt' \
+        'tls-key-file /certs/server.key' \
+        'tls-ca-cert-file /certs/ca.crt' \
+        'tls-auth-clients yes' \
+        'tls-replication yes' \
+        'daemonize no' \
+        'sentinel resolve-hostnames yes' \
+        'sentinel announce-hostnames yes' \
+        'sentinel monitor redis-master redis-master 6379 2' \
+        'sentinel auth-pass redis-master strongpassword' \
+        'sentinel down-after-milliseconds redis-master 5000' \
+        'sentinel failover-timeout redis-master 60000' \
+        'sentinel parallel-syncs redis-master 1' \
+        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt",
-             "--cert", "/certs/client.crt", "--key", "/certs/client.key",
-             "-p", "26379", "SENTINEL", "masters"]
+      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "--cert", "/certs/client.crt", "--key", "/certs/client.key", "-p", "26379", "SENTINEL", "masters"]
 
   sentinel-2:
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        printf '%s\n' \
-          'port 0' \
-          'tls-port 26379' \
-          'tls-cert-file /certs/server.crt' \
-          'tls-key-file /certs/server.key' \
-          'tls-ca-cert-file /certs/ca.crt' \
-          'tls-auth-clients yes' \
-          'tls-replication yes' \
-          'daemonize no' \
-          'sentinel resolve-hostnames yes' \
-          'sentinel announce-hostnames yes' \
-          'sentinel monitor redis-master redis-master 6379 2' \
-          'sentinel auth-pass redis-master strongpassword' \
-          'sentinel down-after-milliseconds redis-master 5000' \
-          'sentinel failover-timeout redis-master 60000' \
-          'sentinel parallel-syncs redis-master 1' \
-          > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+    - |
+      printf '%s\n' \
+        'port 0' \
+        'tls-port 26379' \
+        'tls-cert-file /certs/server.crt' \
+        'tls-key-file /certs/server.key' \
+        'tls-ca-cert-file /certs/ca.crt' \
+        'tls-auth-clients yes' \
+        'tls-replication yes' \
+        'daemonize no' \
+        'sentinel resolve-hostnames yes' \
+        'sentinel announce-hostnames yes' \
+        'sentinel monitor redis-master redis-master 6379 2' \
+        'sentinel auth-pass redis-master strongpassword' \
+        'sentinel down-after-milliseconds redis-master 5000' \
+        'sentinel failover-timeout redis-master 60000' \
+        'sentinel parallel-syncs redis-master 1' \
+        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt",
-             "--cert", "/certs/client.crt", "--key", "/certs/client.key",
-             "-p", "26379", "SENTINEL", "masters"]
+      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "--cert", "/certs/client.crt", "--key", "/certs/client.key", "-p", "26379", "SENTINEL", "masters"]
 
   # ---------- OpenEMR: TLS + X.509 client certs ----------
   openemr:
@@ -251,7 +245,7 @@ services:
       REDIS_X509: "yes"
       REDIS_TLS_CERT_KEY_PATH: /redis-certs
     volumes:
-      - redis-certs:/redis-certs:ro
+    - redis-certs:/redis-certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully

--- a/ci/apache_85_118_redis_sentinel_mtls/docker-compose.yml
+++ b/ci/apache_85_118_redis_sentinel_mtls/docker-compose.yml
@@ -20,162 +20,160 @@ services:
     image: alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        set -ex
+    - |
+      set -ex
 
-        # Idempotent: skip if certs already exist.  docker compose up may
-        # restart this container on subsequent calls; regenerating would
-        # invalidate certs the running Redis/Sentinel containers already loaded.
-        if [ -f /certs/ca.crt ]; then
-            echo "Certs already present — skipping generation."
-            exit 0
-        fi
+      # Idempotent: skip if certs already exist.  docker compose up may
+      # restart this container on subsequent calls; regenerating would
+      # invalidate certs the running Redis/Sentinel containers already loaded.
+      if [ -f /certs/ca.crt ]; then
+          echo "Certs already present — skipping generation."
+          exit 0
+      fi
 
-        apk add --no-cache openssl
-        cd /certs
+      apk add --no-cache openssl
+      cd /certs
 
-        # --- CA ---
-        openssl genrsa -out ca.key 2048
-        openssl req -x509 -new -key ca.key -days 1 -out ca.crt -subj "/CN=test-ca"
+      # --- CA ---
+      openssl genrsa -out ca.key 2048
+      openssl req -x509 -new -key ca.key -days 1 -out ca.crt -subj "/CN=test-ca"
 
-        # --- Server cert (covers every Redis/Sentinel hostname) ---
-        echo "subjectAltName=DNS:redis-master,DNS:redis-replica-1,DNS:redis-replica-2,DNS:sentinel-1,DNS:sentinel-2,DNS:localhost" > /tmp/san.ext
-        openssl genrsa -out server.key 2048
-        openssl req -new -key server.key -subj "/CN=redis" \
-          | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
-              -extfile /tmp/san.ext -days 1 -out server.crt
+      # --- Server cert (covers every Redis/Sentinel hostname) ---
+      echo "subjectAltName=DNS:redis-master,DNS:redis-replica-1,DNS:redis-replica-2,DNS:sentinel-1,DNS:sentinel-2,DNS:localhost" > /tmp/san.ext
+      openssl genrsa -out server.key 2048
+      openssl req -new -key server.key -subj "/CN=redis" \
+        | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
+            -extfile /tmp/san.ext -days 1 -out server.crt
 
-        # --- Client cert (required for mTLS) ---
-        openssl genrsa -out client.key 2048
-        openssl req -new -key client.key -subj "/CN=openemr-client" \
-          | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
-              -days 1 -out client.crt
+      # --- Client cert (required for mTLS) ---
+      openssl genrsa -out client.key 2048
+      openssl req -new -key client.key -subj "/CN=openemr-client" \
+        | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
+            -days 1 -out client.crt
 
-        # --- Symlinks matching SentinelUtil's expected filenames ---
-        ln -sf ca.crt redis-sentinel-ca
-        ln -sf client.crt redis-sentinel-cert
-        ln -sf client.key redis-sentinel-key
-        ln -sf ca.crt redis-master-ca
-        ln -sf client.crt redis-master-cert
-        ln -sf client.key redis-master-key
+      # --- Symlinks matching SentinelUtil's expected filenames ---
+      ln -sf ca.crt redis-sentinel-ca
+      ln -sf client.crt redis-sentinel-cert
+      ln -sf client.key redis-sentinel-key
+      ln -sf ca.crt redis-master-ca
+      ln -sf client.crt redis-master-cert
+      ln -sf client.key redis-master-key
 
-        chmod 644 *.crt *.key ca.key
-        ls -la /certs/
+      chmod 644 *.crt *.key ca.key
+      ls -la /certs/
     volumes:
-      - redis-certs:/certs
+    - redis-certs:/certs
 
   # ---------- Redis overrides: TLS + require client certs ----------
   redis-master:
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --tls-port
-      - "6379"
-      - --port
-      - "0"
-      - --tls-cert-file
-      - /certs/server.crt
-      - --tls-key-file
-      - /certs/server.key
-      - --tls-ca-cert-file
-      - /certs/ca.crt
-      - --tls-auth-clients
-      - "yes"
-      - --tls-replication
-      - "yes"
-      - --replica-announce-ip
-      - redis-master
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --tls-port
+    - "6379"
+    - --port
+    - "0"
+    - --tls-cert-file
+    - /certs/server.crt
+    - --tls-key-file
+    - /certs/server.key
+    - --tls-ca-cert-file
+    - /certs/ca.crt
+    - --tls-auth-clients
+    - "yes"
+    - --tls-replication
+    - "yes"
+    - --replica-announce-ip
+    - redis-master
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt",
-             "--cert", "/certs/client.crt", "--key", "/certs/client.key",
-             "-a", "strongpassword", "ping"]
+      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "--cert", "/certs/client.crt", "--key", "/certs/client.key", "-a", "strongpassword", "ping"]
 
   redis-replica-1:
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --replicaof
-      - redis-master
-      - "6379"
-      - --tls-port
-      - "6379"
-      - --port
-      - "0"
-      - --tls-cert-file
-      - /certs/server.crt
-      - --tls-key-file
-      - /certs/server.key
-      - --tls-ca-cert-file
-      - /certs/ca.crt
-      - --tls-auth-clients
-      - "yes"
-      - --tls-replication
-      - "yes"
-      - --replica-announce-ip
-      - redis-replica-1
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --replicaof
+    - redis-master
+    - "6379"
+    - --tls-port
+    - "6379"
+    - --port
+    - "0"
+    - --tls-cert-file
+    - /certs/server.crt
+    - --tls-key-file
+    - /certs/server.key
+    - --tls-ca-cert-file
+    - /certs/ca.crt
+    - --tls-auth-clients
+    - "yes"
+    - --tls-replication
+    - "yes"
+    - --replica-announce-ip
+    - redis-replica-1
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
 
   redis-replica-2:
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --replicaof
-      - redis-master
-      - "6379"
-      - --tls-port
-      - "6379"
-      - --port
-      - "0"
-      - --tls-cert-file
-      - /certs/server.crt
-      - --tls-key-file
-      - /certs/server.key
-      - --tls-ca-cert-file
-      - /certs/ca.crt
-      - --tls-auth-clients
-      - "yes"
-      - --tls-replication
-      - "yes"
-      - --replica-announce-ip
-      - redis-replica-2
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --replicaof
+    - redis-master
+    - "6379"
+    - --tls-port
+    - "6379"
+    - --port
+    - "0"
+    - --tls-cert-file
+    - /certs/server.crt
+    - --tls-key-file
+    - /certs/server.key
+    - --tls-ca-cert-file
+    - /certs/ca.crt
+    - --tls-auth-clients
+    - "yes"
+    - --tls-replication
+    - "yes"
+    - --replica-announce-ip
+    - redis-replica-2
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
@@ -184,64 +182,60 @@ services:
   sentinel-1:
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        printf '%s\n' \
-          'port 0' \
-          'tls-port 26379' \
-          'tls-cert-file /certs/server.crt' \
-          'tls-key-file /certs/server.key' \
-          'tls-ca-cert-file /certs/ca.crt' \
-          'tls-auth-clients yes' \
-          'tls-replication yes' \
-          'daemonize no' \
-          'sentinel resolve-hostnames yes' \
-          'sentinel announce-hostnames yes' \
-          'sentinel monitor redis-master redis-master 6379 2' \
-          'sentinel auth-pass redis-master strongpassword' \
-          'sentinel down-after-milliseconds redis-master 5000' \
-          'sentinel failover-timeout redis-master 60000' \
-          'sentinel parallel-syncs redis-master 1' \
-          > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+    - |
+      printf '%s\n' \
+        'port 0' \
+        'tls-port 26379' \
+        'tls-cert-file /certs/server.crt' \
+        'tls-key-file /certs/server.key' \
+        'tls-ca-cert-file /certs/ca.crt' \
+        'tls-auth-clients yes' \
+        'tls-replication yes' \
+        'daemonize no' \
+        'sentinel resolve-hostnames yes' \
+        'sentinel announce-hostnames yes' \
+        'sentinel monitor redis-master redis-master 6379 2' \
+        'sentinel auth-pass redis-master strongpassword' \
+        'sentinel down-after-milliseconds redis-master 5000' \
+        'sentinel failover-timeout redis-master 60000' \
+        'sentinel parallel-syncs redis-master 1' \
+        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt",
-             "--cert", "/certs/client.crt", "--key", "/certs/client.key",
-             "-p", "26379", "SENTINEL", "masters"]
+      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "--cert", "/certs/client.crt", "--key", "/certs/client.key", "-p", "26379", "SENTINEL", "masters"]
 
   sentinel-2:
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        printf '%s\n' \
-          'port 0' \
-          'tls-port 26379' \
-          'tls-cert-file /certs/server.crt' \
-          'tls-key-file /certs/server.key' \
-          'tls-ca-cert-file /certs/ca.crt' \
-          'tls-auth-clients yes' \
-          'tls-replication yes' \
-          'daemonize no' \
-          'sentinel resolve-hostnames yes' \
-          'sentinel announce-hostnames yes' \
-          'sentinel monitor redis-master redis-master 6379 2' \
-          'sentinel auth-pass redis-master strongpassword' \
-          'sentinel down-after-milliseconds redis-master 5000' \
-          'sentinel failover-timeout redis-master 60000' \
-          'sentinel parallel-syncs redis-master 1' \
-          > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+    - |
+      printf '%s\n' \
+        'port 0' \
+        'tls-port 26379' \
+        'tls-cert-file /certs/server.crt' \
+        'tls-key-file /certs/server.key' \
+        'tls-ca-cert-file /certs/ca.crt' \
+        'tls-auth-clients yes' \
+        'tls-replication yes' \
+        'daemonize no' \
+        'sentinel resolve-hostnames yes' \
+        'sentinel announce-hostnames yes' \
+        'sentinel monitor redis-master redis-master 6379 2' \
+        'sentinel auth-pass redis-master strongpassword' \
+        'sentinel down-after-milliseconds redis-master 5000' \
+        'sentinel failover-timeout redis-master 60000' \
+        'sentinel parallel-syncs redis-master 1' \
+        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt",
-             "--cert", "/certs/client.crt", "--key", "/certs/client.key",
-             "-p", "26379", "SENTINEL", "masters"]
+      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "--cert", "/certs/client.crt", "--key", "/certs/client.key", "-p", "26379", "SENTINEL", "masters"]
 
   # ---------- OpenEMR: TLS + X.509 client certs ----------
   openemr:
@@ -251,7 +245,7 @@ services:
       REDIS_X509: "yes"
       REDIS_TLS_CERT_KEY_PATH: /redis-certs
     volumes:
-      - redis-certs:/redis-certs:ro
+    - redis-certs:/redis-certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully

--- a/ci/apache_85_118_redis_sentinel_tls/docker-compose.yml
+++ b/ci/apache_85_118_redis_sentinel_tls/docker-compose.yml
@@ -23,161 +23,160 @@ services:
     image: alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        set -ex
+    - |
+      set -ex
 
-        # Idempotent: skip if certs already exist.  docker compose up may
-        # restart this container on subsequent calls; regenerating would
-        # invalidate certs the running Redis/Sentinel containers already loaded.
-        if [ -f /certs/ca.crt ]; then
-            echo "Certs already present — skipping generation."
-            exit 0
-        fi
+      # Idempotent: skip if certs already exist.  docker compose up may
+      # restart this container on subsequent calls; regenerating would
+      # invalidate certs the running Redis/Sentinel containers already loaded.
+      if [ -f /certs/ca.crt ]; then
+          echo "Certs already present — skipping generation."
+          exit 0
+      fi
 
-        apk add --no-cache openssl
-        cd /certs
+      apk add --no-cache openssl
+      cd /certs
 
-        # --- CA ---
-        openssl genrsa -out ca.key 2048
-        openssl req -x509 -new -key ca.key -days 1 -out ca.crt -subj "/CN=test-ca"
+      # --- CA ---
+      openssl genrsa -out ca.key 2048
+      openssl req -x509 -new -key ca.key -days 1 -out ca.crt -subj "/CN=test-ca"
 
-        # --- Server cert (covers every Redis/Sentinel hostname) ---
-        echo "subjectAltName=DNS:redis-master,DNS:redis-replica-1,DNS:redis-replica-2,DNS:sentinel-1,DNS:sentinel-2,DNS:localhost" > /tmp/san.ext
-        openssl genrsa -out server.key 2048
-        openssl req -new -key server.key -subj "/CN=redis" \
-          | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
-              -extfile /tmp/san.ext -days 1 -out server.crt
+      # --- Server cert (covers every Redis/Sentinel hostname) ---
+      echo "subjectAltName=DNS:redis-master,DNS:redis-replica-1,DNS:redis-replica-2,DNS:sentinel-1,DNS:sentinel-2,DNS:localhost" > /tmp/san.ext
+      openssl genrsa -out server.key 2048
+      openssl req -new -key server.key -subj "/CN=redis" \
+        | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
+            -extfile /tmp/san.ext -days 1 -out server.crt
 
-        # --- Client cert (for mTLS variant; harmless to generate always) ---
-        openssl genrsa -out client.key 2048
-        openssl req -new -key client.key -subj "/CN=openemr-client" \
-          | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
-              -days 1 -out client.crt
+      # --- Client cert (for mTLS variant; harmless to generate always) ---
+      openssl genrsa -out client.key 2048
+      openssl req -new -key client.key -subj "/CN=openemr-client" \
+        | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
+            -days 1 -out client.crt
 
-        # --- Symlinks matching SentinelUtil's expected filenames ---
-        ln -sf ca.crt redis-sentinel-ca
-        ln -sf client.crt redis-sentinel-cert
-        ln -sf client.key redis-sentinel-key
-        ln -sf ca.crt redis-master-ca
-        ln -sf client.crt redis-master-cert
-        ln -sf client.key redis-master-key
+      # --- Symlinks matching SentinelUtil's expected filenames ---
+      ln -sf ca.crt redis-sentinel-ca
+      ln -sf client.crt redis-sentinel-cert
+      ln -sf client.key redis-sentinel-key
+      ln -sf ca.crt redis-master-ca
+      ln -sf client.crt redis-master-cert
+      ln -sf client.key redis-master-key
 
-        chmod 644 *.crt *.key ca.key
-        ls -la /certs/
+      chmod 644 *.crt *.key ca.key
+      ls -la /certs/
     volumes:
-      - redis-certs:/certs
+    - redis-certs:/certs
 
   # ---------- Redis overrides: enable TLS, disable plain TCP ----------
   redis-master:
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --tls-port
-      - "6379"
-      - --port
-      - "0"
-      - --tls-cert-file
-      - /certs/server.crt
-      - --tls-key-file
-      - /certs/server.key
-      - --tls-ca-cert-file
-      - /certs/ca.crt
-      - --tls-auth-clients
-      - "no"
-      - --tls-replication
-      - "yes"
-      - --replica-announce-ip
-      - redis-master
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --tls-port
+    - "6379"
+    - --port
+    - "0"
+    - --tls-cert-file
+    - /certs/server.crt
+    - --tls-key-file
+    - /certs/server.key
+    - --tls-ca-cert-file
+    - /certs/ca.crt
+    - --tls-auth-clients
+    - "no"
+    - --tls-replication
+    - "yes"
+    - --replica-announce-ip
+    - redis-master
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt",
-             "-a", "strongpassword", "ping"]
+      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "-a", "strongpassword", "ping"]
 
   redis-replica-1:
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --replicaof
-      - redis-master
-      - "6379"
-      - --tls-port
-      - "6379"
-      - --port
-      - "0"
-      - --tls-cert-file
-      - /certs/server.crt
-      - --tls-key-file
-      - /certs/server.key
-      - --tls-ca-cert-file
-      - /certs/ca.crt
-      - --tls-auth-clients
-      - "no"
-      - --tls-replication
-      - "yes"
-      - --replica-announce-ip
-      - redis-replica-1
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --replicaof
+    - redis-master
+    - "6379"
+    - --tls-port
+    - "6379"
+    - --port
+    - "0"
+    - --tls-cert-file
+    - /certs/server.crt
+    - --tls-key-file
+    - /certs/server.key
+    - --tls-ca-cert-file
+    - /certs/ca.crt
+    - --tls-auth-clients
+    - "no"
+    - --tls-replication
+    - "yes"
+    - --replica-announce-ip
+    - redis-replica-1
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
 
   redis-replica-2:
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --replicaof
-      - redis-master
-      - "6379"
-      - --tls-port
-      - "6379"
-      - --port
-      - "0"
-      - --tls-cert-file
-      - /certs/server.crt
-      - --tls-key-file
-      - /certs/server.key
-      - --tls-ca-cert-file
-      - /certs/ca.crt
-      - --tls-auth-clients
-      - "no"
-      - --tls-replication
-      - "yes"
-      - --replica-announce-ip
-      - redis-replica-2
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --replicaof
+    - redis-master
+    - "6379"
+    - --tls-port
+    - "6379"
+    - --port
+    - "0"
+    - --tls-cert-file
+    - /certs/server.crt
+    - --tls-key-file
+    - /certs/server.key
+    - --tls-ca-cert-file
+    - /certs/ca.crt
+    - --tls-auth-clients
+    - "no"
+    - --tls-replication
+    - "yes"
+    - --replica-announce-ip
+    - redis-replica-2
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
@@ -186,62 +185,60 @@ services:
   sentinel-1:
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        printf '%s\n' \
-          'port 0' \
-          'tls-port 26379' \
-          'tls-cert-file /certs/server.crt' \
-          'tls-key-file /certs/server.key' \
-          'tls-ca-cert-file /certs/ca.crt' \
-          'tls-auth-clients no' \
-          'tls-replication yes' \
-          'daemonize no' \
-          'sentinel resolve-hostnames yes' \
-          'sentinel announce-hostnames yes' \
-          'sentinel monitor redis-master redis-master 6379 2' \
-          'sentinel auth-pass redis-master strongpassword' \
-          'sentinel down-after-milliseconds redis-master 5000' \
-          'sentinel failover-timeout redis-master 60000' \
-          'sentinel parallel-syncs redis-master 1' \
-          > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+    - |
+      printf '%s\n' \
+        'port 0' \
+        'tls-port 26379' \
+        'tls-cert-file /certs/server.crt' \
+        'tls-key-file /certs/server.key' \
+        'tls-ca-cert-file /certs/ca.crt' \
+        'tls-auth-clients no' \
+        'tls-replication yes' \
+        'daemonize no' \
+        'sentinel resolve-hostnames yes' \
+        'sentinel announce-hostnames yes' \
+        'sentinel monitor redis-master redis-master 6379 2' \
+        'sentinel auth-pass redis-master strongpassword' \
+        'sentinel down-after-milliseconds redis-master 5000' \
+        'sentinel failover-timeout redis-master 60000' \
+        'sentinel parallel-syncs redis-master 1' \
+        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt",
-             "-p", "26379", "SENTINEL", "masters"]
+      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "-p", "26379", "SENTINEL", "masters"]
 
   sentinel-2:
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        printf '%s\n' \
-          'port 0' \
-          'tls-port 26379' \
-          'tls-cert-file /certs/server.crt' \
-          'tls-key-file /certs/server.key' \
-          'tls-ca-cert-file /certs/ca.crt' \
-          'tls-auth-clients no' \
-          'tls-replication yes' \
-          'daemonize no' \
-          'sentinel resolve-hostnames yes' \
-          'sentinel announce-hostnames yes' \
-          'sentinel monitor redis-master redis-master 6379 2' \
-          'sentinel auth-pass redis-master strongpassword' \
-          'sentinel down-after-milliseconds redis-master 5000' \
-          'sentinel failover-timeout redis-master 60000' \
-          'sentinel parallel-syncs redis-master 1' \
-          > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+    - |
+      printf '%s\n' \
+        'port 0' \
+        'tls-port 26379' \
+        'tls-cert-file /certs/server.crt' \
+        'tls-key-file /certs/server.key' \
+        'tls-ca-cert-file /certs/ca.crt' \
+        'tls-auth-clients no' \
+        'tls-replication yes' \
+        'daemonize no' \
+        'sentinel resolve-hostnames yes' \
+        'sentinel announce-hostnames yes' \
+        'sentinel monitor redis-master redis-master 6379 2' \
+        'sentinel auth-pass redis-master strongpassword' \
+        'sentinel down-after-milliseconds redis-master 5000' \
+        'sentinel failover-timeout redis-master 60000' \
+        'sentinel parallel-syncs redis-master 1' \
+        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
     volumes:
-      - redis-certs:/certs:ro
+    - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt",
-             "-p", "26379", "SENTINEL", "masters"]
+      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "-p", "26379", "SENTINEL", "masters"]
 
   # ---------- OpenEMR: add TLS env vars + cert volume ----------
   openemr:
@@ -250,7 +247,7 @@ services:
       REDIS_TLS: "yes"
       REDIS_TLS_CERT_KEY_PATH: /redis-certs
     volumes:
-      - redis-certs:/redis-certs:ro
+    - redis-certs:/redis-certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully

--- a/ci/compose-shared-redis-sentinel/docker-compose.yml
+++ b/ci/compose-shared-redis-sentinel/docker-compose.yml
@@ -27,19 +27,19 @@ services:
     # silently resolves to the wrong directory when this template is combined
     # with other compose files.
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --replica-announce-ip
-      - redis-master
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --replica-announce-ip
+    - redis-master
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "strongpassword", "ping"]
       interval: 5s
@@ -50,22 +50,22 @@ services:
   redis-replica-1:
     image: redis:8.8.0@sha256:0a972391db0b24ec336e35d1bc98b237237e26f82bf5120cf2f6b1688d1df973
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --replicaof
-      - redis-master
-      - "6379"
-      - --replica-announce-ip
-      - redis-replica-1
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --replicaof
+    - redis-master
+    - "6379"
+    - --replica-announce-ip
+    - redis-replica-1
     depends_on:
       redis-master:
         condition: service_healthy
@@ -73,22 +73,22 @@ services:
   redis-replica-2:
     image: redis:8.8.0@sha256:0a972391db0b24ec336e35d1bc98b237237e26f82bf5120cf2f6b1688d1df973
     command:
-      - redis-server
-      - --bind
-      - "0.0.0.0"
-      - --protected-mode
-      - "no"
-      - --appendonly
-      - "yes"
-      - --requirepass
-      - strongpassword
-      - --masterauth
-      - strongpassword
-      - --replicaof
-      - redis-master
-      - "6379"
-      - --replica-announce-ip
-      - redis-replica-2
+    - redis-server
+    - --bind
+    - "0.0.0.0"
+    - --protected-mode
+    - "no"
+    - --appendonly
+    - "yes"
+    - --requirepass
+    - strongpassword
+    - --masterauth
+    - strongpassword
+    - --replicaof
+    - redis-master
+    - "6379"
+    - --replica-announce-ip
+    - redis-replica-2
     depends_on:
       redis-master:
         condition: service_healthy
@@ -98,18 +98,18 @@ services:
     # Config is written inline to avoid bind-mount directory pollution — see file header.
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        printf '%s\n' \
-          'port 26379' \
-          'daemonize no' \
-          'sentinel resolve-hostnames yes' \
-          'sentinel announce-hostnames yes' \
-          'sentinel monitor redis-master redis-master 6379 2' \
-          'sentinel auth-pass redis-master strongpassword' \
-          'sentinel down-after-milliseconds redis-master 5000' \
-          'sentinel failover-timeout redis-master 60000' \
-          'sentinel parallel-syncs redis-master 1' \
-          > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+    - |
+      printf '%s\n' \
+        'port 26379' \
+        'daemonize no' \
+        'sentinel resolve-hostnames yes' \
+        'sentinel announce-hostnames yes' \
+        'sentinel monitor redis-master redis-master 6379 2' \
+        'sentinel auth-pass redis-master strongpassword' \
+        'sentinel down-after-milliseconds redis-master 5000' \
+        'sentinel failover-timeout redis-master 60000' \
+        'sentinel parallel-syncs redis-master 1' \
+        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
     depends_on:
       redis-master:
         condition: service_healthy
@@ -126,18 +126,18 @@ services:
     # Config is written inline to avoid bind-mount directory pollution — see file header.
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - |
-        printf '%s\n' \
-          'port 26379' \
-          'daemonize no' \
-          'sentinel resolve-hostnames yes' \
-          'sentinel announce-hostnames yes' \
-          'sentinel monitor redis-master redis-master 6379 2' \
-          'sentinel auth-pass redis-master strongpassword' \
-          'sentinel down-after-milliseconds redis-master 5000' \
-          'sentinel failover-timeout redis-master 60000' \
-          'sentinel parallel-syncs redis-master 1' \
-          > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+    - |
+      printf '%s\n' \
+        'port 26379' \
+        'daemonize no' \
+        'sentinel resolve-hostnames yes' \
+        'sentinel announce-hostnames yes' \
+        'sentinel monitor redis-master redis-master 6379 2' \
+        'sentinel auth-pass redis-master strongpassword' \
+        'sentinel down-after-milliseconds redis-master 5000' \
+        'sentinel failover-timeout redis-master 60000' \
+        'sentinel parallel-syncs redis-master 1' \
+        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
     depends_on:
       redis-master:
         condition: service_healthy

--- a/ci/inferno/test_configs/standalone-full-access.yml
+++ b/ci/inferno/test_configs/standalone-full-access.yml
@@ -7,22 +7,22 @@
   options:
     mode: auth
     components:
-      - name: auth_type
-        default: symmetric
-        options:
-          list_options:
-            - label: Public
-              value: public
-            - label: Confidential Symmetric
-              value: symmetric
-        locked: true
-      - name: auth_request_method
-        default: GET
-        locked: true
-      - name: use_discovery
-        locked: true
-      - name: requested_scopes
-        default: launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/Procedure.read patient/Provenance.read patient/PractitionerRole.read
+    - name: auth_type
+      default: symmetric
+      options:
+        list_options:
+        - label: Public
+          value: public
+        - label: Confidential Symmetric
+          value: symmetric
+      locked: true
+    - name: auth_request_method
+      default: GET
+      locked: true
+    - name: use_discovery
+      locked: true
+    - name: requested_scopes
+      default: launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/Procedure.read patient/Provenance.read patient/PractitionerRole.read
   title: Standalone Launch Credentials
   type: auth_info
   value:


### PR DESCRIPTION
## Summary

Ten YAML files have been failing pre-commit's `pretty-format-yaml` hook since it was added in #9740 (2026-01-03). The hook enforces `--indent=2` + block-sequence-at-parent-indent style; these ten files were authored before the hook landed and never reformatted. No CI workflow runs `pretty-format-yaml --all-files`, so the failures went unnoticed until a manual audit caught them.

This PR is the autofixer output — `prek run pretty-format-yaml --all-files` applied verbatim.

## Files

All ten files are repo-owned — no upstream provenance concerns:

| File | Category |
|---|---|
| `.github/actions/setup-php-composer/action.yml` | Composite action |
| `.github/stale.yml` | Stalebot config |
| `.github/workflows/integration-tests.yml` | CI workflow |
| `.github/workflows/test-frontcontroller.yml` | CI workflow |
| `.github/workflows/weekly-build-php-fpm-dockers.yml` | CI workflow |
| `ci/apache_82_118_redis_sentinel_mtls/docker-compose.yml` | CI compose |
| `ci/apache_85_118_redis_sentinel_mtls/docker-compose.yml` | CI compose |
| `ci/apache_85_118_redis_sentinel_tls/docker-compose.yml` | CI compose |
| `ci/compose-shared-redis-sentinel/docker-compose.yml` | Shared CI compose |
| `ci/inferno/test_configs/standalone-full-access.yml` | Inferno test config |

## Verification

The four redis-sentinel compose files contain inline shell scripts inside `command: - |` block scalars (the cert-init container's setup script). Block scalars in YAML are sensitive to indentation handling — if the autofixer were to mishandle them, the script content could change.

I verified semantic equivalence on all ten files via PyYAML:

```python
for f in [...]:
    a = yaml.safe_load(open(f + '.before'))
    b = yaml.safe_load(open(f + '.after'))
    assert a == b   # ← all ten passed
```

Output:

```
.github/actions/setup-php-composer/action.yml => EQUAL
.github/stale.yml => EQUAL
.github/workflows/integration-tests.yml => EQUAL
.github/workflows/test-frontcontroller.yml => EQUAL
.github/workflows/weekly-build-php-fpm-dockers.yml => EQUAL
ci/apache_82_118_redis_sentinel_mtls/docker-compose.yml => EQUAL
ci/apache_85_118_redis_sentinel_mtls/docker-compose.yml => EQUAL
ci/apache_85_118_redis_sentinel_tls/docker-compose.yml => EQUAL
ci/compose-shared-redis-sentinel/docker-compose.yml => EQUAL
ci/inferno/test_configs/standalone-full-access.yml => EQUAL
```

`yaml.safe_load()` produces identical Python objects pre- and post-reformat. The block scalars' captured string content is byte-identical (the autofixer correctly adjusts both the block-scalar header indent and the content indent in lockstep, so the indentation-stripped script content matches). Only the YAML *source* formatting changed.

## Test plan

- [x] `prek run pretty-format-yaml --all-files` passes on the result
- [x] `yaml.safe_load(before) == yaml.safe_load(after)` for all ten files
- [x] CI runs all the workflows that consume these files (the touched workflow files self-validate by being run)

## Related

Sibling cleanup of #12570 (which addresses `check-json` failure on `Pain_Initial_Assessment.json`). After both land, the only remaining pre-commit hook with master-state failures is `pretty-format-json` — that one has more nuance (JSON-style culture war + upstream-derived healthcare data) and gets its own design-heavy follow-up PR. Once all three hooks pass cleanly on master, broadening `.github/workflows/pre-commit.yml` to run every hook on `--all-files` (so Dependabot rev bumps get real CI validation) becomes safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)