### PR TITLE
feat(cli): add list and discover actions to zfc-module CLI

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -5137,16 +5137,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Immunization/src/Immunization/Model/ImmunizationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between "\\\\n\\-\\-\\- Run command \\["\\|"\\\\r\\\\n\\-\\-\\- Run command \\[" and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'module \\[\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'pre\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
@@ -5168,7 +5158,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 40,
+    'count' => 39,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1428,7 +1428,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 11,
+    'count' => 9,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
 ];
 $ignoreErrors[] = [
@@ -3600,11 +3600,6 @@ $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Command/SymfonyCommandRunner.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Common/Command/ZfcModule.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',

--- a/.phpstan/baseline/method.notFound.php
+++ b/.phpstan/baseline/method.notFound.php
@@ -158,7 +158,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to an undefined method Laminas\\\\Stdlib\\\\RequestInterface\\:\\:getPost\\(\\)\\.$#',
-    'count' => 24,
+    'count' => 16,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -11387,16 +11387,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method Installer\\\\Controller\\\\InstallerController\\:\\:commandInstallModuleAction\\(\\) has parameter \\$moduleAction with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method Installer\\\\Controller\\\\InstallerController\\:\\:commandInstallModuleAction\\(\\) has parameter \\$moduleName with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method Installer\\\\Controller\\\\InstallerController\\:\\:getFilesForUpgrade\\(\\) has parameter \\$modDirectory with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -11377,21 +11377,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Immunization/src/Immunization/Model/ImmunizationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method Installer\\\\Controller\\\\InstallerController\\:\\:DisableModule\\(\\) has parameter \\$modId with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method Installer\\\\Controller\\\\InstallerController\\:\\:EnableModule\\(\\) has parameter \\$modId with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method Installer\\\\Controller\\\\InstallerController\\:\\:InstallModule\\(\\) has parameter \\$modId with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method Installer\\\\Controller\\\\InstallerController\\:\\:InstallModule\\(\\) has parameter \\$mod_enc_menu with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -6577,11 +6577,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/Module.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method Installer\\\\Controller\\\\InstallerController\\:\\:commandInstallModuleAction\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method Installer\\\\Model\\\\InstModule\\:\\:exchangeArray\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModule.php',

--- a/.phpstan/baseline/parameter.notFound.php
+++ b/.phpstan/baseline/parameter.notFound.php
@@ -97,11 +97,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^PHPDoc tag @param references unknown parameter\\: \\$dir$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^PHPDoc tag @param references unknown parameter\\: \\$mod$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModuleTable.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -1192,11 +1192,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method Installer\\\\Controller\\\\InstallerController\\:\\:getModuleId\\(\\) should return bool but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method Installer\\\\Controller\\\\InstallerController\\:\\:upgradeAclFromVersion\\(\\) should return int\\|string but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php',

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -943,7 +943,7 @@ class InstallerController extends AbstractActionController
             $mod = new InstModule();
             $mod->exchangeArray($dataArray);
             $mod = $this->makeButtonForSqlAction($mod);
-            $mod = $this->makeButtonForAClAction($mod);
+            $mod = $this->makeButtonForACLAction($mod);
             $modules[] = $mod;
         }
         return $modules;

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -660,22 +660,19 @@ class InstallerController extends AbstractActionController
         return $mod;
     }
 
-    /**
-     * @param $moduleName
-     * @return bool
-     */
-    public function getModuleId($moduleName): bool
+    public function getModuleId($moduleName): ?int
     {
         if (empty($moduleName)) {
-            return false;
+            return null;
         }
         $allModules = $this->InstallerTable->allModules();
         foreach ($allModules as $module) {
             if ($module["mod_directory"] === $moduleName) {
-                return $module["mod_id"];
+                $modId = $module["mod_id"];
+                return is_numeric($modId) ? (int) $modId : null;
             }
         }
-        return false;
+        return null;
     }
 
     /**

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -928,6 +928,28 @@ class InstallerController extends AbstractActionController
     }
 
     /**
+     * Build the list of registered modules with their status, mirroring what
+     * the Manage Modules UI computes (sql_action / acl_action indicate whether
+     * a SQL or ACL install/upgrade is pending). Read-only: unlike indexAction()
+     * this does not scan/register new on-disk modules -- run the discover action
+     * for that.
+     *
+     * @return InstModule[]
+     */
+    public function commandListModulesAction(): array
+    {
+        $modules = [];
+        foreach ($this->InstallerTable->allModules() as $dataArray) {
+            $mod = new InstModule();
+            $mod->exchangeArray($dataArray);
+            $mod = $this->makeButtonForSqlAction($mod);
+            $mod = $this->makeButtonForAClAction($mod);
+            $modules[] = $mod;
+        }
+        return $modules;
+    }
+
+    /**
      *
      */
     public function commandInstallModuleAction($moduleName, $moduleAction)

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -26,7 +26,6 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\ModulesClassLoader;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\Utils\SQLUpgradeService;
-use RuntimeException;
 
 class InstallerController extends AbstractActionController
 {
@@ -942,63 +941,5 @@ class InstallerController extends AbstractActionController
             $modules[] = $mod;
         }
         return $modules;
