### PR TITLE
feat(release): openemr-tag dispatch now carries prev_release

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -493,6 +493,16 @@ jobs:
         MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         TAG_NAME: ${{ steps.tag.outputs.tag-name }}
       run: |
+        # G20: openemr-tag now carries prev_release so website-openemr's
+        # release-docs.yml can generate acknowledgements + release-notes
+        # on the FINAL cut. Historically this dispatch omitted the field
+        # and the two generators SKIPPED (their `if: prev_release != ''`
+        # gates) on every release, leaving each shipped version without
+        # markdown files on master until a manual openemr-rel-update
+        # recovery dispatch. Derived from the same
+        # BranchVersionResolver::previousRelease() the sibling rel-cut/
+        # update dispatches use.
+        prev_release="$(php tools/release/bin/derive-prev-release.php "${VERSION}")"
         # Demo_farm_openemr no longer consumes openemr-tag: its bump-tag.yml
         # was retired in demo_farm_openemr#141 in favor of the auto-derive
         # bot, which subscribes to release-targets-changed instead. Explicit
@@ -505,4 +515,5 @@ jobs:
           --actor='openemr-release-bot' \
           --branch="${REL_BRANCH}" \
           --release-version="${VERSION}" \
-          --tag="${TAG_NAME}"
+          --tag="${TAG_NAME}" \
+          --prev-release="${prev_release}"

--- a/tests/Tests/Isolated/Release/Contracts/DispatchRequestGoldenTest.php
+++ b/tests/Tests/Isolated/Release/Contracts/DispatchRequestGoldenTest.php
@@ -73,7 +73,12 @@ final class DispatchRequestGoldenTest extends TestCase
                 actor: 'openemr-release-bot',
                 dispatchedAt: '2026-04-29T12:30:00Z',
                 appToken: 'tok',
-                data: ['tag' => 'v8_1_0', 'branch' => 'rel-810', 'version' => '8.1.0'],
+                data: [
+                    'tag' => 'v8_2_0',
+                    'branch' => 'rel-820',
+                    'version' => '8.2.0',
+                    'prev_release' => '8.0.0',
+                ],
             ),
         ];
 
@@ -86,7 +91,12 @@ final class DispatchRequestGoldenTest extends TestCase
                 actor: 'openemr-release-bot',
                 dispatchedAt: '2026-04-29T12:30:00Z',
                 appToken: 'tok',
-                data: ['tag' => 'v8_1_0-test.abcdef0', 'branch' => 'rel-test', 'version' => '8.1.0'],
+                data: [
+                    'tag' => 'v8_2_0-test.abcdef0',
+                    'branch' => 'rel-test',
+                    'version' => '8.2.0',
+                    'prev_release' => '8.0.0',
+                ],
             ),
         ];
 

--- a/tests/Tests/Isolated/Release/DispatchDataBuilderTest.php
+++ b/tests/Tests/Isolated/Release/DispatchDataBuilderTest.php
@@ -35,15 +35,21 @@ final class DispatchDataBuilderTest extends TestCase
         );
     }
 
-    public function testTagBuildsTagBranchVersion(): void
+    public function testTagBuildsTagBranchVersionPrev(): void
     {
         $builder = new DispatchDataBuilder($this->reader([
             '--tag' => 'v8_1_0',
             '--branch' => 'rel-810',
             '--release-version' => '8.1.0',
+            '--prev-release' => '8.0.0',
         ]));
         self::assertSame(
-            ['tag' => 'v8_1_0', 'branch' => 'rel-810', 'version' => '8.1.0'],
+            [
+                'tag' => 'v8_1_0',
+                'branch' => 'rel-810',
+                'version' => '8.1.0',
+                'prev_release' => '8.0.0',
+            ],
             $builder->build(DispatchRequest::EVENT_TAG),
         );
     }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag-test.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag-test.json
