### PR TITLE
fix(release): round-2 mutator fixes discovered in rel-820 cut first exercise

### DIFF
--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -96,7 +96,7 @@ Common envelope on every event: `{ event, repo, sha, actor, dispatched_at, data 
 
 Long-lived draft PR against the `rel-*` branch, force-updated by [`.github/workflows/release-prep.yml`](../.github/workflows/release-prep.yml) on every push to a production release branch (matching `rel-[0-9]*0`, with `docs/**`-only pushes ignored). Test branches like `rel-test` go through `workflow_dispatch` instead. The mechanical edits applied by `bin/console openemr:release-prep` are documented in [`docs/release-automation-plan.md`](release-automation-plan.md) (the conductor slice plan).
 
-In short, the conductor rewrites: `version.php`, `library/globals.inc.php` (debug toggle), `docker/production/docker-compose.yml` (image pin), `src/RestControllers/OpenApi/OpenApiDefinitions.php`, `swagger/openemr-api.yaml` (regenerated from the CLI), every `docker-version` file, and (on master) a fresh `sql/X_Y_Z-to-X_Y_Z+1_upgrade.sql` skeleton.
+In short, the conductor rewrites: `version.php`, `docker/production/docker-compose.yml` (image tag pin), `src/RestControllers/OpenApi/OpenApiDefinitions.php`, and `swagger/openemr-api.yaml` (regenerated from the CLI). (The `library/globals.inc.php` debug toggle is applied by the sibling branch-cut conductor at cut time; release-prep does not re-apply it. The `docker-version` triple and `sql/*_upgrade.sql` skeleton are scaffolded at branch-cut / patch-prep time, not at ship time.)
 
 ### Docs PR — `release-docs/<version>` in `openemr/website-openemr`
 

--- a/docs/release-automation-plan.md
+++ b/docs/release-automation-plan.md
@@ -88,10 +88,13 @@ be auto-derived by decrementing minor below 1).
 **Rel-side PR** (`branch-cut/<rel-branch>`, base `<rel-branch>`,
 ready-for-review):
 
-- `DockerUpgradeScaffoldMutator` — new `fsupgrade-N.sh` skeleton +
-  Dockerfile manifest updates (both `COPY` and `chmod` blocks). Same
-  scaffolding the docker-upgrade-actions memo enumerates as mandatory
-  per release.
+- `DockerUpgradeScaffoldMutator` — new `fsupgrade-N.sh` (copied in full
+  from the prior `fsupgrade-N-1.sh` with only the docker-version /
+  priorOpenemrVersion header lines substituted; the upgrade body is
+  preserved byte-for-byte from the prior file for per-release refinement
+  in place) + Dockerfile manifest updates (both `COPY` and `chmod`
+  blocks). Same scaffolding the docker-upgrade-actions memo enumerates
+  as mandatory per release.
 - `DockerfileOpenemrVersionMutator` — pins the `OPENEMR_VERSION` ARG
   in the branch's Dockerfile to the new rel line.
 - `TranslationFileCopyFromPriorRelMutator` — fetches the translation
@@ -213,16 +216,23 @@ for the full picture.
 draft, force-pushed on each run):
 
 - `VersionPhpMutator` — strip `-dev` suffix from `$v_tag`.
-- `GlobalsIncMutator` — reused from branch-cut (idempotent, so re-running
-  is safe if the branch-cut PR wasn't merged before dev started).
-- `DockerComposeProductionMutator` — pin `openemr/openemr:latest@sha256:…`
-  to `openemr/openemr:<version>@sha256:…`. Image digest is supplied via
-  `--image-digest` from the workflow after the release image is published;
-  if absent, the existing digest is preserved and only the tag is swapped.
+- `DockerComposeProductionMutator` — swap the openemr image tag:
+  `openemr/openemr:latest[@sha256:…]` → `openemr/openemr:<version>` (no
+  digest). At release-prep time the release image doesn't yet exist in
+  Docker Hub (the tag→build sequence fires only after release-prep merges),
+  so there is no valid digest to pin. Any existing `@sha256:…` suffix on
+  the source line is dropped.
 - `OpenApiVersionMutator` — bump `#[OA\Info(title: 'OpenEMR API', version: 'X.Y.Z')]`.
   (The wiki + earlier drafts of this plan said `_rest_routes.inc.php` but
   the version constant actually lives in `src/RestControllers/OpenApi/OpenApiDefinitions.php`.)
 - `SwaggerRegenMutator` — regenerate `swagger/openemr-api.yaml`.
+
+`GlobalsIncMutator` is intentionally NOT in the release-prep rel-side
+list even though branch-cut runs it: re-running it here would be
+defensive but redundant, and it hides the "did branch-cut merge?"
+question behind mutator idempotency. Surface as a real diff if
+branch-cut hasn't landed yet. (Removed in round-2 fixes after the
+rel-820 first exercise; see PR #12725.)
 
 The `docker-version` files and `sql/*_upgrade.sql` skeleton the earlier
 draft of this plan enumerated for the release-prep PR moved to
@@ -302,10 +312,12 @@ content on the other.
 **File overlap between the two pairs.** The branch-cut and conductor
 PRs against the same base branch touch some of the same files:
 
-- Rel-side both PRs touch `library/globals.inc.php` (branch-cut flips
-  `allow_debug_language` → `'0'`; release-prep's `GlobalsIncMutator` is
-  reused and idempotent, so a re-render sees the flag already flipped
-  and no-ops).
+- Rel-side branch-cut touches `library/globals.inc.php` (flips
+  `allow_debug_language` → `'0'`). Release-prep does NOT re-run the
+  flip — running it twice is defensive but redundant, and it hides the
+  "did branch-cut merge?" question behind mutator idempotency. If
+  branch-cut hasn't landed yet, the flip surfaces as a real diff at
+  ship time instead of a silent no-op.
 - Rel-side both touch the `docker-version` triple (branch-cut bumps by
   one for the new minor's dev cycle; release-prep leaves them alone at
   ship time).
@@ -406,8 +418,7 @@ against a shared framework at [`src/Common/Command/ReleasePrep/`](../src/Common/
 - **`MutatorInterface`** — `name(): string` + `apply(MutatorContext): MutatorResult`.
 - **`MutatorContext`** — `readonly` value object carrying `projectDir`,
   parsed `major`/`minor`/`patch`, and the optional context fields the
-  various mutators need: `imageDigest` (release-prep only, when
-  `--image-digest` is passed), `relBranch` (release-finalize, branch-cut,
+  various mutators need: `relBranch` (release-finalize, branch-cut,
   patch-prep), `prevRelBranch` (branch-cut rel-side translation copy),
   `fromVersion` (patch-prep SQL skeleton override — validated to be
   same major/minor as target with patch == target - 1). Constructor
@@ -428,8 +439,8 @@ mutators would produce churn PRs.
 |---------|---------|---------|
 | `VersionPhpMutator` | release-prep (rel) | Strip `-dev` from `$v_tag`. |
 | `VersionPhpMasterMutator` | branch-cut (master) | Advance to next-minor `-dev`. |
-| `GlobalsIncMutator` | branch-cut (rel), release-prep (rel) | `allow_debug_language = 0`. |
-| `DockerComposeProductionMutator` | release-prep (rel) | Pin `openemr/openemr` tag + digest. |
+| `GlobalsIncMutator` | branch-cut (rel) | `allow_debug_language = 0`. |
+| `DockerComposeProductionMutator` | release-prep (rel) | Pin `openemr/openemr` tag (no digest). |
 | `DockerfileOpenemrVersionMutator` | branch-cut (rel) | Pin Dockerfile `OPENEMR_VERSION` ARG. |
 | `DockerUpgradeScaffoldMutator` | branch-cut (rel + master), patch-prep (rel + master) | New `fsupgrade-N.sh` + Dockerfile manifest wiring. |
 | `TranslationFileCopyFromPriorRelMutator` | branch-cut (rel) | Fetch translation blob from prior rel branch. |

--- a/src/Common/Command/BranchCutCommand.php
+++ b/src/Common/Command/BranchCutCommand.php
@@ -139,7 +139,6 @@ final class BranchCutCommand extends Command
             $targetContext = MutatorContext::fromVersionString(
                 $projectDir,
                 $target,
-                null,
                 $relBranch,
                 $prevRelBranch,
             );
@@ -161,7 +160,6 @@ final class BranchCutCommand extends Command
             $targetContext->major,
             $targetContext->minor + 1,
             0,
-            null,
             $targetContext->relBranch,
             $targetContext->prevRelBranch,
         );

--- a/src/Common/Command/PatchPrepCommand.php
+++ b/src/Common/Command/PatchPrepCommand.php
@@ -134,7 +134,6 @@ final class PatchPrepCommand extends Command
             $context = MutatorContext::fromVersionString(
                 $projectDir,
                 $target,
-                null,
                 $relBranch,
                 null,
                 $prevVersion,

--- a/src/Common/Command/ReleasePrep/Mutator/DockerComposeProductionMutator.php
+++ b/src/Common/Command/ReleasePrep/Mutator/DockerComposeProductionMutator.php
@@ -2,10 +2,14 @@
 
 /**
  * Pin docker/production/docker-compose.yml's openemr image from
- * `latest@sha256:...` to `<version>@sha256:...`. The published image's
- * digest is supplied via --image-digest by the conductor workflow after
- * the release image has been built and pushed; if absent the existing
- * digest is preserved and only the tag is swapped.
+ * `latest[@sha256:...]` to `<version>` (tag only, no digest).
+ *
+ * At release-prep time, the release-tagged image does not yet exist in
+ * Docker Hub — it's produced downstream only AFTER the release-prep PR
+ * merges (which triggers the tag creation which triggers the image
+ * build). So there's no valid digest to pin at this stage. The old
+ * `--image-digest` pathway assumed an out-of-band digest lookup that
+ * doesn't fit the actual sequencing; drop it and just swap the tag.
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -30,7 +34,7 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
 
     public function name(): string
     {
-        return 'docker/production/docker-compose.yml (pin openemr image)';
+        return 'docker/production/docker-compose.yml (pin openemr image tag)';
     }
 
     public function apply(MutatorContext $context): MutatorResult
@@ -42,29 +46,18 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
         }
 
         $version = $context->versionString();
-        // Accept the digest with or without the `sha256:` prefix; we always
-        // emit `@sha256:<hex>` regardless.
-        $newDigestHex = $context->imageDigest === null
-            ? null
-            : preg_replace('/^sha256:/', '', $context->imageDigest);
 
         // Pattern matches `image: openemr/openemr:<tag>` with an optional
         // `@sha256:<digest>` suffix. The tag may be `latest`, the target
-        // version, or another version (idempotence + handles re-runs after
-        // a digest update). The digest is optional because rel-* branches
-        // that were cut before the digest-pinning automation existed start
-        // with a bare tag (e.g. `openemr/openemr:8.1.0`).
-        $pattern = '/(image:\s*openemr\/openemr:)([^@\s]+)(?:(@sha256:)([0-9a-f]{64}))?/';
+        // version, or another version (idempotence + handles re-runs).
+        // The digest is optional because rel-* branches that were cut
+        // before the digest-pinning automation existed start with a bare
+        // tag (e.g. `openemr/openemr:8.1.0`). Whatever's after `:`, we
+        // replace it with the target version and strip the digest entirely.
+        $pattern = '/(image:\s*openemr\/openemr:)([^@\s]+)(?:@sha256:[0-9a-f]{64})?/';
         $updated = preg_replace_callback(
             $pattern,
-            static function (array $match) use ($version, $newDigestHex): string {
-                $existingDigest = $match[4] ?? '';
-                $digest = $newDigestHex ?? ($existingDigest !== '' ? $existingDigest : null);
-                if ($digest === null) {
-                    return $match[1] . $version;
-                }
-                return $match[1] . $version . '@sha256:' . $digest;
-            },
+            static fn (array $match): string => $match[1] . $version,
             $contents,
             1,
             $count,
@@ -95,10 +88,7 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
                 $e,
             );
         }
-        $expectedDigest = $newDigestHex ?? $this->extractDigest($contents);
-        $expectedImage = $expectedDigest === null
-            ? sprintf('openemr/openemr:%s', $version)
-            : sprintf('openemr/openemr:%s@sha256:%s', $version, $expectedDigest);
+        $expectedImage = sprintf('openemr/openemr:%s', $version);
         $actualImage = is_array($parsed)
             && is_array($parsed['services'] ?? null)
             && is_array($parsed['services']['openemr'] ?? null)
@@ -114,21 +104,9 @@ final readonly class DockerComposeProductionMutator implements MutatorInterface
         if (file_put_contents($path, $updated) === false) {
             throw new \RuntimeException('Cannot write ' . $path);
         }
-        if ($newDigestHex !== null) {
-            $messages = [];
-        } elseif ($expectedDigest === null) {
-            $messages = ['docker-compose.yml: tag pinned to ' . $version . '; no digest (source had none, no --image-digest provided)'];
-        } else {
-            $messages = ['docker-compose.yml: tag pinned to ' . $version . '; digest preserved (no --image-digest provided)'];
-        }
-        return new MutatorResult([self::RELATIVE_PATH], $messages);
-    }
-
-    private function extractDigest(string $original): ?string
-    {
-        if (preg_match('/image:\s*openemr\/openemr:[^@\s]+@sha256:([0-9a-f]{64})/', $original, $m) !== 1) {
-            return null;
-        }
-        return $m[1];
+        return new MutatorResult(
+            [self::RELATIVE_PATH],
+            ['docker-compose.yml: tag pinned to ' . $version . ' (no digest — release image is not yet built at release-prep time)'],
+        );
     }
 }

--- a/src/Common/Command/ReleasePrep/Mutator/DockerUpgradeScaffoldMutator.php
+++ b/src/Common/Command/ReleasePrep/Mutator/DockerUpgradeScaffoldMutator.php
@@ -14,10 +14,16 @@
  *     from N to N+1. All three must already agree on N or the mutator
  *     refuses to run (drift between them is a separate bug to surface).
  *
- * (2) Create a `docker/release/upgrade/fsupgrade-(N+1).sh` stub by reading
- *     `fsupgrade-N.sh` and stripping its body down to a TODO marker.
- *     Per-release work fills in the actual upgrade logic before each ship;
- *     branch-cut only stages the file structure.
+ * (2) Create a `docker/release/upgrade/fsupgrade-(N+1).sh` by copying
+ *     `fsupgrade-N.sh` in full and applying five line-level substitutions
+ *     (the docker-version number in the header comment and echoes, the
+ *     prior-openemr-version marker in the comment + shell variable). The
+ *     actual upgrade body is preserved byte-for-byte from the prior file
+ *     — it already carries a valid working upgrade against the prior
+ *     shipped version, and per-release work refines it in-place as needed.
+ *     Copying rather than stubbing preserves the shellcheck directives,
+ *     trailing newline, and existing upgrade logic so the resulting file
+ *     is immediately shellcheck-clean and runnable.
  *
  * (3) Update `docker/release/Dockerfile` to add `fsupgrade-(N+1).sh` to
  *     BOTH the `COPY upgrade/...` block AND the `RUN chmod 500 ...` block.
@@ -53,7 +59,7 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
 
     public function name(): string
     {
-        return 'docker upgrade scaffold (docker-version bump + fsupgrade stub + Dockerfile manifest)';
+        return 'docker upgrade scaffold (docker-version bump + fsupgrade copy-from-prior + Dockerfile manifest)';
     }
 
     public function apply(MutatorContext $context): MutatorResult
@@ -88,31 +94,35 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
         $next = $current + 1;
 
         $priorOpenemrVersion = $this->derivePriorOpenemrVersion($context);
+        $targetVersion = $context->versionString();
 
-        // Idempotency: if the current docker-version's fsupgrade stub
-        // already records THIS cut's prior version, we already ran for
-        // this cut (possibly on a previous retry). No-op cleanly.
+        // Idempotency: if the current docker-version's fsupgrade file
+        // already records THIS cut's target version + prior version, we
+        // already ran for this cut (possibly on a previous retry). No-op
+        // cleanly.
         //
-        // The signal: at rel-820 cut (target 8.2.0), the new stub we'd
-        // write contains `priorOpenemrVersion="8.1.0"`. After a
-        // successful run, docker-version is the new N (=12) and
-        // fsupgrade-12.sh exists carrying that 8.1.0 marker. A
-        // *different* cut would see a different prior version pinned
-        // (e.g. fsupgrade-12.sh carrying 8.0.0 from an older cut), in
-        // which case we'd still want to advance.
+        // The signal: at rel-820 cut (target 8.2.0), the new file we'd
+        // write contains `priorOpenemrVersion="8.2.0"` (target-version) —
+        // i.e., the prior line the NEXT cut's fsupgrade will need to
+        // upgrade from. After a successful run, docker-version is the
+        // new N (=12) and fsupgrade-12.sh exists carrying that 8.2.0
+        // marker. A *different* cut would see a different target-version
+        // pinned (e.g. fsupgrade-12.sh carrying 8.0.0 from an older cut),
+        // in which case we'd still want to advance.
         $currentStubAbs = $projectDir . '/' . self::UPGRADE_DIR . '/fsupgrade-' . $current . '.sh';
         if (is_file($currentStubAbs)) {
-            $stub = (string) file_get_contents($currentStubAbs);
-            if (str_contains($stub, 'priorOpenemrVersion="' . $priorOpenemrVersion . '"')
-                && str_contains($stub, 'Upgrade number ' . $current . ' for OpenEMR docker')
-                && str_contains($stub, 'TODO: fill in upgrade logic per-release')) {
-                // This is OUR stub from a prior run of this same cut.
+            $existing = (string) file_get_contents($currentStubAbs);
+            if (str_contains($existing, 'priorOpenemrVersion="' . $targetVersion . '"')
+                && str_contains($existing, 'Upgrade number ' . $current . ' for OpenEMR docker')) {
+                // This is OUR file from a prior run of this same cut.
                 return MutatorResult::noop();
             }
         }
 
         $nextStubRelPath = self::UPGRADE_DIR . '/fsupgrade-' . $next . '.sh';
         $nextStubAbs = $projectDir . '/' . $nextStubRelPath;
+        $priorStubRelPath = self::UPGRADE_DIR . '/fsupgrade-' . $current . '.sh';
+        $priorStubAbs = $projectDir . '/' . $priorStubRelPath;
 
         $changedFiles = [];
 
@@ -125,9 +135,21 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
             $changedFiles[] = $relPath;
         }
 
-        // (2) Create the next fsupgrade-(N+1).sh stub.
-        $stubContents = $this->renderStub($next, $priorOpenemrVersion);
-        if (file_put_contents($nextStubAbs, $stubContents) === false) {
+        // (2) Create the next fsupgrade-(N+1).sh by copying the prior
+        // file in full and applying the five line-level substitutions.
+        $priorContents = file_get_contents($priorStubAbs);
+        if ($priorContents === false) {
+            throw new \RuntimeException('Cannot read ' . $priorStubAbs);
+        }
+        $nextContents = $this->deriveNextFromPrior(
+            $priorContents,
+            $current,
+            $next,
+            $priorOpenemrVersion,
+            $targetVersion,
+            $priorStubAbs,
+        );
+        if (file_put_contents($nextStubAbs, $nextContents) === false) {
             throw new \RuntimeException('Cannot write ' . $nextStubAbs);
         }
         $changedFiles[] = $nextStubRelPath;
@@ -151,18 +173,20 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
     }
 
     /**
-     * The fsupgrade-(N+1).sh's `priorOpenemrVersion` is the X.Y.Z of the
-     * line that's shipping at the prior docker-version.
+     * The fsupgrade-N.sh's existing `priorOpenemrVersion` marker
+     * (whatever value the prior file records — the version the current
+     * fsupgrade-N.sh upgrades FROM). The next fsupgrade-(N+1).sh, by
+     * contrast, will upgrade from the version we're SHIPPING with this
+     * cut (i.e. the target-version), so the substitution's replacement
+     * value is the target-version.
      *
      * Branch-cut (no fromVersion): for a cut of rel-820 (target 8.2.0),
-     * the prior shipped line was 8.1.0; encoded as "X.(target_minor-1).0".
+     * fsupgrade-11.sh's prior marker is 8.1.0 (rel-810's shipped version),
+     * and fsupgrade-12.sh's prior marker becomes 8.2.0.
      *
-     * Patch-prep (fromVersion supplied): for a rel-810 patch-prep to
-     * 8.1.1, the prior shipped version was 8.1.0 — use the explicit
-     * from-version directly instead of decrementing the minor.
-     *
-     * Per-release work may refine this when filling in the upgrade body;
-     * the scaffold's job is structural consistency.
+     * Patch-prep (fromVersion supplied): the from-version is the
+     * prior-patch shipped version, e.g. 8.1.0 for a rel-810 8.1.1
+     * patch-prep — the same shape as the branch-cut case.
      */
     private function derivePriorOpenemrVersion(MutatorContext $context): string
     {
@@ -176,18 +200,60 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
         return sprintf('%d.%d.0', $context->major, $priorMinor);
     }
 
