### PR TITLE
fix(ci): only require release-targets.yml in master context for byte-identical canary

### DIFF
--- a/.github/scripts/validate-byte-identical.sh
+++ b/.github/scripts/validate-byte-identical.sh
@@ -2,10 +2,13 @@
 #
 # Validate the byte-identical file set across master and every rel branch.
 #
-# Reads FILES_ALL from .github/docker-byte-identical.yml in cwd and
-# REL_BRANCHES from .github/release-targets.yml in cwd. Compares each
-# FILES_ALL entry across branches via raw.githubusercontent.com fetches.
-# Behavior depends on run context -- see the header of
+# Reads FILES_ALL from .github/docker-byte-identical.yml in cwd. In
+# master context also reads REL_BRANCHES from .github/release-targets.yml;
+# that file is master-only orchestrator config and rel branches don't
+# carry it (the rel-* path doesn't need it -- it just walks FILES_ALL
+# and compares each entry to master HEAD). Compares each FILES_ALL
+# entry across branches via raw.githubusercontent.com fetches. Behavior
+# depends on run context -- see the header of
 # .github/workflows/docker-validate-byte-identical.yml for the rationale.
 #
 # Inputs (env)
@@ -90,28 +93,19 @@ command -v yq >/dev/null 2>&1 || {
   emit_error ".github/docker-byte-identical.yml not present in cwd."
   exit 2
 }
-[[ -f .github/release-targets.yml ]] || {
-  emit_error ".github/release-targets.yml not present in cwd."
-  exit 2
-}
+# Note: .github/release-targets.yml presence is only required in master
+# context; the file is master-side orchestrator config that rel branches
+# don't carry (and don't need -- the rel-* path only walks FILES_ALL and
+# fetches master's copy of each entry). Its check moves into the
+# master-context branch below.
 
