### PR TITLE
test(release): drop leftover 8.1.0 refs from dispatch fixtures + goldens

### DIFF
--- a/tests/Tests/Isolated/Release/Contracts/DispatchRequestGoldenTest.php
+++ b/tests/Tests/Isolated/Release/Contracts/DispatchRequestGoldenTest.php
@@ -47,7 +47,7 @@ final class DispatchRequestGoldenTest extends TestCase
                 actor: 'openemr-release-bot',
                 dispatchedAt: '2026-04-29T12:00:00Z',
                 appToken: 'tok',
-                data: ['branch' => 'rel-810', 'version' => '8.1.0', 'prev_release' => '8.0.0'],
+                data: ['branch' => 'rel-820', 'version' => '8.2.0', 'prev_release' => '8.0.0'],
             ),
         ];
 
@@ -60,7 +60,7 @@ final class DispatchRequestGoldenTest extends TestCase
                 actor: 'openemr-release-bot',
                 dispatchedAt: '2026-04-29T12:15:30Z',
                 appToken: 'tok',
-                data: ['branch' => 'rel-810', 'version' => '8.1.0', 'prev_release' => '8.0.0'],
+                data: ['branch' => 'rel-820', 'version' => '8.2.0', 'prev_release' => '8.0.0'],
             ),
         ];
 
@@ -110,9 +110,9 @@ final class DispatchRequestGoldenTest extends TestCase
                 dispatchedAt: '2026-04-29T13:00:00Z',
                 appToken: 'tok',
                 data: [
-                    'version' => '8.1.0',
-                    'branch' => 'rel-810',
-                    'files' => ['openemr-8.1.0-ehi.tar.gz', 'openemr-8.1.0-b10.tar.gz'],
+                    'version' => '8.2.0',
+                    'branch' => 'rel-820',
+                    'files' => ['openemr-8.2.0-ehi.tar.gz', 'openemr-8.2.0-b10.tar.gz'],
                 ],
             ),
         ];

--- a/tests/Tests/Isolated/Release/DispatchDataBuilderTest.php
+++ b/tests/Tests/Isolated/Release/DispatchDataBuilderTest.php
@@ -25,12 +25,12 @@ final class DispatchDataBuilderTest extends TestCase
     public function testRelCutBuildsBranchVersionPrev(): void
     {
         $builder = new DispatchDataBuilder($this->reader([
-            '--branch' => 'rel-810',
-            '--release-version' => '8.1.0',
+            '--branch' => 'rel-820',
+            '--release-version' => '8.2.0',
             '--prev-release' => '8.0.0',
         ]));
         self::assertSame(
-            ['branch' => 'rel-810', 'version' => '8.1.0', 'prev_release' => '8.0.0'],
+            ['branch' => 'rel-820', 'version' => '8.2.0', 'prev_release' => '8.0.0'],
             $builder->build(DispatchRequest::EVENT_REL_CUT),
         );
     }
