### PR TITLE
refactor(audit): Add multi-sink destination

### DIFF
--- a/src/Common/Logging/Audit/AtnaSink.php
+++ b/src/Common/Logging/Audit/AtnaSink.php
@@ -65,10 +65,10 @@ MSG;
     ) {
     }
 
-    public function record(Event $event): bool
+    public function record(Event $event): void
     {
         if (!$this->isEnabled()) {
-            return false;
+            return;
         }
 
         $message = $this->createRfc3881Msg(
@@ -79,7 +79,7 @@ MSG;
             $event->success,
             $event->comments,
         );
-        return $this->writer->writeMessage($message);
+        $this->writer->writeMessage($message);
     }
 
     /**

--- a/src/Common/Logging/Audit/LogTablesSink.php
+++ b/src/Common/Logging/Audit/LogTablesSink.php
@@ -35,7 +35,7 @@ readonly class LogTablesSink implements SinkInterface
     ) {
     }
 
-    public function record(Event $event): bool
+    public function record(Event $event): void
     {
         $api = $event->api;
 
@@ -97,7 +97,5 @@ readonly class LogTablesSink implements SinkInterface
         if ($api !== null) {
             $this->conn->insert('api_log', $apiLogData);
         }
-
-        return true;
     }
 }

--- a/src/Common/Logging/Audit/MultiSink.php
+++ b/src/Common/Logging/Audit/MultiSink.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Common\Logging\Audit;
 
-class MultiSink implements SinkInterface
+readonly class MultiSink implements SinkInterface
 {
     /**
      * @param SinkInterface[] $sinks

--- a/src/Common/Logging/Audit/MultiSink.php
+++ b/src/Common/Logging/Audit/MultiSink.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Writes the audit event to multiple sinks
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 Eric Stern
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Logging\Audit;
+
+class MultiSink implements SinkInterface
+{
+    /**
+     * @param SinkInterface[] $sinks
+     */
+    public function __construct(
+        private array $sinks,
+    ) {
+    }
+
+    public function record(Event $event): void
+    {
+        foreach ($this->sinks as $sink) {
+            $sink->record($event);
+        }
+    }
+}

--- a/src/Common/Logging/Audit/SinkInterface.php
+++ b/src/Common/Logging/Audit/SinkInterface.php
@@ -6,5 +6,5 @@ namespace OpenEMR\Common\Logging\Audit;
 
 interface SinkInterface
 {
-    public function record(Event $event): bool;
+    public function record(Event $event): void;
 }

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -82,7 +82,7 @@ class EventAuditLogger
         );
 
         return new self(
-            sinks: $sinks,
+            sink: new Audit\MultiSink($sinks),
             session: SessionWrapperFactory::getInstance()->getActiveSession(),
             config: $auditConfig,
             breakglassChecker: new BreakglassChecker($auditConn),

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -90,11 +90,8 @@ class EventAuditLogger
         );
     }
 
-    /**
-     * @param Audit\SinkInterface[] $sinks
-     */
     public function __construct(
-        private readonly array $sinks,
+        private readonly Audit\SinkInterface $sink,
         private readonly SessionInterface $session,
         private readonly AuditConfig $config,
         private readonly BreakglassCheckerInterface $breakglassChecker,
@@ -694,9 +691,7 @@ class EventAuditLogger
             $api,
         );
 