-# Read configs. Each subprocess captured separately so SC2312 (return-value
-# masking via process substitution) does not bite.
+# Read FILES_ALL (needed in both contexts). The subprocess is captured
+# separately so SC2312 (return-value masking via process substitution)
+# does not bite.
 files_yq_output=$(yq -r '.files[]' .github/docker-byte-identical.yml)
 mapfile -t FILES_ALL <<<"${files_yq_output}"
 if [[ ${#FILES_ALL[@]} -eq 1 && -z "${FILES_ALL[0]}" ]]; then
   FILES_ALL=()
-fi
-
-rel_yq_output=$(yq -r '.[] | select(.branch != "master") | .branch' .github/release-targets.yml)
-mapfile -t REL_BRANCHES <<<"${rel_yq_output}"
-if [[ ${#REL_BRANCHES[@]} -eq 1 && -z "${REL_BRANCHES[0]}" ]]; then
-  REL_BRANCHES=()
-fi
-
-if [[ ${#REL_BRANCHES[@]} -eq 0 ]]; then
-  emit_warning "No rel branches found in release-targets.yml -- nothing to check."
-  exit 0
 fi
 
 if [[ ${#FILES_ALL[@]} -eq 0 ]]; then
@@ -158,6 +152,22 @@ fetch_status() {
 }
 
 if [[ "${CONTEXT_BRANCH}" == "master" ]]; then
+  # Master context needs the rel branch list -- read release-targets.yml
+  # here (not at script start) so the rel-* context doesn't require it.
+  [[ -f .github/release-targets.yml ]] || {
+    emit_error ".github/release-targets.yml not present in cwd (required in master context)."
+    exit 2
+  }
+  rel_yq_output=$(yq -r '.[] | select(.branch != "master") | .branch' .github/release-targets.yml)
+  mapfile -t REL_BRANCHES <<<"${rel_yq_output}"
+  if [[ ${#REL_BRANCHES[@]} -eq 1 && -z "${REL_BRANCHES[0]}" ]]; then
+    REL_BRANCHES=()
+  fi
+  if [[ ${#REL_BRANCHES[@]} -eq 0 ]]; then
+    emit_warning "No rel branches found in release-targets.yml -- nothing to check."
+    exit 0
+  fi
+
   # Master context: master is canonical. Every FILES_ALL entry must
   # exist on master; missing ones are a config bug.
   missing=()

--- a/tests/bats/ci-scripts/validate-byte-identical/validate.bats
+++ b/tests/bats/ci-scripts/validate-byte-identical/validate.bats
@@ -150,6 +150,31 @@ teardown() {
     [[ "$output" == *"foo.txt matches master"* ]]
 }
 
+@test "rel-810 PR: succeeds when release-targets.yml is absent (rel branches don't carry it)" {
+    rm -f .github/release-targets.yml
+    write_files_all_config foo.txt
+    write_local_file       foo.txt   "in-sync"
+    write_remote_file master foo.txt "in-sync"
+
+    set_pr_context rel-810
+    run bash "$VALIDATE_BYTE_IDENTICAL_SCRIPT"
+
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"foo.txt matches master"* ]]
+}
+
+@test "master context: missing release-targets.yml -> precondition error (still required on master)" {
+    rm -f .github/release-targets.yml
+    write_files_all_config foo.txt
+    write_local_file foo.txt "v1"
+
+    set_schedule_context master
+    run bash "$VALIDATE_BYTE_IDENTICAL_SCRIPT"
+
+    [[ $status -eq 2 ]]
+    [[ "$output" == *"release-targets.yml not present"* ]]
+}
+
 @test "rel-810 PR: drift vs master -> error, fail" {
     write_files_all_config foo.txt
     write_local_file       foo.txt   "rel-edit"


### PR DESCRIPTION
## Summary

Follow-up to #12580. The canary's first real fire on rel-branch sync
PRs (#12582 / #12583 / #12584) blew up immediately on a precondition
check:

```
##[error].github/release-targets.yml not present in cwd.
##[error]Process completed with exit code 2.
```

`release-targets.yml` is master-only orchestrator config (the list of
rel branches the daily build orchestrator dispatches against). Rel
branches don't carry it and don't need to: the canary's rel-context
branch iterates `FILES_ALL` and compares each entry to master HEAD —
it never references `REL_BRANCHES`.

Fix: move the `release-targets.yml` precondition + read inside the
master-context branch. Rel context no longer depends on a file that
rel branches don't ship.

## Future rel-branch cuts

For new rel branches cut from master, this works either way:

- They inherit `release-targets.yml` automatically (just another file
  in the master tree), but the canary's rel-context branch
  reads-and-ignores in that case. Harmless dead file.
- If a future branch-cut process intentionally strips master-only
  config from the new branch, the canary still works.

No change to the cut process needed.

## Test coverage

Two new BATS cases at `tests/bats/ci-scripts/validate-byte-identical/`:

- `rel-810 PR: succeeds when release-targets.yml is absent (rel
  branches don't carry it)` — locks in the new rel-context property.
- `master context: missing release-targets.yml -> precondition error
  (still required on master)` — proves master-context enforcement is
  unchanged.

All 16 tests pass (`GITHUB_ACTIONS=true bats
tests/bats/ci-scripts/validate-byte-identical/`).

## What lands afterward

1. This PR merges → master has the fixed script.
2. Auto-sync (#12577) fires on the master push. The existing sync PRs
   (#12582 / #12583 / #12584) are long-lived branches — auto-sync force-
   updates them with the fixed script content.
3. The canary re-runs on each updated sync PR using the fixed script,
   passes via the rel-context branch (LOCAL == master HEAD for every
   FILES_ALL entry, since they were just synced).
4. Merge the 3 sync PRs → rel branches carry the canary trio for real.

## Test plan

- [ ] CI green here. `test-byte-identical-scripts.yml` runs the BATS
      suite; this PR touches both the script and its tests, so the
      suite fires.
- [ ] Canary on this PR (master context, pull_request) runs cleanly
      against master + rel branches (master has the new entries since
      PR D landed; the new entries match because no FILES_ALL file is
      modified here).
- [ ] After merge: confirm auto-sync force-updates #12582 / #12583 /
      #12584 with the fixed script and their canary checks turn green.
- [ ] Merge the 3 sync PRs and confirm rel branches now carry the
      canary trio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)