### PR TITLE
feat(ci): glob-pattern support in byte-identical validator + sync scripts

### DIFF
--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -51,3 +51,4 @@ files:
 - .github/workflows/validate-byte-identical.yml
 - .github/byte-identical.yml
 - .github/scripts/validate-byte-identical.sh
+- .github/scripts/lib/glob-expand.sh

--- a/.github/scripts/lib/glob-expand.sh
+++ b/.github/scripts/lib/glob-expand.sh
@@ -81,6 +81,11 @@ glob_to_regex() {
   done
   # 3. Restore ** placeholder as regex `.*`
   out="${out//${GLOBSTAR}/.*}"
+  # 4. Convert POSIX glob negated character classes [!...] to ERE
+  #    negated classes [^...]. Shell globs don't permit a literal `[`
+  #    outside class context, so any `[!` in the built-up string is
+  #    unambiguously a negated-class opener.
+  out="${out//\[!/[^}"
   printf '^%s$\n' "${out}"
 }
 

--- a/.github/scripts/lib/glob-expand.sh
+++ b/.github/scripts/lib/glob-expand.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Shared glob-expansion helpers for the byte-identical scripts.
+#
+# Sourced by both .github/scripts/validate-byte-identical.sh and
+# .github/scripts/sync-byte-identical.sh. Not executable on its own --
+# these are function definitions consumed by the caller.
+#
+# Callers are expected to have already defined an `emit_warning`
+# function (both scripts do) before sourcing this file, so
+# expand_patterns_into can surface stale-manifest warnings for globs
+# that expanded to zero files.
+
+# Expand one FILES_ALL entry against a git ref into zero-or-more
+# concrete paths. Non-glob entries (no *, ?, or [ metachars) pass
+# through verbatim -- callers handle existence checks in their main
+# loops. Glob entries resolve against `git ls-tree -r`:
+#
+#   dir/**            -> `git ls-tree -r --name-only <ref> -- dir/`
+#                        (fast path for whole-subtree matches)
+#   any other glob    -> `git ls-tree -r --name-only <ref>` piped
+#                        through `grep -E` with a regex synthesized
+#                        from the glob (see glob_to_regex below)
+#
+# `git ls-tree`'s :(glob) pathspec magic isn't supported (unlike
+# `git ls-files`), which forces the pipe-through-grep fallback for
+# arbitrary globs.
+expand_pattern() {
+  local ref="${1}" pattern="${2}"
+  case "${pattern}" in
+    *'*'* | *'?'* | *'['*)
+      # Fast path for the common `<dir>/**` shape
+      if [[ "${pattern}" == *'/**' ]] && [[ "${pattern%/**}" != *'*'* ]] \
+        && [[ "${pattern%/**}" != *'?'* ]] && [[ "${pattern%/**}" != *'['* ]]; then
+        local dir="${pattern%/**}"
+        git ls-tree -r --name-only "${ref}" -- "${dir}/" 2>/dev/null || true
+      else
+        # Generic glob: full ls-tree, filter via regex. Split the
+        # pipeline so the ls-tree exit status isn't masked (SC2312).
+        local regex tree
+        regex="$(glob_to_regex "${pattern}")"
+        tree="$(git ls-tree -r --name-only "${ref}" 2>/dev/null || true)"
+        echo "${tree}" | grep -E "${regex}" || true
+      fi
+      ;;
+    *)
+      echo "${pattern}"
+      ;;
+  esac
+}
+
+# Convert a shell-glob pattern to an anchored ERE regex. Semantics:
+#   **  -> `.*`               (matches across path separators)
+#   *   -> `[^/]*`            (matches within one path component)
+#   ?   -> `[^/]`             (single non-slash char)
+#   [..] preserved as-is (character class)
+# Regex metacharacters other than * ? [ are escaped. Result is wrapped
+# in ^...$ so `grep -E` gives whole-path matches only.
+glob_to_regex() {
+  local p="${1}"
+  # Placeholder swap so `**` is treated distinctly from `*` before we
+  # escape and rewrite. `\x00` isn't valid in bash strings; use a
+  # rare printable sentinel instead.
+  local GLOBSTAR=$'\x1F\x1FGS\x1F\x1F'
+  # 1. Substitute ** with the sentinel (must happen before single-*
+  #    substitution, otherwise ** becomes [^/]*[^/]*).
+  p="${p//\*\*/${GLOBSTAR}}"
+  # 2. Escape regex metacharacters except: * ? [ ] (glob chars) and /
+  #    (path separator, safe as-is).
+  local out=""
+  local i c
+  for ((i = 0; i < ${#p}; i++)); do
+    c="${p:i:1}"
+    case "${c}" in
+      '.' | '+' | '(' | ')' | '{' | '}' | '^' | '$' | '|') out+="\\${c}" ;;
+      $'\\')  out+=$'\\\\' ;;
+      '*')    out+='[^/]*' ;;
+      '?')    out+='[^/]' ;;
+      *)      out+="${c}" ;;
+    esac
+  done
+  # 3. Restore ** placeholder as regex `.*`
+  out="${out//${GLOBSTAR}/.*}"
+  printf '^%s$\n' "${out}"
+}
+
+# Expand a list of patterns against a git ref into a sorted list of
+# concrete paths. Signature:
+#   expand_patterns_into <ref> <input_patterns_array_name> <output_array_name>
+#
+# Deliberately DOES NOT dedup: callers rely on the raw multi-set to
+# detect overlap-between-patterns as a config bug (via a downstream
+# `uniq -d` check on the expanded set). The sync script's own callers
+# ALSO dedup via `sort -u` when they union multiple expansions, so
+# leaving per-call dedup out doesn't compromise its correctness either.
+#
+# Glob patterns that expanded to zero files surface as warnings
+# (usually a stale manifest entry) but are not fatal at this layer.
+expand_patterns_into() {
+  local ref="${1}" in_var="${2}" out_var="${3}"
+  # shellcheck disable=SC2178  # nameref -- assigned from another array
+  local -n in_arr="${in_var}"
+  # shellcheck disable=SC2034,SC2178  # nameref -- referenced by caller
+  local -n out_arr="${out_var}"
+  local pattern p
+  local -a expanded=()
+  local -a empty_patterns=()
+  for pattern in "${in_arr[@]}"; do
+    local pattern_matched=0
+    # shellcheck disable=SC2312  # expand_pattern handles its own errors
+    while IFS= read -r p; do
+      [[ -z "${p}" ]] && continue
+      pattern_matched=1
+      expanded+=("${p}")
+    done < <(expand_pattern "${ref}" "${pattern}")
+    case "${pattern}" in
+      *'*'* | *'?'* | *'['*)
+        if [[ ${pattern_matched} -eq 0 ]]; then
+          empty_patterns+=("${pattern}")
+        fi
+        ;;
+      *) ;;
+    esac
+  done
+  # sort for stable iteration (helps golden-comparison tests too).
+  # `printf '%s\n' "${arr[@]}"` on an empty array still emits one empty
+  # line in bash (format applied once with no args); filter with
+  # `grep -v '^$'` so out_arr comes back as a genuinely empty array
+  # rather than a one-empty-string array.
+  local sorted
+  sorted="$(printf '%s\n' "${expanded[@]}" | grep -v '^$' | sort || true)"
+  if [[ -n "${sorted}" ]]; then
+    mapfile -t out_arr <<<"${sorted}"
+  else
+    # shellcheck disable=SC2034  # nameref -- consumed by caller
+    out_arr=()
+  fi
+  # Warn (do not fail) on globs that matched nothing -- almost always
+  # a stale manifest entry. Callers surface these via the emit_warning
+  # function they define.
+  local ep
+  for ep in "${empty_patterns[@]}"; do
+    emit_warning "Glob pattern '${ep}' expanded to zero files on ${ref}; manifest may be stale."
+  done
+}

