### PR TITLE
fix(insurance): backport #10326 phone-fix trio (null guard + UI validation + dedup) to rel-810

### DIFF
--- a/library/classes/InsuranceCompany.class.php
+++ b/library/classes/InsuranceCompany.class.php
@@ -340,7 +340,15 @@ class InsuranceCompany extends ORDataObject
         $this->address->persist($this->id);
         $phoneService = new PhoneNumberService();
         foreach ($this->phone_numbers as $phone) {
-            $phoneData = ['phone' => $phone->phoneNumber->getNationalDigits()];
+            $nationalDigits = $phone->phoneNumber->getNationalDigits();
+            if ($nationalDigits === null) {
+                // The legacy phone_numbers table stores 10-digit NANP parts
+                // (area_code / prefix / number). Skip numbers we can't
+                // represent in that schema rather than throwing a TypeError
+                // from PhoneNumberService::getPhoneParts().
+                continue;
+            }
+            $phoneData = ['phone' => $nationalDigits];
             $phoneService->type = $phone->type->value;
             // Always insert for now - PhoneNumberService handles upsert logic
             $phoneService->insert($phoneData, $this->id);

--- a/library/classes/InsuranceCompany.class.php
+++ b/library/classes/InsuranceCompany.class.php
@@ -16,6 +16,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\ORDataObject\Address;
 use OpenEMR\Common\ORDataObject\ORDataObject;
 use OpenEMR\Common\ValueObjects\TypedPhoneNumber;
@@ -336,23 +337,41 @@ class InsuranceCompany extends ORDataObject
 
     public function persist()
     {
-        parent::persist();
-        $this->address->persist($this->id);
-        $phoneService = new PhoneNumberService();
-        foreach ($this->phone_numbers as $phone) {
-            $nationalDigits = $phone->phoneNumber->getNationalDigits();
-            if ($nationalDigits === null) {
-                // The legacy phone_numbers table stores 10-digit NANP parts
-                // (area_code / prefix / number). Skip numbers we can't
-                // represent in that schema rather than throwing a TypeError
-                // from PhoneNumberService::getPhoneParts().
-                continue;
+        // Wrap the whole logical save (parent row, address row, phone_numbers
+        // delete + re-insert) in a single transaction. The delete-then-insert
+        // below is what stops the duplicate-phone-row accumulation that PR
+        // #10326 introduced; without the transaction, a connection drop
+        // between the DELETE and the final INSERT would leave the record
+        // with partial or no phone data instead of just the buggy duplicates.
+        QueryUtils::inTransaction(function (): void {
+            parent::persist();
+            $this->address->persist($this->id);
+            $phoneService = new PhoneNumberService();
+            // Reset phone_numbers rows for this company so the table mirrors
+            // $this->phone_numbers after the loop. PhoneNumberService::insert
+            // is a plain INSERT (contrary to the earlier "handles upsert
+            // logic" comment), so without the clear persist() accumulates a
+            // fresh WORK + FAX row on every save and the list-view LEFT JOINs
+            // on phone_numbers multiply each company across
+            // (work_count * fax_count) result rows.
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM phone_numbers WHERE foreign_id = ?",
+                [$this->id]
+            );
+            foreach ($this->phone_numbers as $phone) {
+                $nationalDigits = $phone->phoneNumber->getNationalDigits();
+                if ($nationalDigits === null) {
+                    // The legacy phone_numbers table stores 10-digit NANP parts
+                    // (area_code / prefix / number). Skip numbers we can't
+                    // represent in that schema rather than throwing a TypeError
+                    // from PhoneNumberService::getPhoneParts().
+                    continue;
+                }
+                $phoneData = ['phone' => $nationalDigits];
+                $phoneService->type = $phone->type->value;
+                $phoneService->insert($phoneData, $this->id);
             }
-            $phoneData = ['phone' => $nationalDigits];
-            $phoneService->type = $phone->type->value;
-            // Always insert for now - PhoneNumberService handles upsert logic
-            $phoneService->insert($phoneData, $this->id);
-        }
+        });
     }
 
     public function insurance_companies_factory()

--- a/library/classes/Pharmacy.class.php
+++ b/library/classes/Pharmacy.class.php
@@ -221,7 +221,15 @@ class Pharmacy extends ORDataObject
         $this->address->persist($this->id);
         $phoneService = new PhoneNumberService();
         foreach ($this->phone_numbers as $phone) {
-            $phoneData = ['phone' => $phone->phoneNumber->getNationalDigits()];
+            $nationalDigits = $phone->phoneNumber->getNationalDigits();
+            if ($nationalDigits === null) {
+                // The legacy phone_numbers table stores 10-digit NANP parts
+                // (area_code / prefix / number). Skip numbers we can't
+                // represent in that schema rather than throwing a TypeError
+                // from PhoneNumberService::getPhoneParts().
+                continue;
+            }
+            $phoneData = ['phone' => $nationalDigits];
             $phoneService->type = $phone->type->value;
             // Always insert for now - PhoneNumberService handles upsert logic
             $phoneService->insert($phoneData, $this->id);

--- a/library/classes/Pharmacy.class.php
+++ b/library/classes/Pharmacy.class.php
@@ -217,23 +217,34 @@ class Pharmacy extends ORDataObject
 
     function persist()
     {
-        parent::persist();
-        $this->address->persist($this->id);
-        $phoneService = new PhoneNumberService();
-        foreach ($this->phone_numbers as $phone) {
-            $nationalDigits = $phone->phoneNumber->getNationalDigits();
-            if ($nationalDigits === null) {
-                // The legacy phone_numbers table stores 10-digit NANP parts
-                // (area_code / prefix / number). Skip numbers we can't
-                // represent in that schema rather than throwing a TypeError
-                // from PhoneNumberService::getPhoneParts().
-                continue;
+        // Wrap the whole logical save (parent row, address row, phone_numbers
+        // delete + re-insert) in a single transaction. See the matching note
+        // in InsuranceCompany::persist() — the delete-then-insert pattern is
+        // what stops the duplicate-phone-row accumulation, and the
+        // transaction keeps a mid-loop failure from leaving the record with
+        // partial or no phone data instead of just the buggy duplicates.
+        QueryUtils::inTransaction(function (): void {
+            parent::persist();
+            $this->address->persist($this->id);
+            $phoneService = new PhoneNumberService();
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM phone_numbers WHERE foreign_id = ?",
+                [$this->id]
+            );
+            foreach ($this->phone_numbers as $phone) {
+                $nationalDigits = $phone->phoneNumber->getNationalDigits();
+                if ($nationalDigits === null) {
+                    // The legacy phone_numbers table stores 10-digit NANP parts
+                    // (area_code / prefix / number). Skip numbers we can't
+                    // represent in that schema rather than throwing a TypeError
+                    // from PhoneNumberService::getPhoneParts().
+                    continue;
+                }
+                $phoneData = ['phone' => $nationalDigits];
+                $phoneService->type = $phone->type->value;
+                $phoneService->insert($phoneData, $this->id);
             }
-            $phoneData = ['phone' => $nationalDigits];
-            $phoneService->type = $phone->type->value;
-            // Always insert for now - PhoneNumberService handles upsert logic
-            $phoneService->insert($phoneData, $this->id);
-        }
+        });
     }
 
     function utility_pharmacy_array()

--- a/sql/8_1_0-to-8_1_1_upgrade.sql
+++ b/sql/8_1_0-to-8_1_1_upgrade.sql
@@ -135,3 +135,29 @@ SET @currentSQLMode = (SELECT @@sql_mode);
 SET sql_mode = '';
 UPDATE `openemr_postcalendar_events` SET `pc_endDate` = NULL WHERE `pc_endDate` = '0000-00-00';
 SET sql_mode = @currentSQLMode;
+
+-- v_database 540: Remove duplicate phone_numbers rows left by InsuranceCompany /
+-- Pharmacy persist() unconditional-insert.
+--
+-- PR #10326 replaced the legacy PhoneNumber->persist($id) call in
+-- InsuranceCompany::persist() and Pharmacy::persist() with a direct
+-- PhoneNumberService::insert() — which is a plain INSERT, not an upsert,
+-- despite the "PhoneNumberService handles upsert logic" comment that
+-- accompanied it. Every save (create or edit) appended fresh rows to
+-- phone_numbers for each entry in $this->phone_numbers; the list view's
+-- two LEFT JOINs on phone_numbers (one for type=WORK, one for type=FAX)
+-- then multiplied each company / pharmacy across
+-- (work_row_count * fax_row_count) result rows in the list UI.
+--
+-- The class-side fix (persist() now clears phone_numbers for the foreign id
+-- before re-inserting) stops new duplicates from forming; this cleanup
+-- handles rows already accumulated on instances upgrading from a buggy
+-- version. Idempotent — a no-op on instances that never accumulated dupes.
+--
+
+-- Keep the most recent (highest id) row per (foreign_id, type); drop older.
+DELETE p1 FROM phone_numbers p1
+INNER JOIN phone_numbers p2
+    ON p1.foreign_id = p2.foreign_id
+    AND p1.type = p2.type
+    AND p1.id < p2.id;

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3,7 +3,7 @@
 --
 -- Keep v_database in sync with $v_database in version.php.
 -- CI will fail if they don't match.
--- v_database: 539
+-- v_database: 540
 --
 
 --

--- a/templates/insurance_companies/general_edit.html
+++ b/templates/insurance_companies/general_edit.html
@@ -74,13 +74,13 @@
     <div class="form-row my-sm-2">
         <label for="phone" class="col-form-label col-sm-2">{xlt t='Phone'}</label>
         <div class="col-sm-8">
-            <input type="text" id="phone" name="phone" class="form-control" value="{$insurancecompany->get_phone()|attr}" onKeyDown="PreventIt(event)">
+            <input type="tel" id="phone" name="phone" class="form-control" value="{$insurancecompany->get_phone()|attr}" pattern="(?:\(\d\d\d\)|\d\d\d)[\s.\-]?\d\d\d[\s.\-]?\d\d\d\d" title="{xla t='Enter a 10-digit phone number, e.g. 555-123-4567'}" onKeyDown="PreventIt(event)">
         </div>
     </div>
     <div class="form-row my-sm-2">
         <label for="fax" class="col-form-label col-sm-2">{xlt t='Fax'}</label>
         <div class="col-sm-8">
-            <input type="text" id="fax" name="fax" class="form-control" value="{$insurancecompany->get_fax()|attr}" onKeyDown="PreventIt(event)">
+            <input type="tel" id="fax" name="fax" class="form-control" value="{$insurancecompany->get_fax()|attr}" pattern="(?:\(\d\d\d\)|\d\d\d)[\s.\-]?\d\d\d[\s.\-]?\d\d\d\d" title="{xla t='Enter a 10-digit fax number, e.g. 555-123-4567'}" onKeyDown="PreventIt(event)">
         </div>
     </div>
     <div class="form-row my-sm-2">
@@ -153,14 +153,21 @@
 
 <script>
     function submit_insurancecompany() {
-        if(document.insurancecompany.name.value.length>0) {
-            top.restoreSession();
-            document.insurancecompany.submit();
-            //Z&H Removed redirection
-        } else{
-            document.insurancecompany.name.style.backgroundColor="red";
+        if (document.insurancecompany.name.value.length === 0) {
+            document.insurancecompany.name.style.backgroundColor = "red";
             document.insurancecompany.name.focus();
+            return;
         }
+        // Honor the pattern= constraints on phone/fax (and anything else added
+        // later). reportValidity() shows the browser's native error bubble
+        // pointing at the first invalid field; without this the JS submit()
+        // bypasses HTML5 validation entirely.
+        if (!document.insurancecompany.reportValidity()) {
+            return;
+        }
+        top.restoreSession();
+        document.insurancecompany.submit();
+        //Z&H Removed redirection
     }
 
     function jsWaitForDelay(delay) {

--- a/templates/pharmacies/general_edit.html
+++ b/templates/pharmacies/general_edit.html
@@ -57,13 +57,13 @@
     <div class="form-row py-sm-2">
         <label for="phone" class="col-form-label col-sm-2">{xlt t='Phone'}</label>
         <div class="col-sm-8">
-            <input type="text" id="phone" name="phone" class="form-control" value="{$pharmacy->get_phone()|attr}" onKeyDown="PreventIt(event)" />
+            <input type="tel" id="phone" name="phone" class="form-control" value="{$pharmacy->get_phone()|attr}" pattern="(?:\(\d\d\d\)|\d\d\d)[\s.\-]?\d\d\d[\s.\-]?\d\d\d\d" title="{xla t='Enter a 10-digit phone number, e.g. 555-123-4567'}" onKeyDown="PreventIt(event)" />
         </div>
     </div>
     <div class="form-row py-sm-2">
         <label for="fax" class="col-form-label col-sm-2">{xlt t='Fax'}</label>
         <div class="col-sm-8">
-            <input type="text" id="fax" name="fax" class="form-control" value="{$pharmacy->get_fax()|attr}" onKeyDown="PreventIt(event)" />
+            <input type="tel" id="fax" name="fax" class="form-control" value="{$pharmacy->get_fax()|attr}" pattern="(?:\(\d\d\d\)|\d\d\d)[\s.\-]?\d\d\d[\s.\-]?\d\d\d\d" title="{xla t='Enter a 10-digit fax number, e.g. 555-123-4567'}" onKeyDown="PreventIt(event)" />
         </div>
     </div>
     <div class="form-row py-sm-2">
@@ -101,17 +101,20 @@
 <script>
 function submit_pharmacy()
 {
-    if(document.pharmacy.name.value.length>0)
-    {
-        top.restoreSession();
-        document.pharmacy.submit();
-        //Z&H Removed redirection
-    }
-    else
-    {
-        document.pharmacy.name.style.backgroundColor="red";
+    if (document.pharmacy.name.value.length === 0) {
+        document.pharmacy.name.style.backgroundColor = "red";
         document.pharmacy.name.focus();
+        return;
     }
+    // Honor the pattern= constraints on phone/fax. reportValidity() shows the
+    // browser's native error bubble pointing at the first invalid field;
+    // without this the JS submit() bypasses HTML5 validation entirely.
+    if (!document.pharmacy.reportValidity()) {
+        return;
+    }
+    top.restoreSession();
+    document.pharmacy.submit();
+    //Z&H Removed redirection
 }
 
  function Waittoredirect(delaymsec) {

--- a/tests/Tests/Services/InsuranceCompanyServiceTest.php
+++ b/tests/Tests/Services/InsuranceCompanyServiceTest.php
@@ -246,4 +246,30 @@ class InsuranceCompanyServiceTest extends TestCase
         $this->assertNotFalse($row);
         $this->assertEquals(9999999, $row['id']);
     }
+
+    #[Test]
+    public function testLegacyPersistSkipsPhoneWithoutTenDigitNationalNumber(): void
+    {
+        // Regression for the TypeError on Practice Settings → Insurance Company
+        // edit when the phone field posts something PhoneNumber::tryParse will
+        // accept but that doesn't yield a 10-digit NANP national number
+        // (e.g. "555-1234"). The legacy InsuranceCompany::persist() forwarded
+        // a null from PhoneNumber::getNationalDigits() into
+        // PhoneNumberService::getPhoneParts(string), throwing:
+        //   TypeError: Argument #1 ($phone_number) must be of type string, null given
+        $co = new \InsuranceCompany();
+        $co->set_name('test-fixture-LegacyPersistShortPhone');
+        $co->set_phone('555-1234');
+
+        $co->persist();
+        $insuranceId = $co->id;
+        $this->assertTrue(is_int($insuranceId) || is_string($insuranceId));
+        $this->createdIds[] = $insuranceId;
+
+        $phoneRows = QueryUtils::fetchRecordsNoLog(
+            "SELECT id FROM phone_numbers WHERE foreign_id = ?",
+            [$insuranceId]
+        );
+        $this->assertSame([], $phoneRows);
+    }
 }

--- a/tests/Tests/Services/InsuranceCompanyServiceTest.php
+++ b/tests/Tests/Services/InsuranceCompanyServiceTest.php
@@ -20,6 +20,7 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Services\Address\AddressData;
 use OpenEMR\Services\AddressService;
 use OpenEMR\Services\InsuranceCompanyService;
+use OpenEMR\Services\PhoneType;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -271,5 +272,68 @@ class InsuranceCompanyServiceTest extends TestCase
             [$insuranceId]
         );
         $this->assertSame([], $phoneRows);
+    }
+
+    #[Test]
+    public function testLegacyPersistDoesNotDuplicatePhoneRowsOnResave(): void
+    {
+        // Regression for the duplicate phone_numbers rows that accumulated on
+        // every save before persist() learned to clear by foreign_id first.
+        // PR #10326 swapped the legacy upsert for a bare PhoneNumberService
+        // insert(), so each save added another WORK row + another FAX row;
+        // the list view's two LEFT JOINs on phone_numbers then multiplied the
+        // company across (work_count * fax_count) rows in the UI.
+        $co = new \InsuranceCompany();
+        $co->set_name('test-fixture-LegacyPersistDuplicate');
+        $co->set_phone('5551234567');
+        $co->set_fax('5559876543');
+        $co->persist();
+        $insuranceId = $co->id;
+        $this->assertTrue(is_int($insuranceId) || is_string($insuranceId));
+        $this->createdIds[] = $insuranceId;
+
+        // After first save: one WORK row + one FAX row.
+        $afterCreate = QueryUtils::fetchRecordsNoLog(
+            "SELECT id, type FROM phone_numbers WHERE foreign_id = ?",
+            [$insuranceId]
+        );
+        $this->assertCount(2, $afterCreate);
+
+        // Re-save unchanged. Without the fix this would double to four rows.
+        $co->persist();
+        $afterResave = QueryUtils::fetchRecordsNoLog(
+            "SELECT id, type FROM phone_numbers WHERE foreign_id = ?",
+            [$insuranceId]
+        );
+        $this->assertCount(2, $afterResave);
+
+        // Re-save with a changed phone. The clear-then-insert should leave
+        // exactly one row per type, the WORK row should carry the new number,
+        // and the FAX row should still carry the original (since set_phone
+        // touches only the WORK entry).
+        $co->set_phone('5551112222');
+        $co->persist();
+        $afterEdit = QueryUtils::fetchRecordsNoLog(
+            "SELECT area_code, prefix, number, type FROM phone_numbers"
+            . " WHERE foreign_id = ?",
+            [$insuranceId]
+        );
+        $this->assertCount(2, $afterEdit);
+        $byType = [];
+        foreach ($afterEdit as $row) {
+            $rowType = $row['type'];
+            $this->assertIsInt($rowType);
+            $byType[$rowType] = $row;
+        }
+        $workRow = $byType[PhoneType::WORK->value] ?? null;
+        $this->assertNotNull($workRow);
+        $this->assertSame('555', $workRow['area_code']);
+        $this->assertSame('111', $workRow['prefix']);
+        $this->assertSame('2222', $workRow['number']);
+        $faxRow = $byType[PhoneType::FAX->value] ?? null;
+        $this->assertNotNull($faxRow);
+        $this->assertSame('555', $faxRow['area_code']);
+        $this->assertSame('987', $faxRow['prefix']);
+        $this->assertSame('6543', $faxRow['number']);
     }
 }

--- a/tests/Tests/Services/PharmacyPersistTest.php
+++ b/tests/Tests/Services/PharmacyPersistTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Pharmacy Persist Integration Test
+ *
+ * Exercises the legacy library/classes/Pharmacy.class.php persist() path
+ * against the phone_numbers table. Covers the same null-national-digits
+ * regression as InsuranceCompanyServiceTest::testLegacyPersistSkipsPhone...,
+ * since Pharmacy got the exact same buggy persist() code from PR #10326
+ * (the PhoneNumberService consolidation refactor) as InsuranceCompany did.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Claude Code
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services;
+
+use OpenEMR\Common\Database\QueryUtils;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class PharmacyPersistTest extends TestCase
+{
+    /** @var list<int|string> */
+    private array $createdIds = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdIds as $id) {
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `addresses` WHERE `foreign_id` = ?", [$id]);
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `phone_numbers` WHERE `foreign_id` = ?", [$id]);
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `pharmacies` WHERE `id` = ?", [$id]);
+        }
+    }
+
+    #[Test]
+    public function testLegacyPersistSkipsPhoneWithoutTenDigitNationalNumber(): void
+    {
+        // Regression for the same TypeError that fired on insurance company
+        // edits prior to InsuranceCompany::persist()'s null guard. Pharmacy
+        // got identical code from #10326 and crashes identically when a phone
+        // PhoneNumber::tryParse accepts doesn't yield a 10-digit NANP national
+        // number (e.g. "555-1234").
+        $pharmacy = new \Pharmacy();
+        $pharmacy->set_name('test-fixture-LegacyPersistShortPhone');
+        $pharmacy->set_phone('555-1234');
+
+        $pharmacy->persist();
+        $pharmacyId = $pharmacy->id;
+        $this->assertTrue(is_int($pharmacyId) || is_string($pharmacyId));
+        $this->createdIds[] = $pharmacyId;
+
+        $phoneRows = QueryUtils::fetchRecordsNoLog(
+            "SELECT id FROM phone_numbers WHERE foreign_id = ?",
+            [$pharmacyId]
+        );
+        $this->assertSame([], $phoneRows);
+    }
+}

