### PR TITLE
fix(release): add --skip-globals to patch-prep CLI invocations (rel-820 cherry-pick of #12722)

### DIFF
--- a/.github/workflows/branch-cut-automation.yml
+++ b/.github/workflows/branch-cut-automation.yml
@@ -171,6 +171,7 @@ jobs:
         PREV_REL_BRANCH: ${{ steps.resolve.outputs.prev-rel-branch }}
       run: |
         php bin/console openemr:branch-cut \
+          --skip-globals \
           --target-version="${VERSION}" \
           --rel-branch="${REL_BRANCH}" \
           --prev-rel-branch="${PREV_REL_BRANCH}" \
@@ -230,6 +231,7 @@ jobs:
         PREV_REL_BRANCH: ${{ steps.resolve.outputs.prev-rel-branch }}
       run: |
         php bin/console openemr:branch-cut \
+          --skip-globals \
           --target-version="${VERSION}" \
           --rel-branch="${REL_BRANCH}" \
           --prev-rel-branch="${PREV_REL_BRANCH}" \

--- a/.github/workflows/patch-prep-automation.yml
+++ b/.github/workflows/patch-prep-automation.yml
@@ -283,6 +283,7 @@ jobs:
         PREV_VERSION: ${{ steps.resolve.outputs.prev-version }}
       run: |
         php bin/console openemr:patch-prep \
+          --skip-globals \
           --target-version="${VERSION}" \
           --rel-branch="${REL_BRANCH}" \
           --prev-version="${PREV_VERSION}" \
@@ -347,6 +348,7 @@ jobs:
         PREV_VERSION: ${{ steps.resolve.outputs.prev-version }}
       run: |
         php bin/console openemr:patch-prep \
+          --skip-globals \
           --target-version="${VERSION}" \
           --rel-branch="${REL_BRANCH}" \
           --prev-version="${PREV_VERSION}" \


### PR DESCRIPTION
Cherry-pick of the master-side fix (openemr/openemr#12722) onto rel-820.

## Why this is needed on rel-820

`patch-prep-automation.yml` triggers on `push` to `rel-*`. When a push event fires, GitHub reads the workflow YAML from **the branch being pushed to**, not from the default branch. rel-820 inherited the buggy workflow at cut time (before #12722 was authored), so a future `$v_patch` bump on rel-820 would fire the workflow from rel-820's stale copy and crash with the same `mysqli_query` bootstrap error that hit branch-cut earlier today.

`branch-cut-automation.yml` doesn't have this problem — it fires only on `create` events (which read the workflow from the default branch), so the master-side fix in #12722 is sufficient for future rel-830+ cuts. But the file is included in the cherry-pick anyway for consistency, and it's harmless dead code on rel-820 (branch-cut won't fire from rel-820 again).

## Test plan

- [ ] Land #12722 to master first (so master's copy is fixed for future cuts).
- [ ] Merge this PR to rel-820.
- [ ] After both merge, patch-prep-automation.yml on rel-820 has the fix; the workflow will run successfully when someone eventually bumps `$v_patch` on rel-820.

Related: openemr/openemr#12696 (workstream 2), openemr/openemr#12697 (workstream 6).