### PR TITLE
refactor(audit): Centralize and simplify "should log" logic

### DIFF
--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -100,6 +100,16 @@ class EventAuditLogger
     }
 
     /**
+     * Returns true when the breakglass override should force logging for this
+     * user, even when logging would otherwise be disabled.
+     */
+    private function shouldForceLogForUser(string $user): bool
+    {
+        return $this->config->forceBreakglass
+            && $this->breakglassChecker->isBreakglassUser($user);
+    }
+
+    /**
      * Keep track of the table mapping in a class constant to prevent reloading the data each time the method is called.
      *
      * @var array
@@ -406,11 +416,8 @@ class EventAuditLogger
     {
         $user = (string) ($this->session->get('authUser') ?? '');
 
-        /* Don't log anything if the audit logging is not enabled. Exception for "emergency" users */
-        if (!$this->config->enabled) {
-            if (!$this->config->forceBreakglass || !$this->breakglassChecker->isBreakglassUser($user)) {
-                return;
-            }
+        if (!$this->config->enabled && !$this->shouldForceLogForUser($user)) {
+            return;
         }
 
         $statement = trim((string) $statement);
@@ -436,11 +443,8 @@ class EventAuditLogger
             }
         }
 
-        /* If query events are not enabled, don't log them. Exception for "emergency" users. */
-        if (($querytype == "select") && !$this->config->queryEvents) {
-            if (!$this->config->forceBreakglass || !$this->breakglassChecker->isBreakglassUser($user)) {
-                return;
-            }
+        if ($querytype === 'select' && !$this->config->queryEvents && !$this->shouldForceLogForUser($user)) {
+            return;
         }
 
         $comments = $statement;
@@ -513,7 +517,7 @@ class EventAuditLogger
             }
         }
 
-        if (!$this->config->isEventTypeEnabled($event) && (!$this->config->forceBreakglass || !$this->breakglassChecker->isBreakglassUser($user))) {
+        if (!$this->config->isEventTypeEnabled($event) && !$this->shouldForceLogForUser($user)) {
             return;
         }
 

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -100,13 +100,25 @@ class EventAuditLogger
     }
 
     /**
-     * Returns true when the breakglass override should force logging for this
-     * user, even when logging would otherwise be disabled.
+     * Determines whether a SQL event should be logged based on config settings
+     * and breakglass overrides.
      */
-    private function shouldForceLogForUser(string $user): bool
+    private function shouldLogSqlEvent(string $user, string $querytype, string $event): bool
     {
-        return $this->config->forceBreakglass
-            && $this->breakglassChecker->isBreakglassUser($user);
+        // Selects from uncategorized tables are never logged
+        if ($querytype === 'select' && $event === 'other') {
+            return false;
+        }
+
+        // Breakglass override: log everything for emergency access users
+        if ($this->config->forceBreakglass && $this->breakglassChecker->isBreakglassUser($user)) {
+            return true;
+        }
+
+        // Normal path: all config flags must be satisfied
+        return $this->config->enabled
+            && ($querytype !== 'select' || $this->config->queryEvents)
+            && $this->config->isEventTypeEnabled($event);
     }
 
     /**
@@ -414,12 +426,6 @@ class EventAuditLogger
      */
     public function auditSQLEvent($statement, $outcome, $binds = null)
     {
-        $user = (string) ($this->session->get('authUser') ?? '');
-
-        if (!$this->config->enabled && !$this->shouldForceLogForUser($user)) {
-            return;
-        }
-
         $statement = trim((string) $statement);
 
         if (
@@ -441,10 +447,6 @@ class EventAuditLogger
                 $querytype = $qtype;
                 break;
             }
-        }
-
-        if ($querytype === 'select' && !$this->config->queryEvents && !$this->shouldForceLogForUser($user)) {
-            return;
         }
 
         $comments = $statement;
@@ -499,13 +501,10 @@ class EventAuditLogger
             }
         }
 
-        /* Avoid filling the audit log with trivial SELECT statements.
-         * Skip SELECTs from unknown tables.
-         */
-        if ($querytype == "select") {
-            if ($event == "other") {
-                return;
-            }
+        // Now that we know _what_ to log, check _if_ it should be logged
+        $user = (string) ($this->session->get('authUser') ?? '');
+        if (!$this->shouldLogSqlEvent($user, $querytype, $event)) {
+            return;
         }
 
         /* If the event is a patient-record, then note the patient id */
@@ -515,10 +514,6 @@ class EventAuditLogger
             if ($sessionPid !== null && $sessionPid != '') {
                 $pid = $sessionPid;
             }
-        }
-
-        if (!$this->config->isEventTypeEnabled($event) && !$this->shouldForceLogForUser($user)) {
-            return;
         }
 
         $event = $event . "-" . $querytype;

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -110,7 +110,10 @@ class EventAuditLogger
             return false;
         }
 
