### PR TITLE
ci(claude-review): pin orchestrator to Sonnet, drop the premium Opus default

### DIFF
--- a/.github/workflows/claude-review-reusable.yml
+++ b/.github/workflows/claude-review-reusable.yml
@@ -54,4 +54,12 @@ jobs:
           # https://github.com/anthropics/claude-code/tree/main/plugins/code-review
         plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
         plugins: "code-review@claude-code-plugins"
+          # Pin the orchestrator to Sonnet. Without this pin the action
+          # defaults to claude-opus-4-8[1m] (Opus with 1M-context, the
+          # premium tier) — a large PR with the plugin was $5+ in that
+          # config. Sonnet drives cost 3-5x lower for the orchestration
+          # work. The skill's subagents (Haiku for skip-check, Sonnet for
+          # CLAUDE.md compliance, Opus for bug detection) are hardcoded
+          # in the skill and ignore this flag.
+        claude_args: "--model claude-sonnet-4-6"
         prompt: "/code-review:code-review --comment"


### PR DESCRIPTION
## Summary

Adds `claude_args: "--model claude-sonnet-4-6"` to the reusable so the plugin's orchestrator runs on Sonnet instead of the action's premium default.

## Why

Without an explicit `--model` pin the action defaults the orchestrator to `claude-opus-4-8[1m]` — Opus 4.8 with the 1M-context variant, Anthropic's most expensive tier. Live evidence from PR #12696 (workstream 2 branch-cut automation, +2791 lines / 22 files):

- `total_cost_usd: $5.07`
- `num_turns: 37`
- `duration_ms: 481774` (~8 min)
- `permission_denials_count: 27`
- `model: "claude-opus-4-8[1m]"`

The orchestrator's job is mostly to spawn subagents and collect results — it doesn't need Opus 4.8 with a 1M context window for that.

## What this changes

Only the orchestrator model. The skill's subagents are hardcoded in `commands/code-review.md`:

- Haiku for the skip-check + CLAUDE.md path collector
- Sonnet for CLAUDE.md compliance agents (2x)
- Opus for bug detection agents (2x) + their validators

These ignore any `--model` set at the action level, so bug-detection quality is unchanged. Only the orchestration portion — spawning agents, gathering results, driving the workflow — moves to Sonnet.

## Cost expectation

Rough: 3-5x drop on the orchestrator's share of the bill. On a PR the size of #12696, expect ~$2-3 total instead of $5+.

## Test plan

- [ ] Merge and comment `@claude review` on any open PR.
- [ ] Confirm workflow still runs to completion.
- [ ] Confirm log shows `"model": "claude-sonnet-4-6"` at the orchestrator level (subagents will still show `opus`/`sonnet`/`haiku` per the skill).
- [ ] Compare the run's `total_cost_usd` against the #12696 baseline of $5.07 on a similarly-sized PR to confirm the drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)