### PR TITLE
refactor(session): Adopt DTO for settings & tidy cookie path

### DIFF
--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -3758,11 +3758,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../src/Common/Session/SessionConfigurationBuilder.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../src/Common/Session/SessionTracker.php',
 ];

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -4387,11 +4387,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Http/HttpRestRouteHandler.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Http\\\\HttpSessionFactory\\:\\:getSessionHandlerInterface\\(\\) has parameter \\$settings with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Http/HttpSessionFactory.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Common\\\\Http\\\\Psr17Factory\\:\\:createServerRequest\\(\\) has parameter \\$serverParams with no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Http/Psr17Factory.php',

--- a/src/Common/Http/HttpSessionFactory.php
+++ b/src/Common/Http/HttpSessionFactory.php
@@ -4,6 +4,7 @@ namespace OpenEMR\Common\Http;
 
 use OpenEMR\Common\Logging\SystemLoggerAwareTrait;
 use OpenEMR\Common\Session\Predis\SentinelUtil;
+use OpenEMR\Common\Session\SessionConfiguration;
 use OpenEMR\Common\Session\SessionConfigurationBuilder;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\Storage\ReadAndCloseNativeSessionStorage;
@@ -61,10 +62,8 @@ class HttpSessionFactory implements SessionFactoryInterface
     {
         return $this->lastCreatedStorage;
     }
-    /**
-     * @return array<string, mixed>
-     */
-    private function getSessionSettings(): array
+
+    private function getSessionSettings(): SessionConfiguration
     {
         return match ($this->sessionType) {
             self::SESSION_TYPE_OAUTH => SessionConfigurationBuilder::forOAuth($this->web_root),
@@ -84,13 +83,14 @@ class HttpSessionFactory implements SessionFactoryInterface
             default => SessionUtil::CORE_SESSION_ID,
         };
     }
-    private function getSessionHandlerInterface(array $settings): ?\SessionHandlerInterface
+
+    private function getSessionHandlerInterface(SessionConfiguration $settings): ?\SessionHandlerInterface
     {
         $sessionHandler = null;
         if (!empty(getenv('SESSION_STORAGE_MODE', true))  && getenv('SESSION_STORAGE_MODE', true) === "predis-sentinel") {
             $this->getSystemLogger()->debug("SessionUtil: using predis sentinel session storage mode");
             try {
-                $sessionHandler = (new SentinelUtil())->configure($settings['gc_maxlifetime']);
+                $sessionHandler = (new SentinelUtil())->configure($settings->gcMaxLifetime);
             } catch (\Throwable $e) {
                 // we want to log the error and throw a runtime exception, since we don't want to fail silently when sessions are not working
                 $this->getSystemLogger()->error(

--- a/src/Common/Session/SessionConfiguration.php
+++ b/src/Common/Session/SessionConfiguration.php
@@ -27,4 +27,29 @@ final readonly class SessionConfiguration
         public bool $readAndClose = false,
     ) {
     }
+
+    /**
+     * Returns an array of session configuration directives, without the
+     * `session.` prefix.
+     *
+     * @see https://www.php.net/manual/en/session.configuration.php
+     * @see https://php.net/session_start
+     *
+     * @return array<string, mixed>
+     */
+    public function toSessionStartOptions(): array
+    {
+        return [
+            'name' => $this->name,
+            'cookie_path' => $this->cookiePath,
+            'gc_maxlifetime' => $this->gcMaxLifetime,
+            'use_strict_mode' => $this->useStrictMode,
+            'use_cookies' => $this->useCookies,
+            'use_only_cookies' => $this->useOnlyCookies,
+            'cookie_samesite' => $this->cookieSameSite,
+            'cookie_secure' => $this->cookieSecure,
+            'cooke_httponly' => $this->cookieHttpOnly,
+            'read_and_close' => $this->readAndClose,
+        ];
+    }
 }

--- a/src/Common/Session/SessionConfiguration.php
+++ b/src/Common/Session/SessionConfiguration.php
@@ -48,7 +48,7 @@ final readonly class SessionConfiguration
             'use_only_cookies' => $this->useOnlyCookies,
             'cookie_samesite' => $this->cookieSameSite,
             'cookie_secure' => $this->cookieSecure,
-            'cooke_httponly' => $this->cookieHttpOnly,
+            'cookie_httponly' => $this->cookieHttpOnly,
             'read_and_close' => $this->readAndClose,
         ];
     }

