### PR TITLE
feat(release): allow multiple rows per branch in release-targets.yml

### DIFF
--- a/.github/release-targets.yml
+++ b/.github/release-targets.yml
@@ -48,6 +48,33 @@
 #     patches without affecting the published image until you bump this
 #     field to a new tag like v8_1_0_1.
 #
+#   unreleased (optional, default: false)
+#     Marks the row as "this configuration has never been used to
+#     publish anything." Consumers SKIP these rows -- they don't fan
+#     out a docker build, they don't update the dockerhub readme, they
+#     don't update demo_farm. The validator still applies all per-row
+#     checks (version-ref resolves, docker_tag aligns with version.php),
+#     so dropping the flag (or removing the field) activates a ready-
+#     to-publish entry.
+#
+#     Multi-row use case: a rel branch can carry more than one row
+#     simultaneously. When a rel branch increments its patch version
+#     into dev mode (e.g., rel-810 enters 8.1.2-dev), the existing
+#     rel-810 row retargets at the new dev (docker_tags: 8.1.2,next +
+#     openemr_version_ref: rel-810) and a SECOND row is added for the
+#     prior shipped version (docker_tags: 8.1.1 + openemr_version_ref:
+#     v8_1_1) so daily builds keep republishing the stable image while
+#     the new dev iterates. When the new dev (8.1.2) ships, the prior-
+#     release row gets dropped entirely (back to one rel branch, one
+#     row). During the dev cycle the prior-release row publishes for
+#     real -- `unreleased` is NOT set on it.
+#
+#     `unreleased: true` exists for the narrower case of adding a
+#     placeholder entry whose corresponding release isn't ready to be
+#     published from this configuration yet -- e.g., wiring up the
+#     multi-row mechanism without immediately starting to push an old
+#     version's daily images.
+#
 # Editing:
 #
 # * Branch-cut for rel-X.Y.Z: append a new row. No edit to the new
@@ -56,6 +83,11 @@
 #   openemr_version_ref (e.g., rel-810 -> v8_1_0).
 # * Rotate `latest`: edit two rows' docker_tags (drop from the outgoing
 #   row, add to the incoming row).
+# * Enter dev for a new patch: add a second row for the prior shipped
+#   version + retarget the existing row at the new dev. Drop the
+#   prior-version row when the new dev ships.
+# * Pre-stage a not-yet-publishing row: add the row with
+#   `unreleased: true`. Drop the flag (or the whole row) to activate.
 #
 # All of these are 1-line YAML edits. Tooling and bots can parse and
 # edit this file with any YAML library; no need to understand workflow
@@ -73,6 +105,17 @@
 - branch: rel-810
   docker_tags: 8.1.1,next
   openemr_version_ref: rel-810
+
+# Second rel-810 row -- placeholder for the multi-row dev pattern (see
+# `unreleased` field doc above). Wires up the second-row mechanism
+# without actually publishing 8.1.0 from this configuration. When a real
+# dev cycle on rel-810 starts (e.g., 8.1.2-dev with 8.1.1 already
+# shipped), this row gets repurposed: docker_tags -> 8.1.1,
+# openemr_version_ref -> v8_1_1, `unreleased` flag dropped.
+- branch: rel-810
+  docker_tags: 8.1.0
+  openemr_version_ref: v8_1_0
+  unreleased: true
 
 - branch: rel-800
   # 8.0.0 is the floating "current latest 8.0.0.x" pointer (always advances

--- a/.github/workflows/docker-release-orchestrator.yml
+++ b/.github/workflows/docker-release-orchestrator.yml
@@ -81,7 +81,12 @@ jobs:
             ) |
             select(
               ($exc | split(",") | map(. == $row.branch) | any) | not
-            )
+            ) |
+            # Skip rows flagged unreleased — placeholder entries that
+            # the validator still checks for ready-to-flip-live, but
+            # consumers do not process. See .github/release-targets.yml
+            # header for the multi-row-per-branch mechanism this enables.
+            select(.unreleased != true)
           ]
         ')
 

--- a/.github/workflows/docker-validate-release-targets.yml
+++ b/.github/workflows/docker-validate-release-targets.yml
@@ -7,13 +7,16 @@
 # Checks:
 #   1. The YAML parses cleanly.
 #   2. Every row has all three required fields (branch, docker_tags,
