### PR TITLE
ci(phpstan): drop vestigial Remove Rector step

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -20,13 +20,6 @@ concurrency:
 jobs:
   phpstan:
     runs-on: ubuntu-24.04
-    env:
-      # Authenticate Composer with the workflow token so its GitHub API
-      # calls (e.g. resolving commit refs for the openemr/wkhtmltopdf-openemr
-      # vcs dep) get the 5000/hr authenticated rate limit instead of the
-      # ~60/hr anonymous one. Without this the "Remove Rector" step
-      # intermittently HTTP-429s.
-      COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ secrets.GITHUB_TOKEN }}"}}'
     strategy:
       matrix:
         # Single-element matrix provides named variable and job title
@@ -38,10 +31,6 @@ jobs:
       uses: ./.github/actions/setup-php-composer
       with:
         php-version: ${{ matrix.php-version }}
-    # Hack: temporarily uninstall rector, which interferes with PHPStan
-    # (it bundles some type-incomplete polyfills which can throw off results)
-    - name: Remove Rector
-      run: composer remove --dev --optimize-autoloader rector/rector
     # Resolve the installed phpstan version so the cache key invalidates on
     # tool bumps but survives unrelated dependency changes. Hashing the whole
     # composer.lock over-invalidates; fallback restore would otherwise serve


### PR DESCRIPTION
## Summary

Drops the \`Remove Rector\` step from the PHPStan workflow. Empirically verified: phpstan output is byte-identical with and without rector installed on current versions. The hack the workflow comment described ("rector bundles type-incomplete polyfills which can throw off results") no longer applies.

## Verification

Ran phpstan locally in the openemr docker stack — twice. With rector present and with \`vendor/rector\` removed + autoloader regenerated.

\`\`\`
Run 1 (rector present): [OK] No errors  — 53s
Run 2 (rector absent):  [OK] No errors  — 50s
diff: (empty)
\`\`\`

## Side benefit: eliminates the persistent phpstan flake

The \`Remove Rector\` step's \`composer remove --dev --optimize-autoloader rector/rector\` was the **only \`composer remove\` operation** in any openemr workflow. \`composer remove\` triggers full dep resolution which re-probes every vcs repository in \`repositories:\` — most notably \`openemr/wkhtmltopdf-openemr\` (a 7-year-stable vcs repo nothing actually requires). GitHub's secondary rate limit on the commits endpoint had been firing on this probe all day, failing phpstan with HTTP 429.

Every other workflow does \`composer install --no-dev\` which reads composer.lock and skips probes entirely. That's why every other workflow passed while phpstan kept failing.

Removing this step eliminates the only vcs-probe code path in CI. Faster too — skips the composer remove + autoloader regen.

## Also drops COMPOSER_AUTH env (from #12658)

The COMPOSER_AUTH env added in #12658 was a band-aid for this 429. With no composer operation probing vcs repos, the env is now unnecessary.

## Test plan

- [ ] CI passes (phpstan job runs successfully without the remove step)
- [ ] Spot-check phpstan completes in similar/faster time than today

🤖 Generated with [Claude Code](https://claude.com/claude-code)