--- a/src/Common/Session/SessionConfiguration.php
+++ b/src/Common/Session/SessionConfiguration.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Session;
+
+final readonly class SessionConfiguration
+{
+    public function __construct(
+        public string $name,
+        public string $cookiePath,
+        public int $gcMaxLifetime = SessionUtil::DEFAULT_GC_MAXLIFETIME,
+        public bool $useStrictMode = true,
+        public bool $useCookies = true,
+        public bool $useOnlyCookies = true,
+        public string $cookieSameSite = 'Strict',
+        public bool $cookieSecure = false,
+        public bool $cookieHttpOnly = true,
+        public bool $readAndClose = false,
+    ) {
+    }
+}

--- a/src/Common/Session/SessionConfigurationBuilder.php
+++ b/src/Common/Session/SessionConfigurationBuilder.php
@@ -1,131 +1,60 @@
 <?php
 
-/*
- * SessionConfigurationBuilder.php
- * @package openemr
+/**
+ * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+declare(strict_types=1);
 
 namespace OpenEMR\Common\Session;
 
 class SessionConfigurationBuilder
 {
-    /** @var array<string, mixed> */
-    private array $config = [];
-
-    public function __construct()
+    public static function forCore(string $webRoot = '', bool $readOnly = true): SessionConfiguration
     {
-        // Set default values that are common across all session types
-        $this->config = [
-            'gc_maxlifetime' => SessionUtil::DEFAULT_GC_MAXLIFETIME,
-            'use_strict_mode' => true,
-            'use_cookies' => true,
-            'use_only_cookies' => true,
-            'cookie_samesite' => 'Strict',
-            'cookie_secure' => false,
-            'cookie_httponly' => true
-        ];
-
-        // Add PHP version-specific settings
-        if (version_compare(phpversion(), '8.4.0', '<')) {
-            $this->config['sid_bits_per_character'] = 6;
-            $this->config['sid_length'] = 48;
-        }
+        return new SessionConfiguration(
+            name: SessionUtil::CORE_SESSION_ID,
+            cookiePath: $webRoot . '/',
+            cookieHttpOnly: false,
+            readAndClose: $readOnly,
+        );
     }
 
-    public function setName(string $name): self
+    public static function forOAuth(string $webRoot = ''): SessionConfiguration
     {
-        $this->config['name'] = $name;
-        return $this;
+        return new SessionConfiguration(
+            name: SessionUtil::OAUTH_SESSION_ID,
+            cookiePath: $webRoot . SessionUtil::OAUTH_WEBROOT,
+            cookieSameSite: 'None',
+            cookieSecure: true,
+        );
     }
 
-    public function setCookiePath(string $path): self
+    public static function forApi(string $webRoot = ''): SessionConfiguration
     {
-        $this->config['cookie_path'] = $path;
-        return $this;
+        return new SessionConfiguration(
+            name: SessionUtil::API_SESSION_ID,
+            cookiePath: $webRoot . SessionUtil::API_WEBROOT,
+            cookieSecure: true,
+        );
     }
 
-    public function setCookieSameSite(string $sameSite): self
+    public static function forPortal(string $webRoot = '', bool $readOnly = true): SessionConfiguration
     {
-        $this->config['cookie_samesite'] = $sameSite;
-        return $this;
+        return new SessionConfiguration(
+            name: SessionUtil::PORTAL_SESSION_ID,
+            cookiePath: $webRoot . '/',
+            readAndClose: $readOnly,
+        );
     }
 