-    }
-
-    /**
-     *
-     */
-    public function commandInstallModuleAction($moduleName, $moduleAction)
-    {
-        if (php_sapi_name() !== 'cli') {
-            throw new RuntimeException('You can only use this action from a console!');
-        }
-
-        $moduleId = null;
-        $div = [];
-
-        echo PHP_EOL . '--- Run command [' . $moduleAction . '] in module:  ' . $moduleName . '---' . PHP_EOL;
-        echo 'start process - ' . date('Y-m-d H:i:s') . PHP_EOL;
-
-        if (!empty($moduleAction) && !empty($moduleName) && $moduleName != "all") {
-            $moduleId = $this->getModuleId($moduleName);
-        }
-
-        if ($moduleId !== null) {
-            echo 'module [' . $moduleName . '] was found' . PHP_EOL;
-
-            $msg = "command completed successfully";
-
-            if ($moduleAction === "install_sql") {
-                $this->InstallModuleSQL($moduleId);
-            } elseif ($moduleAction === "upgrade_sql") {
-                $div = $this->UpgradeModuleSQL($moduleId);
-            } elseif ($moduleAction === "install_acl") {
-                $div = $this->InstallModuleACL($moduleId);
-            } elseif ($moduleAction === "upgrade_acl") {
-                $div = $this->UpgradeModuleACL($moduleId);
-            } elseif ($moduleAction === "enable") {
-                $div = $this->EnableModule($moduleId);
-            } elseif ($moduleAction === "disable") {
-                $div = $this->DisableModule($moduleId);
-            } elseif ($moduleAction === "install") {
-                $div = $this->InstallModule($moduleId);
-            } elseif ($moduleAction === "unregister") {
-                $div = $this->UnregisterModule($moduleId);
-            } else {
-                $msg = 'Unsupported command';
-            }
-        } else {
-            $msg = "module Id is null";
-        }
-
-
-        $output = "";
-
-        if (is_array($div)) {
-            $output = implode("<br />\n", $div) . PHP_EOL;
-        }
-        echo $output;
-
-        exit($msg . PHP_EOL);
     }
 }

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -76,9 +76,15 @@ class InstallerController extends AbstractActionController
     }
 
     /**
+     * Scan the zend and custom module directories on disk and register any
+     * module that does not yet have a row in the modules table. Invoked from
+     * indexAction() when the Manage Modules UI loads, and from the console
+     * (openemr:zfc-module --modaction=discover) so new modules can be picked
+     * up without visiting the UI first.
+     *
      * @return void
      */
