### PR TITLE
ci(claude-review): allow-list GitHub comment tools + surface transcript

### DIFF
--- a/.github/workflows/claude-review-reusable.yml
+++ b/.github/workflows/claude-review-reusable.yml
@@ -67,7 +67,7 @@ jobs:
         claude_args: |
           --model claude-sonnet-5
           --max-turns 15
-          --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
         prompt: |
           REPO: ${{ github.repository }}
           PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
@@ -98,8 +98,10 @@ jobs:
           How to post the review — this is mandatory, not optional:
           - Use `mcp__github_inline_comment__create_inline_comment` (with
             `confirmed: true`) for every line-specific finding.
-          - Use `gh pr comment` (via Bash) for the overall summary and the
-            final call (approve / comment / request-changes).
+          - Use `gh pr comment` (via Bash) for the overall summary text.
+          - Use `gh pr review --approve` / `--request-changes` / `--comment`
+            (via Bash) to submit the final call. `gh pr comment` only posts a
+            plain issue comment and cannot set a review state.
           - Do NOT emit the review as a chat message; only comments posted via
             the tools above are visible to reviewers. Every comment must be
             concrete and actionable.

--- a/.github/workflows/claude-review-reusable.yml
+++ b/.github/workflows/claude-review-reusable.yml
@@ -52,10 +52,26 @@ jobs:
           # the org's API workspace — independent of Pro/Max subscription limits.
           # Cap spend on the workspace's Limits page. Set as an ORG secret.
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # DEBUG: surface Claude's full transcript in the workflow log while
+          # we validate that reviews actually post. Remove once verified.
+        show_full_output: true
+          # Post a sticky "Claude Code is reviewing..." comment updated with
+          # progress checkboxes so it is obvious the workflow is doing work,
+          # even before the final review is posted.
+        track_progress: true
+          # Tools Claude needs to post reviews. Without an explicit allow-list
+          # the default sandbox denies the GitHub comment tools, and Claude
+          # finishes the run with nothing posted (see PR review on #12662).
           # If claude-sonnet-5 isn't resolvable yet on your plan, swap to
           # claude-sonnet-4-6 (same price after the intro window).
-        claude_args: "--model claude-sonnet-5 --max-turns 15"
+        claude_args: |
+          --model claude-sonnet-5
+          --max-turns 15
+          --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
         prompt: |
+          REPO: ${{ github.repository }}
+          PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
           You are reviewing a pull request for OpenEMR, a production PHP/Symfony
           electronic health record system running in live clinical settings.
 
@@ -79,6 +95,11 @@ jobs:
           Do NOT report pure formatting/style nits — PHPStan (level 10), Rector,
           and linters already cover those. Skip praise and filler.
 
-          Post inline comments on the specific lines that need attention. Finish
-          with a short summary and an overall call (approve / comment /
-          request-changes). Every comment must be concrete and actionable.
+          How to post the review — this is mandatory, not optional:
+          - Use `mcp__github_inline_comment__create_inline_comment` (with
+            `confirmed: true`) for every line-specific finding.
+          - Use `gh pr comment` (via Bash) for the overall summary and the
+            final call (approve / comment / request-changes).
+          - Do NOT emit the review as a chat message; only comments posted via
+            the tools above are visible to reviewers. Every comment must be
+            concrete and actionable.


### PR DESCRIPTION
## Summary

Follow-up to #12700. The first real invocation of the review workflow (on #12662) completed cleanly — 12 turns, 25s of Claude time, cost \$0.25 — but posted no review comments. The action's own run summary showed the smoking gun:

- `permission_denials_count: 8` — Claude repeatedly tried to use tools that the default sandbox denies.
- `No buffered inline comments` — nothing was ever queued for posting.

Three changes to actually deliver a review.

1. **Expand `claude_args` to allow-list the comment tools.** Without an explicit `--allowedTools`, `mcp__github_inline_comment__create_inline_comment` and `Bash(gh pr comment:*)` are denied, which is where the 8 permission denials came from. The tool set here mirrors [`anthropics/claude-code-action` docs/solutions.md](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md#automatic-pr-code-review).
2. **Prepend `REPO:` / `PR NUMBER:` to the prompt and append explicit tool-naming instructions.** The `PR NUMBER` expression uses a conditional that resolves for both `pull_request` and `issue_comment` triggers. The tool-naming block makes clear to Claude that posting via the allow-listed tools is mandatory, not optional — otherwise it tends to emit the review as a chat message that never becomes a GitHub comment.
3. **Turn on `show_full_output: true` (temporary) and `track_progress: true`.** The former surfaces Claude's transcript in the workflow log so the next failed run is diagnosable without guessing. The latter posts a sticky "Claude Code is reviewing..." comment updated with progress checkboxes, so it is visibly obvious that the workflow is doing work while the review runs. `show_full_output` should be dropped in a follow-up once we see a successful posted review.

## Test plan

- [ ] Merge and then comment `@claude review` on any open PR.
- [ ] Confirm the sticky "reviewing..." comment appears within a few seconds.
- [ ] Confirm the workflow log now contains Claude's full transcript.
- [ ] Confirm at least one inline comment or a summary comment gets posted.
- [ ] Open a follow-up PR removing `show_full_output: true` once the above is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)