### PR TITLE
refactor(ci): trim docker/.gitignore + docker/COVERAGE.md from byte-identical set

### DIFF
--- a/.github/docker-byte-identical.yml
+++ b/.github/docker-byte-identical.yml
@@ -31,6 +31,16 @@
 #                                                  container_benchmarking/;
 #                                                  rel branches' docker/
 #                                                  doesn't carry those
+#   docker/.gitignore                              one-line ignore pattern;
+#                                                  divergence is at-worst a
+#                                                  cosmetic per-branch gitignore
+#                                                  difference, no behavior load
+#   docker/COVERAGE.md                             documentation about kcov
+#                                                  coverage; each rel branch
+#                                                  may legitimately have
+#                                                  different coverage notes
+#                                                  (different PHP / Alpine
+#                                                  combos, different flows)
 
 files:
 - .github/workflows/docker-build-release.yml
@@ -38,5 +48,3 @@ files:
 - .github/workflows/docker-test-release.yml
 - .github/actions/test-actions-core/action.yml
 - docker/compose.yml
-- docker/.gitignore
-- docker/COVERAGE.md

--- a/docs/docker-migration-from-devops.md
+++ b/docs/docker-migration-from-devops.md
@@ -415,18 +415,17 @@ Four complementary checks assert that the image baked from `openemr_version_ref`
    5. Every `openemr_version_ref` resolves to a real ref in openemr/openemr (catches typos like `rel-8100` or `v8_1_0_`).
    6. The first version-number `docker_tag` in each row aligns with the `major.minor.patch` composed from `version.php` at that row's `openemr_version_ref`. Catches the drift bug where master bumps `version.php` from `8.1.1-dev` to `8.1.2-dev` but `release-targets.yml` still says `docker_tags: 8.1.1,dev,next`.
 
-5. **Byte-identical drift canary across rel branches** (`docker-validate-byte-identical.yml`). The orchestrator-driven pipeline depends on eight files being character-for-character identical across master and every rel branch:
+5. **Byte-identical drift canary across rel branches** (`docker-validate-byte-identical.yml`). The orchestrator-driven pipeline depends on a set of files being character-for-character identical across master and every rel branch. The current set, defined in [`.github/docker-byte-identical.yml`](../.github/docker-byte-identical.yml), is:
 
    * `.github/workflows/docker-build-release.yml`
    * `.github/workflows/docker-test-core.yml`
    * `.github/workflows/docker-test-release.yml`
    * `.github/actions/test-actions-core/action.yml`
    * `docker/compose.yml`
-   * `docker/.gitignore`
-   * `docker/COVERAGE.md`
-   * `docker/README.md`
 