@@ -5,9 +5,9 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:30:00Z",
   "data": {
-    "tag": "v8_1_0-test.abcdef0",
+    "tag": "v8_2_0-test.abcdef0",
     "branch": "rel-test",
-    "version": "8.1.0",
+    "version": "8.2.0",
     "prev_release": "8.0.0"
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag-test.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag-test.json
@@ -7,6 +7,7 @@
   "data": {
     "tag": "v8_1_0-test.abcdef0",
     "branch": "rel-test",
-    "version": "8.1.0"
+    "version": "8.1.0",
+    "prev_release": "8.0.0"
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag.json
@@ -7,6 +7,7 @@
   "data": {
     "tag": "v8_1_0",
     "branch": "rel-810",
-    "version": "8.1.0"
+    "version": "8.1.0",
+    "prev_release": "8.0.0"
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag.json
@@ -5,9 +5,9 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:30:00Z",
   "data": {
-    "tag": "v8_1_0",
-    "branch": "rel-810",
-    "version": "8.1.0",
+    "tag": "v8_2_0",
+    "branch": "rel-820",
+    "version": "8.2.0",
     "prev_release": "8.0.0"
   }
 }

--- a/tools/release/contracts/dispatch.schema.json
+++ b/tools/release/contracts/dispatch.schema.json
@@ -162,7 +162,8 @@
       "required": [
         "tag",
         "branch",
-        "version"
+        "version",
+        "prev_release"
       ],
       "additionalProperties": false,
       "properties": {
@@ -173,6 +174,9 @@
           "$ref": "#/definitions/branch"
         },
         "version": {
+          "$ref": "#/definitions/version"
+        },
+        "prev_release": {
           "$ref": "#/definitions/version"
         }
       }

--- a/tools/release/src/DispatchDataBuilder.php
+++ b/tools/release/src/DispatchDataBuilder.php
@@ -39,6 +39,7 @@ final readonly class DispatchDataBuilder
                 'tag' => $this->opts->string('tag'),
                 'branch' => $this->opts->string('branch'),
                 'version' => $this->opts->string('release-version'),
+                'prev_release' => $this->opts->string('prev-release'),
             ],
             DispatchRequest::EVENT_RELEASE_TARGETS_CHANGED => [],
             DispatchRequest::EVENT_PROBE => [


### PR DESCRIPTION
Openemr/openemr third of **G20** in `docs/release-mechanism-gaps.md`. Turns out to be a three-repo change:

- **[openemr/openemr-devops#855](https://github.com/openemr/openemr-devops/pull/855)** — canonical dispatch schema (\`tools/release/contracts/dispatch.schema.json\`) adds \`prev_release\` to \`tagData\`.
- **[openemr/website-openemr#189](https://github.com/openemr/website-openemr/pull/189)** — website envelope schema + jq builder + fixtures accept \`prev_release\`.
- **This PR** — vendored copy of the canonical schema, emitter update, tests, fixtures.

## Order-of-merge

**Both #855 and #189 must land before this PR.**

- Until **#855** merges, this PR's `Check vendored contracts against canonical` job fails because openemr's vendored schema copy will diverge from openemr-devops's canonical.
- Until **#189** merges, the openemr-tag emitter this PR wires would fail `validate-payload` on the website-openemr consumer side (its `additionalProperties: false` guard would reject the new field).

#855 and #189 can land in either order between themselves.

## Problem

`release-prep.yml`'s `Dispatch openemr-tag to consumers` step emitted `--branch --release-version --tag` but not `--prev-release`, so the `openemr-tag` payload's `data` never included the field. Downstream on `website-openemr`, `release-docs.yml` gates its "Generate acknowledgements" and "Generate release notes" steps on `if: prev_release != ''`. Both SKIPPED on the 8.2.0 shipping path and the docs PR merged without either markdown file. Recovery required an out-of-band `openemr-rel-update` dispatch ([openemr/website-openemr#181](https://github.com/openemr/website-openemr/pull/181)).

## Changes in this repo

1. **`.github/workflows/release-prep.yml`** — the `openemr-tag` emitter now computes `prev_release` via `derive-prev-release.php` (same helper the sibling `openemr-rel-cut` / `openemr-rel-update` emitter already calls) and passes `--prev-release`.
2. **`tools/release/src/DispatchDataBuilder.php`** — the `DispatchRequest::EVENT_TAG` match arm now includes `'prev_release' => \$this->opts->string('prev-release')`. The CLI option was already defined on `dispatch.php` line 67; it just wasn't being read into the tag event's data block.
3. **`tools/release/contracts/dispatch.schema.json`** — vendored copy mirrors #855's canonical change: `tagData` adds `prev_release` to `required` + `properties`.
4. **Tests**:
   - `tests/Tests/Isolated/Release/DispatchDataBuilderTest.php` — renames `testTagBuildsTagBranchVersion` to `testTagBuildsTagBranchVersionPrev`, wires `--prev-release=8.0.0` into the fixture input, expects `prev_release` in the output array.
   - `tests/Tests/Isolated/Release/Contracts/DispatchRequestGoldenTest.php` — golden expectations for the `openemr-tag` and `openemr-tag (test)` yields now include `prev_release` and use `8.2.0 / v8_2_0 / rel-820` to match the updated fixtures.
   - `tests/Tests/Isolated/Release/fixtures/dispatch/good-tag.json` and `good-tag-test.json` — add `"prev_release": "8.0.0"` and bump `8.1.0 → 8.2.0`, `v8_1_0 → v8_2_0`, `rel-810 → rel-820`. 8.1.0 was cut as a prerelease and skipped -- never publicly released; using it as the canonical example implied a shipped 8.1.0 existed. 8.2.0 is a real released version. `prev_release=8.0.0` is the actual previous shipped release per `website-openemr/data/releases.json`'s FINAL entries.

## Recovery for the 8.2.0 acknowledgements page

Already handled out of band via [openemr/website-openemr#181](https://github.com/openemr/website-openemr/pull/181)'s recovery dispatch. This PR is prospective — the next release and every one after will emit `prev_release` on `openemr-tag` automatically, so acknowledgements + release-notes will generate on the FINAL cut without a manual recovery step.

## Test plan

- [ ] CI on this PR (Isolated tests exercise `DispatchDataBuilderTest`, `DispatchRequestGoldenTest`, and `DispatchSchemaTest`)
- [ ] Wait for #855 to merge — the vendored-contract drift check re-runs against the updated canonical and turns green
- [ ] After all three PRs land, the next release's `openemr-tag` dispatch will include `prev_release` in the payload → website-openemr's `Generate acknowledgements` + `Generate release notes` steps run instead of skipping → the FINAL release-docs PR contains both markdown files without needing a recovery dispatch