-        foreach ($this->sinks as $sink) {
-            $sink->record($auditEvent);
-        }
+        $this->sink->record($auditEvent);
     }
 
     /**

--- a/tests/Tests/Isolated/Common/Logging/Audit/LogTablesSinkTest.php
+++ b/tests/Tests/Isolated/Common/Logging/Audit/LogTablesSinkTest.php
@@ -88,8 +88,7 @@ class LogTablesSinkTest extends TestCase
 
         $sink = new LogTablesSink(conn: $this->connection);
 
-        $result = $sink->record($event);
-        self::assertTrue($result);
+        $sink->record($event);
     }
 
     public function testRecordInsertsIntoLogCommentEncryptWithCorrectChecksum(): void

--- a/tests/Tests/Isolated/Common/Logging/Audit/MultiSinkTest.php
+++ b/tests/Tests/Isolated/Common/Logging/Audit/MultiSinkTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Tests for MultiSink
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Logging\Audit;
+
+use OpenEMR\Common\Logging\Audit\Event;
+use OpenEMR\Common\Logging\Audit\MultiSink;
+use OpenEMR\Common\Logging\Audit\SinkInterface;
+use PHPUnit\Framework\TestCase;
+
+class MultiSinkTest extends TestCase
+{
+    private function createEvent(): Event
+    {
+        return new Event(
+            current_datetime: '2026-06-26 12:00:00',
+            event: 'test-event',
+            category: 'test-category',
+            user: 'testuser',
+            group: 'testgroup',
+            comments: 'Test comment',
+            user_notes: '',
+            patientId: 123,
+            success: 1,
+            logFrom: 'open-emr',
+            menuItemId: null,
+            ccdaDocId: null,
+            api: null,
+        );
+    }
+
+    public function testRecordWithSingleSinkDispatchesToIt(): void
+    {
+        $event = $this->createEvent();
+
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->once())
+            ->method('record')
+            ->with($event);
+
+        $multiSink = new MultiSink([$sink]);
+        $multiSink->record($event);
+    }
+
+    public function testRecordDispatchesToAllSinks(): void
+    {
+        $event = $this->createEvent();
+
+        $sink1 = $this->createMock(SinkInterface::class);
+        $sink1->expects($this->once())
+            ->method('record')
+            ->with($event);
+
+        $sink2 = $this->createMock(SinkInterface::class);
+        $sink2->expects($this->once())
+            ->method('record')
+            ->with($event);
+
+        $sink3 = $this->createMock(SinkInterface::class);
+        $sink3->expects($this->once())
+            ->method('record')
+            ->with($event);
+
+        $multiSink = new MultiSink([$sink1, $sink2, $sink3]);
+        $multiSink->record($event);
+    }
+
+    public function testRecordWithEmptySinksArrayDoesNotError(): void
+    {
+        // This test is implicitly checking no exceptions are thrown
+        $this->expectNotToPerformAssertions();
+
+        $multiSink = new MultiSink([]);
+        $multiSink->record($this->createEvent());
+    }
+
+    public function testRecordPropagatesExceptionsFromSink(): void
+    {
+        // Note: we _may_ want to change this behavior to try dispatching to
+        // all, log all errors, and throw the last one at the end. This was the
+        // previous behavior.
+        $event = $this->createEvent();
+
+        $throwingSink = $this->createMock(SinkInterface::class);
+        $throwingSink->expects($this->once())
+            ->method('record')
+            ->willThrowException(new \RuntimeException('Sink failed'));
+
+        $neverCalledSink = $this->createMock(SinkInterface::class);
+        $neverCalledSink->expects($this->never())
+            ->method('record');
+
+        $multiSink = new MultiSink([$throwingSink, $neverCalledSink]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Sink failed');
+        $multiSink->record($event);
+    }
+
+    public function testRecordPassesSameEventToAllSinks(): void
+    {
+        $event = $this->createEvent();
+
+        $sink1 = $this->createMock(SinkInterface::class);
+        $sink1->expects($this->once())
+            ->method('record')
+            ->willReturnCallback(function (Event $e) use ($event): void {
+                self::assertSame($event, $e, 'Expects original instance');
+            });
+
+        $sink2 = $this->createMock(SinkInterface::class);
+        $sink2->expects($this->once())
+            ->method('record')
+            ->willReturnCallback(function (Event $e) use ($event): void {
+                self::assertSame($event, $e, 'Expects original instance');
+            });
+
+        $multiSink = new MultiSink([$sink1, $sink2]);
+        $multiSink->record($event);
+    }
+}

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerAuthFailureTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerAuthFailureTest.php
@@ -56,7 +56,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
     private function makeLogger(SinkInterface $sink): EventAuditLogger
     {
         return new EventAuditLogger(
-            sinks: [$sink],
+            sink: $sink,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -73,7 +73,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
                 self::assertSame('mfa', $event->event);
                 return true;
             }))
-            ->willReturn(true);
+;
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -92,7 +92,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
                 self::assertSame(0, $event->success);
                 return true;
             }))
-            ->willReturn(true);
+;
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -115,7 +115,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
                 self::assertStringStartsWith('failure:', $decoded);
                 return true;
             }))
-            ->willReturn(true);
+;
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -135,7 +135,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
                 self::assertSame('physicians', $event->group);
                 return true;
             }))
-            ->willReturn(true);
+;
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -154,7 +154,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
                 self::assertSame('', $event->user);
                 return true;
             }))
-            ->willReturn(true);
+;
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -173,7 +173,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
                 self::assertNull($event->patientId);
                 return true;
             }))
-            ->willReturn(true);
+;
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -192,7 +192,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
                 self::assertSame(42, $event->patientId);
                 return true;
             }))
-            ->willReturn(true);
+;
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -215,7 +215,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
                 self::assertStringContainsString('10.0.0.1', $decoded);
                 return true;
             }))
-            ->willReturn(true);
+;
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerAuthFailureTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerAuthFailureTest.php
@@ -72,8 +72,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
             ->with(self::callback(function (Event $event): bool {
                 self::assertSame('mfa', $event->event);
                 return true;
-            }))
-;
+            }));
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -91,8 +90,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
             ->with(self::callback(function (Event $event): bool {
                 self::assertSame(0, $event->success);
                 return true;
-            }))
-;
+            }));
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -114,8 +112,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
                 self::assertStringContainsString('TOTP code incorrect', $decoded);
                 self::assertStringStartsWith('failure:', $decoded);
                 return true;
-            }))
-;
+            }));
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -134,8 +131,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
                 self::assertSame('drsmith', $event->user);
                 self::assertSame('physicians', $event->group);
                 return true;
-            }))
-;
+            }));
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -153,8 +149,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
             ->with(self::callback(function (Event $event): bool {
                 self::assertSame('', $event->user);
                 return true;
-            }))
-;
+            }));
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -172,8 +167,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
             ->with(self::callback(function (Event $event): bool {
                 self::assertNull($event->patientId);
                 return true;
-            }))
-;
+            }));
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -191,8 +185,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
             ->with(self::callback(function (Event $event): bool {
                 self::assertSame(42, $event->patientId);
                 return true;
-            }))
-;
+            }));
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),
@@ -214,8 +207,7 @@ class EventAuditLoggerAuthFailureTest extends TestCase
                 $decoded = base64_decode($event->comments);
                 self::assertStringContainsString('10.0.0.1', $decoded);
                 return true;
-            }))
-;
+            }));
 
         $this->makeLogger($sink)->logAuthFailure(
             AuthEvent::mfa(),

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -90,11 +90,10 @@ class EventAuditLoggerTest extends TestCase
                 self::assertSame(1, $event->success);
                 self::assertSame('patient-record', $event->category);
                 return true;
-            }))
-            ->willReturn(true);
+            }));
 
         $logger = new EventAuditLogger(
-            sinks: [$sink],
+            sink: $sink,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -120,11 +119,10 @@ class EventAuditLoggerTest extends TestCase
             ->with(self::callback(function (Event $event): bool {
                 self::assertSame(base64_encode('Plain text'), $event->comments);
                 return true;
-            }))
-            ->willReturn(true);
+            }));
 
         $logger = new EventAuditLogger(
-            sinks: [$sink],
+            sink: $sink,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -140,10 +138,12 @@ class EventAuditLoggerTest extends TestCase
         );
     }
 
-    public function testRecordLogItemWithNoSinksDoesNotError(): void
+    public function testRecordLogItemWithNoOpSinkDoesNotError(): void
     {
+        $sink = $this->createStub(SinkInterface::class);
+
         $logger = new EventAuditLogger(
-            sinks: [],
+            sink: $sink,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -199,11 +199,10 @@ class EventAuditLoggerTest extends TestCase
             ->with(self::callback(function (Event $event): bool {
                 self::assertNull($event->patientId);
                 return true;
-            }))
-            ->willReturn(true);
+            }));
 
         $logger = new EventAuditLogger(
-            sinks: [$sink],
+            sink: $sink,
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -46,37 +46,6 @@ class EventAuditLoggerTest extends TestCase
         $this->clock = new FrozenClock(new \DateTimeImmutable('2026-01-15 10:30:00'));
     }
 
-    public function testRecordLogItemDispatchesToAllSinks(): void
-    {
-        $sink1 = $this->createMock(SinkInterface::class);
-        $sink1->expects($this->once())
-            ->method('record')
-            ->with(self::isInstanceOf(Event::class))
-            ->willReturn(true);
-
-        $sink2 = $this->createMock(SinkInterface::class);
-        $sink2->expects($this->once())
-            ->method('record')
-            ->with(self::isInstanceOf(Event::class))
-            ->willReturn(true);
-
-        $logger = new EventAuditLogger(
-            sinks: [$sink1, $sink2],
-            session: $this->session,
-            config: $this->config,
-            breakglassChecker: $this->breakglassChecker,
-            clock: $this->clock,
-        );
-
-        $logger->recordLogItem(
-            success: 1,
-            event: 'test-event',
-            user: 'testuser',
-            group: 'testgroup',
-            comments: 'Test comments',
-        );
-    }
-
     public function testRecordLogItemPassesCorrectEventData(): void
     {
         $sink = $this->createMock(SinkInterface::class);
@@ -135,59 +104,6 @@ class EventAuditLoggerTest extends TestCase
             user: 'testuser',
             group: 'testgroup',
             comments: 'Plain text',
-        );
-    }
-
-    public function testRecordLogItemWithNoOpSinkDoesNotError(): void
-    {
-        $sink = $this->createStub(SinkInterface::class);
-
-        $logger = new EventAuditLogger(
-            sink: $sink,
-            session: $this->session,
-            config: $this->config,
-            breakglassChecker: $this->breakglassChecker,
-            clock: $this->clock,
-        );
-
-        $logger->recordLogItem(
-            success: 1,
-            event: 'test-event',
-            user: 'testuser',
-            group: 'testgroup',
-            comments: 'Test comments',
-        );
-
-        // Test passes if no exception is thrown
-        $this->addToAssertionCount(1);
-    }
-
-    public function testRecordLogItemContinuesIfSinkFails(): void
-    {
-        $failingSink = $this->createMock(SinkInterface::class);
-        $failingSink->expects($this->once())
-            ->method('record')
-            ->willReturn(false);
-
-        $successSink = $this->createMock(SinkInterface::class);
-        $successSink->expects($this->once())
-            ->method('record')
-            ->willReturn(true);
-
-        $logger = new EventAuditLogger(
-            sinks: [$failingSink, $successSink],
-            session: $this->session,
-            config: $this->config,
-            breakglassChecker: $this->breakglassChecker,
-            clock: $this->clock,
-        );
-
-        $logger->recordLogItem(
-            success: 1,
-            event: 'test-event',
-            user: 'testuser',
-            group: 'testgroup',
-            comments: 'Test comments',
         );
     }
 

--- a/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Unit\Common\Logging;
 
 use Lcobucci\Clock\FrozenClock;
+use OpenEMR\Common\Logging\Audit\SinkInterface;
 use OpenEMR\Common\Logging\AuditConfig;
 use OpenEMR\Common\Logging\BreakglassCheckerInterface;
 use OpenEMR\Common\Logging\EventAuditLogger;
@@ -132,7 +133,7 @@ final class EventAuditLoggerTest extends TestCase
 
         // Get EventAuditLogger instance (works with existing singleton)
         $this->eventAuditLogger = new EventAuditLogger(
-            sinks: [],
+            sink: $this->createStub(SinkInterface::class),
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,
@@ -253,9 +254,9 @@ final class EventAuditLoggerTest extends TestCase
             ->willReturnCallback(fn(string $key) => $sessionValues[$key] ?? null);
 
         // Return positional array matching constructor parameter order:
-        // sinks, cryptoGen,  session, config, breakglassChecker, clock
+        // sink, session, config, breakglassChecker, clock
         return [
-            [],                                         // sinks
+            $this->createStub(SinkInterface::class),
             $sessionMock,                               // session
             $config ?? $this->config,                   // config
             $this->breakglassChecker,                   // breakglassChecker
@@ -507,7 +508,7 @@ final class EventAuditLoggerTest extends TestCase
         $GLOBALS['enable_auditlog'] = false;
 
         $eventAuditLogger = new EventAuditLogger(
-            sinks: [],
+            sink: $this->createStub(SinkInterface::class),
             session: $this->session,
             config: $this->config,
             breakglassChecker: $this->breakglassChecker,


### PR DESCRIPTION
#### Short description of what this changes or resolves:
Improve compatibility of EventAuditLogger with DI/autowiring by changing from an array param to an interface. This is another step towards making EAL be able to work with DBAL+ORM as query middleware.

#### Changes proposed in this pull request:
- Add `MultiSink`
- Move "dispatch event to all sinks" from the logger itself to the MultiSink class
- Update factory to use MultiSink
- Add tests for new class
- Adjust tests to account for signature changes

#### Was an AI assistant used? Yes / No
Yes, for test cleanup