### PR TITLE
fix(release): skip unshipped tags when deriving prev_release (rel-820 backport)

### DIFF
--- a/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
+++ b/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
@@ -14,6 +14,8 @@ namespace OpenEMR\Tests\Isolated\Release;
 
 use OpenEMR\Release\BranchVersionResolver;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Process\Process;
 
 final class BranchVersionResolverTest extends TestCase
@@ -140,6 +142,80 @@ final class BranchVersionResolverTest extends TestCase
         $this->git(['tag', '-a', 'v8_2_0', '-m', 'OpenEMR 8.2.0 released 2026-04-01']);
         $resolver = new BranchVersionResolver($this->tmpDir);
         self::assertSame('8.0.0', $resolver->previousRelease('8.1.0'));
+    }
+
+    public function testPreviousReleaseSkipsTagsMissingFromManifest(): void
+    {
+        // 8.1.0 was cut as an annotated v8_1_0 tag but never released -
+        // it's absent from data/releases.json. When computing prev_release
+        // for 8.2.0, the resolver must skip 8.1.0 and fall through to
+        // 8.0.0 (the last actually-shipped release).
+        $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 cut but skipped']);
+        $resolver = new BranchVersionResolver(
+            $this->tmpDir,
+            $this->manifestClient(['8.0.0']),
+        );
+        self::assertSame('8.0.0', $resolver->previousRelease('8.2.0'));
+    }
+
+    public function testPreviousReleaseAcceptsTagsPresentInManifest(): void
+    {
+        // Same tag set as above, but this time 8.1.0 shipped normally.
+        // The manifest contains both entries; both are eligible; 8.1.0
+        // wins as the newest below target 8.2.0.
+        $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 released 2026-06-01']);
+        $resolver = new BranchVersionResolver(
+            $this->tmpDir,
+            $this->manifestClient(['8.0.0', '8.1.0']),
+        );
+        self::assertSame('8.1.0', $resolver->previousRelease('8.2.0'));
+    }
+
+    public function testPreviousReleaseTreatsDraftEntriesAsUnshipped(): void
+    {
+        // A DRAFT entry in the manifest is not FINAL, so its version is
+        // not considered shipped. In practice this covers the case where
+        // the release-docs bot pre-populates a DRAFT entry for the next
+        // release before it flips FINAL - that draft mustn't be used as
+        // a prev_release for anything.
+        $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 draft']);
+        $manifest = [
+            '8.0.0' => ['status' => 'FINAL',  'released_at' => '2026-01-01'],
+            '8.1.0' => ['status' => 'DRAFT',  'branch' => 'rel-810', 'sha' => str_repeat('0', 40), 'released_at' => null],
+        ];
+        $client = new MockHttpClient([new MockResponse((string) json_encode($manifest))]);
+        $resolver = new BranchVersionResolver($this->tmpDir, $client);
+        self::assertSame('8.0.0', $resolver->previousRelease('8.2.0'));
+    }
+
+    public function testPreviousReleaseFallsBackToTagsWhenManifestFetchFails(): void
+    {
+        // Network hiccup / rate-limit / bad JSON should never crash the
+        // conductor. When the manifest fetch fails the resolver falls
+        // back to tag-only behaviour - accepting 8.1.0 as prev, which is
+        // the pre-manifest behaviour. Preferable to a hard failure that
+        // would block every release dispatch on any GitHub raw-content
+        // hiccup.
+        $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 cut but skipped']);
+        $client = new MockHttpClient([new MockResponse('not json at all', ['http_code' => 200])]);
+        $resolver = new BranchVersionResolver($this->tmpDir, $client);
+        self::assertSame('8.1.0', $resolver->previousRelease('8.2.0'));
+    }
+
+    /**
+     * @param list<string> $shippedVersions
+     */
+    private function manifestClient(array $shippedVersions): MockHttpClient
+    {
+        $entries = [];
+        foreach ($shippedVersions as $version) {
+            $entries[$version] = ['status' => 'FINAL', 'released_at' => '2026-01-01'];
+        }
+        return new MockHttpClient([new MockResponse((string) json_encode($entries))]);
     }
 
     /**

--- a/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
+++ b/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
@@ -154,7 +154,7 @@ final class BranchVersionResolverTest extends TestCase
         $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 cut but skipped']);
         $resolver = new BranchVersionResolver(
             $this->tmpDir,
-            $this->manifestClient(['8.0.0']),
+            $this->manifestClient(['8.0.0' => 'FINAL']),
         );
         self::assertSame('8.0.0', $resolver->previousRelease('8.2.0'));
     }
@@ -168,7 +168,7 @@ final class BranchVersionResolverTest extends TestCase
         $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 released 2026-06-01']);
         $resolver = new BranchVersionResolver(
             $this->tmpDir,
-            $this->manifestClient(['8.0.0', '8.1.0']),
+            $this->manifestClient(['8.0.0' => 'FINAL', '8.1.0' => 'FINAL']),
         );
         self::assertSame('8.1.0', $resolver->previousRelease('8.2.0'));
     }
@@ -182,23 +182,22 @@ final class BranchVersionResolverTest extends TestCase
         // a prev_release for anything.
         $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
         $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 draft']);
-        $manifest = [
-            '8.0.0' => ['status' => 'FINAL',  'released_at' => '2026-01-01'],
-            '8.1.0' => ['status' => 'DRAFT',  'branch' => 'rel-810', 'sha' => str_repeat('0', 40), 'released_at' => null],
-        ];
-        $client = new MockHttpClient([new MockResponse((string) json_encode($manifest))]);
-        $resolver = new BranchVersionResolver($this->tmpDir, $client);
+        $resolver = new BranchVersionResolver(
+            $this->tmpDir,
+            $this->manifestClient(['8.0.0' => 'FINAL', '8.1.0' => 'DRAFT']),
+        );
         self::assertSame('8.0.0', $resolver->previousRelease('8.2.0'));
     }
 
-    public function testPreviousReleaseFallsBackToTagsWhenManifestFetchFails(): void
+    public function testPreviousReleaseFallsBackToTagsOnBadJson(): void
     {
-        // Network hiccup / rate-limit / bad JSON should never crash the
-        // conductor. When the manifest fetch fails the resolver falls
-        // back to tag-only behaviour - accepting 8.1.0 as prev, which is
-        // the pre-manifest behaviour. Preferable to a hard failure that
-        // would block every release dispatch on any GitHub raw-content
-        // hiccup.
+        // Manifest fetch returns a 200 body that isn't valid JSON (some
+        // upstream issue on raw.githubusercontent, cached error page,
+        // etc.). Resolver's JSON-decode wrapper catches JsonException
+        // and falls back to tag-only behaviour - accepting 8.1.0 as
+        // prev, which is the pre-manifest behaviour. Preferable to a
+        // hard failure that would block every release dispatch on any
+        // parse hiccup.
         $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
         $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 cut but skipped']);
         $client = new MockHttpClient([new MockResponse('not json at all', ['http_code' => 200])]);
@@ -206,14 +205,31 @@ final class BranchVersionResolverTest extends TestCase
         self::assertSame('8.1.0', $resolver->previousRelease('8.2.0'));
     }
 
+    public function testPreviousReleaseFallsBackToTagsOnHttpError(): void
+    {
+        // Manifest fetch gets a non-2xx status (rate limit, GitHub Pages
+        // downtime, DNS blip). getContent() throws a ClientException /
+        // ServerException (both extend HttpClientException); resolver's
+        // try/catch on the HTTP call catches and falls back to tag-only.
+        $this->git(['tag', '-a', 'v8_0_0', '-m', 'OpenEMR 8.0.0 released 2026-01-01']);
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'OpenEMR 8.1.0 cut but skipped']);
+        $client = new MockHttpClient([new MockResponse('server error', ['http_code' => 500])]);
+        $resolver = new BranchVersionResolver($this->tmpDir, $client);
+        self::assertSame('8.1.0', $resolver->previousRelease('8.2.0'));
+    }
+
     /**
-     * @param list<string> $shippedVersions
+     * @param array<string, string> $versionStatuses map of version to status
+     *   (e.g. `['8.0.0' => 'FINAL', '8.1.0' => 'DRAFT']`). Each entry gets
+     *   a plausible-shaped stub of the fields data/releases.json entries
+     *   carry - the fetchShippedVersions() reader only inspects `status`,
+     *   so the rest of the payload just needs to be structurally valid.
      */
