### PR TITLE
feat(portal): Add view only mode to portal appointments

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -3169,6 +3169,13 @@ $GLOBALS_METADATA = [
             xl('Allow Patient to make and view appointments online.')
         ],
 
+        'view_only_portal_appointments' => [
+            xl('Allow Online Appointments View Only.'),
+            'bool',                           // data type
+            '0',
+            xl('Allow Patient only to view appointments online. Overrides the above setting to allow only view of appointments.')
+        ],
+
         'allow_custom_report' => [
             xl('Allow Online Custom Content Report'),
             'bool',                           // data type

--- a/portal/home.php
+++ b/portal/home.php
@@ -361,6 +361,7 @@ try {
         'newcnt' => $newcnt,
         'menuLogo' => $logoService->getLogo('portal/menu/primary'),
         'allow_portal_appointments' => $globalsBag->getBoolean('allow_portal_appointments'),
+        'viewOnlyAppointments' => $globalsBag->getBoolean('view_only_portal_appointments'),
         'web_root' => $globalsBag->get('web_root'),
         'payment_gateway' => $globalsBag->get('payment_gateway'),
         'gateway_mode_production' => $globalsBag->getBoolean('gateway_mode_production'),

--- a/portal/patient/scripts/app.js
+++ b/portal/patient/scripts/app.js
@@ -7,11 +7,11 @@
  */
 var app = {
 
-	/** @var landmarks used to screen-scrape the html error output for a friendly message */
-	errorLandmarkStart: '<!-- ERROR ',
-	errorLandmarkEnd: ' /ERROR -->',
+    /** @var landmarks used to screen-scrape the html error output for a friendly message */
+    errorLandmarkStart: '<!-- ERROR ',
+    errorLandmarkEnd: ' /ERROR -->',
 
-	/**
+    /**
      * Display an alert message inside the element with the id containerId
      *
      * @param message
@@ -19,18 +19,18 @@ var app = {
      * @param timeout
      * @param containerId
      */
-	appendAlert: function(message, style, timeout,containerId) {
-	    if (!message) {
-	        return;
+    appendAlert: function(message, style, timeout,containerId) {
+        if (!message) {
+            return;
         }
         if (timeout < 1000) {
             timeout = 15000;
         }
-        if (typeof signerAlertMsg !== 'undefined') {
+        if (typeof asyncAlertMsg !== 'undefined') {
             if (message.includes("Site ID is missing from session data") !== false) {
                 parent.parent.location.replace(top.webroot_url + "/portal/verify_session.php" + '?w&u');
             }
-            signerAlertMsg(message, timeout, style);
+            asyncAlertMsg(message, timeout, style);
         } else {
             alert(message);
         }

--- a/templates/portal/appointment-item.html.twig
+++ b/templates/portal/appointment-item.html.twig
@@ -1,9 +1,9 @@
 <div class="card m-0 col-12 col-md-6 col-lg-4">
     <div class="card-header">
-        {% if past == false %}
-        <a href="#" onclick="editAppointment({{ appt.mode | attr_js }},{{ appt.pc_eid | attr_js }})" title="{{ appt.etitle | attr }}">
-            <i class='float-right fa fa-edit fa-lg {% if appt.pc_recurrtype > 0 %} text-danger {% else %} text-success {% endif %} bg-light font-weight-light'></i>
-        </a>
+        {% if past == false and viewOnlyAppointments == false %}
+            <a href="#" onclick="editAppointment({{ appt.mode | attr_js }},{{ appt.pc_eid | attr_js }})" title="{{ appt.etitle | attr }}">
+                <i class='float-right fa fa-edit fa-lg {% if appt.pc_recurrtype > 0 %} text-danger {% else %} text-success {% endif %} bg-light font-weight-light'></i>
+            </a>
         {% endif %}
     </div>
     <div class="card-body p-0 font-weight-bold">

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -171,7 +171,6 @@
             }
 
             function resetLogOutTimer() {
-                $('#alert_box').remove(); // reset alert if set
                 resetWarnTimer();
                 clearTimeout(timeOut);
                 timeOut = setTimeout(logout, time);

--- a/templates/portal/partial/cards/_appointment_card.html.twig
+++ b/templates/portal/partial/cards/_appointment_card.html.twig
@@ -11,9 +11,7 @@
             };
         } else if (mode === 'recurring') {
             let msg = {{ 'A Recurring Appointment. Please contact your appointment desk for any changes.' | xlj }};
-            {# TODO: look at refactoring signerAlertMsg into a portalAlertMsg function, would better fit
-                Single Responsibility Principle to use that instead of the digital signature api here to show alert messages #}
-            signerAlertMsg(msg, 8000);
+            asyncAlertMsg(msg, 8000);
             return false;
         } else {
             title = {{ 'Edit Appointment' | xlj }};
@@ -74,9 +72,11 @@
                 </div>
             {% endif %}
         </div>
-        <div class="mt-3">
-            <a class='btn btn-primary btn-block' href='#' onclick="editAppointment('add',{{ patientID | attr_js }})">{{ 'Schedule A New Appointment' | xlt }}</a>
-        </div>
+        {% if viewOnlyAppointments == false %}
+            <div class="mt-3">
+                <a class='btn btn-primary btn-block' href='#' onclick="editAppointment('add',{{ patientID | attr_js }})">{{ 'Schedule A New Appointment' | xlt }}</a>
+            </div>
+        {% endif %}
     </div>
     <div class="container-fluid">
         <h3 class="text-center">{{ 'Past Appointments' | xlt }}</h3>


### PR DESCRIPTION
Cherry-pick of #12820 to `rel-820`.

Backports the portal appointments view-only mode that landed on master in 051f0945f1.

See #12820 for the full description. Cherry-pick applied clean; patch-id verified byte-equal to the master merge before push.

## Test plan

- [ ] Same acceptance path as #12820.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)