@@ -38,16 +38,16 @@ final class DispatchDataBuilderTest extends TestCase
     public function testTagBuildsTagBranchVersionPrev(): void
     {
         $builder = new DispatchDataBuilder($this->reader([
-            '--tag' => 'v8_1_0',
-            '--branch' => 'rel-810',
-            '--release-version' => '8.1.0',
+            '--tag' => 'v8_2_0',
+            '--branch' => 'rel-820',
+            '--release-version' => '8.2.0',
             '--prev-release' => '8.0.0',
         ]));
         self::assertSame(
             [
-                'tag' => 'v8_1_0',
-                'branch' => 'rel-810',
-                'version' => '8.1.0',
+                'tag' => 'v8_2_0',
+                'branch' => 'rel-820',
+                'version' => '8.2.0',
                 'prev_release' => '8.0.0',
             ],
             $builder->build(DispatchRequest::EVENT_TAG),

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/bad-docs-binaries.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/bad-docs-binaries.json
@@ -5,8 +5,8 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T13:00:00Z",
   "data": {
-    "version": "8.1.0",
-    "branch": "rel-810",
+    "version": "8.2.0",
+    "branch": "rel-820",
     "files": []
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/bad-rel-cut.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/bad-rel-cut.json
@@ -5,7 +5,7 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:00:00Z",
   "data": {
-    "branch": "rel-810",
-    "version": "8.1.0"
+    "branch": "rel-820",
+    "version": "8.2.0"
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/bad-rel-update.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/bad-rel-update.json
@@ -5,8 +5,8 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:15:30Z",
   "data": {
-    "branch": "rel-810",
-    "version": "8.1.0",
+    "branch": "rel-820",
+    "version": "8.2.0",
     "prev_release": "8.0.0"
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/bad-tag.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/bad-tag.json
@@ -5,8 +5,8 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:30:00Z",
   "data": {
-    "tag": "v8.1.0",
-    "branch": "rel-810",
-    "version": "8.1.0"
+    "tag": "v8.2.0",
+    "branch": "rel-820",
+    "version": "8.2.0"
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-docs-binaries.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-docs-binaries.json
@@ -5,11 +5,11 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T13:00:00Z",
   "data": {
-    "version": "8.1.0",
-    "branch": "rel-810",
+    "version": "8.2.0",
+    "branch": "rel-820",
     "files": [
-      "openemr-8.1.0-ehi.tar.gz",
-      "openemr-8.1.0-b10.tar.gz"
+      "openemr-8.2.0-ehi.tar.gz",
+      "openemr-8.2.0-b10.tar.gz"
     ]
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-rel-cut.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-rel-cut.json
@@ -5,8 +5,8 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:00:00Z",
   "data": {
-    "branch": "rel-810",
-    "version": "8.1.0",
+    "branch": "rel-820",
+    "version": "8.2.0",
     "prev_release": "8.0.0"
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-rel-update.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-rel-update.json
@@ -5,8 +5,8 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:15:30Z",
   "data": {
-    "branch": "rel-810",
-    "version": "8.1.0",
+    "branch": "rel-820",
+    "version": "8.2.0",
     "prev_release": "8.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #12887's fixture cleanup pass. That PR bumped the openemr-tag goldens + \`good-tag.json\` / \`good-tag-test.json\` from \`8.1.0 / v8_1_0 / rel-810\` → \`8.2.0 / v8_2_0 / rel-820\`, but left the parallel \`openemr-rel-cut\` / \`openemr-rel-update\` / \`openemr-docs-binaries\` goldens + their fixture JSON files + the corresponding unit-test cases in \`DispatchDataBuilderTest\` still at \`8.1.0 / rel-810\`.

Same reasoning as the original cleanup: 8.1.0 was cut as a prerelease and skipped, never publicly released. Using it as the canonical fixture example implies a shipped 8.1.0 exists, which is misleading.

## Scope

9 files touched — sweep the remaining occurrences to \`8.2.0 / rel-820 / v8_2_0\` for consistency with the openemr-tag path:

- \`tests/Tests/Isolated/Release/Contracts/DispatchRequestGoldenTest.php\` — 3 goldens (rel-cut, rel-update, docs-binaries)
- \`tests/Tests/Isolated/Release/DispatchDataBuilderTest.php\` — 2 tests (RelCut, Tag)
- \`tests/Tests/Isolated/Release/fixtures/dispatch/good-rel-cut.json\`
- \`tests/Tests/Isolated/Release/fixtures/dispatch/good-rel-update.json\`
- \`tests/Tests/Isolated/Release/fixtures/dispatch/good-docs-binaries.json\`
- \`tests/Tests/Isolated/Release/fixtures/dispatch/bad-rel-cut.json\`
- \`tests/Tests/Isolated/Release/fixtures/dispatch/bad-rel-update.json\`
- \`tests/Tests/Isolated/Release/fixtures/dispatch/bad-tag.json\`
- \`tests/Tests/Isolated/Release/fixtures/dispatch/bad-docs-binaries.json\`

## What this PR does NOT change

- **\`BranchVersionResolverTest.php\`** — those 8.1.0 refs are semantically load-bearing. Multiple tests exercise the "8.1.0 was cut but skipped" manifest-filter behavior that motivated the prev-release resolver in the first place. Bumping them would either break the tests or require redesigning around a different skipped version.
- **The "badness" property of \`bad-*\` fixtures** — bad-tag.json still uses the dotted \`v8.2.0\` (invalid tag format), bad-rel-cut.json still omits \`prev_release\`, bad-rel-update.json still uses \`"not-a-valid-sha"\`, bad-docs-binaries.json still uses an empty \`files\` array. What changes is only the version-number window each fixture is expressed in.

## Backport plan

rel-820 backport to follow after this lands (byte-identical patch-id enforcement since both branches should have the same fixture state).

## Test plan

- [ ] CI green — isolated tests (\`DispatchDataBuilderTest\`, \`DispatchRequestGoldenTest\`, \`DispatchSchemaTest\`) all still pass with the new fixture values, both good and bad paths
- [ ] Local: \`openemr-cmd pit tests/Tests/Isolated/Release\` — verified 3716 tests pass (with pre-existing unrelated warnings on Cqm + Immunization tests)