### PR TITLE
fix(docker): irp imports 0 patients because synthea output is in root-only /root/

### DIFF
--- a/contrib/util/ccda_import/import_ccda.php
+++ b/contrib/util/ccda_import/import_ccda.php
@@ -14,7 +14,10 @@
  *      will directly import the new patient data from the ccda. This will also turn off the audit log during
  *      the import.
  *   3, NOTE THAT THIS SCRIPT IS NOT WORKING AT THIS TIME IF THE DEVELOPMENT MODE IS TURNED OFF
- *   4. Note that a log.txt file is created with log/stats of the run.
+ *   4. Note that a log file with run stats is written to /tmp/ccda_import.log.
+ *      An absolute path is used so the script works under su-exec apache
+ *      (which has no writable cwd when invoked via run_php_as_apache from
+ *      docker/<image>/utilities/devtoolsLibrary.source's importRandomPatients).
  *
  * Description of what this script automates (for unlimited number of ccda documents):
  *  1. import ccda document (bypassed in development-mode)
@@ -92,7 +95,11 @@ function outputMessage($message): void
 {
     echo("\n");
     echo $message;
-    file_put_contents("log.txt", $message, FILE_APPEND);
+    // Absolute path so the write works regardless of cwd. The previous
+    // relative 'log.txt' produced "Permission denied" warnings on every
+    // call when this script ran via su-exec apache (apache has no
+    // writable cwd in the openemr container).
+    file_put_contents('/tmp/ccda_import.log', $message, FILE_APPEND);
 }
 
 // collect parameters (need to do before globals)

--- a/docker/binary/utilities/devtoolsLibrary.source
+++ b/docker/binary/utilities/devtoolsLibrary.source
@@ -696,7 +696,7 @@ importRandomPatients() {
     # which is the exact failure mode that hid the unreachable-/root bug
     # before this fix. Guard explicitly so a future regression in synthea
     # still fails the irp command loudly.
-    if [ -z "$(ls -A /tmp/synthea/output/ccda 2>/dev/null)" ]; then
+    if [[ -z "$(ls -A /tmp/synthea/output/ccda 2>/dev/null || true)" ]]; then
         echo "FAIL: no CCDA files produced in /tmp/synthea/output/ccda; nothing to import" >&2
         return 1
     fi

--- a/docker/binary/utilities/devtoolsLibrary.source
+++ b/docker/binary/utilities/devtoolsLibrary.source
@@ -674,12 +674,22 @@ importRandomPatients() {
         cd /root/synthea || exit
         wget https://github.com/synthetichealth/synthea/releases/download/master-branch-latest/synthea-with-dependencies.jar
     fi
-    rm -fr /root/synthea/output
-    cd /root/synthea || exit
-    java -jar synthea-with-dependencies.jar --exporter.fhir.export false --exporter.ccda.export true --generate.only_alive_patients true -p "$1"
+    # Synthea writes its output relative to cwd (./output/). The import
+    # step below runs as the apache user via run_php_as_apache (the
+    # RootCliGuard wrapper from #12267), and apache cannot traverse
+    # /root (mode 700, root-only) — so generating into /root/synthea/
+    # would leave the CCDA files unreadable to the importer and glob()
+    # would silently return zero matches. Generate into /tmp/synthea
+    # instead, which is 1777, while keeping the cached JAR in
+    # /root/synthea (apache never needs to touch it). Pass the JAR by
+    # absolute path so the cwd change is harmless.
+    mkdir -p /tmp/synthea
+    rm -fr /tmp/synthea/output
+    cd /tmp/synthea || exit
+    java -jar /root/synthea/synthea-with-dependencies.jar --exporter.fhir.export false --exporter.ccda.export true --generate.only_alive_patients true -p "$1"
     sed -i "s@exit;@//exit;@" /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php
     export OPENEMR_ENABLE_CCDA_IMPORT=1
-    run_php_as_apache /usr/local/bin/php /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php --sourcePath=/root/synthea/output/ccda --site=default --openemrPath=/var/www/localhost/htdocs/openemr "--isDev=$2"
+    run_php_as_apache /usr/local/bin/php /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php --sourcePath=/tmp/synthea/output/ccda --site=default --openemrPath=/var/www/localhost/htdocs/openemr "--isDev=$2"
     sed -i "s@//exit;@exit;@" /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php
     echo "Completed run for following number of random patients: ${1}"
 }

--- a/docker/binary/utilities/devtoolsLibrary.source
+++ b/docker/binary/utilities/devtoolsLibrary.source
@@ -685,8 +685,21 @@ importRandomPatients() {
     # absolute path so the cwd change is harmless.
     mkdir -p /tmp/synthea
     rm -fr /tmp/synthea/output
-    cd /tmp/synthea || exit
-    java -jar /root/synthea/synthea-with-dependencies.jar --exporter.fhir.export false --exporter.ccda.export true --generate.only_alive_patients true -p "$1"
+    cd /tmp/synthea || { echo "FAIL: could not enter /tmp/synthea" >&2; return 1; }
+    if ! java -jar /root/synthea/synthea-with-dependencies.jar --exporter.fhir.export false --exporter.ccda.export true --generate.only_alive_patients true -p "$1"; then
+        echo "FAIL: synthea generation failed; aborting before import" >&2
+        return 1
+    fi
+    # Belt-and-suspenders: synthea may exit 0 without producing CCDA files
+    # in some edge cases. import_ccda.php treats an empty source directory
+    # as a no-op — silently logs "Finished patients import 0" and exits 0,
+    # which is the exact failure mode that hid the unreachable-/root bug
+    # before this fix. Guard explicitly so a future regression in synthea
+    # still fails the irp command loudly.
+    if [ -z "$(ls -A /tmp/synthea/output/ccda 2>/dev/null)" ]; then
+        echo "FAIL: no CCDA files produced in /tmp/synthea/output/ccda; nothing to import" >&2
+        return 1
+    fi
     sed -i "s@exit;@//exit;@" /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php
     export OPENEMR_ENABLE_CCDA_IMPORT=1
     run_php_as_apache /usr/local/bin/php /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php --sourcePath=/tmp/synthea/output/ccda --site=default --openemrPath=/var/www/localhost/htdocs/openemr "--isDev=$2"

--- a/docker/flex/utilities/devtoolsLibrary.source
+++ b/docker/flex/utilities/devtoolsLibrary.source
@@ -453,7 +453,17 @@ importRandomPatients() {
         rm -fr /tmp/synthea/output
         cd /tmp/synthea &&
             java -jar /root/synthea/synthea-with-dependencies.jar --exporter.fhir.export false --exporter.ccda.export true --generate.only_alive_patients true -p "${1}"
-    )
+    ) || { echo "FAIL: synthea setup or generation failed; aborting before import" >&2; return 1; }
+    # Belt-and-suspenders: the subshell exit status above covers most
+    # failure modes, but import_ccda.php treats an empty source directory
+    # as a no-op — silently logs "Finished patients import 0" and exits 0.
+    # That is the exact failure mode that hid the unreachable-/root bug
+    # before this fix; guard against it explicitly so a future regression
+    # in the synthea step still fails the irp command loudly.
+    if [ -z "$(ls -A /tmp/synthea/output/ccda 2>/dev/null)" ]; then
+        echo "FAIL: no CCDA files produced in /tmp/synthea/output/ccda; nothing to import" >&2
+        return 1
+    fi
     sed -i "s@exit;@//exit;@" /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php
     export OPENEMR_ENABLE_CCDA_IMPORT=1
     run_php_as_apache php /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php --sourcePath=/tmp/synthea/output/ccda --site=default --openemrPath=/var/www/localhost/htdocs/openemr "--isDev=${2}"

--- a/docker/flex/utilities/devtoolsLibrary.source
+++ b/docker/flex/utilities/devtoolsLibrary.source
@@ -460,7 +460,7 @@ importRandomPatients() {
     # That is the exact failure mode that hid the unreachable-/root bug
     # before this fix; guard against it explicitly so a future regression
     # in the synthea step still fails the irp command loudly.
-    if [ -z "$(ls -A /tmp/synthea/output/ccda 2>/dev/null)" ]; then
+    if [[ -z "$(ls -A /tmp/synthea/output/ccda 2>/dev/null || true)" ]]; then
         echo "FAIL: no CCDA files produced in /tmp/synthea/output/ccda; nothing to import" >&2
         return 1
     fi

--- a/docker/flex/utilities/devtoolsLibrary.source
+++ b/docker/flex/utilities/devtoolsLibrary.source
@@ -440,13 +440,23 @@ importRandomPatients() {
             cd /root/synthea || exit
             wget https://github.com/synthetichealth/synthea/releases/download/master-branch-latest/synthea-with-dependencies.jar
         fi
-        rm -fr /root/synthea/output
-        cd /root/synthea &&
-            java -jar synthea-with-dependencies.jar --exporter.fhir.export false --exporter.ccda.export true --generate.only_alive_patients true -p "${1}"
+        # Synthea writes its output relative to cwd (./output/). The import
+        # step below runs as the apache user via run_php_as_apache (the
+        # RootCliGuard wrapper from #12267), and apache cannot traverse
+        # /root (mode 700, root-only) — so generating into /root/synthea/
+        # would leave the CCDA files unreadable to the importer and glob()
+        # would silently return zero matches. Generate into /tmp/synthea
+        # instead, which is 1777, while keeping the cached JAR in
+        # /root/synthea (apache never needs to touch it). Pass the JAR by
+        # absolute path so the cwd change is harmless.
+        mkdir -p /tmp/synthea
+        rm -fr /tmp/synthea/output
+        cd /tmp/synthea &&
+            java -jar /root/synthea/synthea-with-dependencies.jar --exporter.fhir.export false --exporter.ccda.export true --generate.only_alive_patients true -p "${1}"
     )
     sed -i "s@exit;@//exit;@" /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php
     export OPENEMR_ENABLE_CCDA_IMPORT=1
-    run_php_as_apache php /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php --sourcePath=/root/synthea/output/ccda --site=default --openemrPath=/var/www/localhost/htdocs/openemr "--isDev=${2}"
+    run_php_as_apache php /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php --sourcePath=/tmp/synthea/output/ccda --site=default --openemrPath=/var/www/localhost/htdocs/openemr "--isDev=${2}"
     sed -i "s@//exit;@exit;@" /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php
     echo "Completed run for following number of random patients: ${1}"
 }

--- a/docker/release/utilities/devtoolsLibrary.source
+++ b/docker/release/utilities/devtoolsLibrary.source
@@ -696,7 +696,7 @@ importRandomPatients() {
     # which is the exact failure mode that hid the unreachable-/root bug
     # before this fix. Guard explicitly so a future regression in synthea
     # still fails the irp command loudly.
-    if [ -z "$(ls -A /tmp/synthea/output/ccda 2>/dev/null)" ]; then
+    if [[ -z "$(ls -A /tmp/synthea/output/ccda 2>/dev/null || true)" ]]; then
         echo "FAIL: no CCDA files produced in /tmp/synthea/output/ccda; nothing to import" >&2
         return 1
     fi

--- a/docker/release/utilities/devtoolsLibrary.source
+++ b/docker/release/utilities/devtoolsLibrary.source
@@ -685,8 +685,21 @@ importRandomPatients() {
     # absolute path so the cwd change is harmless.
     mkdir -p /tmp/synthea
     rm -fr /tmp/synthea/output
-    cd /tmp/synthea || exit
-    java -jar /root/synthea/synthea-with-dependencies.jar --exporter.fhir.export false --exporter.ccda.export true --generate.only_alive_patients true -p "$1"
+    cd /tmp/synthea || { echo "FAIL: could not enter /tmp/synthea" >&2; return 1; }
+    if ! java -jar /root/synthea/synthea-with-dependencies.jar --exporter.fhir.export false --exporter.ccda.export true --generate.only_alive_patients true -p "$1"; then
+        echo "FAIL: synthea generation failed; aborting before import" >&2
+        return 1
+    fi
+    # Belt-and-suspenders: synthea may exit 0 without producing CCDA files
+    # in some edge cases. import_ccda.php treats an empty source directory
+    # as a no-op — silently logs "Finished patients import 0" and exits 0,
+    # which is the exact failure mode that hid the unreachable-/root bug
+    # before this fix. Guard explicitly so a future regression in synthea
+    # still fails the irp command loudly.
+    if [ -z "$(ls -A /tmp/synthea/output/ccda 2>/dev/null)" ]; then
+        echo "FAIL: no CCDA files produced in /tmp/synthea/output/ccda; nothing to import" >&2
+        return 1
+    fi
     sed -i "s@exit;@//exit;@" /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php
     export OPENEMR_ENABLE_CCDA_IMPORT=1
     run_php_as_apache php /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php --sourcePath=/tmp/synthea/output/ccda --site=default --openemrPath=/var/www/localhost/htdocs/openemr "--isDev=$2"

--- a/docker/release/utilities/devtoolsLibrary.source
+++ b/docker/release/utilities/devtoolsLibrary.source
@@ -674,12 +674,22 @@ importRandomPatients() {
         cd /root/synthea || exit
         wget https://github.com/synthetichealth/synthea/releases/download/master-branch-latest/synthea-with-dependencies.jar
     fi
-    rm -fr /root/synthea/output
-    cd /root/synthea || exit
-    java -jar synthea-with-dependencies.jar --exporter.fhir.export false --exporter.ccda.export true --generate.only_alive_patients true -p "$1"
+    # Synthea writes its output relative to cwd (./output/). The import
+    # step below runs as the apache user via run_php_as_apache (the
+    # RootCliGuard wrapper from #12267), and apache cannot traverse
+    # /root (mode 700, root-only) — so generating into /root/synthea/
+    # would leave the CCDA files unreadable to the importer and glob()
+    # would silently return zero matches. Generate into /tmp/synthea
+    # instead, which is 1777, while keeping the cached JAR in
+    # /root/synthea (apache never needs to touch it). Pass the JAR by
+    # absolute path so the cwd change is harmless.
+    mkdir -p /tmp/synthea
+    rm -fr /tmp/synthea/output
+    cd /tmp/synthea || exit
+    java -jar /root/synthea/synthea-with-dependencies.jar --exporter.fhir.export false --exporter.ccda.export true --generate.only_alive_patients true -p "$1"
     sed -i "s@exit;@//exit;@" /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php
     export OPENEMR_ENABLE_CCDA_IMPORT=1
-    run_php_as_apache php /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php --sourcePath=/root/synthea/output/ccda --site=default --openemrPath=/var/www/localhost/htdocs/openemr "--isDev=$2"
+    run_php_as_apache php /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php --sourcePath=/tmp/synthea/output/ccda --site=default --openemrPath=/var/www/localhost/htdocs/openemr "--isDev=$2"
     sed -i "s@//exit;@exit;@" /var/www/localhost/htdocs/openemr/contrib/util/ccda_import/import_ccda.php
     echo "Completed run for following number of random patients: ${1}"
 }


### PR DESCRIPTION
## Problem

`openemr-cmd irp <count>` (alias for `/root/devtools import-random-patients`) silently imports **zero** patients while reporting success. From outside, irp looks fine: synthea prints "You've just generated 3 patients!" and the wrapper logs "Completed run for following number of random patients: 3" — but the database has 0 new patients.

The actual import log showed:
```
You've just generated 3 patients!
...
PHP Warning: file_put_contents(log.txt): Failed to open stream: Permission denied
...
Starting patients import.

Finished patients import 0                          ← ZERO actually imported
```

## Root cause

`importRandomPatients` in `docker/{binary,release,flex}/utilities/devtoolsLibrary.source` generates Synthea CCDA files into `/root/synthea/output/ccda/` and then invokes `contrib/util/ccda_import/import_ccda.php` to load them.

With the recent `run_php_as_apache` wrapper (the RootCliGuard landing in #12267), `import_ccda.php` now runs as the `apache` user via `su-exec`. But `/root` is mode `700` and root-only, so apache cannot even traverse it. `glob('/root/synthea/output/ccda/*')` inside `import_ccda.php` silently returns zero matches, the import loop never executes, counter stays 0, and the script reports `Finished patients import 0` while still exiting 0.

The cross-repo functional round-trip e2e test in [openemr-devops#832](https://github.com/openemr/openemr-devops/pull/832) is what surfaced this — `drid` loaded 3 demo patients, `irp 3` was expected to bring the count to 6, but it stayed at 3.

## Changes

### 1. Move synthea output to an apache-readable path (primary fix)

Generate Synthea output under `/tmp/synthea` (mode `1777`, apache-readable) instead of `/root/synthea/output`. The cached Synthea JAR stays in `/root/synthea` (apache never needs to touch it) and is passed to `java` by absolute path so the cwd change is harmless. The `--sourcePath` arg on `import_ccda.php` is updated to match the new location.

### 2. Fail-fast on synthea generation failure (from CodeRabbit review)

If `java -jar synthea-with-dependencies.jar` exits non-zero **or** exits 0 without producing CCDA files, abort with `return 1` and a clear `FAIL:` message before invoking the importer. This guards against the same silent-zero-import failure mode from any future cause (synthea jar download corruption, disk full, etc.), not just the unreachable-`/root/` symptom this PR was originally about.

### 3. `import_ccda.php`'s log file: `log.txt` → `/tmp/ccda_import.log`

`outputMessage()` wrote progress lines to a relative `log.txt`. Under `su-exec apache`, apache has no writable cwd in the openemr container, so every call emitted a `PHP Warning: file_put_contents(log.txt): Failed to open stream: Permission denied` — visible noise alongside the genuine output. Switch to an absolute `/tmp/ccda_import.log` that's always writable regardless of cwd or invoking uid. Docstring at the top of the file updated to match.

All three image-variant copies of `devtoolsLibrary.source` (binary, release, flex) patched consistently.

## Verification

Reproduced and verified in a live `openemr-cmd worktree` stack:

| State | irp 3 result | DB count |
|---|---|---|
| Pre-fix (master) | "Finished patients import 0" (success exit code) | 0 |
| Post-fix | "Finished patients import 3" + three "System has successfully imported CCDA number: N" lines, no PHP warnings | 3 |
| Post-fix, drid + irp 3 round-trip | 3 demo patients (from drid) + 3 random (from irp) | 6 |

## Test plan

- [x] `openemr-cmd irp 3` against the flex image with patched script: 3 patients imported, DB count = 3
- [x] `drid` + `irp 3` round-trip: count goes 0 → 3 (demo) → 6 (demo + irp), proving irp is now correctly additive
- [x] No PHP Warning about `log.txt` in the output
- [x] CI: ShellCheck pass (after addressing SC2292 / SC2312 nits with `[[ ]]` + `|| true`)
- [x] CI: All Checks Passed
- [x] CodeRabbit review: pass

Assisted-by: Claude Code