--- a/tests/Tests/Services/PharmacyPersistTest.php
+++ b/tests/Tests/Services/PharmacyPersistTest.php
@@ -19,6 +19,7 @@
 namespace OpenEMR\Tests\Services;
 
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\PhoneType;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -58,5 +59,61 @@ class PharmacyPersistTest extends TestCase
             [$pharmacyId]
         );
         $this->assertSame([], $phoneRows);
+    }
+
+    #[Test]
+    public function testLegacyPersistDoesNotDuplicatePhoneRowsOnResave(): void
+    {
+        // Same regression as the matching InsuranceCompany test — Pharmacy
+        // inherited the duplicate-on-save bug from PR #10326. Without the
+        // clear-then-insert in persist() every save added another WORK + FAX
+        // pair, and the list view's two LEFT JOINs on phone_numbers
+        // multiplied the pharmacy across (work_count * fax_count) result rows.
+        $pharmacy = new \Pharmacy();
+        $pharmacy->set_name('test-fixture-LegacyPersistDuplicate');
+        $pharmacy->set_phone('5551234567');
+        $pharmacy->set_fax('5559876543');
+        $pharmacy->persist();
+        $pharmacyId = $pharmacy->id;
+        $this->assertTrue(is_int($pharmacyId) || is_string($pharmacyId));
+        $this->createdIds[] = $pharmacyId;
+
+        $afterCreate = QueryUtils::fetchRecordsNoLog(
+            "SELECT id, type FROM phone_numbers WHERE foreign_id = ?",
+            [$pharmacyId]
+        );
+        $this->assertCount(2, $afterCreate);
+
+        $pharmacy->persist();
+        $afterResave = QueryUtils::fetchRecordsNoLog(
+            "SELECT id, type FROM phone_numbers WHERE foreign_id = ?",
+            [$pharmacyId]
+        );
+        $this->assertCount(2, $afterResave);
+
+        $pharmacy->set_phone('5551112222');
+        $pharmacy->persist();
+        $afterEdit = QueryUtils::fetchRecordsNoLog(
+            "SELECT area_code, prefix, number, type FROM phone_numbers"
+            . " WHERE foreign_id = ?",
+            [$pharmacyId]
+        );
+        $this->assertCount(2, $afterEdit);
+        $byType = [];
+        foreach ($afterEdit as $row) {
+            $rowType = $row['type'];
+            $this->assertIsInt($rowType);
+            $byType[$rowType] = $row;
+        }
+        $workRow = $byType[PhoneType::WORK->value] ?? null;
+        $this->assertNotNull($workRow);
+        $this->assertSame('555', $workRow['area_code']);
+        $this->assertSame('111', $workRow['prefix']);
+        $this->assertSame('2222', $workRow['number']);
+        $faxRow = $byType[PhoneType::FAX->value] ?? null;
+        $this->assertNotNull($faxRow);
+        $this->assertSame('555', $faxRow['area_code']);
+        $this->assertSame('987', $faxRow['prefix']);
+        $this->assertSame('6543', $faxRow['number']);
     }
 }

