### PR TITLE
test(api): add tests for FHIR Condition endpoints

### DIFF
--- a/tests/Tests/Api/ConditionFhirApiTest.php
+++ b/tests/Tests/Api/ConditionFhirApiTest.php
@@ -1,5 +1,17 @@
 <?php
 
+/**
+ * FHIR Condition API tests.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Vasilii Tereshchenko <vasilii.tereshchenko@gmail.com>
+ * @copyright Copyright (c) 2026 Vasilii Tereshchenko <vasilii.tereshchenko@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
 namespace OpenEMR\Tests\Api;
 
 use OpenEMR\Tests\Fixtures\FixtureManager;

--- a/tests/Tests/Api/ConditionFhirApiTest.php
+++ b/tests/Tests/Api/ConditionFhirApiTest.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace OpenEMR\Tests\Api;
+
+use OpenEMR\Tests\Fixtures\FixtureManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tests for the FHIR Condition endpoints:
+ *   GET /fhir/Condition          (search -> returns a Bundle)
+ *   GET /fhir/Condition/:uuid     (read one -> returns a single Condition)
+ *
+ * Modeled on PatientFhirApiTest, but with one big difference: there is NO
+ * POST /fhir/Condition route, so we cannot create test data by POSTing a
+ * Condition the way the Patient test POSTs a Patient. Instead we seed a
+ * patient + a medical-problem row directly through FixtureManager in setUp,
+ * and remove it in tearDown via ConditionFixtureManager::removeFixtures().
+ *
+ * OpenEMR vs FHIR conventions (tests pin current server behavior, not the spec):
+ * - Search bundles use type "collection" (FhirResourcesService), not FHIR's "searchset".
+ * - getOne errors return validationErrors (400) or an empty JSON array (404), not OperationOutcome.
+ *   A follow-up issue could align these with FHIR if desired.
+ * - Problem-list Conditions expose code.text from the list title when diagnosis is not parsed
+ *   into structured coding (see FhirConditionProblemListItemService::searchForOpenEMRRecords).
+ *   ICD-10 coding (code.coding) requires a separate product fix; do not assert it here.
+ */
+class ConditionFhirApiTest extends TestCase
+{
+    private ApiTestClient $testClient;
+    private FixtureManager $fixtureManager;
+
+    /** FHIR uuid of the condition we seed, so we can read it back and assert on it. */
+    private string $conditionUuid;
+
+    /** FHIR uuid of the patient that owns the seeded condition. */
+    private string $patientUuid;
+
+    protected function setUp(): void
+    {
+        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
+        $this->testClient = new ApiTestClient($baseUrl, false);
+        $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+
+        $this->fixtureManager = new FixtureManager();
+        $seeded = $this->fixtureManager->installConditionFixtures();
+        $this->patientUuid = $seeded['patientUuid'];
+        $this->conditionUuid = $seeded['conditionUuid'];
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fixtureManager->removeConditionFixtures();
+        $this->testClient->cleanupRevokeAuth();
+        $this->testClient->cleanupClient();
+    }
+
+    // ---------------------------------------------------------------------
+    // Happy path: search
+    // ---------------------------------------------------------------------
+
+    /**
+     * Searching by patient should return a FHIR Bundle containing the seeded condition.
+     *
+     * OpenEMR returns bundle type "collection", not FHIR's conventional "searchset".
+     */
+    public function testSearchReturnsCollectionBundle(): void
+    {
+        $result = $this->testClient->get(
+            "/apis/default/fhir/Condition",
+            ['patient' => $this->patientUuid]
+        );
+        $this->assertEquals(Response::HTTP_OK, $result->getStatusCode());
+
+        $body = $result->getBody()->getContents();
+        $this->assertNotEmpty($body, "Condition search should return a body");
+        $bundle = json_decode((string) $body, true);
+        $this->assertIsArray($bundle);
+
+        $this->assertEquals("Bundle", $bundle['resourceType'] ?? null);
+        $this->assertEquals("collection", $bundle['type'] ?? null);
+        $this->assertArrayHasKey("entry", $bundle);
+        $this->assertIsArray($bundle['entry']);
+        $this->assertNotEmpty($bundle['entry'], "Search should return at least the seeded condition");
+
+        $foundSeededCondition = false;
+        foreach ($bundle['entry'] as $entry) {
+            $this->assertIsArray($entry);
+            $this->assertArrayHasKey("resource", $entry);
+            $this->assertIsArray($entry['resource']);
+            $this->assertEquals("Condition", $entry['resource']['resourceType'] ?? null);
+            if (($entry['resource']['id'] ?? null) === $this->conditionUuid) {
+                $foundSeededCondition = true;
+            }
+        }
+        $this->assertTrue($foundSeededCondition, "Search should include the seeded condition");
+    }
+
+    /**
+     * Searching by the seeded condition's _id should return exactly that one
+     * condition, and it should reference the seeded patient as its subject.
+     */
+    public function testSearchByIdReturnsSeededCondition(): void
+    {
+        $result = $this->testClient->get(
+            "/apis/default/fhir/Condition",
+            ['_id' => $this->conditionUuid]
+        );
+        $this->assertEquals(Response::HTTP_OK, $result->getStatusCode());
+
+        $bundle = json_decode((string) $result->getBody()->getContents(), true);
+        $this->assertIsArray($bundle);
+        $this->assertArrayHasKey("entry", $bundle);
+        $this->assertIsArray($bundle['entry']);
+        $this->assertCount(1, $bundle['entry'], "Search by _id should return a single condition");
+
+        $this->assertIsArray($bundle['entry'][0]);
+        $this->assertArrayHasKey('resource', $bundle['entry'][0]);
+        $resource = $bundle['entry'][0]['resource'];
+        $this->assertIsArray($resource);
+        $this->assertEquals($this->conditionUuid, $resource['id']);
+
+        // The subject reference should point at our patient, e.g. "Patient/<uuid>".
+        $this->assertArrayHasKey("subject", $resource);
+        $this->assertIsArray($resource['subject']);
+        $this->assertArrayHasKey('reference', $resource['subject']);
+        $this->assertIsString($resource['subject']['reference']);
+        $this->assertStringContainsString(
+            $this->patientUuid,
+            $resource['subject']['reference'],
+            "Condition subject should reference the seeded patient"
+        );
+        /** @var array<string, mixed> $resource */
+        $this->assertConditionCodeText($resource);
+    }
+
+    // ---------------------------------------------------------------------
+    // Happy path: read one
+    // ---------------------------------------------------------------------
+
+    /**
+     * Reading a single condition by uuid should return a Condition resource
+     * with the US Core required elements populated.
+     */
+    public function testGetOneReturnsConditionResource(): void
+    {
+        $result = $this->testClient->get(
+            "/apis/default/fhir/Condition/" . $this->conditionUuid
+        );
+        $this->assertEquals(Response::HTTP_OK, $result->getStatusCode());
+
+        $resource = json_decode((string) $result->getBody()->getContents(), true);
+        $this->assertIsArray($resource);
+        $this->assertEquals("Condition", $resource['resourceType'] ?? null);
+        $this->assertEquals($this->conditionUuid, $resource['id'] ?? null);
+
+        // US Core Condition required-ish elements. If the seed data omits any of
+        // these, tighten the fixture rather than loosening the assert.
+        $this->assertArrayHasKey("clinicalStatus", $resource);
+        $this->assertArrayHasKey("category", $resource);
+        $this->assertArrayHasKey("code", $resource);
+        $this->assertArrayHasKey("subject", $resource);
+        $this->assertIsArray($resource['subject']);
+        $this->assertArrayHasKey('reference', $resource['subject']);
+        $this->assertIsString($resource['subject']['reference']);
+        $this->assertStringContainsString(
+            $this->patientUuid,
+            $resource['subject']['reference']
+        );
+        /** @var array<string, mixed> $resource */
+        $this->assertConditionCodeText($resource);
+    }
+
+    // ---------------------------------------------------------------------
+    // Empty result (this is the one people get wrong: it's 200, not 404)
+    // ---------------------------------------------------------------------
+
+    /**
+     * A search that matches nothing should return an empty Bundle
+     * with HTTP 200 -- NOT a 404.
+     */
+    public function testSearchWithNoMatchReturnsEmptyBundle(): void
+    {
+        // A well-formed uuid that will not exist in the DB.
+        $randomUuid = "00000000-0000-0000-0000-000000000000";
+
+        $result = $this->testClient->get(
+            "/apis/default/fhir/Condition",
+            ['_id' => $randomUuid]
+        );
+        $this->assertEquals(Response::HTTP_OK, $result->getStatusCode());
+
+        $bundle = json_decode((string) $result->getBody()->getContents(), true);
+        $this->assertIsArray($bundle);
+        $this->assertEquals("Bundle", $bundle['resourceType'] ?? null);
+        $this->assertEquals("collection", $bundle['type'] ?? null);
+        $this->assertEquals(0, $bundle['total'] ?? null, "No-match search should have total 0");
+        $this->assertEmpty($bundle['entry'] ?? [], "No-match search should have no entries");
+    }
+
+    // ---------------------------------------------------------------------
+    // Error paths: read one
+    // ---------------------------------------------------------------------
+
+    /**
+     * A malformed uuid should produce HTTP 400 with validationErrors (not OperationOutcome).
+     */
+    public function testGetOneMalformedUuidReturnsBadRequest(): void
+    {
+        $result = $this->testClient->get("/apis/default/fhir/Condition/not-a-uuid");
+
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $result->getStatusCode());
+
+        $body = json_decode((string) $result->getBody()->getContents(), true);
+        $this->assertIsArray($body);
+        $this->assertArrayHasKey("validationErrors", $body);
+    }
+
+    /**
+     * A well-formed but non-existent uuid should return 404 with an empty JSON array (not OperationOutcome).
+     */
+    public function testGetOneNonexistentUuidReturnsNotFound(): void
+    {
+        $absentUuid = "11111111-1111-1111-1111-111111111111";
+
+        $result = $this->testClient->get("/apis/default/fhir/Condition/" . $absentUuid);
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $result->getStatusCode());
+
+        $body = json_decode((string) $result->getBody()->getContents(), true);
+        $this->assertIsArray($body);
+        $this->assertEmpty($body);
+    }
+
+    // ---------------------------------------------------------------------
+    // Authorization
+    // ---------------------------------------------------------------------
+
+    /**
+     * Search without a valid token should be rejected with 401 and an OAuth denial body.
+     */
+    public function testSearchUnauthorizedReturns401(): void
+    {
+        $unauthClient = new ApiTestClient(
+            getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost",
+            false
+        );
+        // Deliberately do NOT call setAuthToken().
+        $result = $unauthClient->get("/apis/default/fhir/Condition");
+        $this->assertOAuthUnauthorizedResponse($result);
+    }
+
+    /**
+     * Read-one without a valid token should be rejected with 401 and an OAuth denial body.
+     */
+    public function testGetOneUnauthorizedReturns401(): void
+    {
+        $unauthClient = new ApiTestClient(
+            getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost",
+            false
+        );
+        $result = $unauthClient->get("/apis/default/fhir/Condition/" . $this->conditionUuid);
+        $this->assertOAuthUnauthorizedResponse($result);
+    }
+
+    private function assertOAuthUnauthorizedResponse(ResponseInterface $response): void
+    {
+        $this->assertEquals(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody()->getContents(), true);
+        $this->assertIsArray($body);
+        $this->assertArrayHasKey('error', $body);
+        $this->assertArrayHasKey('message', $body);
+        $this->assertIsString($body['message']);
+        $this->assertStringContainsString(
+            'denied the request',
+            $body['message'],
+            '401 should be an OAuth authorization denial, not a routing or server error'
+        );
+        $this->assertArrayNotHasKey('resourceType', $body, '401 body should not be a FHIR resource');
+    }
+
+    /**
+     * Assert code on master: problem-list items without parsed diagnosis use title as code.text.
+     *
+     * @param array<string, mixed> $resource
+     */
+    private function assertConditionCodeText(array $resource): void
+    {
+        $this->assertArrayHasKey('code', $resource);
+        $this->assertIsArray($resource['code']);
+        $this->assertEquals('Essential hypertension', $resource['code']['text'] ?? null);
+    }
+}

