### PR TITLE
ci(docker): authenticated version.php pre-fetch + distinguish 404 from 429

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -150,12 +150,39 @@ jobs:
       id: image_version
       env:
         REF: ${{ steps.resolve_openemr_version_ref.outputs.ref }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Fetch version.php at the resolved ref via raw.githubusercontent.com.
-        # No git checkout needed; works for branches, tags, and SHAs alike.
-        URL="https://raw.githubusercontent.com/openemr/openemr/${REF}/version.php"
-        if ! curl -fsSL "$URL" -o /tmp/version.php; then
-          echo "::error::Couldn't fetch version.php at openemr@${REF}. The ref likely doesn't exist; check release-targets.yml."
+        # Fetch version.php at the resolved ref via the authenticated
+        # GitHub Contents API. Works for branches, tags, and SHAs alike;
+        # no git checkout needed.
+        #
+        # Previously used anonymous raw.githubusercontent.com. On the
+        # 8.2.0 orchestrator fanout that came back with HTTP 429 (shared-
+        # IP anonymous quota exhausted by 4 parallel per-branch dispatches
+        # hitting the same URL family concurrently) and the error path
+        # here misreported the 429 as "ref likely doesn't exist," sending
+        # operators on wild goose chases through release-targets.yml.
+        # gaps doc G19 has the incident detail. Authenticated GH_TOKEN
+        # gets us the per-token 5000/hr budget instead, which even at
+        # 8-branch fanout is comfortably ahead of any rate-limit floor.
+        #
+        # `Accept: application/vnd.github.raw` returns the file body
+        # directly (no base64 wrapping).
+        if ! gh api "/repos/openemr/openemr/contents/version.php?ref=${REF}" \
+             -H 'Accept: application/vnd.github.raw' \
+             > /tmp/version.php 2> /tmp/gh-api-err; then
+          # Distinguish "ref doesn't resolve" (bad release-targets.yml
+          # entry -- actionable) from every other failure (transient --
+          # worth surfacing verbatim so the operator sees the actual
+          # HTTP status / gh error rather than a wrong "ref doesn't
+          # exist" claim). 404 is the only case that means "check
+          # release-targets.yml"; 429 / 5xx / network errors do not.
+          if grep -qE 'HTTP 404|Not Found' /tmp/gh-api-err; then
+            echo "::error::openemr_version_ref '${REF}' does not resolve in openemr/openemr; check release-targets.yml."
+          else
+            echo "::error::Failed to fetch version.php at openemr@${REF} (not a 404 -- check the underlying gh error below rather than release-targets.yml):"
+            cat /tmp/gh-api-err
+          fi
           exit 1
         fi
 

--- a/.github/workflows/docker-validate-release-targets.yml
+++ b/.github/workflows/docker-validate-release-targets.yml
@@ -88,21 +88,35 @@ jobs:
         echo "✓ Schema check passed."
 
     - name: Verify every openemr_version_ref resolves in openemr/openemr
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        # Uses the authenticated GitHub Contents API (5000/hr per-token
+        # budget) rather than anonymous raw.githubusercontent.com (60/hr
+        # shared-IP). Same G19 rationale as docker-build-release.yml's
+        # own fetch: an anonymous 429 previously showed up here as "does
+        # not resolve," which lied about the actual cause.
         yq -o=json -I=0 . .github/release-targets.yml | jq -r '.[] | "\(.branch)\t\(.openemr_version_ref)"' | \
         while IFS=$'\t' read -r BRANCH REF; do
-          # raw.githubusercontent.com returns 200 only when the ref resolves.
-          URL="https://raw.githubusercontent.com/openemr/openemr/${REF}/version.php"
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$URL")
-          if [ "$STATUS" != "200" ]; then
-            echo "::error::Row '$BRANCH': openemr_version_ref '$REF' does not resolve in openemr/openemr (HTTP $STATUS at $URL)"
+          if err_output=$(gh api "/repos/openemr/openemr/contents/version.php?ref=${REF}" \
+               --silent 2>&1); then
+            echo "✓ $BRANCH: openemr_version_ref '$REF' resolves."
+          elif echo "$err_output" | grep -qE 'HTTP 404|Not Found'; then
+            echo "::error::Row '$BRANCH': openemr_version_ref '$REF' does not resolve in openemr/openemr"
+            exit 1
+          else
+            echo "::error::Row '$BRANCH': failed to check openemr_version_ref '$REF' (not a 404): $err_output"
             exit 1
           fi
-          echo "✓ $BRANCH: openemr_version_ref '$REF' resolves."
         done
 
     - name: Cross-check docker_tag version against version.php at openemr_version_ref
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        # Uses the authenticated GitHub Contents API for the non-master
+        # rows (same G19 rationale as the previous step). Master row keeps
+        # the local checkout for the chicken-and-egg reason detailed below.
         # Use process substitution so the loop body runs in the current shell
         # (no subshell), letting FAIL increments propagate.
         FAIL=0
@@ -138,8 +152,19 @@ jobs:
             # raw URL because their openemr_version_ref is a stable git tag
             # that a PR can't modify locally.
             cp version.php /tmp/v.php
-          elif ! curl -fsSL "https://raw.githubusercontent.com/openemr/openemr/${REF}/version.php" -o /tmp/v.php; then
-            echo "::error::Row '$BRANCH': failed to fetch version.php at ref '$REF' from raw.githubusercontent.com"
+          elif ! gh api "/repos/openemr/openemr/contents/version.php?ref=${REF}" \
+                    -H 'Accept: application/vnd.github.raw' \
+                    > /tmp/v.php 2> /tmp/gh-api-err; then
+            # Distinguish 404 (real bad ref -- release-targets.yml
+            # points at a sha/tag/branch that doesn't resolve) from
+            # transient failures. Same G19 pattern as the sibling step
+            # above and docker-build-release.yml's fetch.
+            if grep -qE 'HTTP 404|Not Found' /tmp/gh-api-err; then
+              echo "::error::Row '$BRANCH': openemr_version_ref '$REF' does not resolve in openemr/openemr"
+            else
+              echo "::error::Row '$BRANCH': failed to fetch version.php at ref '$REF' (not a 404):"
+              cat /tmp/gh-api-err
+            fi
             FAIL=1
             continue
           fi


### PR DESCRIPTION
Fixes **G19** in `docs/release-mechanism-gaps.md`.

## Problem

Two release-flow workflows in this repo fetched `version.php` via anonymous curl against `raw.githubusercontent.com`:

- `docker-build-release.yml` — pre-build fetch to derive `IMAGE_VERSION` from the `openemr_version_ref`.
- `docker-validate-release-targets.yml` — two fetches on every PR that touches `release-targets.yml` or `version.php`: one status-only probe of each row's `openemr_version_ref`, and one content-fetch for the docker_tag-vs-version.php cross-check.

On the 8.2.0 orchestrator fanout (2026-07-08), rel-820's build failed with:

```
##[error]Couldn't fetch version.php at openemr@v8_2_0. The ref likely doesn't exist; check release-targets.yml.
```

The tag DID exist. Real cause: HTTP 429 from `raw.githubusercontent.com`'s anonymous shared-IP quota, exhausted by 4 parallel per-branch dispatches hitting the same URL family in the same second. The misleading error sent operators through `release-targets.yml` looking for a ref problem that wasn't there. Recovery required a workflow rerun once the anonymous window reset. `docker-validate-release-targets.yml`'s two fetches carry the identical vulnerability — they'd misreport HTTP 429 as "does not resolve in openemr/openemr" (CodeRabbit review on the initial commit caught this).

## Fix — two coupled changes, applied uniformly across three fetches

### 1. Switch to authenticated `gh api`

All three anonymous curl fetches → `gh api` at the GitHub Contents API. Authenticated calls use the per-token 5000/hr budget instead of the anonymous 60/hr shared-IP quota that got exhausted. Content-fetch calls use `Accept: application/vnd.github.raw` to get the file body directly (no base64 unwrapping). Status-only probes use the default representation and check the return code.

Each affected step now has `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` in its `env:` block. Workflow-level `permissions: contents: read` is already granted (both workflows).

### 2. Distinguish 404 from every other failure

Previously any curl failure was reported as "ref likely doesn't exist; check release-targets.yml" — misleading for HTTP 429, 5xx, network hiccups. Now uniform across all three fetches:

- **404** → "does not resolve in openemr/openemr; check release-targets.yml" (still actionable; that IS the case where the ref is wrong)
- **anything else** → surface the underlying `gh api` error verbatim so the operator sees the actual HTTP status. Prevents future wild goose chases through `release-targets.yml` for problems that aren't there.

## Files touched

- `.github/workflows/docker-build-release.yml` — the pre-build IMAGE_VERSION fetch (one call)
- `.github/workflows/docker-validate-release-targets.yml` — the "Verify every openemr_version_ref resolves" step (one call) + the "Cross-check docker_tag version" step's non-master fetch (one call). Master row still uses local checkout (chicken-and-egg reasoning preserved inline).

## Cross-branch propagation

- **`docker-build-release.yml`** is byte-identical-enforced across master + rel-820 + rel-810 + rel-800 + rel-704 via `.github/docker-byte-identical.yml`. Master merge auto-syncs to the four rel branches via `sync-byte-identical.yml` — no per-branch cherry-picking needed.
- **`docker-validate-release-targets.yml`** is NOT in the byte-identical set. Only fires on `pull_request: branches: [master]`, so only needs to exist on master. No cross-branch propagation concerns.

## Test plan

- [ ] CI on this PR (workflow syntax + actionlint on both files)
- [ ] Confirm `docker-validate-release-targets` runs against this PR's own trigger paths (both files land in the trigger's `paths:` filter — the validator's own workflow file is in it)
- [ ] After merge, watch a `docker-build-release` run (next daily orchestrator tick or manual dispatch) and confirm `gh api` returns the version.php body successfully
- [ ] Manual verification path (not required for merge): dispatch `docker-build-release.yml` with an intentionally bad `openemr_version_ref` (e.g., `v_bogus`) and confirm the error message includes `"does not resolve in openemr/openemr"` rather than the old "likely doesn't exist" phrasing