### PR TITLE
feat(release): add release-targets-changed dispatch event + workflow

### DIFF
--- a/.github/workflows/notify-release-targets-changed.yml
+++ b/.github/workflows/notify-release-targets-changed.yml
@@ -42,6 +42,9 @@ jobs:
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: demo_farm_openemr
+        # Repository_dispatch only needs contents:write; without this the
+        # token inherits every permission the App installation has.
+        permission-contents: write
 
     - name: Checkout
       uses: actions/checkout@v7

--- a/.github/workflows/notify-release-targets-changed.yml
+++ b/.github/workflows/notify-release-targets-changed.yml
@@ -1,0 +1,67 @@
+name: Notify release-targets-changed
+
+# When .github/release-targets.yml is pushed to master, dispatch a
+# `release-targets-changed` event to the demo_farm_openemr repo so its
+# auto-derive bot reconciles immediately instead of waiting for the next
+# daily 07:00 UTC tick. Without this workflow the bot still works on its
+# daily schedule; this just removes the up-to-24h latency.
+#
+# Companion to openemr/demo_farm_openemr#141 (adds the listener side).
+
+on:
+  push:
+    branches: [master]
+    paths: [.github/release-targets.yml]
+  # Workflow-dispatch escape hatch for recovery / manual reruns.
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: notify-release-targets-changed-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch release-targets-changed to demo_farm_openemr (${{ matrix.php-version }})
+    if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr'
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        # Conductor tooling runs only on CI runners (no customer
+        # deployment), so per OCE conventions it tracks the latest
+        # stable PHP rather than the openemr application floor.
+        php-version:
+        - '8.5'
+    steps:
+    - name: Mint App token
+      id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: demo_farm_openemr
+
+    - name: Checkout
+      uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+
+    - name: Setup PHP and Composer
+      uses: ./.github/actions/setup-php-composer
+      with:
+        php-version: ${{ matrix.php-version }}
+
+    - name: Dispatch release-targets-changed to demo_farm_openemr
+      env:
+        RELEASE_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        REPO: ${{ github.repository }}
+        COMMIT_SHA: ${{ github.sha }}
+      run: |
+        php tools/release/bin/dispatch.php \
+          --event=release-targets-changed \
+          --repo="${REPO}" \
+          --sha="${COMMIT_SHA}" \
+          --actor='openemr-release-bot' \
+          --target-repos=openemr/demo_farm_openemr

--- a/tests/Tests/Isolated/Release/Contracts/DispatchSchemaTest.php
+++ b/tests/Tests/Isolated/Release/Contracts/DispatchSchemaTest.php
@@ -28,6 +28,8 @@ final class DispatchSchemaTest extends TestCase
 
     /**
      * @return iterable<string, array{0: string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
     public static function goodFixtures(): iterable
     {
@@ -41,6 +43,8 @@ final class DispatchSchemaTest extends TestCase
 
     /**
      * @return iterable<string, array{0: string, 1: string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
     public static function badFixtures(): iterable
     {

--- a/tests/Tests/Isolated/Release/Contracts/DispatchSchemaTest.php
+++ b/tests/Tests/Isolated/Release/Contracts/DispatchSchemaTest.php
@@ -2,7 +2,7 @@
 
 /**
  * Validate the vendored dispatch.schema.json against good and bad fixtures
- * for each of the four cross-repo repository_dispatch events. The schema is
+ * for each cross-repo repository_dispatch event. The schema is
  * authored canonically in openemr/openemr-devops; this test asserts the
  * vendored copy in this repo behaves identically.
  *
@@ -31,11 +31,12 @@ final class DispatchSchemaTest extends TestCase
      */
     public static function goodFixtures(): iterable
     {
-        yield 'openemr-rel-cut'       => ['good-rel-cut.json'];
-        yield 'openemr-rel-update'    => ['good-rel-update.json'];
-        yield 'openemr-tag'           => ['good-tag.json'];
-        yield 'openemr-tag (test)'    => ['good-tag-test.json'];
-        yield 'openemr-docs-binaries' => ['good-docs-binaries.json'];
+        yield 'openemr-rel-cut'          => ['good-rel-cut.json'];
+        yield 'openemr-rel-update'       => ['good-rel-update.json'];
+        yield 'openemr-tag'              => ['good-tag.json'];
+        yield 'openemr-tag (test)'       => ['good-tag-test.json'];
+        yield 'openemr-docs-binaries'    => ['good-docs-binaries.json'];
+        yield 'release-targets-changed'  => ['good-release-targets-changed.json'];
     }
 
     /**
@@ -43,10 +44,11 @@ final class DispatchSchemaTest extends TestCase
      */
     public static function badFixtures(): iterable
     {
-        yield 'openemr-rel-cut missing prev_release'    => ['bad-rel-cut.json', 'prev_release'];
-        yield 'openemr-rel-update non-hex sha'          => ['bad-rel-update.json', 'sha'];
-        yield 'openemr-tag with dotted version'         => ['bad-tag.json', 'tag'];
-        yield 'openemr-docs-binaries empty files array' => ['bad-docs-binaries.json', 'files'];
+        yield 'openemr-rel-cut missing prev_release'        => ['bad-rel-cut.json', 'prev_release'];
+        yield 'openemr-rel-update non-hex sha'              => ['bad-rel-update.json', 'sha'];
+        yield 'openemr-tag with dotted version'             => ['bad-tag.json', 'tag'];
+        yield 'openemr-docs-binaries empty files array'     => ['bad-docs-binaries.json', 'files'];
+        yield 'release-targets-changed with stray data key' => ['bad-release-targets-changed.json', 'stray_field'];
     }
 
     #[DataProvider('goodFixtures')]

