### PR TITLE
fix(release): use docker/* glob so docker/production/ actually ships in tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 .github/                       export-ignore
 .phpstan/                      export-ignore
 ci/                            export-ignore
-docker/                        export-ignore
+docker/*                       export-ignore
 # Selective carve-out: docker/production/ ships as a reference-production
 # compose template so tarball users have a blessed starting point for a
 # self-hosted Docker deployment (its image ref gets pinned by the release-


### PR DESCRIPTION
## Summary

Follow-up to #12776/#12777, which added a \`docker/production/\` carve-out in \`.gitattributes\` intended to include the reference production compose template in the release tarball. End-to-end pre-ship testing of 8.2.0 revealed the carve-out did not actually work — \`git archive\` produced zero entries under \`docker/\` despite the \`-export-ignore\` rules for \`docker/production/\`.

Closes #12833.

## Root cause

\`git archive\` behavior: when a parent directory is marked \`export-ignore\` via a directory rule (\`docker/  export-ignore\`), \`git archive\` prunes the whole subtree and never descends into it, so the negative carve-out rules for \`docker/production/\` never get evaluated.

## Fix — one character

Change \`docker/  export-ignore\` to \`docker/*  export-ignore\`. The glob marks each immediate entry under \`docker/\` individually (files + subdirectory entries), which lets \`git archive\` evaluate each entry's attributes when walking. The negative carve-out for \`docker/production/\` is honored under the glob form.

The two negative carve-out lines stay identical:
\`\`\`
docker/production/            -export-ignore
docker/production/**          -export-ignore
\`\`\`

## Empirical verification

**Small isolated test** — fresh git repo with \`docker/production/keep.md\`, \`docker/binary/skip.md\`, \`docker/flex/skip.md\`, \`docker/README.md\`, and the fixed \`.gitattributes\`:

\`\`\`
$ git archive HEAD --format=tar | tar -tf -
docker/
docker/production/
docker/production/keep.md    ← included
.gitattributes
\`\`\`

**On this PR's actual commit against openemr's rel-820 tree** — verified locally:

\`\`\`
$ git archive HEAD --format=tar | tar -tf - | grep ^docker
docker-version
docker/
docker/production/
docker/production/README.md
docker/production/docker-compose.yml
\`\`\`

## Future-proof property

\`docker/*  export-ignore\` catches any new file or subdirectory added at \`docker/\` top level — defaults to excluded. Any future carve-out still requires an explicit \`-export-ignore\` rule matching the existing \`docker/production/\` pattern.

## Test plan

- [x] Empirical git archive test (see above)
- [x] Fresh rel-820 checkout → git archive → confirms docker/production/ files present
- [ ] rel-820 backport companion PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)