### PR TITLE
fix(release): skip unshipped tags when deriving prev_release

### DIFF
--- a/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
+++ b/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
@@ -14,6 +14,8 @@ namespace OpenEMR\Tests\Isolated\Release;
 
 use OpenEMR\Release\BranchVersionResolver;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Process\Process;
 
 final class BranchVersionResolverTest extends TestCase
@@ -140,6 +142,80 @@ final class BranchVersionResolverTest extends TestCase
         $this->git(['tag', '-a', 'v8_2_0', '-m', 'OpenEMR 8.2.0 released 2026-04-01']);
         $resolver = new BranchVersionResolver($this->tmpDir);
         self::assertSame('8.0.0', $resolver->previousRelease('8.1.0'));
+    }
+
+    public function testPreviousReleaseSkipsTagsMissingFromManifest(): void
+    {
+        // 8.1.0 was cut as an annotated v8_1_0 tag but never released -
+        // it's absent from data/releases.json. When computing prev_release
+        // for 8.2.0, the resolver must skip 8.1.0 and fall through to
+        // 8.0.0 (the last actually-shipped release).
+        $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 cut but skipped']);
+        $resolver = new BranchVersionResolver(
+            $this->tmpDir,
+            $this->manifestClient(['8.0.0']),
+        );
+        self::assertSame('8.0.0', $resolver->previousRelease('8.2.0'));
+    }
+
+    public function testPreviousReleaseAcceptsTagsPresentInManifest(): void
+    {
+        // Same tag set as above, but this time 8.1.0 shipped normally.
+        // The manifest contains both entries; both are eligible; 8.1.0
+        // wins as the newest below target 8.2.0.
+        $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 released 2026-06-01']);
+        $resolver = new BranchVersionResolver(
+            $this->tmpDir,
+            $this->manifestClient(['8.0.0', '8.1.0']),
+        );
+        self::assertSame('8.1.0', $resolver->previousRelease('8.2.0'));
+    }
+
+    public function testPreviousReleaseTreatsDraftEntriesAsUnshipped(): void
+    {
+        // A DRAFT entry in the manifest is not FINAL, so its version is
+        // not considered shipped. In practice this covers the case where
+        // the release-docs bot pre-populates a DRAFT entry for the next
+        // release before it flips FINAL - that draft mustn't be used as
+        // a prev_release for anything.
+        $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 draft']);
+        $manifest = [
+            '8.0.0' => ['status' => 'FINAL',  'released_at' => '2026-01-01'],
+            '8.1.0' => ['status' => 'DRAFT',  'branch' => 'rel-810', 'sha' => str_repeat('0', 40), 'released_at' => null],
+        ];
+        $client = new MockHttpClient([new MockResponse((string) json_encode($manifest))]);
+        $resolver = new BranchVersionResolver($this->tmpDir, $client);
+        self::assertSame('8.0.0', $resolver->previousRelease('8.2.0'));
+    }
+
+    public function testPreviousReleaseFallsBackToTagsWhenManifestFetchFails(): void
+    {
+        // Network hiccup / rate-limit / bad JSON should never crash the
+        // conductor. When the manifest fetch fails the resolver falls
+        // back to tag-only behaviour - accepting 8.1.0 as prev, which is
+        // the pre-manifest behaviour. Preferable to a hard failure that
+        // would block every release dispatch on any GitHub raw-content
+        // hiccup.
+        $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 cut but skipped']);
+        $client = new MockHttpClient([new MockResponse('not json at all', ['http_code' => 200])]);
+        $resolver = new BranchVersionResolver($this->tmpDir, $client);
+        self::assertSame('8.1.0', $resolver->previousRelease('8.2.0'));
+    }
+
+    /**
+     * @param list<string> $shippedVersions
+     */
+    private function manifestClient(array $shippedVersions): MockHttpClient
+    {
+        $entries = [];
+        foreach ($shippedVersions as $version) {
+            $entries[$version] = ['status' => 'FINAL', 'released_at' => '2026-01-01'];
+        }
+        return new MockHttpClient([new MockResponse((string) json_encode($entries))]);
     }
 
     /**

--- a/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
+++ b/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
@@ -154,7 +154,7 @@ final class BranchVersionResolverTest extends TestCase
         $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 cut but skipped']);
         $resolver = new BranchVersionResolver(
             $this->tmpDir,
-            $this->manifestClient(['8.0.0']),
+            $this->manifestClient(['8.0.0' => 'FINAL']),
         );
         self::assertSame('8.0.0', $resolver->previousRelease('8.2.0'));
     }
@@ -168,7 +168,7 @@ final class BranchVersionResolverTest extends TestCase
         $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 released 2026-06-01']);
         $resolver = new BranchVersionResolver(
             $this->tmpDir,
-            $this->manifestClient(['8.0.0', '8.1.0']),
+            $this->manifestClient(['8.0.0' => 'FINAL', '8.1.0' => 'FINAL']),
         );
         self::assertSame('8.1.0', $resolver->previousRelease('8.2.0'));
     }
@@ -182,23 +182,22 @@ final class BranchVersionResolverTest extends TestCase
         // a prev_release for anything.
         $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
         $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 draft']);
-        $manifest = [
-            '8.0.0' => ['status' => 'FINAL',  'released_at' => '2026-01-01'],
-            '8.1.0' => ['status' => 'DRAFT',  'branch' => 'rel-810', 'sha' => str_repeat('0', 40), 'released_at' => null],
-        ];
-        $client = new MockHttpClient([new MockResponse((string) json_encode($manifest))]);
-        $resolver = new BranchVersionResolver($this->tmpDir, $client);
+        $resolver = new BranchVersionResolver(
+            $this->tmpDir,
+            $this->manifestClient(['8.0.0' => 'FINAL', '8.1.0' => 'DRAFT']),
+        );
         self::assertSame('8.0.0', $resolver->previousRelease('8.2.0'));
     }
 
-    public function testPreviousReleaseFallsBackToTagsWhenManifestFetchFails(): void
+    public function testPreviousReleaseFallsBackToTagsOnBadJson(): void
     {
-        // Network hiccup / rate-limit / bad JSON should never crash the
-        // conductor. When the manifest fetch fails the resolver falls
-        // back to tag-only behaviour - accepting 8.1.0 as prev, which is
-        // the pre-manifest behaviour. Preferable to a hard failure that
-        // would block every release dispatch on any GitHub raw-content
-        // hiccup.
+        // Manifest fetch returns a 200 body that isn't valid JSON (some
+        // upstream issue on raw.githubusercontent, cached error page,
+        // etc.). Resolver's JSON-decode wrapper catches JsonException
+        // and falls back to tag-only behaviour - accepting 8.1.0 as
+        // prev, which is the pre-manifest behaviour. Preferable to a
+        // hard failure that would block every release dispatch on any
+        // parse hiccup.
         $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
         $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 cut but skipped']);
         $client = new MockHttpClient([new MockResponse('not json at all', ['http_code' => 200])]);
@@ -206,14 +205,31 @@ final class BranchVersionResolverTest extends TestCase
         self::assertSame('8.1.0', $resolver->previousRelease('8.2.0'));
     }
 
+    public function testPreviousReleaseFallsBackToTagsOnHttpError(): void
+    {
+        // Manifest fetch gets a non-2xx status (rate limit, GitHub Pages
+        // downtime, DNS blip). getContent() throws a ClientException /
+        // ServerException (both extend HttpClientException); resolver's
+        // try/catch on the HTTP call catches and falls back to tag-only.
+        $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 cut but skipped']);
+        $client = new MockHttpClient([new MockResponse('server error', ['http_code' => 500])]);
+        $resolver = new BranchVersionResolver($this->tmpDir, $client);
+        self::assertSame('8.1.0', $resolver->previousRelease('8.2.0'));
+    }
+
     /**
-     * @param list<string> $shippedVersions
+     * @param array<string, string> $versionStatuses map of version to status
+     *   (e.g. `['8.0.0' => 'FINAL', '8.1.0' => 'DRAFT']`). Each entry gets
+     *   a plausible-shaped stub of the fields data/releases.json entries
+     *   carry - the fetchShippedVersions() reader only inspects `status`,
+     *   so the rest of the payload just needs to be structurally valid.
      */