-        // Breakglass override: log everything for emergency access users
+        // Breakglass override: log everything for emergency access users,
+        // except uncategorized reads above (this has been preserved across
+        // refactors, not entirely clear if this was the originally intended
+        // behavior)
         if ($this->config->forceBreakglass && $this->breakglassChecker->isBreakglassUser($user)) {
             return true;
         }

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -20,6 +20,7 @@ use OpenEMR\Common\Logging\Audit\SinkInterface;
 use OpenEMR\Common\Logging\AuditConfig;
 use OpenEMR\Common\Logging\BreakglassCheckerInterface;
 use OpenEMR\Common\Logging\EventAuditLogger;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
@@ -134,5 +135,91 @@ class EventAuditLoggerTest extends TestCase
             comments: 'Test comments',
             patientId: 'NULL',
         );
+    }
+
+    /**
+     * @return array<string, array{
+     *   sql: string,
+     *   enabled: bool,
+     *   forceBreakglass: bool,
+     *   isBreakglassUser: bool,
+     *   expectLog: bool,
+     * }>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function breakglassOverrideProvider(): array
+    {
+        return [
+            'breakglass active: logs despite disabled config' => [
+                'sql' => 'SELECT * FROM patient_data WHERE pid = 1',
+                'enabled' => false,
+                'forceBreakglass' => true,
+                'isBreakglassUser' => true,
+                'expectLog' => true,
+            ],
+            'breakglass config off: skips even if user in group' => [
+                'sql' => 'SELECT * FROM patient_data WHERE pid = 1',
+                'enabled' => false,
+                'forceBreakglass' => false,
+                'isBreakglassUser' => true,
+                'expectLog' => false,
+            ],
+            'user not in breakglass group: skips even if config on' => [
+                'sql' => 'SELECT * FROM patient_data WHERE pid = 1',
+                'enabled' => false,
+                'forceBreakglass' => true,
+                'isBreakglassUser' => false,
+                'expectLog' => false,
+            ],
+            'breakglass does not override select from unknown table' => [
+                'sql' => 'SELECT * FROM some_unknown_table',
+                'enabled' => false,
+                'forceBreakglass' => true,
+                'isBreakglassUser' => true,
+                'expectLog' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('breakglassOverrideProvider')]
+    public function testAuditSQLEventBreakglassOverride(
+        string $sql,
+        bool $enabled,
+        bool $forceBreakglass,
+        bool $isBreakglassUser,
+        bool $expectLog,
+    ): void {
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($expectLog ? $this->once() : $this->never())
+            ->method('record');
+
+        $this->session->method('get')
+            ->willReturnMap([
+                ['authUser', null, 'testuser'],
+                ['authProvider', null, 'default'],
+                ['pid', null, null],
+            ]);
+
+        $this->breakglassChecker->method('isBreakglassUser')
+            ->willReturn($isBreakglassUser);
+
+        $config = new AuditConfig(
+            enabled: $enabled,
+            forceBreakglass: $forceBreakglass,
+            queryEvents: true,
+            httpRequestEvents: false,
+            eventTypeFlags: ['patient-record' => true, 'other' => true],
+        );
+
+        $logger = new EventAuditLogger(
+            sink: $sink,
+            session: $this->session,
+            config: $config,
+            breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
+        );
+
+        $logger->auditSQLEvent($sql, true);
     }
 }

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -195,11 +195,11 @@ class EventAuditLoggerTest extends TestCase
             ->method('record');
 
         $this->session->method('get')
-            ->willReturnMap([
-                ['authUser', null, 'testuser'],
-                ['authProvider', null, 'default'],
-                ['pid', null, null],
-            ]);
+            ->willReturnCallback(fn (string $key) => match ($key) {
+                'authUser' => 'testuser',
+                'authProvider' => 'default',
+                default => null,
+            });
 
         $this->breakglassChecker->method('isBreakglassUser')
             ->willReturn($isBreakglassUser);


### PR DESCRIPTION
#### Short description of what this changes or resolves:
The logic in the audit logger, especially around the break glass user, is difficult to follow. Multiple nested conditionals with joined negation and four different short-circuit points within the SQL logger. In a security-critical path like this, that's Not Great™ - it should be immediately obvious what the expected behavior is, especially with respect to the near-dozen configuration options (its own challenge).

#### Changes proposed in this pull request:

This consolidates and flattens the logic into a helper method, which is called once after all the needed information has been gathered.

There's marginally higher overhead with the SQL parsing since it's not short-circuited under all conditions, but that's mostly cheap string operations and the aim is to eventually make that path obsolete.

#### Was an AI assistant used? Yes / No
Yes, Claude