### PR TITLE
feat(bc): add internal deprecation utility

### DIFF
--- a/ci/compose-shared-apache.yml
+++ b/ci/compose-shared-apache.yml
@@ -16,6 +16,7 @@ services:
     environment:
       EMPTY: yes
       FORCE_NO_BUILD_MODE: yes
+      OPENEMR_DEPRECATION_MODE: error
       OPENEMR_ENABLE_CI_PHP: '1'
       ENABLE_COVERAGE: ${ENABLE_COVERAGE:-false}
       PCOV_ON: ${ENABLE_COVERAGE:-false}

--- a/ci/compose-shared-nginx/compose.yml
+++ b/ci/compose-shared-nginx/compose.yml
@@ -2,6 +2,7 @@ services:
   openemr:
     environment:
       OPENEMR_BASE_URL_API: "https://nginx"
+      OPENEMR_DEPRECATION_MODE: "error"
       OPENEMR_ENABLE_CI_PHP: "1"
       ENABLE_COVERAGE: "${ENABLE_COVERAGE:-false}"
       SELENIUM_BASE_URL: "http://nginx"

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -14,6 +14,8 @@
  */
 
 use Dotenv\Dotenv;
+use OpenEMR\BC\Deprecation;
+use OpenEMR\BC\DeprecationMode;
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Http\HttpRestRequest;
@@ -68,6 +70,10 @@ if (IS_WINDOWS) {
  */
 if (file_exists("{$webserver_root}/.env")) {
     Dotenv::createImmutable($webserver_root)->load();
+}
+
+if (($_ENV['OPENEMR_DEPRECATION_MODE'] ?? null) === 'error') {
+    Deprecation::$mode = DeprecationMode::Error;
 }
 
 $logger = ServiceContainer::getLogger();

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/tests/bootstrap.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/tests/bootstrap.php
@@ -12,6 +12,9 @@
 
 declare(strict_types=1);
 
+use OpenEMR\BC\Deprecation;
+use OpenEMR\BC\DeprecationMode;
+
 // make sure this can only be run on the command line.
 if (php_sapi_name() !== 'cli') {
     exit;
@@ -20,3 +23,5 @@ if (php_sapi_name() !== 'cli') {
 $_GET['site'] = 'default';
 $ignoreAuth = true;
 require_once(__DIR__ . "/../../../../globals.php");
+
+Deprecation::$mode = DeprecationMode::Error;

--- a/public/index.php
+++ b/public/index.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 use Firehed\Container\TypedContainerInterface;
 use GuzzleHttp\Psr7\ServerRequest;
+use OpenEMR\BC\Deprecation;
+use OpenEMR\BC\DeprecationMode;
 use OpenEMR\BC\FallbackRouter;
 use Psr\Log\LoggerInterface;
 
@@ -19,6 +21,8 @@ $container = require_once __DIR__ . '/../bootstrap.php';
 if (!$container instanceof TypedContainerInterface) {
     throw new \LogicException('bootstrap.php must return a ' . TypedContainerInterface::class);
 }
+
+Deprecation::$mode = DeprecationMode::Error;
 
 $request = ServerRequest::fromGlobals();
 

--- a/src/BC/Deprecation.php
+++ b/src/BC/Deprecation.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OpenEMR\BC;
+
+use LogicException;
+
+/**
+ * Utility class to emit deprecation messages in a runtime-configurable mode.
+ *
+ * This exists for two purposes:
+ *
+ * OpenEMR (as of writing) targets PHP 8.2+, and native `#[Deprecated]` is 8.4+
+ *
+ * It can be called in specific paths, such as deprecated kys within
+ * a container without the entire container being deprecated.
+ *
+ */
+final class Deprecation
+{
+    public static DeprecationMode $mode = DeprecationMode::Warning;
+
+    /**
+     * @param literal-string $message
+     */
+    public static function emit(string $message): void
+    {
+        $message = 'OpenEMR deprecation: ' . $message;
+        if (self::$mode === DeprecationMode::Warning) {
+            trigger_error($message, E_USER_DEPRECATED);
+        } else {
+            throw new LogicException($message);
+        }
+    }
+}

--- a/src/BC/Deprecation.php
+++ b/src/BC/Deprecation.php
@@ -1,19 +1,35 @@
 <?php
 
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
 namespace OpenEMR\BC;
 
-use LogicException;
+use ErrorException;
+
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * Utility class to emit deprecation messages in a runtime-configurable mode.
  *
  * This exists for two purposes:
  *
- * OpenEMR (as of writing) targets PHP 8.2+, and native `#[Deprecated]` is 8.4+
+ * 1. OpenEMR (as of writing) targets PHP 8.2+, and native `#[Deprecated]` is 8.4+
  *
- * It can be called in specific paths, such as deprecated kys within
- * a container without the entire container being deprecated.
+ * 2. It can be called in specific paths, such as deprecated keys within
+ *    a container without the entire container being deprecated.
  *
+ * Legacy bootstrap paths intentionally omit ErrorHandler, so this class
+ * provides a direct throw path that works regardless of handler registration.
  */
 final class Deprecation
 {
@@ -24,11 +40,14 @@ final class Deprecation
      */
     public static function emit(string $message): void
     {
-        $message = 'OpenEMR deprecation: ' . $message;
+        $message = 'Deprecated: ' . $message;
         if (self::$mode === DeprecationMode::Warning) {
             trigger_error($message, E_USER_DEPRECATED);
         } else {
-            throw new LogicException($message);
+            throw new ErrorException(
+                message: $message,
+                severity: E_USER_DEPRECATED,
+            );
         }
     }
 }

--- a/src/BC/DeprecationMode.php
+++ b/src/BC/DeprecationMode.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 declare(strict_types=1);
 
 namespace OpenEMR\BC;

--- a/src/BC/DeprecationMode.php
+++ b/src/BC/DeprecationMode.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\BC;
+
+enum DeprecationMode
+{
+    /**
+     * Emits a E_USER_DEPRECATED warning, which will be logged.
+     */
+    case Warning;
+    /**
+     * Throws an exception. Recommended during development for immediate
+     * feedback.
+     */
+    case Error;
+}

--- a/tests/PHPUnit/Extension.php
+++ b/tests/PHPUnit/Extension.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace OpenEMR\PHPUnit;
 
+use OpenEMR\BC\Deprecation;
+use OpenEMR\BC\DeprecationMode;
 use PHPUnit\Runner\Extension\Extension as PHPUnitExtension;
 use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
@@ -33,6 +35,8 @@ class Extension implements PHPUnitExtension
         Facade $facade,
         ParameterCollection $parameters
     ): void {
+        Deprecation::$mode = DeprecationMode::Error;
+
         $shutdownTracker = new ShutdownTracker();
         $shutdownTracker->install();
         $facade->registerSubscriber($shutdownTracker);

--- a/tests/Tests/Isolated/BC/DeprecationTest.php
+++ b/tests/Tests/Isolated/BC/DeprecationTest.php
@@ -5,6 +5,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
+ * @author    Eric Stern <erics@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/Isolated/BC/DeprecationTest.php
+++ b/tests/Tests/Isolated/BC/DeprecationTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Tests for BC\Deprecation utility.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\BC;
+
+use ErrorException;
+use OpenEMR\BC\Deprecation;
+use OpenEMR\BC\DeprecationMode;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
+use PHPUnit\Framework\TestCase;
+
+use const E_USER_DEPRECATED;
+
+class DeprecationTest extends TestCase
+{
+    private DeprecationMode $originalMode;
+
+    protected function setUp(): void
+    {
+        $this->originalMode = Deprecation::$mode;
+    }
+
+    protected function tearDown(): void
+    {
+        Deprecation::$mode = $this->originalMode;
+    }
+
+    #[WithoutErrorHandler]
+    public function testEmitInWarningModeTriggersDeprecation(): void
+    {
+        Deprecation::$mode = DeprecationMode::Warning;
+
+        $triggered = null;
+        set_error_handler(function (int $errno, string $errstr) use (&$triggered): bool {
+            $triggered = ['errno' => $errno, 'errstr' => $errstr];
+            return true;
+        });
+
+        try {
+            Deprecation::emit('test message');
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertNotNull($triggered, 'Deprecation should have been triggered');
+        self::assertSame(E_USER_DEPRECATED, $triggered['errno'], 'Error level should be E_USER_DEPRECATED');
+        self::assertSame('Deprecated: test message', $triggered['errstr'], 'Error message should match');
+    }
+
+    public function testEmitInErrorModeThrowsErrorException(): void
+    {
+        Deprecation::$mode = DeprecationMode::Error;
+
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Deprecated: test message');
+
+        Deprecation::emit('test message');
+    }
+
+    public function testErrorExceptionHasCorrectSeverity(): void
+    {
+        Deprecation::$mode = DeprecationMode::Error;
+
+        try {
+            Deprecation::emit('test message');
+            self::fail('Expected ErrorException to be thrown');
+        } catch (ErrorException $e) {
+            self::assertSame(
+                E_USER_DEPRECATED,
+                $e->getSeverity(),
+                'ErrorException severity should be E_USER_DEPRECATED',
+            );
+        }
+    }
+}

--- a/tests/Tests/Isolated/BC/DeprecationTest.php
+++ b/tests/Tests/Isolated/BC/DeprecationTest.php
@@ -67,20 +67,4 @@ class DeprecationTest extends TestCase
 
         Deprecation::emit('test message');
     }
-
-    public function testErrorExceptionHasCorrectSeverity(): void
-    {
-        Deprecation::$mode = DeprecationMode::Error;
-
-        try {
-            Deprecation::emit('test message');
-            self::fail('Expected ErrorException to be thrown');
-        } catch (ErrorException $e) {
-            self::assertSame(
-                E_USER_DEPRECATED,
-                $e->getSeverity(),
-                'ErrorException severity should be E_USER_DEPRECATED',
-            );
-        }
-    }
 }


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Adds a `Deprecation::emit()` utility for marking code paths as deprecated with runtime-configurable behavior (warning vs exception).

This is partially in response to https://github.com/openemr/openemr/issues/12690#issuecomment-4836549020 and partially in response to work on #12751 and friends.

#### Changes proposed in this pull request:

- **`src/BC/Deprecation.php`** — Utility class with `emit(string $message)` that either triggers `E_USER_DEPRECATED` or throws `ErrorException` based on `$mode`
- **`src/BC/DeprecationMode.php`** — Enum with `Warning` (default) and `Error` cases
- **`tests/Tests/Isolated/BC/DeprecationTest.php`** — Full test coverage for both paths

**Mode configuration by environment:**

| Environment | Mode | Rationale |
|-------------|------|-----------|
| PHPUnit (via Extension) | Error | Catch deprecated usage in tests immediately |
| Front controller (`public/index.php`) | Error | Modern bootstrap has full error handling |
| Legacy bootstrap (`interface/globals.php`) | Warning (default) | Opt-in via `OPENEMR_DEPRECATION_MODE=error` env var |
| CI (Apache + Nginx stacks) | Error | Fail fast on deprecated code paths |

Note that the FC's fallback to legacy will result in the warning/default mode on legacy code while keeping strict rules on new code. This is by design.

The config is done by env over the traditional systems because:
- Absolutely no good can come out of a non-operator changing this value in a production instance
- It's meant primarily for internal development feedback; it should not be enabled in production
- Some of the first things that will be deprecated are certain OEGlobalsBag keys; reading from it creates a horrible bootstrapping nightmare

**Why this exists:**
1. PHP 8.4's native `#[Deprecated]` attribute isn't available (project targets 8.2+)
2. Can mark specific code paths (e.g., deprecated container keys) without deprecating entire classes
3. Legacy bootstrap intentionally omits `ErrorHandler`, so this provides a direct throw path regardless of handler registration

#### Was an AI assistant used? Yes

All commits include the `Assisted-by: Claude Code` trailer.

🤖 Generated with [Claude Code](https://claude.ai/code)