-    private function manifestClient(array $shippedVersions): MockHttpClient
+    private function manifestClient(array $versionStatuses): MockHttpClient
     {
         $entries = [];
-        foreach ($shippedVersions as $version) {
-            $entries[$version] = ['status' => 'FINAL', 'released_at' => '2026-01-01'];
+        foreach ($versionStatuses as $version => $status) {
+            $entries[$version] = ['status' => $status, 'released_at' => '2026-01-01'];
         }
         return new MockHttpClient([new MockResponse((string) json_encode($entries))]);
     }

--- a/tools/release/bin/derive-prev-release.php
+++ b/tools/release/bin/derive-prev-release.php
@@ -34,6 +34,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\SingleCommandApplication;
+use Symfony\Component\HttpClient\HttpClient;
 
 (new SingleCommandApplication())
     ->setName('derive-prev-release')
@@ -46,15 +47,28 @@ use Symfony\Component\Console\SingleCommandApplication;
         'Repo path (defaults to cwd)',
         getcwd() === false ? '.' : getcwd(),
     )
+    ->addOption(
+        'manifest-url',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Overrides the website-openemr data/releases.json URL used to filter skipped tags',
+        BranchVersionResolver::DEFAULT_MANIFEST_URL,
+    )
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
         $target = $input->getArgument('target-version');
         $repoDir = $input->getOption('repo-dir');