-    private function manifestClient(array $shippedVersions): MockHttpClient
+    private function manifestClient(array $versionStatuses): MockHttpClient
     {
         $entries = [];
-        foreach ($shippedVersions as $version) {
-            $entries[$version] = ['status' => 'FINAL', 'released_at' => '2026-01-01'];
+        foreach ($versionStatuses as $version => $status) {
+            $entries[$version] = ['status' => $status, 'released_at' => '2026-01-01'];
         }
         return new MockHttpClient([new MockResponse((string) json_encode($entries))]);
     }

--- a/tools/release/bin/derive-prev-release.php
+++ b/tools/release/bin/derive-prev-release.php
@@ -34,6 +34,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\SingleCommandApplication;
+use Symfony\Component\HttpClient\HttpClient;
 
 (new SingleCommandApplication())
     ->setName('derive-prev-release')
@@ -46,15 +47,28 @@ use Symfony\Component\Console\SingleCommandApplication;
         'Repo path (defaults to cwd)',
         getcwd() === false ? '.' : getcwd(),
     )
+    ->addOption(
+        'manifest-url',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Overrides the website-openemr data/releases.json URL used to filter skipped tags',
+        BranchVersionResolver::DEFAULT_MANIFEST_URL,
+    )
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
         $target = $input->getArgument('target-version');
         $repoDir = $input->getOption('repo-dir');
