### PR TITLE
fix(modules): Move module loading after OPENEMR_GLOBALS_LOADED

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -731,40 +731,6 @@ if (!$ignoreAuth) {
 // Currently it is applicable only to the "Search or Add Patient" form.
 $globalsBag->set('layout_search_color', '#ff9919');
 
-// module configurations
-// upgrade fails for versions prior to 4.2.0 since no modules table
-$checkModulesTableExists = QueryUtils::existsTable('modules');
-
-if (!empty($checkModulesTableExists)) {
-    $globalsBag->set('baseModDir', "interface/modules/"); //default path of modules
-    $globalsBag->set('customModDir', "custom_modules"); //non zend modules
-    $globalsBag->set('zendModDir', "zend_modules"); //zend modules
-
-    try {
-        // load up the modules system and bootstrap them.
-        // This has to be fast, so any modules that tie into the bootstrap must be kept lightweight
-        // registering event listeners, etc.
-        // TODO: why do we have 3 different directories we need to pass in for the zend dir path. shouldn't zendModDir already have all the paths set up?
-        $globalsBag->set('modules_application', new ModulesApplication(
-            $globalsBag->getKernel(),
-            $globalsBag->getString('fileroot'),
-            $globalsBag->getString('baseModDir'),
-            $globalsBag->getString('zendModDir')
-        ));
-    } catch (\OpenEMR\Common\Acl\AccessDeniedException $accessDeniedException) {
-        // this occurs when the current SCRIPT_PATH is to a module that is not currently allowed to be accessed
-        http_response_code(401);
-        $logger->warning($accessDeniedException->getMessage(), ['exception' => $accessDeniedException]);
-        exit(1);
-    } catch (\Throwable $ex) {
-        http_response_code(500);
-        $logger->error($ex->getMessage(), ['exception' => $ex]);
-        exit(1);
-    }
-}
-
-// Don't change anything below this line. ////////////////////////////
-
 $encounter = EncounterSessionUtil::getEncounter();
 
 if (!empty($_GET['pid']) && empty($session->get('pid'))) {
@@ -859,5 +825,39 @@ if ($globalsBag->getBoolean('translation_preload_cache')) {
  * Used by include files to guard against direct HTTP access.
  */
 const OPENEMR_GLOBALS_LOADED = true;
+
+// Module configurations.
+// Runs after OPENEMR_GLOBALS_LOADED is defined so that module class files
+// with direct-access guards can be autoloaded without tripping the guard.
+// Upgrade fails for versions prior to 4.2.0 since no modules table.
+$checkModulesTableExists = QueryUtils::existsTable('modules');
+
+if (!empty($checkModulesTableExists)) {
+    $globalsBag->set('baseModDir', "interface/modules/"); //default path of modules
+    $globalsBag->set('customModDir', "custom_modules"); //non zend modules
+    $globalsBag->set('zendModDir', "zend_modules"); //zend modules
+
+    try {
+        // load up the modules system and bootstrap them.
+        // This has to be fast, so any modules that tie into the bootstrap must be kept lightweight
+        // registering event listeners, etc.
+        // TODO: why do we have 3 different directories we need to pass in for the zend dir path. shouldn't zendModDir already have all the paths set up?
+        $globalsBag->set('modules_application', new ModulesApplication(
+            $globalsBag->getKernel(),
+            $globalsBag->getString('fileroot'),
+            $globalsBag->getString('baseModDir'),
+            $globalsBag->getString('zendModDir')
+        ));
+    } catch (\OpenEMR\Common\Acl\AccessDeniedException $accessDeniedException) {
+        // this occurs when the current SCRIPT_PATH is to a module that is not currently allowed to be accessed
+        http_response_code(401);
+        $logger->warning($accessDeniedException->getMessage(), ['exception' => $accessDeniedException]);
+        exit(1);
+    } catch (\Throwable $ex) {
+        http_response_code(500);
+        $logger->error($ex->getMessage(), ['exception' => $ex]);
+        exit(1);
+    }
+}
 
 return $globalsBag; // if anyone wants to use the global bag they can just use the return value


### PR DESCRIPTION
## Summary

- Moves module bootstrapping to run after the `OPENEMR_GLOBALS_LOADED` constant is defined
- Fixes a hard 404 that occurs when a configured module eagerly autoloads a class file containing a direct-access guard

## Problem

Module class files with direct-access guards check `defined('OPENEMR_GLOBALS_LOADED')`, but modules were bootstrapped ~100 lines before the constant was defined at the end of `globals.php`. When a module like `oe-module-comlink-telehealth` is configured and its bootstrap code triggers autoloading of a guarded class, the guard fires:

```php
if (!defined('OPENEMR_GLOBALS_LOADED')) {
    http_response_code(404);
    exit();
}
```

This `exit()` is uncatchable, so `ModulesApplication`'s try/catch does nothing. The entire application returns 404, including the login page.

## Solution

Move module loading to after the constant is defined. Analysis confirmed that:
- No events are dispatched between the old and new module loading positions
- Modules gain access to more context (`$GLOBALS['pid']`, `$GLOBALS['encounter']`, auth state) than they had before
- Module dependencies (Kernel, database, globals from DB) are all available at the new position

Closes #12688

## Test plan

- [ ] Verify login page loads with TeleHealth module enabled and configured
- [ ] Verify module event listeners still fire correctly
- [ ] Run unit/integration test suite
