### PR TITLE
fix(sql-upgrade): skip audit logging on the status poll endpoint

### DIFF
--- a/library/ajax/sql_server_status.php
+++ b/library/ajax/sql_server_status.php
@@ -19,6 +19,13 @@ $ignoreAuth = true;
 // to prevent config.php call keys table oops
 $GLOBALS['ongoing_sql_upgrade'] = true;
 $GLOBALS['connection_pooling_off'] = true; // force off database connection pooling
+// Skip HTTP request audit logging on this endpoint. The poll fires 20+ times
+// per second during sql_upgrade; letting each poll write INSERT INTO log +
+// INSERT INTO log_comment_encrypt entries makes those queries show up in
+// subsequent polls' INFORMATION_SCHEMA.PROCESSLIST snapshots, which pollutes
+// the "no DB activity" signal that sql_upgrade.php's fallback termination
+// counter relies on. Health-check requests already use this same flag.
+$skipAuditLog = true;
 require_once(__DIR__ . '/../../interface/globals.php');
 
 use OpenEMR\Common\Csrf\CsrfUtils;


### PR DESCRIPTION
## Summary

Follow-up to #12826. End-to-end reproduction of the polling bug with the initial fix applied revealed the fallback termination counter could never trip — the poll response was never empty because the poll endpoint was generating its own DB activity via audit logging.

## Root cause

The polling endpoint (\`library/ajax/sql_server_status.php\`) runs \`interface/globals.php\` on every request, which writes two audit-log entries per call:
- \`INSERT INTO log (date, event, category, user, groupname, ...)\` — main audit log
- \`INSERT INTO log_comment_encrypt (log_id, encrypt, checksum, ...)\` — audit log encryption

The polling loop fires 20+ times per second during a running \`sql_upgrade\`. Those INSERTs from a previous poll are almost always still in flight (or in the async write path) when the next poll runs its \`SELECT ... FROM INFORMATION_SCHEMA.PROCESSLIST WHERE COMMAND <> 'Sleep' AND DB = ?\`. Result: the poll response is *never* empty. \`emptyPollCount\` in the JS fallback never increments. The fallback never trips. Polling runs forever even though the actual upgrade is done.

Verified via direct MySQL sampling during the reproduction:

```
$ mariadb -uroot -proot openemr -e "SELECT COUNT(*) FROM log WHERE date > NOW() - INTERVAL 1 MINUTE"
2530   # 1265 http-request-update + 1265 security-administration-select
```

That's 42 audit inserts per second, all from the polling endpoint itself.

## Fix

Set \`\$skipAuditLog = true\` before requiring \`globals.php\`. The mechanism already exists in \`interface/globals.php\` line 813-814:

```php
// Skip HTTP request logging if $skipAuditLog is set (e.g., health checks)
if (empty(\$skipAuditLog)) {
    // audit log INSERT happens here
}
```

Existing health-check endpoints already use this flag for the same reason (avoid flooding the audit log with heartbeat noise).

## Measured effect

Reproduction rig, before → after:
- Query rate: **~2,774 queries/second → ~0.7 queries/second** (99.97% drop)
- \`INFORMATION_SCHEMA.PROCESSLIST\` filter (poll's own query): consistently non-empty → consistently empty
- \`sql_upgrade.php\` fallback: never fired → **fires cleanly at 60s of continuous idle**, showing the softened warning as designed
- Verified end-to-end with a fresh 8.0.0 install upgraded to 8.2.0-dev via tarball + flex container

## Impact on the audit log during a normal upgrade

- \`sql_upgrade.php\` run itself is still audited normally — the driver script is not skipped
- Only the per-poll HTTP request audit entries from the polling endpoint are skipped
- Prevents the audit log from being flooded with tens of thousands of poll-endpoint entries per upgrade (~42/sec × upgrade duration = huge audit noise)
- Anyone reviewing an audit trail still sees who ran the upgrade + what actions ran during it, just not thousands of "poll for status" entries between them

## Test plan

- [x] End-to-end reproduction: 8.0.0 tarball → flex container → install wizard → apply this fix → tree swap to 8.2.0-dev candidate → fire sql_upgrade.php → fallback fires at 60s idle as designed
- [ ] Standard CI (phpstan, phpcs, rector, etc.) on the small edit
- [ ] rel-820 backport for 8.2.0 ship (companion PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)