### PR TITLE
fix(release): add --skip-globals to branch-cut and patch-prep CLI invocations

### DIFF
--- a/.github/workflows/branch-cut-automation.yml
+++ b/.github/workflows/branch-cut-automation.yml
@@ -171,6 +171,7 @@ jobs:
         PREV_REL_BRANCH: ${{ steps.resolve.outputs.prev-rel-branch }}
       run: |
         php bin/console openemr:branch-cut \
+          --skip-globals \
           --target-version="${VERSION}" \
           --rel-branch="${REL_BRANCH}" \
           --prev-rel-branch="${PREV_REL_BRANCH}" \
@@ -230,6 +231,7 @@ jobs:
         PREV_REL_BRANCH: ${{ steps.resolve.outputs.prev-rel-branch }}
       run: |
         php bin/console openemr:branch-cut \
+          --skip-globals \
           --target-version="${VERSION}" \
           --rel-branch="${REL_BRANCH}" \
           --prev-rel-branch="${PREV_REL_BRANCH}" \

--- a/.github/workflows/patch-prep-automation.yml
+++ b/.github/workflows/patch-prep-automation.yml
@@ -283,6 +283,7 @@ jobs:
         PREV_VERSION: ${{ steps.resolve.outputs.prev-version }}
       run: |
         php bin/console openemr:patch-prep \
+          --skip-globals \
           --target-version="${VERSION}" \
           --rel-branch="${REL_BRANCH}" \
           --prev-version="${PREV_VERSION}" \
@@ -347,6 +348,7 @@ jobs:
         PREV_VERSION: ${{ steps.resolve.outputs.prev-version }}
       run: |
         php bin/console openemr:patch-prep \
+          --skip-globals \
           --target-version="${VERSION}" \
           --rel-branch="${REL_BRANCH}" \
           --prev-version="${PREV_VERSION}" \


### PR DESCRIPTION
Fixes the branch-cut-automation.yml and patch-prep-automation.yml workflows which have been failing on their real invocations because the `bin/console openemr:{branch-cut,patch-prep}` calls omit `--skip-globals`.

## Symptom

The rel-820 cut at 18:19Z today fired `branch-cut-automation.yml` on the `create` event. The workflow crashed at the "Run branch-cut mutators (rel side)" step with:

```
mysqli_query(): Argument #1 ($mysql) must be of type mysqli, false given
  at vendor/adodb/adodb-php/drivers/adodb-mysqli.inc.php:1454
```

## Root cause

`bin/console` bootstraps `interface/globals.php` which connects to the DB — GH runners have no DB, so the connect fails and the command exits before any mutator runs. `--skip-globals` is the escape hatch that bypasses the DB bootstrap for CLI-only paths.

`release-prep.yml` correctly passes `--skip-globals` (lines 170 + 229). The two newer workflows (`branch-cut-automation.yml` from #12696 and `patch-prep-automation.yml` from #12697) both missed it — on both rel-side and master-side invocations.

## Fix

Add `--skip-globals` to all four invocations:
- `branch-cut-automation.yml`: rel-side (line 173) + master-side (line 232)
- `patch-prep-automation.yml`: rel-side (line 285) + master-side (line 349)

Verified locally: same mutators produce clean diffs when invoked with `--skip-globals` (that's what Path A of the pre-cut dry-run earlier today used).

## After merge

Re-fire branch-cut against rel-820 via workflow_dispatch:

```
gh workflow run branch-cut-automation.yml --repo openemr/openemr --ref master \
  -f rel-branch=rel-820
```

Should open the two branch-cut PRs (branch-cut/rel-820 + branch-cut/rel-820-master) that failed to open at cut time.