### PR TITLE
ci(phpstan): authenticate Composer with GITHUB_TOKEN to dodge API throttle

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -20,6 +20,13 @@ concurrency:
 jobs:
   phpstan:
     runs-on: ubuntu-24.04
+    env:
+      # Authenticate Composer with the workflow token so its GitHub API
+      # calls (e.g. resolving commit refs for the openemr/wkhtmltopdf-openemr
+      # vcs dep) get the 5000/hr authenticated rate limit instead of the
+      # ~60/hr anonymous one. Without this the "Remove Rector" step
+      # intermittently HTTP-429s.
+      COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ secrets.GITHUB_TOKEN }}"}}'
     strategy:
       matrix:
         # Single-element matrix provides named variable and job title


### PR DESCRIPTION
## Summary

The PHPStan workflow's \`Remove Rector\` step (\`composer remove --dev --optimize-autoloader rector/rector\`) intermittently fails with HTTP 429 from GitHub's commits API when Composer resolves the \`openemr/wkhtmltopdf-openemr\` vcs dependency. The whole job fails with no actual PHPStan finding — pure CI flake.

Setting \`COMPOSER_AUTH\` with \`secrets.GITHUB_TOKEN\` authenticates Composer's GitHub API calls, raising the rate limit from ~60/hr (anonymous) to 5000/hr (authenticated).

## Failure pattern

Example from PR #12657:
\`\`\`
phpstan (8.5)	Remove Rector	[error] The "https://api.github.com/repos/openemr/wkhtmltopdf-openemr/commits/06e3830d..." file could not be downloaded (HTTP/2 429):
{"message":"This endpoint is temporarily being throttled. Please try again later..."}
In CurlDownloader.php line 674
##[error]Process completed with exit code 100.
\`\`\`

Reproduced across multiple runs and multiple PRs.

## Scope

\`env:\` set at job level (under \`runs-on:\`) rather than the single \`Remove Rector\` step. \`phpstan.yml\` also runs \`composer phpstan-baseline\` later in the job; covering both at job level avoids re-adding the env on each new Composer step.

\`secrets.GITHUB_TOKEN\` is the workflow-scoped token — auto-provided to every workflow run, automatically scoped to the PR's permissions, no manual secret management.

## Test plan

- [ ] CI passes (including phpstan job itself)
- [ ] Future PRs no longer see intermittent \`Remove Rector\` HTTP 429 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)