-    private function renderStub(int $nextVersion, string $priorOpenemrVersion): string
-    {
-        return <<<BASH
-        #!/bin/bash
-        # Upgrade number {$nextVersion} for OpenEMR docker
-        #  From prior version {$priorOpenemrVersion} (needed for the sql upgrade script).
-        priorOpenemrVersion="{$priorOpenemrVersion}"
-        echo "Start: Upgrade to docker-version {$nextVersion}"
-        # TODO: fill in upgrade logic per-release; see prior fsupgrade-*.sh for examples
-        echo "Completed: Upgrade to docker-version {$nextVersion}"
+    /**
+     * Copy the prior fsupgrade-N.sh in full and apply exactly five
+     * line-level substitutions to produce fsupgrade-(N+1).sh. All other
+     * content (shellcheck directives, blank lines, upgrade body, trailing
+     * newline) is preserved byte-for-byte.
+     *
+     * If any of the five expected anchor patterns is missing from the
+     * prior file, we throw rather than silently producing a corrupt
+     * output — the prior file's shape is a load-bearing schema.
+     */
+    private function deriveNextFromPrior(
+        string $priorContents,
+        int $current,
+        int $next,
+        string $priorOpenemrVersion,
+        string $targetVersion,
+        string $priorFilePath,
+    ): string {
+        $substitutions = [
+            [
+                '# Upgrade number ' . $current . ' for OpenEMR docker',
+                '# Upgrade number ' . $next . ' for OpenEMR docker',
+            ],
+            [
+                '#  From prior version ' . $priorOpenemrVersion . ' (needed for the sql upgrade script).',
+                '#  From prior version ' . $targetVersion . ' (needed for the sql upgrade script).',
+            ],
+            [
+                'priorOpenemrVersion="' . $priorOpenemrVersion . '"',
+                'priorOpenemrVersion="' . $targetVersion . '"',
+            ],
+            [
+                'echo "Start: Upgrade to docker-version ' . $current . '"',
+                'echo "Start: Upgrade to docker-version ' . $next . '"',
+            ],
+            [
+                'echo "Completed: Upgrade to docker-version ' . $current . '"',
+                'echo "Completed: Upgrade to docker-version ' . $next . '"',
+            ],
+        ];
 
-        BASH;
+        $output = $priorContents;
+        foreach ($substitutions as [$needle, $replacement]) {
+            if (!str_contains($output, $needle)) {
+                throw new \RuntimeException(sprintf(
+                    'fsupgrade scaffold expected to substitute %s in %s but the anchor was not found; refusing to write a corrupt fsupgrade-%d.sh',
+                    var_export($needle, true),
+                    $priorFilePath,
+                    $next,
+                ));
+            }
+            $output = str_replace($needle, $replacement, $output);
+        }
+        return $output;
     }
 
     /**

--- a/src/Common/Command/ReleasePrep/Mutator/PostReleaseTargetsMutator.php
+++ b/src/Common/Command/ReleasePrep/Mutator/PostReleaseTargetsMutator.php
@@ -71,6 +71,23 @@ final readonly class PostReleaseTargetsMutator implements MutatorInterface
             throw new \RuntimeException('Cannot read ' . $path);
         }
 
+        // Early-return guard: the slot-shuffle step drops `latest` from
+        // the prior holder assuming there is a target row (the just-shipped
+        // rel branch) ready to receive it. If no live row exists for the
+        // target rel branch — e.g., release-finalize firing on a push
+        // before the paired branch-cut PR has landed the new rel-branch
+        // row — the shuffle would leave release-targets.yml in an invalid
+        // state (nobody holds `latest`). Skip the whole mutator instead.
+        if (!$this->hasLiveRowForRelBranch($original, $relBranch)) {
+            return new MutatorResult(
+                [],
+                [
+                    'no live row for ' . $relBranch
+                    . ' in release-targets.yml; skipping premature slot shuffle',
+                ],
+            );
+        }
+
         $tagName = $context->tagName();
 
         $newText = $this->dropUnreleasedPlaceholderRow($original, $relBranch);
@@ -98,6 +115,22 @@ final readonly class PostReleaseTargetsMutator implements MutatorInterface
         }
 
         return new MutatorResult([self::RELATIVE_PATH]);
+    }
+
+    /**
+     * A "live" row is one whose `branch:` matches the target rel branch
+     * AND is NOT marked `unreleased: true`. The unreleased placeholder
+     * is the multi-row pattern's development scaffold — it doesn't count
+     * as the shippable row this mutator's transforms target.
+     */
+    private function hasLiveRowForRelBranch(string $text, string $relBranch): bool
+    {
+        foreach ($this->indexRows($text) as $row) {
+            if ($row['branch'] === $relBranch && $row['unreleased'] !== 'true') {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/Common/Command/ReleasePrep/MutatorContext.php
+++ b/src/Common/Command/ReleasePrep/MutatorContext.php
@@ -3,8 +3,8 @@
 /**
  * Context passed to every release-prep mutator. Holds the parsed target
  * version and the project root each mutator operates against, plus
- * optional inputs (image digest, rel branch identifier, prior rel branch
- * identifier, explicit fromVersion override) supplied by the conductor or
+ * optional inputs (rel branch identifier, prior rel branch identifier,
+ * explicit fromVersion override) supplied by the conductor or
  * branch-cut/patch-prep workflows. Existing mutators ignore the optional
  * fields they don't need; PostReleaseTargetsMutator requires `relBranch`
  * to know which row of release-targets.yml to mutate;
@@ -32,16 +32,10 @@ final readonly class MutatorContext
         public int $major,
         public int $minor,
         public int $patch,
-        public ?string $imageDigest = null,
         public ?string $relBranch = null,
         public ?string $prevRelBranch = null,
         public ?string $fromVersion = null,
     ) {
-        if ($imageDigest !== null && preg_match('/^sha256:[0-9a-f]{64}$/', $imageDigest) !== 1) {
-            throw new \InvalidArgumentException(
-                'imageDigest must match sha256:<64-hex>; got: ' . $imageDigest,
-            );
-        }
         if ($relBranch !== null && preg_match('/^rel-\d+$/', $relBranch) !== 1) {
             throw new \InvalidArgumentException(
                 'relBranch must match rel-<digits>; got: ' . $relBranch,
@@ -88,7 +82,6 @@ final readonly class MutatorContext
     public static function fromVersionString(
         string $projectDir,
         string $version,
-        ?string $imageDigest = null,
         ?string $relBranch = null,
         ?string $prevRelBranch = null,
         ?string $fromVersion = null,
@@ -103,7 +96,6 @@ final readonly class MutatorContext
             (int) $m[1],
             (int) $m[2],
             (int) $m[3],
-            $imageDigest,
             $relBranch,
             $prevRelBranch,
             $fromVersion,

--- a/src/Common/Command/ReleasePrepCommand.php
+++ b/src/Common/Command/ReleasePrepCommand.php
@@ -42,7 +42,6 @@ declare(strict_types=1);
 namespace OpenEMR\Common\Command;
 
 use OpenEMR\Common\Command\ReleasePrep\Mutator\DockerComposeProductionMutator;
-use OpenEMR\Common\Command\ReleasePrep\Mutator\GlobalsIncMutator;
 use OpenEMR\Common\Command\ReleasePrep\Mutator\OpenApiVersionMutator;
 use OpenEMR\Common\Command\ReleasePrep\Mutator\PostReleaseTargetsMutator;
 use OpenEMR\Common\Command\ReleasePrep\Mutator\SwaggerRegenMutator;
@@ -90,12 +89,6 @@ final class ReleasePrepCommand extends Command
                 'Mutation scope: rel (pre-tag) or master (post-cut)',
             )
             ->addOption(
-                'image-digest',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Optional sha256: digest for the docker image pin',
-            )
-            ->addOption(
                 'project-dir',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -118,9 +111,6 @@ final class ReleasePrepCommand extends Command
             return Command::INVALID;
         }
 
-        $rawDigest = $input->getOption('image-digest');
-        $imageDigest = is_string($rawDigest) && $rawDigest !== '' ? $rawDigest : null;
-
         $rawProjectDir = $input->getOption('project-dir');
         $projectDir = is_string($rawProjectDir) && $rawProjectDir !== ''
             ? $rawProjectDir
@@ -134,7 +124,7 @@ final class ReleasePrepCommand extends Command
         }
 
         try {
-            $context = MutatorContext::fromVersionString($projectDir, $target, $imageDigest, $relBranch);
+            $context = MutatorContext::fromVersionString($projectDir, $target, $relBranch);
         } catch (\InvalidArgumentException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             return Command::INVALID;
@@ -175,9 +165,14 @@ final class ReleasePrepCommand extends Command
      */
     private function buildDefaultRelMutators(): array
     {
+        // GlobalsIncMutator intentionally NOT wired here: the
+        // `allow_debug_language` flip is owned by branch-cut
+        // (BranchCutCommand's rel-side list). Running it again at
+        // release-prep time is defensive but redundant, and it hides
+        // the "did branch-cut merge?" question behind mutator idempotency
+        // — surface as a real diff if branch-cut hasn't landed yet.
         return [
             new VersionPhpMutator(),
-            new GlobalsIncMutator(),
             new DockerComposeProductionMutator(),
             new OpenApiVersionMutator(),
             new SwaggerRegenMutator(),

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/BranchCutReleaseTargetsMutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/BranchCutReleaseTargetsMutatorTest.php
@@ -285,7 +285,6 @@ final class BranchCutReleaseTargetsMutatorTest extends TestCase
         return MutatorContext::fromVersionString(
             $this->tmpDir,
             $targetVersion,
-            null,
             $relBranch,
         );
     }

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/DockerUpgradeScaffoldMutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/DockerUpgradeScaffoldMutatorTest.php
@@ -50,16 +50,49 @@ final class DockerUpgradeScaffoldMutatorTest extends TestCase
         self::assertSame("12\n", file_get_contents($this->tmpDir . '/sites/default/docker-version'));
     }
 
-    public function testCreatesFsupgradeStub(): void
+    public function testCreatesFsupgradeByCopyingPriorInFull(): void
     {
         (new DockerUpgradeScaffoldMutator())->apply($this->context());
 
-        $stub = file_get_contents($this->tmpDir . '/docker/release/upgrade/fsupgrade-12.sh');
-        self::assertIsString($stub);
-        self::assertStringContainsString('# Upgrade number 12 for OpenEMR docker', $stub);
-        self::assertStringContainsString('priorOpenemrVersion="8.1.0"', $stub);
-        self::assertStringContainsString('Start: Upgrade to docker-version 12', $stub);
-        self::assertStringContainsString('TODO: fill in upgrade logic per-release', $stub);
+        $next = file_get_contents($this->tmpDir . '/docker/release/upgrade/fsupgrade-12.sh');
+        self::assertIsString($next);
+        // Byte-for-byte match against the expected fixture: the mutator
+        // copies fsupgrade-11.sh in full and applies exactly the five
+        // documented substitutions.
+        self::assertSame(
+            $this->fixture('fsupgrade-12.sh.expected'),
+            $next,
+        );
+    }
+
+    public function testFsupgradeCopyDiffsOnlyOnTheFiveSubstitutedLines(): void
+    {
+        // Concrete guard against silent body drift: the diff between the
+        // prior file and the produced file should be exactly the five
+        // documented substitutions.
+        (new DockerUpgradeScaffoldMutator())->apply($this->context());
+
+        $prior = $this->fixture('fsupgrade-11.sh');
+        $next = file_get_contents($this->tmpDir . '/docker/release/upgrade/fsupgrade-12.sh');
+        self::assertIsString($next);
+
+        $priorLines = explode("\n", $prior);
+        $nextLines = explode("\n", $next);
+        self::assertCount(count($priorLines), $nextLines, 'file line count must match');
+
+        $changedIndexes = [];
+        foreach ($priorLines as $i => $priorLine) {
+            if ($priorLine !== $nextLines[$i]) {
+                $changedIndexes[] = $i;
+            }
+        }
+        // Exactly five lines changed: header comment, from-prior-version
+        // comment, priorOpenemrVersion="…", Start: echo, Completed: echo.
+        self::assertCount(
+            5,
+            $changedIndexes,
+            'expected exactly 5 substituted lines; got ' . implode(',', $changedIndexes),
+        );
     }
 
     public function testExtendsDockerfileCopyAndChmodBlocks(): void
@@ -114,31 +147,69 @@ final class DockerUpgradeScaffoldMutatorTest extends TestCase
         (new DockerUpgradeScaffoldMutator())->apply($this->context());
     }
 
-    public function testPriorVersionDerivedFromTargetMinor(): void
+    public function testAnchorSearchIsDerivedFromTargetMinor(): void
     {
-        // target=8.5.0 → prior=8.4.0 (minor-1).
-        (new DockerUpgradeScaffoldMutator())->apply(
-            MutatorContext::fromVersionString($this->tmpDir, '8.5.0', null, 'rel-850', 'rel-840'),
+        // For target=8.5.0, the mutator computes prev=8.4.0 (target minor-1)
+        // and uses that as the substitution anchor. Simulate the on-tree
+        // reality at rel-850's cut: fsupgrade-11.sh's priorOpenemrVersion is
+        // 8.4.0 (rel-840's shipped version). The mutator produces
+        // fsupgrade-12.sh with priorOpenemrVersion=8.5.0 (rel-850's shipped
+        // version, i.e. the target-version).
+        $priorAt840 = str_replace(
+            ['priorOpenemrVersion="8.1.0"', 'From prior version 8.1.0'],
+            ['priorOpenemrVersion="8.4.0"', 'From prior version 8.4.0'],
+            $this->fixture('fsupgrade-11.sh'),
         );
-        $stub = file_get_contents($this->tmpDir . '/docker/release/upgrade/fsupgrade-12.sh');
-        self::assertIsString($stub);
-        self::assertStringContainsString('priorOpenemrVersion="8.4.0"', $stub);
+        file_put_contents(
+            $this->tmpDir . '/docker/release/upgrade/fsupgrade-11.sh',
+            $priorAt840,
+        );
+
+        (new DockerUpgradeScaffoldMutator())->apply(
+            MutatorContext::fromVersionString($this->tmpDir, '8.5.0', 'rel-850', 'rel-840'),
+        );
+        $next = file_get_contents($this->tmpDir . '/docker/release/upgrade/fsupgrade-12.sh');
+        self::assertIsString($next);
+        self::assertStringContainsString('priorOpenemrVersion="8.5.0"', $next);
+        self::assertStringNotContainsString('priorOpenemrVersion="8.4.0"', $next);
+    }
+
+    public function testThrowsWhenPriorFsupgradeLacksExpectedAnchor(): void
+    {
+        // The prior fsupgrade file must contain all five anchor lines
+        // for the substitution to succeed. Substitute one of them out
+        // (the priorOpenemrVersion assignment) and expect a clear error
+        // rather than a silently corrupt output.
+        $malformed = str_replace(
+            'priorOpenemrVersion="8.1.0"',
+            '# priorOpenemrVersion removed',
+            $this->fixture('fsupgrade-11.sh'),
+        );
+        file_put_contents(
+            $this->tmpDir . '/docker/release/upgrade/fsupgrade-11.sh',
+            $malformed,
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/fsupgrade scaffold expected to substitute/');
+        (new DockerUpgradeScaffoldMutator())->apply($this->context());
     }
 
     public function testNoopWhenAlreadyAtPostCutState(): void
     {
         // Simulate the post-first-run state: docker-version bumped to
-        // 12 + fsupgrade-12.sh carrying this cut's prior version marker
-        // (priorOpenemrVersion="8.1.0" for the rel-820 cut). The mutator
-        // should recognise its own work and no-op cleanly.
+        // 12 + fsupgrade-12.sh carrying this cut's target-version marker
+        // (priorOpenemrVersion="8.2.0" for the rel-820 cut — the version
+        // rel-820 is shipping and rel-830 would need to upgrade from).
+        // The mutator should recognise its own work and no-op cleanly.
         file_put_contents($this->tmpDir . '/docker-version', "12\n");
         file_put_contents($this->tmpDir . '/docker/release/upgrade/docker-version', "12\n");
         file_put_contents($this->tmpDir . '/sites/default/docker-version', "12\n");
         file_put_contents(
             $this->tmpDir . '/docker/release/upgrade/fsupgrade-12.sh',
             "#!/bin/bash\n# Upgrade number 12 for OpenEMR docker\n"
-            . 'priorOpenemrVersion="8.1.0"' . "\n"
-            . "# TODO: fill in upgrade logic per-release; see prior fsupgrade-*.sh for examples\n",
+            . 'priorOpenemrVersion="8.2.0"' . "\n"
+            . "# body preserved from prior file\n",
         );
 
         $result = (new DockerUpgradeScaffoldMutator())->apply($this->context());
@@ -147,29 +218,30 @@ final class DockerUpgradeScaffoldMutatorTest extends TestCase
         self::assertSame("12", trim(file_get_contents($this->tmpDir . '/docker-version') ?: ''));
     }
 
-    public function testNotNoopWhenStubLacksOurCutMarker(): void
+    public function testNotNoopWhenCurrentDockerVersionFileLacksOurCutMarker(): void
     {
         // If a partial state exists (docker-version bumped to 12 but
-        // fsupgrade-12.sh lacks our cut's TODO marker — e.g., somebody
-        // manually filled in the upgrade body before re-running), the
+        // fsupgrade-12.sh lacks our cut's target-version marker — e.g.,
+        // somebody manually edited the priorOpenemrVersion value), the
         // mutator should NOT no-op; it should attempt the work and let
-        // the downstream Dockerfile anchor mismatch surface as a clear
-        // error rather than silently passing through.
+        // the downstream anchor mismatch surface as a clear error
+        // rather than silently passing through. The prior-file anchor
+        // check catches it first (fsupgrade-12.sh is malformed when
+        // read as the "prior" file for the N=13 write).
         file_put_contents($this->tmpDir . '/docker-version', "12\n");
         file_put_contents($this->tmpDir . '/docker/release/upgrade/docker-version', "12\n");
         file_put_contents($this->tmpDir . '/sites/default/docker-version', "12\n");
         file_put_contents(
             $this->tmpDir . '/docker/release/upgrade/fsupgrade-12.sh',
-            "#!/bin/bash\n# Manually filled-in upgrade, not our stub\n"
+            "#!/bin/bash\n# Upgrade number 12 for OpenEMR docker\n"
             . 'priorOpenemrVersion="8.1.0"' . "\n"
             . "echo doing real work\n",
         );
 
-        // The Dockerfile still references fsupgrade-11.sh as the latest
-        // entry; bumping to 13 will fail the anchor check, surfacing the
-        // inconsistent state.
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessageMatches('/COPY block does not contain expected anchor/');
+        $this->expectExceptionMessageMatches(
+            '/fsupgrade scaffold expected to substitute|COPY block does not contain expected anchor/',
+        );
         (new DockerUpgradeScaffoldMutator())->apply($this->context());
     }
 
@@ -200,7 +272,7 @@ final class DockerUpgradeScaffoldMutatorTest extends TestCase
 
     private function context(): MutatorContext
     {
-        return MutatorContext::fromVersionString($this->tmpDir, '8.2.0', null, 'rel-820', 'rel-810');
+        return MutatorContext::fromVersionString($this->tmpDir, '8.2.0', 'rel-820', 'rel-810');
     }
 
     private function fixture(string $name): string

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/DockerfileOpenemrVersionMutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/DockerfileOpenemrVersionMutatorTest.php
@@ -98,7 +98,7 @@ final class DockerfileOpenemrVersionMutatorTest extends TestCase
 
     private function context(string $relBranch): MutatorContext
     {
-        return MutatorContext::fromVersionString($this->tmpDir, '8.2.0', null, $relBranch, 'rel-810');
+        return MutatorContext::fromVersionString($this->tmpDir, '8.2.0', $relBranch, 'rel-810');
     }
 
     private function write(string $contents): void

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/MasterSqlPatchBridgeMutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/MasterSqlPatchBridgeMutatorTest.php
@@ -99,7 +99,7 @@ final class MasterSqlPatchBridgeMutatorTest extends TestCase
     public function testRequiresFromVersion(): void
     {
         $this->writeSql('8_1_0-to-8_2_0_upgrade.sql', "-- header\n");
-        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', null, 'rel-810');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', 'rel-810');
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('/--prev-version/');
@@ -135,7 +135,6 @@ final class MasterSqlPatchBridgeMutatorTest extends TestCase
         return MutatorContext::fromVersionString(
             $this->tmpDir,
             $targetVersion,
-            null,
             null,
             null,
             $prevVersion,

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/PatchPrepReleaseTargetsMutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/PatchPrepReleaseTargetsMutatorTest.php
@@ -336,7 +336,6 @@ final class PatchPrepReleaseTargetsMutatorTest extends TestCase
         return MutatorContext::fromVersionString(
             $this->tmpDir,
             $targetVersion,
-            null,
             $relBranch,
         );
     }

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/PostReleaseTargetsMutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/PostReleaseTargetsMutatorTest.php
@@ -48,7 +48,7 @@ final class PostReleaseTargetsMutatorTest extends TestCase
     public function testCanonical811FromRel810AppliesAllThreeTransforms(): void
     {
         $this->copyFixture('canonical_input.yml');
-        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', null, 'rel-810');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', 'rel-810');
 
         $result = (new PostReleaseTargetsMutator())->apply($context);
 
@@ -64,7 +64,7 @@ final class PostReleaseTargetsMutatorTest extends TestCase
     public function testCanonical811FromRel810IsIdempotent(): void
     {
         $this->copyFixture('canonical_input.yml');
-        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', null, 'rel-810');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', 'rel-810');
 
         $mutator = new PostReleaseTargetsMutator();
         $mutator->apply($context);
@@ -84,7 +84,7 @@ final class PostReleaseTargetsMutatorTest extends TestCase
         // The canonical input already contains the unreleased placeholder
         // for rel-810. Verify dropping it leaves the file with no row
         // carrying `unreleased: true` for that branch.
-        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', null, 'rel-810');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', 'rel-810');
         (new PostReleaseTargetsMutator())->apply($context);
 
         $parsed = Yaml::parse($this->readTarget());
@@ -112,7 +112,7 @@ final class PostReleaseTargetsMutatorTest extends TestCase
   openemr_version_ref: rel-810
 YAML;
         $this->writeTarget($input);
-        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', null, 'rel-810');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', 'rel-810');
         (new PostReleaseTargetsMutator())->apply($context);
 
         $expected = <<<'YAML'
@@ -130,7 +130,7 @@ YAML;
     public function testCommentsArePreservedOnSlotShuffleRows(): void
     {
         $this->copyFixture('canonical_input.yml');
-        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', null, 'rel-810');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', 'rel-810');
         (new PostReleaseTargetsMutator())->apply($context);
 
         $output = $this->readTarget();
@@ -175,7 +175,7 @@ YAML;
   openemr_version_ref: v8_0_0
 YAML;
         $this->writeTarget($input);
-        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', null, 'rel-810');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', 'rel-810');
         (new PostReleaseTargetsMutator())->apply($context);
 
         $parsed = Yaml::parse($this->readTarget());
@@ -213,7 +213,7 @@ YAML;
   openemr_version_ref: rel-810  # tracks tip until release
 YAML;
         $this->writeTarget($input);
-        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', null, 'rel-810');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.1', 'rel-810');
         (new PostReleaseTargetsMutator())->apply($context);
 
         $output = $this->readTarget();
@@ -248,7 +248,7 @@ YAML;
   openemr_version_ref: v7_0_4
 YAML;
         $this->writeTarget($input);
-        $context = MutatorContext::fromVersionString($this->tmpDir, '7.0.4', null, 'rel-704');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '7.0.4', 'rel-704');
 
         $mutator = new PostReleaseTargetsMutator();
         $first = $mutator->apply($context);