--- a/tests/Tests/Isolated/Release/DispatchDataBuilderTest.php
+++ b/tests/Tests/Isolated/Release/DispatchDataBuilderTest.php
@@ -48,6 +48,15 @@ final class DispatchDataBuilderTest extends TestCase
         );
     }
 
+    public function testReleaseTargetsChangedBuildsEmptyData(): void
+    {
+        $builder = new DispatchDataBuilder($this->reader([]));
+        self::assertSame(
+            [],
+            $builder->build(DispatchRequest::EVENT_RELEASE_TARGETS_CHANGED),
+        );
+    }
+
     public function testUnknownEventThrows(): void
     {
         $builder = new DispatchDataBuilder($this->reader([]));

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/bad-release-targets-changed.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/bad-release-targets-changed.json
@@ -1,0 +1,10 @@
+{
+  "event": "release-targets-changed",
+  "repo": "openemr/openemr",
+  "sha": "cafebabecafebabecafebabecafebabecafebabe",
+  "actor": "openemr-release-bot",
+  "dispatched_at": "2026-04-29T13:30:00Z",
+  "data": {
+    "stray_field": "release-targets-changed carries no event-specific data; additionalProperties:false rejects this"
+  }
+}

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-release-targets-changed.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-release-targets-changed.json
@@ -1,0 +1,8 @@
+{
+  "event": "release-targets-changed",
+  "repo": "openemr/openemr",
+  "sha": "cafebabecafebabecafebabecafebabecafebabe",
+  "actor": "openemr-release-bot",
+  "dispatched_at": "2026-04-29T13:30:00Z",
+  "data": {}
+}

--- a/tools/release/contracts/dispatch.schema.json
+++ b/tools/release/contracts/dispatch.schema.json
@@ -15,13 +15,14 @@
   "additionalProperties": false,
   "properties": {
     "event": {
-      "description": "Dispatch event name. Conductor emits the first three; website-openemr emits openemr-docs-binaries to website-openemr-files.",
+      "description": "Dispatch event name. Conductor emits the first three (rel-cut/rel-update/tag) plus release-targets-changed; website-openemr emits openemr-docs-binaries to website-openemr-files.",
       "type": "string",
       "enum": [
         "openemr-rel-cut",
         "openemr-rel-update",
         "openemr-tag",
-        "openemr-docs-binaries"
+        "openemr-docs-binaries",
+        "release-targets-changed"
       ]
     },
     "repo": {
@@ -86,6 +87,16 @@
         },
         "data": {
           "$ref": "#/definitions/docsBinariesData"
+        }
+      }
+    },
+    {
+      "properties": {
+        "event": {
+          "const": "release-targets-changed"
+        },
+        "data": {
+          "$ref": "#/definitions/releaseTargetsChangedData"
         }
       }
     }
@@ -190,6 +201,12 @@
           }
         }
       }
+    },
+    "releaseTargetsChangedData": {
+      "description": "Notification that openemr/openemr's .github/release-targets.yml was updated on master. Carries no event-specific fields; the envelope's sha/actor/dispatched_at fully identify the change. Consumers (e.g. demo_farm_openemr's auto-derive bot) re-read the file directly from openemr/openemr@master.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {}
     }
   }
 }