-    public function setCookieSecure(bool $secure): self
+    public static function forSetup(): SessionConfiguration
     {
-        $this->config['cookie_secure'] = $secure;
-        return $this;
-    }
-
-    public function setCookieHttpOnly(bool $httpOnly): self
-    {
-        $this->config['cookie_httponly'] = $httpOnly;
-        return $this;
-    }
-
-    public function setReadOnly(bool $readOnly): self
-    {
-        $this->config['read_and_close'] = $readOnly;
-        return $this;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function build(): array
-    {
-        return $this->config;
-    }
-
-    // Preset configurations for different session types
-    /** @return array<string, mixed> */
-    public static function forCore(string $webRoot = '', bool $readOnly = true): array
-    {
-        return (new self())
-            ->setName(SessionUtil::CORE_SESSION_ID)
-            ->setCookiePath($webRoot . '/')
-            ->setCookieHttpOnly(false)
-            ->setReadOnly($readOnly)
-            ->build();
-    }
-
-    /** @return array<string, mixed> */
-    public static function forOAuth(string $webRoot = ''): array
-    {
-        return (new self())
-            ->setName(SessionUtil::OAUTH_SESSION_ID)
-            ->setCookiePath($webRoot . SessionUtil::OAUTH_WEBROOT)
-            ->setCookieSameSite('None')
-            ->setCookieSecure(true)
-            ->build();
-    }
-
-    /** @return array<string, mixed> */
-    public static function forApi(string $webRoot = ''): array
-    {
-        return (new self())
-            ->setName(SessionUtil::API_SESSION_ID)
-            ->setCookiePath($webRoot . SessionUtil::API_WEBROOT)
-            ->setCookieSecure(true)
-            ->build();
-    }
-
-    /** @return array<string, mixed> */
-    public static function forPortal(string $webRoot = '', bool $readOnly = true): array
-    {
-        return (new self())
-            ->setName(SessionUtil::PORTAL_SESSION_ID)
-            ->setCookiePath($webRoot . '/')
-            ->setReadOnly($readOnly)
-            ->build();
-    }
-
-    /** @return array<string, mixed> */
-    public static function forSetup(): array
-    {
-        return (new self())
-            ->setName(SessionUtil::SETUP_SESSION_ID)
-            ->build();
+        return new SessionConfiguration(
+            name: SessionUtil::SETUP_SESSION_ID,
+            cookiePath: '/',
+        );
     }
 }

