### PR TITLE
ci(release): backport all-checks-passed.yml to rel-810

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -1,0 +1,20 @@
+name: All Checks Passed
+
+on:
+  push:
+    branches: [rel-810]
+  pull_request:
+    branches: [rel-810]
+
+jobs:
+  all-checks:
+    name: All Checks Passed
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: lewagon/wait-on-check-action@v1.8.0
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        running-workflow-name: All Checks Passed
+        ignore-checks: codecov/project,codecov/patch
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        wait-interval: 30


### PR DESCRIPTION
## Summary

Backports master's umbrella status-check aggregator
`.github/workflows/all-checks-passed.yml` to rel-810, adapted to fire
on `push`/`pull_request` events whose branch matches `rel-810` instead
of `master`.

## Why

rel-810's branch protection requires the `All Checks Passed` status
check (same gate as master). On master the workflow exists, fires,
and reports the status. On rel-810 the file didn't exist, so the
required status was never reported — every PR targeting rel-810 shows
"Expected — Waiting for status to be reported" indefinitely and stays
`mergeStateStatus=BLOCKED`.

Past rel-810 PRs (e.g. #12608, #12610) merged via admin-override.
That generates `mergeStateStatus=UNKNOWN` post-merge — matches the
GitHub API state I see now for those PRs.

## Why this matters for 8.1.1

`ship-release.yml`'s preflight refuses to merge a PR whose
`mergeStateStatus` is not `CLEAN` — it doesn't admin-override. So
even with the spell-check fix in PR #12648, the release-prep PR
(#12377) would still be `BLOCKED` until this workflow exists on
rel-810. Landing this PR is the second of two prerequisites to clear
the conductor PR's preflight (the other being the codespell fix
#12648).

## Mechanism

`lewagon/wait-on-check-action` polls the PR head SHA's other checks
every 30 seconds, ignoring `codecov/project` + `codecov/patch` (same
exclusion pattern as master). When all other required checks finish,
this workflow's job completes and produces the `All Checks Passed`
status, clearing the branch-protection requirement.

## Per-branch divergence from master

Only the trigger `branches:` list differs (`[rel-810]` here vs
`[master]` on master). Workflow body identical. Not added to
FILES_ALL — branch-specific config is intentional.

## Test plan

- [ ] CI passes (this workflow itself fires on its own PR and should
      go green once all other PR checks pass)
- [ ] After merge, rel-810 push events also produce the
      'All Checks Passed' status
- [ ] PR #12377's `mergeStateStatus` clears from `BLOCKED` to
      `CLEAN`/`MERGEABLE` (after #12648 also lands)
- [ ] `ship-release.yml --version=8.1.1 --rel_branch=rel-810`
      preflight passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)