### PR TITLE
ci(claude-review): drop show_full_output debug flag

### DIFF
--- a/.github/workflows/claude-review-reusable.yml
+++ b/.github/workflows/claude-review-reusable.yml
@@ -54,7 +54,4 @@ jobs:
           # https://github.com/anthropics/claude-code/tree/main/plugins/code-review
         plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
         plugins: "code-review@claude-code-plugins"
-          # DEBUG: surface the full transcript in the workflow log while we
-          # validate the plugin runs end-to-end. Remove once verified.
-        show_full_output: true
         prompt: "/code-review:code-review --comment"


### PR DESCRIPTION
## Summary

Removes `show_full_output: true` from the reusable workflow. Added in #12704 as a temporary belt-and-suspenders while we verified reviews were actually posting; per the test plan on #12705, this drops it now that we've seen a clean run.

## Verification

The plugin's first live run against #12662 posted a proper `## Code review — No issues found. Checked for bugs and CLAUDE.md compliance.` comment on 2026-07-01 at 07:14:01Z (workflow run [28500027726](https://github.com/openemr/openemr/actions/runs/28500027726)). Auth worked, plugin installed cleanly, all 4 parallel agents ran to completion, confidence-scored findings were filtered, and the summary comment landed as designed.

## Why remove it

Subagent transcripts contain PR diff snippets. Those are already visible in the PR itself (nothing secret leaks), but leaving the full transcript in every workflow log adds noise and marginal information-exposure surface. The action's default (summarized log output only) is the right steady state.

## Test plan

- [ ] Merge and comment `@claude review` on any open PR to confirm the plugin still runs end-to-end without the debug flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)