--- a/tools/release/src/DispatchDataBuilder.php
+++ b/tools/release/src/DispatchDataBuilder.php
@@ -40,6 +40,7 @@ final readonly class DispatchDataBuilder
                 'branch' => $this->opts->string('branch'),
                 'version' => $this->opts->string('release-version'),
             ],
+            DispatchRequest::EVENT_RELEASE_TARGETS_CHANGED => [],
             DispatchRequest::EVENT_PROBE => [
                 'note' => 'release-permissions-probe; ignored by consumers',
             ],

--- a/tools/release/src/DispatchRequest.php
+++ b/tools/release/src/DispatchRequest.php
@@ -24,6 +24,7 @@ final readonly class DispatchRequest
     public const EVENT_REL_UPDATE = 'openemr-rel-update';
     public const EVENT_TAG = 'openemr-tag';
     public const EVENT_DOCS_BINARIES = 'openemr-docs-binaries';
+    public const EVENT_RELEASE_TARGETS_CHANGED = 'release-targets-changed';
     public const EVENT_PROBE = 'release-permissions-probe';
 
     /**


### PR DESCRIPTION
## What

Adds a fifth cross-repo dispatch event, `release-targets-changed`, plus a new workflow that emits it:

- **Schema** (`tools/release/contracts/dispatch.schema.json`):
  - `release-targets-changed` added to the `event` enum
  - New `releaseTargetsChangedData` definition with `additionalProperties: false` and no properties (the envelope's `sha`/`actor`/`dispatched_at` fully identify the change; consumers re-read release-targets.yml directly from `openemr/openemr@master`)
  - Matching `oneOf` arm
  - `event` field description updated
- **PHP**:
  - `DispatchRequest::EVENT_RELEASE_TARGETS_CHANGED`
  - `DispatchDataBuilder` match arm returning `[]`
- **Workflow** (`.github/workflows/notify-release-targets-changed.yml`):
  - Triggered by push to `master` touching `.github/release-targets.yml`, plus manual `workflow_dispatch`
  - Mints the release App token scoped to `demo_farm_openemr` only
  - Reuses `./.github/actions/setup-php-composer` on PHP 8.5 (conductor-tooling convention)
  - Calls `tools/release/bin/dispatch.php --event=release-targets-changed --target-repos=openemr/demo_farm_openemr`
- **Tests**:
  - `DispatchDataBuilderTest::testReleaseTargetsChangedBuildsEmptyData`
  - `DispatchSchemaTest` good + bad fixtures (bad fixture exercises `additionalProperties: false` via a stray data key)

## Why

To drive openemr/demo_farm_openemr's auto-derive bot immediately when `.github/release-targets.yml` changes, instead of waiting for its daily 07:00 UTC tick. Removes up to ~24h of latency between editing release-targets.yml and demo_farm reconciling. The bot's existing daily-schedule safety net is unaffected — this is purely additive.

## Companion PR

openemr/demo_farm_openemr#141 adds the `repository_dispatch: types: [release-targets-changed]` listener on the bot side. That PR works on its own (daily schedule still ticks). This PR is what makes the dispatch arrive.

## Scope decisions

- **`Dispatcher::DEFAULT_TARGET_REPOS` left untouched** — the new workflow scopes via explicit `--target-repos` so openemr-devops and website-openemr don't receive an event they don't consume.
- **Existing `openemr-tag` dispatch in `release-prep.yml` left intact** — openemr-devops's `release-announcements.yml` still consumes it.

## Vendor sync follow-up

openemr-devops carries a vendored copy of `dispatch.schema.json` validated by `tools/release/bin/check-vendored.php` in its CI. That check will fail on the next devops PR after this lands; a small sync PR there will resolve it. **Not blocking for this PR** — demo_farm_openemr consumes the dispatch directly via the workflow listener and does no schema validation itself, so the bot works end-to-end the moment both PRs are merged regardless of when the devops vendor copy catches up.

## Test plan

- [ ] CI passes (isolated release tests run all schema fixtures + new DispatchDataBuilder case; actionlint passes on the new workflow)
- [ ] After merge: editing `.github/release-targets.yml` on master fires `notify-release-targets-changed`, which dispatches `release-targets-changed` to demo_farm_openemr; the demo_farm bot's derive-ip-map run starts within seconds rather than at the next 07:00 UTC tick
- [ ] `openemr-tag` dispatch from `release-prep.yml` continues to fire normally on the next release-prep merge
- [ ] Open the follow-up vendor-sync PR against openemr-devops once that repo's CI surfaces the drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)