### PR TITLE
ci(all-checks-passed): trigger on rel-* branches

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -2,9 +2,13 @@ name: All Checks Passed
 
 on:
   push:
-    branches: [master]
+    branches:
+    - master
+    - rel-*
   pull_request:
-    branches: [master]
+    branches:
+    - master
+    - rel-*
 
 jobs:
   all-checks:


### PR DESCRIPTION
## Summary
- The required-status-checks ruleset gates both `master` and `rel-*` on the `All Checks Passed` context, but `.github/workflows/all-checks-passed.yml` only fired on `master`.
- On any PR whose base is a `rel-*` branch (e.g. #12742 `release-prep/rel-820` -> `rel-820`), every individual check went green but the aggregate never appeared, so the PR stayed `BLOCKED` on a phantom pending required check.
- Add `rel-*` to both trigger lists, matching the pattern already used by `isolated-tests`, `integration-tests`, `phpstan`, and the other rel-* aware workflows.

## Test plan
- [ ] After merge, re-run / poke #12742 and confirm the `All Checks Passed` aggregate now reports and unblocks the merge queue.
- [ ] Confirm the workflow still fires as expected on `master` PRs (this PR itself is the first exercise of that path).