### PR TITLE
feat(codes): Modernized DBAL/ORM service path for code type syncing

### DIFF
--- a/cli
+++ b/cli
@@ -9,10 +9,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Console\ConsoleRunner as ORMConsoleRunner;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Firehed\Container\TypedContainerInterface;
-use OpenEMR\Console\Command\{
-    InstallCommand,
-    ShellCommand,
-};
+use OpenEMR\Console\Command;
 use Symfony\Component\Console\Application;
 
 $container = require_once __DIR__ . '/bootstrap.php';
@@ -29,8 +26,9 @@ file_put_contents(
 );
 
 $application = new Application();
-$application->addCommand($container->get(InstallCommand::class));
-$application->addCommand($container->get(ShellCommand::class));
+$application->addCommand($container->get(Command\InstallCommand::class));
+$application->addCommand($container->get(Command\ShellCommand::class));
+$application->addCommand($container->get(Command\Codes\UpdateMappingsCommand::class));
 
 // Doctrine Migrations integration
 MigrationsConsoleRunner::addCommands($application, $container->get(DependencyFactory::class));

--- a/config/cli.php
+++ b/config/cli.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace OpenEMR\Console\Command;
 
 return [
+    Codes\UpdateMappingsCommand::class,
     InstallCommand::class,
     ShellCommand::class,
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -29,6 +29,7 @@ use OpenEMR\BC\FallbackRouter;
 use OpenEMR\Common\Http\Psr17Factory;
 use OpenEMR\Common\Installer\InstallerInterface;
 use OpenEMR\Core\ErrorHandler;
+use OpenEMR\Services;
 use OpenEMR\Services\Storage\{
     Location,
     Manager,
@@ -89,4 +90,7 @@ return [
     Psr17Factory::class,
 
     SystemClock::class => fn () => SystemClock::fromSystemTimezone(),
+
+    // General services
+    Services\CodeTypes\CodeTypeMappingUpdater::class,
 ];

--- a/src/Console/Command/Codes/UpdateMappingsCommand.php
+++ b/src/Console/Command/Codes/UpdateMappingsCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Console\Command\Codes;
+
+use OpenEMR\Services\CodeTypes\CodeTypeMappingUpdater;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'codes:update-mappings',
+    description: 'Update list_options.codes mappings for activated code types (SNOMED, CPT4)',
+)]
+class UpdateMappingsCommand extends Command
+{
+    public function __construct(private readonly CodeTypeMappingUpdater $updater)
+    {
+        parent::__construct();
+    }
+
+    public function __invoke(
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
+        $this->updater->updateActivatedMappings();
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Console/Command/Codes/UpdateMappingsCommand.php
+++ b/src/Console/Command/Codes/UpdateMappingsCommand.php
@@ -20,11 +20,10 @@ use Symfony\Component\Console\Command\Command;
     name: 'codes:update-mappings',
     description: 'Update list_options.codes mappings for activated code types (SNOMED, CPT4)',
 )]
-class UpdateMappingsCommand extends Command
+class UpdateMappingsCommand
 {
     public function __construct(private readonly CodeTypeMappingUpdater $updater)
     {
-        parent::__construct();
     }
 
     public function __invoke(): int

--- a/src/Console/Command/Codes/UpdateMappingsCommand.php
+++ b/src/Console/Command/Codes/UpdateMappingsCommand.php
@@ -15,8 +15,6 @@ namespace OpenEMR\Console\Command\Codes;
 use OpenEMR\Services\CodeTypes\CodeTypeMappingUpdater;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
     name: 'codes:update-mappings',
@@ -29,10 +27,8 @@ class UpdateMappingsCommand extends Command
         parent::__construct();
     }
 