-    private function scanAndRegisterCustomModules(): void
+    public function scanAndRegisterCustomModules(): void
     {
         $baseModuleDir = OEGlobalsBag::getInstance()->get('baseModDir');
         $customDir = OEGlobalsBag::getInstance()->get('customModDir');

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -194,7 +194,8 @@ class InstallerController extends AbstractActionController
         $request = $this->getRequest();
         $status = $this->listenerObject->z_xlt("Failure");
         if ($request->isPost()) {
-            $modId = $request->getPost('modId') ?? null;
+            $postedModId = $request->getPost('modId');
+            $modId = is_numeric($postedModId) ? (int) $postedModId : 0;
             $registryEntry = $this->InstallerTable->getRegistryEntry($modId, "mod_directory");
             $dirModule = $registryEntry->modDirectory;
             $modType = $registryEntry->type;
@@ -212,37 +213,36 @@ class InstallerController extends AbstractActionController
                 }
             }
             if ($action == "enable") {
-                $status = $this->EnableModule($request->getPost('modId'));
+                $status = $this->EnableModule($modId);
             } elseif ($action == "disable") {
-                $status = $this->DisableModule($request->getPost('modId'));
+                $status = $this->DisableModule($modId);
             } elseif ($action == "install") {
-                $modId = $request->getPost('modId');
                 $mod_enc_menu = $request->getPost('mod_enc_menu');
                 $mod_nick_name = $request->getPost('mod_nick_name');
                 $status = $this->InstallModule($modId, $mod_enc_menu, $mod_nick_name);
             } elseif ($action == 'install_sql') {
-                if ($this->InstallModuleSQL($request->getPost('modId'))) {
+                if ($this->InstallModuleSQL($modId)) {
                     $status = $this->listenerObject->z_xlt("Success");
                 } else {
                     $status = $this->listenerObject->z_xlt("ERROR") . ':' . $this->listenerObject->z_xlt("could not open table") . '.' . $this->listenerObject->z_xlt("sql") . ', ' . $this->listenerObject->z_xlt("broken form") . "?";
                 }
             } elseif ($action == 'upgrade_sql') {
-                $div = $this->UpgradeModuleSQL($request->getPost('modId'));
+                $div = $this->UpgradeModuleSQL($modId);
                 $status = $this->listenerObject->z_xlt("Success");
             } elseif ($action == 'install_acl') {
-                if ($div = $this->InstallModuleACL($request->getPost('modId'))) {
+                if ($div = $this->InstallModuleACL($modId)) {
                     $status = $this->listenerObject->z_xlt("Success");
                 } else {
                     $status = $this->listenerObject->z_xlt("ERROR") . ':' . $this->listenerObject->z_xlt("could not install ACL");
                 }
             } elseif ($action == 'upgrade_acl') {
-                if ($div = $this->UpgradeModuleACL($request->getPost('modId'))) {
+                if ($div = $this->UpgradeModuleACL($modId)) {
                     $status = $this->listenerObject->z_xlt("Success");
                 } else {
                     $status = $this->listenerObject->z_xlt("ERROR") . ':' . $this->listenerObject->z_xlt("could not install ACL");
                 }
             } elseif ($action == "unregister") {
-                $status = $this->UnregisterModule($request->getPost('modId'));
+                $status = $this->UnregisterModule($modId);
             } elseif ($action == "reset_module") {
                 // call listener to reset module to initial state perhaps!
                 $status =  "Success";
@@ -676,10 +676,9 @@ class InstallerController extends AbstractActionController
     }
 
     /**
-     * @param string $modId
      * @return bool
      */
-    public function InstallModuleSQL($modId = '')
+    public function InstallModuleSQL(int $modId)
     {
         $registryEntry = $this->InstallerTable->getRegistryEntry($modId, "mod_directory");
         $dirModule = $registryEntry->modDirectory;
@@ -700,10 +699,9 @@ class InstallerController extends AbstractActionController
     }
 
     /**
-     * @param string $modId
      * @return array
      */
-    public function UpgradeModuleSQL($modId = '')
+    public function UpgradeModuleSQL(int $modId)
     {
         $Module = $this->InstallerTable->getRegistryEntry($modId, "mod_directory");
         $modType = $Module->type;
@@ -771,10 +769,9 @@ class InstallerController extends AbstractActionController
     }
 
     /**
-     * @param string $modId
      * @return bool
      */
-    public function InstallModuleACL($modId = '')
+    public function InstallModuleACL(int $modId)
     {
         $Module = $this->InstallerTable->getRegistryEntry($modId, "mod_directory");
         $modDir = OEGlobalsBag::getInstance()->getSrcDir() . "/../" . OEGlobalsBag::getInstance()->get('baseModDir') . "zend_modules/module/" . $Module->modDirectory;
@@ -798,10 +795,9 @@ class InstallerController extends AbstractActionController
     /**
      * Function to Enable Module
      *
-     * @param string $dir Location of the php file which calling functions to add sections,aco etc.
      * @return bool
      */
-    public function EnableModule($modId = '')
+    public function EnableModule(int $modId)
     {
         $resp = $this->InstallerTable->updateRegistered($modId, "mod_active=1");
         if ($resp['status'] == 'failure' && $resp['code'] == '200') {
@@ -815,10 +811,9 @@ class InstallerController extends AbstractActionController
     /**
      * Function to Disable Module
      *
-     * @param string $dir Location of the php file which calling functions to add sections,aco etc.
      * @return bool
      */
-    public function DisableModule($modId = '')
+    public function DisableModule(int $modId)
     {
         $resp = $this->InstallerTable->updateRegistered($modId, "mod_active=0");
         if ($resp['status'] == 'failure' && $resp['code'] == '200') {
@@ -839,10 +834,9 @@ class InstallerController extends AbstractActionController
     /**
      * Function to Install Module
      *
-     * @param string $dir Location of the php file which calling functions to add sections,aco etc.
      * @return bool
      */
-    public function InstallModule($modId = '', $mod_enc_menu = '', $mod_nick_name = '')
+    public function InstallModule(int $modId, $mod_enc_menu = '', $mod_nick_name = '')
     {
         $registryEntry = $this->InstallerTable->getRegistryEntry($modId, "mod_directory");
         $modType = $registryEntry->type;
@@ -879,10 +873,9 @@ class InstallerController extends AbstractActionController
     /**
      * Function to Unregister Module
      *
-     * @param string $modId
      * @return bool
      */
-    public function UnregisterModule($modId = ''): bool|string
+    public function UnregisterModule(int $modId): bool|string
     {
         $resp = $this->InstallerTable->unRegister($modId);
         if ($resp == 'failure') {
@@ -896,10 +889,9 @@ class InstallerController extends AbstractActionController
 
 
     /**
-     * @param string $modId
      * @return array|bool
      */
-    public function UpgradeModuleACL($modId = '')
+    public function UpgradeModuleACL(int $modId)
     {
         $Module = $this->InstallerTable->getRegistryEntry($modId, "mod_directory");
         $modDir = OEGlobalsBag::getInstance()->getSrcDir() . "/../" . OEGlobalsBag::getInstance()->get('baseModDir') . "zend_modules/module/" . $Module->modDirectory;

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -82,9 +82,9 @@ class InstallerController extends AbstractActionController
      * (openemr:zfc-module --modaction=discover) so new modules can be picked
      * up without visiting the UI first.
      *
-     * @return void
+     * @return string[] Directory names of modules newly registered by this scan
      */
-    public function scanAndRegisterCustomModules(): void
+    public function scanAndRegisterCustomModules(): array
     {
         $baseModuleDir = OEGlobalsBag::getInstance()->get('baseModDir');
         $customDir = OEGlobalsBag::getInstance()->get('customModDir');
@@ -132,14 +132,20 @@ class InstallerController extends AbstractActionController
                 }
             }
         }
+        $registered = [];
         foreach ($inDirLaminas as $file_name) {
             $rel_path = $file_name . "/index.php";
-            $status = $this->InstallerTable->register($file_name, $rel_path, 0, $zendModDir);
+            if ($this->InstallerTable->register($file_name, $rel_path, 0, $zendModDir)) {
+                $registered[] = $file_name;
+            }
         }
         foreach ($inDirCustom as $file_name) {
             $rel_path = $file_name . "/index.php";
-            $status = $this->InstallerTable->register($file_name, $rel_path);
+            if ($this->InstallerTable->register($file_name, $rel_path)) {
+                $registered[] = $file_name;
+            }
         }
+        return $registered;
     }
 
     /**

--- a/src/Common/Command/ZfcModule.php
+++ b/src/Common/Command/ZfcModule.php
@@ -57,12 +57,21 @@ class ZfcModule extends Command
 
         if ($modaction === 'list') {
             $this->renderModuleList($controller->commandListModulesAction(), $output);
+            $output->writeln('Only registered modules are shown. Run --modaction=discover to register newly added on-disk modules.');
             return 0;
         }
 
         if ($modaction === 'discover') {
-            $controller->scanAndRegisterCustomModules();
-            $output->writeln('Scanned module directories; newly found modules are now registered (disabled). Run --modaction=list to review.');
+            $registered = $controller->scanAndRegisterCustomModules();
+            if ($registered === []) {
+                $output->writeln('No new modules found; all on-disk modules are already registered.');
+                return 0;
+            }
+            $output->writeln(sprintf('Registered %d new module(s), disabled by default:', count($registered)));
+            foreach ($registered as $moduleDirectory) {
+                $output->writeln('  - ' . $moduleDirectory);
+            }
+            $output->writeln('Run --modaction=list to review, then enable/install as needed.');
             return 0;
         }
 

--- a/src/Common/Command/ZfcModule.php
+++ b/src/Common/Command/ZfcModule.php
@@ -25,6 +25,23 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ZfcModule extends Command
 {
+    /**
+     * Actions that operate on a single named module. Kept in sync with the
+     * match arms in dispatchModuleAction(); used to reject unknown actions
+     * up front so they fail with a clear message rather than a misleading
+     * "module missing" error or an exception from the match default.
+     */
+    private const MODULE_ACTIONS = [
+        'install_sql',
+        'upgrade_sql',
+        'install_acl',
+        'upgrade_acl',
+        'enable',
+        'disable',
+        'install',
+        'unregister',
+    ];
+
     protected function configure(): void
     {
         $this
@@ -75,6 +92,11 @@ class ZfcModule extends Command
             return 0;
         }
 
+        if (!in_array($modaction, self::MODULE_ACTIONS, true)) {
+            $output->writeln(sprintf('Unsupported action "%s".', $modaction));
+            return 2;
+        }
+
         $modname = $input->getOption('modname');
         if (!is_string($modname) || $modname === '') {
             $output->writeln('modname parameter is missing (required), so exiting');
@@ -107,7 +129,9 @@ class ZfcModule extends Command
             'disable' => $controller->DisableModule($moduleId),
             'install' => $controller->InstallModule($moduleId),
             'unregister' => $controller->UnregisterModule($moduleId),
-            default => throw new \InvalidArgumentException(sprintf('Unsupported action "%s".', $modaction)),
+            // Unreachable: execute() validates $modaction against MODULE_ACTIONS
+            // before dispatching. Guards against that list drifting from these arms.
+            default => throw new \LogicException(sprintf('Action "%s" is in MODULE_ACTIONS but has no dispatch arm.', $modaction)),
         };
 
         foreach ($this->resultLines($result) as $line) {

--- a/src/Common/Command/ZfcModule.php
+++ b/src/Common/Command/ZfcModule.php
@@ -13,9 +13,11 @@
 namespace OpenEMR\Common\Command;
 
 use Installer\Controller\InstallerController;
+use Installer\Model\InstModule;
 use Installer\Model\InstModuleTable;
 use OpenEMR\Core\OEGlobalsBag;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -27,12 +29,14 @@ class ZfcModule extends Command
     {
         $this
             ->setName('openemr:zfc-module')
-            ->setDescription('Module maintenance (install_sql, install_acl, upgrade_acl, upgrade_sql, install, enable, disable, unregister)')
+            ->setDescription('Module maintenance (list, discover, install_sql, install_acl, upgrade_acl, upgrade_sql, install, enable, disable, unregister)')
+            ->addUsage('--modaction=list')
+            ->addUsage('--modaction=discover')
             ->addUsage('--site=default --modname=Carecoordination --modaction=install')
             ->setDefinition(
                 new InputDefinition([
-                    new InputOption('modname', null, InputOption::VALUE_REQUIRED, 'Name of module'),
-                    new InputOption('modaction', null, InputOption::VALUE_REQUIRED, 'Available actions: install_sql, install_acl, upgrade_acl, upgrade_sql, install, enable, disable, unregister'),
+                    new InputOption('modname', null, InputOption::VALUE_REQUIRED, 'Name of module (mod_directory); not required for list or discover'),
+                    new InputOption('modaction', null, InputOption::VALUE_REQUIRED, 'Available actions: list, discover, install_sql, install_acl, upgrade_acl, upgrade_sql, install, enable, disable, unregister'),
                     new InputOption('site', null, InputOption::VALUE_REQUIRED, 'Name of site', 'default'),
                 ])
             )
@@ -41,18 +45,75 @@ class ZfcModule extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (empty($input->getOption('modname'))) {
-            $output->writeln('modname parameter is missing (required), so exiting');
-            return 2;
-        }
         if (empty($input->getOption('modaction'))) {
             $output->writeln('modaction parameter is missing (required), so exiting');
             return 2;
         }
 
-        $modname = $input->getOption('modname');
         $modaction = $input->getOption('modaction');
-        (new InstallerController(OEGlobalsBag::getInstance()->get('modules_application')->getServiceManager()->build(InstModuleTable::class)))->commandInstallModuleAction($modname, $modaction);
+        $controller = new InstallerController(
+            OEGlobalsBag::getInstance()->get('modules_application')->getServiceManager()->build(InstModuleTable::class)
+        );
+
+        if ($modaction === 'list') {
+            $this->renderModuleList($controller->commandListModulesAction(), $output);
+            return 0;
+        }
+
+        if ($modaction === 'discover') {
+            $controller->scanAndRegisterCustomModules();
+            $output->writeln('Scanned module directories; newly found modules are now registered (disabled). Run --modaction=list to review.');
+            return 0;
+        }
+
+        if (empty($input->getOption('modname'))) {
+            $output->writeln('modname parameter is missing (required), so exiting');
+            return 2;
+        }
+
+        $modname = $input->getOption('modname');
+        $controller->commandInstallModuleAction($modname, $modaction);
         return 0;
+    }
+
+    /**
+     * @param InstModule[] $modules
+     */
+    private function renderModuleList(array $modules, OutputInterface $output): void
+    {
+        $table = new Table($output);
+        $table->setHeaders(['Directory', 'Name', 'Type', 'Active', 'SQL ver', 'SQL pending', 'ACL ver', 'ACL pending']);
+        foreach ($modules as $mod) {
+            $table->addRow([
+                $this->displayValue($mod->modDirectory),
+                $this->displayValue($mod->modUiName),
+                $this->isZend($mod->type) ? 'zend' : 'custom',
+                $this->isActive($mod->modActive) ? 'yes' : 'no',
+                $this->displayValue($mod->sql_version),
+                $this->displayValue($mod->sql_action),
+                $this->displayValue($mod->acl_version),
+                $this->displayValue($mod->acl_action),
+            ]);
+        }
+        $table->render();
+    }
+
+    /**
+     * InstModule exposes untyped (mixed) properties sourced from the modules
+     * table, so narrow at this boundary rather than blindly casting.
+     */
+    private function displayValue(mixed $value): string
+    {
+        return is_string($value) && $value !== '' ? $value : '-';
+    }
+
+    private function isZend(mixed $type): bool
+    {
+        return is_numeric($type) && (int) $type === InstModuleTable::MODULE_TYPE_ZEND;
+    }
+
+    private function isActive(mixed $active): bool
+    {
+        return is_numeric($active) && (int) $active === 1;
     }
 }

--- a/src/Common/Command/ZfcModule.php
+++ b/src/Common/Command/ZfcModule.php
@@ -45,12 +45,12 @@ class ZfcModule extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (empty($input->getOption('modaction'))) {
+        $modaction = $input->getOption('modaction');
+        if (!is_string($modaction) || $modaction === '') {
             $output->writeln('modaction parameter is missing (required), so exiting');
             return 2;
         }
 
-        $modaction = $input->getOption('modaction');
         $controller = new InstallerController(
             OEGlobalsBag::getInstance()->get('modules_application')->getServiceManager()->build(InstModuleTable::class)
         );
@@ -75,14 +75,76 @@ class ZfcModule extends Command
             return 0;
         }
 
-        if (empty($input->getOption('modname'))) {
+        $modname = $input->getOption('modname');
+        if (!is_string($modname) || $modname === '') {
             $output->writeln('modname parameter is missing (required), so exiting');
             return 2;
         }
 
-        $modname = $input->getOption('modname');
-        $controller->commandInstallModuleAction($modname, $modaction);
+        return $this->dispatchModuleAction($controller, $modname, $modaction, $output);
+    }
+
+    private function dispatchModuleAction(
+        InstallerController $controller,
+        string $modname,
+        string $modaction,
+        OutputInterface $output,
+    ): int {
+        $moduleId = $controller->getModuleId($modname);
+        if ($moduleId === null) {
+            $output->writeln(sprintf('Module "%s" is not registered; run --modaction=discover if it was added recently.', $modname));
+            return 1;
+        }
+
+        $output->writeln(sprintf('Running "%s" on module "%s"...', $modaction, $modname));
+
+        $result = match ($modaction) {
+            'install_sql' => $controller->InstallModuleSQL($moduleId),
+            'upgrade_sql' => $controller->UpgradeModuleSQL($moduleId),
+            'install_acl' => $controller->InstallModuleACL($moduleId),
+            'upgrade_acl' => $controller->UpgradeModuleACL($moduleId),
+            'enable' => $controller->EnableModule($moduleId),
+            'disable' => $controller->DisableModule($moduleId),
+            'install' => $controller->InstallModule($moduleId),
+            'unregister' => $controller->UnregisterModule($moduleId),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported action "%s".', $modaction)),
+        };
+
+        foreach ($this->resultLines($result) as $line) {
+            $output->writeln($line);
+        }
+        $output->writeln('Done.');
         return 0;
+    }
+
+    /**
+     * The installer methods return heterogeneous shapes (bool status, a status
+     * message, or an array of log fragments). Normalise to plain-text lines for
+     * console output.
+     *
+     * strip_tags() is applied because some methods (upgrade_sql, *_acl) were
+     * written for the web UI and return HTML markup (spoiler divs, <br />), which
+     * is noise in a terminal. The installer returning view markup is the real
+     * smell; laundering it here is a pragmatic stopgap until those methods return
+     * structured data.
+     *
+     * @return string[]
+     */
+    private function resultLines(mixed $result): array
+    {
+        if (is_array($result)) {
+            $lines = [];
+            foreach ($result as $line) {
+                if (is_string($line)) {
+                    $lines[] = trim(strip_tags($line));
+                }
+            }
+            return $lines;
+        }
+        if (is_string($result) && $result !== '') {
+            return [trim(strip_tags($result))];
+        }
+        return [];
     }
 
     /**


### PR DESCRIPTION
Note: this has nothing to do with the proposed plugin system. It's just extending CLI tooling already in place for the current modules.

#### Short description of what this changes or resolves:

Adds module management to the `openemr:zfc-module` console command so modules can be listed and discovered from the CLI, and fixes a data-destructive type-coercion bug in the module installer that this work surfaced.

Previously the CLI could only act on modules already registered in the `modules` table, and registration only happened as a side effect of loading the Manage Modules UI page. It also had no way to list modules or their status.

#### Changes proposed in this pull request:

**New CLI actions on `openemr:zfc-module`:**

- `--modaction=list` — renders a table of registered modules (directory, name, type, active state, SQL version + pending, ACL version + pending). Read-only; prints a hint to run `discover` for newly added on-disk modules.
- `--modaction=discover` — scans the zend and custom module directories and registers any not yet in the `modules` table (disabled by default), reporting which modules it registered. Closes the gap where a new module was invisible to the CLI until the UI had been opened.
- `modname` is now optional for `list` / `discover`.

It'd probably be better to split the actions into sub-commands instead of input flags, but that's a much bigger project and seems likely to break automation somewhere.

**Bug fix — `getModuleId()` type coercion (data loss):**

`InstallerController::getModuleId()` was declared `: bool` but returned the integer `mod_id`. In this non-`strict_types` file the id silently coerced to `true`, so every action `commandInstallModuleAction()` dispatched (`enable`, `disable`, `install`, `unregister`, …) resolved `mod_id = true`, i.e. `WHERE mod_id = 1`, and operated on whatever module had id 1 (Immunization by default) regardless of `--modname`. `unregister` therefore deleted the wrong module row.

- `getModuleId()` now returns `?int` (the existing `!== null` guard becomes correct; a missing/unknown module is skipped instead of coercing).
- The module id is threaded through as `int` across `manageAction()` (UI) and the eight id-taking installer methods, parsing the posted id at the boundary. Removes a batch of now-obsolete PHPStan baseline entries and some incorrect `@param $dir` docblocks on these methods.

**Refactor — CLI dispatch moved out of the controller:**

The action dispatch previously lived in `InstallerController::commandInstallModuleAction()`, which `echo`ed HTML (`<br />`) output and `exit()`ed — web-UI-shaped code being run from the console. That method is removed and the command now owns CLI orchestration:

- Dispatches to the installer methods (all already `public`, so nothing new was exposed) via a `match` on the action, throwing on an unknown action.
- Renders results to the console with proper exit codes (a `discover` hint on unknown modules, a hard error on unknown actions) instead of echoing HTML and calling `exit()`.
- `strip_tags()` normalises the few installer methods that still return HTML fragments (`upgrade_sql`, `*_acl`); the underlying methods returning view markup is a pre-existing smell left for a separate change.

This leaves `InstallerController` holding domain operations and `ZfcModule` owning presentation, consistent with how `list` / `discover` already work.

**Known limitation (not addressed here):** ACL install and ACL-pending detection hardcode the `zend_modules/module/` path, so they are inaccurate for custom modules — the `list` "ACL pending" column reflects this. Tracked in #12846.

#### Was an AI assistant used? Yes

Claude Code (`Assisted-by` trailer on each commit). Verified manually against a running dev database: `list` / `discover` output, discover of a new on-disk module, that `enable` / `disable` / `unregister` now target the named module with Immunization left untouched, and that the moved dispatch handles unknown modules and actions correctly.
