### PR TITLE
fix(release): round-3 mutator + PR template fixes surfaced by second rel-820 exercise

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/branch-cut-master.md
+++ b/.github/PULL_REQUEST_TEMPLATE/branch-cut-master.md
@@ -12,8 +12,8 @@ Master-side partner PR for the freshly-cut `<REL_BRANCH>` branch (target version
 
 ## What this PR covers (master-side, next-dev advance)
 
-- **Docker upgrade scaffolding** — same docker-version bump + new `fsupgrade-N.sh` stub + Dockerfile manifest update as the rel-side PR (cross-branch sync requirement per the `docker upgrade actions mandatory per release` rule).
-- **SQL upgrade skeleton** — creates `sql/<from>-to-<to>_upgrade.sql` stub (header only; per-release work fills the body).
+- **Docker upgrade scaffolding** — same docker-version bump + new `fsupgrade-N.sh` (full copy of `fsupgrade-(N-1).sh` with the five version-substituted lines) + Dockerfile manifest update as the rel-side PR (cross-branch sync requirement per the `docker upgrade actions mandatory per release` rule; byte-identical between rel-side and master-side).
+- **SQL upgrade skeleton** — creates `sql/<from>-to-<to>_upgrade.sql` carrying the comment-meta-language header copied from the most recent existing bridge (body is empty; per-release work fills it in). The `<from>` is derived from `version.php` (branch-cut) or supplied via `--prev-version` (patch-prep).
 - **`version.php`** — bumps from `8.M.0-dev` to `8.(M+1).0-dev` so master keeps marking development builds for the next minor line.
 - **`src/RestControllers/OpenApi/OpenApiDefinitions.php`** — bumps `OA\Info(version: ...)` to the new master version.
 - **`swagger/openemr-api.yaml`** — regenerated from `OpenApiDefinitions.php` via `openemr:create-api-documentation`.
@@ -22,8 +22,8 @@ Master-side partner PR for the freshly-cut `<REL_BRANCH>` branch (target version
 ## Lifecycle
 
 1. Workflow fires on `create` event for the new `rel-NNN0` branch (or via `workflow_dispatch` for recovery).
-2. This master-side PR opens as a draft alongside the rel-side PR.
-3. Maintainer reviews both, marks Ready, and merges in order: rel-side first, then master-side.
+2. This master-side PR opens (ready-for-review, not draft) alongside the rel-side PR.
+3. Maintainer reviews both and merges in order: rel-side first, then master-side. The rel-side must land first — the master-side PR touches `.github/release-targets.yml`, and the docker release orchestrator fires on pushes to that file, so merging master-side kicks off an image build against the rel branch tip; landing rel-side first ensures that build carries the rel-branch identity mutations.
 
 ## Release manager checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE/branch-cut-rel.md
+++ b/.github/PULL_REQUEST_TEMPLATE/branch-cut-rel.md
@@ -12,7 +12,7 @@ Rel-side partner PR for the freshly-cut `<REL_BRANCH>` branch (target version `<
 
 ## What this PR covers (rel-side)
 
-- **Docker upgrade scaffolding** — bumps `docker-version` (3 files), creates the next `fsupgrade-N.sh` stub, extends the Dockerfile manifest's COPY and chmod blocks. Per-release work fills the upgrade body before each ship.
+- **Docker upgrade scaffolding** — bumps `docker-version` (3 files), creates the next `fsupgrade-N.sh` by copying `fsupgrade-(N-1).sh` in full and applying exactly five line-level version substitutions (upgrade number in header + start/completed echoes, `From prior version` comment, `priorOpenemrVersion="..."` shell variable). The upgrade body is preserved byte-for-byte from the prior file — it's immediately shellcheck-clean and runnable. Extends the Dockerfile manifest's COPY and chmod blocks to reference the new file. Per-release work refines the upgrade body in-place as needed. The `priorOpenemrVersion` value is the last-shipped version from the prior release line, derived by scanning `sql/*_upgrade.sql` for the highest LEFT-side version.
 - **`docker/release/Dockerfile`** — changes `ARG OPENEMR_VERSION=master` → `ARG OPENEMR_VERSION=<REL_BRANCH>` for branch-identity consistency (CI overrides via `--build-arg`).
 - **`contrib/util/language_translations/currentLanguage_utf8.sql`** — copies from the prior rel branch's tip so the freshly-cut branch starts with the latest translation snapshot.
 - **`library/globals.inc.php`** — flips `allow_debug_language` default from `'1'` (dev) to `'0'` (production).
@@ -20,13 +20,14 @@ Rel-side partner PR for the freshly-cut `<REL_BRANCH>` branch (target version `<
 ## Lifecycle
 
 1. Workflow fires on `create` event for the new `rel-NNN0` branch (or via `workflow_dispatch` for recovery).
-2. This rel-side PR opens as a draft alongside the master-side PR.
-3. Maintainer reviews both, marks Ready, and merges in order: rel-side first, then master-side.
+2. This rel-side PR opens (ready-for-review, not draft) alongside the master-side PR.
+3. Maintainer reviews both and merges in order: rel-side first, then master-side. Landing this rel-side PR first is critical because the master-side PR updates `.github/release-targets.yml` and the docker release orchestrator fires on pushes to that file — merging master-side kicks off an image build against the rel branch tip, and the image should carry this PR's rel-branch identity mutations (Dockerfile `ARG OPENEMR_VERSION`, docker-version bump, translation blob copy, `allow_debug_language` flip) before that build happens.
 
 ## Release manager checklist
 
 - [ ] Confirm the docker-version bump matches the expected next integer.
-- [ ] Confirm the new `fsupgrade-N.sh` stub is present and the Dockerfile manifest references it.
+- [ ] Confirm the new `fsupgrade-N.sh` is present, differs from `fsupgrade-(N-1).sh` on exactly the five version-substituted lines, and that the Dockerfile manifest references it in both the COPY and chmod blocks.
+- [ ] Confirm the new `fsupgrade-N.sh`'s `priorOpenemrVersion="..."` value matches the last-shipped version from the prior release line (highest LEFT among `sql/*_upgrade.sql`).
 - [ ] Verify the translation file copy matches the prior rel branch's blob.
 - [ ] Confirm the paired `branch-cut/<REL_BRANCH>-master` PR opened and is in the same review queue.
 - [ ] Merge this PR (rel-side).

--- a/.github/PULL_REQUEST_TEMPLATE/patch-prep-master.md
+++ b/.github/PULL_REQUEST_TEMPLATE/patch-prep-master.md
@@ -12,8 +12,8 @@ Master-side partner PR for `<REL_BRANCH>` entering dev for patch `<VERSION>` (pr
 
 ## What this PR covers (master-side)
 
-- **Docker upgrade scaffolding** — same docker-version bump + new `fsupgrade-N.sh` stub + Dockerfile manifest update as the rel-side PR (cross-branch sync requirement per the `docker upgrade actions mandatory per release` rule).
-- **SQL patch upgrade skeleton** — new `sql/<from>-to-<to>_upgrade.sql` carrying the comment header only. Same file as the rel-side stub; master accumulates the cumulative upgrade catalog.
+- **Docker upgrade scaffolding** — same docker-version bump + new `fsupgrade-N.sh` (full copy of `fsupgrade-(N-1).sh` with the five version-substituted lines) + Dockerfile manifest update as the rel-side PR (cross-branch sync requirement per the `docker upgrade actions mandatory per release` rule; byte-identical between rel-side and master-side).
+- **SQL patch upgrade skeleton** — new `sql/<from>-to-<to>_upgrade.sql` carrying the comment-meta-language header only. Same file as the rel-side skeleton; master accumulates the cumulative upgrade catalog.
 - **Master bridge file rename** — renames the long-lived `sql/<X_Y_(P-1)>-to-<X_(Y+1)_0>_upgrade.sql` → `sql/<X_Y_P>-to-<X_(Y+1)_0>_upgrade.sql`. The file's *contents* are preserved (they accumulate dev-cycle SQL); only the "from" anchor in the filename advances to reflect the new patch shipping.
 - **`.github/release-targets.yml`** — adds a new dev row for the rel branch carrying `docker_tags: <VERSION>,next`, and drops any rows for this branch flagged `unreleased: true` (covers the initial-cycle placeholder dropped when real dev begins). Existing finalized rows (the just-shipped patch carrying `latest`) are left alone.
 
@@ -27,7 +27,8 @@ Master-side partner PR for `<REL_BRANCH>` entering dev for patch `<VERSION>` (pr
 ## Release manager checklist
 
 - [ ] Confirm the docker-version bump matches the rel-side PR's bump (byte-identical).
-- [ ] Confirm the new SQL upgrade skeleton filename matches the patch pair (e.g., `8_1_0-to-8_1_1_upgrade.sql`) and matches the rel-side stub.
+- [ ] Confirm the new `fsupgrade-N.sh` is byte-identical to the rel-side PR's `fsupgrade-N.sh` (cross-branch sync).
+- [ ] Confirm the new SQL upgrade skeleton filename matches the patch pair (e.g., `8_1_0-to-8_1_1_upgrade.sql`) and its contents match the rel-side skeleton.
 - [ ] Verify the bridge rename: `sql/<X_Y_(P-1)>-to-<X_(Y+1)_0>_upgrade.sql` is gone; `sql/<X_Y_P>-to-<X_(Y+1)_0>_upgrade.sql` is present with the same content.
 - [ ] Verify the `release-targets.yml` diff: new dev row present with `<VERSION>,next`; any prior `unreleased: true` row for this branch dropped; the just-shipped patch row carrying `latest` is untouched.
 - [ ] Confirm the paired `patch-prep/<REL_BRANCH>` (rel-side) PR opened and merged first.

--- a/.github/PULL_REQUEST_TEMPLATE/patch-prep-rel.md
+++ b/.github/PULL_REQUEST_TEMPLATE/patch-prep-rel.md
@@ -12,8 +12,8 @@ Rel-side partner PR for `<REL_BRANCH>` entering dev for patch `<VERSION>` (prior
 
 ## What this PR covers (rel-side)
 
-- **Docker upgrade scaffolding** — bumps `docker-version` (3 files), creates the next `fsupgrade-N.sh` stub, extends the Dockerfile manifest's COPY and chmod blocks. Per-release work fills the upgrade body before the patch ships.
-- **SQL patch upgrade skeleton** — scaffolds `sql/<from>-to-<to>_upgrade.sql` (header only; per-release work fills the body). The from-version is supplied explicitly (`--prev-version`) because `version.php` has already been bumped to the new `$v_patch`.
+- **Docker upgrade scaffolding** — bumps `docker-version` (3 files), creates the next `fsupgrade-N.sh` by copying `fsupgrade-(N-1).sh` in full and applying the five line-level version substitutions, extends the Dockerfile manifest's COPY and chmod blocks. The `priorOpenemrVersion` value written into the new file is the explicit `--prev-version` supplied on the CLI (which matches the last-shipped patch version). Per-release work refines the upgrade body in-place as needed.
+- **SQL patch upgrade skeleton** — scaffolds `sql/<from>-to-<to>_upgrade.sql` carrying the comment-meta-language header from the most recent existing bridge (body is empty; per-release work fills it in). The from-version is supplied explicitly (`--prev-version`) because `version.php` has already been bumped to the new `$v_patch`.
 
 ## Lifecycle
 
@@ -25,7 +25,8 @@ Rel-side partner PR for `<REL_BRANCH>` entering dev for patch `<VERSION>` (prior
 ## Release manager checklist
 
 - [ ] Confirm the docker-version bump matches the expected next integer.
-- [ ] Confirm the new `fsupgrade-N.sh` stub is present and the Dockerfile manifest references it.
+- [ ] Confirm the new `fsupgrade-N.sh` is present, differs from `fsupgrade-(N-1).sh` on exactly the five version-substituted lines, and that the Dockerfile manifest references it in both the COPY and chmod blocks.
+- [ ] Confirm the new `fsupgrade-N.sh`'s `priorOpenemrVersion="..."` value matches `<PREV_VERSION>`.
 - [ ] Confirm the new SQL upgrade skeleton filename matches the patch pair (e.g., `8_1_0-to-8_1_1_upgrade.sql`).
 - [ ] Confirm the paired `patch-prep/<REL_BRANCH>-master` PR opened and is in the same review queue.
 - [ ] Merge this PR (rel-side).

--- a/docs/release-automation-plan.md
+++ b/docs/release-automation-plan.md
@@ -89,12 +89,19 @@ be auto-derived by decrementing minor below 1).
 ready-for-review):
 
 - `DockerUpgradeScaffoldMutator` — new `fsupgrade-N.sh` (copied in full
-  from the prior `fsupgrade-N-1.sh` with only the docker-version /
-  priorOpenemrVersion header lines substituted; the upgrade body is
-  preserved byte-for-byte from the prior file for per-release refinement
-  in place) + Dockerfile manifest updates (both `COPY` and `chmod`
-  blocks). Same scaffolding the docker-upgrade-actions memo enumerates
-  as mandatory per release.
+  from the prior `fsupgrade-N-1.sh` with only the five docker-version
+  and `priorOpenemrVersion` header lines substituted; the upgrade body
+  is preserved byte-for-byte from the prior file for per-release
+  refinement in place) + Dockerfile manifest updates (both `COPY` and
+  `chmod` blocks). The `priorOpenemrVersion` value is the last-shipped
+  version from the prior release line — derived by scanning
+  `sql/*_upgrade.sql` for the highest LEFT-side version at branch-cut
+  time, or supplied explicitly via `MutatorContext::$fromVersion` at
+  patch-prep time. A strictly-less-than-target invariant catches
+  ordering bugs (e.g. `SqlUpgradeSkeletonMutator` accidentally running
+  first would inflate the sql-scan result to the target). Same
+  scaffolding the docker-upgrade-actions memo enumerates as mandatory
+  per release.
 - `DockerfileOpenemrVersionMutator` — pins the `OPENEMR_VERSION` ARG
   in the branch's Dockerfile to the new rel line.
 - `TranslationFileCopyFromPriorRelMutator` — fetches the translation
@@ -449,7 +456,7 @@ mutators would produce churn PRs.
 | `SqlUpgradeSkeletonMutator` | branch-cut (master), patch-prep (rel + master) | Scaffold `sql/X_Y_Z-to-X_Y_Z+N_upgrade.sql`. |
 | `MasterSqlPatchBridgeMutator` | patch-prep (master) | Rename bridge file to track new patch. |
 | `BranchCutReleaseTargetsMutator` | branch-cut (master) | Insert row for new rel branch. |
-| `PatchPrepReleaseTargetsMutator` | patch-prep (master) | Insert unreleased placeholder row for new patch. |
+| `PatchPrepReleaseTargetsMutator` | patch-prep (master) | Insert new dev row (`docker_tags: <version>,next`) for the patch + drop any prior `unreleased: true` placeholder for the branch. |
 | `PostReleaseTargetsMutator` | release-prep (master, release-finalize) | Pin rel row + slot shuffle + drop placeholder. |
 
 Adding a new lifecycle event (or a new mutation to an existing one) is

--- a/src/Common/Command/ReleasePrep/Mutator/DockerUpgradeScaffoldMutator.php
+++ b/src/Common/Command/ReleasePrep/Mutator/DockerUpgradeScaffoldMutator.php
@@ -157,6 +157,30 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
         $priorStubRelPath = self::UPGRADE_DIR . '/fsupgrade-' . $current . '.sh';
         $priorStubAbs = $projectDir . '/' . $priorStubRelPath;
 
+        // Validate + derive everything that can throw BEFORE any
+        // destructive writes. Otherwise a mid-flight failure (unreadable
+        // prior fsupgrade, missing marker, invariant violation) would
+        // leave docker-version files bumped without the paired new
+        // fsupgrade — a partial state that's harder to recover from
+        // than a clean throw.
+        $priorContents = file_get_contents($priorStubAbs);
+        if ($priorContents === false) {
+            throw new \RuntimeException('Cannot read ' . $priorStubAbs);
+        }
+        $priorFileMarker = $this->extractPriorMarkerFromFsupgrade($priorContents, $priorStubAbs);
+        // The `priorOpenemrVersion` marker in the prior file is the
+        // PRIOR CYCLE's value (e.g. "8.1.0" in fsupgrade-11.sh, from the
+        // rel-810 cut). That's the search anchor. The REPLACEMENT is
+        // this cut's derived last-shipped value (e.g. "8.1.1" for rel-820).
+        $nextContents = $this->deriveNextFromPrior(
+            $priorContents,
+            $current,
+            $next,
+            $priorFileMarker,
+            $priorOpenemrVersion,
+            $priorStubAbs,
+        );
+
         $changedFiles = [];
 
         // (1) Bump the three docker-version files.
@@ -168,25 +192,8 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
             $changedFiles[] = $relPath;
         }
 
-        // (2) Create the next fsupgrade-(N+1).sh by copying the prior
-        // file in full and applying the five line-level substitutions.
-        // The `priorOpenemrVersion` marker in the prior file is the
-        // PRIOR CYCLE's value (e.g. "8.1.0" in fsupgrade-11.sh, from the
-        // rel-810 cut). That's the search anchor. The REPLACEMENT is
-        // this cut's derived last-shipped value (e.g. "8.1.1" for rel-820).
-        $priorContents = file_get_contents($priorStubAbs);
-        if ($priorContents === false) {
-            throw new \RuntimeException('Cannot read ' . $priorStubAbs);
-        }
-        $priorFileMarker = $this->extractPriorMarkerFromFsupgrade($priorContents, $priorStubAbs);
-        $nextContents = $this->deriveNextFromPrior(
-            $priorContents,
-            $current,
-            $next,
-            $priorFileMarker,
-            $priorOpenemrVersion,
-            $priorStubAbs,
-        );
+        // (2) Write the next fsupgrade-(N+1).sh (contents pre-derived
+        // above so the write itself cannot throw a parse/marker error).
         if (file_put_contents($nextStubAbs, $nextContents) === false) {
             throw new \RuntimeException('Cannot write ' . $nextStubAbs);
         }

--- a/src/Common/Command/ReleasePrep/Mutator/DockerUpgradeScaffoldMutator.php
+++ b/src/Common/Command/ReleasePrep/Mutator/DockerUpgradeScaffoldMutator.php
@@ -25,12 +25,30 @@
  *     trailing newline, and existing upgrade logic so the resulting file
  *     is immediately shellcheck-clean and runnable.
  *
+ *     The `priorOpenemrVersion` value written into the new file is the
+ *     LAST SHIPPED version from the prior release line — derived by
+ *     scanning `sql/*_upgrade.sql` and taking the highest LEFT (see
+ *     `derivePriorOpenemrVersion` for the full contract, including the
+ *     patch-prep `fromVersion` override and the strictly-less-than-target
+ *     invariant that catches ordering / regression bugs).
+ *
  * (3) Update `docker/release/Dockerfile` to add `fsupgrade-(N+1).sh` to
  *     BOTH the `COPY upgrade/...` block AND the `RUN chmod 500 ...` block.
  *
- * Idempotency signal: if `fsupgrade-(N+1).sh` already exists, all three
- * transformations are assumed done and the mutator no-ops. (The
- * docker-version files are still validated for drift.)
+ * Idempotency signal: the mutator recognises its own post-scaffold work
+ * by inspecting fsupgrade-(current).sh — after a successful run,
+ * docker-version has been bumped to N+1 so `current` reads as the bumped
+ * value and the file at that path is one WE wrote. Two markers must
+ * match: `Upgrade number <current> for OpenEMR docker` (structural) and
+ * `priorOpenemrVersion="<X>"` where X is what we WOULD write now
+ * (derived from the sql scan with any at-or-above-target bridge filtered
+ * out, mirroring the pre-scaffold state — see
+ * `derivePriorOpenemrVersionFromSqlIgnoringAtOrAboveTarget`). If either
+ * marker differs, we're either at the pre-scaffold state (fsupgrade-N
+ * is the prior cycle's file) or in a wrong-ordering scenario (Sql
+ * accidentally ran first), and the mutation proceeds — in the
+ * wrong-ordering case, `derivePriorOpenemrVersion` trips the
+ * strictly-less-than-target invariant with a clear ordering-bug message.
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -93,31 +111,46 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
         $current = reset($unique);
         $next = $current + 1;
 
-        $priorOpenemrVersion = $this->derivePriorOpenemrVersion($context);
         $targetVersion = $context->versionString();
 
-        // Idempotency: if the current docker-version's fsupgrade file
-        // already records THIS cut's target version + prior version, we
-        // already ran for this cut (possibly on a previous retry). No-op
-        // cleanly.
+        // Compute the "pre-scaffold" priorOpenemrVersion — what the
+        // derivation SHOULD produce ignoring any sql bridge whose left
+        // >= target. That's the value we WOULD write into a fresh
+        // fsupgrade-(N+1).sh. Idempotency compares it against the
+        // marker in fsupgrade-(current).sh.
         //
-        // The signal: at rel-820 cut (target 8.2.0), the new file we'd
-        // write contains `priorOpenemrVersion="8.2.0"` (target-version) —
-        // i.e., the prior line the NEXT cut's fsupgrade will need to
-        // upgrade from. After a successful run, docker-version is the
-        // new N (=12) and fsupgrade-12.sh exists carrying that 8.2.0
-        // marker. A *different* cut would see a different target-version
-        // pinned (e.g. fsupgrade-12.sh carrying 8.0.0 from an older cut),
-        // in which case we'd still want to advance.
+        // Master-side post-scaffold: the sibling SqlUpgradeSkeletonMutator
+        // has run and added a `<target>-to-<next>_upgrade.sql` bridge.
+        // A naive sql scan would then yield `target` and trip the
+        // strictly-less-than-target invariant. Filtering out bridges
+        // with left >= target restores the "pre-scaffold view", which
+        // is the value we ACTUALLY wrote into fsupgrade-(current).sh
+        // during the successful run. If they match, we no-op cleanly.
+        //
+        // Wrong-ordering scenario (Sql accidentally ran BEFORE Docker
+        // in the same chain): docker-version hasn't been bumped yet,
+        // fsupgrade-(current).sh is the PRIOR cycle's file with an
+        // OLDER priorOpenemrVersion marker. That doesn't match the
+        // pre-scaffold-view derivation, so the idempotency short-circuit
+        // is skipped and derivePriorOpenemrVersion is called — which
+        // then trips the invariant with the clear ordering-bug message.
+        $preScaffoldPrior = $context->fromVersion
+            ?? $this->derivePriorOpenemrVersionFromSqlIgnoringAtOrAboveTarget(
+                $context->projectDir,
+                $targetVersion,
+            );
         $currentStubAbs = $projectDir . '/' . self::UPGRADE_DIR . '/fsupgrade-' . $current . '.sh';
-        if (is_file($currentStubAbs)) {
+        if ($preScaffoldPrior !== null && is_file($currentStubAbs)) {
             $existing = (string) file_get_contents($currentStubAbs);
-            if (str_contains($existing, 'priorOpenemrVersion="' . $targetVersion . '"')
-                && str_contains($existing, 'Upgrade number ' . $current . ' for OpenEMR docker')) {
-                // This is OUR file from a prior run of this same cut.
+            if (
+                str_contains($existing, 'Upgrade number ' . $current . ' for OpenEMR docker')
+                && str_contains($existing, 'priorOpenemrVersion="' . $preScaffoldPrior . '"')
+            ) {
                 return MutatorResult::noop();
             }
         }
+
+        $priorOpenemrVersion = $this->derivePriorOpenemrVersion($context);
 
         $nextStubRelPath = self::UPGRADE_DIR . '/fsupgrade-' . $next . '.sh';
         $nextStubAbs = $projectDir . '/' . $nextStubRelPath;
@@ -137,16 +170,21 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
 
         // (2) Create the next fsupgrade-(N+1).sh by copying the prior
         // file in full and applying the five line-level substitutions.
+        // The `priorOpenemrVersion` marker in the prior file is the
+        // PRIOR CYCLE's value (e.g. "8.1.0" in fsupgrade-11.sh, from the
+        // rel-810 cut). That's the search anchor. The REPLACEMENT is
+        // this cut's derived last-shipped value (e.g. "8.1.1" for rel-820).
         $priorContents = file_get_contents($priorStubAbs);
         if ($priorContents === false) {
             throw new \RuntimeException('Cannot read ' . $priorStubAbs);
         }
+        $priorFileMarker = $this->extractPriorMarkerFromFsupgrade($priorContents, $priorStubAbs);
         $nextContents = $this->deriveNextFromPrior(
             $priorContents,
             $current,
             $next,
+            $priorFileMarker,
             $priorOpenemrVersion,
-            $targetVersion,
             $priorStubAbs,
         );
         if (file_put_contents($nextStubAbs, $nextContents) === false) {
@@ -173,31 +211,148 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
     }
 
     /**
-     * The fsupgrade-N.sh's existing `priorOpenemrVersion` marker
-     * (whatever value the prior file records — the version the current
-     * fsupgrade-N.sh upgrades FROM). The next fsupgrade-(N+1).sh, by
-     * contrast, will upgrade from the version we're SHIPPING with this
-     * cut (i.e. the target-version), so the substitution's replacement
-     * value is the target-version.
+     * The `priorOpenemrVersion` marker to embed in the newly-scaffolded
+     * fsupgrade-(N+1).sh. Semantically: the LAST SHIPPED version from
+     * the prior release line — the version fsupgrade-(N+1).sh will
+     * upgrade FROM when it eventually runs against a customer's install.
      *
-     * Branch-cut (no fromVersion): for a cut of rel-820 (target 8.2.0),
-     * fsupgrade-11.sh's prior marker is 8.1.0 (rel-810's shipped version),
-     * and fsupgrade-12.sh's prior marker becomes 8.2.0.
+     * Historical shape (see fsupgrade-10 / fsupgrade-11 on rel-810 tip):
+     *   fsupgrade-10.sh (created for 8.1.0 line): priorOpenemrVersion="8.0.0"
+     *   fsupgrade-11.sh (created for 8.1.1 release): priorOpenemrVersion="8.1.0"
+     * At rel-820 cut, fsupgrade-12.sh's prior marker must be "8.1.1"
+     * (the highest sql/*_upgrade.sql left-side), NOT "8.2.0" (the target).
      *
-     * Patch-prep (fromVersion supplied): the from-version is the
-     * prior-patch shipped version, e.g. 8.1.0 for a rel-810 8.1.1
-     * patch-prep — the same shape as the branch-cut case.
+     * Derivation (canonical): scan sql/*_upgrade.sql, find the file with
+     * the highest LEFT version via version_compare — that's the last
+     * shipped upgrade bridge, so its left is the last shipped version.
+     *
+     * Patch-prep override: MutatorContext::$fromVersion is set by
+     * PatchPrepCommand to the immediate prior patch version (e.g., 8.1.0
+     * when preparing 8.1.1). That's exactly the prior-shipped-version
+     * shape the sql scan would derive too, so it's semantically the
+     * same, but the override bypasses filesystem state and is the
+     * authoritative signal on that path.
+     *
+     * Defensive invariant: whichever derivation path is used, the
+     * result must be STRICTLY LESS than the target version. If it's
+     * equal, one of two bugs is in play:
+     *   (a) the old target-based derivation snuck back in, or
+     *   (b) a mutator earlier in the list (e.g. SqlUpgradeSkeletonMutator)
+     *       already wrote a `<target>-to-<next>_upgrade.sql` file, which
+     *       promoted the sql-scan result up to the target.
+     * Both are load-bearing bugs — throw with a clear message rather
+     * than emit a corrupt fsupgrade file.
      */
     private function derivePriorOpenemrVersion(MutatorContext $context): string
     {
-        if ($context->fromVersion !== null) {
-            return $context->fromVersion;
+        $priorVersion = $context->fromVersion
+            ?? $this->derivePriorOpenemrVersionFromSql($context->projectDir);
+        $target = $context->versionString();
+        if (version_compare($priorVersion, $target, '<') !== true) {
+            throw new \RuntimeException(sprintf(
+                'priorOpenemrVersion %s must be strictly less than target %s. '
+                . 'This usually indicates SqlUpgradeSkeletonMutator ran before '
+                . 'DockerUpgradeScaffoldMutator; check the mutator list order '
+                . 'in BranchCutCommand/PatchPrepCommand.',
+                $priorVersion,
+                $target,
+            ));
         }
-        $priorMinor = $context->minor - 1;
-        if ($priorMinor < 0) {
-            $priorMinor = 0;
+        return $priorVersion;
+    }
+
+    /**
+     * Read the `priorOpenemrVersion="X.Y.Z"` value from the prior
+     * fsupgrade-N.sh contents. Used as the search anchor when copying
+     * the file forward — the substitution replaces this marker with
+     * this cut's derived last-shipped version. Throws if the marker is
+     * absent (same "load-bearing schema" invariant as
+     * `deriveNextFromPrior`).
+     */
+    private function extractPriorMarkerFromFsupgrade(string $priorContents, string $priorFilePath): string
+    {
+        if (preg_match('/priorOpenemrVersion="(\d+\.\d+\.\d+)"/', $priorContents, $m) !== 1) {
+            throw new \RuntimeException(sprintf(
+                'fsupgrade scaffold cannot find priorOpenemrVersion="X.Y.Z" marker in %s; '
+                . 'refusing to copy the file forward without a search anchor for the version substitution',
+                $priorFilePath,
+            ));
         }
-        return sprintf('%d.%d.0', $context->major, $priorMinor);
+        return $m[1];
+    }
+
+    /**
+     * Idempotency helper: scan sql/*_upgrade.sql for the highest LEFT
+     * version STRICTLY LESS THAN target, returning the "pre-scaffold
+     * view" of the derivation. Bridges with left >= target are ignored
+     * — those are either the sibling SqlUpgradeSkeletonMutator's output
+     * (master-side post-scaffold) or an anomalous newer bridge; either
+     * way they don't reflect the last-shipped-version state we
+     * scaffolded from.
+     *
+     * Returns null when the pre-scaffold view produces no valid
+     * candidate (e.g., sql/ is empty, or every bridge is at-or-above
+     * target). A null return skips the idempotency check and lets
+     * `derivePriorOpenemrVersion` produce the load-bearing error.
+     */
+    private function derivePriorOpenemrVersionFromSqlIgnoringAtOrAboveTarget(
+        string $projectDir,
+        string $targetVersion,
+    ): ?string {
+        $sqlDir = $projectDir . '/sql';
+        $files = glob($sqlDir . '/*-to-*_upgrade.sql');
+        if ($files === false || $files === []) {
+            return null;
+        }
+        $highest = null;
+        foreach ($files as $file) {
+            $name = basename($file);
+            if (preg_match('/^(\d+)_(\d+)_(\d+)-to-(\d+)_(\d+)_(\d+)_upgrade\.sql$/', $name, $m) !== 1) {
+                continue;
+            }
+            $left = $m[1] . '.' . $m[2] . '.' . $m[3];
+            if (version_compare($left, $targetVersion, '>=')) {
+                continue;
+            }
+            if ($highest === null || version_compare($left, $highest, '>')) {
+                $highest = $left;
+            }
+        }
+        return $highest;
+    }
+
+    /**
+     * Scan sql/*_upgrade.sql for the file with the highest LEFT
+     * version via version_compare, and return its left as the prior
+     * shipped version. Filenames match `X_Y_Z-to-A_B_C_upgrade.sql`
+     * with underscore-separated version segments.
+     */
+    private function derivePriorOpenemrVersionFromSql(string $projectDir): string
+    {
+        $sqlDir = $projectDir . '/sql';
+        $files = glob($sqlDir . '/*-to-*_upgrade.sql');
+        if ($files === false || $files === []) {
+            throw new \RuntimeException(
+                'Cannot derive priorOpenemrVersion: no sql/*-to-*_upgrade.sql files found in ' . $sqlDir,
+            );
+        }
+        $highest = null;
+        foreach ($files as $file) {
+            $name = basename($file);
+            if (preg_match('/^(\d+)_(\d+)_(\d+)-to-(\d+)_(\d+)_(\d+)_upgrade\.sql$/', $name, $m) !== 1) {
+                continue;
+            }
+            $left = $m[1] . '.' . $m[2] . '.' . $m[3];
+            if ($highest === null || version_compare($left, $highest, '>')) {
+                $highest = $left;
+            }
+        }
+        if ($highest === null) {
+            throw new \RuntimeException(
+                'Cannot derive priorOpenemrVersion: no sql/X_Y_Z-to-A_B_C_upgrade.sql files matched in ' . $sqlDir,
+            );
+        }
+        return $highest;
     }
 
     /**
@@ -205,6 +360,12 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
      * line-level substitutions to produce fsupgrade-(N+1).sh. All other
      * content (shellcheck directives, blank lines, upgrade body, trailing
      * newline) is preserved byte-for-byte.
+     *
+     * The prior-file marker for `priorOpenemrVersion` is what fsupgrade-N.sh
+     * currently contains (e.g., "8.1.0" — the LAST shipped from the
+     * cycle that created it). The replacement is THIS cut's derived
+     * last-shipped version (e.g., "8.1.1"). Both may match on very rare
+     * degenerate cycles; the substitution is idempotent in that case.
      *
      * If any of the five expected anchor patterns is missing from the
      * prior file, we throw rather than silently producing a corrupt
@@ -214,8 +375,8 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
         string $priorContents,
         int $current,
         int $next,
-        string $priorOpenemrVersion,
-        string $targetVersion,
+        string $priorFileMarker,
+        string $newFileMarker,
         string $priorFilePath,
     ): string {
         $substitutions = [
@@ -224,12 +385,12 @@ final readonly class DockerUpgradeScaffoldMutator implements MutatorInterface
                 '# Upgrade number ' . $next . ' for OpenEMR docker',
             ],
             [
-                '#  From prior version ' . $priorOpenemrVersion . ' (needed for the sql upgrade script).',
-                '#  From prior version ' . $targetVersion . ' (needed for the sql upgrade script).',
+                '#  From prior version ' . $priorFileMarker . ' (needed for the sql upgrade script).',
+                '#  From prior version ' . $newFileMarker . ' (needed for the sql upgrade script).',
             ],
             [
-                'priorOpenemrVersion="' . $priorOpenemrVersion . '"',
-                'priorOpenemrVersion="' . $targetVersion . '"',
+                'priorOpenemrVersion="' . $priorFileMarker . '"',
+                'priorOpenemrVersion="' . $newFileMarker . '"',
             ],
             [
                 'echo "Start: Upgrade to docker-version ' . $current . '"',

--- a/src/Common/Command/ReleasePrep/Mutator/SqlUpgradeSkeletonMutator.php
+++ b/src/Common/Command/ReleasePrep/Mutator/SqlUpgradeSkeletonMutator.php
@@ -141,6 +141,16 @@ final readonly class SqlUpgradeSkeletonMutator implements MutatorInterface
      * blank lines. The first non-comment, non-blank line ends the
      * header; everything after it is real upgrade SQL from the source
      * release that we don't want to copy.
+     *
+     * The output ends with exactly one trailing newline. A double
+     * trailing newline breaks the `end-of-file-fixer` pre-commit hook
+     * on the generated file. That can happen when either
+     *   (a) the source file is 100% comment/blank lines and ends `\n`,
+     *       so split leaves a trailing empty element, or
+     *   (b) the header run itself ends with one or more blank lines
+     *       before the first SQL statement.
+     * Trim any trailing blanks from the kept run and append a single
+     * `\n` so the emitted file is always canonical.
      */
     private function extractCommentHeader(string $contents): string
     {
@@ -155,6 +165,9 @@ final readonly class SqlUpgradeSkeletonMutator implements MutatorInterface
                 continue;
             }
             break;
+        }
+        while ($kept !== [] && end($kept) === '') {
+            array_pop($kept);
         }
         return implode("\n", $kept) . "\n";
     }

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/DockerUpgradeScaffoldMutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/DockerUpgradeScaffoldMutatorTest.php
@@ -147,14 +147,22 @@ final class DockerUpgradeScaffoldMutatorTest extends TestCase
         (new DockerUpgradeScaffoldMutator())->apply($this->context());
     }
 
-    public function testAnchorSearchIsDerivedFromTargetMinor(): void
+    public function testPriorOpenemrVersionDerivedFromSqlBridgeLeft(): void
     {
-        // For target=8.5.0, the mutator computes prev=8.4.0 (target minor-1)
-        // and uses that as the substitution anchor. Simulate the on-tree
-        // reality at rel-850's cut: fsupgrade-11.sh's priorOpenemrVersion is
-        // 8.4.0 (rel-840's shipped version). The mutator produces
-        // fsupgrade-12.sh with priorOpenemrVersion=8.5.0 (rel-850's shipped
-        // version, i.e. the target-version).
+        // Happy-path branch-cut derivation: fsupgrade-12.sh's
+        // priorOpenemrVersion is read from the highest LEFT version
+        // among sql/*_upgrade.sql bridges — that's the last shipped
+        // version. Seed a rel-850 cut fixture: `8_4_1-to-8_5_0_upgrade.sql`
+        // is the latest bridge, so priorOpenemrVersion must resolve to
+        // "8.4.1".
+        //
+        // Prior fsupgrade file's own priorOpenemrVersion marker (the
+        // search anchor for the substitution) is whatever the prior
+        // cycle wrote; here we set it to "8.4.0" (rel-840's shipped
+        // version). The scaffold reads the marker from the file, so the
+        // substitution succeeds regardless of what the marker value is,
+        // provided the load-bearing schema (all five anchor patterns)
+        // is intact.
         $priorAt840 = str_replace(
             ['priorOpenemrVersion="8.1.0"', 'From prior version 8.1.0'],
             ['priorOpenemrVersion="8.4.0"', 'From prior version 8.4.0'],
@@ -164,25 +172,143 @@ final class DockerUpgradeScaffoldMutatorTest extends TestCase
             $this->tmpDir . '/docker/release/upgrade/fsupgrade-11.sh',
             $priorAt840,
         );
+        // Wipe the setUp's default sql bridge and seed rel-850 shape.
+        foreach (glob($this->tmpDir . '/sql/*_upgrade.sql') ?: [] as $f) {
+            unlink($f);
+        }
+        file_put_contents(
+            $this->tmpDir . '/sql/8_4_1-to-8_5_0_upgrade.sql',
+            "-- rel-850 bridge fixture\n",
+        );
 
         (new DockerUpgradeScaffoldMutator())->apply(
             MutatorContext::fromVersionString($this->tmpDir, '8.5.0', 'rel-850', 'rel-840'),
         );
         $next = file_get_contents($this->tmpDir . '/docker/release/upgrade/fsupgrade-12.sh');
         self::assertIsString($next);
-        self::assertStringContainsString('priorOpenemrVersion="8.5.0"', $next);
-        self::assertStringNotContainsString('priorOpenemrVersion="8.4.0"', $next);
+        self::assertStringContainsString('priorOpenemrVersion="8.4.1"', $next);
+        self::assertStringNotContainsString('priorOpenemrVersion="8.5.0"', $next);
+        self::assertStringContainsString('#  From prior version 8.4.1 ', $next);
     }
 
-    public function testThrowsWhenPriorFsupgradeLacksExpectedAnchor(): void
+    public function testFromVersionOverridesTheSqlScan(): void
     {
-        // The prior fsupgrade file must contain all five anchor lines
-        // for the substitution to succeed. Substitute one of them out
-        // (the priorOpenemrVersion assignment) and expect a clear error
-        // rather than a silently corrupt output.
+        // Patch-prep supplies an explicit fromVersion via MutatorContext.
+        // The mutator must use it verbatim as the last-shipped marker,
+        // bypassing the sql scan.
+        //
+        // Target 8.1.2, fromVersion 8.1.1. sql/ has a bridge with a
+        // DIFFERENT left (8.0.9 — deliberately below fromVersion) to
+        // prove the mutator picks fromVersion, not the sql scan.
+        foreach (glob($this->tmpDir . '/sql/*_upgrade.sql') ?: [] as $f) {
+            unlink($f);
+        }
+        file_put_contents(
+            $this->tmpDir . '/sql/8_0_9-to-8_1_0_upgrade.sql',
+            "-- older bridge fixture\n",
+        );
+
+        (new DockerUpgradeScaffoldMutator())->apply(
+            MutatorContext::fromVersionString(
+                $this->tmpDir,
+                '8.1.2',
+                'rel-810',
+                null,
+                '8.1.1',
+            ),
+        );
+        $next = file_get_contents($this->tmpDir . '/docker/release/upgrade/fsupgrade-12.sh');
+        self::assertIsString($next);
+        self::assertStringContainsString('priorOpenemrVersion="8.1.1"', $next);
+        self::assertStringContainsString('#  From prior version 8.1.1 ', $next);
+    }
+
+    public function testThrowsWhenSqlScanYieldsVersionEqualToTarget(): void
+    {
+        // Simulates the bug shape: sql/ already contains a bridge whose
+        // left equals the target version (as if the sibling
+        // SqlUpgradeSkeletonMutator ran BEFORE us on master-side, or a
+        // stale sql tree was checked out). Invariant fires with a
+        // pointed message rather than emitting a corrupt fsupgrade.
+        foreach (glob($this->tmpDir . '/sql/*_upgrade.sql') ?: [] as $f) {
+            unlink($f);
+        }
+        file_put_contents(
+            $this->tmpDir . '/sql/8_2_0-to-8_3_0_upgrade.sql',
+            "-- shouldn't be here yet\n",
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches(
+            '/priorOpenemrVersion 8\.2\.0 must be strictly less than target 8\.2\.0.*SqlUpgradeSkeletonMutator ran before DockerUpgradeScaffoldMutator/s',
+        );
+        (new DockerUpgradeScaffoldMutator())->apply($this->context());
+    }
+
+    public function testThrowsWhenSqlScanYieldsVersionGreaterThanTarget(): void
+    {
+        // Extreme regression signal: sql/ already contains a bridge
+        // with a left > target (e.g., a checkout from a much newer line).
+        foreach (glob($this->tmpDir . '/sql/*_upgrade.sql') ?: [] as $f) {
+            unlink($f);
+        }
+        file_put_contents(
+            $this->tmpDir . '/sql/9_0_0-to-9_1_0_upgrade.sql',
+            "-- future bridge\n",
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches(
+            '/priorOpenemrVersion 9\.0\.0 must be strictly less than target 8\.2\.0/',
+        );
+        (new DockerUpgradeScaffoldMutator())->apply($this->context());
+    }
+
+    public function testThrowsWhenSqlHasNoUpgradeBridge(): void
+    {
+        // Rel-side branch-cut in a hypothetical fully-empty sql/ dir:
+        // the derivation can't complete; surface a clear message rather
+        // than proceed with a bogus value.
+        foreach (glob($this->tmpDir . '/sql/*_upgrade.sql') ?: [] as $f) {
+            unlink($f);
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches(
+            '/Cannot derive priorOpenemrVersion.*no sql\/.*_upgrade\.sql files/',
+        );
+        (new DockerUpgradeScaffoldMutator())->apply($this->context());
+    }
+
+    public function testThrowsWhenPriorFsupgradeLacksPriorOpenemrVersionAnchor(): void
+    {
+        // The prior fsupgrade file must carry a `priorOpenemrVersion="X.Y.Z"`
+        // marker — that's what the scaffold uses as the substitution
+        // anchor to derive the new file's marker. Strip it and expect
+        // a clear error rather than a silently corrupt output.
         $malformed = str_replace(
             'priorOpenemrVersion="8.1.0"',
             '# priorOpenemrVersion removed',
+            $this->fixture('fsupgrade-11.sh'),
+        );
+        file_put_contents(
+            $this->tmpDir . '/docker/release/upgrade/fsupgrade-11.sh',
+            $malformed,
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/cannot find priorOpenemrVersion/');
+        (new DockerUpgradeScaffoldMutator())->apply($this->context());
+    }
+
+    public function testThrowsWhenPriorFsupgradeLacksUpgradeNumberAnchor(): void
+    {
+        // The five-substitution schema is load-bearing. Strip the
+        // "Upgrade number N" header and expect the substitution loop
+        // to fail with a clear error.
+        $malformed = str_replace(
+            '# Upgrade number 11 for OpenEMR docker',
+            '# header stripped',
             $this->fixture('fsupgrade-11.sh'),
         );
         file_put_contents(
@@ -195,21 +321,31 @@ final class DockerUpgradeScaffoldMutatorTest extends TestCase
         (new DockerUpgradeScaffoldMutator())->apply($this->context());
     }
 
-    public function testNoopWhenAlreadyAtPostCutState(): void
+    public function testNoopMasterSidePostScaffoldWithSqlSiblingOutputPresent(): void
     {
-        // Simulate the post-first-run state: docker-version bumped to
-        // 12 + fsupgrade-12.sh carrying this cut's target-version marker
-        // (priorOpenemrVersion="8.2.0" for the rel-820 cut — the version
-        // rel-820 is shipping and rel-830 would need to upgrade from).
-        // The mutator should recognise its own work and no-op cleanly.
+        // Master-side post-scaffold state: docker-version bumped to 12,
+        // fsupgrade-12.sh exists carrying priorOpenemrVersion="8.1.1",
+        // AND the sibling SqlUpgradeSkeletonMutator has run —
+        // sql/8_2_0-to-8_3_0_upgrade.sql is present alongside the
+        // pre-existing 8_1_1-to-8_2_0 bridge from setup. Idempotency
+        // relies on the "pre-scaffold view" derivation filtering out
+        // any sql bridge with left >= target (8.2.0), so 8.1.1 remains
+        // the highest LEFT and matches fsupgrade-12.sh's marker.
+        // Without that filter, the invariant would trip on the raw
+        // sql scan yielding "8.2.0".
         file_put_contents($this->tmpDir . '/docker-version', "12\n");
         file_put_contents($this->tmpDir . '/docker/release/upgrade/docker-version', "12\n");
         file_put_contents($this->tmpDir . '/sites/default/docker-version', "12\n");
         file_put_contents(
             $this->tmpDir . '/docker/release/upgrade/fsupgrade-12.sh',
             "#!/bin/bash\n# Upgrade number 12 for OpenEMR docker\n"
-            . 'priorOpenemrVersion="8.2.0"' . "\n"
+            . 'priorOpenemrVersion="8.1.1"' . "\n"
             . "# body preserved from prior file\n",
+        );
+        // SqlUpgradeSkeletonMutator's output on master-side.
+        file_put_contents(
+            $this->tmpDir . '/sql/8_2_0-to-8_3_0_upgrade.sql',
+            "-- master-side skeleton\n",
         );
 
         $result = (new DockerUpgradeScaffoldMutator())->apply($this->context());
@@ -218,10 +354,34 @@ final class DockerUpgradeScaffoldMutatorTest extends TestCase
         self::assertSame("12", trim(file_get_contents($this->tmpDir . '/docker-version') ?: ''));
     }
 
+    public function testNoopRelSidePostScaffoldViaFsupgradeMarker(): void
+    {
+        // Rel-side post-scaffold state: there is no master-side sql
+        // bridge signal to key off (SqlUpgradeSkeletonMutator doesn't
+        // run on rel-side branch-cut). Instead, idempotency detects OUR
+        // work by matching fsupgrade-(current).sh's markers against
+        // what derivePriorOpenemrVersion produces RIGHT NOW: docker-version
+        // is bumped to 12, fsupgrade-12.sh has Upgrade number 12 and
+        // priorOpenemrVersion="8.1.1" (matches sql-scan of the setup
+        // fixture's 8_1_1-to-8_2_0 bridge).
+        file_put_contents($this->tmpDir . '/docker-version', "12\n");
+        file_put_contents($this->tmpDir . '/docker/release/upgrade/docker-version', "12\n");
+        file_put_contents($this->tmpDir . '/sites/default/docker-version', "12\n");
+        file_put_contents(
+            $this->tmpDir . '/docker/release/upgrade/fsupgrade-12.sh',
+            "#!/bin/bash\n# Upgrade number 12 for OpenEMR docker\n"
+            . 'priorOpenemrVersion="8.1.1"' . "\n"
+            . "# body preserved from prior file\n",
+        );
+
+        $result = (new DockerUpgradeScaffoldMutator())->apply($this->context());
+        self::assertFalse($result->changed());
+    }
+
     public function testNotNoopWhenCurrentDockerVersionFileLacksOurCutMarker(): void
     {
         // If a partial state exists (docker-version bumped to 12 but
-        // fsupgrade-12.sh lacks our cut's target-version marker — e.g.,
+        // fsupgrade-12.sh lacks our cut's last-shipped marker — e.g.,
         // somebody manually edited the priorOpenemrVersion value), the
         // mutator should NOT no-op; it should attempt the work and let
         // the downstream anchor mismatch surface as a clear error
@@ -234,7 +394,7 @@ final class DockerUpgradeScaffoldMutatorTest extends TestCase
         file_put_contents(
             $this->tmpDir . '/docker/release/upgrade/fsupgrade-12.sh',
             "#!/bin/bash\n# Upgrade number 12 for OpenEMR docker\n"
-            . 'priorOpenemrVersion="8.1.0"' . "\n"
+            . 'priorOpenemrVersion="8.0.5"' . "\n"
             . "echo doing real work\n",
         );
 
@@ -251,6 +411,7 @@ final class DockerUpgradeScaffoldMutatorTest extends TestCase
             $this->tmpDir,
             $this->tmpDir . '/docker/release/upgrade',
             $this->tmpDir . '/sites/default',
+            $this->tmpDir . '/sql',
         ];
         foreach ($dirs as $d) {
             if (!is_dir($d) && !mkdir($d, 0700, true)) {
@@ -267,6 +428,13 @@ final class DockerUpgradeScaffoldMutatorTest extends TestCase
         file_put_contents(
             $this->tmpDir . '/docker/release/Dockerfile',
             $this->fixture('Dockerfile.input'),
+        );
+        // Seed sql/ with an 8_1_1-to-8_2_0_upgrade.sql bridge so the
+        // mutator's sql-scan derivation resolves priorOpenemrVersion to
+        // "8.1.1" (the last shipped version before the rel-820 cut).
+        file_put_contents(
+            $this->tmpDir . '/sql/8_1_1-to-8_2_0_upgrade.sql',
+            "-- last shipped bridge fixture\n",
         );
     }
 

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/MutatorTest.php
@@ -209,6 +209,47 @@ final class MutatorTest extends TestCase
         self::assertSame(['sql/8_1_0-to-8_1_1_upgrade.sql'], $result->changedFiles);
     }
 
+    public function testSqlUpgradeSkeletonTrimsTrailingBlankBeforeSql(): void
+    {
+        // Source header ends with a blank line before the first SQL
+        // statement. Prior behavior would concatenate `implode + "\n"`
+        // and produce a double trailing newline in the output, breaking
+        // the `end-of-file-fixer` pre-commit hook on the emitted skeleton.
+        $this->writeFile('version.php', "<?php\n\$v_major='8';\n\$v_minor='1';\n\$v_patch='1';\n");
+        $existing = "-- header line\n\nINSERT INTO foo VALUES (1);\n";
+        $this->writeFile('sql/8_0_0-to-8_1_0_upgrade.sql', $existing);
+
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.2');
+        $result = (new SqlUpgradeSkeletonMutator())->apply($context);
+        self::assertSame(['sql/8_1_1-to-8_1_2_upgrade.sql'], $result->changedFiles);
+        $output = $this->readFile($this->tmpDir . '/sql/8_1_1-to-8_1_2_upgrade.sql');
+        self::assertSame("-- header line\n", $output);
+        // Explicit byte-level guard: the file must end with a single `\n`,
+        // not `\n\n` (double newline breaks end-of-file-fixer pre-commit).
+        // Redundant given assertSame above but calls out the invariant.
+        self::assertStringEndsWith("\n", $output);
+        self::assertFalse(
+            str_ends_with($output, "\n\n"),
+            'skeleton must not end with a double newline',
+        );
+    }
+
+    public function testSqlUpgradeSkeletonTrimsTrailingBlankWhenSourceIsAllCommentsAndEndsWithNewline(): void
+    {
+        // Real-world shape: source file is entirely comment-meta-language
+        // lines and ends with a trailing `\n`. preg_split yields a trailing
+        // empty element that our loop kept; implode+"\n" then produced
+        // `...\n\n`. Trim to a single trailing newline.
+        $this->writeFile('version.php', "<?php\n\$v_major='8';\n\$v_minor='1';\n\$v_patch='1';\n");
+        $existing = "-- alpha\n-- beta\n-- gamma\n";
+        $this->writeFile('sql/8_0_0-to-8_1_0_upgrade.sql', $existing);
+
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.1.2');
+        (new SqlUpgradeSkeletonMutator())->apply($context);
+        $output = file_get_contents($this->tmpDir . '/sql/8_1_1-to-8_1_2_upgrade.sql');
+        self::assertSame("-- alpha\n-- beta\n-- gamma\n", $output);
+    }
+
     public function testSwaggerRegenInvokesConsoleSubprocess(): void
     {
         $this->writeFile('swagger/openemr-api.yaml', "openapi: 3.0.0\ninfo:\n  version: 8.0.1\n");

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Upgrade number 12 for OpenEMR docker
-#  From prior version 8.2.0 (needed for the sql upgrade script).
-priorOpenemrVersion="8.2.0"
+#  From prior version 8.1.1 (needed for the sql upgrade script).
+priorOpenemrVersion="8.1.1"
 echo "Start: Upgrade to docker-version 12"
 # Perform codebase upgrade on each directory in sites/
 for dir in /var/www/localhost/htdocs/openemr/sites/*/; do


### PR DESCRIPTION
## Summary

Two mutator bugs caught by the second end-to-end rel-820 cut dry-run, plus an audit of the six PR body templates against the current mutator behavior after rounds 1+2+3.

### `SqlUpgradeSkeletonMutator`: double trailing newline

The emitted `sql/*_upgrade.sql` skeleton ended with `\n\n` when the source bridge was 100% comment/blank lines and ended with `\n` (which the current `8_1_1-to-8_2_0` bridge is). This broke the `end-of-file-fixer` pre-commit hook on the resulting file. `extractCommentHeader` now trims trailing blank lines from the kept run before appending a single `\n`.

### `DockerUpgradeScaffoldMutator`: `priorOpenemrVersion` wrongly set to target

`derivePriorOpenemrVersion` was returning the target version (e.g. `8.2.0` at rel-820 cut) as the new `fsupgrade-N.sh`'s `priorOpenemrVersion` shell variable. Semantically wrong: `priorOpenemrVersion` is the LAST SHIPPED version from the prior release line — the version the new file will upgrade FROM when it runs against a customer install. Historical shape confirms:

- `fsupgrade-10.sh` (for 8.1.0 line): `priorOpenemrVersion=\"8.0.0\"`
- `fsupgrade-11.sh` (for 8.1.1 release): `priorOpenemrVersion=\"8.1.0\"`
- `fsupgrade-12.sh` at rel-820 cut MUST be `priorOpenemrVersion=\"8.1.1\"` (was wrongly `\"8.2.0\"`)

New derivation:
- Scan `sql/*_upgrade.sql`, take the highest LEFT via `version_compare` — that's the last shipped upgrade bridge's from-version.
- Patch-prep supplies an explicit `fromVersion` override via `MutatorContext`, which is used verbatim.
- Strictly-less-than-target invariant: if the derived value is not `< target`, throw with a pointed message calling out the most likely bug (`SqlUpgradeSkeletonMutator` ran BEFORE `DockerUpgradeScaffoldMutator`, promoting the sql-scan result up to target).
- Idempotency uses a \"pre-scaffold view\" of the sql scan (filter out any bridge with left `>= target`) so post-scaffold master runs no-op cleanly without tripping the invariant.

### PR template audit

Six templates in `.github/PULL_REQUEST_TEMPLATE/` audited against actual mutator behavior after rounds 1+2+3:

- **`branch-cut-rel.md`**: replaced \"fsupgrade-N.sh stub\" language with the accurate \"copy `fsupgrade-(N-1).sh` in full + five version substitutions\"; documented the sql-scan-derived `priorOpenemrVersion`; expanded merge-order guidance to match `docs/release-automation-plan.md`'s Lifecycle section (rel-side first because master-side kicks the orchestrator, ready-for-review not draft); expanded checklist to verify the five-line diff shape + `priorOpenemrVersion` value.
- **`branch-cut-master.md`**: same fsupgrade-stub fix; same merge-order expansion; refined SQL skeleton description.
- **`patch-prep-rel.md`**: fsupgrade-stub fix + explicit `priorOpenemrVersion` = `--prev-version` note + checklist item verifying that.
- **`patch-prep-master.md`**: fsupgrade-stub fix + added byte-identical cross-branch sync checklist item.
- **`release-prep.md`**: no changes — template was already minimal and didn't enumerate mutators; the round-2 `GlobalsIncMutator` removal and docker-compose \"tag swap, no digest\" changes never appeared here.
- **`release-finalize.md`**: no changes — same reason.

### Docs

`docs/release-automation-plan.md`: expanded the `DockerUpgradeScaffoldMutator` bullet to cover the sql-scan derivation + `fromVersion` override + invariant; fixed a stale `PatchPrepReleaseTargetsMutator` table entry (it inserts a real dev row + drops unreleased placeholder, not \"insert unreleased placeholder\").

## Verification

**Rel-side dry-run** (`openemr:branch-cut --side=rel --target-version=8.2.0 --rel-branch=rel-820 --prev-rel-branch=rel-810 --skip-globals`):
- `docker/release/upgrade/fsupgrade-12.sh` has `priorOpenemrVersion=\"8.1.1\"` (correct).
- Diff between `fsupgrade-11.sh` and `fsupgrade-12.sh` = exactly 5 lines.
- `shellcheck --check-sourced --external-sources fsupgrade-12.sh` — clean.

**Master-side dry-run**:
- `sql/8_2_0-to-8_3_0_upgrade.sql` ends with a SINGLE `0a` byte (no `0a 0a`).
- `fsupgrade-12.sh` has `priorOpenemrVersion=\"8.1.1\"`.
- Second run of the same command is a clean idempotent no-op.

**Invariant test**: manually seeded a `sql/8_2_0-to-8_3_0_upgrade.sql` as if `SqlUpgradeSkeletonMutator` ran first, then invoked `--side=master`. The mutator throws:
```
priorOpenemrVersion 8.2.0 must be strictly less than target 8.2.0. This usually indicates SqlUpgradeSkeletonMutator ran before DockerUpgradeScaffoldMutator; check the mutator list order in BranchCutCommand/PatchPrepCommand.
```

**Tests**: `openemr-cmd worktree exec release-mutator-fixes-round3 pit` — 3595 tests, all green. New test coverage for the SQL skeleton double-newline path, `priorOpenemrVersion` sql-scan derivation, `fromVersion` override, target-equal invariant, target-exceeding invariant, and empty-sql derivation error. Pre-commit hooks all pass (phpstan, rector, phpcs, codespell, actionlint).

## Fixes

After this lands the three round-2 PRs (openemr/openemr#12732, openemr/openemr#12733, openemr/openemr#12734) get closed and the clean-slate rebuild happens again: delete rel-820 + recreate to re-fire branch-cut against the fixed mutators.

## Test plan
- [x] Isolated PHPUnit — 3595 green
- [x] Rel-side dry-run — fsupgrade-12.sh correct + shellcheck-clean
- [x] Master-side dry-run — sql skeleton single-trailing-newline + fsupgrade-12 correct
- [x] Idempotency — second run of master-side is a no-op
- [x] Invariant fires with clear message on simulated wrong-ordering
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)