### PR TITLE
fix(gacl): Fix invalid property access in gacl

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -792,36 +792,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../custom/qrda_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'  Database Prefix\\: \\\\\'\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'  Database Type\\: \' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'  Database Version\\: \' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'  Database…\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'  phpGACL Schema…\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'  phpGACL Version\\: \' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \' Browser\\: \' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../gacl/admin/about.php',

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -88,11 +88,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../gacl/admin/acl_admin.php',
 ];

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -692,21 +692,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../custom/qrda_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method ServerInfo\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method get_schema_version\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method get_version\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method GetRows\\(\\) on ADORecordSet\\|bool\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../gacl/admin/acl_test2.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -652,11 +652,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../gacl/Cache_Lite/Lite.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function get_system_info\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method Profiler\\:\\:__resumeTimer\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../gacl/profiler.inc.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -1717,16 +1717,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../gacl/Cache_Lite/Lite.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'description\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'version\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access an offset on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../gacl/admin/acl_admin.php',

--- a/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
@@ -107,11 +107,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../custom/qrda_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use of the "global" keyword is forbidden \\(\\$gacl_api\\)\\. Use dependency injection instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use of the "global" keyword is forbidden \\(\\$db\\)\\. Use dependency injection instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../gacl/admin/object_search.php',

--- a/.phpstan/baseline/property.nonObject.php
+++ b/.phpstan/baseline/property.nonObject.php
@@ -132,31 +132,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../custom/qrda_category1_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access property \\$_caching on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access property \\$_db_table_prefix on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access property \\$_db_type on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access property \\$_force_cache_expire on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access property \\$db on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../gacl/admin/about.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access property \\$data on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/clickmap/C_AbstractClickmap.php',

--- a/gacl/admin/about.php
+++ b/gacl/admin/about.php
@@ -58,7 +58,7 @@ $system_info = get_system_info($gacl_api);
 $smarty->assign("credits", implode('',file('../CREDITS')) );
 
 $smarty->assign("system_info", $system_info);
-$smarty->assign("system_info_md5", md5((string) $system_info) );
+$smarty->assign("system_info_md5", md5($system_info) );
 
 $smarty->assign("return_page", $_SERVER['PHP_SELF'] );
 

