### PR TITLE
docs(claude): warn against git fetch --update-head-ok in the primary repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,13 @@ skips both the state registration and the stack. If you already made that
 mistake, recovery is `git worktree remove <path>` then `openemr-cmd worktree
 add <branch> --start` (omit `-b` since the branch persists).
 
+**Never use `git fetch ... --update-head-ok` in the primary openemr repo,
+regardless of remote or URL.** It overwrites the current branch's ref
+without updating the working tree, leaving the index showing "staged
+deletions of everything new on master" — a stray `git commit` after that
+wipes recent work. Use `git pull` or plain `git fetch` (then read via
+tracking ref) instead.
+
 If `openemr-cmd worktree list` shows entries with status `missing` or
 `invalid` (and a footer `(N stale state entries — run "openemr-cmd worktree
 prune" to clean up; directories on disk are left intact)`), a worktree's


### PR DESCRIPTION
## Summary

Adds a 6-line stanza to the "Working in a git worktree" section of
[`CLAUDE.md`](CLAUDE.md) flagging the one git-fetch flag combination
that silently drifts the primary repo's working tree.

## Why

Discovered during the byte-identical canary work (PRs #12575 →
#12594): the AI assistant repeatedly used
`git fetch <url> master:master --update-head-ok` from
`/home/brady2/git/openemr` (the primary clone, on master) to "advance
master locally" after each merge. `--update-head-ok` lets fetch
overwrite the current branch's ref, but fetch never touches the
working tree -- so the index inherited the gap and accumulated
~20 staged deletions of every file the recent PRs had added (canary
trio, script extraction, compose relocation, insurance fix, etc.).
A stray `git commit` in that state would have wiped all that work
on top of master.

`--update-head-ok` exists specifically to bypass git's normal
protection against overwriting the current branch's ref via fetch.
The only legitimate use case is decoupling ref-advance from
working-tree update -- which is exactly the foot-gun. AI assistants
don't need it because the safer primitives cover every reasonable
use case.

## What's in here

| File | Change |
|---|---|
| [`CLAUDE.md`](CLAUDE.md) | 7 lines added inside "Working in a git worktree" |

The stanza:

```
**Never use `git fetch ... --update-head-ok` in the primary openemr repo,
regardless of remote or URL.** It overwrites the current branch's ref
without updating the working tree, leaving the index showing "staged
deletions of everything new on master" — a stray `git commit` after that
wipes recent work. Use `git pull` or plain `git fetch` (then read via
tracking ref) instead.
```

## Why narrow

The rule bans exactly one flag combination on one repo. Plain `git pull`
and plain `git fetch` both stay available, with any remote or URL --
AI assistants keep full flexibility to grab latest master from `origin`,
`upstream`, or an arbitrary direct GitHub URL. They just don't need
`--update-head-ok` to do it. Keeps CLAUDE.md compact (it'll keep growing
over time) while still catching the specific failure mode.

## Defense-in-depth at multi-agent scale (separate, not in this PR)

The per-agent CLAUDE.md rule scales fine -- each agent reads CLAUDE.md
and follows the rule independently. But for the structural fix at scale,
a future change to `openemr-cmd worktree add -b` could internally do
`git fetch origin master` and branch the new worktree directly from
`origin/master`. That removes the assistant's *need* to ever advance
the primary's local master ref, and -- importantly -- it works under
concurrent agents because each worktree-add becomes self-contained:
no shared coordination surface on the primary's branch state.

An earlier-considered "park primary on a sacrificial branch" convention
was dropped from the defense-in-depth set: it works as a single-user
emergency measure but breaks under concurrent agents (one agent parks
at commit T1, another's later `worktree add -b` then branches from
parked@T1 instead of latest master). The openemr-cmd tool-level fix
is the multi-agent-friendly answer.

Out of scope for this PR -- pure docs.

## Test plan

- [ ] CI green (docs-only change; only YAML / markdown / spellcheck
      hooks fire).
- [ ] Future AI-assisted sessions across the codebase don't recreate
      the staged-deletions drift. (Hard to assert preventively; this
      stanza is the assertion.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)