### PR TITLE
chore(di): Prepare BreakglassChecker(Interface) for autowiring

### DIFF
--- a/config/audit.php
+++ b/config/audit.php
@@ -13,7 +13,7 @@ use OpenEMR\Common\Logging\{
 return [
     BreakglassCheckerInterface::class => BreakglassChecker::class,
     // See notes in BreakglassChecker's constructor: it must use the
-    // non-audited connection in order to avoid an infinte loop w/ SQL logging
+    // non-audited connection in order to avoid an infinite loop w/ SQL logging
     BreakglassChecker::class => fn (TC $c) => new BreakglassChecker(
         $c->get(ConnectionManager::class)->get(ConnectionType::NonAudited),
     ),

--- a/config/audit.php
+++ b/config/audit.php
@@ -1,5 +1,17 @@
 <?php
 
+/**
+ * Auditing-related services and configuration
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
 use Firehed\Container\TypedContainerInterface as TC;
 use OpenEMR\Common\Database\{
     ConnectionManager,

--- a/config/audit.php
+++ b/config/audit.php
@@ -1,0 +1,20 @@
+<?php
+
+use Firehed\Container\TypedContainerInterface as TC;
+use OpenEMR\Common\Database\{
+    ConnectionManager,
+    ConnectionType,
+};
+use OpenEMR\Common\Logging\{
+    BreakglassChecker,
+    BreakglassCheckerInterface,
+};
+
+return [
+    BreakglassCheckerInterface::class => BreakglassChecker::class,
+    // See notes in BreakglassChecker's constructor: it must use the
+    // non-audited connection in order to avoid an infinte loop w/ SQL logging
+    BreakglassChecker::class => fn (TC $c) => new BreakglassChecker(
+        $c->get(ConnectionManager::class)->get(ConnectionType::NonAudited),
+    ),
+];


### PR DESCRIPTION
#### Short description of what this changes or resolves:
Sets up one of a bunch of services needed so the EventAuditLogger can be connected to DBAL (in addition to and eventually replacing ADODB)

#### Changes proposed in this pull request:
Adds BreakglassCheckerInterface to available services, maps to the one implementation, which itself is explicitly given the non-audited connection. It needs that specific connection so that it doesn't cause infinite recursion since it's _used_ in the auditing layer.

#### Was an AI assistant used? Yes / No
No