### PR TITLE
chore(release): include docker/production/ in release tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,15 @@
 .phpstan/                      export-ignore
 ci/                            export-ignore
 docker/                        export-ignore
+# Selective carve-out: docker/production/ ships as a reference-production
+# compose template so tarball users have a blessed starting point for a
+# self-hosted Docker deployment (its image ref gets pinned by the release-
+# prep conductor before tag time). Development docker stacks (docker/
+# development-easy*, docker/flex, docker/dockerhub, docker/binary,
+# docker/container_benchmarking) stay excluded — they carry no user-facing
+# artifacts for the released tarball.
+docker/production/            -export-ignore
+docker/production/**          -export-ignore
 tests/                         export-ignore
 tools/                         export-ignore
 .gitattributes                 export-ignore


### PR DESCRIPTION
Adds a selective `-export-ignore` carve-out to `.gitattributes` so `docker/production/` ships in the release archive alongside the rest of the runtime tree.

## What changes

```diff
 docker/                        export-ignore
+# Selective carve-out: docker/production/ ships as a reference-production
+# compose template so tarball users have a blessed starting point for a
+# self-hosted Docker deployment (its image ref gets pinned by the release-
+# prep conductor before tag time). Development docker stacks (docker/
+# development-easy*, docker/flex, docker/dockerhub, docker/binary,
+# docker/container_benchmarking) stay excluded — they carry no user-facing
+# artifacts for the released tarball.
+docker/production/            -export-ignore
+docker/production/**          -export-ignore
```

## Why

`docker/production/` carries exactly two files — `README.md` + `docker-compose.yml`, ~10KB total. Ships as a **reference template** for tarball users who want to base a self-hosted Docker deployment on the same production compose the `openemr/openemr` Docker Hub image is built from. Currently users have to clone the repo to get it.

The `docker/production/docker-compose.yml` image ref gets pinned to the release version (`openemr/openemr:v8_2_0` etc.) by the release-prep conductor as part of every per-release conductor PR — so the compose file that ships in the tarball references the correct image tag at ship time.

Development docker stacks (`docker/development-easy*`, `docker/flex`, `docker/dockerhub`, `docker/binary`, `docker/container_benchmarking`) stay excluded — none carry user-facing artifacts.

## Verification

Ran `git archive HEAD` on a local branch with this change and confirmed:

- **Before:** `docker/**` entirely absent from the archive
- **After:** `docker/production/README.md` and `docker/production/docker-compose.yml` present at expected paths; no other `docker/` subdirs leak in

## Test plan

- [x] `.gitattributes` still parses (no syntax change, just adding `-export-ignore` entries which is the same syntax used elsewhere in the file)
- [x] `git archive HEAD` with the new `.gitattributes` produces the expected shape (verified locally)
- [ ] rel-820 backport with identical patch-id (separate PR to follow)
- [ ] After merge: next release tarball built via `openemr-devops/tools/release/bin/package-assemble.php` includes `docker/production/*`

Assisted-by: Claude Code