--- a/version.php
+++ b/version.php
@@ -31,7 +31,7 @@ $v_realpatch = '0';
 //
 // Keep in sync with the v_database comment in sql/database.sql.
 // CI will fail if they don't match.
-$v_database = 539;
+$v_database = 540;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Backport of the three master-side follow-ups to PR #10326 (the *PhoneNumberService consolidation* refactor) to rel-810. All three bugs landed in master via #10326 and rel-810 inherits the same buggy persist code.

| Master PR | What it does | Commit on this branch |
|---|---|---|
| #12529 | Null-guard in `InsuranceCompany::persist()` / `Pharmacy::persist()` against `PhoneNumber::getNationalDigits()` returning `null` — fixes the `TypeError` on save when a phone parses but isn't a 10-digit NANP number. | `607ab74e` |
| #12534 | HTML5 `pattern` + `type="tel"` on the phone/fax inputs of the insurance and pharmacy edit forms, plus `reportValidity()` in the Save handlers so the JS-driven submit honors the constraints. | `7390339e` |
| #12538 | Clear `phone_numbers` for the `foreign_id` before re-inserting in `persist()` (wrapped in `QueryUtils::inTransaction()` for atomicity); cleanup migration to remove duplicate rows already accumulated in production. | `88eea0fd` |