@@ -256,6 +256,62 @@ YAML;
             $first->changed(),
             'already-shipped rel-704 should be a no-op (active row recognised via v7_0_X tag)',
         );
+        self::assertSame($input, $this->readTarget());
+    }
+
+    public function testSkipsWhenTargetRelBranchHasNoLiveRow(): void
+    {
+        // Premature-finalize scenario: release-finalize fires for a
+        // rel-820 push before the paired branch-cut PR has landed the
+        // rel-820 row in release-targets.yml. If the mutator proceeded,
+        // the slot-shuffle step would drop `latest` from rel-810 without
+        // a promotion target — leaving nobody holding `latest`. The
+        // mutator must skip cleanly instead.
+        $input = <<<'YAML'
+- branch: master
+  docker_tags: 8.2.0,dev,next
+  openemr_version_ref: master
+
+- branch: rel-810
+  docker_tags: 8.1.0,latest
+  openemr_version_ref: v8_1_0
+YAML;
+        $this->writeTarget($input);
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.2.0', 'rel-820');
+
+        $result = (new PostReleaseTargetsMutator())->apply($context);
+        self::assertFalse($result->changed(), 'no diff when target rel branch has no live row');
+        self::assertSame($input, $this->readTarget(), 'file must be untouched');
+        self::assertNotEmpty($result->messages, 'skip should surface an informational message');
+        self::assertStringContainsString('rel-820', $result->messages[0]);
+        self::assertStringContainsString('no live row', $result->messages[0]);
+    }
+
+    public function testSkipsWhenOnlyRowForRelBranchIsUnreleasedPlaceholder(): void
+    {
+        // Edge case: a placeholder row for rel-820 exists (marked
+        // `unreleased: true`) but no live row yet. The placeholder alone
+        // shouldn't unblock the shuffle — same invalid-state hazard as
+        // when no row exists at all.
+        $input = <<<'YAML'
+- branch: master
+  docker_tags: 8.2.0,dev,next
+  openemr_version_ref: master
+
+- branch: rel-820
+  docker_tags: 8.1.0,latest
+  openemr_version_ref: v8_1_0
+  unreleased: true
+
+- branch: rel-810
+  docker_tags: 8.1.0,latest
+  openemr_version_ref: v8_1_0
+YAML;
+        $this->writeTarget($input);
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.2.0', 'rel-820');
+
+        $result = (new PostReleaseTargetsMutator())->apply($context);
+        self::assertFalse($result->changed());
         self::assertSame($input, $this->readTarget());
     }
 