--- a/gacl/admin/about.php
+++ b/gacl/admin/about.php
@@ -5,6 +5,7 @@ require_once("../../interface/globals.php");
 
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Gacl\GaclAdminApi;
 
 //ensure user has proper access
 if (!AclMain::aclCheckCore('admin', 'acl')) {
@@ -13,9 +14,7 @@ if (!AclMain::aclCheckCore('admin', 'acl')) {
 
 require_once("gacl_admin.inc.php");
 
-function get_system_info() {
-    global $gacl_api;
-
+function get_system_info(GaclAdminApi $gacl_api) {
     //Grab system info
     $system_info = 'PHP Version: '.phpversion()."\n";
     $system_info .= 'Zend Version: '.zend_version()."\n";
@@ -24,14 +23,14 @@ function get_system_info() {
     $system_info .= '  phpGACL Version: '.$gacl_api->get_version()."\n";
     $system_info .= '  phpGACL Schema Version: '.$gacl_api->get_schema_version()."\n";
 
-    $caching = $gacl_api->_caching == TRUE ? 'True' : 'False';
-    $system_info .= '  Caching Enabled: '. $caching ."\n";
+    // $caching = $gacl_api->_caching == TRUE ? 'True' : 'False';
+    // $system_info .= '  Caching Enabled: '. $caching ."\n";
 
-    $force_cache_expire = $gacl_api->_force_cache_expire == TRUE ? 'True' : 'False';
-    $system_info .= '  Force Cache Expire: '.$force_cache_expire."\n";
+    // $force_cache_expire = $gacl_api->_force_cache_expire == TRUE ? 'True' : 'False';
+    // $system_info .= '  Force Cache Expire: '.$force_cache_expire."\n";
 
     $system_info .= '  Database Prefix: \''.$gacl_api->_db_table_prefix."'\n";
-    $system_info .= '  Database Type: '.$gacl_api->_db_type."\n";
+    // $system_info .= '  Database Type: '.$gacl_api->_db_type."\n";
 
     $database_server_info = $gacl_api->db->ServerInfo();
     $system_info .= '  Database Version: '.$database_server_info['version']."\n";
@@ -47,11 +46,12 @@ function get_system_info() {
     return trim($system_info);
 }
 
-$system_info = get_system_info();
 
 /** @var \OpenEMR\Gacl\GaclAdminApi $gacl_api */
 /** @var \ADOConnection $db */
 /** @var \Smarty $smarty */
+
+$system_info = get_system_info($gacl_api);
 
 //Read credits.
 $smarty->assign("credits", implode('',file('../CREDITS')) );

--- a/gacl/admin/about.php
+++ b/gacl/admin/about.php
@@ -14,7 +14,8 @@ if (!AclMain::aclCheckCore('admin', 'acl')) {
 
 require_once("gacl_admin.inc.php");
 
-function get_system_info(GaclAdminApi $gacl_api) {
+function get_system_info(GaclAdminApi $gacl_api): string
+{
     //Grab system info
     $system_info = 'PHP Version: '.phpversion()."\n";
     $system_info .= 'Zend Version: '.zend_version()."\n";

--- a/gacl/admin/acl_test2.php
+++ b/gacl/admin/acl_test2.php
@@ -23,7 +23,6 @@ $profiler = new Profiler(true,true);
 
 require_once("gacl_admin.inc.php");
 
-/** @var \OpenEMR\Gacl\GaclAdminApi $gacl */
 /** @var \OpenEMR\Gacl\GaclAdminApi $gacl_api */
 /** @var \ADOConnection $db */
 /** @var \Smarty $smarty */
@@ -60,7 +59,7 @@ foreach ($rows as $row) {
     [$aco_section_value, $aco_section_name, $aco_value, $aco_name, $aro_section_value, $aro_section_name, $aro_value, $aro_name] = $row;
 
     $acl_check_begin_time = $profiler->getMicroTime();
-    $acl_result = $gacl->acl_query($aco_section_value, $aco_value, $aro_section_value, $aro_value);
+    $acl_result = $gacl_api->acl_query($aco_section_value, $aco_value, $aro_section_value, $aro_value);
     $acl_check_end_time = $profiler->getMicroTime();
 
     $access = &$acl_result['allow'];

--- a/gacl/admin/acl_test3.php
+++ b/gacl/admin/acl_test3.php
@@ -26,7 +26,6 @@ $profiler = new Profiler(true,true);
 
 require_once("gacl_admin.inc.php");
 
-/** @var \OpenEMR\Gacl\GaclAdminApi $gacl */
 /** @var \OpenEMR\Gacl\GaclAdminApi $gacl_api */
 /** @var \ADOConnection $db */
 /** @var \Smarty $smarty */
@@ -79,7 +78,7 @@ foreach ($rows as $row) {
     [$aco_section_value, $aco_section_name, $aco_value, $aco_name, $aro_section_value, $aro_section_name, $aro_value, $aro_name, $axo_section_value, $axo_section_name, $axo_value, $axo_name] = $row;
 
     $acl_check_begin_time = $profiler->getMicroTime();
-    $acl_result = $gacl->acl_query($aco_section_value, $aco_value, $aro_section_value, $aro_value, $axo_section_value, $axo_value);
+    $acl_result = $gacl_api->acl_query($aco_section_value, $aco_value, $aro_section_value, $aro_value, $axo_section_value, $axo_value);
     $acl_check_end_time = $profiler->getMicroTime();
 
     $access = &$acl_result['allow'];

--- a/gacl/admin/gacl_admin.inc.php
+++ b/gacl/admin/gacl_admin.inc.php
@@ -55,9 +55,7 @@ if ( file_exists($config_file) ) {
 /** @var array<string, mixed>|null $gacl_options */
 $gacl_api = new GaclAdminApi(is_array($gacl_options ?? null) ? $gacl_options : null);
 
-$gacl = &$gacl_api;
-
-$db = &$gacl->db;
+$db = $gacl_api->db;
 
 $smarty = new Smarty;
 $smarty->setCompileCheck(true);

--- a/src/Gacl/Gacl.php
+++ b/src/Gacl/Gacl.php
@@ -57,7 +57,7 @@ class Gacl {
     private $_db;
 
     /** @var \ADOConnection An ADODB database connector object */
-    protected $db;
+    public $db;
 
     /*
      * NOTE:    This cache must be manually cleaned each time ACL's are modified.


### PR DESCRIPTION
#### Short description of what this changes or resolves:
```
An error has occurred. Error: Cannot access protected property OpenEMR\Gacl\GaclAdminApi::$db in /var/www/localhost/htdocs/openemr/gacl/admin/gacl_admin.inc.php:60 Stack trace: #0 /var/www/localhost/htdocs/openemr/gacl/admin/about.php(14): require_once() #1 {main}
```

I think this was my fault during a refactor a couple months ago. For some reason, PHPStan wasn't picking up the property access issue due to a (completely unnecessary for ~20 yrs) by-reference read. I cannot reproduce this in the phpstan playground so maybe there's already an upstream fix 🤷 

After this change, I went through all of the tabs and saw them _at the very least_ load properly.

There are still _over 600 issues_ reported by PHPStan following this change, all existing. The majority are either `mixed` or inappropriate superglobal access. I can't be sure nothing else is broken, but it at least loads now.

#### Changes proposed in this pull request:
- Make DB public for now (simple fix to avoid excessive change)
- Set up the variable read normally
- Bypass a couple similar issues on the about page
- Fixed a bunch of phpstan issues by replacing a `global` with a normal function argument

#### Was an AI assistant used? Yes / No
No