### PR TITLE
ci(release): drop demo_farm from openemr-tag dispatch target-repos

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -253,8 +253,13 @@ jobs:
         # Scope the installation token to this repo plus the dispatch
         # targets, otherwise repository_dispatch to the consumer repos
         # returns 403 "Resource not accessible by integration".
+        # demo_farm_openemr dropped (was: ...,demo_farm_openemr) because
+        # the only dispatch in this `finalize` job is openemr-tag, and
+        # demo_farm no longer consumes it (demo_farm_openemr#141 retired
+        # bump-tag.yml; the auto-derive bot subscribes to
+        # release-targets-changed instead).
         owner: ${{ github.repository_owner }}
-        repositories: openemr,openemr-devops,website-openemr,demo_farm_openemr
+        repositories: openemr,openemr-devops,website-openemr
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -333,8 +333,14 @@ jobs:
         MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         TAG_NAME: ${{ steps.tag.outputs.tag-name }}
       run: |
+        # Demo_farm_openemr no longer consumes openemr-tag: its bump-tag.yml
+        # was retired in demo_farm_openemr#141 in favor of the auto-derive
+        # bot, which subscribes to release-targets-changed instead. Explicit
+        # --target-repos to drop demo_farm from the default list so the
+        # dispatch doesn't fire into a void.
         php tools/release/bin/dispatch.php \
           --event=openemr-tag \
+          --target-repos=openemr/openemr-devops,openemr/website-openemr \
           --sha="${MERGE_SHA}" \
           --actor='openemr-release-bot' \
           --branch="${REL_BRANCH}" \


### PR DESCRIPTION
## Summary

demo_farm_openemr no longer consumes \`openemr-tag\` after PR demo_farm_openemr#141 (which retired \`bump-tag.yml\` in favor of the auto-derive bot subscribing to \`release-targets-changed\`). The dispatch was firing to a void. This PR drops demo_farm from the target-repos list so the dispatch only fires to the actual consumers (openemr-devops + website-openemr).

## What changes

\`release-prep.yml\`'s \"Dispatch openemr-tag to consumers\" step gains an explicit \`--target-repos=openemr/openemr-devops,openemr/website-openemr\` flag, overriding the default which would include demo_farm. Added an inline comment pointing at demo_farm_openemr#141 for the history.

## Why not change the default?

\`Dispatcher::DEFAULT_TARGET_REPOS\` still includes demo_farm because future events (or workflow_dispatch test runs against \`--event=release-permissions-probe\` etc.) may legitimately target it. The exclusion is event-specific — only \`openemr-tag\` no longer has a demo_farm consumer.

## Test plan

- [ ] CI passes
- [ ] Next \`openemr-tag\` dispatch (any release) fires only to devops + website-openemr per the action log
- [ ] No regression on devops's \`build-release-on-tag.yml\` / \`release-announcements.yml\` (both still consume \`openemr-tag\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)