### PR TITLE
chore(release): include docker/production/ in release tarball (rel-820 backport)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,15 @@
 .phpstan/                      export-ignore
 ci/                            export-ignore
 docker/                        export-ignore
+# Selective carve-out: docker/production/ ships as a reference-production
+# compose template so tarball users have a blessed starting point for a
+# self-hosted Docker deployment (its image ref gets pinned by the release-
+# prep conductor before tag time). Development docker stacks (docker/
+# development-easy*, docker/flex, docker/dockerhub, docker/binary,
+# docker/container_benchmarking) stay excluded — they carry no user-facing
+# artifacts for the released tarball.
+docker/production/            -export-ignore
+docker/production/**          -export-ignore
 tests/                         export-ignore
 tools/                         export-ignore
 .gitattributes                 export-ignore


### PR DESCRIPTION
Backport of #12776 to rel-820.

Clean cherry-pick, patch-id verified identical: `02f327f169d3da1baf2451b6c03d35871a6c56ad` on both master and rel-820. See #12776 for the full rationale.

## Why on rel-820 specifically

The 8.2.0 release ships from rel-820. If this backport lands before the ship, the 8.2.0 tarball will include `docker/production/`. If it lands only on master, users of 8.2.0 won't see it — has to wait until rel-830 to reach users.

`.gitattributes` is not in the byte-identical set, so no auto-sync from master.

Assisted-by: Claude Code