### PR TITLE
ci(release): drop paths-ignore from release-prep push trigger

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -16,8 +16,6 @@ on:
     # workflow_dispatch instead.
     branches:
     - 'rel-[0-9]*0'
-    paths-ignore:
-    - 'docs/**'
   pull_request:
     types:
     - closed

--- a/docs/release-automation-plan.md
+++ b/docs/release-automation-plan.md
@@ -190,12 +190,15 @@ Workflow: [`.github/workflows/release-prep.yml`](../.github/workflows/release-pr
 partner PR on master alongside the rel-side PR (see
 [release-finalize](#release-finalize-partner-pr)).
 
-**Trigger.** `push` to `rel-<digits ending 0>` (production shape), with
-`paths-ignore: docs/**` so doc-only pushes don't churn the prep PR. Also
+**Trigger.** `push` to `rel-<digits ending 0>` (production shape). Also
 `pull_request: closed` on `rel-*` (drives the tag-and-dispatch finalize
 job on merge), and `workflow_dispatch` with `target-version` + `branch` +
 optional `test` (opens `release-prep-test/<branch>` for end-to-end test
-runs) and `force-dispatch`.
+runs) and `force-dispatch`. No `paths-ignore` — every push, including
+doc-only pushes, fires the conductor. Force-pushes with no diff are no-ops
+via peter-evans's `pull-request-operation=none` signal, and the downstream
+consumer dispatch is gated on that same signal, so idle refires produce
+no external churn.
 
 The `push` filter matches the branch-creation push too, so this
 workflow fires *at cut time* alongside `branch-cut-automation.yml` —


### PR DESCRIPTION
Discovered when the rel-820 cut fired today: `release-prep.yml` didn't open its (expected) premature draft pair alongside `branch-cut-automation.yml`. Cause: master's tip commit before the cut was PR #12721 (docs-only), so the create/push event for rel-820 inherited that "docs-only" change set and `paths-ignore: docs/**` filtered the workflow out.

## Change

Remove `paths-ignore: docs/**` from the `push:` trigger. The `on:` block goes from:

\`\`\`yaml
on:
  push:
    branches:
    - 'rel-[0-9]*0'
    paths-ignore:
    - 'docs/**'
\`\`\`

to:

\`\`\`yaml
on:
  push:
    branches:
    - 'rel-[0-9]*0'
\`\`\`

## Why the filter isn't needed

The filter was intended to avoid churning the long-lived release-prep PR on doc-only pushes. That concern is already handled at a lower layer:

- `peter-evans/create-pull-request` reports `pull-request-operation=none` when the force-push produces no diff.
- The downstream `openemr-rel-cut` / `openemr-rel-update` dispatch is gated on that same signal (workflow line ~245: `if: steps.prep-pr.outputs.pull-request-operation != 'none' || inputs.force-dispatch`).

So a doc-only push now fires the workflow but produces no PR update and no external dispatch. Wasted work: workflow start + composer install + mutator run, roughly 1 minute per doc push. Doc-only pushes to rel-* branches are rare; the tradeoff favors predictable "all four PRs open at cut" behavior over saving a minute occasionally.

Also updates `docs/release-automation-plan.md`'s corresponding paragraph to reflect the change + note the lower-layer no-op semantics.