### PR TITLE
feat(docker): declare HOST_UID/HOST_GID env in insane dev compose

### DIFF
--- a/docker/development-insane/docker-compose.yml
+++ b/docker/development-insane/docker-compose.yml
@@ -77,6 +77,8 @@ services:
     volumes:
     - ../..:/var/www/localhost/htdocs/openemr
     environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
@@ -107,6 +109,8 @@ services:
     volumes:
     - ../..:/var/www/localhost/htdocs/openemr
     environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
@@ -137,6 +141,8 @@ services:
     volumes:
     - ../..:/var/www/localhost/htdocs/openemr
     environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
@@ -167,6 +173,8 @@ services:
     volumes:
     - ../..:/var/www/localhost/htdocs/openemr
     environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
@@ -198,6 +206,8 @@ services:
     - ../..:/var/www/localhost/htdocs/openemr
     - couchdbvolume:/couchdb/data
     environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
@@ -267,6 +277,8 @@ services:
     volumes:
     - ../..:/var/www/localhost/htdocs/openemr
     environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
@@ -297,6 +309,8 @@ services:
     volumes:
     - ../..:/var/www/localhost/htdocs/openemr
     environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
@@ -328,6 +342,8 @@ services:
     volumes:
     - ../..:/var/www/localhost/htdocs/openemr
     environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
@@ -359,6 +375,8 @@ services:
     volumes:
     - ../..:/var/www/localhost/htdocs/openemr
     environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
@@ -390,6 +408,8 @@ services:
     volumes:
     - ../..:/var/www/localhost/htdocs/openemr
     environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
@@ -421,6 +441,8 @@ services:
     volumes:
     - ../..:/var/www/localhost/htdocs/openemr
     environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
@@ -452,6 +474,8 @@ services:
     volumes:
     - ../..:/var/www/localhost/htdocs/openemr
     environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor


### PR DESCRIPTION
## Summary

Extends the HOST_UID/HOST_GID compose-side declaration (added for `development-easy` / `easy-light` / `easy-redis` in #12647) to the **insane env**'s 12 openemr service variants. Closes the last gap in the HOST_UID story so that contributors using the insane env get the same transparent host-uid alignment as those using the standard dev envs.

Touches 12 openemr service blocks: `openemr-8-1`, `openemr-8-2`, `openemr-8-3`, `openemr-8-4`, `openemr-8-5`, `openemr-edge`, and the 6 `*-redis` variants. Adds `HOST_UID: "${HOST_UID:-1000}"` and `HOST_GID: "${HOST_GID:-1000}"` to each — 24 lines added total.

## How the activation chain works

All 12 insane variant images (`flex-3.17`, `flex-3.22-php-{8.2,8.3,8.4}`, `flex-3.23-php-{8.3,8.4,8.5}`, `flex-edge`) build from the **same** `docker/flex/Dockerfile` via `docker-build-flex-core.yml`, parameterized by `ALPINE_VERSION` and `PHP_VERSION`. That Dockerfile COPYs `docker/flex/openemr.sh` (which already has #12642's HOST_UID entrypoint adoption) into every variant.

| Timeline | Event |
|---|---|
| **T-0** | This PR adds HOST_UID/HOST_GID env declarations |
| **Daily 02:00 UTC** | Cron rebuilds all variant tags from the latest flex Dockerfile/entrypoint (`docker-build-322` / `docker-build-323` / `docker-build-edge`) |
| **T+1–2 days** | Dependabot opens SHA-bump PR for `docker/development-insane/docker-compose.yml` (tracked per `.github/dependabot.yml`) — merge to land the new HOST_UID-aware SHAs |
| **After merge** | Insane env fully honors HOST_UID adoption for any host uid |

## Backwards compatibility

Total. If a user runs an older SHA-pinned image that doesn't have the HOST_UID entrypoint adoption, the env var is silently received-and-ignored by the container — no regression. After SHA bumps land, adoption activates with no further changes needed.

## Test plan

- [x] YAML validates (12 service blocks updated, verified locally via Python yaml.safe_load)
- [x] prek hooks pass (trim-whitespace, end-of-file-fixer, check-yaml, codespell, mixed-line-ending, pretty-format-yaml, conventional-commits all green)
- [ ] No new CI breakage — change is purely additive YAML; insane stack itself isn't run in CI per PR
- [ ] After dependabot SHA bump lands: verify HOST_UID adoption by `docker compose -f docker/development-insane/docker-compose.yml up -d openemr-edge` then `stat -c '%u' sites/default/sqlconf.php` matches `$(id -u)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)