### PR TITLE
chore(release): advance master to 8.2.0-dev

### DIFF
--- a/.github/release-targets.yml
+++ b/.github/release-targets.yml
@@ -62,12 +62,12 @@
 # YAML structure.
 
 - branch: master
-  # 8.1.1 is the version master is currently developing (see version.php's
+  # 8.2.0 is the version master is currently developing (see version.php's
   # $v_major.$v_minor.$v_patch). Bump this when master moves to the next
-  # release cycle (e.g., when version.php switches to 8.1.2-dev or 8.2.0-dev).
+  # release cycle (e.g., when version.php switches to 8.3.0-dev).
   # The docker_tag <-> version.php alignment guard in
   # docker-validate-release-targets.yml catches drift on PRs.
-  docker_tags: 8.1.1,dev
+  docker_tags: 8.2.0,dev
   openemr_version_ref: master
 
 - branch: rel-810

--- a/sql/8_1_1-to-8_2_0_upgrade.sql
+++ b/sql/8_1_1-to-8_2_0_upgrade.sql
@@ -1,0 +1,114 @@
+--
+--  Comment Meta Language Constructs:
+--
+--  #IfNotTable
+--    argument: table_name
+--    behavior: if the table_name does not exist,  the block will be executed
+
+--  #IfTable
+--    argument: table_name
+--    behavior: if the table_name does exist, the block will be executed
+
+--  #IfColumn
+--    arguments: table_name colname
+--    behavior:  if the table and column exist,  the block will be executed
+
+--  #IfMissingColumn
+--    arguments: table_name colname
+--    behavior:  if the table exists but the column does not,  the block will be executed
+
+--  #IfNotColumnType
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does not have a column colname with a data type equal to value, then the block will be executed
+
+--  #IfNotColumnTypeDefault
+--    arguments: table_name colname value value2
+--    behavior:  If the table table_name does not have a column colname with a data type equal to value and a default equal to value2, then the block will be executed
+
+--  #IfNotRow
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does not have a row where colname = value, the block will be executed.
+
+--  #IfNotRow2D
+--    arguments: table_name colname value colname2 value2
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2, the block will be executed.
+
+--  #IfNotRow3D
+--    arguments: table_name colname value colname2 value2 colname3 value3
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2 AND colname3 = value3, the block will be executed.
+
+--  #IfNotRow4D
+--    arguments: table_name colname value colname2 value2 colname3 value3 colname4 value4
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2 AND colname3 = value3 AND colname4 = value4, the block will be executed.
+
+--  #IfNotRow2Dx2
+--    desc:      This is a very specialized function to allow adding items to the list_options table to avoid both redundant option_id and title in each element.
+--    arguments: table_name colname value colname2 value2 colname3 value3
+--    behavior:  The block will be executed if both statements below are true:
+--               1) The table table_name does not have a row where colname = value AND colname2 = value2.
+--               2) The table table_name does not have a row where colname = value AND colname3 = value3.
+
+--  #IfRow
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does have a row where colname = value, the block will be executed.
+
+--  #IfRow2D
+--    arguments: table_name colname value colname2 value2
+--    behavior:  If the table table_name does have a row where colname = value AND colname2 = value2, the block will be executed.
+
+--  #IfRow3D
+--        arguments: table_name colname value colname2 value2 colname3 value3
+--        behavior:  If the table table_name does have a row where colname = value AND colname2 = value2 AND colname3 = value3, the block will be executed.
+
+--  #IfRowIsNull
+--    arguments: table_name colname
+--    behavior:  If the table table_name does have a row where colname is null, the block will be executed.
+
+--  #IfIndex
+--    desc:      This function is most often used for dropping of indexes/keys.
+--    arguments: table_name colname
+--    behavior:  If the table and index exist the relevant statements are executed, otherwise not.
+
+--  #IfNotIndex
+--    desc:      This function will allow adding of indexes/keys.
+--    arguments: table_name colname
+--    behavior:  If the index does not exist, it will be created
+
+--  #EndIf
+--    all blocks are terminated with a #EndIf statement.
+
+--  #IfNotListReaction
+--    Custom function for creating Reaction List
+
+--  #IfNotListOccupation
+--    Custom function for creating Occupation List
+
+--  #IfTextNullFixNeeded
+--    desc: convert all text fields without default null to have default null.
+--    arguments: none
+
+--  #IfTableEngine
+--    desc:      Execute SQL if the table has been created with given engine specified.
+--    arguments: table_name engine
+--    behavior:  Use when engine conversion requires more than one ALTER TABLE
+
+--  #IfInnoDBMigrationNeeded
+--    desc: find all MyISAM tables and convert them to InnoDB.
+--    arguments: none
+--    behavior: can take a long time.
+
+--  #IfDocumentNamingNeeded
+--    desc: populate name field with document names.
+--    arguments: none
+
+--  #IfUpdateEditOptionsNeeded
+--    desc: Change Layout edit options.
+--    arguments: mode(add or remove) layout_form_id the_edit_option comma_separated_list_of_field_ids
+
+--  #IfVitalsDatesNeeded
+--    desc: Change date from zeroes to date of vitals form creation.
+--    arguments: none
+
+--  #IfMBOEncounterNeeded
+--    desc: Add encounter to the form_misc_billing_options table
+--    arguments: none

