### PR TITLE
fix(ci): sync-byte-identical.yml materializes lib/glob-expand.sh alongside sync script

### DIFF
--- a/.github/workflows/sync-byte-identical.yml
+++ b/.github/workflows/sync-byte-identical.yml
@@ -134,7 +134,19 @@ jobs:
         # FILES_ALL, no need to sync it to rel branches). The current
         # checkout is the rel branch, which may not have the script at
         # all. Materialize master's copy into RUNNER_TEMP and run that.
+        #
+        # The script sources .github/scripts/lib/glob-expand.sh at load
+        # time (added in PR #12904 for glob-pattern support). Also
+        # materialize that lib next to the script so the source directive
+        # resolves. The lib IS in FILES_ALL so rel branches carry their
+        # own copy too, but we can't use it because this workflow runs
+        # against master's version of the sync logic + rel branch's
+        # working tree -- reading the lib from the rel branch could
+        # cross wires if the lib has diverged. Master's copy alongside
+        # master's script is the safe pairing.
         git show master:.github/scripts/sync-byte-identical.sh > "$RUNNER_TEMP/sync-byte-identical.sh"
+        mkdir -p "$RUNNER_TEMP/lib"
+        git show master:.github/scripts/lib/glob-expand.sh > "$RUNNER_TEMP/lib/glob-expand.sh"
         bash "$RUNNER_TEMP/sync-byte-identical.sh" "$TARGET_BRANCH"
 
         # Translate the script's structured outputs into GitHub step outputs.


### PR DESCRIPTION
## Summary

**Hotfix for master.** #12904 broke `sync-byte-identical.yml`. The sync workflow materializes master's `sync-byte-identical.sh` into `RUNNER_TEMP` and runs it from there — but didn't extract the new shared lib alongside it, so post-#12904 sync runs die at the source directive:

```
/home/runner/work/_temp/sync-byte-identical.sh: line 87:
/home/runner/work/_temp/lib/glob-expand.sh: No such file or directory
```

First observed on the sync run that fired immediately after #12904 merged. All three parallel jobs (`sync (rel-820)`, `sync (rel-800)`, `sync (rel-704)`) failed identically.

## Fix

Extract master's `lib/glob-expand.sh` into `$RUNNER_TEMP/lib/` alongside the sync script. Now the script's `source "$(dirname "${BASH_SOURCE[0]}")/lib/glob-expand.sh"` resolves correctly.

```yaml
git show master:.github/scripts/sync-byte-identical.sh > "$RUNNER_TEMP/sync-byte-identical.sh"
mkdir -p "$RUNNER_TEMP/lib"
git show master:.github/scripts/lib/glob-expand.sh > "$RUNNER_TEMP/lib/glob-expand.sh"
bash "$RUNNER_TEMP/sync-byte-identical.sh" "$TARGET_BRANCH"
```

Deliberately uses master's copy of the lib rather than reading from the rel branch's own copy: this workflow pairs master's sync logic with master's supporting files. The lib IS in `FILES_ALL` (added in #12904 commit `42785e62c8`) so rel branches will carry it too, but the `RUNNER_TEMP` execution is decoupled from that.

## Impact of not fixing

Sync workflow stays broken → no automatic propagation of byte-identical files from master to rel branches. Any future manifest edits or in-set file changes on master won't reach rel-820/rel-800/rel-704 via auto-sync until this fix lands.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: manual `workflow_dispatch` of `sync-byte-identical.yml` should succeed against all three rel branches (or wait for the daily 09:00 UTC schedule)
- [ ] Confirm the sync produces expected diffs (any leftover drift from the failed run should now be picked up and PR'd)