### PR TITLE
chore(coderabbit): skip auto-review on bot-authored PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,2 +1,11 @@
 reviews:
   high_level_summary: false
+  auto_review:
+    # Skip auto-review on PRs opened by these bots. Human maintainers can
+    # still opt-in per PR by commenting "@coderabbitai review" when a bot
+    # PR warrants a look (e.g., a suspicious dependency bump).
+    ignore_usernames:
+    - dependabot[bot]
+    - openemr-release-bot[bot]
+    - openemr-reserved-word-bot[bot]
+    - github-actions[bot]


### PR DESCRIPTION
## Summary

Adds `reviews.auto_review.ignore_usernames` to `.coderabbit.yaml` for four bot accounts. CodeRabbit will still be available on request for any of these PRs via `@coderabbitai review`; only the automatic per-PR review is suppressed.

## Why

Bot PR volume in the last 30 days on this repo:

| Bot | Count |
|---|---|
| `dependabot[bot]` | 183 |
| `openemr-release-bot[bot]` | 11 |
| `openemr-reserved-word-bot[bot]` | 3 |
| `github-actions[bot]` | 1 |
| **Total** | **198 / 322 (62%)** |

Nearly two-thirds of CodeRabbit's automatic reviews land on dependency bumps, release automation, or scheduled bot PRs where the review adds little signal — the diffs are mechanical, the intent is known, and human maintainers rarely act on the review. Filtering these focuses CodeRabbit's attention (and its comment noise) on the ~40% of PRs where human review actually happens.

## Escape hatch

Any maintainer can still invoke CodeRabbit on a bot PR by commenting `@coderabbitai review` — useful for a suspicious dependency bump or a bot PR that touches unusual paths.

## Test plan

- [ ] Merge and wait for the next dependabot PR to open.
- [ ] Confirm CodeRabbit does not post an auto-review.
- [ ] Comment `@coderabbitai review` on that same PR.
- [ ] Confirm CodeRabbit responds and posts a review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)