--- a/src/Common/Session/SessionConfigurationBuilder.php
+++ b/src/Common/Session/SessionConfigurationBuilder.php
@@ -84,7 +84,7 @@ class SessionConfigurationBuilder
     {
         return (new self())
             ->setName(SessionUtil::CORE_SESSION_ID)
-            ->setCookiePath((!empty($webRoot)) ? $webRoot . '/' : '/')
+            ->setCookiePath($webRoot . '/')
             ->setCookieHttpOnly(false)
             ->setReadOnly($readOnly)
             ->build();
@@ -95,7 +95,7 @@ class SessionConfigurationBuilder
     {
         return (new self())
             ->setName(SessionUtil::OAUTH_SESSION_ID)
-            ->setCookiePath((!empty($webRoot)) ? $webRoot . SessionUtil::OAUTH_WEBROOT : SessionUtil::OAUTH_WEBROOT)
+            ->setCookiePath($webRoot . SessionUtil::OAUTH_WEBROOT)
             ->setCookieSameSite('None')
             ->setCookieSecure(true)
             ->build();
@@ -106,7 +106,7 @@ class SessionConfigurationBuilder
     {
         return (new self())
             ->setName(SessionUtil::API_SESSION_ID)
-            ->setCookiePath((!empty($webRoot)) ? $webRoot . SessionUtil::API_WEBROOT : SessionUtil::API_WEBROOT)
+            ->setCookiePath($webRoot . SessionUtil::API_WEBROOT)
             ->setCookieSecure(true)
             ->build();
     }
@@ -116,7 +116,7 @@ class SessionConfigurationBuilder
     {
         return (new self())
             ->setName(SessionUtil::PORTAL_SESSION_ID)
-            ->setCookiePath($webRoot !== '' ? $webRoot . '/' : '/')
+            ->setCookiePath($webRoot . '/')
             ->setReadOnly($readOnly)
             ->build();
     }

--- a/src/Common/Session/SessionUtil.php
+++ b/src/Common/Session/SessionUtil.php
@@ -214,7 +214,7 @@ class SessionUtil
     {
         $settings = SessionConfigurationBuilder::forSetup();
         $handler = self::getSessionHandler();
-        $storage = new NativeSessionStorage($settings, $handler);
+        $storage = new NativeSessionStorage($settings->toSessionStartOptions(), $handler);
         $session = new Session($storage);
         $session->start();
         SessionWrapperFactory::getInstance()->setActiveSession($session);

--- a/src/Common/Session/Storage/ReadAndCloseNativeSessionStorage.php
+++ b/src/Common/Session/Storage/ReadAndCloseNativeSessionStorage.php
@@ -37,15 +37,15 @@ class ReadAndCloseNativeSessionStorage extends NativeSessionStorage
 
     private bool $wasOriginallyReadAndClose = false;
 
-    /**
-     * @param AbstractProxy|\SessionHandlerInterface|null $handler
-     */
-    public function __construct(SessionConfiguration $options, AbstractProxy|\SessionHandlerInterface|null $handler = null, ?MetadataBag $metaBag = null)
-    {
+    public function __construct(
+        SessionConfiguration $options,
+        AbstractProxy|\SessionHandlerInterface|null $handler = null,
+        ?MetadataBag $metaBag = null,
+    ) {
         // Extract read_and_close before parent sees it (parent would silently drop it)
         $this->readAndClose = $options->readAndClose;
 
-        parent::__construct($options, $handler, $metaBag);
+        parent::__construct($options->toSessionStartOptions(), $handler, $metaBag);
     }
 
     /**

--- a/src/Common/Session/Storage/ReadAndCloseNativeSessionStorage.php
+++ b/src/Common/Session/Storage/ReadAndCloseNativeSessionStorage.php
@@ -24,6 +24,7 @@
 namespace OpenEMR\Common\Session\Storage;
 
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Session\SessionConfiguration;
 use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy;
@@ -37,16 +38,12 @@ class ReadAndCloseNativeSessionStorage extends NativeSessionStorage
     private bool $wasOriginallyReadAndClose = false;
 
     /**
-     * @param array<string, mixed> $options Session configuration options (may include 'read_and_close')
      * @param AbstractProxy|\SessionHandlerInterface|null $handler
      */
-    public function __construct(array $options = [], AbstractProxy|\SessionHandlerInterface|null $handler = null, ?MetadataBag $metaBag = null)
+    public function __construct(SessionConfiguration $options, AbstractProxy|\SessionHandlerInterface|null $handler = null, ?MetadataBag $metaBag = null)
     {
         // Extract read_and_close before parent sees it (parent would silently drop it)
-        if (isset($options['read_and_close'])) {
-            $this->readAndClose = (bool) $options['read_and_close'];
-            unset($options['read_and_close']);
-        }
+        $this->readAndClose = $options->readAndClose;
 
         parent::__construct($options, $handler, $metaBag);
     }

--- a/tests/Tests/Isolated/Common/Session/ReadAndCloseNativeSessionStorageTest.php
+++ b/tests/Tests/Isolated/Common/Session/ReadAndCloseNativeSessionStorageTest.php
@@ -19,6 +19,7 @@
 
 namespace OpenEMR\Tests\Isolated\Common\Session;
 
+use OpenEMR\Common\Session\SessionConfiguration;
 use OpenEMR\Common\Session\Storage\ReadAndCloseNativeSessionStorage;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
@@ -59,10 +60,11 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testConstructorExtractsReadAndClose(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSession',
-            'read_and_close' => true,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSession',
+            cookiePath: '/',
+            readAndClose: true,
+        ));
 
         // The storage should have extracted read_and_close.
         // We verify by checking that isClosedByReadAndClose is false before start
@@ -77,9 +79,10 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testConstructorWithoutReadAndClose(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSession',
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSession',
+            cookiePath: '/',
+        ));
 
         $this->assertFalse(
             $storage->isClosedByReadAndClose(),
@@ -96,12 +99,13 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testStartWithReadAndCloseOpensAndClosesSession(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestReadClose',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestReadClose',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
 
         $result = $storage->start();
 
@@ -124,11 +128,12 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testStartWithoutReadAndCloseDelegatesToParent(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestNormal',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestNormal',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
 
         $result = $storage->start();
 
@@ -151,12 +156,13 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testStartReturnsTrueIfAlreadyStarted(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestDouble',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestDouble',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
 
         $storage->start();
         $result = $storage->start(); // second call
@@ -170,11 +176,12 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
     public function testSessionDataAccessibleAfterReadAndCloseStart(): void
     {
         // First, create a session with some data
-        $setupStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestDataAccess',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $setupStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestDataAccess',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $setupSession = new Session($setupStorage, new AttributeBag('TestDataAccess'));
         $setupSession->start();
         $setupSession->set('test_key', 'hello_world');
@@ -183,12 +190,13 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
 
         // Now open the same session with read_and_close
         session_id($sessionId);
-        $readStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestDataAccess',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $readStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestDataAccess',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $readSession = new Session($readStorage, new AttributeBag('TestDataAccess'));
         $readSession->start();
 
@@ -208,12 +216,13 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testSaveIsNoOpForReadAndCloseSession(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSaveNoop',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSaveNoop',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
 
         $storage->start();
         $this->assertTrue($storage->isClosedByReadAndClose());
@@ -234,11 +243,12 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testSaveDelegatesToParentForNormalSession(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSaveNormal',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSaveNormal',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
 
         $storage->start();
         $this->assertFalse($storage->isClosedByReadAndClose());
@@ -260,12 +270,13 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testReopenForWritingTransitionsToWritableMode(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestReopen',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestReopen',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
 
         $storage->start();
         $this->assertTrue($storage->isClosedByReadAndClose());
@@ -292,11 +303,12 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testReopenForWritingIsNoOpWhenNotReadAndClose(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestReopenNoop',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestReopenNoop',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
 
         $storage->start();
         $this->assertFalse($storage->isClosedByReadAndClose());
@@ -316,11 +328,12 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
     public function testFullWriteCycleAfterReadAndClose(): void
     {
         // Create a session with initial data
-        $setupStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestWriteCycle',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $setupStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestWriteCycle',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $setupSession = new Session($setupStorage, new AttributeBag('TestWriteCycle'));
         $setupSession->start();
         $setupSession->set('initial_key', 'initial_value');
@@ -329,12 +342,13 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
 
         // Open with read_and_close
         session_id($sessionId);
-        $readStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestWriteCycle',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $readStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestWriteCycle',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $readSession = new Session($readStorage, new AttributeBag('TestWriteCycle'));
         $readSession->start();
 
@@ -352,12 +366,13 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
 
         // Verify the data was persisted by opening again
         session_id($sessionId);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestWriteCycle',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestWriteCycle',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestWriteCycle'));
         $verifySession->start();
 
@@ -382,12 +397,13 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testStateTransitionsThroughLifecycle(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestStates',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestStates',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
 
         // Before start: false
         $this->assertFalse($storage->isClosedByReadAndClose(), 'Before start');
@@ -415,12 +431,13 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testIsClosedByReadAndCloseReturnsTrueAfterReopenSaveCycle(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestReopenSave',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestReopenSave',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
 
         $storage->start();
         $this->assertTrue($storage->isClosedByReadAndClose(), 'After start');
@@ -446,11 +463,12 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testMultipleReopenWriteSaveCyclesPersistData(): void
     {
-        $setupStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestMultiWrite',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $setupStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestMultiWrite',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $setupSession = new Session($setupStorage, new AttributeBag('TestMultiWrite'));
         $setupSession->start();
         $sessionId = $setupSession->getId();
@@ -458,12 +476,13 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
 
         // Open with read_and_close
         session_id($sessionId);
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestMultiWrite',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestMultiWrite',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $session = new Session($storage, new AttributeBag('TestMultiWrite'));
         $session->start();
 
@@ -484,12 +503,13 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
 
         // Verify all three values persisted
         session_id($sessionId);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestMultiWrite',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestMultiWrite',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestMultiWrite'));
         $verifySession->start();
 
@@ -503,12 +523,13 @@ class ReadAndCloseNativeSessionStorageTest extends TestCase
      */
     public function testReadAndCloseFalseBehavesLikeStock(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestFalseFlag',
-            'read_and_close' => false,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestFalseFlag',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: false,
+        ));
 
         $storage->start();
 

--- a/tests/Tests/Isolated/Common/Session/SessionConfigurationTest.php
+++ b/tests/Tests/Isolated/Common/Session/SessionConfigurationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Session;
+
+use OpenEMR\Common\Session\SessionConfiguration;
+use PHPUnit\Framework\TestCase;
+
+class SessionConfigurationTest extends TestCase
+{
+    public function testToSessionStartOptionsReturnsValidPhpSessionKeys(): void
+    {
+        $config = new SessionConfiguration(
+            name: 'TestSession',
+            cookiePath: '/test',
+        );
+
+        $options = $config->toSessionStartOptions();
+
+        $expectedKeys = [
+            'name',
+            'cookie_path',
+            'gc_maxlifetime',
+            'use_strict_mode',
+            'use_cookies',
+            'use_only_cookies',
+            'cookie_samesite',
+            'cookie_secure',
+            'cookie_httponly',
+            'read_and_close',
+        ];
+
+        self::assertSame(
+            $expectedKeys,
+            array_keys($options),
+            'toSessionStartOptions must return exactly the keys PHP session_start() expects',
+        );
+
+        self::assertSame('TestSession', $options['name'], 'name should match constructor value');
+        self::assertSame('/test', $options['cookie_path'], 'cookie_path should match constructor value');
+    }
+}

--- a/tests/Tests/Isolated/Common/Session/SessionUtilReadAndCloseTest.php
+++ b/tests/Tests/Isolated/Common/Session/SessionUtilReadAndCloseTest.php
@@ -16,6 +16,7 @@
 
 namespace OpenEMR\Tests\Isolated\Common\Session;
 
+use OpenEMR\Common\Session\SessionConfiguration;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Session\Storage\ReadAndCloseNativeSessionStorage;
@@ -96,11 +97,12 @@ class SessionUtilReadAndCloseTest extends TestCase
     private function createReadAndCloseSession(): array
     {
         // First create a writable session to establish session data
-        $setupStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSessionUtil',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $setupStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSessionUtil',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $setupSession = new Session($setupStorage, new AttributeBag('TestSessionUtil'));
         $setupSession->start();
         // Sentinel value prevents write() from short-circuiting to destroy()
@@ -110,12 +112,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Now open the same session with read_and_close
         session_id($sessionId);
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSessionUtil',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSessionUtil',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $session = new WriteThroughSession($storage, new AttributeBag('TestSessionUtil'));
         $session->start();
 
@@ -156,12 +159,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Verify the data was persisted
         session_id($ctx['sessionId']);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSessionUtil',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSessionUtil',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestSessionUtil'));
         $verifySession->start();
 
@@ -188,12 +192,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Verify persistence
         session_id($ctx['sessionId']);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSessionUtil',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSessionUtil',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestSessionUtil'));
         $verifySession->start();
 
@@ -206,11 +211,12 @@ class SessionUtilReadAndCloseTest extends TestCase
      */
     public function testSetSessionWorksWithWritableSession(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestWritable',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestWritable',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $session = new Session($storage, new AttributeBag('TestWritable'));
         $session->start();
 
@@ -241,11 +247,12 @@ class SessionUtilReadAndCloseTest extends TestCase
     public function testUnsetSessionReopensAndClosesReadAndCloseSession(): void
     {
         // Create session with initial data
-        $setupStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestUnset',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $setupStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestUnset',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $setupSession = new Session($setupStorage, new AttributeBag('TestUnset'));
         $setupSession->start();
         $setupSession->set('to_remove', 'exists');
@@ -255,12 +262,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Reopen with read_and_close
         session_id($sessionId);
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestUnset',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestUnset',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $session = new Session($storage, new AttributeBag('TestUnset'));
         $session->start();
 
@@ -275,12 +283,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Verify the key was removed and the other key remains
         session_id($sessionId);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestUnset',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestUnset',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestUnset'));
         $verifySession->start();
 
@@ -300,11 +309,12 @@ class SessionUtilReadAndCloseTest extends TestCase
      */
     public function testUnsetSessionArrayReopensAndClosesReadAndCloseSession(): void
     {
-        $setupStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestUnsetArr',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $setupStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestUnsetArr',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $setupSession = new Session($setupStorage, new AttributeBag('TestUnsetArr'));
         $setupSession->start();
         $setupSession->set('rem1', 'a');
@@ -314,12 +324,13 @@ class SessionUtilReadAndCloseTest extends TestCase
         $setupSession->save();
 
         session_id($sessionId);
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestUnsetArr',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestUnsetArr',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $session = new Session($storage, new AttributeBag('TestUnsetArr'));
         $session->start();
 
@@ -330,12 +341,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Verify
         session_id($sessionId);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestUnsetArr',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestUnsetArr',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestUnsetArr'));
         $verifySession->start();
 
@@ -353,11 +365,12 @@ class SessionUtilReadAndCloseTest extends TestCase
      */
     public function testSetUnsetSessionReopensAndClosesReadAndCloseSession(): void
     {
-        $setupStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSetUnset',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $setupStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSetUnset',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $setupSession = new Session($setupStorage, new AttributeBag('TestSetUnset'));
         $setupSession->start();
         $setupSession->set('old_key', 'old_value');
@@ -365,12 +378,13 @@ class SessionUtilReadAndCloseTest extends TestCase
         $setupSession->save();
 
         session_id($sessionId);
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSetUnset',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSetUnset',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $session = new Session($storage, new AttributeBag('TestSetUnset'));
         $session->start();
 
@@ -388,12 +402,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Verify
         session_id($sessionId);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSetUnset',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSetUnset',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestSetUnset'));
         $verifySession->start();
 
@@ -437,12 +452,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Verify all three values were persisted
         session_id($ctx['sessionId']);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSessionUtil',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSessionUtil',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestSessionUtil'));
         $verifySession->start();
 
@@ -457,11 +473,12 @@ class SessionUtilReadAndCloseTest extends TestCase
     public function testMixedSetAndUnsetSessionCallsPersistOnReadAndCloseSession(): void
     {
         // Create session with initial data
-        $setupStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestMixed',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $setupStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestMixed',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $setupSession = new Session($setupStorage, new AttributeBag('TestMixed'));
         $setupSession->start();
         $setupSession->set('existing_key', 'old_value');
@@ -470,12 +487,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Open with read_and_close
         session_id($sessionId);
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestMixed',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestMixed',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $session = new Session($storage, new AttributeBag('TestMixed'));
         $session->start();
 
@@ -489,12 +507,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Verify
         session_id($sessionId);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestMixed',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestMixed',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestMixed'));
         $verifySession->start();
 
@@ -543,12 +562,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Verify persistence
         session_id($ctx['sessionId']);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSessionUtil',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSessionUtil',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestSessionUtil'));
         $verifySession->start();
 
@@ -565,11 +585,12 @@ class SessionUtilReadAndCloseTest extends TestCase
     public function testClearSessionReopensAndClosesReadAndCloseSession(): void
     {
         // Create session with initial data
-        $setupStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestClear',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $setupStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestClear',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $setupSession = new Session($setupStorage, new AttributeBag('TestClear'));
         $setupSession->start();
         $setupSession->set('key1', 'value1');
@@ -580,12 +601,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Reopen with read_and_close
         session_id($sessionId);
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestClear',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestClear',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $session = new Session($storage, new AttributeBag('TestClear'));
         $session->start();
 
@@ -603,12 +625,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Verify all keys were removed
         session_id($sessionId);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestClear',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestClear',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestClear'));
         $verifySession->start();
 
@@ -623,11 +646,12 @@ class SessionUtilReadAndCloseTest extends TestCase
      */
     public function testClearSessionWorksWithWritableSession(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestClearWritable',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestClearWritable',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $session = new Session($storage, new AttributeBag('TestClearWritable'));
         $session->start();
         $session->set('key1', 'value1');
@@ -650,11 +674,12 @@ class SessionUtilReadAndCloseTest extends TestCase
     public function testSetSessionAfterClearSessionOnReadAndCloseSession(): void
     {
         // Create session with initial data
-        $setupStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestClearThenSet',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $setupStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestClearThenSet',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $setupSession = new Session($setupStorage, new AttributeBag('TestClearThenSet'));
         $setupSession->start();
         $setupSession->set('old_key', 'old_value');
@@ -663,12 +688,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Reopen with read_and_close
         session_id($sessionId);
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestClearThenSet',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestClearThenSet',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $session = new Session($storage, new AttributeBag('TestClearThenSet'));
         $session->start();
 
@@ -681,12 +707,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Verify old data gone, new data present
         session_id($sessionId);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestClearThenSet',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestClearThenSet',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestClearThenSet'));
         $verifySession->start();
 
@@ -722,12 +749,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Verify data is persisted to the session file
         session_id($ctx['sessionId']);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestSessionUtil',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestSessionUtil',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestSessionUtil'));
         $verifySession->start();
 
@@ -747,11 +775,12 @@ class SessionUtilReadAndCloseTest extends TestCase
     public function testDirectRemoveOnReadAndCloseSessionPersists(): void
     {
         // Create session with initial data
-        $setupStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestDirectRemove',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $setupStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestDirectRemove',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $setupSession = new Session($setupStorage, new AttributeBag('TestDirectRemove'));
         $setupSession->start();
         $setupSession->set('relogin', 1);
@@ -760,12 +789,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Reopen with read_and_close
         session_id($sessionId);
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestDirectRemove',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestDirectRemove',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $session = new WriteThroughSession($storage, new AttributeBag('TestDirectRemove'));
         $session->start();
 
@@ -779,12 +809,13 @@ class SessionUtilReadAndCloseTest extends TestCase
 
         // Verify the removal persisted
         session_id($sessionId);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestDirectRemove',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestDirectRemove',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestDirectRemove'));
         $verifySession->start();
 
@@ -810,12 +841,13 @@ class SessionUtilReadAndCloseTest extends TestCase
         $factory = SessionWrapperFactory::getInstance();
 
         // readOnly defaults to true, so this creates a read_and_close session
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestOrdering',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestOrdering',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $session = new WriteThroughSession($storage, new AttributeBag('TestOrdering'));
         $session->start();
         $sessionId = $session->getId();
@@ -838,12 +870,13 @@ class SessionUtilReadAndCloseTest extends TestCase
         $session->set('late_write', 'should_persist');
 
         session_id($sessionId);
-        $verifyStorage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestOrdering',
-            'read_and_close' => true,
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $verifyStorage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestOrdering',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+            readAndClose: true,
+        ));
         $verifySession = new Session($verifyStorage, new AttributeBag('TestOrdering'));
         $verifySession->start();
 
@@ -864,11 +897,12 @@ class SessionUtilReadAndCloseTest extends TestCase
      */
     public function testSetSessionWorksWhenStorageIsNull(): void
     {
-        $storage = new ReadAndCloseNativeSessionStorage([
-            'name' => 'TestNullStorage',
-            'use_cookies' => false,
-            'use_only_cookies' => false,
-        ]);
+        $storage = new ReadAndCloseNativeSessionStorage(new SessionConfiguration(
+            name: 'TestNullStorage',
+            cookiePath: '/',
+            useCookies: false,
+            useOnlyCookies: false,
+        ));
         $session = new Session($storage, new AttributeBag('TestNullStorage'));
         $session->start();
 


### PR DESCRIPTION
#### Short description of what this changes or resolves:
Motivating factors:

- disambiguates `web_root` from session cookie processing logic. I was originally misled to believe that it was in reference to location on disk, when in fact it's actually the cookie's path (used for security scoping)
- continuing to untangle the audit logger setup from other application bootstrapping (also `web_root`)

#### Changes proposed in this pull request:

- Create and adopt DTO with well-known types for session config
- Thread it through the touch points
- Remove some redundant/inappropriate `empty()` checks in the cookie path handling

#### Was an AI assistant used? Yes / No
Some mechanical stuff mostly with tests