### PR TITLE
test(release): drop leftover 8.1.0 refs from dispatch fixtures + goldens (rel-820 backport of #12893)

### DIFF
--- a/tests/Tests/Isolated/Release/Contracts/DispatchRequestGoldenTest.php
+++ b/tests/Tests/Isolated/Release/Contracts/DispatchRequestGoldenTest.php
@@ -47,7 +47,7 @@ final class DispatchRequestGoldenTest extends TestCase
                 actor: 'openemr-release-bot',
                 dispatchedAt: '2026-04-29T12:00:00Z',
                 appToken: 'tok',
-                data: ['branch' => 'rel-810', 'version' => '8.1.0', 'prev_release' => '8.0.0'],
+                data: ['branch' => 'rel-820', 'version' => '8.2.0', 'prev_release' => '8.0.0'],
             ),
         ];
 
@@ -60,7 +60,7 @@ final class DispatchRequestGoldenTest extends TestCase
                 actor: 'openemr-release-bot',
                 dispatchedAt: '2026-04-29T12:15:30Z',
                 appToken: 'tok',
-                data: ['branch' => 'rel-810', 'version' => '8.1.0', 'prev_release' => '8.0.0'],
+                data: ['branch' => 'rel-820', 'version' => '8.2.0', 'prev_release' => '8.0.0'],
             ),
         ];
 
@@ -110,9 +110,9 @@ final class DispatchRequestGoldenTest extends TestCase
                 dispatchedAt: '2026-04-29T13:00:00Z',
                 appToken: 'tok',
                 data: [
-                    'version' => '8.1.0',
-                    'branch' => 'rel-810',
-                    'files' => ['openemr-8.1.0-ehi.tar.gz', 'openemr-8.1.0-b10.tar.gz'],
+                    'version' => '8.2.0',
+                    'branch' => 'rel-820',
+                    'files' => ['openemr-8.2.0-ehi.tar.gz', 'openemr-8.2.0-b10.tar.gz'],
                 ],
             ),
         ];

--- a/tests/Tests/Isolated/Release/DispatchDataBuilderTest.php
+++ b/tests/Tests/Isolated/Release/DispatchDataBuilderTest.php
@@ -25,12 +25,12 @@ final class DispatchDataBuilderTest extends TestCase
     public function testRelCutBuildsBranchVersionPrev(): void
     {
         $builder = new DispatchDataBuilder($this->reader([
-            '--branch' => 'rel-810',
-            '--release-version' => '8.1.0',
+            '--branch' => 'rel-820',
+            '--release-version' => '8.2.0',
             '--prev-release' => '8.0.0',
         ]));
         self::assertSame(
-            ['branch' => 'rel-810', 'version' => '8.1.0', 'prev_release' => '8.0.0'],
+            ['branch' => 'rel-820', 'version' => '8.2.0', 'prev_release' => '8.0.0'],
             $builder->build(DispatchRequest::EVENT_REL_CUT),
         );
     }
