### PR TITLE
chore: gitignore .worktrees.json.lock/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ tmp-phpstan/*
 
 # easy dev worktree support
 .worktrees.json
+.worktrees.json.lock/
 docker/development-easy/docker-compose.override.yml
 docker/development-easy-light/docker-compose.override.yml
 docker/development-easy-redis/docker-compose.override.yml

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ tmp-phpstan/*
 
 # easy dev worktree support
 .worktrees.json
-.worktrees.json.lock/
+.worktrees.json.lock*
 docker/development-easy/docker-compose.override.yml
 docker/development-easy-light/docker-compose.override.yml
 docker/development-easy-redis/docker-compose.override.yml

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ tmp-phpstan/*
 
 # easy dev worktree support
 .worktrees.json
-.worktrees.json.lock*
+.worktrees.json.lock
 docker/development-easy/docker-compose.override.yml
 docker/development-easy-light/docker-compose.override.yml
 docker/development-easy-redis/docker-compose.override.yml


### PR DESCRIPTION
## Summary

openemr/openemr-devops#823's race-fix landed a `set -C` + atomic-redirect acquire for openemr-cmd's state lock. The on-disk artifact at \`\${OPENEMR_ROOT}/.worktrees.json.lock\` is a regular FILE (not a directory). No staging or temp files — only the lockfile itself ever appears on disk.

In the happy path the lockfile exists for milliseconds. A SIGKILL'd holder leaves it orphaned, where it'd show up in \`git status\` because the existing \`.worktrees.json\` gitignore entry is exact-match.

## Change

```diff
 # easy dev worktree support
 .worktrees.json
+.worktrees.json.lock
 docker/development-easy/docker-compose.override.yml
```

Single exact-match line. The lockfile is the only artifact the acquire path can leave behind.

## Related

- openemr/openemr-devops#823 — the openemr-cmd state-lock race fix that introduces the lockfile

## Test plan

- [x] Local: \`touch .worktrees.json.lock; git status\` shows it as untracked BEFORE this change and clean AFTER
- [x] Pre-commit hooks pass (codespell, conventional-commits, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)