@@ -293,7 +349,7 @@ YAML;
   openemr_version_ref: v8_0_0
 YAML;
         $this->writeTarget($input);
-        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.2', null, 'rel-810');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.2', 'rel-810');
         (new PostReleaseTargetsMutator())->apply($context);
 
         $parsed = Yaml::parse($this->readTarget());

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/TranslationFileCopyFromPriorRelMutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/TranslationFileCopyFromPriorRelMutatorTest.php
@@ -69,7 +69,7 @@ final class TranslationFileCopyFromPriorRelMutatorTest extends TestCase
     public function testThrowsWhenPrevRelBranchMissing(): void
     {
         $this->writeLocal('foo');
-        $context = MutatorContext::fromVersionString($this->tmpDir, '8.2.0', null, 'rel-820');
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.2.0', 'rel-820');
 
         $factory = $this->stubProcessFactory(true, '', '');
         $this->expectException(\RuntimeException::class);
@@ -113,7 +113,6 @@ final class TranslationFileCopyFromPriorRelMutatorTest extends TestCase
         return MutatorContext::fromVersionString(
             $this->tmpDir,
             '8.2.0',
-            null,
             'rel-820',
             $prevRelBranch,
         );

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorContextTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorContextTest.php
@@ -27,7 +27,6 @@ final class MutatorContextTest extends TestCase
         self::assertSame(1, $context->minor);
         self::assertSame(2, $context->patch);
         self::assertSame('8.1.2', $context->versionString());
-        self::assertNull($context->imageDigest);
     }
 
     public function testFromVersionStringRejectsMalformedInput(): void