--- a/tests/Tests/Api/ConditionFhirApiTest.php
+++ b/tests/Tests/Api/ConditionFhirApiTest.php
@@ -143,7 +143,6 @@ class ConditionFhirApiTest extends TestCase
             $resource['subject']['reference'],
             "Condition subject should reference the seeded patient"
         );
-        /** @var array<string, mixed> $resource */
         $this->assertConditionCodeText($resource);
     }
 
@@ -180,7 +179,6 @@ class ConditionFhirApiTest extends TestCase
             $this->patientUuid,
             $resource['subject']['reference']
         );
-        /** @var array<string, mixed> $resource */
         $this->assertConditionCodeText($resource);
     }
 
@@ -207,7 +205,7 @@ class ConditionFhirApiTest extends TestCase
         $this->assertIsArray($bundle);
         $this->assertEquals("Bundle", $bundle['resourceType'] ?? null);
         $this->assertEquals("collection", $bundle['type'] ?? null);
-        $this->assertEquals(0, $bundle['total'] ?? null, "No-match search should have total 0");
+        $this->assertSame(0, $bundle['total'] ?? null, "No-match search should have total 0");
         $this->assertEmpty($bundle['entry'] ?? [], "No-match search should have no entries");
     }
 
@@ -295,7 +293,7 @@ class ConditionFhirApiTest extends TestCase
     /**
      * Assert code on master: problem-list items without parsed diagnosis use title as code.text.
      *
-     * @param array<string, mixed> $resource
+     * @param array<array-key, mixed> $resource
      */
     private function assertConditionCodeText(array $resource): void
     {

--- a/tests/Tests/Fixtures/FixtureManager.php
+++ b/tests/Tests/Fixtures/FixtureManager.php
@@ -38,6 +38,8 @@ class FixtureManager
      */
     private $fhirAllergyIntoleranceFixtures;
 
+    private ?ConditionFixtureManager $conditionFixtureManager = null;
+
     public function __construct()
     {
         $this->addressFixtures = $this->loadPhpFile("addresses.php");
@@ -272,6 +274,37 @@ class FixtureManager
             QueryUtils::sqlStatementThrowException($sqlStatement, $pids);
         }
         $this->removePatientFixtures();
+    }
+
+    /**
+     * Seeds a patient and medical-problem condition for FHIR Condition API tests.
+     *
+     * @return array{patientUuid: string, conditionUuid: string}
+     */
+    public function installConditionFixtures(): array
+    {
+        $this->conditionFixtureManager = new ConditionFixtureManager();
+        $patient = $this->conditionFixtureManager->createTestPatient();
+        $condition = $this->conditionFixtureManager->createTestCondition($patient, [
+            'title' => 'Essential hypertension',
+        ]);
+
+        $patientUuid = $patient['uuid'] ?? null;
+        $conditionUuid = $condition['lists_uuid'] ?? null;
+        if (!is_string($patientUuid) || !is_string($conditionUuid)) {
+            throw new \RuntimeException('installConditionFixtures expected string UUIDs from fixtures');
+        }
+
+        return [
+            'patientUuid' => $patientUuid,
+            'conditionUuid' => $conditionUuid,
+        ];
+    }
+
+    public function removeConditionFixtures(): void
+    {
+        $this->conditionFixtureManager?->removeFixtures();
+        $this->conditionFixtureManager = null;
     }
 
     /**


### PR DESCRIPTION
Generated-By: Cursor
Assisted-By: Claude
Assisted-By: Codex

<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
Adds API-level test coverage for the two FHIR Condition read routes (`GET /fhir/Condition` and `GET /fhir/Condition/:uuid`), closing two entries from the coverage inventory in #12343. Tests drive the real HTTP path through `ApiTestClient` (real OAuth token, real request/response), not in-process controller calls. Test-only — no changes to production code under `src/`.

Refs #12343

#### Changes proposed in this pull request:
**`tests/Tests/Api/ConditionFhirApiTest.php`** (new) — eight tests:

- Search returns a collection bundle
- Search by `_id` returns the seeded condition (exactly one entry)
- Read-one returns a Condition resource with the US Core elements present on this path (clinicalStatus, category, code, subject)
- Search with no match returns an empty bundle (HTTP 200, not 404)
- Read-one with a malformed uuid returns 400
- Read-one with a well-formed but non-existent uuid returns 404
- Unauthenticated search returns 401
- Unauthenticated read-one returns 401

**`tests/Tests/Fixtures/FixtureManager.php`**

- `installConditionFixtures()` — seeds a patient + a problem-list condition and returns `{ patientUuid, conditionUuid }`.
- `removeConditionFixtures()` — cleans up the seeded rows.

Condition has no POST route, so data is seeded through the fixture layer rather than by POSTing a resource (the pattern `PatientFhirApiTest` uses).

**Notes on current OpenEMR behavior** — these tests assert current behavior, not strict FHIR conventions:

- Search bundles use `type: "collection"` (`FhirResourcesService::createBundle`), not FHIR's usual `"searchset"`.
- Errors from `FhirGenericRestController` / `RestControllerHelper::handleFhirProcessingResult` return `validationErrors` (400) or `[]` (404), not `OperationOutcome`.
- Problem-list Conditions currently surface the diagnosis as `code.text` only; no structured `code.coding` is emitted even when `lists.diagnosis` holds an ICD-10 code. The read-one test asserts `code.text`. This coding gap is raised separately for maintainer input (see #12343) and could be covered by a follow-up assertion.

Pinning real behavior is intentional for regression coverage.

**Testing**

- Full `Api` suite; all 8 `ConditionFhirApiTest` cases pass against unmodified production code.
- Run twice consecutively — fixture teardown is idempotent (no leftover seeded rows between runs).
- 401 responses confirmed to be OAuth resource-server denials.
- Both changed files pass PHPStan level 10 (targeted analysis).

#### Was an AI assistant used? Yes

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