--- a/.github/scripts/sync-byte-identical.sh
+++ b/.github/scripts/sync-byte-identical.sh
@@ -80,7 +80,10 @@ emit_warning() {
 # Source the shared glob-expansion helpers (expand_pattern,
 # glob_to_regex, expand_patterns_into). Sourced AFTER emit_warning is
 # defined -- expand_patterns_into calls it on stale-glob patterns.
-# shellcheck source=lib/glob-expand.sh
+# See validate-byte-identical.sh's source line for the /dev/null
+# rationale (avoids requiring source-path=SCRIPTDIR in .shellcheckrc,
+# which isn't byte-identical enforced and would stay master-only).
+# shellcheck source=/dev/null
 source "$(dirname "${BASH_SOURCE[0]}")/lib/glob-expand.sh"
 
 # Preconditions

--- a/.github/scripts/sync-byte-identical.sh
+++ b/.github/scripts/sync-byte-identical.sh
@@ -65,93 +65,23 @@ emit_error() {
   fi
 }
 
-# Expand one FILES_ALL entry against a git ref into zero-or-more concrete
-# paths. Non-glob entries pass through verbatim. Glob entries resolve
-# against `git ls-tree -r`:
-#
-#   dir/**            -> `git ls-tree -r --name-only <ref> -- dir/`
-#                        (fast path for whole-subtree matches)
-#   any other glob    -> `git ls-tree -r --name-only <ref>` piped
-#                        through `grep -E` with a regex from
-#                        glob_to_regex below
-#
-# `git ls-tree`'s :(glob) pathspec magic isn't supported (unlike
-# `git ls-files`), which forces the pipe-through-grep fallback.
-expand_pattern() {
-  local ref="$1" pattern="$2"
-  case "$pattern" in
-    *'*'* | *'?'* | *'['*)
-      if [[ "$pattern" == *'/**' ]] && [[ "${pattern%/**}" != *'*'* ]] \
-        && [[ "${pattern%/**}" != *'?'* ]] && [[ "${pattern%/**}" != *'['* ]]; then
-        local dir="${pattern%/**}"
-        git ls-tree -r --name-only "$ref" -- "${dir}/" 2>/dev/null || true
-      else
-        local regex
-        regex=$(glob_to_regex "$pattern")
-        git ls-tree -r --name-only "$ref" 2>/dev/null | grep -E "$regex" || true
-      fi
-      ;;
-    *)
-      echo "$pattern"
-      ;;
-  esac
+# expand_patterns_into (sourced below) surfaces stale-glob patterns via
+# emit_warning; provide the passthrough so those warnings show up in
+# the sync workflow summary. Matches the shape of emit_error above.
+emit_warning() {
+  local msg="$1"
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::warning::${msg}"
+  else
+    echo "WARNING: ${msg}"
+  fi
 }
 