@@ -38,16 +38,16 @@ final class DispatchDataBuilderTest extends TestCase
     public function testTagBuildsTagBranchVersionPrev(): void
     {
         $builder = new DispatchDataBuilder($this->reader([
-            '--tag' => 'v8_1_0',
-            '--branch' => 'rel-810',
-            '--release-version' => '8.1.0',
+            '--tag' => 'v8_2_0',
+            '--branch' => 'rel-820',
+            '--release-version' => '8.2.0',
             '--prev-release' => '8.0.0',
         ]));
         self::assertSame(
             [
-                'tag' => 'v8_1_0',
-                'branch' => 'rel-810',
-                'version' => '8.1.0',
+                'tag' => 'v8_2_0',
+                'branch' => 'rel-820',
+                'version' => '8.2.0',
                 'prev_release' => '8.0.0',
             ],
             $builder->build(DispatchRequest::EVENT_TAG),

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/bad-docs-binaries.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/bad-docs-binaries.json
@@ -5,8 +5,8 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T13:00:00Z",
   "data": {
-    "version": "8.1.0",
-    "branch": "rel-810",
+    "version": "8.2.0",
+    "branch": "rel-820",
     "files": []
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/bad-rel-cut.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/bad-rel-cut.json
@@ -5,7 +5,7 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:00:00Z",
   "data": {
-    "branch": "rel-810",
-    "version": "8.1.0"
+    "branch": "rel-820",
+    "version": "8.2.0"
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/bad-rel-update.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/bad-rel-update.json
@@ -5,8 +5,8 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:15:30Z",
   "data": {
-    "branch": "rel-810",
-    "version": "8.1.0",
+    "branch": "rel-820",
+    "version": "8.2.0",
     "prev_release": "8.0.0"
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/bad-tag.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/bad-tag.json
@@ -5,8 +5,8 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:30:00Z",
   "data": {
-    "tag": "v8.1.0",
-    "branch": "rel-810",
-    "version": "8.1.0"
+    "tag": "v8.2.0",
+    "branch": "rel-820",
+    "version": "8.2.0"
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-docs-binaries.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-docs-binaries.json
@@ -5,11 +5,11 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T13:00:00Z",
   "data": {
-    "version": "8.1.0",
-    "branch": "rel-810",
+    "version": "8.2.0",
+    "branch": "rel-820",
     "files": [
-      "openemr-8.1.0-ehi.tar.gz",
-      "openemr-8.1.0-b10.tar.gz"
+      "openemr-8.2.0-ehi.tar.gz",
+      "openemr-8.2.0-b10.tar.gz"
     ]
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-rel-cut.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-rel-cut.json
@@ -5,8 +5,8 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:00:00Z",
   "data": {
-    "branch": "rel-810",
-    "version": "8.1.0",
+    "branch": "rel-820",
+    "version": "8.2.0",
     "prev_release": "8.0.0"
   }
 }

--- a/tests/Tests/Isolated/Release/fixtures/dispatch/good-rel-update.json
+++ b/tests/Tests/Isolated/Release/fixtures/dispatch/good-rel-update.json
@@ -5,8 +5,8 @@
   "actor": "openemr-release-bot",
   "dispatched_at": "2026-04-29T12:15:30Z",
   "data": {
-    "branch": "rel-810",
-    "version": "8.1.0",
+    "branch": "rel-820",
+    "version": "8.2.0",
     "prev_release": "8.0.0"
   }
 }


### PR DESCRIPTION
## Summary

rel-820 backport of #12893 (fixture-cleanup sweep for the remaining rel-cut / rel-update / docs-binaries goldens + their good-/bad-* fixture JSONs + parallel DispatchDataBuilderTest cases that #12887's pass didn't reach).

Not byte-identical enforced yet (release-mechanism files aren't in `.github/docker-byte-identical.yml`'s manifest until the migration folds them in), so this is a manual backport per the discipline of keeping release-mechanism state uniform across master + rel-820.

## Patch-id parity

**Byte-identical** to master's squash-merge:

- master #12893 → `a09836f3a5`: `02fa2f1c2926e1074531e9d5d727a611ee00823f`
- backport `5157bf147e`: `02fa2f1c2926e1074531e9d5d727a611ee00823f`

Cherry-pick applied cleanly with no conflicts.

## Files (same 9 as master)

- `tests/Tests/Isolated/Release/Contracts/DispatchRequestGoldenTest.php`
- `tests/Tests/Isolated/Release/DispatchDataBuilderTest.php`
- `tests/Tests/Isolated/Release/fixtures/dispatch/good-rel-cut.json`
- `tests/Tests/Isolated/Release/fixtures/dispatch/good-rel-update.json`
- `tests/Tests/Isolated/Release/fixtures/dispatch/good-docs-binaries.json`
- `tests/Tests/Isolated/Release/fixtures/dispatch/bad-rel-cut.json`
- `tests/Tests/Isolated/Release/fixtures/dispatch/bad-rel-update.json`
- `tests/Tests/Isolated/Release/fixtures/dispatch/bad-tag.json`
- `tests/Tests/Isolated/Release/fixtures/dispatch/bad-docs-binaries.json`

## Test plan

- [ ] CI green on rel-820 (same isolated-test suite that guarded #12893: `DispatchDataBuilderTest`, `DispatchRequestGoldenTest`, `DispatchSchemaTest`)