### PR TITLE
ci(docker): trigger docker-test-release on version.php bumps

### DIFF
--- a/.github/workflows/docker-test-release.yml
+++ b/.github/workflows/docker-test-release.yml
@@ -9,6 +9,14 @@
 # workflow primarily exists to validate. Changes to flex / binary fire their
 # own targeted test-flex-*.yml and BATS workflows respectively.
 #
+# Also triggers on version.php changes -- docker-build-release.yml bakes
+# version.php's contents into the shipped image as OCI labels (IMAGE_VERSION
+# arg → org.opencontainers.image.version), so a version.php bump is a
+# legitimate change to the release image's identity even when the Dockerfile
+# itself is unchanged. This is what fires the full production-mode docker
+# test on release-prep PRs (the conductor's version.php bump is the canonical
+# rel-branch push that trips this path).
+#
 #  - is_production_docker: true  -- triggers the production-mode test path
 #    inside docker-test-core.yml (vs the dev-mode path used by the
 #    docker-test-flex-*.yml callers).
@@ -31,12 +39,14 @@ on:
     paths:
     - '.github/workflows/docker-test-release.yml'
     - 'docker/release/**'
+    - 'version.php'
     - '.github/actions/test-actions-core/action.yml'
     - '.github/workflows/docker-test-core.yml'
   pull_request:
     paths:
     - '.github/workflows/docker-test-release.yml'
     - 'docker/release/**'
+    - 'version.php'
     - '.github/actions/test-actions-core/action.yml'
     - '.github/workflows/docker-test-core.yml'
 


### PR DESCRIPTION
## Summary

- Adds `version.php` to `docker-test-release.yml`'s paths filter (both push + pull_request)
- `docker-build-release.yml` already bakes `version.php`'s contents into the shipped image as `org.opencontainers.image.version` via the `IMAGE_VERSION` build arg; `version.php` is therefore a legitimate source-of-truth for the release image's identity even when `docker/release/**` is unchanged
- Effect: every release-prep PR that bumps `version.php` — the canonical rel-branch push the conductor issues — now fires the full production-mode docker test (build via `docker-test-core.yml`, boot, smoke via `test-actions-core`) as a required check on the release-prep PR

## Why

The release-prep conductor's mechanical edits touch `version.php`, `docker/production/docker-compose.yml`, `.github/release-targets.yml`, and docs. None of those hit `docker-test-release.yml`'s paths filter today, so release-prep PRs merged without pre-tag CI validation of the image content that gets pushed to Docker Hub as `openemr/openemr:<version>`. This closes that gap using existing test infrastructure.

## Byte-identity preserved

This change keeps `docker-test-release.yml` in the byte-identical file set (`docker-validate-byte-identical.yml`'s `FILES_ALL`). Same edit will land on rel-820 as a companion backport.

## Test plan

- [ ] `docker-validate-byte-identical` on this PR passes (confirms byte-identity across master + all rel-* copies of `docker-test-release.yml`)
- [ ] Next push to a rel-* branch that bumps `version.php` fires `Docker release test` on the resulting release-prep PR
- [ ] No spurious fires on PRs that touch only `version.php` from an unrelated non-conductor edit — expected: yes, fires, that's the whole point

🤖 Generated with [Claude Code](https://claude.com/claude-code)