### PR TITLE
feat(flex): honor HOST_UID/HOST_GID for apache uid alignment

### DIFF
--- a/docker/flex/openemr.sh
+++ b/docker/flex/openemr.sh
@@ -70,6 +70,59 @@ flex_timing() {
 . /root/devtoolsLibrary.source
 
 # ============================================================================
+# HOST UID/GID PASSTHROUGH
+# ============================================================================
+# When the host bind-mounts the webroot (e.g., docker/development-easy
+# stacks where the openemr source lives on the host filesystem), allow
+# the host to specify its uid/gid via HOST_UID/HOST_GID env vars so
+# the in-container apache user adopts them. Without this, apache stays
+# at uid=1000 (Alpine default, set in the Dockerfile) and any host
+# whose uid is not 1000 (CI runners, multi-user dev boxes, distros that
+# start uids at 1001, macOS via Docker Desktop) gets bind-mount files
+# apache writes that they can't modify on the host — `git commit`
+# fails with EACCES, IDE writes get rejected, etc.
+#
+# This runs BEFORE any chown operations in the entrypoint so subsequent
+# `chown apache:apache` calls target the adopted uid. The chown of the
+# webroot bind mount (auto_setup) and per-file caches then naturally
+# match the host's ownership.
+#
+# Backwards compatible: if HOST_UID is unset or empty, no change —
+# apache stays at its Dockerfile-baked uid=1000. Idempotent: re-running
+# with the same HOST_UID is a no-op against the same apache identity.
+# Silently no-op on HOST_UID=0 (root) — apache should never run as root.
+#
+# Non-numeric values (e.g., HOST_UID=foo from a compose-env typo) log a
+# warning to stderr and fall back to the default rather than aborting
+# startup under set -euo pipefail.
+#
+# Limitation: changing HOST_UID between container starts against the
+# same set of named volumes leaves old-uid-owned files inside those
+# volumes that the new apache uid can't write. Recover with
+# `docker compose down -v` (purges volumes) then bring up fresh.
+if [[ -z "${HOST_UID:-}" ]] || [[ "${HOST_UID}" = "0" ]]; then
+    : # unset or root — no-op
+elif ! [[ "${HOST_UID}" =~ ^[0-9]+$ ]]; then
+    echo "Warning: HOST_UID='${HOST_UID}' is not numeric; ignoring (apache stays at uid=1000)" >&2
+else
+    # GID is optional; validate it independently so a bad HOST_GID
+    # doesn't block a good HOST_UID adoption.
+    if [[ -n "${HOST_GID:-}" ]] && [[ "${HOST_GID}" != "0" ]]; then
+        if [[ "${HOST_GID}" =~ ^[0-9]+$ ]]; then
+            # -o (non-unique) tolerates a collision with an existing
+            # group (e.g. on some hosts uid/gid 1000 maps to a system
+            # group); the override is intentional.
+            groupmod -o -g "${HOST_GID}" apache
+        else
+            echo "Warning: HOST_GID='${HOST_GID}' is not numeric; ignoring gid override" >&2
+        fi
+    fi
+    echo "Adopting host uid/gid: HOST_UID=${HOST_UID} HOST_GID=${HOST_GID:-(unset)}"
+    # -o (non-unique) for the same reason as groupmod above.
+    usermod -o -u "${HOST_UID}" apache
+fi
+
+# ============================================================================
 # PATH CONFIGURATION
 # ============================================================================
 # Define paths used throughout the script for OpenEMR installation and configuration


### PR DESCRIPTION
## Summary

When the host bind-mounts the webroot (typical of `docker/development-*` dev stacks), files apache writes inside the container appear on the host as `uid=1000` (apache's Dockerfile-baked uid). Any host whose uid is not 1000 — **CI runners (uid=1001), multi-user dev boxes, distros that start uids at 1001+, macOS via Docker Desktop** — can't modify those files. `git commit` fails with EACCES, IDE writes get rejected, and contributors hit a friction wall that's invisible to anyone on a default uid=1000 Linux desktop.

This PR adds `HOST_UID`/`HOST_GID` env var support to the flex entrypoint. If either is set, the entrypoint runs `usermod -o -u $HOST_UID apache` (and the groupmod analog) **before** any chown operations. Subsequent chowns then target the adopted uid, and bind-mount files end up host-owned. Both host and apache can write throughout the stack's lifetime — no manual chown dance on either side.

## Behaviour

| `HOST_UID` | Behaviour |
|---|---|
| Unset / empty | No change — apache stays at Dockerfile-baked uid=1000 (today's default) |
| Set, non-zero | `usermod` apache to that uid before any chown |
| `0` (root) | Silently no-op — apache should never run as root |

- **Backwards compatible:** existing deployments see no change
- **Idempotent:** re-running with the same `HOST_UID` is a no-op
- **`-o` flag** on both `groupmod`/`usermod` tolerates collisions with existing system users at the target uid

## Limitation

Changing `HOST_UID` between container starts against the same named volumes leaves old-uid-owned files inside those volumes that the new apache uid can't write. Recover with `docker compose down -v` (purges volumes) then bring up fresh. Acceptable trade-off for a feature that's invisible unless intentionally opted into.

## Scope

This PR only modifies the flex variant — the one used by every `docker/development-*` dev stack. Binary and release entrypoints also have apache uid baked in via their Dockerfiles, but they have no runtime chown to take advantage of (those images pre-own everything at build time and don't bind-mount the webroot). Adding `HOST_UID` support there is straightforward follow-up if there's demand.

## Cross-repo context

Part of a coordinated effort with openemr/openemr-devops:
- **This PR (openemr-side):** entrypoint reads HOST_UID/HOST_GID and adopts them
- **Follow-up (openemr-devops-side):** worktree compose override generator passes HOST_UID/HOST_GID through, so `openemr-cmd worktree add` Just Works on any host uid

Once both land and a new image is published, several CI workarounds in openemr-devops/.github/workflows/test-bats-openemr-cmd-real-docker.yml (manual sudo chown steps) become unnecessary and can be removed.

## Test plan

- [ ] Existing flex tests (which don't set HOST_UID) pass — backwards-compat
- [ ] Manual: set `HOST_UID=2000` (or any non-1000 value) in compose env, bring up the stack, confirm `docker exec ... id apache` shows the adopted uid
- [ ] Manual: confirm files apache writes in `/var/www/localhost/htdocs/openemr/` (e.g., after `auto_setup`) are owned by HOST_UID on the host
- [ ] Manual: as a non-1000-uid user, confirm host-side `git commit` works against the bind-mounted worktree
- [ ] CI: `prek` checks pass on the diff (verified locally: trim-whitespace, end-of-file-fixer, codespell, mixed-line-ending all green; nothing else triggers on a `.sh` file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)