### PR TITLE
docs(release): add 'Lifecycle: rel-NNN0 cut event' section to release-automation-plan.md

### DIFF
--- a/docs/release-automation-plan.md
+++ b/docs/release-automation-plan.md
@@ -355,79 +355,40 @@ rel row picking up `next`. Meanwhile the conductor still fires its
 premature draft against the new rel — same story as any cut, just with
 zero surviving rows for the outgoing rel branch.
 
-### Sequence: cut → 8.M.0 release
+### Flow: cut → 8.M.0 release
 
 ```mermaid
-sequenceDiagram
-    autonumber
-    actor M as Maintainer
-    participant BC as branch-cut-automation.yml
-    participant CP as release-prep.yml
-    participant R as rel-NNN0
-    participant Mas as master
-
-    M->>R: git push master:rel-NNN0
-    par branch-cut on create
-        BC->>R: open branch-cut/rel-NNN0
-        BC->>Mas: open branch-cut/rel-NNN0-master
-    and conductor on push
-        CP->>R: open release-prep/rel-NNN0 (draft)
-        CP->>Mas: open release-finalize/rel-NNN0 (draft)
-    end
-
-    M->>R: merge branch-cut/rel-NNN0 (rel-side FIRST)
-    CP-->>R: refire, force-push release-prep
-    CP-->>Mas: refire, force-push release-finalize
-
-    M->>Mas: merge branch-cut/rel-NNN0-master
-
-    Note over R,CP: dev cycle — every push refires conductor pair
-
-    M->>R: mark release-prep ready + merge
-    CP->>R: create annotated tag vN_M_0
-    CP->>Mas: dispatch openemr-tag
-
-    M->>Mas: merge release-finalize/rel-NNN0
+flowchart TD
+    A["git push master:rel-NNN0<br/>(cut)"]
+    A --> B["branch-cut-automation.yml fires<br/>opens branch-cut/rel-NNN0 +<br/>branch-cut/rel-NNN0-master<br/><i>ready-for-review</i>"]
+    A --> C["release-prep.yml fires<br/>opens release-prep/rel-NNN0 +<br/>release-finalize/rel-NNN0<br/><i>draft, premature</i>"]
+    B --> D["Merge branch-cut/rel-NNN0<br/><b>rel-side FIRST</b>"]
+    D --> E["release-prep.yml refires<br/>force-pushes conductor pair<br/>(still draft)"]
+    D --> F["Merge branch-cut/rel-NNN0-master"]
+    F --> G["Dev cycle:<br/>every rel-branch push refires<br/>conductor pair"]
+    G --> H["Mark release-prep/rel-NNN0 ready<br/>+ merge"]
+    H --> I["Finalize job:<br/>create annotated tag vN_M_0<br/>+ dispatch openemr-tag"]
+    I --> J["Merge release-finalize/rel-NNN0"]
 ```
 
-### Sequence: cut → patch bump → 8.M.P release
+### Flow: cut → patch bump → 8.M.P release
 
 Same start as above (cut → 8.M.0 ships). Later, a `$v_patch` bump on
 the rel branch fires patch-prep alongside the conductor:
 
 ```mermaid
-sequenceDiagram
-    autonumber
-    actor M as Maintainer
-    participant PP as patch-prep-automation.yml
-    participant CP as release-prep.yml
-    participant R as rel-NNN0
-    participant Mas as master
-
-    Note over M,Mas: 8.M.0 already shipped (see prior diagram)
-
-    M->>R: bump $v_patch, set $v_tag = -dev
-    par patch-prep on push (paths version.php)
-        PP->>R: open patch-prep/rel-NNN0
-        PP->>Mas: open patch-prep/rel-NNN0-master
-    and conductor on push
-        CP-->>R: force-push release-prep (target N.M.1)
-        CP-->>Mas: force-push release-finalize (target N.M.1)
-    end
-
-    M->>R: merge patch-prep/rel-NNN0 (rel-side FIRST)
-    CP-->>R: refire, force-push release-prep
-    CP-->>Mas: refire, force-push release-finalize
-
-    M->>Mas: merge patch-prep/rel-NNN0-master
-
-    Note over R,CP: dev cycle for N.M.1
-
-    M->>R: mark release-prep ready + merge
-    CP->>R: create annotated tag vN_M_1
-    CP->>Mas: dispatch openemr-tag
-
-    M->>Mas: merge release-finalize/rel-NNN0
+flowchart TD
+    A["8.M.0 already shipped<br/>(tag vN_M_0 exists)"]
+    A --> B["Commit on rel-NNN0:<br/>bump $v_patch<br/>set $v_tag = -dev"]
+    B --> C["patch-prep-automation.yml fires<br/>opens patch-prep/rel-NNN0 +<br/>patch-prep/rel-NNN0-master<br/><i>ready-for-review</i>"]
+    B --> D["release-prep.yml refires<br/>force-pushes conductor pair<br/>(target now N.M.1)"]
+    C --> E["Merge patch-prep/rel-NNN0<br/><b>rel-side FIRST</b>"]
+    E --> F["release-prep.yml refires again<br/>force-pushes conductor pair"]
+    E --> G["Merge patch-prep/rel-NNN0-master"]
+    G --> H["Dev cycle for N.M.1:<br/>pushes refire conductor pair"]
+    H --> I["Mark release-prep/rel-NNN0 ready<br/>+ merge"]
+    I --> J["Finalize job:<br/>create annotated tag vN_M_1<br/>+ dispatch openemr-tag"]
+    J --> K["Merge release-finalize/rel-NNN0"]
 ```
 
 Subsequent patch bumps (`N.M.1 → N.M.2 → …`) follow the same shape;

