### PR TITLE
fix(sql-upgrade): skip audit logging on the status poll endpoint (rel-820 backport for 8.2.0)

### DIFF
--- a/library/ajax/sql_server_status.php
+++ b/library/ajax/sql_server_status.php
@@ -19,6 +19,13 @@ $ignoreAuth = true;
 // to prevent config.php call keys table oops
 $GLOBALS['ongoing_sql_upgrade'] = true;
 $GLOBALS['connection_pooling_off'] = true; // force off database connection pooling
+// Skip HTTP request audit logging on this endpoint. The poll fires 20+ times
+// per second during sql_upgrade; letting each poll write INSERT INTO log +
+// INSERT INTO log_comment_encrypt entries makes those queries show up in
+// subsequent polls' INFORMATION_SCHEMA.PROCESSLIST snapshots, which pollutes
+// the "no DB activity" signal that sql_upgrade.php's fallback termination
+// counter relies on. Health-check requests already use this same flag.
+$skipAuditLog = true;
 require_once(__DIR__ . '/../../interface/globals.php');
 
 use OpenEMR\Common\Csrf\CsrfUtils;


### PR DESCRIPTION
## Summary

rel-820 backport of #12831 for 8.2.0 tonight.

Same patch-id as master: \`abe4d714c43ba25d46ef71e8403a3de811e32f3e\`.

Follow-up to the initial polling-termination fix (#12826/#12827). End-to-end reproduction on the merged code revealed the fallback counter could never trip because the poll endpoint was generating its own DB activity via audit logging. See #12831 for full root cause + measured effect.

## Why in 8.2.0

Without this follow-up, the previous fix's fallback path is inert. Users hitting the tarball-based upgrade path on a fast install would still see the "polling never stops" behavior — the primary path's sleep(5) delivery margin helps but doesn't eliminate the bug entirely. This closes the gap.

## Test plan

- [x] End-to-end reproduction on rel-820 tree + this fix applied — fallback fires cleanly at 60s of idle
- [ ] CI standard suite on the small edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)