### PR TITLE
ci(claude-review): add reusable + caller workflow for PR reviews

### DIFF
--- a/.github/workflows/claude-review-reusable.yml
+++ b/.github/workflows/claude-review-reusable.yml
@@ -6,7 +6,7 @@ name: Claude PR Review (reusable)
 on:
   workflow_call:
     secrets:
-      CLAUDE_CODE_OAUTH_TOKEN:
+      ANTHROPIC_API_KEY:
         required: true
 
 jobs:
@@ -40,9 +40,10 @@ jobs:
     - name: Claude review
       uses: anthropics/claude-code-action@v1
       with:
-          # Subscription auth -> draws from the separate ~$100/mo programmatic
-          # credit, NOT your interactive Claude Code limits. Set as an ORG secret.
-        claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Metered API-key auth (platform.claude.com). Billed per token against
+          # the org's API workspace — independent of Pro/Max subscription limits.
+          # Cap spend on the workspace's Limits page. Set as an ORG secret.
+        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # If claude-sonnet-5 isn't resolvable yet on your plan, swap to
           # claude-sonnet-4-6 (same price after the intro window).
         claude_args: "--model claude-sonnet-5 --max-turns 15"

--- a/.github/workflows/claude-review-reusable.yml
+++ b/.github/workflows/claude-review-reusable.yml
@@ -1,0 +1,75 @@
+# .github/workflows/claude-review-reusable.yml
+# Lives ONCE in openemr/openemr. All four repos (including openemr itself)
+# call it via the thin caller workflow claude-review.yml.
+name: Claude PR Review (reusable)
+
+on:
+  workflow_call:
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+
+jobs:
+  review:
+    # Run when EITHER:
+    #  (a) a NON-bot PR is opened  -> auto-review on open
+    #  (b) a maintainer comments "@claude review" on a PR -> force review
+    #      (also covers fork PRs and bot PRs; the only path with secret
+    #       access for forks, so it doubles as the fork/bot escape hatch)
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.user.type != 'Bot')
+      ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@claude review') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read          # read-only: this bot reviews, it does not push
+      pull-requests: write     # needed to post review + inline comments
+      issues: read
+      id-token: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+      with:
+        fetch-depth: 1
+
+    - name: Claude review
+      uses: anthropics/claude-code-action@v1
+      with:
+          # Subscription auth -> draws from the separate ~$100/mo programmatic
+          # credit, NOT your interactive Claude Code limits. Set as an ORG secret.
+        claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # If claude-sonnet-5 isn't resolvable yet on your plan, swap to
+          # claude-sonnet-4-6 (same price after the intro window).
+        claude_args: "--model claude-sonnet-5 --max-turns 15"
+        prompt: |
+          You are reviewing a pull request for OpenEMR, a production PHP/Symfony
+          electronic health record system running in live clinical settings.
+
+          If the repository contains a CLAUDE.md, follow its standards; they take
+          precedence over the general guidance below.
+
+          Review the DIFF for this PR in the context of the surrounding code.
+          Prioritize substance over style, in this order:
+
+          1. SECURITY (treat as high severity — this is an EHR):
+             authn/authz gaps, missing access checks, SQL injection, XSS, CSRF,
+             unsafe deserialization, path traversal, secrets in code, PHI exposure,
+             and injection through Symfony/Doctrine query building.
+          2. CORRECTNESS: logic errors, null/undefined handling, off-by-one,
+             race conditions, incorrect SQL, broken or changed API contracts,
+             backward-compatibility breaks.
+          3. TESTS: missing coverage for the changed behavior, assertions that
+             test the wrong thing, tests that mock away the logic under test.
+          4. MAINTAINABILITY: only flag issues that materially hurt clarity.
+
+          Do NOT report pure formatting/style nits — PHPStan (level 10), Rector,
+          and linters already cover those. Skip praise and filler.
+
+          Post inline comments on the specific lines that need attention. Finish
+          with a short summary and an overall call (approve / comment /
+          request-changes). Every comment must be concrete and actionable.

