### PR TITLE
feat(release): finalize job updates release-finalize PR post-tag (rel-820 backport of #12889)

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -517,3 +517,111 @@ jobs:
           --release-version="${VERSION}" \
           --tag="${TAG_NAME}" \
           --prev-release="${prev_release}"
+
+    # G28: post-tag update to the release-finalize/<rel-branch> partner PR.
+    # The prep job's equivalent steps (Checkout master... through Create or
+    # update release-finalize PR) write the *preview* state during the -dev
+    # cycle. Under the G16 fix that same prep job skips on the release-prep
+    # merge push (Layer 2 gate rejects $v_tag == '' post-mutator), so
+    # nothing was updating the release-finalize PR to reflect the actual
+    # just-shipped state -- openemr_version_ref would stay pinned at the
+    # rel-branch tip instead of the just-created annotated tag. Fold the
+    # master-scope mutator + PR update work into the finalize job here so
+    # the release-finalize PR content and its draft/ready state both
+    # reflect post-tag reality by the time a maintainer sees it.
+    #
+    # Test-mode runs are skipped: the partner PR only exists for real
+    # releases and would produce a confusing master-side draft on every
+    # test exercise of the conductor.
+    - name: Checkout master for release-finalize post-tag update
+      if: steps.resolve.outputs.test != 'true'
+      uses: actions/checkout@v7
+      with:
+        ref: master
+        path: master-checkout
+        token: ${{ steps.app-token.outputs.token }}
+        fetch-depth: 0
+
+    # setup-php-composer installs into the workflow's default working
+    # directory only; the second checkout above has no vendor/, so
+    # install composer deps there directly to boot the autoloader.
+    - name: Install Composer dependencies (master-checkout, finalize)
+      if: steps.resolve.outputs.test != 'true'
+      working-directory: master-checkout
+      shell: bash
+      run: composer install --prefer-dist --no-progress --no-interaction
+
+    - name: Run release-prep mutators (master scope, release-finalize) -- post-tag
+      if: steps.resolve.outputs.test != 'true'
+      working-directory: master-checkout
+      env:
+        VERSION: ${{ steps.resolve.outputs.version }}
+        REL_BRANCH: ${{ steps.resolve.outputs.branch }}
+      run: |
+        php bin/console openemr:release-prep \
+          --skip-globals \
+          --target-version="${VERSION}" \
+          --rel-branch="${REL_BRANCH}" \
+          --scope=master
+
+    - name: Render release-finalize PR body -- post-tag
+      id: finalize-pr-body-post-tag
+      if: steps.resolve.outputs.test != 'true'
+      env:
+        VERSION: ${{ steps.resolve.outputs.version }}
+        REL_BRANCH: ${{ steps.resolve.outputs.branch }}
+      run: |
+        {
+          echo 'body<<EOF'
+          php tools/release/bin/render-pr-body.php "${VERSION}" \
+            --template=.github/PULL_REQUEST_TEMPLATE/release-finalize.md \
+            --rel-branch="${REL_BRANCH}"
+          echo 'EOF'
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Update release-finalize PR -- post-tag
+      id: finalize-post-tag-pr
+      if: steps.resolve.outputs.test != 'true'
+      uses: peter-evans/create-pull-request@v8
+      with:
+        path: master-checkout
+        token: ${{ steps.app-token.outputs.token }}
+        branch: release-finalize/${{ steps.resolve.outputs.branch }}
+        base: master
+        title: 'chore(release): finalize ${{ steps.resolve.outputs.version }} on master'
+        body: ${{ steps.finalize-pr-body-post-tag.outputs.body }}
+        commit-message: 'chore(release): finalize ${{ steps.resolve.outputs.version }} on master (post-tag)'
+        author: 'openemr-release-bot <release-bot@openemr.invalid>'
+        committer: 'openemr-release-bot <release-bot@openemr.invalid>'
+        draft: false
+        delete-branch: false
+
+    # peter-evans's `draft: false` only applies on PR creation -- it does
+    # NOT flip an existing draft PR out of draft. Do that explicitly here.
+    # Also post a maintainer-facing comment on the PR to signal the phase-2
+    # transition: content now reflects post-tag reality (openemr_version_
+    # ref pinned to the just-created annotated tag) and the PR is ready
+    # to be merged onto master.
+    #
+    # `gh pr ready` errors if the PR isn't a draft, which happens in two
+    # legitimate cases: (a) finalize job re-run after the PR was already
+    # flipped to ready, (b) release-finalize PR didn't previously exist
+    # and peter-evans created it fresh in this same run (its `draft: false`
+    # DOES apply on creation). Guard with an isDraft probe so those cases
+    # don't fail the step and skip the signal comment.
+    - name: Flip release-finalize PR to ready-for-review + signal comment
+      if: steps.resolve.outputs.test != 'true' && steps.finalize-post-tag-pr.outputs.pull-request-number != ''
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        PR_NUMBER: ${{ steps.finalize-post-tag-pr.outputs.pull-request-number }}
+        VERSION: ${{ steps.resolve.outputs.version }}
+        REL_BRANCH: ${{ steps.resolve.outputs.branch }}
+        TAG_NAME: ${{ steps.tag.outputs.tag-name }}
+        REPO: ${{ github.repository }}
+      run: |
+        is_draft=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isDraft --jq '.isDraft')
+        if [ "$is_draft" = "true" ]; then
+          gh pr ready "$PR_NUMBER" --repo "$REPO"
+        fi
+        gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+          "Post-tag update applied. \`openemr_version_ref\` for \`${REL_BRANCH}\` is now pinned to \`${TAG_NAME}\` (the just-created annotated tag for ${VERSION}) and \`docker_tags\` slot rotations reflect actual shipped state. PR flipped out of draft; ready to merge to master."

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -108,7 +108,12 @@ On the `openemr-tag` event, the same workflow also regenerates the EHI / ONC (b)
 
 ### Finalize-on-master PR — `release-finalize/<rel-branch>` in `openemr/openemr`
 
-Auto-opened alongside the conductor PR during the release-prep phase. Carries the master-side updates to `.github/release-targets.yml`: pins the rel-branch row's `openemr_version_ref` to the new tag, slot-shuffles `latest` / `next` / `dev` across rows, and drops any `unreleased: true` placeholder row. The content is auto-updated one more time by the conductor after the annotated tag is created, so the merged diff reflects the actual just-shipped state.
+Auto-opened alongside the conductor PR during the release-prep phase. Carries the master-side updates to `.github/release-targets.yml`: pins the rel-branch row's `openemr_version_ref` to the new tag, slot-shuffles `latest` / `next` / `dev` across rows, and drops any `unreleased: true` placeholder row.
+
+Two-phase lifecycle:
+
+1. **Preview phase (during the `-dev` cycle).** Opened as a **draft** by `release-prep.yml`'s `prep` job on each push to the rel branch while `$v_tag == '-dev'`. Content reflects the *planned* post-ship rotation (`openemr_version_ref` points at the rel-branch tip as a preview since the annotated tag doesn't exist yet). Maintainers can preview and sanity-check the rotation shape here, but the draft state signals "not yet safe to merge."
+2. **Post-tag phase (after conductor PR merge).** The `finalize` job re-runs the master-scope mutators after creating the annotated tag, force-updates the PR body + commit with the actual just-shipped state (`openemr_version_ref` pinned to the real `v_X_Y_Z` tag), then explicitly flips the PR from draft to ready-for-review and posts a maintainer-facing signal comment ("Post-tag update applied ... ready to merge to master"). Only after this flip is the PR safe to merge.
 
 ### Changelog PRs — `changelog-<version>-<rel-branch>` and `changelog-<version>-master` in `openemr/openemr`
 
