### PR TITLE
fix(translation): Ensure xl() doesn't leave hints when translation is disabled

### DIFF
--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -2263,7 +2263,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../library/translation.inc.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -1852,11 +1852,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/sql.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function xl\\(\\) should return string but returns string\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/translation.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function getUserIDInfo\\(\\) should return array\\|false\\|null but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/user.inc.php',

--- a/library/translation.inc.php
+++ b/library/translation.inc.php
@@ -38,8 +38,11 @@ if (!(function_exists('xl'))) {
      */
     function xl($constant)
     {
+        // Translation engine disabled: skip the cache/DB lookup for performance,
+        // but still run xlCleanup() so {{context}} markers (and newline/quote
+        // normalization) are stripped rather than leaking to the UI.
         if (OEGlobalsBag::getInstance()->getBoolean('disable_translation') || !empty(OEGlobalsBag::getInstance()->get('temp_skip_translations'))) {
-            return $constant;
+            return xlCleanup($constant);
         }
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
         $language_choice = $session->get('language_choice');
@@ -80,19 +83,31 @@ if (!(function_exists('xl'))) {
         if ($string == '') {
             $string = "$constant";
         }
-        // remove dangerous characters and remove comments
+
+        return xlCleanup((string) $string);
+    }
+}
+
+if (!(function_exists('xlCleanup'))) {
+    /**
+     * Normalize a translated (or untranslated) string for display: collapse
+     * newlines to spaces, drop carriage returns, and strip {{context}}
+     * disambiguation markers. Unless translate_no_safe_apostrophe is set, quotes
+     * and apostrophes are also converted to backticks. Shared by both the
+     * translated and the disable_translation paths of xl().
+     */
+    function xlCleanup(string $string): string
+    {
         if (OEGlobalsBag::getInstance()->getBoolean('translate_no_safe_apostrophe')) {
             $patterns =  ['/\n/','/\r/','/\{\{.*\}\}/'];
             $replace =  [' ','',''];
-            $string = preg_replace($patterns, $replace, (string) $string);
         } else {
             // convert apostrophes and quotes to safe apostrophe
             $patterns =  ['/\n/','/\r/','/"/',"/'/",'/\{\{.*\}\}/'];
             $replace =  [' ','','`','`',''];
-            $string = preg_replace($patterns, $replace, (string) $string);
         }
 
-        return $string;
+        return preg_replace($patterns, $replace, $string) ?? $string;
     }
 }
 

--- a/tests/Tests/Isolated/library/SmartyXlPluginsTest.php
+++ b/tests/Tests/Isolated/library/SmartyXlPluginsTest.php
@@ -15,11 +15,13 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\library;
 
+use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
 
 #[Small]
+#[BackupGlobals(true)]
 class SmartyXlPluginsTest extends TestCase
 {
     private const PLUGINS_DIR = __DIR__ . '/../../../../library/smarty/plugins';
@@ -28,13 +30,11 @@ class SmartyXlPluginsTest extends TestCase
     {
         // Make xl() a pass-through so we test the escaping behavior of the
         // Smarty plugins in isolation, without touching the DB or the
-        // translation cache.
+        // translation cache. translate_no_safe_apostrophe keeps quotes intact
+        // so xla()'s ENT_QUOTES escaping still has a quote to act on; without
+        // it xl() rewrites quotes to backticks before the plugin sees them.
         $GLOBALS['disable_translation'] = true;
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['disable_translation']);
+        $GLOBALS['translate_no_safe_apostrophe'] = true;
     }
 
     private function loadPlugin(string $file): void

--- a/tests/Tests/Isolated/library/TranslationDisabledPathTest.php
+++ b/tests/Tests/Isolated/library/TranslationDisabledPathTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * TranslationDisabledPathTest
+ *
+ * Tests xl() when disable_translation is enabled.
+ *
+ * The disable_translation path should still run xlCleanup() so that
+ * {{context}} markers, newlines, carriage returns, and unsafe quotes
+ * are stripped/normalized — matching the behavior of the enabled path.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\library;
+
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+#[Small]
+#[BackupGlobals(true)]
+class TranslationDisabledPathTest extends TestCase
+{
+    /**
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function contextMarkerProvider(): array
+    {
+        return [
+            'day-of-week header' => ['S{{Sunday}}', 'S'],
+            'day-of-week header Monday' => ['M{{Monday}}', 'M'],
+            'button label' => ['Find Available{{Provider}}', 'Find Available'],
+            'tab label' => ['Dashboard{{patient file}}', 'Dashboard'],
+            'dataTables footer' => ['Showing 1 to{{range}}', 'Showing 1 to'],
+        ];
+    }
+
+    #[DataProvider('contextMarkerProvider')]
+    public function testXlStripsContextMarkersWhenTranslationDisabled(
+        string $input,
+        string $expected
+    ): void {
+        // With disable_translation = true, xl() should skip the cache/DB lookup
+        // but still call xlCleanup(), which strips {{…}} markers.
+        $GLOBALS['disable_translation'] = true;
+
+        $this->assertSame($expected, xl($input));
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function quoteNormalizationProvider(): array
+    {
+        return [
+            'double quote' => ['He said "hello"', 'He said `hello`'],
+            'apostrophe' => ['It\'s working', 'It`s working'],
+            'both quotes and apostrophe' => ['He said "it\'s fine"', 'He said `it`s fine`'],
+        ];
+    }
+
+    #[DataProvider('quoteNormalizationProvider')]
+    public function testXlNormalizesQuotesWhenTranslationDisabled(
+        string $input,
+        string $expected
+    ): void {
+        // With translate_no_safe_apostrophe = false (default), xl() converts
+        // double quotes and apostrophes to safe backticks.
+        $GLOBALS['disable_translation'] = true;
+        // Explicitly ensure translate_no_safe_apostrophe is NOT set so the
+        // "convert to safe apostrophe" branch runs.
+        unset($GLOBALS['translate_no_safe_apostrophe']);
+
+        $this->assertSame($expected, xl($input));
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function noSafeApostropheProvider(): array
+    {
+        return [
+            'double quote preserved' => ['He said "hello"', 'He said "hello"'],
+            'apostrophe preserved' => ['It\'s working', 'It\'s working'],
+            'both preserved' => ['He said "it\'s fine"', 'He said "it\'s fine"'],
+        ];
+    }
+
+    #[DataProvider('noSafeApostropheProvider')]
+    public function testXlPreservesQuotesWhenNoSafeApostrophe(
+        string $input,
+        string $expected
+    ): void {
+        // With translate_no_safe_apostrophe = true, xl() does NOT convert
+        // quotes/apostrophes — they pass through unchanged.
+        $GLOBALS['disable_translation'] = true;
+        $GLOBALS['translate_no_safe_apostrophe'] = true;
+
+        $this->assertSame($expected, xl($input));
+    }
+
+    public function testXlStripsNewlinesAndCRWhenTranslationDisabled(): void
+    {
+        $GLOBALS['disable_translation'] = true;
+        unset($GLOBALS['translate_no_safe_apostrophe']);
+
+        $input = "line1\r\nline2\nline3";
+        $this->assertSame('line1 line2 line3', xl($input));
+    }
+}

--- a/tests/Tests/Isolated/library/TranslationDisabledPathTest.php
+++ b/tests/Tests/Isolated/library/TranslationDisabledPathTest.php
@@ -54,6 +54,7 @@ class TranslationDisabledPathTest extends TestCase
         // but still call xlCleanup(), which strips {{…}} markers.
         $GLOBALS['disable_translation'] = true;
 
+        // @phpstan-ignore argument.type (literal-string rule not relevant here)
         $this->assertSame($expected, xl($input));
     }
 
@@ -83,6 +84,7 @@ class TranslationDisabledPathTest extends TestCase
         // "convert to safe apostrophe" branch runs.
         unset($GLOBALS['translate_no_safe_apostrophe']);
 
+        // @phpstan-ignore argument.type (literal-string rule not relevant here)
         $this->assertSame($expected, xl($input));
     }
 
@@ -110,6 +112,7 @@ class TranslationDisabledPathTest extends TestCase
         $GLOBALS['disable_translation'] = true;
         $GLOBALS['translate_no_safe_apostrophe'] = true;
 
+        // @phpstan-ignore argument.type (literal-string rule not relevant here)
         $this->assertSame($expected, xl($input));
     }
 


### PR DESCRIPTION
#### Short description of what this changes or resolves:

If translation is turned off completely, some of the translation hint markers are left in place verbatim and render to end-users:

<img width="620" height="262" alt="Screenshot 2026-07-08 at 10 39 10 AM" src="https://github.com/user-attachments/assets/321c0a8a-f64b-43cc-9d2f-292bc1b67699" />

#### Changes proposed in this pull request:

Extracts the cleanup path that strips this data to its own function (a cheap regex) and calls it on the short-circuit path. This ensures that it still cheap - it won't hit the DB, warm the cache, etc.

<img width="608" height="238" alt="Screenshot 2026-07-08 at 10 39 24 AM" src="https://github.com/user-attachments/assets/2f863e7b-0ee4-4a22-8b0b-f4e813db0910" />

Tests added as well (some from me, some from @kojiromike)

#### Was an AI assistant used? Yes / No
Yes