### PR TITLE
refactor(index): validate site_id and encapsulate

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -892,11 +892,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../gacl/profiler.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'sites/\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../index.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'From\\: \\<\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/batchcom/batchEmail.php',

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -179,11 +179,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../index.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 2,
     'path' => __DIR__ . '/../../interface/batchcom/batch_reminders.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -212,11 +212,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../gacl/profiler.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$site_id \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../index.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$v \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/billing/edih_main.php',

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -357,16 +357,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../gacl/admin/object_search.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../index.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_SERVER is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../index.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/batchcom/batchEmail.php',

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -357,11 +357,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../custom/qrda_category1_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$config might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../index.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$Table might not be defined\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/billing/edit_payment.php',

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -49,7 +49,7 @@ return [
         'return.missing.php' => 0,
         'staticMethod.notFound.php' => 0,
         'trait.notFound.php' => 0,
-        'variable.undefined.php' => 510,
+        'variable.undefined.php' => 509,
     ],
     'confidentNonObject' => [
         'classConstant.nonObject.php' => 0,

--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@
         default:
             $site_id = filter_input(INPUT_GET, 'site') ?: (filter_input(INPUT_SERVER, 'HTTP_HOST') ?: 'default');
             if (!in_array($site_id, $valid_site_ids, true)) {
-                throw new RuntimeException("Invalid site id: {$site_id}");
+                throw new RuntimeException('Invalid site id');
             };
     }
     require_once "sites/{$site_id}/sqlconf.php";

--- a/index.php
+++ b/index.php
@@ -35,5 +35,6 @@
             };
     }
     require_once "sites/{$site_id}/sqlconf.php";
+    /** @var int $config Defined in sqlconf.php */
     header('Location: ' . ($config === 1 ? 'interface/login/login.php' : 'setup.php') . "?site=$site_id");
 })();

--- a/index.php
+++ b/index.php
@@ -4,27 +4,37 @@
 // modify it under the terms of the GNU General Public License
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
-// Set the site ID if required.  This must be done before any database
-// access is attempted.
 
-$site_id = '';
 
-if (!empty($_GET['site'])) {
-    $site_id = $_GET['site'];
-} elseif (is_dir("sites/" . ($_SERVER['HTTP_HOST'] ?? 'default'))) {
-    $site_id = ($_SERVER['HTTP_HOST'] ?? 'default');
-} else {
-    $site_id = 'default';
-}
+/**
+ * Set the site ID if required.
+ *
+ * This must be done before any database access is attempted.
+ * Use an IIFE to ensure no variables leak.
+ */
+(function () {
+    // Any directory name in sites that contains a sqlconf.php can be a site id.
+    $valid_site_ids = array_map(
+        basename(...),
+        array_filter(
+            glob('sites/*', GLOB_ONLYDIR),
+            fn($d) => is_file("{$d}/sqlconf.php")
+        )
+    );
 
-if (empty($site_id) || preg_match('/[^A-Za-z0-9\\-.]/', $site_id)) {
-    die("Site ID '" . htmlspecialchars($site_id, ENT_NOQUOTES) . "' contains invalid characters.");
-}
-
-require_once "sites/$site_id/sqlconf.php";
-
-if ($config == 1) {
-    header("Location: interface/login/login.php?site=$site_id");
-} else {
-    header("Location: setup.php?site=$site_id");
-}
+    switch(count($valid_site_ids)) {
+        case 0:
+            throw new RuntimeError('No valid sites found');
+        // Often there's only one valid request id, so we can ignore input.
+        case 1:
+            $site_id = $valid_site_ids[0];
+            break;
+        default:
+            $site_id = filter_input(INPUT_GET, 'site') ?: (filter_input(INPUT_SERVER, 'HTTP_HOST') ?: 'default');
+            if (!in_array($site_id, $valid_site_ids, true)) {
+                throw new RuntimeError("Invalid site id: {$site_id}");
+            };
+    }
+    require_once "sites/{$site_id}/sqlconf.php";
+    header('Location: ' . ($config === 1 ? 'interface/login/login.php' : 'setup.php') . "?site=$site_id");
+})();

--- a/index.php
+++ b/index.php
@@ -12,7 +12,8 @@
  * This must be done before any database access is attempted.
  * Use an IIFE to ensure no variables leak.
  */
-(function () {
+
+(function (): void {
     // Any directory name in sites that contains a sqlconf.php can be a site id.
     $sites_dirs = glob('sites/*', GLOB_ONLYDIR) ?: [];
     $valid_site_ids = array_map(

--- a/index.php
+++ b/index.php
@@ -14,17 +14,15 @@
  */
 (function () {
     // Any directory name in sites that contains a sqlconf.php can be a site id.
+    $sites_dirs = glob('sites/*', GLOB_ONLYDIR) ?: [];
     $valid_site_ids = array_map(
         basename(...),
-        array_filter(
-            glob('sites/*', GLOB_ONLYDIR),
-            fn($d) => is_file("{$d}/sqlconf.php")
-        )
+        array_filter($sites_dirs, fn($d) => is_file("{$d}/sqlconf.php"))
     );
 
     switch(count($valid_site_ids)) {
         case 0:
-            throw new RuntimeError('No valid sites found');
+            throw new RuntimeException('No valid sites found');
         // Often there's only one valid request id, so we can ignore input.
         case 1:
             $site_id = $valid_site_ids[0];
@@ -32,7 +30,7 @@
         default:
             $site_id = filter_input(INPUT_GET, 'site') ?: (filter_input(INPUT_SERVER, 'HTTP_HOST') ?: 'default');
             if (!in_array($site_id, $valid_site_ids, true)) {
-                throw new RuntimeError("Invalid site id: {$site_id}");
+                throw new RuntimeException("Invalid site id: {$site_id}");
             };
     }
     require_once "sites/{$site_id}/sqlconf.php";


### PR DESCRIPTION
Eliminate all phpstan findings on index.php

1. Validate site_id as a dirname containing sqlconf.php.
2. Only check input when relevant.
3. Use `filter_input`, not superglobals.
4. Encapsulate in an IIFE -> no globals.
