### PR TITLE
fix(ci): docker-validate-release-targets reads master version.php from PR checkout

### DIFF
--- a/.github/workflows/docker-validate-release-targets.yml
+++ b/.github/workflows/docker-validate-release-targets.yml
@@ -19,7 +19,12 @@
 #      (X.Y.Z, when realpatch == 0) or the base.realpatch form
 #      (X.Y.Z.W, when realpatch > 0). Catches both the version.php-bump-
 #      without-release-targets-bump drift case AND typo'd secondary tags
-#      like `8.0.0,9.9.9` in a multi-tag row.
+#      like `8.0.0,9.9.9` in a multi-tag row. For the master row the
+#      check reads version.php from the PR's local checkout (which is
+#      the merge-commit state -- "what master will look like after this
+#      PR merges") so a PR that coordinately bumps BOTH docker_tags and
+#      version.php validates cleanly; non-master rows use raw URL fetch
+#      against the stable git tag in openemr_version_ref.
 
 name: Validate release-targets.yml
 
@@ -119,7 +124,21 @@ jobs:
           # transient curl failure can't fall through to parsing a stale file
           # for the wrong branch's version.
           rm -f /tmp/v.php
-          if ! curl -fsSL "https://raw.githubusercontent.com/openemr/openemr/${REF}/version.php" -o /tmp/v.php; then
+          if [ "$REF" = "master" ]; then
+            # Use the PR's local checkout instead of raw.githubusercontent.com.
+            # This workflow only fires on `pull_request: branches: [master]`,
+            # so the checkout is always the PR's merge-commit content -- i.e.,
+            # "what master will look like after this PR merges." Validating
+            # against that closes a chicken-and-egg: a PR that coordinately
+            # bumps BOTH .github/release-targets.yml's master row docker_tags
+            # AND version.php would otherwise fail here because the new
+            # docker_tags would be compared against the upstream master's
+            # PRE-bump version.php (the PR hasn't merged yet, so raw URL
+            # serves the old content). Non-master rows continue to use the
+            # raw URL because their openemr_version_ref is a stable git tag
+            # that a PR can't modify locally.
+            cp version.php /tmp/v.php
+          elif ! curl -fsSL "https://raw.githubusercontent.com/openemr/openemr/${REF}/version.php" -o /tmp/v.php; then
             echo "::error::Row '$BRANCH': failed to fetch version.php at ref '$REF' from raw.githubusercontent.com"
             FAIL=1
             continue


### PR DESCRIPTION
## Summary

Fixes a chicken-and-egg in the
`docker-validate-release-targets.yml` validator's docker_tag ↔
version.php alignment check that surfaced during PR #12596 (manual
master 8.1.1-dev → 8.2.0-dev bump).

## The bug

The validator fetches `version.php` via raw.githubusercontent.com at
the `openemr_version_ref` declared in each `release-targets.yml` row.

- **Non-master rows** (`openemr_version_ref: v8_1_0`, `v8_0_0_3`,
  `v7_0_4`) — refs are stable git tags, raw URL serves correct content.
  Validates fine.
- **Master row** (`openemr_version_ref: master`) — ref is master's
  current HEAD. A PR that coordinately bumps BOTH the master row's
  `docker_tags` AND `version.php` has its new `docker_tags` validated
  against upstream master's PRE-bump `version.php` (the PR hasn't
  merged yet, so raw URL serves the old content). The PR's internal
  state is self-consistent but fails this check.

PR #12596 hit exactly this: bumped `docker_tags: 8.1.1,dev` →
`8.2.0,dev` together with `version.php` to `8.2.0-dev`. Validator
fetched upstream master's `8.1.1` version.php and rejected the new
`8.2.0` docker_tag as misaligned.

## The fix

For the master row, read `version.php` from the PR's local checkout
instead of raw.githubusercontent.com. The workflow only fires on
`pull_request: branches: [master]`, so the checkout is always the
PR's merge-commit content — i.e., "what master will look like after
this PR merges." Validating against that closes the chicken-and-egg.

Non-master rows continue to use the raw URL fetch (their refs are
stable tags that a PR can't modify locally anyway).

```diff
+ if [ "$REF" = "master" ]; then
+   cp version.php /tmp/v.php
+ elif ! curl -fsSL "https://raw.githubusercontent.com/openemr/openemr/${REF}/version.php" -o /tmp/v.php; then
    echo "::error::Row '$BRANCH': failed to fetch version.php at ref '$REF' from raw.githubusercontent.com"
    FAIL=1
    continue
  fi
```

Header docstring updated to reflect the master-row local-read path.

## Without this fix

Every future PR that does a coordinated master-side version bump
(e.g., when a new rel branch is cut from master and master advances
to the next minor) would need an admin-override merge through a
failing check. This fix makes the validator structurally sound for
that workflow.

## Test plan

- [ ] CI green here (no functional change to this PR's own validation
      surface — this PR doesn't touch release-targets.yml or version.php).
- [ ] After merge: re-run CI on PR #12596. The `validate` check
      should now pass because master has the smarter validator that
      reads `version.php` from the PR's local checkout (which has the
      coordinated 8.2.0 bump aligned with `docker_tags: 8.2.0,dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)