-   If any drift, the orchestrator can dispatch the same logical build against two branches and silently get different behaviors. This workflow asserts the invariant via three triggers: PR on master or any rel-* branch gated to changes in any of those files (catches a PR that updates one without sync PRs to the others), daily cron at 07:00 UTC (catches latent drift via unrelated rel-branch PRs), and `workflow_dispatch` for ad-hoc investigation. Rel branches come from `release-targets.yml` at runtime, so adding a new rel branch automatically extends the check. Files that are intentionally non-identical (`docker/release/Dockerfile`, `docker-test-bats.yml`, `docker-test-container-functionality.yml`) are deliberately excluded from the watched set.
+   If any drift, the orchestrator can dispatch the same logical build against two branches and silently get different behaviors. The canary asserts the invariant via three triggers: PR on master or any rel-* branch (runs on every PR; the diff check is fast), daily cron at 07:00 UTC (catches latent drift via unrelated rel-branch PRs), and `workflow_dispatch` for ad-hoc investigation. Rel branches come from `release-targets.yml` at runtime, so adding a new rel branch automatically extends the check. Files intentionally non-identical — `docker/release/Dockerfile` (version-pinned per branch), `docker-test-bats.yml` / `docker-test-container-functionality.yml` (per-branch job count), `docker/README.md` (master describes the full subdir set that rel branches don't carry), `docker/.gitignore` and `docker/COVERAGE.md` (docs/hygiene with no runtime-behavior load) — are deliberately excluded; the inclusion criterion is "per-branch divergence would produce different runtime behavior."
+
+   *Post-migration refinement (2026-06-21):* the FILES_ALL list was externalized into [`.github/docker-byte-identical.yml`](../.github/docker-byte-identical.yml) so a future auto-sync workflow can read the same source-of-truth list, and the set was tightened by removing `docker/.gitignore` and `docker/COVERAGE.md` (per the criterion above). `docker/README.md` had already been removed when the file was expanded per-branch in #12551.
 
 Together: the five checks make every published image self-documenting, assert build-time alignment, assert config-time alignment, AND assert the cross-branch invariant. A release-management PR that bumps any of `version.php` / `release-targets.yml` / Dockerfile fails at PR time if the three drift apart; a PR that quietly forks one of the byte-identical files on a rel branch fails at the next daily canary run.
 


### PR DESCRIPTION
## Summary

Trims `docker/.gitignore` and `docker/COVERAGE.md` from the byte-identical FILES_ALL set. Both were defensively listed when the test infrastructure was lifted from openemr-devops in the docker migration; neither carries the criterion the rest of the set is enforcing.

## ⚠️ Stacked on top of [#12575](https://github.com/openemr/openemr/pull/12575)

This branch is stacked on top of `byte-identical-source-of-truth` (PR #12575). The diff against `master` shows BOTH commits: the source-of-truth refactor (#12575) AND this PR's trim. Once #12575 merges, the diff resolves to this PR's commit alone (the trim).

Review path:
1. Review #12575 first (the bigger refactor — externalizes FILES_ALL to a new YAML config file)
2. Once it merges, GitHub auto-rebases this PR or I rebase manually; the diff narrows to just this PR's actual change (one-line moves in the new YAML + doc retrospective updates)

## The criterion (from #12575's source-of-truth config file)

> **Per-branch divergence of this file would produce different runtime behavior.**

Files where divergence has only cosmetic / documentation impact don't qualify.

| File | Why it doesn't qualify |
|---|---|
| `docker/.gitignore` | 1-line ignore pattern (`coverage-reports/`). Per-branch drift = at-worst a coverage dir gets checked in on one branch but not another. Cosmetic, not behavior. |
| `docker/COVERAGE.md` | Documentation about kcov. Each rel branch may legitimately have different coverage notes over time (different PHP/Alpine combos, different flows). Doc drift is not behavior drift. |

## What stays in FILES_ALL post-trim (5 entries, all correctness-load-bearing)

| Entry | Why |
|---|---|
| `docker-build-release.yml` | Orchestrator dispatches identical workflow expecting identical build behavior per branch |
| `docker-test-core.yml` | Reusable workflow called via `uses: ./` — each branch runs its own copy |
| `docker-test-release.yml` | Same reasoning — calls reusable, must agree on inputs + semantics |
| `test-actions-core/action.yml` | Composite action used by docker-test-core; each branch's copy runs |
| `docker/compose.yml` | Test-harness compose used by the composite; each branch's content matters |

## Bonus

Lower future dependabot/sync toil. Any content change to `.gitignore` / `COVERAGE.md` no longer requires coordinated PRs across master + rel-810 + rel-800 + rel-704.

## Docs

- `.github/docker-byte-identical.yml` (added by #12575) — moves the 2 entries from `files:` to the "Intentionally NOT in this list" comment block with one-line reasons matching the criterion
- `docs/docker-migration-from-devops.md` — retrospective updated to reflect the trimmed set, mention the source-of-truth refactor, and clarify the inclusion criterion. Also corrects the stale "eight files" count (was already wrong post-#12551 when docker/README.md was removed)

## Test plan

- [ ] CI green
- [ ] After #12575 merges, the diff here narrows to one commit; canary runs against the trimmed set and passes
- [ ] After merge, daily 07:00 UTC cron continues to validate the trimmed set