### PR TITLE
ci(all-checks-passed): trigger on rel-* branches (rel-820 backport of #12774)

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -2,9 +2,13 @@ name: All Checks Passed
 
 on:
   push:
-    branches: [master]
+    branches:
+    - master
+    - rel-*
   pull_request:
-    branches: [master]
+    branches:
+    - master
+    - rel-*
 
 jobs:
   all-checks:


### PR DESCRIPTION
## Summary
- Backport of #12774 to `rel-820`.
- The required-status-checks ruleset gates both `master` and `rel-*` on the `All Checks Passed` context, but `.github/workflows/all-checks-passed.yml` on `rel-820` only fires on `master`. So PRs targeting `rel-820` (e.g. #12742 `release-prep/rel-820` -> `rel-820`) have every individual check go green while the aggregate never appears, leaving the PR permanently `BLOCKED`.
- For `pull_request` events, the workflow definition consulted is from the merge of head + base — so master having the fix does not help PRs into `rel-820`; the fix must live on `rel-820` too.
- Add `rel-*` to both trigger lists, matching the pattern already used by `isolated-tests`, `integration-tests`, `phpstan`, and the other rel-* aware workflows.

## Test plan
- [ ] After merge, rebase (or merge `rel-820` into) `release-prep/rel-820` on PR #12742 so its head picks up the updated workflow file — then confirm the `All Checks Passed` aggregate reports and unblocks the merge.