### PR TITLE
fix(release): use docker/* glob so docker/production/ actually ships in tarball (rel-820 backport for 8.2.0)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 .github/                       export-ignore
 .phpstan/                      export-ignore
 ci/                            export-ignore
-docker/                        export-ignore
+docker/*                       export-ignore
 # Selective carve-out: docker/production/ ships as a reference-production
 # compose template so tarball users have a blessed starting point for a
 # self-hosted Docker deployment (its image ref gets pinned by the release-


### PR DESCRIPTION
## Summary

rel-820 backport of #12834 for 8.2.0.

Same patch-id as master: \`8600c9c31ce0eb25254ecd99ec9cf8e970c34612\`.

One-character diff (\`docker/\` → \`docker/*\`) so that the \`docker/production/\` reference compose template from #12776/#12777 actually ships in the 8.2.0 tarball. Full root cause + empirical verification in #12834. Closes #12833.

🤖 Generated with [Claude Code](https://claude.com/claude-code)