### PR TITLE
fix(spell): exclude CHANGELOG line quoting 'Dislay' typo from codespell

### DIFF
--- a/.codespell-exclude-lines.txt
+++ b/.codespell-exclude-lines.txt
@@ -3,6 +3,7 @@
 
 # CHANGELOG: documenting a bug fix about misspelling
 - "Retrieve" is sometimes misspelled "retrive" ([#8595](https://github.com/openemr/openemr/issues/8595))
+- correct "Dislay" typo in main menu logo description ([#10988](https://github.com/openemr/openemr/pull/10988))
 
 # Company name in copyright notice (Wrapp was a Swedish mobile commerce company)
  * (c) 2013-2016 Nicklas Ansman, 2013 Wrapp


### PR DESCRIPTION
## Summary

Adds the CHANGELOG.md:68 line to `.codespell-exclude-lines.txt`,
following the same pattern already in the file for PR #8595's
'retrive' entry.

The line is a quoted PR title from #10988 (which literally was
*correcting* the 'Dislay' typo in the main menu logo description).
Codespell can't tell a legitimate quoted-typo reference from a real
misspelling, so it has been failing on CHANGELOG.md:68 since the
8.1.0 changelog-PR landed on 2026-06-02. Every subsequent push to
rel-810 has produced a red spell-check; nobody noticed because no
merge attempt was made.

## Why line-level exclude (not word allowlist)

Keeps codespell's strictness intact for the rest of the codebase —
a real 'Dislay' typo elsewhere would still be flagged. Line-level
exclude is content-based (not line-number-based), so it survives
file growth.

The file already had this pattern for 'retrive' (PR #8595) — same
shape, same comment block.

## Why this PR matters now

ship-release.yml's preflight requires `mergeStateStatus=CLEAN` on
the conductor PR. The 8.1.1 release-prep PR (openemr/openemr#12377)
has `mergeStateStatus=BLOCKED` because of this single spell-check
failure. Landing this unblocks the 8.1.1 ship.

## Why CHANGELOG itself isn't fixed

CHANGELOG.md is auto-generated by `openemr-devops`'s
`ChangelogGenerator` from PR titles via `git shortlog vPREV..HEAD`.
PR #10988's title contains the literal 'Dislay' (intentionally —
the PR was fixing that typo). Editing CHANGELOG.md to 'Display'
would misrepresent the historical PR title. The exclude file is the
right surface for "intentional spellings in specific contexts" per
its own header.

## Test plan

- [ ] CI passes (spell check goes green on this PR)
- [ ] After merge, rel-810's push-event spell check goes green
- [ ] Conductor re-fires on this PR's merge and #12377's
      `mergeStateStatus` clears to `CLEAN`/`MERGEABLE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)