--- a/.github/workflows/claude-review-reusable.yml
+++ b/.github/workflows/claude-review-reusable.yml
@@ -18,7 +18,8 @@ jobs:
     #       access for forks, so it doubles as the fork/bot escape hatch)
     if: >-
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.user.type != 'Bot')
+       github.event.pull_request.user.type != 'Bot' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
       ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
@@ -36,6 +37,13 @@ jobs:
       uses: actions/checkout@v5
       with:
         fetch-depth: 1
+        persist-credentials: false
+        # issue_comment events fire in base-branch context; pin to the PR
+        # head so @claude review sees the actual proposed code, not master.
+        ref: >-
+          ${{ github.event_name == 'issue_comment'
+              && format('refs/pull/{0}/head', github.event.issue.number)
+              || github.ref }}
 
     - name: Claude review
       uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,4 +17,4 @@ jobs:
     # (@master vs @main) to match that repo's default branch.
     uses: openemr/openemr/.github/workflows/claude-review-reusable.yml@master
     secrets:
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,20 @@
+# .github/workflows/claude-review.yml
+# Drop this IDENTICAL file into all FOUR repos:
+#   openemr, openemr-devops, website-openemr, demo_farm_openemr
+#
+# It forwards events to the shared reusable workflow in openemr/openemr.
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened]        # auto-review non-bot PRs on open
+  issue_comment:
+    types: [created]       # maintainers force a review with "@claude review"
+
+jobs:
+  call-review:
+    # Reusable workflow lives in openemr/openemr. Adjust the branch ref
+    # (@master vs @main) to match that repo's default branch.
+    uses: openemr/openemr/.github/workflows/claude-review-reusable.yml@master
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,6 +13,14 @@ on:
 
 jobs:
   call-review:
+    # Reusable workflows can only reduce, not elevate, the caller job's
+    # permissions. Declare the same scopes the reusable's job needs so the
+    # effective GITHUB_TOKEN can actually post review comments.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
     # Reusable workflow lives in openemr/openemr. Adjust the branch ref
     # (@master vs @main) to match that repo's default branch.
     uses: openemr/openemr/.github/workflows/claude-review-reusable.yml@master


### PR DESCRIPTION
## Summary

- Adds a `workflow_call` reusable at `.github/workflows/claude-review-reusable.yml` that runs `anthropics/claude-code-action` to review PRs, tuned for this repo (security-first prompt appropriate to an EHR, defers to `CLAUDE.md` when present).
- Adds the thin caller `.github/workflows/claude-review.yml` in this repo that forwards events into the reusable. The **identical caller** is being placed in `openemr-devops`, `website-openemr`, and `demo_farm_openemr` so all four repos share a single review definition — future prompt/model/permission tweaks happen in one place.

## When it runs

- **Auto-review**: any non-bot PR when it is opened (`pull_request: opened`, with a `user.type != 'Bot'` guard).
- **Manual / fork / bot escape hatch**: any PR when an `OWNER`/`MEMBER`/`COLLABORATOR` comments `@claude review` (`issue_comment: created`). This is the only path where the workflow secret is accessible on fork PRs.

## Required secret

`CLAUDE_CODE_OAUTH_TOKEN` must exist as an **organization secret** on `openemr` (visible to this repo and the three caller repos). It uses subscription auth against the separate programmatic credit — does not draw from interactive Claude Code limits.

## Test plan

- [ ] Confirm `CLAUDE_CODE_OAUTH_TOKEN` is provisioned on the org and available to `openemr`, `openemr-devops`, `website-openemr`, `demo_farm_openemr`.
- [ ] After merge, open a small no-op PR here and confirm the "Claude PR Review" workflow runs and posts a review.
- [ ] From a maintainer account, comment `@claude review` on an existing PR and confirm the workflow re-runs.
- [ ] Open the corresponding caller-only PRs in the other three repos and confirm they resolve `openemr/openemr/.github/workflows/claude-review-reusable.yml@master` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)