-# Convert a shell-glob pattern to an anchored ERE regex. Semantics:
-#   **  -> `.*`               (matches across path separators)
-#   *   -> `[^/]*`            (matches within one path component)
-#   ?   -> `[^/]`             (single non-slash char)
-#   [..] preserved as-is
-# Regex metacharacters other than * ? [ are escaped. Result is wrapped
-# in ^...$ so `grep -E` gives whole-path matches only.
-glob_to_regex() {
-  local p="$1"
-  local GLOBSTAR=$'\x1F\x1FGS\x1F\x1F'
-  p="${p//\*\*/${GLOBSTAR}}"
-  local out=""
-  local i c
-  for ((i = 0; i < ${#p}; i++)); do
-    c="${p:i:1}"
-    case "$c" in
-      '.' | '+' | '(' | ')' | '{' | '}' | '^' | '$' | '|' | '\')
-        out+="\\${c}"
-        ;;
-      '*') out+='[^/]*' ;;
-      '?') out+='[^/]' ;;
-      *)   out+="$c" ;;
-    esac
-  done
-  out="${out//${GLOBSTAR}/.*}"
-  printf '^%s$\n' "$out"
-}
-
-# Expand a list of patterns against a git ref into a dedup+sorted list
-# of concrete paths. Signature:
-#   expand_patterns_into <ref> <input_patterns_array_name> <output_array_name>
-# Sync uses this three times (master patterns against master, master
-# patterns against rel HEAD, rel patterns against rel HEAD) so the union
-# and sweep logic below has the concrete-path sets it needs.
-expand_patterns_into() {
-  local ref="$1" in_var="$2" out_var="$3"
-  local -n in_arr="$in_var"
-  local -n out_arr="$out_var"
-  local pattern p
-  local -A seen=()
-  local -a expanded=()
-  for pattern in "${in_arr[@]}"; do
-    while IFS= read -r p; do
-      [[ -z "$p" ]] && continue
-      if [[ -z "${seen[$p]:-}" ]]; then
-        seen[$p]=1
-        expanded+=("$p")
-      fi
-    done < <(expand_pattern "$ref" "$pattern")
-  done
-  # `printf '%s\n' "${arr[@]}"` on an empty array still emits one empty
-  # line in bash (format applied once with no args); filter with
-  # `grep -v '^$'` so out_arr comes back as a genuinely empty array.
-  mapfile -t out_arr < <(printf '%s\n' "${expanded[@]}" | grep -v '^$' | sort)
-}
+# Source the shared glob-expansion helpers (expand_pattern,
+# glob_to_regex, expand_patterns_into). Sourced AFTER emit_warning is
+# defined -- expand_patterns_into calls it on stale-glob patterns.
+# shellcheck source=lib/glob-expand.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/glob-expand.sh"
 
 # Preconditions
 command -v yq >/dev/null 2>&1 || {
@@ -209,12 +139,15 @@ expand_patterns_into HEAD   FILES_ALL REL_PATHS_UNDER_MASTER_CONFIG
 # Union of the two expansions -- everything master's config wants us to
 # consider on this rel branch. Dedup + sort for stable iteration order.
 # `grep -v '^$'` filters the empty-line printf-with-empty-array leaves.
+# Split into two steps so pipe stages' exit statuses aren't masked
+# (SC2312 -- printf/grep/sort are all no-fail here in practice, but
+# make it explicit).
 declare -a FILES_TO_CHECK=()
-mapfile -t FILES_TO_CHECK < <(
-  printf '%s\n' "${MASTER_PATHS[@]}" "${REL_PATHS_UNDER_MASTER_CONFIG[@]}" \
-    | grep -v '^$' \
-    | sort -u
-)
+FILES_TO_CHECK_INPUT="$(printf '%s\n' "${MASTER_PATHS[@]}" "${REL_PATHS_UNDER_MASTER_CONFIG[@]}" | grep -v '^$' | sort -u || true)"
+if [[ -n "${FILES_TO_CHECK_INPUT}" ]]; then
+  mapfile -t FILES_TO_CHECK <<<"${FILES_TO_CHECK_INPUT}"
+fi
+unset FILES_TO_CHECK_INPUT
 echo "Concrete paths after glob expansion (master + rel union): ${#FILES_TO_CHECK[@]}"
 
 CHANGES=()

--- a/.github/scripts/sync-byte-identical.sh
+++ b/.github/scripts/sync-byte-identical.sh
@@ -65,6 +65,94 @@ emit_error() {
   fi
 }
 
+# Expand one FILES_ALL entry against a git ref into zero-or-more concrete
+# paths. Non-glob entries pass through verbatim. Glob entries resolve
+# against `git ls-tree -r`:
+#
+#   dir/**            -> `git ls-tree -r --name-only <ref> -- dir/`
+#                        (fast path for whole-subtree matches)
+#   any other glob    -> `git ls-tree -r --name-only <ref>` piped
+#                        through `grep -E` with a regex from
+#                        glob_to_regex below
+#
+# `git ls-tree`'s :(glob) pathspec magic isn't supported (unlike
+# `git ls-files`), which forces the pipe-through-grep fallback.
+expand_pattern() {
+  local ref="$1" pattern="$2"
+  case "$pattern" in
+    *'*'* | *'?'* | *'['*)
+      if [[ "$pattern" == *'/**' ]] && [[ "${pattern%/**}" != *'*'* ]] \
+        && [[ "${pattern%/**}" != *'?'* ]] && [[ "${pattern%/**}" != *'['* ]]; then
+        local dir="${pattern%/**}"
+        git ls-tree -r --name-only "$ref" -- "${dir}/" 2>/dev/null || true
+      else
+        local regex
+        regex=$(glob_to_regex "$pattern")
+        git ls-tree -r --name-only "$ref" 2>/dev/null | grep -E "$regex" || true
+      fi
+      ;;
+    *)
+      echo "$pattern"
+      ;;
+  esac
+}
+
+# Convert a shell-glob pattern to an anchored ERE regex. Semantics:
+#   **  -> `.*`               (matches across path separators)
+#   *   -> `[^/]*`            (matches within one path component)
+#   ?   -> `[^/]`             (single non-slash char)
+#   [..] preserved as-is
+# Regex metacharacters other than * ? [ are escaped. Result is wrapped
+# in ^...$ so `grep -E` gives whole-path matches only.
+glob_to_regex() {
+  local p="$1"
+  local GLOBSTAR=$'\x1F\x1FGS\x1F\x1F'
+  p="${p//\*\*/${GLOBSTAR}}"
+  local out=""
+  local i c
+  for ((i = 0; i < ${#p}; i++)); do
+    c="${p:i:1}"
+    case "$c" in
+      '.' | '+' | '(' | ')' | '{' | '}' | '^' | '$' | '|' | '\')
+        out+="\\${c}"
+        ;;
+      '*') out+='[^/]*' ;;
+      '?') out+='[^/]' ;;
+      *)   out+="$c" ;;
+    esac
+  done
+  out="${out//${GLOBSTAR}/.*}"
+  printf '^%s$\n' "$out"
+}
+
+# Expand a list of patterns against a git ref into a dedup+sorted list
+# of concrete paths. Signature:
+#   expand_patterns_into <ref> <input_patterns_array_name> <output_array_name>
+# Sync uses this three times (master patterns against master, master
+# patterns against rel HEAD, rel patterns against rel HEAD) so the union
+# and sweep logic below has the concrete-path sets it needs.
+expand_patterns_into() {
+  local ref="$1" in_var="$2" out_var="$3"
+  local -n in_arr="$in_var"
+  local -n out_arr="$out_var"
+  local pattern p
+  local -A seen=()
+  local -a expanded=()
+  for pattern in "${in_arr[@]}"; do
+    while IFS= read -r p; do
+      [[ -z "$p" ]] && continue
+      if [[ -z "${seen[$p]:-}" ]]; then
+        seen[$p]=1
+        expanded+=("$p")
+      fi
+    done < <(expand_pattern "$ref" "$pattern")
+  done
+  # `printf '%s\n' "${arr[@]}"` on an empty array still emits one empty
+  # line in bash (format applied once with no args); filter with
+  # `grep -v '^$'` so out_arr comes back as a genuinely empty array.
+  mapfile -t out_arr < <(printf '%s\n' "${expanded[@]}" | grep -v '^$' | sort)
+}
+
 # Preconditions
 command -v yq >/dev/null 2>&1 || {
   emit_error "yq not found on PATH (need Mike Farah's Go-based yq)."
@@ -107,10 +195,30 @@ fi
 
 master_sha=$(git rev-parse master)
 echo "Syncing master (${master_sha}) -> ${target_branch}"
-echo "Files in FILES_ALL: ${#FILES_ALL[@]}"
+echo "Patterns in master's FILES_ALL: ${#FILES_ALL[@]}"
+
+# Expand master's FILES_ALL against BOTH refs. A path may exist only on
+# master (add), only on rel (delete), on both (identical/update), or --
+# for a stale glob pattern -- on neither (config bug, caught in the
+# main loop's both-missing branch).
+declare -a MASTER_PATHS=()
+declare -a REL_PATHS_UNDER_MASTER_CONFIG=()
+expand_patterns_into master FILES_ALL MASTER_PATHS
+expand_patterns_into HEAD   FILES_ALL REL_PATHS_UNDER_MASTER_CONFIG
+
+# Union of the two expansions -- everything master's config wants us to
+# consider on this rel branch. Dedup + sort for stable iteration order.
+# `grep -v '^$'` filters the empty-line printf-with-empty-array leaves.
+declare -a FILES_TO_CHECK=()
+mapfile -t FILES_TO_CHECK < <(
+  printf '%s\n' "${MASTER_PATHS[@]}" "${REL_PATHS_UNDER_MASTER_CONFIG[@]}" \
+    | grep -v '^$' \
+    | sort -u
+)
+echo "Concrete paths after glob expansion (master + rel union): ${#FILES_TO_CHECK[@]}"
 
 CHANGES=()
-for FILE in "${FILES_ALL[@]}"; do
+for FILE in "${FILES_TO_CHECK[@]}"; do
   master_has=n
   branch_has=n
   if git cat-file -e "master:${FILE}" 2>/dev/null; then master_has=y; fi
@@ -118,7 +226,10 @@ for FILE in "${FILES_ALL[@]}"; do
 
   if [[ "${master_has}" == "n" ]] && [[ "${branch_has}" == "n" ]]; then
     # File is in FILES_ALL but absent from both branches -- always a config
-    # bug (someone removed the file but forgot to update the list).
+    # bug (someone removed the file but forgot to update the list). With
+    # glob expansion this should be unreachable (union of master + rel
+    # expansions only includes files present on at least one side), but
+    # kept as a defense in depth.
     emit_error "${FILE}: listed in byte-identical.yml but missing from both master and ${target_branch}"
     exit 1
   fi
@@ -152,24 +263,27 @@ for FILE in "${FILES_ALL[@]}"; do
 done
 
 # Rename / removed-from-config sweep: walk the rel branch's own
-# byte-identical.yml (if it has one). Entries that are in rel's
-# FILES_ALL but not master's are paths master dropped from the managed
-# set. There are three sub-cases, distinguished by whether master still
-# carries the file at that path:
+# byte-identical.yml (if it has one) and expand its patterns against
+# rel HEAD to get every path rel's config says it wants to manage.
+# Diff that concrete-path set against MASTER_PATHS (master's own
+# expansion). Paths in rel's set but not master's are paths master
+# dropped from the managed set. Two sub-cases, distinguished by whether
+# master still carries the file at that path:
 #
-#   1. Master neither lists nor carries the path. True removal (or
-#      rename -- the new path appears in master's config and was already
-#      handled as `add` by the main loop above). The old path lingering
-#      on the rel branch is orphaned -- delete it.
+#   1. Master doesn't carry the path (git cat-file -e master:PATH fails).
+#      True removal (or rename -- the new path appears in master's
+#      config and was already handled as `add` by the main loop above).
+#      The old path lingering on the rel branch is orphaned -- delete it.
 #
 #   2. Master still carries the path but dropped it from FILES_ALL.
 #      Deliberate "demote to per-branch divergence" -- the file is no
-#      longer being byte-identity-enforced. Leave the rel-branch copy
-#      alone; it can now legitimately drift.
+#      longer byte-identity-enforced. Leave the rel-branch copy alone.
 #
-#   3. Path not on rel branch HEAD either. Rel's FILES_ALL lists a
-#      path no one carries -- a config bug on rel's side. Silent skip;
-#      the canary's main loop is what surfaces config bugs, not sync.
+# Case 3 (rel doesn't have the file either) survives for literal-path
+# entries -- expand_pattern echoes literals verbatim regardless of
+# existence, so a literal in rel's config that rel HEAD lacks lands
+# in the diff and needs a silent skip. Glob entries only emit
+# existing paths, so case 3 doesn't apply to them.
 if git cat-file -e "HEAD:.github/byte-identical.yml" 2>/dev/null; then
   rel_config_contents=$(git show "HEAD:.github/byte-identical.yml")
   rel_files_yq_output=$(echo "${rel_config_contents}" | yq -r '.files[]')
@@ -178,28 +292,40 @@ if git cat-file -e "HEAD:.github/byte-identical.yml" 2>/dev/null; then
     REL_FILES_ALL=()
   fi
 
-  # Set difference (rel - master). `comm -23` needs sorted input.
-  master_sorted=$(printf '%s\n' "${FILES_ALL[@]}" | sort)
-  rel_sorted=$(printf '%s\n' "${REL_FILES_ALL[@]}" | sort)
-  rel_only=$(comm -23 <(echo "${rel_sorted}") <(echo "${master_sorted}"))
+  if [[ ${#REL_FILES_ALL[@]} -gt 0 ]]; then
+    # Expand rel's own patterns against rel HEAD to get concrete paths
+    # rel intends to manage.
+    declare -a REL_PATHS_UNDER_REL_CONFIG=()
+    expand_patterns_into HEAD REL_FILES_ALL REL_PATHS_UNDER_REL_CONFIG
 
-  if [[ -n "${rel_only}" ]]; then
-    while IFS= read -r STALE; do
-      [[ -z "${STALE}" ]] && continue
-      if ! git cat-file -e "HEAD:${STALE}" 2>/dev/null; then
-        continue   # case 3: rel doesn't have the file either
-      fi
-      if git cat-file -e "master:${STALE}" 2>/dev/null; then
-        # case 2: master still carries the file, just stopped enforcing
-        # byte-identity. Leave rel's copy alone.
-        echo "  ${STALE}  (skip: dropped from FILES_ALL but master still carries the file -- per-branch divergence now allowed)"
-        continue
-      fi
-      # case 1: true removal (or rename's old-path side).
-      echo "  - ${STALE}  (delete: master removed this path entirely)"
-      git rm -- "${STALE}" >/dev/null
-      CHANGES+=("delete: ${STALE}")
-    done <<< "${rel_only}"
+    # Set difference (rel-managed - master-managed). Both are already
+    # sorted by expand_patterns_into.
+    rel_only=$(comm -23 \
+      <(printf '%s\n' "${REL_PATHS_UNDER_REL_CONFIG[@]}") \
+      <(printf '%s\n' "${MASTER_PATHS[@]}"))
+
+    if [[ -n "${rel_only}" ]]; then
+      while IFS= read -r STALE; do
+        [[ -z "${STALE}" ]] && continue
+        if ! git cat-file -e "HEAD:${STALE}" 2>/dev/null; then
+          # case 3: rel doesn't have the file either. Reachable only
+          # for literal-path entries (globs would have filtered this
+          # out at expansion time). Silent skip -- config-bug surfacing
+          # is the canary's job, not sync's.
+          continue
+        fi
+        if git cat-file -e "master:${STALE}" 2>/dev/null; then
+          # case 2: master still carries the file, just stopped enforcing
+          # byte-identity. Leave rel's copy alone.
+          echo "  ${STALE}  (skip: dropped from FILES_ALL but master still carries the file -- per-branch divergence now allowed)"
+          continue
+        fi
+        # case 1: true removal (or rename's old-path side).
+        echo "  - ${STALE}  (delete: master removed this path entirely)"
+        git rm -- "${STALE}" >/dev/null
+        CHANGES+=("delete: ${STALE}")
+      done <<< "${rel_only}"
+    fi
   fi
 fi
 

--- a/.github/scripts/validate-byte-identical.sh
+++ b/.github/scripts/validate-byte-identical.sh
@@ -48,6 +48,128 @@ set -euo pipefail
 
 RAW_FETCH_BASE_URL="${RAW_FETCH_BASE_URL:-https://raw.githubusercontent.com/openemr/openemr}"
 
+# Expand one FILES_ALL entry against a git ref into zero-or-more concrete
+# paths. Non-glob entries (no *, ?, or [ metachars) pass through
+# verbatim -- callers handle existence checking. Glob entries are
+# resolved against `git ls-tree -r`:
+#
+#   dir/**            -> `git ls-tree -r --name-only <ref> -- dir/`
+#                        (fast path -- most manifest globs are whole-
+#                        subtree matches like `tools/release/**`)
+#   any other glob    -> `git ls-tree -r --name-only <ref>` piped
+#                        through `grep -E` with a regex synthesized
+#                        from the glob (see glob_to_regex below)
+#
+# Empty output for a glob that matches nothing is not fatal at this
+# layer -- the caller decides how to interpret it.
+#
+# `git ls-tree`'s :(glob) pathspec magic is not supported (unlike
+# `git ls-files`), which forces the pipe-through-grep fallback for
+# arbitrary globs. The bare-subtree fast path covers the common case
+# and avoids the regex synthesis when possible.
+expand_pattern() {
+  local ref="$1" pattern="$2"
+  case "$pattern" in
+    *'*'* | *'?'* | *'['*)
+      # Fast path for the common `<dir>/**` shape
+      if [[ "$pattern" == *'/**' ]] && [[ "${pattern%/**}" != *'*'* ]] \
+        && [[ "${pattern%/**}" != *'?'* ]] && [[ "${pattern%/**}" != *'['* ]]; then
+        local dir="${pattern%/**}"
+        git ls-tree -r --name-only "$ref" -- "${dir}/" 2>/dev/null || true
+      else
+        # Generic glob: full ls-tree, filter via regex
+        local regex
+        regex=$(glob_to_regex "$pattern")
+        git ls-tree -r --name-only "$ref" 2>/dev/null | grep -E "$regex" || true
+      fi
+      ;;
+    *)
+      echo "$pattern"
+      ;;
+  esac
+}
+
+# Convert a shell-glob pattern to an anchored ERE regex. Semantics:
+#   **  -> `.*`               (matches across path separators)
+#   *   -> `[^/]*`            (matches within one path component)
+#   ?   -> `[^/]`             (single non-slash char)
+#   [..] preserved as-is (character class)
+# Regex metacharacters other than * ? [ are escaped. Result is wrapped
+# in ^...$ so `grep -E` gives whole-path matches only.
+glob_to_regex() {
+  local p="$1"
+  # Placeholder swap so `**` is treated distinctly from `*` before we
+  # escape and rewrite. `\x00` isn't valid in bash strings; use a
+  # rare printable sentinel instead.
+  local GLOBSTAR=$'\x1F\x1FGS\x1F\x1F'
+  # 1. Substitute ** with the sentinel (must happen before single-*
+  #    substitution, otherwise ** becomes [^/]*[^/]*).
+  p="${p//\*\*/${GLOBSTAR}}"
+  # 2. Escape regex metacharacters except: * ? [ ] (glob chars) and /
+  #    (path separator, safe as-is).
+  local out=""
+  local i c
+  for ((i = 0; i < ${#p}; i++)); do
+    c="${p:i:1}"
+    case "$c" in
+      '.' | '+' | '(' | ')' | '{' | '}' | '^' | '$' | '|' | '\')
+        out+="\\${c}"
+        ;;
+      '*') out+='[^/]*' ;;
+      '?') out+='[^/]' ;;
+      *)   out+="$c" ;;
+    esac
+  done
+  # 3. Restore ** placeholder as regex `.*`
+  out="${out//${GLOBSTAR}/.*}"
+  printf '^%s$\n' "$out"
+}
+
+# Expand a list of patterns against a git ref into a dedup+sorted list
+# of concrete paths. Signature:
+#   expand_patterns_into <ref> <input_patterns_array_name> <output_array_name>
+# Glob patterns that expanded to zero files are surfaced as warnings
+# (usually a stale manifest entry) but not fatal at this layer.
+expand_patterns_into() {
+  local ref="$1" in_var="$2" out_var="$3"
+  local -n in_arr="$in_var"
+  local -n out_arr="$out_var"
+  local pattern p
+  local -A seen=()
+  local -a expanded=()
+  local -a empty_patterns=()
+  for pattern in "${in_arr[@]}"; do
+    local pattern_matched=0
+    while IFS= read -r p; do
+      [[ -z "$p" ]] && continue
+      pattern_matched=1
+      if [[ -z "${seen[$p]:-}" ]]; then
+        seen[$p]=1
+        expanded+=("$p")
+      fi
+    done < <(expand_pattern "$ref" "$pattern")
+    case "$pattern" in
+      *'*'* | *'?'* | *'['*)
+        if [[ $pattern_matched -eq 0 ]]; then
+          empty_patterns+=("$pattern")
+        fi
+        ;;
+    esac
+  done
+  # sort for stable iteration (helps golden-comparison tests too).
+  # `printf '%s\n' "${arr[@]}"` on an empty array still emits one empty
+  # line in bash (format applied once with no args); filter with
+  # `grep -v '^$'` so out_arr comes back as a genuinely empty array
+  # rather than a one-empty-string array.
+  mapfile -t out_arr < <(printf '%s\n' "${expanded[@]}" | grep -v '^$' | sort)
+  # Warn (do not fail) on globs that matched nothing -- almost always a
+  # stale manifest entry, worth surfacing but not blocking.
+  local ep
+  for ep in "${empty_patterns[@]}"; do
+    emit_warning "Glob pattern '${ep}' expanded to zero files on ${ref}; manifest may be stale."
+  done
+}
+
 emit_error() {
   local msg="$1"
   if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
@@ -123,6 +245,30 @@ if [[ -n "${dupes}" ]]; then
   exit 1
 fi
 
+# Expand FILES_ALL into concrete paths. Glob patterns (e.g. `tools/release/**`)
+# are expanded against HEAD via `git ls-tree`; literal path entries pass
+# through verbatim (existence gets checked in the main loops below).
+declare -a FILES_ALL_EXPANDED=()
+expand_patterns_into HEAD FILES_ALL FILES_ALL_EXPANDED
+
+if [[ ${#FILES_ALL_EXPANDED[@]} -eq 0 ]]; then
+  # Every entry expanded to zero paths -- either every pattern is stale
+  # or the manifest is entirely glob-only and matched nothing. Fail
+  # closed so we don't silently skip validation.
+  emit_error "byte-identical.yml patterns expanded to zero paths on HEAD; refusing to skip drift validation."
+  exit 1
+fi
+
+# Reject duplicates in the expanded set too -- a glob pattern overlapping
+# a literal entry would produce duplicates post-expansion; catch that as
+# a config bug even though the pre-expansion set was unique.
+dupes_expanded=$(printf '%s\n' "${FILES_ALL_EXPANDED[@]}" | sort | uniq -d)
+if [[ -n "${dupes_expanded}" ]]; then
+  dupes_expanded_one_line=$(echo "${dupes_expanded}" | tr '\n' ' ')
+  emit_error "Duplicate paths after glob expansion (glob overlaps literal or another glob): ${dupes_expanded_one_line}"
+  exit 1
+fi
+
 # Determine run context. pull_request uses the PR's base ref; everything
 # else (schedule, push, workflow_dispatch) uses the ref the workflow
 # ran on.
@@ -168,10 +314,12 @@ if [[ "${CONTEXT_BRANCH}" == "master" ]]; then
     exit 0
   fi
 
-  # Master context: master is canonical. Every FILES_ALL entry must
-  # exist on master; missing ones are a config bug.
+  # Master context: master is canonical. Every FILES_ALL_EXPANDED entry
+  # must exist on master; missing ones are a config bug. For glob
+  # entries this is tautological (expansion only emits existing paths),
+  # so this catches literal-path entries pointing at a missing file.
   missing=()
-  for FILE in "${FILES_ALL[@]}"; do
+  for FILE in "${FILES_ALL_EXPANDED[@]}"; do
     [[ -f "${FILE}" ]] || missing+=("${FILE}")
   done
   if [[ ${#missing[@]} -gt 0 ]]; then
@@ -190,7 +338,7 @@ if [[ "${CONTEXT_BRANCH}" == "master" ]]; then
 
   for BRANCH in "${REL_BRANCHES[@]}"; do
     echo "::group::Compare ${BRANCH} to master"
-    for FILE in "${FILES_ALL[@]}"; do
+    for FILE in "${FILES_ALL_EXPANDED[@]}"; do
       LOCAL_SHA=$(sha256sum "${FILE}" | cut -d' ' -f1)
       URL="${RAW_FETCH_BASE_URL}/${BRANCH}/${FILE}"
       STATUS=$(fetch_status "${URL}")
@@ -228,7 +376,7 @@ else
   # local file is always either a destructive PR or a hand-edit config
   # bug -- either way, fail.
   echo "Comparing ${CONTEXT_BRANCH} (LOCAL) to master HEAD (REMOTE)."
-  for FILE in "${FILES_ALL[@]}"; do
+  for FILE in "${FILES_ALL_EXPANDED[@]}"; do
     if [[ ! -f "${FILE}" ]]; then
       emit_error_file "${FILE}" "${FILE} listed in FILES_ALL but missing from ${CONTEXT_BRANCH}."
       echo "  Either this PR deleted a protected file, or byte-identical.yml lists a file the branch does not carry."

--- a/.github/scripts/validate-byte-identical.sh
+++ b/.github/scripts/validate-byte-identical.sh
@@ -48,128 +48,6 @@ set -euo pipefail
 
 RAW_FETCH_BASE_URL="${RAW_FETCH_BASE_URL:-https://raw.githubusercontent.com/openemr/openemr}"
 
-# Expand one FILES_ALL entry against a git ref into zero-or-more concrete
-# paths. Non-glob entries (no *, ?, or [ metachars) pass through
-# verbatim -- callers handle existence checking. Glob entries are
-# resolved against `git ls-tree -r`:
-#
-#   dir/**            -> `git ls-tree -r --name-only <ref> -- dir/`
-#                        (fast path -- most manifest globs are whole-
-#                        subtree matches like `tools/release/**`)
-#   any other glob    -> `git ls-tree -r --name-only <ref>` piped
-#                        through `grep -E` with a regex synthesized
-#                        from the glob (see glob_to_regex below)
-#
-# Empty output for a glob that matches nothing is not fatal at this
-# layer -- the caller decides how to interpret it.
-#
-# `git ls-tree`'s :(glob) pathspec magic is not supported (unlike
-# `git ls-files`), which forces the pipe-through-grep fallback for
-# arbitrary globs. The bare-subtree fast path covers the common case
-# and avoids the regex synthesis when possible.
-expand_pattern() {
-  local ref="$1" pattern="$2"
-  case "$pattern" in
-    *'*'* | *'?'* | *'['*)
-      # Fast path for the common `<dir>/**` shape
-      if [[ "$pattern" == *'/**' ]] && [[ "${pattern%/**}" != *'*'* ]] \
-        && [[ "${pattern%/**}" != *'?'* ]] && [[ "${pattern%/**}" != *'['* ]]; then
-        local dir="${pattern%/**}"
-        git ls-tree -r --name-only "$ref" -- "${dir}/" 2>/dev/null || true
-      else
-        # Generic glob: full ls-tree, filter via regex
-        local regex
-        regex=$(glob_to_regex "$pattern")
-        git ls-tree -r --name-only "$ref" 2>/dev/null | grep -E "$regex" || true
-      fi
-      ;;
-    *)
-      echo "$pattern"
-      ;;
-  esac
-}
-
-# Convert a shell-glob pattern to an anchored ERE regex. Semantics:
-#   **  -> `.*`               (matches across path separators)
-#   *   -> `[^/]*`            (matches within one path component)
-#   ?   -> `[^/]`             (single non-slash char)
-#   [..] preserved as-is (character class)
-# Regex metacharacters other than * ? [ are escaped. Result is wrapped
-# in ^...$ so `grep -E` gives whole-path matches only.
-glob_to_regex() {
-  local p="$1"
-  # Placeholder swap so `**` is treated distinctly from `*` before we
-  # escape and rewrite. `\x00` isn't valid in bash strings; use a
-  # rare printable sentinel instead.
-  local GLOBSTAR=$'\x1F\x1FGS\x1F\x1F'
-  # 1. Substitute ** with the sentinel (must happen before single-*
-  #    substitution, otherwise ** becomes [^/]*[^/]*).
-  p="${p//\*\*/${GLOBSTAR}}"
-  # 2. Escape regex metacharacters except: * ? [ ] (glob chars) and /
-  #    (path separator, safe as-is).
-  local out=""
-  local i c
-  for ((i = 0; i < ${#p}; i++)); do
-    c="${p:i:1}"
-    case "$c" in
-      '.' | '+' | '(' | ')' | '{' | '}' | '^' | '$' | '|' | '\')
-        out+="\\${c}"
-        ;;
-      '*') out+='[^/]*' ;;
-      '?') out+='[^/]' ;;
-      *)   out+="$c" ;;
-    esac
-  done
-  # 3. Restore ** placeholder as regex `.*`
-  out="${out//${GLOBSTAR}/.*}"
-  printf '^%s$\n' "$out"
-}
-
-# Expand a list of patterns against a git ref into a dedup+sorted list
-# of concrete paths. Signature:
-#   expand_patterns_into <ref> <input_patterns_array_name> <output_array_name>
-# Glob patterns that expanded to zero files are surfaced as warnings
-# (usually a stale manifest entry) but not fatal at this layer.
-expand_patterns_into() {
-  local ref="$1" in_var="$2" out_var="$3"
-  local -n in_arr="$in_var"
-  local -n out_arr="$out_var"
-  local pattern p
-  local -A seen=()
-  local -a expanded=()
-  local -a empty_patterns=()
-  for pattern in "${in_arr[@]}"; do
-    local pattern_matched=0
-    while IFS= read -r p; do
-      [[ -z "$p" ]] && continue
-      pattern_matched=1
-      if [[ -z "${seen[$p]:-}" ]]; then
-        seen[$p]=1
-        expanded+=("$p")
-      fi
-    done < <(expand_pattern "$ref" "$pattern")
-    case "$pattern" in
-      *'*'* | *'?'* | *'['*)
-        if [[ $pattern_matched -eq 0 ]]; then
-          empty_patterns+=("$pattern")
-        fi
-        ;;
-    esac
-  done
-  # sort for stable iteration (helps golden-comparison tests too).
-  # `printf '%s\n' "${arr[@]}"` on an empty array still emits one empty
-  # line in bash (format applied once with no args); filter with
-  # `grep -v '^$'` so out_arr comes back as a genuinely empty array
-  # rather than a one-empty-string array.
-  mapfile -t out_arr < <(printf '%s\n' "${expanded[@]}" | grep -v '^$' | sort)
-  # Warn (do not fail) on globs that matched nothing -- almost always a
-  # stale manifest entry, worth surfacing but not blocking.
-  local ep
-  for ep in "${empty_patterns[@]}"; do
-    emit_warning "Glob pattern '${ep}' expanded to zero files on ${ref}; manifest may be stale."
-  done
-}
-
 emit_error() {
   local msg="$1"
   if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
@@ -205,6 +83,12 @@ emit_warning_file() {
     echo "WARNING ${file}: ${msg}"
   fi
 }
+
+# Source the shared glob-expansion helpers (expand_pattern,
+# glob_to_regex, expand_patterns_into). Sourced AFTER emit_warning is
+# defined -- expand_patterns_into calls it on stale-glob patterns.
+# shellcheck source=lib/glob-expand.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/glob-expand.sh"
 
 # Preconditions
 command -v yq >/dev/null 2>&1 || {

--- a/.github/scripts/validate-byte-identical.sh
+++ b/.github/scripts/validate-byte-identical.sh
@@ -87,7 +87,15 @@ emit_warning_file() {
 # Source the shared glob-expansion helpers (expand_pattern,
 # glob_to_regex, expand_patterns_into). Sourced AFTER emit_warning is
 # defined -- expand_patterns_into calls it on stale-glob patterns.
-# shellcheck source=lib/glob-expand.sh
+#
+# `source=/dev/null` opts out of shellcheck's static follow. The
+# alternative -- pointing the directive at `lib/glob-expand.sh` --
+# requires `source-path=SCRIPTDIR` in .shellcheckrc, which is not in
+# the byte-identical set and would therefore stay master-only,
+# breaking shellcheck on rel branches. Losing shellcheck's view into
+# the sourced helpers is a smaller cost than the cross-branch
+# coordination burden.
+# shellcheck source=/dev/null
 source "$(dirname "${BASH_SOURCE[0]}")/lib/glob-expand.sh"
 
 # Preconditions

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -2,3 +2,7 @@
 # Enable all optional shellcheck checks
 enable=all
 external-sources=true
+# Resolve `# shellcheck source=<relative-path>` directives against
+# each script's own directory. Lets `.github/scripts/*.sh` reference
+# helpers in `.github/scripts/lib/` via `source=lib/foo.sh`.
+source-path=SCRIPTDIR

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -2,7 +2,3 @@
 # Enable all optional shellcheck checks
 enable=all
 external-sources=true
-# Resolve `# shellcheck source=<relative-path>` directives against
-# each script's own directory. Lets `.github/scripts/*.sh` reference
-# helpers in `.github/scripts/lib/` via `source=lib/foo.sh`.
-source-path=SCRIPTDIR

--- a/tests/bats/ci-scripts/sync-byte-identical/helpers.bash
+++ b/tests/bats/ci-scripts/sync-byte-identical/helpers.bash
@@ -30,6 +30,14 @@ setup_test_repo() {
     git config user.name "Test"
     git commit -q --allow-empty -m "seed"
     git branch "$rel_branch"
+
+    # Force plain output regardless of caller environment. On GitHub
+    # Actions runners GITHUB_ACTIONS=true is set globally, which would
+    # flip the emit_warning / emit_error helpers into
+    # ::warning::/::error:: annotation mode and break plain-text
+    # substring asserts in the .bats files. Mirrors the same defence
+    # in tests/bats/ci-scripts/validate-byte-identical/helpers.bash.
+    unset GITHUB_ACTIONS
 }
 
 teardown_test_repo() {

--- a/tests/bats/ci-scripts/sync-byte-identical/sync.bats
+++ b/tests/bats/ci-scripts/sync-byte-identical/sync.bats
@@ -256,3 +256,106 @@ teardown() {
     grep -qxF "add: src/real.txt" "$OUTPUT_DIR/changes.txt"
     ! grep -qF "phantom" "$OUTPUT_DIR/changes.txt"                # not recorded
 }
+
+# --- glob-pattern support (PR 2 of the changelog-surface migration slice) ---
+#
+# The manifest can now list glob patterns like `tools/release/**`.
+# Expansion happens at script-run time via `git ls-tree`, so master and
+# rel branches see whichever concrete paths they actually carry.
+
+@test "glob: pattern matches multiple files, all identical -> no changes" {
+    write_on_branch master   src/a.txt "content-A"
+    write_on_branch master   src/b.txt "content-B"
+    write_on_branch master   src/c.txt "content-C"
+    write_on_branch rel-810  src/a.txt "content-A"
+    write_on_branch rel-810  src/b.txt "content-B"
+    write_on_branch rel-810  src/c.txt "content-C"
+    write_files_all_config 'src/**'
+
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ ! -s "$OUTPUT_DIR/changes.txt" ]]
+}
+
+@test "glob: pattern expands to master-only files -> all added to rel" {
+    write_on_branch master src/a.txt "content-A"
+    write_on_branch master src/b.txt "content-B"
+    write_files_all_config 'src/**'
+
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ -f src/a.txt ]]
+    [[ -f src/b.txt ]]
+    grep -qxF "add: src/a.txt" "$OUTPUT_DIR/changes.txt"
+    grep -qxF "add: src/b.txt" "$OUTPUT_DIR/changes.txt"
+}
+
+@test "glob: pattern-matched file on rel but not master -> delete" {
+    write_on_branch master  src/keeper.txt "keep-content"
+    write_on_branch rel-810 src/keeper.txt "keep-content"
+    write_on_branch rel-810 src/orphan.txt "orphan-on-rel-only"
+    write_files_all_config 'src/**'
+
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ ! -f src/orphan.txt ]]                              # deleted
+    [[ -f src/keeper.txt ]]                                # untouched (identical)
+    grep -qxF "delete: src/orphan.txt" "$OUTPUT_DIR/changes.txt"
+    ! grep -qF "keeper" "$OUTPUT_DIR/changes.txt"
+}
+
+@test "glob: mixed add + update + delete under one pattern all applied in one run" {
+    write_on_branch master  src/added.txt   "new"
+    write_on_branch master  src/changed.txt "master-version"
+    write_on_branch rel-810 src/changed.txt "older-version"
+    write_on_branch rel-810 src/removed.txt "to-remove"
+    write_files_all_config 'src/**'
+
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ -f src/added.txt ]]
+    [[ "$(cat src/changed.txt)" == "master-version" ]]
+    [[ ! -f src/removed.txt ]]
+    grep -qxF "add: src/added.txt" "$OUTPUT_DIR/changes.txt"
+    grep -qxF "update: src/changed.txt" "$OUTPUT_DIR/changes.txt"
+    grep -qxF "delete: src/removed.txt" "$OUTPUT_DIR/changes.txt"
+}
+
+@test "glob: pattern matches nothing on either side -> no error, no changes" {
+    write_on_branch master  src/other.txt "other"
+    write_on_branch rel-810 src/other.txt "other"
+    write_files_all_config 'nonexistent/**' src/other.txt
+
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ ! -s "$OUTPUT_DIR/changes.txt" ]]
+}
+
+@test "glob: mixed literal + glob entries expand and dedupe cleanly" {
+    write_on_branch master  src/lit.txt  "literal-content"
+    write_on_branch master  src/glob.txt "glob-content"
+    write_files_all_config src/lit.txt 'src/**'
+
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    # src/lit.txt appears from both the literal entry AND the glob
+    # expansion; the union+sort+dedupe upstream keeps the main loop
+    # from processing it twice.
+    [[ $status -eq 0 ]]
+    [[ -f src/lit.txt ]]
+    [[ -f src/glob.txt ]]
+    # exactly one "add" line each
+    [[ $(grep -c "^add: src/lit.txt$" "$OUTPUT_DIR/changes.txt") -eq 1 ]]
+    [[ $(grep -c "^add: src/glob.txt$" "$OUTPUT_DIR/changes.txt") -eq 1 ]]
+}

