### PR TITLE
chore(docker): switch release Dockerfile source-fetch to git archive

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -149,18 +149,24 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 # ============================================================================
 # MULTI-STAGE BUILD: OpenEMR Source and Dependencies
 # ============================================================================
-# Stage 1: Fetch OpenEMR source code via git clone
-# Use git clone instead of GitHub archive because OpenEMR's .gitattributes
-# marks tests/, phpunit*.xml, and other dev files as export-ignore, which
-# excludes them from archives but not from clones.
+# Stage 1: Fetch OpenEMR source code and apply .gitattributes export-ignore.
+# Two-step: shallow clone to get the tree, then `git archive HEAD` piped
+# through tar to materialize a copy filtered by the same export-ignore rules
+# the release tarball uses. Result: the shipped image contains only what
+# the release tarball ships (.github/, ci/, docker/, tests/, tools/,
+# build.xml, phpstan.neon.dist, .pre-commit-config.yaml, most of
+# Documentation/EHI_Export/ schemaspy artifacts, etc. all stripped).
+#
 # Supports branches or tags via OPENEMR_VERSION build argument.
 # Examples:
 #   - Branch: --build-arg OPENEMR_VERSION=master
 #   - Tag:    --build-arg OPENEMR_VERSION=v7.0.5
 ARG OPENEMR_VERSION=master
 FROM base AS openemr-source
-RUN git clone https://github.com/openemr/openemr.git --branch "${OPENEMR_VERSION}" --depth 1 \
-    && rm -rf openemr/.git
+RUN git clone https://github.com/openemr/openemr.git --branch "${OPENEMR_VERSION}" --depth 1 openemr-clone \
+    && mkdir openemr \
+    && git -C openemr-clone archive HEAD | tar -x -C openemr \
+    && rm -rf openemr-clone
 
 # Stage 2: Install PHP dependencies (Composer)
 # Separate stage allows Docker to cache this layer independently


### PR DESCRIPTION
## Summary

Switch the release Dockerfile's Stage 1 source-fetch from a shallow clone (\"take everything\") to a shallow clone → \`git archive HEAD | tar -x\` pipeline (\"filter via .gitattributes export-ignore\").

Result: the shipped Docker image no longer contains dev-only content that the release tarball already excludes — \`.github/\`, \`ci/\`, \`docker/\`, \`tests/\`, \`tools/\`, \`build.xml\`, \`phpstan.neon.dist\`, \`.pre-commit-config.yaml\`, most of the ~140M \`Documentation/EHI_Export/\` schemaspy tree, etc.

## Why

The tarball uses \`git archive\` and honors \`export-ignore\` rules; the docker image uses \`git clone\` and doesn't. Two artifacts that should be equivalent ship materially different content:

- Tarball: stripped to runtime-only
- Docker image: full clone incl. test suite, CI config, release tooling, phing config, EHI schemaspy artifacts, etc.

This closes the divergence.

## Effects

- Smaller image (rough estimate: strips ~100-200MB of unused content)
- Content parity with the tarball for SBOM / provenance / audit review
- Downstream Dockerfile stages (composer install, npm build, phing prune) unchanged — they already only touch runtime-relevant paths

## Exploratory

This is a see-what-happens PR to surface any hidden runtime reliance on export-ignored paths. There shouldn't be any — the entrypoint, upgrade scripts, and installer all live under paths that ship in the tarball — but this is the way to find out. Downstream tests (docker-test-release → docker-test-core → test-actions-core) will exercise the built image and catch any missing dependencies.

## Test plan

- [ ] \`Docker release test\` (docker-test-release → docker-test-core) passes: the built image boots, the installer completes, the smoke suite passes
- [ ] Manual inspection of image size before/after to confirm the strip actually happens
- [ ] Manual \`docker exec\` into the built image to spot-check that dev-only paths (\`tests/\`, \`.github/\`, \`tools/\`) are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)