### PR TITLE
fix(main-tabs): open patient dashboard as active tab

### DIFF
--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -35,6 +35,7 @@ use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Services\ListService;
+use OpenEMR\Tabs\PatientDashboardTab;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
@@ -472,18 +473,15 @@ if ($is_expired) {
         "label" => xl("Password Reset"),
     ]);
 } elseif (!empty($_POST['patientID'])) {
-    // Patient is open, so add this to the list of tabs, at the end
+    // Patient is open, so make the dashboard the active (first) tab.
     $patientID = (int) $_POST['patientID'];
-    $_notes = "../patient_file/summary/demographics.php?set_pid=" . attr_url($patientID);
+    // Tab notes are resolved from the project root by DefaultTabsFilter.
+    $_notes = "interface/patient_file/summary/demographics.php?set_pid=" . attr_url($patientID);
     if (!empty($_POST['encounterID'])) {
         $encounterID = (int) $_POST['encounterID'];
         $_notes = $_notes . "&set_encounterid=" . attr_url($encounterID);
     }
-    $_tabs[] = [
-        'notes' => $_notes,
-        'id' => "pat",
-        'label' => xl("Dashboard"),
-    ];
+    $_tabs = PatientDashboardTab::prepend($_tabs, $_notes, xl("Dashboard"));
 } elseif (isset($_GET['mode']) && $_GET['mode'] == "loadcalendar") {
     // Load the calendar, at the end
     $_notes = "calendar/index.php?pid=" . attr_url($_GET['pid']);

--- a/src/Tabs/PatientDashboardTab.php
+++ b/src/Tabs/PatientDashboardTab.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Build the tab entry used when opening a patient in a top-level window.
+ *
+ * @package   OpenEMR
+ *
+ * @link https://www.open-emr.org
+ * @author RobinALG87
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tabs;
+
+/**
+ * Keep the patient dashboard as the active tab when a new top-level window
+ * is opened from a patient list.  The tab shell activates the first entry in
+ * the list, so appending this entry would display the user's default tab
+ * (often Message Center or Calendar) instead of the selected patient.
+ * The notes path must be relative to the project root because it is validated
+ * by {@see DefaultTabsFilter} before the tab shell renders it.
+ */
+final class PatientDashboardTab
+{
+    /**
+     * @param array<int, array<string, mixed>> $tabs
+     * @return array<int, array<string, mixed>>
+     */
+    public static function prepend(array $tabs, string $notes, string $title): array
+    {
+        array_unshift($tabs, [
+            'notes' => $notes,
+            'id' => 'pat',
+            'label' => $title,
+        ]);
+
+        return $tabs;
+    }
+}

--- a/tests/Tests/Isolated/Tabs/PatientDashboardTabTest.php
+++ b/tests/Tests/Isolated/Tabs/PatientDashboardTabTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ *
+ * @link https://www.open-emr.org
+ * @author RobinALG87
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Tabs;
+
+use OpenEMR\Tabs\DefaultTabsFilter;
+use OpenEMR\Tabs\PatientDashboardTab;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+class PatientDashboardTabTest extends TestCase
+{
+    public function testPatientDashboardIsFirstAndExistingTabsArePreserved(): void
+    {
+        $defaultTabs = [
+            [
+                'notes' => 'interface/main/messages/messages.php?form_active=1',
+                'id' => 'msg',
+                'label' => 'Message Center',
+            ],
+            [
+                'notes' => 'interface/main/calendar/index.php',
+                'id' => 'cal',
+                'label' => 'Calendar',
+            ],
+        ];
+
+        $patientNotes = 'interface/patient_file/summary/demographics.php?set_pid=42';
+        $result = PatientDashboardTab::prepend($defaultTabs, $patientNotes, 'Dashboard');
+
+        self::assertSame(
+            [
+                [
+                    'notes' => $patientNotes,
+                    'id' => 'pat',
+                    'label' => 'Dashboard',
+                ],
+                ...$defaultTabs,
+            ],
+            $result,
+        );
+    }
+
+    public function testPrependDoesNotMutateTheInputArray(): void
+    {
+        $defaultTabs = [
+            ['notes' => 'interface/main/messages/messages.php', 'id' => 'msg', 'label' => 'Messages'],
+        ];
+
+        PatientDashboardTab::prepend(
+            $defaultTabs,
+            'interface/patient_file/summary/demographics.php?set_pid=42',
+            'Dashboard',
+        );
+
+        self::assertCount(1, $defaultTabs);
+        self::assertSame('msg', $defaultTabs[0]['id']);
+    }
+
+    public function testPatientDashboardPathSurvivesDefaultTabValidation(): void
+    {
+        $tabs = PatientDashboardTab::prepend(
+            [],
+            'interface/patient_file/summary/demographics.php?set_pid=42',
+            'Dashboard',
+        );
+
+        $result = (new DefaultTabsFilter())->filter($tabs, dirname(__DIR__, 4));
+
+        self::assertCount(1, $result);
+        self::assertSame('pat', $result[0]['option_id']);
+        self::assertSame($tabs[0]['notes'], $result[0]['notes']);
+    }
+}


### PR DESCRIPTION
## Summary

- keep the patient dashboard as the first active tab when opening a patient in a new browser tab
- use a project-root-relative dashboard path accepted by the tab safety filter
- preserve encounter context and add isolated regression coverage for ordering and path validation

## Validation

- Terra implementation and independent review: PASS
- `git diff --check`: PASS
- PHP/PHPUnit unavailable locally; CI should run the isolated suite

Fixes #12876

Generated-By: Terra