### PR TITLE
chore(release): bump rel-810 release-targets row to 8.1.1 / rel-810

### DIFF
--- a/.github/release-targets.yml
+++ b/.github/release-targets.yml
@@ -71,8 +71,8 @@
   openemr_version_ref: master
 
 - branch: rel-810
-  docker_tags: 8.1.0,next
-  openemr_version_ref: v8_1_0
+  docker_tags: 8.1.1,next
+  openemr_version_ref: rel-810
 
 - branch: rel-800
   # 8.0.0 is the floating "current latest 8.0.0.x" pointer (always advances


### PR DESCRIPTION
## Summary

Bumps the rel-810 row in `.github/release-targets.yml` to pre-release
stage 2 for the 8.1.1 release:

```diff
 - branch: rel-810
-  docker_tags: 8.1.0,next
-  openemr_version_ref: v8_1_0
+  docker_tags: 8.1.1,next
+  openemr_version_ref: rel-810
```

## Effect

- Daily scheduled builds + manual dispatches by
  `docker-release-orchestrator.yml` now publish rel-810 HEAD content to
  `openemr/openemr:8.1.1` and `openemr/openemr:next` (plus the
  auto-appended `8.1.1-YYYY-MM-DD` dated sibling for immutable
  per-build pinning).
- `openemr_version_ref: rel-810` (vs `v8_1_0`) means the image bakes
  rel-810 HEAD's content rather than `v8_1_0`'s frozen tag content.
  This is the standard pre-release stage: daily builds track the rel
  branch tip until the actual release ships, at which point P6 will
  flip the ref back to a frozen tag (`v8_1_1`).

## Validator alignment

Coordinated with rel-810's `version.php` at `8.1.1-dev` (PR #12610)
so the `docker-validate-release-targets.yml` docker_tag↔version.php
alignment guard passes. The validator reads rel-810 HEAD's
`version.php` for `openemr_version_ref: rel-810`, and `8.1.1-dev`'s
MMP is `8.1.1` which matches `docker_tags: 8.1.1`.

## P-sequence context (rel-810 8.1.1 release prep)

- ✅ P1 #12608 — docker upgrade machinery on rel-810
- ✅ P2 #12609 — docker upgrade machinery on master
- ✅ P3 #12610 — version.php on rel-810 → 8.1.1-dev
- ✅ #12611 — BranchVersionResolver tag-walk backport (recovery for
  the off-by-one resolver bug exposed by P3)
- ✅ This PR — release-targets row bump (pre-release stage 2)
- ⏭ P5 — merge conductor-generated PR #12377 (the actual ship; runs
  finalize job → annotated tag → build-release → release-announcements)
- ⏭ P6 — post-release: `openemr_version_ref: rel-810 → v8_1_1` +
  slot shuffle (next → latest)

## Test plan

- [ ] CI passes (validator's docker_tag↔version.php alignment guard
      + the standard suite)
- [ ] After merge, next `docker-release-orchestrator.yml` tick (or
      manual dispatch) publishes the first `openemr/openemr:8.1.1`
      daily image