+        $manifestUrl = $input->getOption('manifest-url');
         if (!is_string($target) || $target === '' || !is_string($repoDir) || $repoDir === '') {
             $output->writeln('<error>target-version and --repo-dir are required</error>');
             return 2;
         }
+        if (!is_string($manifestUrl) || $manifestUrl === '') {
+            $output->writeln('<error>--manifest-url must be a non-empty string</error>');
+            return 2;
+        }
         try {
-            $output->writeln((new BranchVersionResolver($repoDir))->previousRelease($target));
+            $resolver = new BranchVersionResolver($repoDir, HttpClient::create(), $manifestUrl);
+            $output->writeln($resolver->previousRelease($target));
             return 0;
         } catch (\InvalidArgumentException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');

--- a/tools/release/src/BranchVersionResolver.php
+++ b/tools/release/src/BranchVersionResolver.php
@@ -127,7 +127,14 @@ final readonly class BranchVersionResolver
             return null;
         }
         try {
-            $response = $this->httpClient->request('GET', $this->manifestUrl);
+            // Both timeout (idle) and max_duration (total wall-clock) are
+            // capped so a slow or hung raw.githubusercontent response
+            // can't stall the conductor workflow for a full 60s (PHP's
+            // default_socket_timeout) before falling back to tag-only.
+            $response = $this->httpClient->request('GET', $this->manifestUrl, [
+                'timeout' => 5,
+                'max_duration' => 10,
+            ]);
             $body = $response->getContent();
         } catch (HttpClientException) {
             return null;

--- a/tools/release/src/BranchVersionResolver.php
+++ b/tools/release/src/BranchVersionResolver.php
@@ -21,11 +21,26 @@ declare(strict_types=1);
 namespace OpenEMR\Release;
 
 use Symfony\Component\Process\Process;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final readonly class BranchVersionResolver
 {
+    /**
+     * Canonical release manifest fetched to distinguish tags that actually
+     * shipped from tags that were cut and then skipped. Any version entry
+     * with `status: FINAL` in this file is a released version; a
+     * v<MAJOR>_<MINOR>_<PATCH> tag whose version isn't in the manifest was
+     * skipped (see: 8.1.0 was cut as v8_1_0 but never released) and must
+     * not be reported as a "previous release" for any subsequent version.
+     */
+    public const DEFAULT_MANIFEST_URL =
+        'https://raw.githubusercontent.com/openemr/website-openemr/master/data/releases.json';
+
     public function __construct(
         private string $repoDir,
+        private ?HttpClientInterface $httpClient = null,
+        private string $manifestUrl = self::DEFAULT_MANIFEST_URL,
     ) {
     }
 
@@ -78,13 +93,70 @@ final readonly class BranchVersionResolver
 
     private function latestVersionTagBelow(string $targetVersion): ?string
     {
+        // Fetch the shipped-versions allow-list once per call. When the
+        // resolver has no HttpClient, or the fetch/parse failed, the value
+        // is null and every tag below the target is accepted — preserving
+        // pre-manifest behaviour as a safety net.
+        $shipped = $this->fetchShippedVersions();
         foreach ($this->releaseTags() as [$major, $minor, $patch]) {
             $candidate = sprintf('%d.%d.%d', $major, $minor, $patch);
-            if (version_compare($candidate, $targetVersion, '<')) {
-                return $candidate;
+            if (version_compare($candidate, $targetVersion, '>=')) {
+                continue;
             }
+            if ($shipped !== null && !in_array($candidate, $shipped, true)) {
+                // Tag exists but isn't in the manifest — skipped release.
+                continue;
+            }
+            return $candidate;
         }
         return null;
+    }
+
+    /**
+     * Fetch the openemr/website-openemr `data/releases.json` manifest and
+     * return the set of versions with `status: FINAL` — the source of
+     * truth for what actually shipped. Returns null when no HTTP client
+     * was supplied, or when the fetch/parse fails for any reason; callers
+     * treat null as "fall back to tag-only".
+     *
+     * @return ?list<string>
+     */
+    private function fetchShippedVersions(): ?array
+    {
+        if ($this->httpClient === null) {
+            return null;
+        }
+        try {
+            $response = $this->httpClient->request('GET', $this->manifestUrl);
+            $body = $response->getContent();
+        } catch (HttpClientException) {
+            return null;
+        }
+        try {
+            $decoded = json_decode($body, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+        if (!is_array($decoded)) {
+            return null;
+        }
+        $shipped = [];
+        foreach ($decoded as $version => $entry) {
+            if (!is_string($version)) {
+                continue;
+            }
+            if (preg_match('/^\d+\.\d+\.\d+$/', $version) !== 1) {
+                continue;
+            }
+            if (!is_array($entry)) {
+                continue;
+            }
+            if (($entry['status'] ?? null) !== 'FINAL') {
+                continue;
+            }
+            $shipped[] = $version;
+        }
+        return $shipped;
     }
 
     /**


### PR DESCRIPTION
Backport of #12769 to rel-820, the branch that dispatches 8.2.0.

Root cause + design are identical to the master PR — see #12769 for the full write-up. Short version:

- `BranchVersionResolver::previousRelease()` walks `v<M>_<m>_<p>` tags and returns the highest below target.
- `v8_1_0` exists as an annotated tag but 8.1.0 was skipped (never in `website-openemr/data/releases.json`).
- 8.2.0's dispatch payload resolved `prev_release=8.1.0`, so PR openemr/website-openemr#164 has acknowledgements + release-notes against the wrong window.
- Fix: consult `data/releases.json` at derive time and skip any tag whose version isn't a FINAL entry.

## Why rel-820 specifically

`release-prep.yml` fires on push to `rel-*` and runs `php tools/release/bin/derive-prev-release.php` from the pushed branch's checkout. So the fix has to live on rel-820 for the next 8.2.0 dispatch to use it. `tools/release/` is not in the byte-identical set (`.github/docker-byte-identical.yml`), so master-side landing doesn't auto-propagate here.

Also landing on:
- **master** (#12769) — source of truth; future rel branches inherit.

**Not** landing on:
- **rel-810** — not in `release-targets.yml`, nothing shipping from it.
- **rel-800**, **rel-704** — their next patch releases (8.0.0.4, 7.0.5) don't cross the skipped-8.1.0 boundary.

## Cherry-pick

`git cherry-pick 3e671e62a5` (the master commit) applied cleanly — no conflicts. Same three files:

- `tools/release/src/BranchVersionResolver.php`
- `tools/release/bin/derive-prev-release.php`
- `tests/Tests/Isolated/Release/BranchVersionResolverTest.php`

## Local verification (rel-820 worktree)

- `composer phpunit-isolated` → 3691 tests pass (all new + existing BranchVersionResolver tests included)
- `openemr-cmd phpstan` → no errors at level 10
- pre-commit ran green

## Effect

Once merged, the next push to rel-820 (or a `--force-dispatch` from the conductor) regenerates PR openemr/website-openemr#164 with correct `prev_release=8.0.0`. Acknowledgements + release-notes then cover the actual 8.0.0 → 8.2.0 window (adds back ~30 days of PRs currently missing from the narrative).

Immediate fix without waiting on this merge: manual `workflow_dispatch` on `openemr/website-openemr/release-docs.yml` with `prev_release=8.0.0`.

Assisted-by: Claude Code