-#      openemr_version_ref).
-#   3. Every `branch` value appears at most once.
-#   4. No two rows declare the same docker_tag (which would race when both
-#      builds tried to push the same image:tag).
-#   5. Every `openemr_version_ref` resolves to a real git ref in
+#      openemr_version_ref). `unreleased` is an optional boolean.
+#   3. No two rows declare the same docker_tag (which would race when both
+#      builds tried to push the same image:tag). Multiple rows for the same
+#      `branch` ARE allowed — the multi-row mechanism enables the in-dev
+#      patch-release pattern (rel branch keeps publishing the prior stable
+#      while a new dev iterates on the same branch). See the
+#      release-targets.yml header for the full mechanism description.
+#   4. Every `openemr_version_ref` resolves to a real git ref in
 #      openemr/openemr.
-#   6. Every version-number entry in each row's docker_tags aligns with the
+#   5. Every version-number entry in each row's docker_tags aligns with the
 #      major.minor.patch from version.php at the same row's
 #      openemr_version_ref. Each tag must match either the base
 #      (X.Y.Z, when realpatch == 0) or the base.realpatch form
@@ -25,6 +28,12 @@
 #      PR merges") so a PR that coordinately bumps BOTH docker_tags and
 #      version.php validates cleanly; non-master rows use raw URL fetch
 #      against the stable git tag in openemr_version_ref.
+#
+# Rows flagged `unreleased: true` are still validated for required fields,
+# version-ref resolution, and docker_tag<->version.php alignment so they
+# stay ready-to-flip-live. Consumers (orchestrator, dockerhub readme
+# pusher, demo_farm bumper) are responsible for skipping these rows -- the
+# validator does not.
 
 name: Validate release-targets.yml
 
@@ -66,16 +75,7 @@ jobs:
           exit 1
         fi
 
