### PR TITLE
fix(ci): Restore Inferno after docker rearranging

### DIFF
--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -243,9 +243,7 @@ install_configure() {
     	actions_chmod 0666 sites/default/sqlconf.php
     	actions_chmod -R 0777 sites/default/documents
     )
-    # we need this to occur on the docker image of OpenEMR, on local systems this may be the same but in the ci engine its inside the docker container
-    # until we get the devops repo setup we'll just grab the auto_configure.php script and use that
-    _exec sh -c 'curl -v https://raw.githubusercontent.com/openemr/openemr-devops/refs/heads/master/docker/openemr/flex/auto_configure.php > /root/auto_configure.php'
+    _exec cp docker/flex/auto_configure.php /root/auto_configure.php
     # InstallerAuto goes through the Installer class, which RootCliGuard
     # refuses to run as root (PR #12267, def8758). Drop to the web user
     # for the subprocess — same approach as the upgradeOpenEMR override


### PR DESCRIPTION
#### Short description of what this changes or resolves:
Inferno tests are failing in CI since 287d4de2d7c5af7d624b3d1761c04274a61bc334

#### Changes proposed in this pull request:

Updates the setup file copy from the old devops path to the new local one.

#### Was an AI assistant used? Yes / No

Implemented by Claude.