+        $manifestUrl = $input->getOption('manifest-url');
         if (!is_string($target) || $target === '' || !is_string($repoDir) || $repoDir === '') {
             $output->writeln('<error>target-version and --repo-dir are required</error>');
             return 2;
         }
+        if (!is_string($manifestUrl) || $manifestUrl === '') {
+            $output->writeln('<error>--manifest-url must be a non-empty string</error>');
+            return 2;
+        }
         try {
-            $output->writeln((new BranchVersionResolver($repoDir))->previousRelease($target));
+            $resolver = new BranchVersionResolver($repoDir, HttpClient::create(), $manifestUrl);
+            $output->writeln($resolver->previousRelease($target));
             return 0;
         } catch (\InvalidArgumentException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');

--- a/tools/release/src/BranchVersionResolver.php
+++ b/tools/release/src/BranchVersionResolver.php
@@ -127,7 +127,14 @@ final readonly class BranchVersionResolver
             return null;
         }
         try {
-            $response = $this->httpClient->request('GET', $this->manifestUrl);
+            // Both timeout (idle) and max_duration (total wall-clock) are
+            // capped so a slow or hung raw.githubusercontent response
+            // can't stall the conductor workflow for a full 60s (PHP's
+            // default_socket_timeout) before falling back to tag-only.
+            $response = $this->httpClient->request('GET', $this->manifestUrl, [
+                'timeout' => 5,
+                'max_duration' => 10,
+            ]);
             $body = $response->getContent();
         } catch (HttpClientException) {
             return null;

--- a/tools/release/src/BranchVersionResolver.php
+++ b/tools/release/src/BranchVersionResolver.php
@@ -21,11 +21,26 @@ declare(strict_types=1);
 namespace OpenEMR\Release;
 
 use Symfony\Component\Process\Process;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final readonly class BranchVersionResolver
 {
+    /**
+     * Canonical release manifest fetched to distinguish tags that actually
+     * shipped from tags that were cut and then skipped. Any version entry
+     * with `status: FINAL` in this file is a released version; a
+     * v<MAJOR>_<MINOR>_<PATCH> tag whose version isn't in the manifest was
+     * skipped (see: 8.1.0 was cut as v8_1_0 but never released) and must
+     * not be reported as a "previous release" for any subsequent version.
+     */
+    public const DEFAULT_MANIFEST_URL =
+        'https://raw.githubusercontent.com/openemr/website-openemr/master/data/releases.json';
+
     public function __construct(
         private string $repoDir,
+        private ?HttpClientInterface $httpClient = null,
+        private string $manifestUrl = self::DEFAULT_MANIFEST_URL,
     ) {
     }
 
@@ -78,13 +93,70 @@ final readonly class BranchVersionResolver
 
     private function latestVersionTagBelow(string $targetVersion): ?string
     {
+        // Fetch the shipped-versions allow-list once per call. When the
+        // resolver has no HttpClient, or the fetch/parse failed, the value
+        // is null and every tag below the target is accepted — preserving
+        // pre-manifest behaviour as a safety net.
+        $shipped = $this->fetchShippedVersions();
         foreach ($this->releaseTags() as [$major, $minor, $patch]) {
             $candidate = sprintf('%d.%d.%d', $major, $minor, $patch);
-            if (version_compare($candidate, $targetVersion, '<')) {
-                return $candidate;
+            if (version_compare($candidate, $targetVersion, '>=')) {
+                continue;
             }
+            if ($shipped !== null && !in_array($candidate, $shipped, true)) {
+                // Tag exists but isn't in the manifest — skipped release.
+                continue;
+            }
+            return $candidate;
         }
         return null;
+    }
+
+    /**
+     * Fetch the openemr/website-openemr `data/releases.json` manifest and
+     * return the set of versions with `status: FINAL` — the source of
+     * truth for what actually shipped. Returns null when no HTTP client
+     * was supplied, or when the fetch/parse fails for any reason; callers
+     * treat null as "fall back to tag-only".
+     *
+     * @return ?list<string>
+     */
+    private function fetchShippedVersions(): ?array
+    {
+        if ($this->httpClient === null) {
+            return null;
+        }
+        try {
+            $response = $this->httpClient->request('GET', $this->manifestUrl);
+            $body = $response->getContent();
+        } catch (HttpClientException) {
+            return null;
+        }
+        try {
+            $decoded = json_decode($body, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+        if (!is_array($decoded)) {
+            return null;
+        }
+        $shipped = [];
+        foreach ($decoded as $version => $entry) {
+            if (!is_string($version)) {
+                continue;
+            }
+            if (preg_match('/^\d+\.\d+\.\d+$/', $version) !== 1) {
+                continue;
+            }
+            if (!is_array($entry)) {
+                continue;
+            }
+            if (($entry['status'] ?? null) !== 'FINAL') {
+                continue;
+            }
+            $shipped[] = $version;
+        }
+        return $shipped;
     }
 
     /**


### PR DESCRIPTION
`BranchVersionResolver::previousRelease()` walks annotated `v<MAJOR>_<MINOR>_<PATCH>` tags and returns the highest below the target. That works as long as every tag corresponds to a shipped release, but **8.1.0 was cut and skipped** — `v8_1_0` exists as an annotated tag with GitHub Release assets, but 8.1.0 was never publicly released and isn't in `website-openemr/data/releases.json`.

Consequence on the current 8.2.0 dispatch: prev_release resolved to `8.1.0`, so the acknowledgements + release-notes generators run against the wrong window. Users going 8.0.0 → 8.2.0 are missing ~30 days of PRs (between v8_0_0_3 and v8_1_0's cut) from the release-notes narrative.

## Fix

Consult the canonical shipped-versions record before accepting a tag.

- **Source of truth:** `website-openemr/data/releases.json` — the manifest is the definitive record of what shipped. Skipped versions are permanently absent from it.
- **Not used as signal:** `release-targets.yml`'s `unreleased: true` marker. That flag is transient — it clears once the next release supersedes the placeholder row — so any code keyed on it would silently break in a later release cycle.
- **How consulted:** fetched fresh over HTTPS at derive time (`raw.githubusercontent.com/openemr/website-openemr/master/data/releases.json`). No vendored copy, no periodic sync process — the dispatch pipeline is already an online workflow.

## Design

Constructor gains an optional `HttpClientInterface`:

```php
public function __construct(
    private string $repoDir,
    private ?HttpClientInterface $httpClient = null,
    private string $manifestUrl = self::DEFAULT_MANIFEST_URL,
) {}
```

- `null` HttpClient → falls back to tag-only behaviour (pre-fix). Preserves every existing single-arg constructor call and test.
- Provided HttpClient → `latestVersionTagBelow()` filters candidates through the manifest's FINAL versions. Only FINAL counts; DRAFT entries are treated as unshipped.
- Any fetch/parse failure → returns null → falls back to tag-only. A raw.githubusercontent hiccup can't block a dispatch.

`tools/release/bin/derive-prev-release.php` — creates `HttpClient::create()` and passes it in. Adds a `--manifest-url` option so tests/dry-runs can point at a fixture.

## Consequence for 8.2.0

Once this lands on rel-820 (backport PR to follow), the next rel-820 push regenerates PR openemr/website-openemr#164 with correct `prev_release=8.0.0`. Acknowledgements + release-notes then cover the actual 8.0.0 → 8.2.0 window.

For the immediate 8.2.0 fix without waiting on rel-820 backport, a `workflow_dispatch` with explicit `prev_release=8.0.0` regenerates the docs right away — see the existing `release-docs.yml` inputs.

## Tests

- `testPreviousReleaseSkipsTagsMissingFromManifest` — the load-bearing case: `v8_1_0` tag exists, manifest lists 8.0.0 only, resolver returns 8.0.0 for target 8.2.0.
- `testPreviousReleaseAcceptsTagsPresentInManifest` — inverse: same tag set, but 8.1.0 also in manifest → resolver returns 8.1.0.
- `testPreviousReleaseTreatsDraftEntriesAsUnshipped` — DRAFT in the manifest counts as unshipped (covers the release-docs bot pre-populating a DRAFT before flipping FINAL).
- `testPreviousReleaseFallsBackToTagsWhenManifestFetchFails` — bad JSON response → resolver behaves as pre-fix. Pins the safety net.
- All existing `previousRelease` and `branchToVersion` tests unchanged — the null-HttpClient constructor path preserves current behaviour.

## Local verification

- `openemr-cmd worktree exec fix-derive-prev-release-manifest phpunit-isolated` → 3695 tests pass (includes all new + existing BranchVersionResolver tests)
- `openemr-cmd worktree exec fix-derive-prev-release-manifest phpstan` → no errors at level 10
- pre-commit ran green on the commit itself (phpcs, phpstan, rector, require-checker, conventional-commits, codespell)

## Backport target

A parallel PR against rel-820 will follow — that's the branch dispatching 8.2.0. rel-810, rel-800, rel-704 don't need it (rel-810 isn't shipping; rel-800 and rel-704 don't cross the skipped-8.1.0 boundary).

Assisted-by: Claude Code