### PR TITLE
ci(docker): trigger orchestrator on push to release-targets.yml

### DIFF
--- a/.github/workflows/docker-release-orchestrator.yml
+++ b/.github/workflows/docker-release-orchestrator.yml
@@ -28,6 +28,14 @@
 name: Docker release orchestrator
 
 on:
+  # Fire immediately when master's release-targets.yml changes (branch-cut,
+  # patch-prep, release-finalize, or a manual edit). Prior to this trigger,
+  # the daily 06:00 UTC tick was the only scheduled path, so a new/modified
+  # row would sit unpublished for up to 24h. Push events treat inputs as
+  # empty -> the fan-out matrix defaults to include=all (same as schedule).
+  push:
+    branches: [master]
+    paths: [.github/release-targets.yml]
   schedule:
   - cron: '0 6 * * *'    # 06:00 UTC daily
   workflow_dispatch:
@@ -40,6 +48,14 @@ on:
         description: 'Branches to skip (comma-separated). Useful with include=all.'
         type: string
         default: ''
+
+# Serialize orchestrator runs so a burst of release-targets.yml pushes
+# (or a schedule tick landing during a manual dispatch) doesn't fan out
+# overlapping builds against the same rows. Single global group by
+# workflow name because include/exclude inputs vary per invocation.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds a `push` trigger on `.github/release-targets.yml` to the docker release orchestrator so branch-cut / patch-prep / release-finalize row updates fan out to docker builds immediately, instead of waiting up to 24h for the next 06:00 UTC cron tick.

## Changes

`.github/workflows/docker-release-orchestrator.yml`:

1. **New `push:` trigger** — `branches: [master]`, `paths: [.github/release-targets.yml]`. Mirrors the pattern in `notify-release-targets-changed.yml`, which already fires on the same file to dispatch the demo_farm reconciliation. Push events treat `inputs.include` / `inputs.exclude` as empty, so the fan-out matrix defaults to `include=all` — same behavior as `schedule` events.

2. **New workflow-level `concurrency:` block** — group by workflow name, `cancel-in-progress: false`. Serializes runs so a burst of `release-targets.yml` pushes (or a schedule tick landing during a manual dispatch) doesn't fan out overlapping builds against the same rows.

## Motivation

Between the branch-cut, patch-prep, and release-finalize automation now landed on master (#12696 / #12697 / #12662), every release event ends with a mutation to `release-targets.yml`. Without a push trigger, the docker images that reflect the new state don't get built until the next daily cron.

For the imminent rel-820 cut specifically: `rel-820 → 8.2.0,next` won't get published as a docker image until the following 06:00 UTC unless someone remembers to manually dispatch. This PR removes that gap.

## Test plan

- [x] YAML parses.
- [ ] After merge, verify next push touching `.github/release-targets.yml` on master fires the orchestrator immediately.
- [ ] Verify a manual `workflow_dispatch` while a scheduled or push-triggered run is in progress queues rather than overlaps (concurrency group works).