--- a/tests/bats/ci-scripts/sync-byte-identical/sync.bats
+++ b/tests/bats/ci-scripts/sync-byte-identical/sync.bats
@@ -359,3 +359,20 @@ teardown() {
     [[ $(grep -c "^add: src/lit.txt$" "$OUTPUT_DIR/changes.txt") -eq 1 ]]
     [[ $(grep -c "^add: src/glob.txt$" "$OUTPUT_DIR/changes.txt") -eq 1 ]]
 }
+
+@test "glob: pattern matches nothing on either side -> emits a stale-manifest warning" {
+    # Pattern doesn't match anywhere: neither master nor rel carries
+    # anything under `nonexistent/`. Sync succeeds (no changes) but
+    # surfaces the empty expansion via the shared expand_patterns_into
+    # emit_warning hook so a maintainer sees the stale manifest entry.
+    write_on_branch master  src/real.txt "real"
+    write_on_branch rel-810 src/real.txt "real"
+    write_files_all_config src/real.txt 'nonexistent/**'
+
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ ! -s "$OUTPUT_DIR/changes.txt" ]]
+    [[ "$output" == *"WARNING"*"nonexistent/**"*"expanded to zero files"* ]]
+}

--- a/tests/bats/ci-scripts/sync-byte-identical/sync.bats
+++ b/tests/bats/ci-scripts/sync-byte-identical/sync.bats
@@ -360,6 +360,26 @@ teardown() {
     [[ $(grep -c "^add: src/glob.txt$" "$OUTPUT_DIR/changes.txt") -eq 1 ]]
 }
 
