### PR TITLE
feat(ci): add release-mechanism surface to byte-identical.yml (12 new entries)

### DIFF
--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -41,14 +41,76 @@
 #                                                  different coverage notes
 #                                                  (different PHP / Alpine
 #                                                  combos, different flows)
+#   .github/workflows/notify-release-targets-changed.yml
+#                                                  master-only-firing
+#   .github/workflows/docker-release-orchestrator.yml
+#                                                  master-only-firing (schedule)
+#   .github/workflows/docker-validate-release-targets.yml
+#                                                  master-only-firing (paths
+#                                                  filter to release-targets.yml
+#                                                  edits on master)
+#   .github/workflows/sync-byte-identical.yml      master-only-firing (push
+#                                                  to master + daily cron);
+#                                                  materializes master's copy
+#                                                  of the sync script at run
+#                                                  time so rel-branch copy is
+#                                                  dead weight
+#   .github/scripts/sync-byte-identical.sh         same rationale as the
+#                                                  workflow above
+#   .github/release-targets.yml                    master-authoritative; see
+#                                                  the file's own header
+#                                                  comment for the rationale
+#   bin/console                                    general-purpose Symfony CLI
+#                                                  runner; not release-
+#                                                  mechanism-owned. Bootstrap
+#                                                  changes evolve for reasons
+#                                                  unrelated to the release
+#                                                  mechanism; if a release-
+#                                                  prep change ever needs a
+#                                                  bootstrap change too,
+#                                                  backport targeted rather
+#                                                  than sync every unrelated
+#                                                  bin/console tweak
 
 files:
+# Docker orchestration surface -- the historical byte-identical scope
 - .github/workflows/docker-build-release.yml
 - .github/workflows/docker-test-core.yml
 - .github/workflows/docker-test-release.yml
 - .github/actions/test-actions-core/action.yml
 - .github/docker/compose.yml
+
+# The byte-identical machinery itself (self-tracking so the trio moves
+# together across master + every rel branch)
 - .github/workflows/validate-byte-identical.yml
 - .github/byte-identical.yml
 - .github/scripts/validate-byte-identical.sh
 - .github/scripts/lib/glob-expand.sh
+
+# Release-mechanism surface (added 2026-07-12 -- see the "Changelog
+# surface early-migration slice" section of
+# docs/release-mechanism-migration-from-devops.md for the plan this is
+# PR 3 of).
+#
+# Files below fire from rel branches (release-prep.yml on every push,
+# branch-cut / patch-prep on lifecycle events, release-permissions-check
+# from anywhere) or are read by other rel-branch-executing code
+# (setup-php-composer composite is used by release-prep.yml; PR body
+# templates are read by peter-evans at rel-branch runtime).
+#
+# Master-only-firing workflows (notify-release-targets-changed,
+# docker-release-orchestrator, docker-validate-release-targets) are
+# NOT in this set -- see the "Intentionally NOT in this list" block
+# above.
+- .github/workflows/release-prep.yml
+- .github/workflows/branch-cut-automation.yml
+- .github/workflows/patch-prep-automation.yml
+- .github/workflows/release-permissions-check.yml
+- .github/actions/setup-php-composer/action.yml
+- .github/PULL_REQUEST_TEMPLATE/release-prep.md
+- .github/PULL_REQUEST_TEMPLATE/release-finalize.md
+- tools/release/**
+- src/Common/Command/ReleasePrep/**
+- src/Common/Command/ReleasePrepCommand.php
+- src/Common/Command/CreateReleaseChangelogCommand.php
+- tests/Tests/Isolated/Release/**


### PR DESCRIPTION
## Summary

PR 3 of six for the ["Changelog surface early-migration slice"](https://github.com/openemr/openemr/blob/master/docs/release-mechanism-migration-from-devops.md#changelog-surface-early-migration-slice-g22-fix--workstream-7-pilot). Uses the glob-pattern capability landed in #12904 to expand `.github/byte-identical.yml` to cover the release-mechanism file surface (~60 files across master + rel-820) via twelve concise entries.

**No script changes.** Manifest content only. PR 4 uses the enforcement to safely move `ChangelogGenerator` + friends from `openemr-devops` into `openemr`'s tree.

## Entries added (12)

**Code + tests:**
```yaml
- tools/release/**
- src/Common/Command/ReleasePrep/**
- src/Common/Command/ReleasePrepCommand.php
- src/Common/Command/CreateReleaseChangelogCommand.php
- tests/Tests/Isolated/Release/**
```

**Workflows + composite actions** (fire from rel branches — matches the manifest's existing "canary travels with the file set it polices" design principle):
```yaml
- .github/workflows/release-prep.yml
- .github/workflows/branch-cut-automation.yml
- .github/workflows/patch-prep-automation.yml
- .github/workflows/release-permissions-check.yml
- .github/actions/setup-php-composer/action.yml
```

**PR body templates** (read at rel-branch runtime by `peter-evans/create-pull-request` in `release-prep.yml`; must exist on rel branches for the step to render the PR body):
```yaml
- .github/PULL_REQUEST_TEMPLATE/release-prep.md
- .github/PULL_REQUEST_TEMPLATE/release-finalize.md
```

## Explicitly excluded (added to the "Intentionally NOT in this list" comment block)

- `.github/workflows/notify-release-targets-changed.yml` — master-only-firing
- `.github/workflows/docker-release-orchestrator.yml` — master-only-firing (schedule)
- `.github/workflows/docker-validate-release-targets.yml` — master-only-firing (paths filter to release-targets.yml edits on master)
- `.github/workflows/sync-byte-identical.yml` + `.github/scripts/sync-byte-identical.sh` — master-only-firing; script is materialized fresh at run time via `git show master:...`
- `.github/release-targets.yml` — master-authoritative by design (file's own header comment)
- `bin/console` — general-purpose Symfony CLI runner, not release-mechanism-owned

## Post-merge behavior

Sync workflow (`sync-byte-identical.yml`) fires on master push and opens sync PRs against the three rel branches:

- **rel-820:** small diff — the release-mechanism files already exist on rel-820 (that branch was cut with the mechanism); sync only needs to reflect any glob-expansion difference vs master's file set.
- **rel-800 / rel-704:** large diff — those branches predate the release-mechanism entirely, so sync creates ~60 new files on each. Dead code on those branches (no workflow to fire them there), but harmless until the branches rotate out entirely. Accepted per the migration doc's "useless files in useless places" discussion.

## Canary behavior on this PR

Master-PR context downgrades rel-branch drift to warnings (drift is intentional in-progress; auto-sync resolves after merge). So the `diff-against-rel-branches` job stays green on this PR itself, and the drift warnings appear as annotations for reviewer awareness.

## Test plan

- [x] Locally verified with `yq -r '.files[]' .github/byte-identical.yml` — 21 total entries, YAML parses cleanly
- [x] Local `bash .github/scripts/validate-byte-identical.sh` (schedule context) correctly reports rel-800/rel-704 drift (~60 files each 404), rel-820 matches
- [ ] CI: `validate-byte-identical.yml` should pass (warnings only on master PR context)
- [ ] After merge: three sync PRs auto-open — expect rel-820 small, rel-800/rel-704 large