### PR TITLE
feat(docker): declare HOST_UID/HOST_GID env in dev compose files

### DIFF
--- a/docker/development-easy-light/docker-compose.yml
+++ b/docker/development-easy-light/docker-compose.yml
@@ -45,6 +45,17 @@ services:
     - logvolume:/var/log
     - couchdbvolume:/couchdb/data
     environment:
+      # HOST_UID/HOST_GID let the entrypoint adopt the host user's uid for
+      # apache (see docker/flex/openemr.sh — adoption is a no-op when these
+      # default to 1000). Without override, behavior matches the original
+      # Dockerfile-baked uid=1000. Override (e.g. `HOST_UID=$(id -u)
+      # docker compose up`) so apache writes bind-mount files as your host
+      # user — eliminates the uid-mismatch class of bugs for any host whose
+      # uid != 1000 (CI runners, multi-user dev boxes, distros that start
+      # uids at 1001+, macOS via Docker Desktop). Always exported by
+      # openemr-cmd, optional everywhere else.
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: "true"
       TERM: xterm-256color
       COLORTERM: truecolor

--- a/docker/development-easy-redis/docker-compose.yml
+++ b/docker/development-easy-redis/docker-compose.yml
@@ -150,6 +150,17 @@ services:
     - couchdbvolume:/couchdb/data
     - ./php.ini:/usr/local/etc/php/php.ini:ro
     environment:
+      # HOST_UID/HOST_GID let the entrypoint adopt the host user's uid for
+      # apache (see docker/flex/openemr.sh — adoption is a no-op when these
+      # default to 1000). Without override, behavior matches the original
+      # Dockerfile-baked uid=1000. Override (e.g. `HOST_UID=$(id -u)
+      # docker compose up`) so apache writes bind-mount files as your host
+      # user — eliminates the uid-mismatch class of bugs for any host whose
+      # uid != 1000 (CI runners, multi-user dev boxes, distros that start
+      # uids at 1001+, macOS via Docker Desktop). Always exported by
+      # openemr-cmd, optional everywhere else.
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: "true"
       TERM: xterm-256color
       COLORTERM: truecolor

--- a/docker/development-easy/docker-compose.yml
+++ b/docker/development-easy/docker-compose.yml
@@ -45,6 +45,17 @@ services:
     - logvolume:/var/log
     - couchdbvolume:/couchdb/data
     environment:
+      # HOST_UID/HOST_GID let the entrypoint adopt the host user's uid for
+      # apache (see docker/flex/openemr.sh — adoption is a no-op when these
+      # default to 1000). Without override, behavior matches the original
+      # Dockerfile-baked uid=1000. Override (e.g. `HOST_UID=$(id -u)
+      # docker compose up`) so apache writes bind-mount files as your host
+      # user — eliminates the uid-mismatch class of bugs for any host whose
+      # uid != 1000 (CI runners, multi-user dev boxes, distros that start
+      # uids at 1001+, macOS via Docker Desktop). Always exported by
+      # openemr-cmd, optional everywhere else.
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: "true"
       TERM: xterm-256color
       COLORTERM: truecolor


### PR DESCRIPTION
## Summary

#12642 added `HOST_UID`/`HOST_GID` adoption to the flex entrypoint, but the dev compose files (`development-easy` / `easy-light` / `easy-redis`) didn't declare these env vars in the openemr service's `environment:` block. So a user who exported `HOST_UID` in their shell got the value **silently dropped by compose** unless they were running via openemr-cmd's worktree path (which writes its own override with the env vars baked in, per openemr-devops#840).

This PR closes that gap by declaring both vars with `\${HOST_UID:-1000}` / `\${HOST_GID:-1000}` defaults — the current Dockerfile-baked apache uid.

## Effect

| Entry path | Before this PR | After this PR |
|---|---|---|
| `openemr-cmd worktree up` (managed) | ✅ adopted via override | ✅ adopted via override |
| `openemr-cmd up` from `docker/development-*` | ❌ ignored (no override) | ✅ adopted (env var passed) |
| Bare `docker compose up` with `HOST_UID` in shell | ❌ silently dropped | ✅ adopted |
| Bare `docker compose up` with no env vars | apache=1000 | apache=1000 (unchanged) |

**Backwards compatible** — defaults preserve current uid=1000 behavior. No-op for anyone not opting in.

## Recommended usage (for non-uid=1000 hosts)

One-shot:
```bash
HOST_UID=\$(id -u) HOST_GID=\$(id -g) docker compose up --detach --wait
```

Or persistent in `~/.profile` / `~/.zshrc`:
```bash
export HOST_UID="\$(id -u)" HOST_GID="\$(id -g)"
```

After which any `docker compose up` Just Works without permission friction.

## Companion PR

The openemr-devops side wires the auto-export into `openemr-cmd up` (non-worktree dispatch) so users on that flow get the adoption transparently — no need to set the env vars manually. Filed separately at openemr/openemr-devops (PR # TBD, will link once filed). The worktree path already exports via `wt_write_override` (openemr-devops#840).

## Test plan

- [ ] Existing CI passes — backwards-compat verified
- [ ] Manual: `HOST_UID=2000 HOST_GID=2000 docker compose up --wait` in `docker/development-easy/`, then `docker exec ... id apache` confirms apache adopted uid 2000
- [ ] Manual: `docker compose up --wait` with no env vars confirms apache stays at uid 1000 (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)