### PR TITLE
ci(docker): trigger docker-test-release on version.php bumps (rel-820 backport)

### DIFF
--- a/.github/workflows/docker-test-release.yml
+++ b/.github/workflows/docker-test-release.yml
@@ -9,6 +9,14 @@
 # workflow primarily exists to validate. Changes to flex / binary fire their
 # own targeted test-flex-*.yml and BATS workflows respectively.
 #
+# Also triggers on version.php changes -- docker-build-release.yml bakes
+# version.php's contents into the shipped image as OCI labels (IMAGE_VERSION
+# arg → org.opencontainers.image.version), so a version.php bump is a
+# legitimate change to the release image's identity even when the Dockerfile
+# itself is unchanged. This is what fires the full production-mode docker
+# test on release-prep PRs (the conductor's version.php bump is the canonical
+# rel-branch push that trips this path).
+#
 #  - is_production_docker: true  -- triggers the production-mode test path
 #    inside docker-test-core.yml (vs the dev-mode path used by the
 #    docker-test-flex-*.yml callers).
@@ -31,12 +39,14 @@ on:
     paths:
     - '.github/workflows/docker-test-release.yml'
     - 'docker/release/**'
+    - 'version.php'
     - '.github/actions/test-actions-core/action.yml'
     - '.github/workflows/docker-test-core.yml'
   pull_request:
     paths:
     - '.github/workflows/docker-test-release.yml'
     - 'docker/release/**'
+    - 'version.php'
     - '.github/actions/test-actions-core/action.yml'
     - '.github/workflows/docker-test-core.yml'
 


### PR DESCRIPTION
## Summary

rel-820 backport of #12778 (same patch-id: `93d512385fc02cd2b340d6103321e0d91836e890`).

Adds `version.php` to `docker-test-release.yml`'s paths filter so the release-prep conductor's `version.php` bump on rel-820 fires the full production-mode docker test via `docker-test-core` before the 8.2.0 tag ships. See #12778 for full context.

Byte-identity across master + rel-* copies of `docker-test-release.yml` preserved.

## Test plan

- [ ] `docker-validate-byte-identical` passes on this PR (once #12778 merges into master; before that, this PR's file is expected to differ from master's HEAD, then converge)
- [ ] Merging this PR causes the next release-prep conductor churn on rel-820 to fire `Docker release test` on the resulting release-prep PR
- [ ] The docker-test-core job builds `docker/release/Dockerfile` from rel-820, boots it, and passes `test-actions-core` smoke suite — pre-tag validation of the 8.2.0 image content

🤖 Generated with [Claude Code](https://claude.com/claude-code)