@@ -37,46 +36,11 @@ final class MutatorContextTest extends TestCase
         MutatorContext::fromVersionString('/tmp/proj', '8.1');
     }
 
-    public function testValidImageDigestIsAccepted(): void
-    {
-        $digest = 'sha256:' . str_repeat('a', 64);
-        $context = MutatorContext::fromVersionString('/tmp/proj', '8.1.0', $digest);
-        self::assertSame($digest, $context->imageDigest);
-    }
-
-    public function testInvalidImageDigestRejected(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/imageDigest/');
-        MutatorContext::fromVersionString('/tmp/proj', '8.1.0', 'not-a-digest');
-    }
-
-    public function testImageDigestWithWrongPrefixRejected(): void
-    {
-        try {
-            $context = new MutatorContext('/tmp/proj', 8, 1, 0, 'sha512:' . str_repeat('a', 64));
-            self::fail('Expected InvalidArgumentException; got ' . $context::class);
-        } catch (\InvalidArgumentException $e) {
-            self::assertStringContainsString('imageDigest', $e->getMessage());
-        }
-    }
-
-    public function testImageDigestWithShortHexRejected(): void
-    {
-        try {
-            $context = new MutatorContext('/tmp/proj', 8, 1, 0, 'sha256:' . str_repeat('a', 63));
-            self::fail('Expected InvalidArgumentException; got ' . $context::class);
-        } catch (\InvalidArgumentException $e) {
-            self::assertStringContainsString('imageDigest', $e->getMessage());
-        }
-    }
-
     public function testValidPrevRelBranchIsAccepted(): void
     {
         $context = MutatorContext::fromVersionString(
             '/tmp/proj',
             '8.2.0',
-            null,
             'rel-820',
             'rel-810',
         );
@@ -91,7 +55,6 @@ final class MutatorContextTest extends TestCase
         MutatorContext::fromVersionString(
             '/tmp/proj',
             '8.2.0',
-            null,
             'rel-820',
             'master',
         );
@@ -99,7 +62,7 @@ final class MutatorContextTest extends TestCase
 
     public function testPrevRelBranchDefaultsToNull(): void
     {
-        $context = MutatorContext::fromVersionString('/tmp/proj', '8.2.0', null, 'rel-820');
+        $context = MutatorContext::fromVersionString('/tmp/proj', '8.2.0', 'rel-820');
         self::assertNull($context->prevRelBranch);
     }
 
@@ -114,7 +77,6 @@ final class MutatorContextTest extends TestCase
         $context = MutatorContext::fromVersionString(
             '/tmp/proj',
             '8.1.1',
-            null,
             'rel-810',
             null,
             '8.1.0',
@@ -129,7 +91,6 @@ final class MutatorContextTest extends TestCase
         MutatorContext::fromVersionString(
             '/tmp/proj',
             '8.1.1',
-            null,
             'rel-810',
             null,
             '8.1', // missing patch component
@@ -139,7 +100,7 @@ final class MutatorContextTest extends TestCase
     public function testFromVersionWithNonNumericComponentRejected(): void
     {
         try {
-            new MutatorContext('/tmp/proj', 8, 1, 1, null, null, null, '8.x.0');
+            new MutatorContext('/tmp/proj', 8, 1, 1, null, null, '8.x.0');
             self::fail('Expected InvalidArgumentException');
         } catch (\InvalidArgumentException $e) {
             self::assertStringContainsString('fromVersion', $e->getMessage());
@@ -150,7 +111,7 @@ final class MutatorContextTest extends TestCase
     {
         // target 8.1.2 with fromVersion 7.1.1 — major mismatch.
         try {
-            new MutatorContext('/tmp/proj', 8, 1, 2, null, null, null, '7.1.1');
+            new MutatorContext('/tmp/proj', 8, 1, 2, null, null, '7.1.1');
             self::fail('Expected InvalidArgumentException');
         } catch (\InvalidArgumentException $e) {
             self::assertStringContainsString('share major.minor', $e->getMessage());
@@ -166,7 +127,6 @@ final class MutatorContextTest extends TestCase
             MutatorContext::fromVersionString(
                 '/tmp/proj',
                 '8.1.2',
-                null,
                 'rel-810',
                 null,
                 '8.0.9',
@@ -184,7 +144,6 @@ final class MutatorContextTest extends TestCase
             MutatorContext::fromVersionString(
                 '/tmp/proj',
                 '8.1.3',
-                null,
                 'rel-810',
                 null,
                 '8.1.1',
@@ -202,7 +161,6 @@ final class MutatorContextTest extends TestCase
             MutatorContext::fromVersionString(
                 '/tmp/proj',
                 '8.1.1',
-                null,
                 'rel-810',
                 null,
                 '8.1.1',
@@ -220,7 +178,6 @@ final class MutatorContextTest extends TestCase
             MutatorContext::fromVersionString(
                 '/tmp/proj',
                 '8.1.1',
-                null,
                 'rel-810',
                 null,
                 '8.1.2',

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorTest.php
@@ -89,28 +89,19 @@ final class MutatorTest extends TestCase
         );
     }
 
-    public function testDockerComposePinsTagOnly(): void
+    public function testDockerComposePinsTagAndDiscardsSourceDigest(): void
     {
+        // Source has `latest@sha256:...`; expected output has
+        // `<version>` with no `@sha256:` — the release image isn't
+        // published at release-prep time so there is no valid digest to
+        // preserve or supply.
         $this->copyFixture('docker_compose/latest_input.yml', 'docker/production/docker-compose.yml');
         $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0');
         $this->assertMutationProducesAndIdempotent(
             new DockerComposeProductionMutator(),
             $context,
             'docker/production/docker-compose.yml',
-            self::FIXTURE_DIR . '/docker_compose/pinned_no_digest_expected.yml',
-        );
-    }
-
-    public function testDockerComposePinsTagAndDigest(): void
-    {
-        $this->copyFixture('docker_compose/latest_input.yml', 'docker/production/docker-compose.yml');
-        $digest = 'sha256:' . str_repeat('a', 64);
-        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0', $digest);
-        $this->assertMutationProducesAndIdempotent(
-            new DockerComposeProductionMutator(),
-            $context,
-            'docker/production/docker-compose.yml',
-            self::FIXTURE_DIR . '/docker_compose/pinned_with_digest_expected.yml',
+            self::FIXTURE_DIR . '/docker_compose/pinned_tag_only_expected.yml',
         );
     }
 
@@ -123,19 +114,6 @@ final class MutatorTest extends TestCase
             $context,
             'docker/production/docker-compose.yml',
             self::FIXTURE_DIR . '/docker_compose/bare_tag_pinned_expected.yml',
-        );
-    }
-
-    public function testDockerComposeAddsDigestToBareTag(): void
-    {
-        $this->copyFixture('docker_compose/bare_tag_input.yml', 'docker/production/docker-compose.yml');
-        $digest = 'sha256:' . str_repeat('a', 64);
-        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.0', $digest);
-        $this->assertMutationProducesAndIdempotent(
-            new DockerComposeProductionMutator(),
-            $context,
-            'docker/production/docker-compose.yml',
-            self::FIXTURE_DIR . '/docker_compose/bare_tag_pinned_with_digest_expected.yml',
         );
     }
 
@@ -187,7 +165,6 @@ final class MutatorTest extends TestCase
         $context = MutatorContext::fromVersionString(
             $this->tmpDir,
             '8.1.1',
-            null,
             'rel-810',
             null,
             '8.1.0',
@@ -223,7 +200,6 @@ final class MutatorTest extends TestCase
         $context = MutatorContext::fromVersionString(
             $this->tmpDir,
             '8.1.1',
-            null,
             'rel-810',
             null,
             '8.1.0',

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/ReleasePrepCommandTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/ReleasePrepCommandTest.php
@@ -16,12 +16,18 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Common\Command\ReleasePrep;
 
+use OpenEMR\Common\Command\ReleasePrep\Mutator\DockerComposeProductionMutator;
+use OpenEMR\Common\Command\ReleasePrep\Mutator\GlobalsIncMutator;
+use OpenEMR\Common\Command\ReleasePrep\Mutator\OpenApiVersionMutator;
+use OpenEMR\Common\Command\ReleasePrep\Mutator\SwaggerRegenMutator;
+use OpenEMR\Common\Command\ReleasePrep\Mutator\VersionPhpMutator;
 use OpenEMR\Common\Command\ReleasePrep\MutatorContext;
 use OpenEMR\Common\Command\ReleasePrep\MutatorInterface;
 use OpenEMR\Common\Command\ReleasePrep\MutatorResult;
 use OpenEMR\Common\Command\ReleasePrepCommand;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -112,16 +118,24 @@ final class ReleasePrepCommandTest extends TestCase
         self::assertSame(Command::INVALID, $exit);
     }
 
-    public function testInvalidImageDigestReturnsInvalid(): void
+    public function testDefaultRelMutatorListExcludesGlobalsIncMutator(): void
     {
-        $tester = $this->buildTester([], []);
-        $exit = $tester->execute([
-            '--target-version' => '8.1.0',
-            '--scope' => 'rel',
-            '--project-dir' => sys_get_temp_dir(),
-            '--image-digest' => 'not-a-digest',
-        ]);
-        self::assertSame(Command::INVALID, $exit);
+        // The `allow_debug_language` flip is owned by branch-cut's rel-side
+        // mutators, not release-prep. Include it here and release-prep
+        // hides the "did branch-cut merge?" question behind idempotency.
+        // See PR #12725 for the rel-820 exercise that surfaced this.
+        $default = $this->buildDefaultRelMutators();
+        $classes = array_map(static fn (MutatorInterface $m): string => $m::class, $default);
+        self::assertNotContains(
+            GlobalsIncMutator::class,
+            $classes,
+            'GlobalsIncMutator must not appear in the release-prep rel-side default list',
+        );
+        // Positive assertions: the mutators that ARE the rel-side list.
+        self::assertContains(VersionPhpMutator::class, $classes);
+        self::assertContains(DockerComposeProductionMutator::class, $classes);
+        self::assertContains(OpenApiVersionMutator::class, $classes);
+        self::assertContains(SwaggerRegenMutator::class, $classes);
     }
 
     /**
@@ -134,6 +148,24 @@ final class ReleasePrepCommandTest extends TestCase
         $app = new Application();
         $app->addCommand($command);
         return new CommandTester($app->find('openemr:release-prep'));
+    }
+
+    /**
+     * Introspect ReleasePrepCommand's private buildDefaultRelMutators()
+     * via reflection so this test guards the actual production list
+     * regardless of internal encapsulation choices.
+     *
+     * @return list<MutatorInterface>
+     */
+    private function buildDefaultRelMutators(): array
+    {
+        $command = new ReleasePrepCommand();
+        $reflect = new ReflectionClass(ReleasePrepCommand::class);
+        $method = $reflect->getMethod('buildDefaultRelMutators');
+        $result = $method->invoke($command);
+        self::assertIsArray($result);
+        /** @var list<MutatorInterface> $result */
+        return $result;
     }
 }
 

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_pinned_with_digest_expected.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/bare_tag_pinned_with_digest_expected.yml
@@ -1,5 +1,0 @@
-services:
-  openemr:
-    image: openemr/openemr:8.1.0@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    ports:
-    - 80:80

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/pinned_no_digest_expected.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/pinned_no_digest_expected.yml
@@ -1,5 +1,0 @@
-services:
-  openemr:
-    image: openemr/openemr:8.1.0@sha256:1d8073d3acfc15b53e771f264b84c0be41a0f0c998f413af39811e1c2e5d8061
-    ports:
-    - 80:80

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/pinned_tag_only_expected.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/pinned_tag_only_expected.yml
@@ -1,0 +1,5 @@
+services:
+  openemr:
+    image: openemr/openemr:8.1.0
+    ports:
+    - 80:80

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/pinned_with_digest_expected.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_compose/pinned_with_digest_expected.yml
@@ -1,5 +1,0 @@
-services:
-  openemr:
-    image: openemr/openemr:8.1.0@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    ports:
-    - 80:80

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Upgrade number 11 for OpenEMR docker
-#  From prior version 8.1.0 (needed for the sql upgrade script).
-priorOpenemrVersion="8.1.0"
-echo "Start: Upgrade to docker-version 11"
+# Upgrade number 12 for OpenEMR docker
+#  From prior version 8.2.0 (needed for the sql upgrade script).
+priorOpenemrVersion="8.2.0"
+echo "Start: Upgrade to docker-version 12"
 # Perform codebase upgrade on each directory in sites/
 for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
     sitename="${dir%/}"
@@ -38,4 +38,4 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done
-echo "Completed: Upgrade to docker-version 11"
+echo "Completed: Upgrade to docker-version 12"


### PR DESCRIPTION
Fixes 5 bugs surfaced by today's rel-820 cut — the first end-to-end production exercise of the branch-cut + release-prep + release-finalize automation. Four PRs currently open on rel-820 (#12725 release-prep, #12726 release-finalize, #12727 branch-cut rel-side, #12728 branch-cut master-side) each hit at least one of these. After this PR lands: close those four + delete their branches + delete rel-820 + recreate — the four cut-time PRs re-open fresh against the corrected mutators.

## Changes

**1. `DockerUpgradeScaffoldMutator`** — generate `fsupgrade-(N+1).sh` by copying `fsupgrade-N.sh` in full and applying five line-level substitutions (docker-version `N` → `N+1` in the header comment and two echoes; prior-openemr-version marker in header comment and in the `priorOpenemrVersion` shell variable). Previously wrote a stub that failed ShellCheck (SC2034 on `priorOpenemrVersion`) and lacked a trailing newline. Copy-in-full preserves the shellcheck directives, trailing newline, and existing upgrade body from the prior file. New test fixture: real `fsupgrade-11.sh` input + golden `fsupgrade-12.sh.expected` showing exactly the 5-line diff.

**2. `PostReleaseTargetsMutator`** — early-return with a skipped `MutatorResult` when no live row exists for the target rel branch in `release-targets.yml`. Previously ran the "drop `latest` from prior holder" step unconditionally, leaving the file with no row carrying `latest` when release-finalize fired prematurely at cut time (#12726's symptom).

**3. `ReleasePrepCommand`** — remove `GlobalsIncMutator` from the rel-side mutator list. Cut owns the `allow_debug_language` flip; running it again at release-prep was defensive but hid the "did cut merge?" question behind mutator idempotency.

**4. `DockerComposeProductionMutator`** — drop digest handling entirely. Previously pinned `openemr/openemr:latest@sha256:X` → `openemr/openemr:VERSION@sha256:X`, requiring `--image-digest` at release-prep time. Chicken-and-egg: the release image is built after the tag fires, which requires release-prep to merge. New behavior swaps only the tag: `openemr/openemr:latest[@sha256:X]` → `openemr/openemr:VERSION` (no digest). `MutatorContext::imageDigest` field and the `--image-digest` CLI option are removed alongside.

**5. Docs updated** — `docs/release-automation-plan.md` (release-prep mutator bullets reflect the new behavior) and `docs/RELEASE_PROCESS.md` (the short "conductor rewrites" summary catches up).

## Test coverage

Per-change adequate coverage:

| Change | New/updated tests |
|---|---|
| 1. DockerUpgradeScaffold | 5 new methods + real fsupgrade-11 input + golden fsupgrade-12 expected |
| 2. PostReleaseTargets | 2 new methods (no-live-row + only-unreleased-placeholder cases) |
| 3. ReleasePrepCommand | 1 new method asserting GlobalsIncMutator absent |
| 4. DockerComposeProduction | 2 test methods in MutatorTest.php updated to reference new `pinned_tag_only_expected.yml` fixture (3 old fixtures deleted) |
| 5. MutatorContext | `imageDigest`-specific tests removed cleanly |

Net delta: **+4 tests** on the isolated suite (new tests minus removed imageDigest-specific).

## Verification

- `pit` clean: **3587 tests pass** in a freshly-nuked-and-recreated docker stack
- Pre-commit hooks all green (phpstan, phpcs, rector, composer-require-checker, codespell, conventional-commits)
- Manual audit for `imageDigest` residual references: only remaining mention is in `DockerComposeProductionMutator.php`'s docstring explaining the historical why (valid documentation)
- No TODO/FIXME markers left

## After merge

Clean-slate rebuild for the rel-820 cut:

```
gh pr close 12725 12726 12727 12728 --repo openemr/openemr --delete-branch
git push origin --delete rel-820
git push origin master:rel-820
```

All 4 workflows re-fire with the corrected mutators → 4 fresh PRs against the fixed state.