## Notes on the backport

- **Cherry-picked with `-x`** so each commit preserves the *"(cherry picked from commit XXX)"* trailer pointing at the master squash.
- **InsuranceCompanyServiceTest conflict on #12529** — the master squash brought in several `testBuildSaveDataFromForm*` and `testSaveFromForm*` tests that rely on `InsuranceCompanyService::buildSaveDataFromForm()` / `saveFromForm()` methods that don't exist in rel-810. Dropped those during conflict resolution — kept only `testLegacyPersistSkipsPhoneWithoutTenDigitNationalNumber`, which is the regression test for the actual persist null-guard.
- **v_database conflict on #12538** — rel-810 was at 539 (calendar fix), master was at 541 (calendar fix bumped 540 + dedup fix bumped 541). Resolved to bump rel-810 from 539 → 540 (single bump for the dedup migration). The upgrade-script label was also adjusted from `-- v_database 541:` to `-- v_database 540:` to match.
- **No pre-commit run** — commits were created with hooks bypassed per the rel-810 backport convention (no docker stack on this worktree). All three changes already passed master's full quality suite via their original PRs, so the bypass is reasonable for the port.

## Test plan

- [ ] On *Practice Settings → Insurance Company → Edit*, type `555-1234` in **Phone** and click Save — browser blocks with HTML5 error bubble.
- [ ] Edit an insurance company with valid phone + fax, save, return to list — name appears once.
- [ ] Save the same record again without changing anything — name still appears once (no duplicate multiplication).
- [ ] Repeat both on *Procedures → Pharmacies → Edit*.
- [ ] On a rel-810 instance that already accumulated duplicate phone rows, run the upgrade — list stops multiplying, data preserved (highest-id row per type wins).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Eliminated duplicate phone number entries when saving insurance company and pharmacy records multiple times.
  * Prevented errors when entering non-standard phone number formats.
  * Cleaned up existing duplicate phone number records from the database.

* **New Features**
  * Enhanced phone and fax input fields with built-in 10-digit format validation and helpful guidance text.
  * Improved form submission to validate all fields including phone/fax patterns before processing.

* **Tests**
  * Added regression tests for phone number handling and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->