+@test "glob: negated character class [!...] converts to ERE [^...]" {
+    # Shell glob `[!aeiou]` matches consonants + non-alphabetics.
+    # Historically our glob_to_regex passed [!...] through verbatim,
+    # which in ERE is a positive class -- opposite semantics. This
+    # pins the fix: master has files matching + not matching the
+    # negation; only the negation-matching one gets synced.
+    write_on_branch master  src/a.txt "vowel-start"
+    write_on_branch master  src/x.txt "consonant-start"
+    write_files_all_config 'src/[!aeiou].txt'
+
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ -f src/x.txt ]]                                           # matched the negation
+    [[ ! -f src/a.txt ]]                                         # excluded (vowel)
+    grep -qxF "add: src/x.txt" "$OUTPUT_DIR/changes.txt"
+    ! grep -qF "src/a.txt" "$OUTPUT_DIR/changes.txt"
+}
+
 @test "glob: pattern matches nothing on either side -> emits a stale-manifest warning" {
     # Pattern doesn't match anywhere: neither master nor rel carries
     # anything under `nonexistent/`. Sync succeeds (no changes) but


### PR DESCRIPTION
## Summary

PR 2 of six for the ["Changelog surface early-migration slice"](https://github.com/openemr/openemr/blob/master/docs/release-mechanism-migration-from-devops.md#changelog-surface-early-migration-slice-g22-fix--workstream-7-pilot). Adds glob-pattern expansion (e.g. `tools/release/**`) to `.github/scripts/validate-byte-identical.sh` and `.github/scripts/sync-byte-identical.sh` so the manifest can list globs instead of enumerating individual files.

**Purely a capability addition** — no manifest content change beyond adding the extracted `lib/glob-expand.sh` to FILES_ALL. PR 3 uses the capability to expand `.github/byte-identical.yml` to cover the release-mechanism surface (~60 files) via ~10 globs.

## Design

**Shared lib** at `.github/scripts/lib/glob-expand.sh` exports three functions, sourced by both scripts:

- **`expand_pattern <ref> <pattern>`** — expands one FILES_ALL entry against a git ref. Non-glob entries pass verbatim; `dir/**` uses fast-path bare-pathspec (`git ls-tree -r --name-only <ref> -- <dir>/`); arbitrary globs pipe through `grep -E` with a regex from `glob_to_regex`.
- **`glob_to_regex <pattern>`** — converts shell glob to anchored ERE: `**` → `.*`, `*` → `[^/]*`, `?` → `[^/]`, POSIX-negated `[!...]` → ERE-negated `[^...]`, regex metachars escaped. Wraps in `^...$`.
- **`expand_patterns_into <ref> <in_var> <out_var>`** — nameref-based expansion into a sorted concrete-path array. Surfaces stale-glob patterns via `emit_warning` (caller-defined).

`git ls-tree` doesn't support `:(glob)` pathspec magic that `git ls-files` does, which forces the pipe-through-grep fallback for anything other than the whole-subtree shape. Verified experimentally.

## Validate script

FILES_ALL expands against HEAD (master in master context, rel-branch in rel context). Post-expansion duplicate check catches glob-overlap-with-literal config bugs. Empty full-manifest expansion fails closed. Per-pattern empty expansion surfaces as a warning. Missing-file check remains for literal-path entries pointing at a missing file.

## Sync script

Expands master's FILES_ALL against **both** refs to get a proper union: paths on master only (add), on rel only (delete), on both (identical/update). Prior main loop iterated master's config literally and relied on the sweep for rel-only files; with globs, expanding against rel HEAD is required to catch rel-drift files matching master's globs. Sweep still runs at the end, refactored to work at concrete-path level. Case 3 (rel doesn't have the file either) still applies for literal-path entries.

## Cross-branch coordination (byte-identical manifest addition)

The new `.github/scripts/lib/glob-expand.sh` is **added to `.github/byte-identical.yml`** so the sync workflow propagates it to rel branches alongside `validate-byte-identical.sh` (which sources it at script-load time). Without this, rel-branch canary runs would fail with "No such file or directory" at source-time.

Source directive uses `# shellcheck source=/dev/null` rather than `source=lib/glob-expand.sh`. The latter would require `source-path=SCRIPTDIR` in `.shellcheckrc`, which isn't byte-identical enforced and would stay master-only — breaking shellcheck on rel-branch PRs with SC1091. Small cost: shellcheck can't lint through the source. BATS covers runtime.

## Tests

Eight new BATS cases in `sync.bats`:

- Pattern matches multiple files, all identical → no changes
- Pattern expands to master-only files → all added to rel
- Pattern-matched file on rel but not master → delete
- Mixed add + update + delete under one pattern in one run
- Pattern matches nothing on either side → no error, no changes
- Mixed literal + glob entries expand + dedupe cleanly
- Negated character class `[!...]` converts to ERE `[^...]` (regression pin)
- Pattern matches nothing on either side → emits stale-manifest warning

**All 22 sync + 16 validate + 1 doc = 39 BATS tests pass locally** (bats 1.11.0, matches CI's ubuntu-24.04 environment). Sync test helpers now `unset GITHUB_ACTIONS` in `setup_test_repo` to force plain-text output for substring asserts (mirrors validate helpers).

`validate.bats` not extended with glob cases — its helpers work in a plain tmpdir (not a git repo), and the two scripts now share `lib/glob-expand.sh` so sync's coverage validates the same underlying logic.

## ShellCheck

All 52 findings from initial submission addressed: SC2250 (braces), SC1003 (backslash escaping via `$'\\'`), SC2312 (pipe splits), SC2034 (nameref suppressions), SC1091 (`source=/dev/null`), SC1073/SC1123 (directive placement), SC2249 (case default). Both scripts fully shellcheck-clean.

## Not in this PR

The manifest-rename sweep-logic gap that required the follow-up cleanup PRs (#12901/#12902/#12903 landed; #12905 landed the stale-refs cleanup on rel-820) isn't fixed here. Once those cleanup PRs landed, all rel branches have the current manifest path, so the transitional issue went away. Documented inline as an open design consideration for any future manifest rename.

## Commit sequence

| SHA | Purpose |
|---|---|
| `592d5a6219` | Initial glob-support implementation |
| `0c6cf278f5` | CodeRabbit round-1 + shellcheck cleanup (shared lib extraction, dropped `seen[]` dedup so downstream overlap-detection is reachable, sync `emit_warning` passthrough) |
| `42785e62c8` | Add `lib/glob-expand.sh` to byte-identical manifest (so sync propagates it to rel branches) |
| `25d6d1f659` | Unset `GITHUB_ACTIONS` in sync BATS helpers (CI-only test 22 failure fix) |
| `a7691abf56` | Convert POSIX `[!...]` → ERE `[^...]` in `glob_to_regex` (CodeRabbit round-2) |
| `80833e3dc7` | Switch source directive to `/dev/null` to avoid rel-branch shellcheck break (`.shellcheckrc` reverted to pre-PR state) |

## Test plan

- [x] BATS suite runs green (`test-byte-identical-scripts.yml`)
- [x] Canary passes (`validate-byte-identical.yml`)
- [x] ShellCheck clean
- [x] CodeRabbit reviews addressed (2 round-1 actionable + 1 nitpick, 1 round-2 actionable)
- [ ] After merge: `sync-byte-identical.yml` fires on master push, opens sync PRs against rel-820/rel-800/rel-704. Each should propagate the new `lib/glob-expand.sh` alongside the updated `validate-byte-identical.sh`; canary on rel-branch PRs stays green (no SC1091 fallout).