### PR TITLE
fix(calendar): stop "Undefined array key 0" on appointment search

### DIFF
--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -11217,11 +11217,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuser.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset 0 on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuser.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access an offset on mixed\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnuserapi.php',

--- a/interface/main/calendar/modules/PostCalendar/pnuser.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuser.php
@@ -194,6 +194,9 @@ function postcalendar_user_search()
 
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
     $sessionPcUsername = $session->get('pc_username', []);
+    // pc_username may be a single username (string) or a list of usernames
+    // (from the multi-select pc_username[] input); normalize to the first one.
+    $firstPcUsername = is_array($sessionPcUsername) ? ($sessionPcUsername[0] ?? null) : $sessionPcUsername;
     $provider_options .= ">" . xlt('All Providers') . "</option>";
     foreach ($provinfo as $provider) {
         $selected = "";
@@ -202,7 +205,7 @@ function postcalendar_user_search()
         if ($ProviderID == "") {
             // that variable stores the 'username' and not the numeric 'id'
 
-            if ($sessionPcUsername[0] == $provider['username']) {
+            if ($firstPcUsername !== null && $firstPcUsername == $provider['username']) {
                 $selected = " SELECTED ";
             }
         } elseif ($ProviderID == $provider['id']) {


### PR DESCRIPTION
#### Short description of what this changes or resolves:

The appointment search page (calendar → Search) renders a PHP warning directly into the iframe HTML, repeated once per provider:

```
Warning: Undefined array key 0 in .../interface/main/calendar/modules/PostCalendar/pnuser.php
```

#### Changes proposed in this pull request:

In `postcalendar_user_search()`, the provider `<select>` builder read `$sessionPcUsername[0]` unconditionally inside the provider loop. The `pc_username` session value may be:

- a single username (string),
- a list of usernames (from the multi-select `pc_username[]` input), or
- absent (defaulted to `[]`).

So indexing `[0]` emitted `Undefined array key 0` on every loop iteration whenever it was empty. This normalizes to the first username once, above the loop, and guards the comparison. It also fixes a latent bug where a plain-string `pc_username` matched only its first character (string offset access), rather than the whole username.

The now-matched PHPStan baseline entry for this file (`Cannot access offset 0 on mixed`) is removed; the baseline was regenerated with `composer phpstan-baseline` and only that one entry changed.

#### Was an AI assistant used? Yes
