### PR TITLE
refactor(globals): Integrate OEGlobalsBag key deprecation tooling

### DIFF
--- a/src/Core/OEGlobalsBag.php
+++ b/src/Core/OEGlobalsBag.php
@@ -41,11 +41,12 @@ class OEGlobalsBag extends ParameterBag
      * Keys being migrated away from OEGlobalsBag. Accessing these via get(),
      * has(), or set() emits a deprecation warning.
      *
-     * When removing a key from this list, also update the corresponding test:
+     * When adding a key to this list, update the tests too.
+     *
      * @see \OpenEMR\Tests\Isolated\Core\OEGlobalsBagIsolatedTest::deprecatedKeysProvider
      */
     private const DEPRECATED_KEYS = [
-        // This is intentionally empty for now.
+        'unit_test_placeholder' => '(placeholder)',
     ];
 
     protected static function createInstance(): static

--- a/src/Core/OEGlobalsBag.php
+++ b/src/Core/OEGlobalsBag.php
@@ -12,6 +12,7 @@
 
 namespace OpenEMR\Core;
 
+use OpenEMR\BC\Deprecation;
 use OpenEMR\Core\Traits\SingletonTrait;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
@@ -36,6 +37,20 @@ class OEGlobalsBag extends ParameterBag
 {
     use SingletonTrait;
 
+    /**
+     * Keys being migrated away from OEGlobalsBag. Accessing these via get(),
+     * has(), or set() emits a deprecation warning.
+     *
+     * When removing a key from this list, also update the corresponding test:
+     * @see \OpenEMR\Tests\Isolated\Core\OEGlobalsBagIsolatedTest::deprecatedKeysProvider
+     */
+    private const DEPRECATED_KEYS = [
+        'pid' => 'Use PatientSessionUtil instead',
+        'encounter' => 'Use EncounterSessionUtil instead',
+        'userauthorized' => 'Use $session->get/set(\'userauthorized\') instead',
+        'authUserID' => 'Use $session->get/set(\'authUserID\') instead',
+    ];
+
     protected static function createInstance(): static
     {
         /** @var array<string, mixed> $GLOBALS */
@@ -53,6 +68,14 @@ class OEGlobalsBag extends ParameterBag
 
     public function get(string $key, mixed $default = null): mixed
     {
+        if (array_key_exists($key, self::DEPRECATED_KEYS)) {
+            Deprecation::emit(sprintf(
+                'Key "%s" will be removed from OEGlobalsBag. %s',
+                $key,
+                self::DEPRECATED_KEYS[$key],
+            ));
+        }
+
         // During the transition from $GLOBALS to OEGlobalsBag, legacy code may
         // still write to or unset from $GLOBALS directly. For the singleton
         // instance, use $GLOBALS as the sole source of truth.
@@ -69,6 +92,14 @@ class OEGlobalsBag extends ParameterBag
 
     public function has(string $key): bool
     {
+        if (array_key_exists($key, self::DEPRECATED_KEYS)) {
+            Deprecation::emit(sprintf(
+                'Key "%s" will be removed from OEGlobalsBag. %s',
+                $key,
+                self::DEPRECATED_KEYS[$key],
+            ));
+        }
+
         if (parent::has($key)) {
             return true;
         }

--- a/src/Core/OEGlobalsBag.php
+++ b/src/Core/OEGlobalsBag.php
@@ -45,10 +45,7 @@ class OEGlobalsBag extends ParameterBag
      * @see \OpenEMR\Tests\Isolated\Core\OEGlobalsBagIsolatedTest::deprecatedKeysProvider
      */
     private const DEPRECATED_KEYS = [
-        'pid' => 'Use PatientSessionUtil instead',
-        'encounter' => 'Use EncounterSessionUtil instead',
-        'userauthorized' => 'Use $session->get/set(\'userauthorized\') instead',
-        'authUserID' => 'Use $session->get/set(\'authUserID\') instead',
+        // This is intentionally empty for now.
     ];
 
     protected static function createInstance(): static

--- a/src/Core/OEGlobalsBag.php
+++ b/src/Core/OEGlobalsBag.php
@@ -38,8 +38,9 @@ class OEGlobalsBag extends ParameterBag
     use SingletonTrait;
 
     /**
-     * Keys being migrated away from OEGlobalsBag. Accessing these via get(),
-     * has(), or set() emits a deprecation warning.
+     * Keys being migrated away from OEGlobalsBag. Accessing these via get() or
+     * has() emits a deprecation warning. set() is intentionally omitted at
+     * this time.
      *
      * When adding a key to this list, update the tests too.
      *
@@ -55,6 +56,17 @@ class OEGlobalsBag extends ParameterBag
         return new self($GLOBALS);
     }
 
+    private static function emitDeprecationIfNeeded(string $key): void
+    {
+        if (array_key_exists($key, self::DEPRECATED_KEYS)) {
+            Deprecation::emit(sprintf(
+                'Key "%s" will be removed from OEGlobalsBag. %s',
+                $key,
+                self::DEPRECATED_KEYS[$key],
+            ));
+        }
+    }
+
     public function set(string $key, mixed $value): void
     {
         parent::set($key, $value);
@@ -66,13 +78,7 @@ class OEGlobalsBag extends ParameterBag
 
     public function get(string $key, mixed $default = null): mixed
     {
-        if (array_key_exists($key, self::DEPRECATED_KEYS)) {
-            Deprecation::emit(sprintf(
-                'Key "%s" will be removed from OEGlobalsBag. %s',
-                $key,
-                self::DEPRECATED_KEYS[$key],
-            ));
-        }
+        self::emitDeprecationIfNeeded($key);
 
         // During the transition from $GLOBALS to OEGlobalsBag, legacy code may
         // still write to or unset from $GLOBALS directly. For the singleton
@@ -90,13 +96,7 @@ class OEGlobalsBag extends ParameterBag
 
     public function has(string $key): bool
     {
-        if (array_key_exists($key, self::DEPRECATED_KEYS)) {
-            Deprecation::emit(sprintf(
-                'Key "%s" will be removed from OEGlobalsBag. %s',
-                $key,
-                self::DEPRECATED_KEYS[$key],
-            ));
-        }
+        self::emitDeprecationIfNeeded($key);
 
         if (parent::has($key)) {
             return true;

--- a/tests/Tests/Isolated/Core/OEGlobalsBagIsolatedTest.php
+++ b/tests/Tests/Isolated/Core/OEGlobalsBagIsolatedTest.php
@@ -64,10 +64,7 @@ class OEGlobalsBagIsolatedTest extends TestCase
     public static function deprecatedKeysProvider(): array
     {
         return [
-            'pid' => ['pid', 'PatientSessionUtil'],
-            'encounter' => ['encounter', 'EncounterSessionUtil'],
-            'userauthorized' => ['userauthorized', '$session->get/set(\'userauthorized\')'],
-            'authUserID' => ['authUserID', '$session->get/set(\'authUserID\')'],
+            // This is intentionally empty for now.
         ];
     }
 

--- a/tests/Tests/Isolated/Core/OEGlobalsBagIsolatedTest.php
+++ b/tests/Tests/Isolated/Core/OEGlobalsBagIsolatedTest.php
@@ -12,7 +12,9 @@
 
 namespace OpenEMR\Tests\Isolated\Core;
 
+use ErrorException;
 use OpenEMR\Core\OEGlobalsBag;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
@@ -48,5 +50,54 @@ class OEGlobalsBagIsolatedTest extends TestCase
 
         $this->assertArrayHasKey($key, $GLOBALS);
         $this->assertSame($value, $GLOBALS[$key]);
+    }
+
+    /**
+     * Deprecated keys and their replacement instructions.
+     *
+     * Keep in sync with OEGlobalsBag::DEPRECATED_KEYS.
+     *
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function deprecatedKeysProvider(): array
+    {
+        return [
+            'pid' => ['pid', 'PatientSessionUtil'],
+            'encounter' => ['encounter', 'EncounterSessionUtil'],
+            'userauthorized' => ['userauthorized', '$session->get/set(\'userauthorized\')'],
+            'authUserID' => ['authUserID', '$session->get/set(\'authUserID\')'],
+        ];
+    }
+
+    #[DataProvider('deprecatedKeysProvider')]
+    public function testGetDeprecatedKeyTriggersWarning(string $key, string $replacement): void
+    {
+        $bag = new OEGlobalsBag([$key => 'test-value']);
+
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Deprecated: Key "%s" will be removed from OEGlobalsBag. Use %s instead',
+            $key,
+            $replacement,
+        ));
+
+        $bag->get($key);
+    }
+
+    #[DataProvider('deprecatedKeysProvider')]
+    public function testHasDeprecatedKeyTriggersWarning(string $key, string $replacement): void
+    {
+        $bag = new OEGlobalsBag([$key => 'test-value']);
+
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Deprecated: Key "%s" will be removed from OEGlobalsBag. Use %s instead',
+            $key,
+            $replacement,
+        ));
+
+        $bag->has($key);
     }
 }

--- a/tests/Tests/Isolated/Core/OEGlobalsBagIsolatedTest.php
+++ b/tests/Tests/Isolated/Core/OEGlobalsBagIsolatedTest.php
@@ -53,48 +53,34 @@ class OEGlobalsBagIsolatedTest extends TestCase
     }
 
     /**
-     * Deprecated keys and their replacement instructions.
-     *
      * Keep in sync with OEGlobalsBag::DEPRECATED_KEYS.
      *
-     * @return array<string, array{string, string}>
+     * @return array<string, array{string}>
      *
      * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
     public static function deprecatedKeysProvider(): array
     {
-        return [
-            // This is intentionally empty for now.
+        $keys = [
+            'unit_test_placeholder',
         ];
+        // Format to DataProvider
+        return array_combine($keys, array_map(fn($k) => [$k], $keys));
     }
 
     #[DataProvider('deprecatedKeysProvider')]
-    public function testGetDeprecatedKeyTriggersWarning(string $key, string $replacement): void
+    public function testGetDeprecatedKeyTriggersWarning(string $key): void
     {
         $bag = new OEGlobalsBag([$key => 'test-value']);
-
         $this->expectException(ErrorException::class);
-        $this->expectExceptionMessage(sprintf(
-            'Deprecated: Key "%s" will be removed from OEGlobalsBag. Use %s instead',
-            $key,
-            $replacement,
-        ));
-
         $bag->get($key);
     }
 
     #[DataProvider('deprecatedKeysProvider')]
-    public function testHasDeprecatedKeyTriggersWarning(string $key, string $replacement): void
+    public function testHasDeprecatedKeyTriggersWarning(string $key): void
     {
         $bag = new OEGlobalsBag([$key => 'test-value']);
-
         $this->expectException(ErrorException::class);
-        $this->expectExceptionMessage(sprintf(
-            'Deprecated: Key "%s" will be removed from OEGlobalsBag. Use %s instead',
-            $key,
-            $replacement,
-        ));
-
         $bag->has($key);
     }
 }


### PR DESCRIPTION
#### Short description of what this changes or resolves:
Defines an array of deprecated keys that will emit deprecation notices when fetched or checked for. 

This intentionally omits the `set()` path, only doing `get()` and `has()` - this allows for backwards-compatible writes to stay in place in case we miss anything, but get early warnings on all read attempts. FWIW I did try the set() path originally on the first actual integration branch, and havoc erupted.

Infrastructure to support #12736.  This could be extended or inverted to support #12692 if we want to eventually convert to an allowlist instead.

#### Changes proposed in this pull request:
- Defines deprecation array
- Integrates into OEGlobalsBag
- Tests integration

There's a single placeholder key in place for now otherwise PHPUnit complains about an invalid DataProvider. The first actual deprecations should remove it.

#### Was an AI assistant used? Yes / No
Yes, Claude-authored on a different branch and extracted out for scoping reasons with some tewaks.