### PR TITLE
chore(release): bump rel-810 version.php to 8.1.1-dev

### DIFF
--- a/version.php
+++ b/version.php
@@ -17,8 +17,8 @@
 
 $v_major = '8';
 $v_minor = '1';
-$v_patch = '0';
-$v_tag   = ''; // minor revision number, should be empty for production releases
+$v_patch = '1';
+$v_tag   = '-dev'; // minor revision number, should be empty for production releases
 
 // A real patch identifier. This is incremented when we release a patch for a
 // production release. Note the above $v_patch variable is a misnomer and actually


### PR DESCRIPTION
## Summary

Advances rel-810 `version.php` from `8.1.0` (post-release stale state)
to `8.1.1-dev`, kicking off the 8.1.1 development cycle on rel-810.

**This is the release trigger PR.** On merge, the push to rel-810 fires
`release-prep.yml` which:

1. Resolves target version via `branch-to-version.php` — walks existing
   tags (sees `v8_1_0`), returns next patch = `8.1.1`
2. Applies rel-scope conductor mutators:
   - `VersionPhpMutator`: strips `-dev` → `8.1.1`
   - `OpenApiVersionMutator`: bumps to `8.1.1`
   - `SwaggerRegenMutator`: regenerates spec
   - `DockerComposeProductionMutator`: pins production compose tag
   - (`SqlUpgradeSkeletonMutator` is master-only — does not fire here)
3. Opens a draft `release-prep/rel-810` PR via peter-evans with the
   above mutations
4. Dispatches `openemr-rel-cut` (first run) or `openemr-rel-update`
   to consumer repos (openemr-devops, website-openemr, demo_farm_openemr)

## Release-prep sequence context

- **P1** #12608 ✅ merged — docker upgrade machinery on rel-810
- **P2** #12609 ✅ merged — docker upgrade machinery on master (cross-branch sync)
- **P3** (this PR) — version.php bump on rel-810 → fires conductor
- **P4** (next) — release-targets master row update:
  `docker_tags: 8.1.0,next → 8.1.1,next` + `openemr_version_ref:
  v8_1_0 → rel-810`. Must follow this PR so validator's
  docker_tag↔version.php check passes (validator reads rel-810
  HEAD's version.php when `openemr_version_ref: rel-810`)
- **P5** — merge the conductor-generated `release-prep/rel-810` PR
  (the actual ship); triggers tag + build-release + announcements

## Why manual?

This bump should be automated post-release (per gap G2 in the
release-mechanism gaps doc). The conductor's `VersionPhpMutator`
runs on master but the equivalent advance-to-next-dev on the rel
branch after release is currently manual. P7 in this same release
prep sequence (post-ship advance to `8.1.2-dev` on rel-810) will
also be manual for the same reason.

## v_database

`v_database = 540` kept as-is. Recent SQL upgrade content on
rel-810 (PR #12520 calendar `pc_endDate` fix, PR #12579 / #12538
insurance phone dedup) did not bump v_database, so this PR
follows that precedent. If the release-prep conductor or
maintainer review concludes a bump is warranted, it can land
separately or be applied to the conductor-generated PR.

## Test plan

- [ ] CI passes (lint/syntax; release-prep won't actually fire until merge)
- [ ] On merge: `release-prep.yml` workflow runs, conductor opens
      a draft `release-prep/rel-810` PR with version.php at `8.1.1`
      (no `-dev`), OpenAPI bumped, swagger regenerated, production
      compose tag pinned to `8.1.1`
- [ ] Consumer repos (openemr-devops, website-openemr,
      demo_farm_openemr) receive the `openemr-rel-cut` /
      `openemr-rel-update` dispatch