### PR TITLE
test(api): add coverage for version, product, and list endpoints

### DIFF
--- a/tests/Tests/Api/ListApiTest.php
+++ b/tests/Tests/Api/ListApiTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * List API Endpoint Test Cases
+ *
+ * Covers GET /api/list/:list_name (Part of #12343).
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Nick To <YOUR_EMAIL_HERE>
+ * @copyright Copyright (c) 2026 Nick To <YOUR_EMAIL_HERE>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Api;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ListApiTest extends TestCase
+{
+    private const LIST_API_ENDPOINT = "/apis/default/api/list";
+
+    private ApiTestClient $testClient;
+
+    protected function setUp(): void
+    {
+        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
+        $this->testClient = new ApiTestClient($baseUrl, false);
+        $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+    }
+
+    #[Test]
+    public function testGetListOptions(): void
+    {
+        // "yesno" is a core list installed with every OpenEMR instance
+        $response = $this->testClient->get(self::LIST_API_ENDPOINT . "/yesno");
+        $this->assertEquals(200, $response->getStatusCode());
+
+        /** @var array<int, array<string, mixed>> $body */
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($body);
+        $this->assertNotEmpty($body, "The yesno list should contain at least one option");
+
+        foreach ($body as $option) {
+            $this->assertArrayHasKey("option_id", $option);
+            $this->assertArrayHasKey("title", $option);
+            $this->assertEquals("yesno", $option["list_id"]);
+        }
+    }
+
+    #[Test]
+    public function testGetMissingListReturns404(): void
+    {
+        $response = $this->testClient->get(self::LIST_API_ENDPOINT . "/definitely-not-a-real-list");
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+}

--- a/tests/Tests/Api/ListApiTest.php
+++ b/tests/Tests/Api/ListApiTest.php
@@ -7,10 +7,12 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Nick To <YOUR_EMAIL_HERE>
- * @copyright Copyright (c) 2026 Nick To <YOUR_EMAIL_HERE>
+ * @author    Nick To <tonick2310@gmail.com>
+ * @copyright Copyright (c) 2026 Nick To <tonick2310@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+declare(strict_types=1);
 
 namespace OpenEMR\Tests\Api;
 

--- a/tests/Tests/Api/ListApiTest.php
+++ b/tests/Tests/Api/ListApiTest.php
@@ -39,12 +39,12 @@ class ListApiTest extends TestCase
         $response = $this->testClient->get(self::LIST_API_ENDPOINT . "/yesno");
         $this->assertEquals(200, $response->getStatusCode());
 
-        /** @var array<int, array<string, mixed>> $body */
         $body = json_decode((string) $response->getBody(), true);
         $this->assertIsArray($body);
         $this->assertNotEmpty($body, "The yesno list should contain at least one option");
 
         foreach ($body as $option) {
+            $this->assertIsArray($option);
             $this->assertArrayHasKey("option_id", $option);
             $this->assertArrayHasKey("title", $option);
             $this->assertEquals("yesno", $option["list_id"]);

--- a/tests/Tests/Api/ProductApiTest.php
+++ b/tests/Tests/Api/ProductApiTest.php
@@ -7,10 +7,12 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Nick To <YOUR_EMAIL_HERE>
- * @copyright Copyright (c) 2026 Nick To <YOUR_EMAIL_HERE>
+ * @author    Nick To <tonick2310@gmail.com>
+ * @copyright Copyright (c) 2026 Nick To <tonick2310@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+declare(strict_types=1);
 
 namespace OpenEMR\Tests\Api;
 

--- a/tests/Tests/Api/ProductApiTest.php
+++ b/tests/Tests/Api/ProductApiTest.php
@@ -38,7 +38,6 @@ class ProductApiTest extends TestCase
         $response = $this->testClient->get(self::PRODUCT_API_ENDPOINT);
         $this->assertEquals(200, $response->getStatusCode());
 
-        /** @var array<string, mixed> $body */
         $body = json_decode((string) $response->getBody(), true);
         $this->assertIsArray($body);
         $this->assertArrayHasKey("status", $body);

--- a/tests/Tests/Api/ProductApiTest.php
+++ b/tests/Tests/Api/ProductApiTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Product Registration API Endpoint Test Cases
+ *
+ * Covers GET /api/product (Part of #12343).
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Nick To <YOUR_EMAIL_HERE>
+ * @copyright Copyright (c) 2026 Nick To <YOUR_EMAIL_HERE>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Api;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ProductApiTest extends TestCase
+{
+    private const PRODUCT_API_ENDPOINT = "/apis/default/api/product";
+
+    private ApiTestClient $testClient;
+
+    protected function setUp(): void
+    {
+        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
+        $this->testClient = new ApiTestClient($baseUrl, false);
+        $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+    }
+
+    #[Test]
+    public function testGetProductRegistrationStatus(): void
+    {
+        $response = $this->testClient->get(self::PRODUCT_API_ENDPOINT);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($body);
+        $this->assertArrayHasKey("status", $body);
+        $this->assertContains(
+            $body["status"],
+            ["REGISTERED", "UNREGISTERED", "OPT_OUT"],
+            "Product registration status should be a known value"
+        );
+    }
+}

--- a/tests/Tests/Api/VersionApiTest.php
+++ b/tests/Tests/Api/VersionApiTest.php
@@ -38,7 +38,6 @@ class VersionApiTest extends TestCase
         $response = $this->testClient->get(self::VERSION_API_ENDPOINT);
         $this->assertEquals(200, $response->getStatusCode());
 
-        /** @var array<string, mixed> $body */
         $body = json_decode((string) $response->getBody(), true);
         $this->assertIsArray($body);
 

--- a/tests/Tests/Api/VersionApiTest.php
+++ b/tests/Tests/Api/VersionApiTest.php
@@ -7,10 +7,12 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Nick To <YOUR_EMAIL_HERE>
- * @copyright Copyright (c) 2026 Nick To <YOUR_EMAIL_HERE>
+ * @author    Nick To <tonick2310@gmail.com>
+ * @copyright Copyright (c) 2026 Nick To <tonick2310@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+declare(strict_types=1);
 
 namespace OpenEMR\Tests\Api;
 

--- a/tests/Tests/Api/VersionApiTest.php
+++ b/tests/Tests/Api/VersionApiTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Version API Endpoint Test Cases
+ *
+ * Covers GET /api/version (Part of #12343).
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Nick To <YOUR_EMAIL_HERE>
+ * @copyright Copyright (c) 2026 Nick To <YOUR_EMAIL_HERE>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Api;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class VersionApiTest extends TestCase
+{
+    private const VERSION_API_ENDPOINT = "/apis/default/api/version";
+
+    private ApiTestClient $testClient;
+
+    protected function setUp(): void
+    {
+        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
+        $this->testClient = new ApiTestClient($baseUrl, false);
+        $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+    }
+
+    #[Test]
+    public function testGetVersion(): void
+    {
+        $response = $this->testClient->get(self::VERSION_API_ENDPOINT);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($body);
+
+        foreach (["v_major", "v_minor", "v_patch", "v_realpatch", "v_database", "v_acl"] as $key) {
+            $this->assertArrayHasKey($key, $body);
+            $this->assertIsInt($body[$key]);
+        }
+
+        $this->assertArrayHasKey("v_tag", $body);
+        $this->assertIsString($body["v_tag"]);
+
+        $this->assertGreaterThan(0, $body["v_major"]);
+    }
+}


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Adds API test coverage for three previously untested standard API route+method combinations. Part of #12343.

#### Changes proposed in this pull request:

- New `VersionApiTest`: GET /api/version — asserts 200 and the version field types
- New `ProductApiTest`: GET /api/product — asserts 200 and a known registration status value
- New `ListApiTest`: GET /api/list/:list_name — asserts 200 with option rows for a core list (`yesno`), and 404 for a missing list

Tests follow the existing `ApiTestClient` pattern in `tests/Tests/Api/`. All pass locally against the development-easy environment (4 tests, 31 assertions); PHPCS clean.

#### Was an AI assistant used? Yes