### PR TITLE
feat(release): openemr-tag dispatch now carries prev_release (rel-820 backport of #12887)

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -493,6 +493,16 @@ jobs:
         MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         TAG_NAME: ${{ steps.tag.outputs.tag-name }}
       run: |
+        # G20: openemr-tag now carries prev_release so website-openemr's
+        # release-docs.yml can generate acknowledgements + release-notes
+        # on the FINAL cut. Historically this dispatch omitted the field
+        # and the two generators SKIPPED (their `if: prev_release != ''`
+        # gates) on every release, leaving each shipped version without
+        # markdown files on master until a manual openemr-rel-update
+        # recovery dispatch. Derived from the same
+        # BranchVersionResolver::previousRelease() the sibling rel-cut/
+        # update dispatches use.
+        prev_release="$(php tools/release/bin/derive-prev-release.php "${VERSION}")"
         # Demo_farm_openemr no longer consumes openemr-tag: its bump-tag.yml
         # was retired in demo_farm_openemr#141 in favor of the auto-derive
         # bot, which subscribes to release-targets-changed instead. Explicit
@@ -505,4 +515,5 @@ jobs:
           --actor='openemr-release-bot' \
           --branch="${REL_BRANCH}" \
           --release-version="${VERSION}" \
-          --tag="${TAG_NAME}"
+          --tag="${TAG_NAME}" \
+          --prev-release="${prev_release}"

--- a/tests/Tests/Isolated/Release/Contracts/DispatchRequestGoldenTest.php
+++ b/tests/Tests/Isolated/Release/Contracts/DispatchRequestGoldenTest.php
@@ -73,7 +73,12 @@ final class DispatchRequestGoldenTest extends TestCase
                 actor: 'openemr-release-bot',
                 dispatchedAt: '2026-04-29T12:30:00Z',
                 appToken: 'tok',
-                data: ['tag' => 'v8_1_0', 'branch' => 'rel-810', 'version' => '8.1.0'],
+                data: [
+                    'tag' => 'v8_2_0',
+                    'branch' => 'rel-820',
+                    'version' => '8.2.0',
+                    'prev_release' => '8.0.0',
+                ],
             ),
         ];
 
@@ -86,7 +91,12 @@ final class DispatchRequestGoldenTest extends TestCase
                 actor: 'openemr-release-bot',
                 dispatchedAt: '2026-04-29T12:30:00Z',
                 appToken: 'tok',
-                data: ['tag' => 'v8_1_0-test.abcdef0', 'branch' => 'rel-test', 'version' => '8.1.0'],
+                data: [
+                    'tag' => 'v8_2_0-test.abcdef0',
+                    'branch' => 'rel-test',
+                    'version' => '8.2.0',
+                    'prev_release' => '8.0.0',
+                ],
             ),
         ];
 

--- a/tests/Tests/Isolated/Release/DispatchDataBuilderTest.php
+++ b/tests/Tests/Isolated/Release/DispatchDataBuilderTest.php
@@ -35,15 +35,21 @@ final class DispatchDataBuilderTest extends TestCase
         );
     }
 
-    public function testTagBuildsTagBranchVersion(): void
+    public function testTagBuildsTagBranchVersionPrev(): void
     {
         $builder = new DispatchDataBuilder($this->reader([
             '--tag' => 'v8_1_0',
             '--branch' => 'rel-810',
             '--release-version' => '8.1.0',
+            '--prev-release' => '8.0.0',
         ]));
         self::assertSame(
-            ['tag' => 'v8_1_0', 'branch' => 'rel-810', 'version' => '8.1.0'],
+            [
+                'tag' => 'v8_1_0',
+                'branch' => 'rel-810',
+                'version' => '8.1.0',
+                'prev_release' => '8.0.0',
+            ],
             $builder->build(DispatchRequest::EVENT_TAG),
         );
     }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag-test.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag-test.json
@@ -5,8 +5,9 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:30:00Z",
   "data": {
-    "tag": "v8_1_0-test.abcdef0",
+    "tag": "v8_2_0-test.abcdef0",
     "branch": "rel-test",
-    "version": "8.1.0"
+    "version": "8.2.0",
+    "prev_release": "8.0.0"
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-tag.json
@@ -5,8 +5,9 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:30:00Z",
   "data": {
-    "tag": "v8_1_0",
-    "branch": "rel-810",
-    "version": "8.1.0"
+    "tag": "v8_2_0",
+    "branch": "rel-820",
+    "version": "8.2.0",
+    "prev_release": "8.0.0"
   }
 }

--- a/tools/release/contracts/dispatch.schema.json
+++ b/tools/release/contracts/dispatch.schema.json
@@ -162,7 +162,8 @@
       "required": [
         "tag",
         "branch",
-        "version"
+        "version",
+        "prev_release"
       ],
       "additionalProperties": false,
       "properties": {
@@ -173,6 +174,9 @@
           "$ref": "#/definitions/branch"
         },
         "version": {
+          "$ref": "#/definitions/version"
+        },
+        "prev_release": {
           "$ref": "#/definitions/version"
         }
       }

--- a/tools/release/src/DispatchDataBuilder.php
+++ b/tools/release/src/DispatchDataBuilder.php
@@ -39,6 +39,7 @@ final readonly class DispatchDataBuilder
                 'tag' => $this->opts->string('tag'),
                 'branch' => $this->opts->string('branch'),
                 'version' => $this->opts->string('release-version'),
+                'prev_release' => $this->opts->string('prev-release'),
             ],
             DispatchRequest::EVENT_RELEASE_TARGETS_CHANGED => [],
             DispatchRequest::EVENT_PROBE => [


### PR DESCRIPTION
## Summary

rel-820 backport of #12887 (G20 — openemr-tag dispatch payload now carries `prev_release`).

Missed on the original G20 landing yesterday; discovered while resolving conflicts on the G28 rel-820 backport (#12891). If left unfixed, the next 8.2.x ship from rel-820 would repeat the exact failure mode G20 fixed for master: `openemr-tag` payload with no `prev_release` → website-openemr's `release-docs.yml` gates `Generate acknowledgements` + `Generate release notes` on `prev_release != ''` → both SKIP → docs PR merges without either markdown file → recovery-dispatch dance.

## Patch-id parity

Byte-identical to master's squash-merge:

- master `359dda14bc` patch-id: `1bb7b0be1ee60d7c249a11d62322c41c45b84d3e`
- backport `98a25e796e` patch-id: `1bb7b0be1ee60d7c249a11d62322c41c45b84d3e`

Cherry-pick applied cleanly with no conflicts.

## Files (same 7 as master)

- `.github/workflows/release-prep.yml` — Dispatch openemr-tag step now derives `prev_release` and passes `--prev-release`
- `tools/release/src/DispatchDataBuilder.php` — tag event data includes `prev_release`
- `tools/release/contracts/dispatch.schema.json` — vendored schema mirrors openemr-devops#855
- 4 test/fixture files updated to include the new field

## Related

Landing this before #12891 (G28 rel-820 backport) means #12891 can be re-based / re-cherry-picked to have byte-identical patch-id parity with master's #12889 as well — the one-line conflict I resolved manually goes away once rel-820 has the same `--prev-release` line master does.

## Test plan

- [ ] CI green (isolated tests exercise `DispatchDataBuilderTest`, `DispatchRequestGoldenTest`, `DispatchSchemaTest` — same suite that guarded master's #12887)
- [ ] After landing: re-cherry-pick #12889 onto rel-820 to update #12891 for byte-identical patch-id parity