-        # 3. No duplicate branches
-        DUPE_BRANCHES=$(yq -o=json -I=0 . .github/release-targets.yml | jq -r '
-          [.[].branch] | group_by(.) | map(select(length > 1) | .[0]) | .[]
-        ')
-        if [ -n "$DUPE_BRANCHES" ]; then
-          echo "::error::Duplicate branch entries (each branch must appear at most once): $DUPE_BRANCHES"
-          exit 1
-        fi
-
-        # 4. No duplicate docker_tags across rows
+        # 3. No duplicate docker_tags across rows
         DUPE_TAGS=$(yq -o=json -I=0 . .github/release-targets.yml | jq -r '
           [.[] | .docker_tags | split(",") | .[] | gsub("\\s"; "")] |
           group_by(.) | map(select(length > 1) | .[0]) | .[]

--- a/docker/dockerhub/render.sh
+++ b/docker/dockerhub/render.sh
@@ -88,7 +88,7 @@ fi
 #    `latest`. release-targets-validator already enforces that exactly one row
 #    can publish `latest`, so the head -1 is defensive only.
 # ---------------------------------------------------------------------------
-LATEST_DOCKER_TAGS=$(yq -r '.[] | select(.docker_tags | split(",") | map(. == "latest") | any) | .docker_tags' "${RELEASE_TARGETS}" | head -1)
+LATEST_DOCKER_TAGS=$(yq -r '.[] | select(.unreleased != true) | select(.docker_tags | split(",") | map(. == "latest") | any) | .docker_tags' "${RELEASE_TARGETS}" | head -1)
 if [[ -z "${LATEST_DOCKER_TAGS}" ]]; then
     echo "warning: no release-targets.yml row carries the 'latest' tag" >&2
     LATEST_VERSION="unknown"
@@ -121,7 +121,11 @@ fi
 RELEASE_BULLETS_FILE="${TMPDIR}/release_bullets"
 : > "${RELEASE_BULLETS_FILE}"
 
-ROW_COUNT=$(yq -r '. | length' "${RELEASE_TARGETS}")
+# Live row indices = rows that consumers should process. Skip rows flagged
+# `unreleased: true` (placeholder entries for the multi-row-per-branch dev
+# pattern, see .github/release-targets.yml header). Preserves the original
+# YAML index for each kept row so downstream yq lookups by index still work.
+mapfile -t LIVE_INDICES < <(yq -r 'to_entries | .[] | select(.value.unreleased != true) | .key' "${RELEASE_TARGETS}")
 
 # Bucket rows by their floating-tag role. A row carrying `latest` is the
 # current-production row (singleton by validator). A row carrying `dev` is
@@ -134,7 +138,7 @@ LATEST_IDX=""
 DEV_IDX=""
 NEXT_IDX=""
 OLDER_INDICES=()
-for ((i = 0; i < ROW_COUNT; i++)); do
+for i in "${LIVE_INDICES[@]}"; do
     ROW_TAGS=$(yq -r ".[${i}].docker_tags" "${RELEASE_TARGETS}")
     HAS_LATEST=0; HAS_DEV=0; HAS_NEXT=0
     printf '%s\n' "${ROW_TAGS}" | tr ',' '\n' | grep -qx 'latest' && HAS_LATEST=1

--- a/docker/dockerhub/tests/fixtures/release-targets.yml
+++ b/docker/dockerhub/tests/fixtures/release-targets.yml
@@ -1,5 +1,5 @@
 # Synthetic release-targets fixture for the golden-file test in
-# docker/dockerhub/tests/golden-test.sh. Designed to exercise the four
+# docker/dockerhub/tests/golden-test.sh. Designed to exercise the five
 # patterns the renderer should handle:
 #
 #   1. Master-style row: combined dev + next floating tags alongside a
@@ -9,6 +9,10 @@
 #   3. Multi-version-tag row: both base and base.realpatch in docker_tags,
 #      matching the rel-800 pattern of 8.0.0 + 8.0.0.3.
 #   4. Minimal row: a single version-number tag, no floating alias.
+#   5. Multi-row-per-branch + unreleased placeholder: second rel-fix row
+#      with unreleased: true (consumers skip it). Locks in regression
+#      coverage for the multi-row + skip mechanism independent of whether
+#      live release-targets.yml currently has an unreleased row.
 #
 # Branch names are deliberately fictional (rel-fix, rel-old, rel-ancient)
 # so the test isn't tracking the live release-targets.yml's content.
@@ -20,6 +24,14 @@
 - branch: rel-fix
   docker_tags: 8.5.0,latest
   openemr_version_ref: v8_5_0
+
+# Multi-row + unreleased placeholder for the rel-fix branch. The renderer
+# must skip this row entirely; golden.md should be byte-identical with or
+# without it. Catches regressions to the consumer-side skip logic.
+- branch: rel-fix
+  docker_tags: 8.4.0
+  openemr_version_ref: v8_4_0
+  unreleased: true
 
 - branch: rel-old
   docker_tags: 7.0.0,7.0.0.5

--- a/docker/dockerhub/tests/sanity.sh
+++ b/docker/dockerhub/tests/sanity.sh
@@ -209,11 +209,11 @@ fi
 # ---------------------------------------------------------------------------
 declare -A EXPECTED_BULLETS_PER_BRANCH
 while read -r BRANCH; do
-    EXPECTED_BULLETS_PER_BRANCH[$BRANCH]=$(( ${EXPECTED_BULLETS_PER_BRANCH[$BRANCH]:-0} + 1 ))
+    EXPECTED_BULLETS_PER_BRANCH[${BRANCH}]=$(( ${EXPECTED_BULLETS_PER_BRANCH[${BRANCH}]:-0} + 1 ))
 done < <(yq -r '.[] | select(.unreleased != true) | .branch' "${RELEASE_TARGETS}")
 MISSING_BRANCHES=()
 for BRANCH in "${!EXPECTED_BULLETS_PER_BRANCH[@]}"; do
-    EXPECTED="${EXPECTED_BULLETS_PER_BRANCH[$BRANCH]}"
+    EXPECTED="${EXPECTED_BULLETS_PER_BRANCH[${BRANCH}]}"
     OCCURRENCES=$(grep -cE "blob/${BRANCH}/docker/release/Dockerfile" "${RENDERED}" || true)
     if [[ "${OCCURRENCES}" -ne "${EXPECTED}" ]]; then
         MISSING_BRANCHES+=("${BRANCH}(${OCCURRENCES}/expected ${EXPECTED})")

--- a/docker/dockerhub/tests/sanity.sh
+++ b/docker/dockerhub/tests/sanity.sh
@@ -88,9 +88,10 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 3. Release bullet count matches release-targets.yml row count.
+# 3. Release bullet count matches release-targets.yml row count (excluding
+#    `unreleased: true` placeholder rows, which the renderer skips).
 # ---------------------------------------------------------------------------
-EXPECTED_RELEASE_ROWS=$(yq -r '. | length' "${RELEASE_TARGETS}")
+EXPECTED_RELEASE_ROWS=$(yq -r '[.[] | select(.unreleased != true)] | length' "${RELEASE_TARGETS}")
 # Release bullets link into docker/release on a branch; flex bullets link
 # into docker/flex on master. Distinguish on the link substring.
 ACTUAL_RELEASE_BULLETS=$(grep -cE '^\* `.*\[Dockerfile\]\(https://github\.com/openemr/openemr/blob/[^)]+/docker/release/Dockerfile\)' "${RENDERED}" || true)
@@ -144,7 +145,7 @@ fi
 #    `latest` in release-targets.yml. Catches the renderer using a different
 #    row's version (or picking the wrong tag from a multi-tag row).
 # ---------------------------------------------------------------------------
-EXPECTED_LATEST=$(yq -r '.[] | select(.docker_tags | split(",") | map(. == "latest") | any) | .docker_tags' "${RELEASE_TARGETS}" \
+EXPECTED_LATEST=$(yq -r '.[] | select(.unreleased != true) | select(.docker_tags | split(",") | map(. == "latest") | any) | .docker_tags' "${RELEASE_TARGETS}" \
     | head -1 | tr ',' '\n' | grep -E '^[0-9]+(\.[0-9]+)+$' | head -1)
 ACTUAL_LATEST=$(grep -oE 'Current production OpenEMR version is [0-9]+(\.[0-9]+)+' "${RENDERED}" \
     | sed 's/Current production OpenEMR version is //')
@@ -197,24 +198,32 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 10. Every release-targets.yml branch shows up exactly once in a release
-#     bullet's Dockerfile link. Catches a row silently getting skipped (which
+# 10. Every release-targets.yml branch's Dockerfile link occurs in the
+#     rendered output exactly as many times as it has non-unreleased rows.
+#     A single-row branch -> 1 bullet. A multi-row branch (e.g., rel-810
+#     during dev mode with both a new-dev row and a prior-stable row) ->
+#     N bullets. Rows flagged `unreleased: true` don't count -- the
+#     renderer skips them. Catches a row silently getting skipped (which
 #     check 3 also catches via count), AND a row getting rendered against
 #     the wrong branch (which check 3 wouldn't catch).
 # ---------------------------------------------------------------------------
+declare -A EXPECTED_BULLETS_PER_BRANCH
+while read -r BRANCH; do
+    EXPECTED_BULLETS_PER_BRANCH[$BRANCH]=$(( ${EXPECTED_BULLETS_PER_BRANCH[$BRANCH]:-0} + 1 ))
+done < <(yq -r '.[] | select(.unreleased != true) | .branch' "${RELEASE_TARGETS}")
 MISSING_BRANCHES=()
-mapfile -t TARGET_BRANCHES < <(yq -r '.[].branch' "${RELEASE_TARGETS}")
-for BRANCH in "${TARGET_BRANCHES[@]}"; do
+for BRANCH in "${!EXPECTED_BULLETS_PER_BRANCH[@]}"; do
+    EXPECTED="${EXPECTED_BULLETS_PER_BRANCH[$BRANCH]}"
     OCCURRENCES=$(grep -cE "blob/${BRANCH}/docker/release/Dockerfile" "${RENDERED}" || true)
-    if [[ "${OCCURRENCES}" -ne 1 ]]; then
-        MISSING_BRANCHES+=("${BRANCH}(${OCCURRENCES})")
+    if [[ "${OCCURRENCES}" -ne "${EXPECTED}" ]]; then
+        MISSING_BRANCHES+=("${BRANCH}(${OCCURRENCES}/expected ${EXPECTED})")
     fi
 done
 if [[ ${#MISSING_BRANCHES[@]} -eq 0 ]]; then
-    assert "every release-targets.yml branch appears in exactly one release bullet" pass
+    assert "every release-targets.yml branch appears as the expected number of release bullets" pass
 else
-    assert "every release-targets.yml branch appears in exactly one release bullet" fail \
-        "expected count != 1 for: ${MISSING_BRANCHES[*]}"
+    assert "every release-targets.yml branch appears as the expected number of release bullets" fail \
+        "branch(actual/expected) mismatch: ${MISSING_BRANCHES[*]}"
 fi
 
 # ---------------------------------------------------------------------------
@@ -227,7 +236,7 @@ RELEASE_BULLET_LINES=$(grep -nE '^\* `.*\[Dockerfile\]\(https://github\.com/open
 FIRST_RELEASE_LINE=$(printf '%s\n' "${RELEASE_BULLET_LINES}" | head -1)
 LAST_RELEASE_LINE=$(printf '%s\n' "${RELEASE_BULLET_LINES}" | tail -1)
 ORDER_ERRORS=()
-LATEST_PRESENT=$(yq -r '.[] | select(.docker_tags | split(",") | map(. == "latest") | any) | .branch' "${RELEASE_TARGETS}" | head -1)
+LATEST_PRESENT=$(yq -r '.[] | select(.unreleased != true) | select(.docker_tags | split(",") | map(. == "latest") | any) | .branch' "${RELEASE_TARGETS}" | head -1)
 if [[ -n "${LATEST_PRESENT}" ]]; then
     # Backticks below are literal markdown code-span delimiters; single
     # quotes prevent shell interpretation, not expansion.
@@ -236,7 +245,7 @@ if [[ -n "${LATEST_PRESENT}" ]]; then
         ORDER_ERRORS+=("first release bullet missing \`latest\`")
     fi
 fi
-DEV_NEXT_PRESENT=$(yq -r '.[] | select(.docker_tags | split(",") | map(. == "dev" or . == "next") | any) | .branch' "${RELEASE_TARGETS}" | head -1)
+DEV_NEXT_PRESENT=$(yq -r '.[] | select(.unreleased != true) | select(.docker_tags | split(",") | map(. == "dev" or . == "next") | any) | .branch' "${RELEASE_TARGETS}" | head -1)
 if [[ -n "${DEV_NEXT_PRESENT}" ]]; then
     # shellcheck disable=SC2016
     if ! sed -n "${LAST_RELEASE_LINE}p" "${RENDERED}" | grep -qE '`(dev|next)`'; then


### PR DESCRIPTION
## Summary

Reverses the prior "one row per branch" decision in
`.github/release-targets.yml` after realizing the mechanism is needed
for in-dev patch releases on a rel branch. Five coordinated changes
across four commits:

1. **Remove the duplicate-branch guard** in
   `docker-validate-release-targets.yml`. The duplicate-docker_tag
   guard stays (still needed — two rows pushing the same image:tag
   would race on Docker Hub).
2. **Add an optional `unreleased: true` row marker**. Consumers
   skip these rows; the validator still applies all per-row checks
   so an unreleased row stays "ready to flip live."
3. **Wire the orchestrator's skip-on-unreleased** —
   `docker-release-orchestrator.yml`'s jq filter gets a
   `select(.unreleased != true)` clause so unreleased rows don't
   fan out builds.
4. **Wire the dockerhub readme renderer's skip-on-unreleased** —
   `docker/dockerhub/render.sh` skips unreleased rows in both the
   `latest`-tag detection and the row-iteration loop. Sanity tests
   updated to filter unreleased rows from expected counts, and
   check 10 reworked to handle multi-row-per-branch (counts
   expected bullets per branch from the data instead of assuming
   1).
5. **Add a static unreleased + multi-row case to the golden-test
   fixture** for permanent regression coverage of the renderer's
   skip path, independent of whether live release-targets.yml
   currently has an unreleased row.

Plus an example production row: a second `rel-810` entry with
`unreleased: true` that wires up the mechanism without immediately
starting to push 8.1.0 daily images (we're in the middle of 8.1.1
prep).

## Why multi-row support

When a rel branch enters dev mode for a new patch (e.g., rel-810
hits 8.1.2-dev after 8.1.1 ships), daily builds still need to keep
publishing the prior stable image until the new dev actually ships.
One row per branch can't express this — the row only targets one
version at a time.

With multi-row, during 8.1.2-dev rel-810 carries:

```yaml
- branch: rel-810
  docker_tags: 8.1.2,next
  openemr_version_ref: rel-810

- branch: rel-810
  docker_tags: 8.1.1
  openemr_version_ref: v8_1_1
```

When 8.1.2 ships, the prior-version row gets dropped (back to one
row per branch).

## The example unreleased row

```yaml
- branch: rel-810
  docker_tags: 8.1.0
  openemr_version_ref: v8_1_0
  unreleased: true
```

Wires up the multi-row mechanism using the v8_1_0 release (which IS
real and IS tagged) without actually triggering daily 8.1.0 builds
right now. When a real dev cycle on rel-810 begins after 8.1.1
ships, this row will be repurposed: `docker_tags` → `8.1.1`,
`openemr_version_ref` → `v8_1_1`, `unreleased` flag dropped.

## What the validator still does on unreleased rows

The validator does NOT skip unreleased rows — they're still
checked for required fields, version-ref resolution, and
docker_tag↔version.php alignment. Skipping validation would let
invalid configurations land silently and only fail when someone
later flipped the flag.

Consumer-side skip is the right surface for "don't actually
process this row right now."

## Consumer-side skip status

Wired in this PR:
- ✅ `docker-release-orchestrator.yml` (jq filter)
- ✅ `docker/dockerhub/render.sh` + sanity tests + fixture coverage

Out of this PR (tracked as follow-up):
- ⏳ `demo_farm_openemr` bumper — relates to gap G6 (demo_farm
  derivation is fully manual today; skip-on-unreleased lands
  alongside the broader automation work)

The orchestrator skip is the most time-critical one — it decides
whether a build actually fires on the next nightly tick. The
dockerhub renderer skip is the next-most-visible (would otherwise
publish stale 8.1.0 content in the readme). The demo_farm bumper
operates on already-published artifacts, so it's less urgent.

## Test coverage durability

The unreleased marker is occasional-use — once 8.1.1 ships and the
current placeholder row gets repurposed (or removed), production
may carry zero unreleased rows for extended periods. To prevent
test coverage from going vacuous during those windows, the
fixture-row addition in commit 4 ensures the golden test
permanently exercises the skip path:

- **Sanity test (Tier 1)** runs against the live
  release-targets.yml — exercises the skip path when production has
  an unreleased row.
- **Golden test (Tier 2)** runs against
  `docker/dockerhub/tests/fixtures/release-targets.yml` which now
  always has a second `rel-fix` row with `unreleased: true`. The
  renderer must skip it for `golden.md` to match → permanent
  regression coverage independent of production state.
- The fixture's new row also exercises the multi-row-per-branch
  case (same `rel-fix` branch in two rows) that sanity check 10
  (per-branch bullet count) implicitly relies on.

## Verification (local in container)

Renderer:
- Emits 4 bullets (master, rel-810/8.1.1, rel-800, rel-704); skips
  the unreleased rel-810/8.1.0 row.

Sanity tests (`docker/dockerhub/tests/sanity.sh`):
- 12 pass, 0 fail.

Golden tests (`docker/dockerhub/tests/golden-test.sh`):
- Rendered output matches golden.md (with the new unreleased
  fixture row in place).

ShellCheck on `sanity.sh`:
- SC2250 brace-quote cleanup applied in commit 3.

## Commits

1. `35ee08c9b5` — schema (release-targets.yml field + header docs) +
   validator (drop dup-branch check, keep dup-docker_tag) +
   orchestrator skip filter + example unreleased production row
2. `a2a5f45a1d` — dockerhub render.sh + sanity.sh updates
   (addressed coderabbitai's inline review request)
3. `b5e18d8221` — SC2250 brace-quote fix for new check-10 logic in
   sanity.sh
4. `19be3aa59e` — unreleased + multi-row fixture row for
   permanent golden-test coverage

## Test plan

- [ ] CI passes (validator runs on this PR + version.php unchanged
      so docker_tag alignment passes; YAML parses; ShellCheck
      green after commit 3)
- [ ] After merge, next `docker-release-orchestrator.yml` schedule
      tick (`0 6 * * *` UTC) fans out **4 dispatches** — master,
      rel-810 (for 8.1.1), rel-800, rel-704 — same as today. The
      unreleased rel-810/8.1.0 row gets filtered out by the new jq
      select.
- [ ] No new dockerhub push fires for 8.1.0 (because the
      orchestrator skipped it, AND because if it did fire the
      renderer would skip it too).
- [ ] Subsequent dockerhub readme push: 4 release bullets, no
      8.1.0 mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)