--- a/src/RestControllers/OpenApi/OpenApiDefinitions.php
+++ b/src/RestControllers/OpenApi/OpenApiDefinitions.php
@@ -14,7 +14,7 @@ namespace OpenEMR\RestControllers\OpenApi;
 
 use OpenApi\Attributes as OA;
 
-#[OA\Info(title: 'OpenEMR API', version: '8.0.1')]
+#[OA\Info(title: 'OpenEMR API', version: '8.2.0')]
 #[OA\Server(url: '/apis/default/')]
 
 #[OA\SecurityScheme(

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: 'OpenEMR API'
-  version: 8.0.1
+  version: 8.2.0
 servers:
   -
     url: /apis/default/

--- a/version.php
+++ b/version.php
@@ -16,8 +16,8 @@
 // upgrade file is the starting point for the next upgrade.
 
 $v_major = '8';
-$v_minor = '1';
-$v_patch = '1';
+$v_minor = '2';
+$v_patch = '0';
 $v_tag   = '-dev'; // minor revision number, should be empty for production releases
 
 // A real patch identifier. This is incremented when we release a patch for a


### PR DESCRIPTION
## Summary

Advances master from `8.1.1-dev` to `8.2.0-dev`. Frees the 8.1.x
docker tag namespace for rel-810 to own (rel-810 will release
8.1.0, 8.1.1, 8.1.2, ... from this point forward) and reflects that
master is now developing toward the next minor, **8.2.0**.

Manual bump per the procedure in
[`openemr-release-mechanism-gaps.md`](https://github.com/bradymiller/openemr/blob/master-bump-820-dev/.. -- working notes in the parent /git/ dir, not in this repo)
— the conductor doesn't currently expose a `--scope=master` workflow
path, so this is run by hand.

## Why now

Pre-bump state:

| File | Value | Note |
|---|---|---|
| `version.php` | `8.1.1-dev` | Conflicted semantically with rel-810 also planning to ship 8.1.1 |
| `OpenApiDefinitions.php` | `'8.0.1'` | Two minor versions stale; long overdue catch-up |
| `release-targets.yml` master row `docker_tags` | `8.1.1,dev` | Same conflict — master's Docker Hub tag `openemr/openemr:8.1.1` would shadow rel-810's official 8.1.1 release |

Doing this before rel-810 ships 8.1.1 prevents the docker tag collision
where `openemr/openemr:8.1.1` would point to master's dev image instead
of rel-810's official release.

## Changes

| File | Change |
|---|---|
| `version.php` | `$v_minor` 1 → 2, `$v_patch` 1 → 0 (keep `$v_tag = -dev`) → `8.2.0-dev` |
| `src/RestControllers/OpenApi/OpenApiDefinitions.php` | `OA\Info` version `8.0.1` → `8.2.0` |
| `swagger/openemr-api.yaml` | regenerated via `openemr-cmd build-api-docs` (info.version derived from `OpenApiDefinitions`) |
| `sql/8_1_1-to-8_2_0_upgrade.sql` | **new** blank bridge file (long Comment Meta Language Constructs header only; body empty, fills as 8.2.0 SQL migrations land on master) |
| `.github/release-targets.yml` master row | `docker_tags: 8.1.1,dev` → `8.2.0,dev`; comment refreshed for 8.2.x cycle |

## Skipped (deliberately)

- **Docker upgrade machinery** (3 `docker-version` files,
  `fsupgrade-N.sh`, `Dockerfile` manifest). Those advance per docker
  version *release*, not per master-side version-state bump — master
  at 8.2.0-dev isn't a release. They'll advance when 8.2.0 (or
  whatever the next release lands) ships, with cross-branch
  propagation to whatever rel branch ships it.
- **Branch-cut-specific work** (release-targets.yml new rel branch
  row, Dockerfile `ARG OPENEMR_VERSION` on a new branch). Not cutting
  a new branch here — just advancing master's version state.

## Test plan

- [ ] CI green. The relevant guard is
      `docker-validate-release-targets.yml` which checks that the
      first `docker_tags` value matches `$v_major.$v_minor.$v_patch`
      from `version.php`. After this PR: both say `8.2.0`. Should
      pass.
- [ ] Spot-check that `swagger/openemr-api.yaml`'s `info.version`
      reads `8.2.0` (visible in this PR's diff).
- [ ] Post-merge: master's Docker Hub `openemr/openemr:8.2.0` tag
      starts publishing from master dev content. The previous
      `openemr/openemr:8.1.1` tag stops being updated from master;
      becomes free for rel-810 to claim when 8.1.1 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)