### PR TITLE
chore(release): pre-cut release-targets.yml for rel-820 (skip 8.1.x)

### DIFF
--- a/.github/release-targets.yml
+++ b/.github/release-targets.yml
@@ -99,12 +99,17 @@
   # release cycle (e.g., when version.php switches to 8.3.0-dev).
   # The docker_tag <-> version.php alignment guard in
   # docker-validate-release-targets.yml catches drift on PRs.
-  docker_tags: 8.2.0,dev
+  docker_tags: 8.2.0,dev,next
   openemr_version_ref: master
 
+# Pre-cut posture for rel-820: 8.1.x is being skipped entirely. Marking
+# this row `unreleased: true` pauses daily rel-810 publishing across the
+# cut window; the branch-cut workflow's BranchCutReleaseTargetsMutator
+# will drop this row (along with the placeholder below) uniformly.
 - branch: rel-810
-  docker_tags: 8.1.1,next
+  docker_tags: 8.1.1
   openemr_version_ref: rel-810
+  unreleased: true
 
 # Second rel-810 row -- placeholder for the multi-row dev pattern (see
 # `unreleased` field doc above). Wires up the second-row mechanism


### PR DESCRIPTION
Prep for the imminent rel-820 cut. 8.1.x is being skipped entirely (no 8.1.1 ship), so both rel-810 rows should be gone by the time \`branch-cut-automation.yml\` fires on the \`create\` event.

## Changes

- **Add \`unreleased: true\` to the rel-810 \`8.1.1,next\` row.** Pauses daily publishing from rel-810 across the cut window. \`BranchCutReleaseTargetsMutator.dropAllUnreleasedRows()\` (from #12696) will then uniformly drop this row alongside the existing \`8.1.0\` placeholder — leaving no rel-810 rows post-cut, matching the skip-line scenario documented in \`docs/release-mechanism-gaps.md\` G5 refinement.
- **Move the \`next\` tag from rel-810 to master.** Interim posture so master owns \`next\` temporarily during the cut. At the \`create\` event, \`BranchCutReleaseTargetsMutator.bumpMasterRow()\` drops master's \`next\` and bumps minor to \`8.3.0,dev\`, and the newly-inserted rel-820 row picks up \`8.2.0,next\`.

## Post-cut end state (once branch-cut workflow runs against rel-820)

\`\`\`yaml
- branch: master
  docker_tags: 8.3.0,dev
  openemr_version_ref: master

- branch: rel-820
  docker_tags: 8.2.0,next
  openemr_version_ref: rel-820

- branch: rel-800
  docker_tags: 8.0.0,8.0.0.3,latest
  openemr_version_ref: v8_0_0_3

- branch: rel-704
  docker_tags: 7.0.4
  openemr_version_ref: v7_0_4
\`\`\`

## Test plan

- [ ] \`docker-validate-release-targets.yml\` CI check passes (docker_tag ↔ version.php alignment: master's \`8.2.0,dev,next\` should still align with master's current \`\$v_major.\$v_minor = 8.2\`; rel-810's \`8.1.1\` is on an unreleased row so should be exempt from the guard).
- [ ] After merge + rel-820 cut, verify the branch-cut PRs open with the expected end state.

## References

Skip-line cut pattern: \`docs/release-mechanism-gaps.md\` G5 "Refinement (2026-06-30) — Skip-line cut scenario" (already in master via #12599).