### PR TITLE
ci(release): wire vendored-contract drift check via devops reusable workflow

### DIFF
--- a/.github/workflows/check-vendored-contracts.yml
+++ b/.github/workflows/check-vendored-contracts.yml
@@ -1,0 +1,42 @@
+name: Check Vendored Contracts
+
+# Drift-check this repo's vendored copies of the cross-repo release
+# contracts against the canonical sources in openemr/openemr-devops.
+#
+# Vendored files (under tools/release/):
+#   - contracts/dispatch.schema.json
+#   - src/TagVerifier.php
+#   - src/TagVerificationResult.php
+#
+# Calls the reusable workflow in openemr/openemr-devops which knows the
+# canonical paths and fails this job on any drift. See that workflow's
+# header for the full file list + override semantics.
+#
+# Trigger: PRs that touch either a vendored file or this workflow itself.
+# A PR touching only unrelated files skips the drift check entirely, since
+# nothing's changed that could introduce drift.
+#
+# This caller is short-lived in the release-mechanism migration sense:
+# Phase 5 of the migration (docs/release-mechanism-migration-from-devops.md)
+# inverts canonical/vendored ownership — this repo becomes canonical, and
+# this caller either disappears or flips direction. Wiring it now defuses
+# a real silent-drift bug today and gives Phase 5 a clean before/after to
+# swap.
+
+on:
+  pull_request:
+    paths:
+    - 'tools/release/contracts/dispatch.schema.json'
+    - 'tools/release/src/TagVerifier.php'
+    - 'tools/release/src/TagVerificationResult.php'
+    - '.github/workflows/check-vendored-contracts.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: Check vendored contracts against canonical
+    uses: openemr/openemr-devops/.github/workflows/check-vendored-contracts.yml@master
+    with:
+      consumer_subpath: tools/release

--- a/tools/release/src/TagVerificationResult.php
+++ b/tools/release/src/TagVerificationResult.php
@@ -1,16 +1,13 @@
 <?php
 
 /**
- * Result of verifying a release tag against the openemr/openemr-devops#664 spec.
+ * Result of verifying a release tag against the openemr-devops#664 spec.
  *
- * Vendored from openemr/openemr-devops; see
- * tools/release/bin/check-vendored.php in that repo for the drift check.
- *
- * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>
- * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
- * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
  */
 
 declare(strict_types=1);

--- a/tools/release/src/TagVerifier.php
+++ b/tools/release/src/TagVerifier.php
@@ -2,16 +2,13 @@
 
 /**
  * Verify a release tag is annotated and its message conforms to the
- * openemr/openemr-devops#664 spec (contains a version, ISO date, and merge SHA).
+ * openemr-devops#664 spec (contains a version, ISO date, and merge SHA).
  *
- * Vendored from openemr/openemr-devops; see
- * tools/release/bin/check-vendored.php in that repo for the drift check.
- *
- * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>
- * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
- * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## Summary

Adds a thin caller workflow that invokes openemr-devops's existing
reusable `check-vendored-contracts.yml` whenever a PR touches one of
this repo's vendored release-contract files:

- `tools/release/contracts/dispatch.schema.json`
- `tools/release/src/TagVerifier.php`
- `tools/release/src/TagVerificationResult.php`

These files are vendored from `openemr/openemr-devops` (the canonical
source as of today). devops's reusable workflow knows the canonical
paths and fails the calling job on any drift.

## Why now

Without this caller, silent drift could land here today — pre-existing
bug, caught during the release-mechanism migration audit (see
[`docs/release-mechanism-migration-from-devops.md`](https://github.com/openemr/openemr/blob/master/docs/release-mechanism-migration-from-devops.md)
"Validated foundation" section).

## Workstream context

**PR 1c** of workstream 1 in the release-mechanism migration plan.
Independent of the rotation-deletion + 2-PR-collapse pair (PRs 1a + 1b
coming separately). Can land anytime.

## Short-lived?

Yes — Phase 5 of the migration inverts canonical/vendored ownership,
at which point this caller either disappears (no consumers vendor from
devops anymore) or flips direction (this repo's vendored-file checker
calls into website-openemr / demo_farm if either repo adds vendoring).

Worth landing now anyway because (1) it defuses a real silent-drift
bug today, and (2) it gives Phase 5 a clear before/after to swap.

## Test plan

- [ ] CI passes (actionlint on the workflow file)
- [ ] After merge, a deliberate-drift PR (e.g., edit
      `tools/release/src/TagVerifier.php` to diverge from devops's
      canonical) triggers the workflow and fails
- [ ] A PR not touching any vendored path doesn't trigger the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)