@@ -137,7 +142,7 @@ Both fire on a single event, open **two coordinated ready-for-review PRs** (rel-
 | Existing `rel-*` receives a `$v_patch` bump into `-dev` | — | fires; opens 2 ready-for-review PRs | fires (on the same push); opens/updates 2 drafts + emits `openemr-rel-update` |
 | Any subsequent commit while `$v_tag == '-dev'` | — | — | fires; updates 2 drafts + emits `openemr-rel-update` |
 | Any commit after the branch shipped (post-tag, `$v_tag` empty) | — | — | fires but exits with `should-run=false`; no draft PR changes, no dispatch |
-| Release-prep PR merged (annotated tag created) | — | — | `finalize` job; creates tag + opens changelog PRs + emits `openemr-tag` |
+| Release-prep PR merged (annotated tag created) | — | — | `finalize` job; creates tag + refreshes release-finalize PR with post-tag content + flips it draft → ready + opens changelog PRs + emits `openemr-tag` |
 
 The two sibling one-shots handle **discrete lifecycle events** (branch creation, patch-cycle start); `release-prep.yml` handles the **continuous state** (draft PRs following the branch tip during an active dev cycle) plus the tag-time emission on merge. Clean separation of concerns — no overlap on which PRs each workflow owns, and the parallel firing on cut events is by design so the ready-for-review scaffolding and the draft tracking both appear together.
 
@@ -196,7 +201,7 @@ The complete ordered checklist for cutting a release. Each step is marked **[Aut
 The conductor merge creates the annotated tag (which flips the docs PR's banner from DRAFT to FINAL and fires the `openemr-tag` cascade for the Release object and announcement drafts). The other bot-created PRs land after the tag exists, in the following order:
 
 1. **Conductor PR** (`openemr/openemr` `release-prep/<rel-branch>`) — merges to rel-branch, creates the annotated tag.
-2. **Finalize-on-master PR** (`openemr/openemr` `release-finalize/<rel-branch>`) — auto-updated by the conductor post-tag; lands the master-side `release-targets.yml` rotation.
+2. **Finalize-on-master PR** (`openemr/openemr` `release-finalize/<rel-branch>`) — auto-updated by the `finalize` job post-tag, flipped from draft to ready-for-review with a signal comment; lands the master-side `release-targets.yml` rotation. Don't merge while it's still in draft state — the draft flag is the "post-tag update hasn't happened yet" indicator.
 3. **Changelog PRs** (`openemr/openemr` `changelog-<version>-<rel-branch>` and `changelog-<version>-master`) — `CHANGELOG.md` updates on both rel-branch and master.
 4. **Docs PR** (`openemr/website-openemr` `release-docs/<version>`) — ships the now-FINAL pages on the website.
 


### PR DESCRIPTION
## Summary

rel-820 backport of #12889 (G28 fix — finalize job now updates the release-finalize partner PR after tag creation + flips it from draft to ready-for-review with a signal comment).

Not byte-identical enforced. Same manual-backport pattern as G16 #12868 → #12872. rel-820 is currently the only shipped rel branch that has the release-mechanism, so no further rel-branch backports needed (rel-810 / rel-800 / rel-704 all predate the mechanism).

## Conflict resolution

One conflict on `.github/workflows/release-prep.yml`: rel-820 does not have G20's \`prev_release\` wiring on the \`Dispatch openemr-tag to consumers\` step (G20 was master-only, #12887). Resolved by keeping the rel-820 shape — dispatch step ends at \`--tag=\"${TAG_NAME}\"\` rather than \`--tag=\"${TAG_NAME}\" \\\` + \`--prev-release=\"${prev_release}\"\`. Everything after that (the six new G28 steps) applies cleanly and is identical to master.

Patch-id divergence from master is exactly one line; the semantic change (finalize-job post-tag PR update + draft→ready flip + signal comment) is identical.

## Doc update carried along

Also carries the RELEASE_PROCESS.md two-phase-lifecycle documentation update from the same master PR — describes the release-finalize PR's preview-during-dev vs post-tag-ready-for-review phases and the don't-merge-if-draft guardrail. The doc lives in both branches identically as of this commit.

## Test plan

- [ ] CI green on rel-820 (workflow syntax, phpstan, conventional-commits pre-commit)
- [ ] On next rel-820 release cut (whenever the next 8.2.x patch ships): verify the release-finalize/rel-820 PR body diff between (a) pre-merge preview state (from prep job) and (b) post-merge/post-tag state (from finalize job's new steps) — post-tag state should have \`openemr_version_ref\` pinned to \`v_8_2_N\` rather than \`rel-820\`
- [ ] Verify the PR flips draft → ready-for-review after the finalize job completes
- [ ] Verify the "Post-tag update applied" comment posts once per real release
- [ ] Verify test-mode dispatches do NOT trigger the new steps