### PR TITLE
docs: document new openemr-cmd worktree add -b default and --base flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,17 @@ skips both the state registration and the stack. If you already made that
 mistake, recovery is `git worktree remove <path>` then `openemr-cmd worktree
 add <branch> --start` (omit `-b` since the branch persists).
 
+When `-b` is supplied, the new branch is based on canonical
+`openemr/openemr` master, fetched directly from GitHub at the time of the
+command — *not* the primary repo's HEAD. Override with `--base <ref>`,
+which accepts two forms: a URL (optionally `#<ref>`, e.g.
+`https://github.com/openemr/openemr.git#rel-810`) for a freshly-fetched
+base, or any git `<commit-ish>` (local branch, `origin/master`, tag, SHA,
+`HEAD`) resolved locally with no fetch. Because the primary's HEAD is
+never read or modified on the default path, concurrent worktree creation
+by multiple agents is safe regardless of which branch happens to be
+checked out in the primary.
+
 **Never use `git fetch ... --update-head-ok` in the primary openemr repo,
 regardless of remote or URL.** It overwrites the current branch's ref
 without updating the working tree, leaving the index showing "staged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,8 +236,12 @@ The OpenEMR development docker environment has a very rich advanced feature set.
       ```
       Usage: openemr-cmd worktree <add|remove|up|down|start|stop|exec|list|regen|set-env|prune> [options]
 
-        add <branch> [-b] [--env easy|easy-light|easy-redis] [--start]
-                                  Create worktree (-b creates new branch, default env: easy)
+        add <branch> [-b] [--base <ref>] [--env easy|easy-light|easy-redis] [--start]
+                                  Create worktree (default env: easy)
+                                  -b           : create new branch; default base is canonical openemr/openemr master (fetched fresh)
+                                  --base <ref> : (with -b) base on a specific ref. Two forms:
+                                                   <url>[#<ref>]  -> fetch from URL (e.g. https://github.com/openemr/openemr.git#rel-810)
+                                                   <commit-ish>   -> standard git resolution (local branch, origin/master, tag, SHA, HEAD, ...)
         remove <branch> [--keep-volumes] Remove worktree (volumes deleted by default)
         up <branch>               Start Docker stack for worktree
         down <branch> [--keep-volumes]  Stop Docker stack for worktree (volumes deleted by default)
@@ -255,6 +259,11 @@ The OpenEMR development docker environment has a very rich advanced feature set.
       ```sh
       openemr-cmd worktree add worktree-branch-label -b
       ```
+      The new branch is based on canonical `openemr/openemr` master, fetched directly from GitHub each time (no named remote needed). To base on a different ref, supply `--base <ref>`:
+      ```sh
+      openemr-cmd worktree add my-release-fix -b --base https://github.com/openemr/openemr.git#rel-810
+      ```
+      `--base` accepts two forms: a URL (optionally `#<ref>`) for a freshly-fetched base, or any git `<commit-ish>` (local branch, `origin/master`, tag, SHA, `HEAD`) resolved locally without a fetch.
 
     - Or can create a new worktree on a existing branch:
       ```sh


### PR DESCRIPTION
## Summary

Paired documentation update for openemr/openemr-devops#815, which changes the default base for `openemr-cmd worktree add <branch> -b` from the primary repo's HEAD to canonical `openemr/openemr` master fetched fresh from GitHub, and adds a new `--base <ref>` flag.

Without this paired update, contributors (and AI assistants reading `CLAUDE.md`) running the new openemr-cmd would assume the old HEAD-based behavior still applies.

## Changes

**`CONTRIBUTING.md`** — embedded `openemr-cmd worktree` usage block updated to show `--base` with both forms (URL or git `<commit-ish>`). Added a `--base` example under the new-branch creation snippet showing the canonical URL form for fetching a release branch.

**`CLAUDE.md`** — new paragraph in the worktree section explaining the new default (canonical fetch, primary HEAD never read), the `--base` override with its two forms, and the multi-agent safety property this gives.

## Related

- Feature PR: openemr/openemr-devops#815
- Original issue: openemr/openemr-devops#814

## Test plan

- [x] Markdown renders cleanly (prek + codespell + trailing-whitespace hooks pass)
- [ ] After openemr/openemr-devops#815 lands, the documented commands work as described

🤖 Generated with [Claude Code](https://claude.com/claude-code)