-    public function __invoke(
-        InputInterface $input,
-        OutputInterface $output,
-    ): int {
+    public function __invoke(): int
+    {
         $this->updater->updateActivatedMappings();
 
         return Command::SUCCESS;

--- a/src/Entities/Code.php
+++ b/src/Entities/Code.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Entities;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping;
+
+#[Mapping\Entity]
+#[Mapping\Table(name: 'codes')]
+class Code
+{
+    #[Mapping\Id]
+    #[Mapping\GeneratedValue]
+    #[Mapping\Column(type: Types::INTEGER)]
+    public readonly int $id; // @phpstan-ignore property.uninitializedReadonly (Doctrine hydrates via reflection)
+
+    #[Mapping\Column(length: 25)]
+    public string $code;
+
+    #[Mapping\Column(type: Types::TEXT, nullable: true)]
+    public ?string $codeText = null;
+
+    #[Mapping\Column(type: Types::SMALLINT, nullable: true)]
+    public ?int $codeType = null;
+}

--- a/src/Entities/CodeType.php
+++ b/src/Entities/CodeType.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Entities;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping;
+
+/**
+ * Important note: the underlying table has the PRIMARY KEY on the `ct_key`
+ * field and a separate UNIQUE on `ct_id` (despite `codes` referencing id, as
+ * per normal conventions). The Doctrine model reverses this to match common
+ * expectations.
+ *
+ * The database should get updated to reverse this, matching model declaration.
+ * See #12540.
+ */
+#[Mapping\Entity]
+#[Mapping\Table(name: 'code_types')]
+#[Mapping\UniqueConstraint(fields: ['key'])]
+class CodeType
+{
+    #[Mapping\Id]
+    #[Mapping\Column(name: 'ct_id', type: Types::INTEGER)]
+    public readonly int $id; // @phpstan-ignore property.uninitializedReadonly (Doctrine hydrates via reflection)
+
+    #[Mapping\Column(name: 'ct_key', length: 15)]
+    public string $key;
+
+    #[Mapping\Column(name: 'ct_seq', type: Types::INTEGER)]
+    public int $seq;
+
+    #[Mapping\Column(name: 'ct_active', type: Types::BOOLEAN)]
+    public bool $active;
+}

--- a/src/Entities/ListOption.php
+++ b/src/Entities/ListOption.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Entities;
+
+use Doctrine\ORM\Mapping;
+
+/**
+ * Important note: this table has a composite PK (see #12541) and must use the
+ * rarely-used array-as-id syntax for `find()` operations, e.g.
+ * `$em->find(ListOption::class, ['listId' => 'asdf', 'optionId' => 'sdfg'])`
+ */
+#[Mapping\Entity]
+#[Mapping\Table(name: 'list_options')]
+class ListOption
+{
+    #[Mapping\Id]
+    #[Mapping\Column(length: 100)]
+    public readonly string $listId; // @phpstan-ignore property.uninitializedReadonly (Doctrine hydrates via reflection)
+
+    #[Mapping\Id]
+    #[Mapping\Column(length: 100)]
+    public readonly string $optionId; // @phpstan-ignore property.uninitializedReadonly
+
+    #[Mapping\Column(length: 255)]
+    public string $codes;
+}

--- a/src/Services/CodeTypes/CodeTypeMappingUpdater.php
+++ b/src/Services/CodeTypes/CodeTypeMappingUpdater.php
@@ -203,15 +203,19 @@ readonly class CodeTypeMappingUpdater
 
     private function findCPT4Code(string $codeText): ?Code
     {
-        $codeTypeEntity = $this->em->getRepository(CodeType::class)->find(self::CODE_TYPE_CPT4);
+        $codeTypeEntity = $this->em->getRepository(CodeType::class)
+            ->findOneBy([
+                'key' => self::CODE_TYPE_CPT4,
+            ]);
         if ($codeTypeEntity === null) {
             return null;
         }
 
-        return $this->em->getRepository(Code::class)->findOneBy([
-            'codeText' => $codeText,
-            'codeType' => $codeTypeEntity->id,
-        ]);
+        return $this->em->getRepository(Code::class)
+            ->findOneBy([
+                'codeText' => $codeText,
+                'codeType' => $codeTypeEntity->id,
+            ]);
     }
 
     private function isSnomedCodeType(string $codeType): bool
@@ -221,10 +225,11 @@ readonly class CodeTypeMappingUpdater
 
     private function isCodeTypeActive(string $codeType): bool
     {
-        $entity = $this->em->getRepository(CodeType::class)->findOneBy([
-            'key' => $codeType,
-            'active' => true,
-        ]);
+        $entity = $this->em->getRepository(CodeType::class)
+            ->findOneBy([
+                'key' => $codeType,
+                'active' => true,
+            ]);
 
         return $entity !== null;
     }
@@ -248,10 +253,11 @@ readonly class CodeTypeMappingUpdater
 
     private function getListOption(string $listId, string $optionId): ?ListOption
     {
-        return $this->em->getRepository(ListOption::class)->find([
-            'listId' => $listId,
-            'optionId' => $optionId,
-        ]);
+        return $this->em->getRepository(ListOption::class)
+            ->find([
+                'listId' => $listId,
+                'optionId' => $optionId,
+            ]);
     }
 
     /**

--- a/src/Services/CodeTypes/CodeTypeMappingUpdater.php
+++ b/src/Services/CodeTypes/CodeTypeMappingUpdater.php
@@ -1,0 +1,288 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2022 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\CodeTypes;
+
+use Doctrine\ORM\EntityManagerInterface;
+use OpenEMR\Entities\Code;
+use OpenEMR\Entities\CodeType;
+use OpenEMR\Entities\ListOption;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Updates list_options.codes mappings for activated code types (SNOMED, CPT4).
+ *
+ * This maps known option_id values to their corresponding medical codes,
+ * allowing the UI to display human-readable labels while storing
+ * standard code references.
+ */
+readonly class CodeTypeMappingUpdater
+{
+    private const SNOMED_ENCOUNTER_TYPE_MAPPINGS = [
+        'visit-after-hours' => '185463005',
+        'visit-after-hours-not-night' => '185464004',
+        'weekend-visit' => '185465003',
+        'office-visit' => '30346009',
+        'established-patient' => '3391000175108',
+        'new-patient' => '37894004',
+        'postoperative-follow-up' => '439740005',
+    ];
+
+    private const SNOMED_IMMUNIZATION_REFUSAL_REASON_MAPPINGS = [
+        'religious_exemption' => '183945002',
+        'patient_decision' => '105480006',
+        'parental_decision' => '105480006',
+        'financial_problem' => '160932005',
+        'financial_circumstances_change' => '160934006',
+        'alternative_treatment_requested' => '182890002',
+        'patient_declined_procedure' => '105480006',
+        'patient_declined_drug' => '182895007',
+        'patient_declined_drug_effects' => '182897004',
+        'patient_declined_drug_beliefs' => '182900006',
+        'patient_declined_drug_cannot_pay' => '182902003',
+        'patient_moved' => '184081006',
+        'patient_dissatisfied_result' => '185479006',
+        'patient_dissatisfied_doctor' => '185481008',
+        'patient_variable_income' => '224187001',
+        'patient_self_discharge' => '225928004',
+        'drugs_not_completed' => '266710000',
+        'family_illness' => '266966009',
+        'follow_defaulted' => '275694009',
+        'patient_noncompliance' => '275936005',
+        'patient_noshow' => '281399006',
+        'patient_further_opinion' => '310343007',
+        'patient_treatment_delay' => '373787003',
+        'patient_medication_declined' => '406149000',
+        'patient_medication_forgot' => '408367005',
+        'patient_non_compliant' => '413311005',
+        'procedure_not_wanted' => '416432009',
+        'income_insufficient' => '423656007',
+        'income_necessities_only' => '424739004',
+        'refused' => '443390004',
+        'patient_procedure_discontinued' => '713247000',
+    ];
+
+    private const CPT4_ENCOUNTER_TYPE_MAPPINGS = [
+        'new-patient-10' => 'New Patient (Brief)',
+        'new-patient-15-29' => 'New Patient (Limited)',
+        'new-patient-30-44' => 'Level 3, New Patient, Office Visit',
+        'new-patient-45-59' => 'Extended Physical Exam',
+        'new-patient-60-74' => 'New Exam (Comprehensive)',
+        'established-patient-10-19' => 'Established Patient (Limited)',
+        'established-patient-20-29' => 'Established Patient (Detailed)',
+        'established-patient-30-39' => 'Established Patient (Extended)',
+        'established-patient-40-54' => 'Established Patient (Comprehensive)',
+    ];
+
+    private const CODE_TYPE_SNOMED = 'SNOMED';
+    private const CODE_TYPE_SNOMED_CT = 'SNOMED-CT';
+    private const CODE_TYPE_SNOMED_PR = 'SNOMED-PR';
+    private const CODE_TYPE_CPT4 = 'CPT4';
+
+    private const LIST_ID_ENCOUNTER_TYPES = 'encounter-types';
+    private const LIST_ID_IMMUNIZATION_REFUSAL = 'immunization_refusal_reason';
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Updates mappings for all currently activated code types.
+     */
+    public function updateActivatedMappings(): void
+    {
+        $repo = $this->em->getRepository(CodeType::class);
+        $activatedCodeTypes = $repo->findBy(
+            ['active' => true],
+            ['seq' => 'ASC', 'key' => 'ASC'],
+        );
+
+        foreach ($activatedCodeTypes as $codeType) {
+            if ($codeType->key === self::CODE_TYPE_CPT4) {
+                if ($this->shouldUpdateCPT4Mappings()) {
+                    $this->logger->info('Updating {codeType} Mappings', ['codeType' => $codeType->key]);
+                    $this->updateCPT4Mappings();
+                } else {
+                    $this->logger->info('Skipping CPT4 mappings update');
+                }
+            } elseif ($this->isSnomedCodeType($codeType->key)) {
+                if ($this->shouldUpdateSNOMEDMappings()) {
+                    $this->logger->info('Updating {codeType} Mappings', ['codeType' => $codeType->key]);
+                    $this->updateSNOMEDMappings();
+                } else {
+                    $this->logger->info('Skipping SNOMED mappings update', ['codeType' => $codeType->key]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Updates SNOMED-CT mappings for encounter types and immunization refusal reasons.
+     */
+    public function updateSNOMEDMappings(): void
+    {
+        $this->updateListWithSnomedCodes(
+            self::SNOMED_ENCOUNTER_TYPE_MAPPINGS,
+            self::LIST_ID_ENCOUNTER_TYPES,
+        );
+        $this->updateListWithSnomedCodes(
+            self::SNOMED_IMMUNIZATION_REFUSAL_REASON_MAPPINGS,
+            self::LIST_ID_IMMUNIZATION_REFUSAL,
+        );
+    }
+
+    /**
+     * Updates CPT4 mappings for encounter types.
+     */
+    public function updateCPT4Mappings(): void
+    {
+        foreach (self::CPT4_ENCOUNTER_TYPE_MAPPINGS as $optionId => $codeText) {
+            $code = $this->findCPT4Code($codeText);
+            if ($code === null) {
+                $this->logger->debug('Failed to find CPT4 code in codes with code_text, skipping', [
+                    'code_text' => $codeText,
+                    'option_id' => $optionId,
+                ]);
+                continue;
+            }
+
+            $codes = self::CODE_TYPE_CPT4 . ':' . $code->code;
+            $this->updateListOptionCodes(self::LIST_ID_ENCOUNTER_TYPES, $optionId, $codes);
+        }
+        $this->em->flush();
+    }
+
+    public function shouldUpdateSNOMEDMappings(): bool
+    {
+        if ($this->listNeedsSnomedUpdate(self::SNOMED_ENCOUNTER_TYPE_MAPPINGS, self::LIST_ID_ENCOUNTER_TYPES)) {
+            return true;
+        }
+
+        if ($this->listNeedsSnomedUpdate(self::SNOMED_IMMUNIZATION_REFUSAL_REASON_MAPPINGS, self::LIST_ID_IMMUNIZATION_REFUSAL)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function shouldUpdateCPT4Mappings(): bool
+    {
+        if (!$this->isCodeTypeActive(self::CODE_TYPE_CPT4)) {
+            return false;
+        }
+
+        foreach (self::CPT4_ENCOUNTER_TYPE_MAPPINGS as $optionId => $codeText) {
+            $code = $this->findCPT4Code($codeText);
+            if ($code === null) {
+                continue;
+            }
+
+            $listOption = $this->getListOption(self::LIST_ID_ENCOUNTER_TYPES, $optionId);
+            $expectedCodes = self::CODE_TYPE_CPT4 . ':' . $code->code;
+
+            if ($listOption?->codes !== $expectedCodes) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function findCPT4Code(string $codeText): ?Code
+    {
+        $codeTypeEntity = $this->em->getRepository(CodeType::class)->find(self::CODE_TYPE_CPT4);
+        if ($codeTypeEntity === null) {
+            return null;
+        }
+
+        return $this->em->getRepository(Code::class)->findOneBy([
+            'codeText' => $codeText,
+            'codeType' => $codeTypeEntity->id,
+        ]);
+    }
+
+    private function isSnomedCodeType(string $codeType): bool
+    {
+        return in_array($codeType, [self::CODE_TYPE_SNOMED, self::CODE_TYPE_SNOMED_CT, self::CODE_TYPE_SNOMED_PR], true);
+    }
+
+    private function isCodeTypeActive(string $codeType): bool
+    {
+        $entity = $this->em->getRepository(CodeType::class)->findOneBy([
+            'key' => $codeType,
+            'active' => true,
+        ]);
+
+        return $entity !== null;
+    }
+
+    /**
+     * @param array<string, string> $mappings
+     */
+    private function listNeedsSnomedUpdate(array $mappings, string $listId): bool
+    {
+        foreach ($mappings as $optionId => $codeId) {
+            $listOption = $this->getListOption($listId, $optionId);
+            $expectedCodes = self::CODE_TYPE_SNOMED_CT . ':' . $codeId;
+
+            if ($listOption?->codes !== $expectedCodes) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getListOption(string $listId, string $optionId): ?ListOption
+    {
+        return $this->em->getRepository(ListOption::class)->find([
+            'listId' => $listId,
+            'optionId' => $optionId,
+        ]);
+    }
+
+    /**
+     * @param array<string, string> $mappings
+     */
+    private function updateListWithSnomedCodes(array $mappings, string $listId): void
+    {
+        foreach ($mappings as $optionId => $codeId) {
+            $codes = self::CODE_TYPE_SNOMED_CT . ':' . $codeId;
+            $this->updateListOptionCodes($listId, $optionId, $codes);
+        }
+        $this->em->flush();
+    }
+
+    private function updateListOptionCodes(string $listId, string $optionId, string $codes): void
+    {
+        $listOption = $this->getListOption($listId, $optionId);
+        if ($listOption === null) {
+            $this->logger->warning('ListOption not found', [
+                'listId' => $listId,
+                'optionId' => $optionId,
+            ]);
+            return;
+        }
+
+        $listOption->codes = $codes;
+
+        $this->logger->debug('Updated list_options', [
+            'listId' => $listId,
+            'optionId' => $optionId,
+            'codes' => $codes,
+        ]);
+    }
+}

--- a/tests/Tests/Isolated/Console/Command/Codes/UpdateMappingsCommandTest.php
+++ b/tests/Tests/Isolated/Console/Command/Codes/UpdateMappingsCommandTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Console\Command\Codes;
+
+use OpenEMR\Console\Command\Codes\UpdateMappingsCommand;
+use OpenEMR\Services\CodeTypes\CodeTypeMappingUpdater;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[Group('isolated')]
+class UpdateMappingsCommandTest extends TestCase
+{
+    public function testCommandCallsUpdater(): void
+    {
+        $updater = $this->createMock(CodeTypeMappingUpdater::class);
+        $updater->expects($this->once())
+            ->method('updateActivatedMappings');
+
+        $command = new UpdateMappingsCommand($updater);
+        $tester = $this->createTester($command);
+
+        $tester->execute([]);
+
+        self::assertSame(
+            Command::SUCCESS,
+            $tester->getStatusCode(),
+            'Command should return success',
+        );
+    }
+
+    private function createTester(UpdateMappingsCommand $command): CommandTester
+    {
+        $app = new Application();
+        $app->addCommand($command);
+        return new CommandTester($app->find('codes:update-mappings'));
+    }
+}

--- a/tests/Tests/Isolated/Services/CodeTypes/CodeTypeMappingUpdaterTest.php
+++ b/tests/Tests/Isolated/Services/CodeTypes/CodeTypeMappingUpdaterTest.php
@@ -95,9 +95,6 @@ class CodeTypeMappingUpdaterTest extends TestCase
         $codeType = $this->makeCodeType('CPT4', 1);
         $this->codeTypeRepo->method('findOneBy')
             ->willReturn($codeType);
-        $this->codeTypeRepo->method('find')
-            ->with('CPT4')
-            ->willReturn($codeType);
 
         $code = $this->makeCode('99201', 'New Patient (Brief)', 1);
         $this->codeRepo->method('findOneBy')
@@ -164,8 +161,8 @@ class CodeTypeMappingUpdaterTest extends TestCase
     public function testUpdateCPT4MappingsUpdatesListOptionsAndFlushes(): void
     {
         $codeType = $this->makeCodeType('CPT4', 1);
-        $this->codeTypeRepo->method('find')
-            ->with('CPT4')
+        $this->codeTypeRepo->method('findOneBy')
+            ->with(['key' => 'CPT4'])
             ->willReturn($codeType);
 
         $code = $this->makeCode('99201', 'New Patient (Brief)', 1);

--- a/tests/Tests/Isolated/Services/CodeTypes/CodeTypeMappingUpdaterTest.php
+++ b/tests/Tests/Isolated/Services/CodeTypes/CodeTypeMappingUpdaterTest.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\CodeTypes;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use OpenEMR\Entities\Code;
+use OpenEMR\Entities\CodeType;
+use OpenEMR\Entities\ListOption;
+use OpenEMR\Services\CodeTypes\CodeTypeMappingUpdater;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use ReflectionClass;
+
+#[Group('isolated')]
+class CodeTypeMappingUpdaterTest extends TestCase
+{
+    private EntityManagerInterface&MockObject $em;
+    /** @var EntityRepository<CodeType>&\PHPUnit\Framework\MockObject\MockObject */
+    private EntityRepository&MockObject $codeTypeRepo;
+    /** @var EntityRepository<Code>&\PHPUnit\Framework\MockObject\MockObject */
+    private EntityRepository&MockObject $codeRepo;
+    /** @var EntityRepository<ListOption>&\PHPUnit\Framework\MockObject\MockObject */
+    private EntityRepository&MockObject $listOptionRepo;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->codeTypeRepo = $this->createMock(EntityRepository::class);
+        $this->codeRepo = $this->createMock(EntityRepository::class);
+        $this->listOptionRepo = $this->createMock(EntityRepository::class);
+
+        $this->em->method('getRepository')
+            ->willReturnCallback(fn (string $class) => match ($class) {
+                CodeType::class => $this->codeTypeRepo,
+                Code::class => $this->codeRepo,
+                ListOption::class => $this->listOptionRepo,
+                default => throw new \InvalidArgumentException("Unexpected repository: $class"),
+            });
+    }
+
+    public function testShouldUpdateCPT4MappingsReturnsFalseWhenCPT4NotActive(): void
+    {
+        $this->codeTypeRepo->method('findOneBy')
+            ->with(['key' => 'CPT4', 'active' => true])
+            ->willReturn(null);
+
+        $updater = new CodeTypeMappingUpdater($this->em, new NullLogger());
+
+        self::assertFalse(
+            $updater->shouldUpdateCPT4Mappings(),
+            'Should return false when CPT4 code type is not active',
+        );
+    }
+
+    public function testShouldUpdateCPT4MappingsReturnsFalseWhenAllMappingsCurrent(): void
+    {
+        $codeType = $this->makeCodeType('CPT4', 1);
+        $this->codeTypeRepo->method('findOneBy')
+            ->willReturn($codeType);
+        $this->codeTypeRepo->method('find')
+            ->with('CPT4')
+            ->willReturn($codeType);
+
+        $code = $this->makeCode('99201', 'New Patient (Brief)', 1);
+        $this->codeRepo->method('findOneBy')
+            ->willReturn($code);
+
+        $listOption = $this->makeListOption('encounter-types', 'new-patient-10', 'CPT4:99201');
+        $this->listOptionRepo->method('find')
+            ->willReturn($listOption);
+
+        $updater = new CodeTypeMappingUpdater($this->em, new NullLogger());
+
+        self::assertFalse(
+            $updater->shouldUpdateCPT4Mappings(),
+            'Should return false when all CPT4 mappings are current',
+        );
+    }
+
+    public function testShouldUpdateCPT4MappingsReturnsTrueWhenMappingOutdated(): void
+    {
+        $codeType = $this->makeCodeType('CPT4', 1);
+        $this->codeTypeRepo->method('findOneBy')
+            ->willReturn($codeType);
+        $this->codeTypeRepo->method('find')
+            ->with('CPT4')
+            ->willReturn($codeType);
+
+        $code = $this->makeCode('99201', 'New Patient (Brief)', 1);
+        $this->codeRepo->method('findOneBy')
+            ->willReturn($code);
+
+        $listOption = $this->makeListOption('encounter-types', 'new-patient-10', 'OLD:value');
+        $this->listOptionRepo->method('find')
+            ->willReturn($listOption);
+
+        $updater = new CodeTypeMappingUpdater($this->em, new NullLogger());
+
+        self::assertTrue(
+            $updater->shouldUpdateCPT4Mappings(),
+            'Should return true when CPT4 mapping needs update',
+        );
+    }
+
+    public function testShouldUpdateSNOMEDMappingsReturnsTrueWhenMappingOutdated(): void
+    {
+        $listOption = $this->makeListOption('encounter-types', 'visit-after-hours', 'OLD:value');
+        $this->listOptionRepo->method('find')
+            ->willReturn($listOption);
+
+        $updater = new CodeTypeMappingUpdater($this->em, new NullLogger());
+
+        self::assertTrue(
+            $updater->shouldUpdateSNOMEDMappings(),
+            'Should return true when SNOMED mapping needs update',
+        );
+    }
+
+    public function testShouldUpdateSNOMEDMappingsReturnsTrueWhenListOptionMissing(): void
+    {
+        $this->listOptionRepo->method('find')
+            ->willReturn(null);
+
+        $updater = new CodeTypeMappingUpdater($this->em, new NullLogger());
+
+        self::assertTrue(
+            $updater->shouldUpdateSNOMEDMappings(),
+            'Should return true when list option does not exist',
+        );
+    }
+
+    public function testUpdateSNOMEDMappingsUpdatesListOptionsAndFlushes(): void
+    {
+        $listOption = $this->makeListOption('encounter-types', 'office-visit', '');
+        $this->listOptionRepo->method('find')
+            ->willReturn($listOption);
+
+        $this->em->expects(self::exactly(2))
+            ->method('flush');
+
+        $updater = new CodeTypeMappingUpdater($this->em, new NullLogger());
+        $updater->updateSNOMEDMappings();
+
+        self::assertStringStartsWith(
+            'SNOMED-CT:',
+            $listOption->codes,
+            'ListOption codes should be updated with SNOMED-CT prefix',
+        );
+    }
+
+    public function testUpdateCPT4MappingsUpdatesListOptionsAndFlushes(): void
+    {
+        $codeType = $this->makeCodeType('CPT4', 1);
+        $this->codeTypeRepo->method('find')
+            ->with('CPT4')
+            ->willReturn($codeType);
+
+        $code = $this->makeCode('99201', 'New Patient (Brief)', 1);
+        $this->codeRepo->method('findOneBy')
+            ->willReturn($code);
+
+        $listOption = $this->makeListOption('encounter-types', 'new-patient-10', '');
+        $this->listOptionRepo->method('find')
+            ->willReturn($listOption);
+
+        $this->em->expects(self::once())
+            ->method('flush');
+
+        $updater = new CodeTypeMappingUpdater($this->em, new NullLogger());
+        $updater->updateCPT4Mappings();
+
+        self::assertSame(
+            'CPT4:99201',
+            $listOption->codes,
+            'ListOption codes should be updated with CPT4 code',
+        );
+    }
+
+    private function makeCodeType(string $key, int $id): CodeType
+    {
+        $entity = (new ReflectionClass(CodeType::class))->newInstanceWithoutConstructor();
+        (new ReflectionClass($entity))->getProperty('id')->setValue($entity, $id);
+        $entity->key = $key;
+        $entity->active = true;
+        $entity->seq = 1;
+        return $entity;
+    }
+
+    private function makeCode(string $code, string $codeText, int $codeType): Code
+    {
+        $entity = (new ReflectionClass(Code::class))->newInstanceWithoutConstructor();
+        (new ReflectionClass($entity))->getProperty('id')->setValue($entity, 1);
+        $entity->code = $code;
+        $entity->codeText = $codeText;
+        $entity->codeType = $codeType;
+        return $entity;
+    }
+
+    private function makeListOption(string $listId, string $optionId, string $codes): ListOption
+    {
+        $entity = (new ReflectionClass(ListOption::class))->newInstanceWithoutConstructor();
+        $ref = new ReflectionClass($entity);
+        $ref->getProperty('listId')->setValue($entity, $listId);
+        $ref->getProperty('optionId')->setValue($entity, $optionId);
+        $entity->codes = $codes;
+        return $entity;
+    }
+}


### PR DESCRIPTION
Closes #12503 (alternative approach), and resolve the last hard-technical gap in switching from the home-rolled migration system to doctrine/migrations.

#### Short description of what this changes or resolves:
Updates the CPT4/SNOMED-to-`list_options` remapping hook so that it works with the new migrations tooling (alongside the previous approach).

This is the additive portion of #12546 without the backwards compatibility adjustment. The two exist in parallel for now, to avoid continued guesswork on the segfaults (!) occurring in CI. I will file a follow-up issue to bridge that gap properly.

Adjusting its context:

- It effectively duplicates the logic of the existing (on this branch) CodeTypesEventSubscriber, adapted to dbal/orm
- There are no automatic hooks post-migration; there's a CLI tool to be run after migration. This should be ok to reconnect _after_ we've switched to doctrine/migrations, but it can't auto-run until after that happens otherwise it breaks CI (CI runs the new migrations; a hook then tries to access a table that does not exist since the tables aren't ported)

#### Changes proposed in this pull request:

- Adds the first three doctrine/orm entities (with the relevant slice of data, per README)
- Ports the existing list_options updater service to a new one leveraging them (the actual logic is the same)
- Exposes it as a command line tool
- Minor adjustment to CLI to reduce future churn
- Tests

#### Was an AI assistant used? Yes / No
Claude with a lot of guidance and corrections