--- a/docs/release-automation-plan.md
+++ b/docs/release-automation-plan.md
@@ -197,6 +197,15 @@ job on merge), and `workflow_dispatch` with `target-version` + `branch` +
 optional `test` (opens `release-prep-test/<branch>` for end-to-end test
 runs) and `force-dispatch`.
 
+The `push` filter matches the branch-creation push too, so this
+workflow fires *at cut time* alongside `branch-cut-automation.yml` —
+opening a premature draft `release-prep/<rel-branch>` (paired with a
+`release-finalize/<rel-branch>-master`) before the branch is anywhere
+near ready to ship. Accepted as a tradeoff: the PRs sit inert as drafts,
+re-render on each push through the dev cycle, and become real when the
+branch is actually ready. See [Lifecycle: rel-NNN0 cut event](#lifecycle-rel-nnn0-cut-event)
+for the full picture.
+
 **Rel-side prep PR** (`release-prep/<rel-branch>`, base `<rel-branch>`,
 draft, force-pushed on each run):
 
@@ -261,6 +270,73 @@ day and lands **after** the tag is created. It's not gated on the tag
 creation (a maintainer can review and land it before merging release-prep);
 the semantic invariant is only that the tag it references exists by
 the time master's `release-targets.yml` is consulted downstream.
+
+## Lifecycle: rel-NNN0 cut event
+
+The most complex per-workflow interaction happens when a new `rel-NNN0`
+branch is cut. A single `git push origin master:rel-NNN0` fires two
+workflows simultaneously — `branch-cut-automation.yml` on the `create`
+event, and `release-prep.yml` on the `push` event (the create is also
+a push of master's tip to the new ref). Between them they open **four
+PRs** in the first minute or two:
+
+| PR (head → base) | Opened by | State | Lifetime |
+| --- | --- | --- | --- |
+| `branch-cut/<rel-branch>` → `<rel-branch>` | branch-cut | ready-for-review | until merged (or re-opened via `workflow_dispatch` recovery) |
+| `branch-cut/<rel-branch>-master` → `master` | branch-cut | ready-for-review | until merged |
+| `release-prep/<rel-branch>` → `<rel-branch>` | release-prep conductor | draft, force-pushed on every rel-branch push | until ship day |
+| `release-finalize/<rel-branch>-master` → `master` | release-prep conductor (Phase A partner) | draft, force-pushed on every rel-branch push | until ship day |
+
+**Lockstep on the conductor pair.** The last two are produced by a
+single `release-prep.yml` run, using two checkouts and one Symfony
+console invocation per side. Every subsequent push to `<rel-branch>` —
+whether it's the branch-cut PR merging, a dev commit, or a
+release-cycle-bot preparation PR — re-fires the conductor and
+force-pushes both sides. Reviewers should treat them as one review
+target that happens to span two PRs; the diff on one implies specific
+content on the other.
+
+**File overlap between the two pairs.** The branch-cut and conductor
+PRs against the same base branch touch some of the same files:
+
+- Rel-side both PRs touch `library/globals.inc.php` (branch-cut flips
+  `allow_debug_language` → `'0'`; release-prep's `GlobalsIncMutator` is
+  reused and idempotent, so a re-render sees the flag already flipped
+  and no-ops).
+- Rel-side both touch the `docker-version` triple (branch-cut bumps by
+  one for the new minor's dev cycle; release-prep leaves them alone at
+  ship time).
+- Master-side both touch `.github/release-targets.yml`, but different
+  operations: branch-cut inserts the new rel row + bumps master's
+  docker_tags; release-finalize does the eventual `latest`/`next` slot
+  shuffle when the branch actually ships.
+
+No merge conflicts at open time — force-pushed regeneration keeps the
+conductor pair current against the rel branch's tip. Recommended merge
+order is **branch-cut PRs first** (they're ready-for-review, not draft,
+and meant to land in the days immediately after the cut); the next push
+to `<rel-branch>` re-renders the conductor pair against the new base.
+
+**Known gap: master-side release-finalize doesn't auto-refresh on
+master pushes.** The conductor fires on `push` to `<rel-branch>`, not
+on `push` to master. So the sequence "merge `branch-cut/<rel-branch>-master`
+→ master advances → `release-finalize/<rel-branch>-master` still points
+at the pre-branch-cut master" persists until the next push to
+`<rel-branch>` refreshes it. Not a practical problem — release-finalize
+is draft, no one merges it until ship day, and dev commits to the rel
+branch fire throughout the cycle — but worth knowing when inspecting
+the diff between the two events.
+
+**Skip-line cut (`unreleased: true` on outgoing rel branch's rows).**
+When a rel line is being skipped entirely (e.g., the 8.1.x skip that
+preceded rel-820 — see openemr/openemr#12712), the pre-cut posture
+flags the outgoing branch's rows as `unreleased: true` and moves the
+`next` docker tag to master interim. At the create event, the
+branch-cut `BranchCutReleaseTargetsMutator` drops all unreleased rows
+uniformly (leaving no rows for the skipped rel), and inserts the new
+rel row picking up `next`. Meanwhile the conductor still fires its
+premature draft against the new rel — same story as any cut, just with
+zero surviving rows for the outgoing rel branch.
 
 ## Mutator framework
 

--- a/docs/release-automation-plan.md
+++ b/docs/release-automation-plan.md
@@ -200,7 +200,7 @@ runs) and `force-dispatch`.
 The `push` filter matches the branch-creation push too, so this
 workflow fires *at cut time* alongside `branch-cut-automation.yml` —
 opening a premature draft `release-prep/<rel-branch>` (paired with a
-`release-finalize/<rel-branch>-master`) before the branch is anywhere
+`release-finalize/<rel-branch>`) before the branch is anywhere
 near ready to ship. Accepted as a tradeoff: the PRs sit inert as drafts,
 re-render on each push through the dev cycle, and become real when the
 branch is actually ready. See [Lifecycle: rel-NNN0 cut event](#lifecycle-rel-nnn0-cut-event)
@@ -285,7 +285,7 @@ PRs** in the first minute or two:
 | `branch-cut/<rel-branch>` → `<rel-branch>` | branch-cut | ready-for-review | until merged (or re-opened via `workflow_dispatch` recovery) |
 | `branch-cut/<rel-branch>-master` → `master` | branch-cut | ready-for-review | until merged |
 | `release-prep/<rel-branch>` → `<rel-branch>` | release-prep conductor | draft, force-pushed on every rel-branch push | until ship day |
-| `release-finalize/<rel-branch>-master` → `master` | release-prep conductor (Phase A partner) | draft, force-pushed on every rel-branch push | until ship day |
+| `release-finalize/<rel-branch>` → `master` | release-prep conductor (Phase A partner) | draft, force-pushed on every rel-branch push | until ship day |
 
 **Lockstep on the conductor pair.** The last two are produced by a
 single `release-prep.yml` run, using two checkouts and one Symfony
@@ -313,19 +313,38 @@ PRs against the same base branch touch some of the same files:
 
 No merge conflicts at open time — force-pushed regeneration keeps the
 conductor pair current against the rel branch's tip. Recommended merge
-order is **branch-cut PRs first** (they're ready-for-review, not draft,
-and meant to land in the days immediately after the cut); the next push
-to `<rel-branch>` re-renders the conductor pair against the new base.
+order:
+
+1. **`branch-cut/<rel-branch>` (rel-side) first.** This transforms the
+   freshly-cut branch into a proper rel branch: Dockerfile `ARG
+   OPENEMR_VERSION` pinned to the rel line, docker-version files
+   bumped, translation blob copied from the prior rel, `allow_debug_language`
+   flipped to `'0'`. Until this lands, `rel-<rel-branch>`'s tip is bit-
+   identical to master.
+2. **`branch-cut/<rel-branch>-master` (master-side) second.** This
+   inserts the new rel branch's row into `.github/release-targets.yml`
+   (with `openemr_version_ref: <rel-branch>`). Since the docker release
+   orchestrator now fires on pushes to `release-targets.yml`
+   (openemr/openemr#12720), merging master-side triggers an image build
+   against the rel branch's tip. If master-side lands *before* rel-side,
+   that build bakes an image labeled `<version>,next` from a rel branch
+   that's still bit-identical to master — no fatal error, but the image
+   won't carry the rel-branch identity mutations until the rel-side PR
+   lands and the next orchestrator run picks it up.
+3. **Conductor pair (release-prep + release-finalize) stays draft** until
+   the branch is actually ready to ship (dev cycle complete, all
+   pre-ship checklists satisfied). The pair re-renders on every push
+   through the dev cycle, so it stays fresh.
 
 **Known gap: master-side release-finalize doesn't auto-refresh on
 master pushes.** The conductor fires on `push` to `<rel-branch>`, not
 on `push` to master. So the sequence "merge `branch-cut/<rel-branch>-master`
-→ master advances → `release-finalize/<rel-branch>-master` still points
-at the pre-branch-cut master" persists until the next push to
-`<rel-branch>` refreshes it. Not a practical problem — release-finalize
-is draft, no one merges it until ship day, and dev commits to the rel
-branch fire throughout the cycle — but worth knowing when inspecting
-the diff between the two events.
+→ master advances → `release-finalize/<rel-branch>` still points at the
+pre-branch-cut master" persists until the next push to `<rel-branch>`
+refreshes it. Not a practical problem — release-finalize is draft, no
+one merges it until ship day, and dev commits to the rel branch fire
+throughout the cycle — but worth knowing when inspecting the diff
+between the two events.
 
 **Skip-line cut (`unreleased: true` on outgoing rel branch's rows).**
 When a rel line is being skipped entirely (e.g., the 8.1.x skip that
@@ -337,6 +356,87 @@ uniformly (leaving no rows for the skipped rel), and inserts the new
 rel row picking up `next`. Meanwhile the conductor still fires its
 premature draft against the new rel — same story as any cut, just with
 zero surviving rows for the outgoing rel branch.
+
+### Sequence: cut → 8.M.0 release
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor M as Maintainer
+    participant BC as branch-cut<br/>workflow
+    participant CP as release-prep<br/>conductor
+    participant R as rel-NNN0
+    participant Mas as master
+
+    M->>R: git push origin master:rel-NNN0<br/>(create event)
+    par branch-cut on `create`
+        BC->>R: open branch-cut/rel-NNN0<br/>(ready-for-review)
+        BC->>Mas: open branch-cut/rel-NNN0-master<br/>(ready-for-review)
+    and conductor on `push`
+        CP->>R: open release-prep/rel-NNN0<br/>(draft, premature)
+        CP->>Mas: open release-finalize/rel-NNN0<br/>(draft, premature)
+    end
+
+    M->>R: merge branch-cut/rel-NNN0 (rel-side FIRST)
+    Note over R,CP: push refires conductor pair
+    CP-->>R: force-push release-prep/rel-NNN0
+    CP-->>Mas: force-push release-finalize/rel-NNN0
+
+    M->>Mas: merge branch-cut/rel-NNN0-master
+
+    Note over R,CP: dev cycle — every push refires<br/>conductor pair with latest target
+
+    M->>R: mark release-prep/rel-NNN0 ready + merge
+    Note over CP: pull_request:closed →<br/>finalize job
+    CP->>R: create annotated tag vN_M_0
+    CP->>Mas: dispatch openemr-tag
+
+    M->>Mas: merge release-finalize/rel-NNN0
+```
+
+### Sequence: cut → patch bump → 8.M.P release
+
+Same start as above (cut → 8.M.0 ships). Then a `$v_patch` bump on the
+rel branch fires patch-prep alongside the conductor:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor M as Maintainer
+    participant PP as patch-prep<br/>workflow
+    participant CP as release-prep<br/>conductor
+    participant R as rel-NNN0
+    participant Mas as master
+
+    Note over R,Mas: 8.M.0 has already shipped<br/>(see prior diagram); tag vN_M_0 exists
+
+    M->>R: commit: bump $v_patch (0→1),<br/>set $v_tag to '-dev'
+    par patch-prep on `push` (paths: version.php)
+        PP->>R: open patch-prep/rel-NNN0<br/>(ready-for-review)
+        PP->>Mas: open patch-prep/rel-NNN0-master<br/>(ready-for-review)
+    and conductor on `push`
+        CP-->>R: force-push release-prep/rel-NNN0<br/>(target now N.M.1)
+        CP-->>Mas: force-push release-finalize/rel-NNN0<br/>(target now N.M.1)
+    end
+
+    M->>R: merge patch-prep/rel-NNN0 (rel-side FIRST)
+    Note over R,CP: push refires conductor pair
+    CP-->>R: force-push release-prep/rel-NNN0
+    CP-->>Mas: force-push release-finalize/rel-NNN0
+
+    M->>Mas: merge patch-prep/rel-NNN0-master
+
+    Note over R,CP: dev cycle for N.M.1
+
+    M->>R: mark release-prep/rel-NNN0 ready + merge
+    CP->>R: create annotated tag vN_M_1
+    CP->>Mas: dispatch openemr-tag
+
+    M->>Mas: merge release-finalize/rel-NNN0
+```
+
+Subsequent patch bumps (`N.M.1 → N.M.2 → …`) follow the same shape
+verbatim; the diagram scales by inspection.
 
 ## Mutator framework
 

--- a/docs/release-automation-plan.md
+++ b/docs/release-automation-plan.md
@@ -355,71 +355,83 @@ rel row picking up `next`. Meanwhile the conductor still fires its
 premature draft against the new rel — same story as any cut, just with
 zero surviving rows for the outgoing rel branch.
 
-### Flow: events → workflows → PRs → consumers
+### Sequence: cut → 8.M.0 release
 
-```text
-                                        openemr/openemr                            consumers
-                                        ─────────────────                          ─────────
-create rel-NNN0                 branch-cut/<rel-branch>            ───┐  (ready-for-review)
-   │                            branch-cut/<rel-branch>-master     ───┤  (ready-for-review)
-   ├──► branch-cut-automation.yml                                     │
-   │                                                                  │
-push $v_patch bump on rel-*     patch-prep/<rel-branch>            ───┤  (ready-for-review)
-   │  (paths: version.php)      patch-prep/<rel-branch>-master     ───┤  (ready-for-review)
-   ├──► patch-prep-automation.yml                                     │
-   │                                                                  │
-push to rel-*                   release-prep/<rel-branch>          ───┤  (draft, force-pushed)
-   │  (any push during the      release-finalize/<rel-branch>      ───┤  (draft, force-pushed)
-   │   dev cycle; also fires                                          │
-   │   on create + on $v_patch                                        │
-   │   push shown above)                                              ├─► openemr-rel-cut     ─► openemr-devops,
-   ├──► release-prep.yml                                              │   openemr-rel-update      website-openemr
-   │                                                                  │
-   ▼                                                                  │
-merge release-prep/<rel-branch>                                       │
-   │                                                                  │
-   ├──► release-prep.yml (finalize job, on pull_request:closed)       │
-   │       │                                                          │
-   │       ▼                                                          │
-   │    annotated tag v{M}_{m}_{p}                                    │
-   │                                                                  ├─► openemr-tag         ─► openemr-devops
-   │                                                                                              (build-release.yml:
-   │                                                                                               build packages,
-   │                                                                                               create Release,
-   │                                                                                               upload assets)
-   │                                                                                          ─► website-openemr
-   │                                                                                              (release-docs PR)
-   │
-merge release-finalize/<rel-branch>       (pins rel branch row to new tag,
-   │   (or merge branch-cut/…-master,      shuffles docker slots)
-   │    or merge patch-prep/…-master)
-   │
-   ├──► push to .github/release-targets.yml on master
-   │
-   └──► docker-release-orchestrator.yml       ─► docker images published
-        (fan-out one build per non-              per active rel branch
-         unreleased row)                     ─► notify-release-targets-changed.yml
-                                                ─► demo_farm_openemr
-                                                    (auto-derive reconciliation PR)
+```mermaid
+sequenceDiagram
+    autonumber
+    actor M as Maintainer
+    participant BC as branch-cut-automation.yml
+    participant CP as release-prep.yml
+    participant R as rel-NNN0
+    participant Mas as master
+
+    M->>R: git push master:rel-NNN0
+    par branch-cut on create
+        BC->>R: open branch-cut/rel-NNN0
+        BC->>Mas: open branch-cut/rel-NNN0-master
+    and conductor on push
+        CP->>R: open release-prep/rel-NNN0 (draft)
+        CP->>Mas: open release-finalize/rel-NNN0 (draft)
+    end
+
+    M->>R: merge branch-cut/rel-NNN0 (rel-side FIRST)
+    CP-->>R: refire, force-push release-prep
+    CP-->>Mas: refire, force-push release-finalize
+
+    M->>Mas: merge branch-cut/rel-NNN0-master
+
+    Note over R,CP: dev cycle — every push refires conductor pair
+
+    M->>R: mark release-prep ready + merge
+    CP->>R: create annotated tag vN_M_0
+    CP->>Mas: dispatch openemr-tag
+
+    M->>Mas: merge release-finalize/rel-NNN0
 ```
 
-Reading the flow:
+### Sequence: cut → patch bump → 8.M.P release
 
-- The top three sections are the three trigger types that produce PRs
-  in `openemr/openemr`. Branch-cut and patch-prep each open a pair
-  (rel-side + master-side, ready-for-review). Release-prep opens its
-  own pair (rel-side + master-side, draft, force-pushed on every push
-  to the rel branch — including the create event and the `$v_patch`
-  bump above, which is why the "push to rel-*" trigger visually
-  encompasses both).
-- Merging the release-prep PR fires the conductor's finalize job,
-  which creates the annotated tag and dispatches the `openemr-tag`
-  event to consumers.
-- Any merge that touches `.github/release-targets.yml` on master —
-  branch-cut master-side, patch-prep master-side, or release-finalize
-  — fires the docker orchestrator (via the push trigger from
-  openemr/openemr#12720) *and* the demo_farm dispatch (via
-  `notify-release-targets-changed.yml`).
+Same start as above (cut → 8.M.0 ships). Later, a `$v_patch` bump on
+the rel branch fires patch-prep alongside the conductor:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor M as Maintainer
+    participant PP as patch-prep-automation.yml
+    participant CP as release-prep.yml
+    participant R as rel-NNN0
+    participant Mas as master
+
+    Note over M,Mas: 8.M.0 already shipped (see prior diagram)
+
+    M->>R: bump $v_patch, set $v_tag = -dev
+    par patch-prep on push (paths version.php)
+        PP->>R: open patch-prep/rel-NNN0
+        PP->>Mas: open patch-prep/rel-NNN0-master
+    and conductor on push
+        CP-->>R: force-push release-prep (target N.M.1)
+        CP-->>Mas: force-push release-finalize (target N.M.1)
+    end
+
+    M->>R: merge patch-prep/rel-NNN0 (rel-side FIRST)
+    CP-->>R: refire, force-push release-prep
+    CP-->>Mas: refire, force-push release-finalize
+
+    M->>Mas: merge patch-prep/rel-NNN0-master
+
+    Note over R,CP: dev cycle for N.M.1
+
+    M->>R: mark release-prep ready + merge
+    CP->>R: create annotated tag vN_M_1
+    CP->>Mas: dispatch openemr-tag
+
+    M->>Mas: merge release-finalize/rel-NNN0
+```
+
+Subsequent patch bumps (`N.M.1 → N.M.2 → …`) follow the same shape;
+the diagram scales by inspection.
 
 ## Mutator framework
 

--- a/docs/release-automation-plan.md
+++ b/docs/release-automation-plan.md
@@ -315,22 +315,20 @@ No merge conflicts at open time — force-pushed regeneration keeps the
 conductor pair current against the rel branch's tip. Recommended merge
 order:
 
-1. **`branch-cut/<rel-branch>` (rel-side) first.** This transforms the
-   freshly-cut branch into a proper rel branch: Dockerfile `ARG
-   OPENEMR_VERSION` pinned to the rel line, docker-version files
-   bumped, translation blob copied from the prior rel, `allow_debug_language`
-   flipped to `'0'`. Until this lands, `rel-<rel-branch>`'s tip is bit-
-   identical to master.
-2. **`branch-cut/<rel-branch>-master` (master-side) second.** This
-   inserts the new rel branch's row into `.github/release-targets.yml`
-   (with `openemr_version_ref: <rel-branch>`). Since the docker release
-   orchestrator now fires on pushes to `release-targets.yml`
-   (openemr/openemr#12720), merging master-side triggers an image build
-   against the rel branch's tip. If master-side lands *before* rel-side,
-   that build bakes an image labeled `<version>,next` from a rel branch
-   that's still bit-identical to master — no fatal error, but the image
-   won't carry the rel-branch identity mutations until the rel-side PR
-   lands and the next orchestrator run picks it up.
+1. **`branch-cut/<rel-branch>` (rel-side) first.** This is the critical
+   ordering: the master-side PR inserts a row in `.github/release-targets.yml`
+   (with `openemr_version_ref: <rel-branch>`), and the docker release
+   orchestrator now fires on pushes to that file
+   (openemr/openemr#12720). So merging master-side kicks off an image
+   build against the rel branch's tip. If master-side lands *before*
+   rel-side, that build bakes an image labeled `<version>,next` from a
+   rel branch that's still bit-identical to master. No fatal error —
+   the Dockerfile is byte-identical across branches — but the image
+   won't carry the rel-branch identity mutations (Dockerfile `ARG
+   OPENEMR_VERSION` pin, docker-version bump, translation blob copy,
+   `allow_debug_language` flip) until rel-side lands and the next
+   orchestrator run picks it up.
+2. **`branch-cut/<rel-branch>-master` (master-side) second.**
 3. **Conductor pair (release-prep + release-finalize) stays draft** until
    the branch is actually ready to ship (dev cycle complete, all
    pre-ship checklists satisfied). The pair re-renders on every push
@@ -357,86 +355,71 @@ rel row picking up `next`. Meanwhile the conductor still fires its
 premature draft against the new rel — same story as any cut, just with
 zero surviving rows for the outgoing rel branch.
 
-### Sequence: cut → 8.M.0 release
+### Flow: events → workflows → PRs → consumers
 
-```mermaid
-sequenceDiagram
-    autonumber
-    actor M as Maintainer
-    participant BC as branch-cut<br/>workflow
-    participant CP as release-prep<br/>conductor
-    participant R as rel-NNN0
-    participant Mas as master
-
-    M->>R: git push origin master:rel-NNN0<br/>(create event)
-    par branch-cut on `create`
-        BC->>R: open branch-cut/rel-NNN0<br/>(ready-for-review)
-        BC->>Mas: open branch-cut/rel-NNN0-master<br/>(ready-for-review)
-    and conductor on `push`
-        CP->>R: open release-prep/rel-NNN0<br/>(draft, premature)
-        CP->>Mas: open release-finalize/rel-NNN0<br/>(draft, premature)
-    end
-
-    M->>R: merge branch-cut/rel-NNN0 (rel-side FIRST)
-    Note over R,CP: push refires conductor pair
-    CP-->>R: force-push release-prep/rel-NNN0
-    CP-->>Mas: force-push release-finalize/rel-NNN0
-
-    M->>Mas: merge branch-cut/rel-NNN0-master
-
-    Note over R,CP: dev cycle — every push refires<br/>conductor pair with latest target
-
-    M->>R: mark release-prep/rel-NNN0 ready + merge
-    Note over CP: pull_request:closed →<br/>finalize job
-    CP->>R: create annotated tag vN_M_0
-    CP->>Mas: dispatch openemr-tag
-
-    M->>Mas: merge release-finalize/rel-NNN0
+```text
+                                        openemr/openemr                            consumers
+                                        ─────────────────                          ─────────
+create rel-NNN0                 branch-cut/<rel-branch>            ───┐  (ready-for-review)
+   │                            branch-cut/<rel-branch>-master     ───┤  (ready-for-review)
+   ├──► branch-cut-automation.yml                                     │
+   │                                                                  │
+push $v_patch bump on rel-*     patch-prep/<rel-branch>            ───┤  (ready-for-review)
+   │  (paths: version.php)      patch-prep/<rel-branch>-master     ───┤  (ready-for-review)
+   ├──► patch-prep-automation.yml                                     │
+   │                                                                  │
+push to rel-*                   release-prep/<rel-branch>          ───┤  (draft, force-pushed)
+   │  (any push during the      release-finalize/<rel-branch>      ───┤  (draft, force-pushed)
+   │   dev cycle; also fires                                          │
+   │   on create + on $v_patch                                        │
+   │   push shown above)                                              ├─► openemr-rel-cut     ─► openemr-devops,
+   ├──► release-prep.yml                                              │   openemr-rel-update      website-openemr
+   │                                                                  │
+   ▼                                                                  │
+merge release-prep/<rel-branch>                                       │
+   │                                                                  │
+   ├──► release-prep.yml (finalize job, on pull_request:closed)       │
+   │       │                                                          │
+   │       ▼                                                          │
+   │    annotated tag v{M}_{m}_{p}                                    │
+   │                                                                  ├─► openemr-tag         ─► openemr-devops
+   │                                                                                              (build-release.yml:
+   │                                                                                               build packages,
+   │                                                                                               create Release,
+   │                                                                                               upload assets)
+   │                                                                                          ─► website-openemr
+   │                                                                                              (release-docs PR)
+   │
+merge release-finalize/<rel-branch>       (pins rel branch row to new tag,
+   │   (or merge branch-cut/…-master,      shuffles docker slots)
+   │    or merge patch-prep/…-master)
+   │
+   ├──► push to .github/release-targets.yml on master
+   │
+   └──► docker-release-orchestrator.yml       ─► docker images published
+        (fan-out one build per non-              per active rel branch
+         unreleased row)                     ─► notify-release-targets-changed.yml
+                                                ─► demo_farm_openemr
+                                                    (auto-derive reconciliation PR)
 ```
 
-### Sequence: cut → patch bump → 8.M.P release
+Reading the flow:
 
-Same start as above (cut → 8.M.0 ships). Then a `$v_patch` bump on the
-rel branch fires patch-prep alongside the conductor:
-
-```mermaid
-sequenceDiagram
-    autonumber
-    actor M as Maintainer
-    participant PP as patch-prep<br/>workflow
-    participant CP as release-prep<br/>conductor
-    participant R as rel-NNN0
-    participant Mas as master
-
-    Note over R,Mas: 8.M.0 has already shipped<br/>(see prior diagram); tag vN_M_0 exists
-
-    M->>R: commit: bump $v_patch (0→1),<br/>set $v_tag to '-dev'
-    par patch-prep on `push` (paths: version.php)
-        PP->>R: open patch-prep/rel-NNN0<br/>(ready-for-review)
-        PP->>Mas: open patch-prep/rel-NNN0-master<br/>(ready-for-review)
-    and conductor on `push`
-        CP-->>R: force-push release-prep/rel-NNN0<br/>(target now N.M.1)
-        CP-->>Mas: force-push release-finalize/rel-NNN0<br/>(target now N.M.1)
-    end
-
-    M->>R: merge patch-prep/rel-NNN0 (rel-side FIRST)
-    Note over R,CP: push refires conductor pair
-    CP-->>R: force-push release-prep/rel-NNN0
-    CP-->>Mas: force-push release-finalize/rel-NNN0
-
-    M->>Mas: merge patch-prep/rel-NNN0-master
-
-    Note over R,CP: dev cycle for N.M.1
-
-    M->>R: mark release-prep/rel-NNN0 ready + merge
-    CP->>R: create annotated tag vN_M_1
-    CP->>Mas: dispatch openemr-tag
-
-    M->>Mas: merge release-finalize/rel-NNN0
-```
-
-Subsequent patch bumps (`N.M.1 → N.M.2 → …`) follow the same shape
-verbatim; the diagram scales by inspection.
+- The top three sections are the three trigger types that produce PRs
+  in `openemr/openemr`. Branch-cut and patch-prep each open a pair
+  (rel-side + master-side, ready-for-review). Release-prep opens its
+  own pair (rel-side + master-side, draft, force-pushed on every push
+  to the rel branch — including the create event and the `$v_patch`
+  bump above, which is why the "push to rel-*" trigger visually
+  encompasses both).
+- Merging the release-prep PR fires the conductor's finalize job,
+  which creates the annotated tag and dispatches the `openemr-tag`
+  event to consumers.
+- Any merge that touches `.github/release-targets.yml` on master —
+  branch-cut master-side, patch-prep master-side, or release-finalize
+  — fires the docker orchestrator (via the push trigger from
+  openemr/openemr#12720) *and* the demo_farm dispatch (via
+  `notify-release-targets-changed.yml`).
 
 ## Mutator framework
 

--- a/docs/release-automation-plan.md
+++ b/docs/release-automation-plan.md
@@ -200,8 +200,8 @@ runs) and `force-dispatch`.
 The `push` filter matches the branch-creation push too, so this
 workflow fires *at cut time* alongside `branch-cut-automation.yml` —
 opening a premature draft `release-prep/<rel-branch>` (paired with a
-`release-finalize/<rel-branch>`) before the branch is anywhere
-near ready to ship. Accepted as a tradeoff: the PRs sit inert as drafts,
+`release-finalize/<rel-branch>` targeting master) before the branch is
+anywhere near ready to ship. Accepted as a tradeoff: the PRs sit inert as drafts,
 re-render on each push through the dev cycle, and become real when the
 branch is actually ready. See [Lifecycle: rel-NNN0 cut event](#lifecycle-rel-nnn0-cut-event)
 for the full picture.
@@ -337,9 +337,9 @@ order:
 **Known gap: master-side release-finalize doesn't auto-refresh on
 master pushes.** The conductor fires on `push` to `<rel-branch>`, not
 on `push` to master. So the sequence "merge `branch-cut/<rel-branch>-master`
-→ master advances → `release-finalize/<rel-branch>` still points at the
-pre-branch-cut master" persists until the next push to `<rel-branch>`
-refreshes it. Not a practical problem — release-finalize is draft, no
+→ master advances → `release-finalize/<rel-branch>` (which targets
+master) still points at the pre-branch-cut master" persists until the
+next push to `<rel-branch>` refreshes it. Not a practical problem — release-finalize is draft, no
 one merges it until ship day, and dev commits to the rel branch fire
 throughout the cycle — but worth knowing when inspecting the diff
 between the two events.
@@ -361,14 +361,14 @@ zero surviving rows for the outgoing rel branch.
 flowchart TD
     A["git push master:rel-NNN0<br/>(cut)"]
     A --> B["branch-cut-automation.yml fires<br/>opens branch-cut/rel-NNN0 +<br/>branch-cut/rel-NNN0-master<br/><i>ready-for-review</i>"]
-    A --> C["release-prep.yml fires<br/>opens release-prep/rel-NNN0 +<br/>release-finalize/rel-NNN0<br/><i>draft, premature</i>"]
-    B --> D["Merge branch-cut/rel-NNN0<br/><b>rel-side FIRST</b>"]
+    A --> C["release-prep.yml fires<br/>opens release-prep/rel-NNN0 (→ rel-NNN0) +<br/>release-finalize/rel-NNN0 (→ master)<br/><i>draft, premature</i>"]
+    B --> D["Merge branch-cut/rel-NNN0 (→ rel-NNN0)<br/><b>rel-side FIRST</b>"]
     D --> E["release-prep.yml refires<br/>force-pushes conductor pair<br/>(still draft)"]
-    D --> F["Merge branch-cut/rel-NNN0-master"]
+    D --> F["Merge branch-cut/rel-NNN0-master (→ master)"]
     F --> G["Dev cycle:<br/>every rel-branch push refires<br/>conductor pair"]
-    G --> H["Mark release-prep/rel-NNN0 ready<br/>+ merge"]
+    G --> H["Mark release-prep/rel-NNN0 ready<br/>+ merge (→ rel-NNN0)"]
     H --> I["Finalize job:<br/>create annotated tag vN_M_0<br/>+ dispatch openemr-tag"]
-    I --> J["Merge release-finalize/rel-NNN0"]
+    I --> J["Merge release-finalize/rel-NNN0 (→ master)"]
 ```
 
 ### Flow: cut → patch bump → 8.M.P release
@@ -382,13 +382,13 @@ flowchart TD
     A --> B["Commit on rel-NNN0:<br/>bump $v_patch<br/>set $v_tag = -dev"]
     B --> C["patch-prep-automation.yml fires<br/>opens patch-prep/rel-NNN0 +<br/>patch-prep/rel-NNN0-master<br/><i>ready-for-review</i>"]
     B --> D["release-prep.yml refires<br/>force-pushes conductor pair<br/>(target now N.M.1)"]
-    C --> E["Merge patch-prep/rel-NNN0<br/><b>rel-side FIRST</b>"]
+    C --> E["Merge patch-prep/rel-NNN0 (→ rel-NNN0)<br/><b>rel-side FIRST</b>"]
     E --> F["release-prep.yml refires again<br/>force-pushes conductor pair"]
-    E --> G["Merge patch-prep/rel-NNN0-master"]
+    E --> G["Merge patch-prep/rel-NNN0-master (→ master)"]
     G --> H["Dev cycle for N.M.1:<br/>pushes refire conductor pair"]
-    H --> I["Mark release-prep/rel-NNN0 ready<br/>+ merge"]
+    H --> I["Mark release-prep/rel-NNN0 ready<br/>+ merge (→ rel-NNN0)"]
     I --> J["Finalize job:<br/>create annotated tag vN_M_1<br/>+ dispatch openemr-tag"]
-    J --> K["Merge release-finalize/rel-NNN0"]
+    J --> K["Merge release-finalize/rel-NNN0 (→ master)"]
 ```
 
 Subsequent patch bumps (`N.M.1 → N.M.2 → …`) follow the same shape;


### PR DESCRIPTION
Follow-up to #12710. The per-workflow sections in `docs/release-automation-plan.md` cover triggers and PR shapes individually, but the multi-workflow interaction at cut time was left implicit — a reader has to piece together what happens from the branch-cut section + release-prep section + the fact that a branch creation is also a push.

## Changes

Two additions to `docs/release-automation-plan.md`:

1. **Brief pointer in the release-prep conductor section** — notes that the `push` filter also matches branch-creation pushes, so the conductor fires at cut time alongside `branch-cut-automation.yml`, opening premature draft PRs that stay inert until ship day. Links forward to the new lifecycle section.

2. **New H2 section — "Lifecycle: rel-NNN0 cut event"** — walks through what actually happens when `git push origin master:rel-NNN0` fires:
   - The four PRs that open in the first minute or two (table)
   - Lockstep behavior of the conductor pair (single workflow run, dual checkouts, force-pushed together on every rel-branch push)
   - File overlap between the branch-cut PRs and the conductor pair (globals.inc.php, docker-version, release-targets.yml)
   - Recommended merge order (branch-cut first, ready-for-review; conductor pair stays draft until ship day)
   - Known gap: `release-finalize/<rel-branch>-master` doesn't auto-refresh when master pushes (only on rel-branch pushes), so the "merge branch-cut-master → master advances → release-finalize now stale" window persists until the next rel-branch push
   - Skip-line cut scenario noted (references #12712 for the rel-820 pre-cut posture that flagged both rel-810 rows unreleased)

## Motivation

We just went through this walkthrough conversationally to answer a specific question about the interaction. Codifying it in the doc means future readers don't need to re-derive it.