### PR TITLE
fix(release): trust manifest over annotated-tag filter for prev_release

### DIFF
--- a/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
+++ b/tests/Tests/Isolated/Release/BranchVersionResolverTest.php
@@ -159,6 +159,30 @@ final class BranchVersionResolverTest extends TestCase
         self::assertSame('8.0.0', $resolver->previousRelease('8.2.0'));
     }
 
+    public function testPreviousReleaseTrustsManifestOverAnnotatedTagFilter(): void
+    {
+        // Historic SourceForge-era v* tags are LIGHTWEIGHT, not annotated
+        // (openemr/openemr's real v8_0_0 predates the annotated-tag policy
+        // TagVerifier enforces on new cuts). The manifest is the source
+        // of truth for what shipped; the resolver must trust it and NOT
+        // discard 8.0.0 just because its tag is lightweight.
+        //
+        // Regression pin for the "8.2.0 dispatch got prev_release=8.1.0
+        // even after the manifest fix" post-merge bug: v8_1_0 was
+        // annotated + skipped, v8_0_0 was lightweight + shipped, so the
+        // original manifest-filter walked the annotated-only set (just
+        // v8_1_0), filtered v8_1_0 out as unshipped, fell through to
+        // null, and previousRelease synthesised 8.1.0 as the prev-minor
+        // fallback — the same skipped version we were trying to avoid.
+        $this->git(['tag', 'v8_0_0']); // lightweight (no -a)
+        $this->git(['tag', '-a', 'v8_1_0', '-m', 'cut and skipped']);
+        $resolver = new BranchVersionResolver(
+            $this->tmpDir,
+            $this->manifestClient(['8.0.0' => 'FINAL']),
+        );
+        self::assertSame('8.0.0', $resolver->previousRelease('8.2.0'));
+    }
+
     public function testPreviousReleaseAcceptsTagsPresentInManifest(): void
     {
         // Same tag set as above, but this time 8.1.0 shipped normally.

--- a/tools/release/src/BranchVersionResolver.php
+++ b/tools/release/src/BranchVersionResolver.php
@@ -93,21 +93,33 @@ final readonly class BranchVersionResolver
 
     private function latestVersionTagBelow(string $targetVersion): ?string
     {
-        // Fetch the shipped-versions allow-list once per call. When the
-        // resolver has no HttpClient, or the fetch/parse failed, the value
-        // is null and every tag below the target is accepted — preserving
-        // pre-manifest behaviour as a safety net.
+        // When the shipped-versions manifest is available it's the source
+        // of truth: iterate its entries directly. The annotated-tag walk
+        // below silently drops lightweight tags — and historic SourceForge-
+        // era releases like v8_0_0 are lightweight. Filtering annotated
+        // tags through the manifest would incorrectly discard v8_0_0 as
+        // "unshipped," even though data/releases.json marks 8.0.0 FINAL.
+        // Keying on the manifest directly avoids that conflation.
         $shipped = $this->fetchShippedVersions();
+        if ($shipped !== null) {
+            usort($shipped, static fn (string $a, string $b): int => version_compare($b, $a));
+            foreach ($shipped as $candidate) {
+                if (version_compare($candidate, $targetVersion, '<')) {
+                    return $candidate;
+                }
+            }
+            return null;
+        }
+        // Manifest fetch/parse failed. Fall back to the pre-manifest
+        // annotated-tag walk — imperfect for the skipped-release edge
+        // case (a cut-then-skipped tag will win over the actually-shipped
+        // predecessor) but the safest available floor when we have no
+        // better source of truth.
         foreach ($this->releaseTags() as [$major, $minor, $patch]) {
             $candidate = sprintf('%d.%d.%d', $major, $minor, $patch);
-            if (version_compare($candidate, $targetVersion, '>=')) {
-                continue;
+            if (version_compare($candidate, $targetVersion, '<')) {
+                return $candidate;
             }
-            if ($shipped !== null && !in_array($candidate, $shipped, true)) {
-                // Tag exists but isn't in the manifest — skipped release.
-                continue;
-            }
-            return $candidate;
         }
         return null;
     }


### PR DESCRIPTION
Follow-up to #12769 — the manifest-aware walk still fell through the annotated-tag filter, which silently drops lightweight tags. Observed live after #12770 merged and dispatched — release-docs regenerated PR openemr/website-openemr#164 with `prev_release=8.1.0` anyway.

## Root cause

`releaseTags()` filters to annotated tags only (`objecttype == 'tag'`), consistent with the release spec that requires `git tag -a` for new cuts. But **historic SourceForge-era tags are lightweight** — `v8_0_0` in the openemr/openemr repo is a lightweight tag, so it gets silently dropped.

Concrete trace on the live repo:
- `releaseTags()` returns just `[v8_1_0]` (annotated + matching regex)
- Manifest walk: v8_1_0 not in shipped → continue → `null`
- `previousRelease()` catches null → synthesises `prevMinor` fallback → `8.1.0`

The synthesised fallback for target 8.2.0 is 8.1.0 — the same skipped version we were trying to avoid.

## Fix

When the manifest is available, iterate the **shipped-version list directly** instead of the git-tag walk. The manifest already knows which versions shipped; funnelling that through an annotated-only tag filter adds a lossy hop that discards historic real releases like `v8_0_0`.

```php
private function latestVersionTagBelow(string $targetVersion): ?string
{
    $shipped = $this->fetchShippedVersions();
    if ($shipped !== null) {
        usort($shipped, static fn (string $a, string $b): int => version_compare($b, $a));
        foreach ($shipped as $candidate) {
            if (version_compare($candidate, $targetVersion, '<')) {
                return $candidate;
            }
        }
        return null;
    }
    // Manifest unreachable — fall back to the pre-manifest tag walk
    ...
}
```

The annotated-tag walk stays as the fallback when the manifest fetch fails — imperfect for skipped-release edges but the safest floor without a source of truth. Same "prefer trusted source, degrade gracefully" shape as the parent fix.

## Regression test

New `testPreviousReleaseTrustsManifestOverAnnotatedTagFilter` pins the exact scenario:
- Lightweight `v8_0_0` tag (no `-a`) in the manifest as `FINAL`
- Annotated `v8_1_0` tag not in the manifest (skipped)
- Target `8.2.0`
- Expected: `8.0.0`

Existing tests continue to pass (3697 total; +1 regression pin).

## Verification against the real openemr repo

```bash
$ php tools/release/bin/derive-prev-release.php 8.2.0
8.0.0
```

Previously returned `8.1.0`. Once this lands, the next rel-820 dispatch will regenerate PR openemr/website-openemr#164 with `prev_release=8.0.0` and the correct 8.0.0 → 8.2.0 window.

## Backport target

rel-820 — parallel PR to follow, cherry-pick.

Assisted-by: Claude Code