### PR TITLE
feat(ci): per-entry exclude-branches in byte-identical manifest

### DIFF
--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -13,6 +13,23 @@
 # Consumed by:
 #   .github/workflows/validate-byte-identical.yml  (drift canary)
 #
+# Two entry shapes are accepted:
+#   - simple string form: applies to master + every rel branch
+#       - .github/workflows/docker-build-release.yml
+#   - object form with per-branch exclusions:
+#       - path: tools/release/**
+#         exclude-branches:
+#         - rel-800
+#         - rel-704
+#     Use for files that master + newer rel branches carry but older
+#     rel branches predate. Applies to master + every rel branch NOT
+#     in the exclude list. The release-mechanism surface is the current
+#     motivating case: rel-800 + rel-704 predate the mechanism, and
+#     forcing the PHP source there would fail phpstan + isolated
+#     tests + composer-require-checker on those branches (those
+#     linters run on every PHP file regardless of whether any
+#     workflow invokes them).
+#
 # To add a file: append under `files:`. The canary picks it up on the
 # next run; no workflow edit needed.
 #
@@ -98,19 +115,39 @@ files:
 # (setup-php-composer composite is used by release-prep.yml; PR body
 # templates are read by peter-evans at rel-branch runtime).
 #
+# All entries in this block exclude rel-800 + rel-704: those branches
+# predate the release mechanism entirely. They lack the composer
+# autoload for OpenEMR\Release\* / OpenEMR\Common\Command\ReleasePrep\*
+# and the Symfony Console classes the release-prep code depends on.
+# Syncing the code there would fail phpstan + isolated tests +
+# composer-require-checker on those branches (see #12912/#12913 for
+# the concrete failure mode this exclusion prevents).
+#
 # Master-only-firing workflows (notify-release-targets-changed,
 # docker-release-orchestrator, docker-validate-release-targets) are
 # NOT in this set -- see the "Intentionally NOT in this list" block
 # above.
-- .github/workflows/release-prep.yml
-- .github/workflows/branch-cut-automation.yml
-- .github/workflows/patch-prep-automation.yml
-- .github/workflows/release-permissions-check.yml
-- .github/actions/setup-php-composer/action.yml
-- .github/PULL_REQUEST_TEMPLATE/release-prep.md
-- .github/PULL_REQUEST_TEMPLATE/release-finalize.md
-- tools/release/**
-- src/Common/Command/ReleasePrep/**
-- src/Common/Command/ReleasePrepCommand.php
-- src/Common/Command/CreateReleaseChangelogCommand.php
-- tests/Tests/Isolated/Release/**
+- path: .github/workflows/release-prep.yml
+  exclude-branches: [rel-800, rel-704]
+- path: .github/workflows/branch-cut-automation.yml
+  exclude-branches: [rel-800, rel-704]
+- path: .github/workflows/patch-prep-automation.yml
+  exclude-branches: [rel-800, rel-704]
+- path: .github/workflows/release-permissions-check.yml
+  exclude-branches: [rel-800, rel-704]
+- path: .github/actions/setup-php-composer/action.yml
+  exclude-branches: [rel-800, rel-704]
+- path: .github/PULL_REQUEST_TEMPLATE/release-prep.md
+  exclude-branches: [rel-800, rel-704]
+- path: .github/PULL_REQUEST_TEMPLATE/release-finalize.md
+  exclude-branches: [rel-800, rel-704]
+- path: tools/release/**
+  exclude-branches: [rel-800, rel-704]
+- path: src/Common/Command/ReleasePrep/**
+  exclude-branches: [rel-800, rel-704]
+- path: src/Common/Command/ReleasePrepCommand.php
+  exclude-branches: [rel-800, rel-704]
+- path: src/Common/Command/CreateReleaseChangelogCommand.php
+  exclude-branches: [rel-800, rel-704]
+- path: tests/Tests/Isolated/Release/**
+  exclude-branches: [rel-800, rel-704]

--- a/.github/scripts/lib/glob-expand.sh
+++ b/.github/scripts/lib/glob-expand.sh
@@ -148,3 +148,83 @@ expand_patterns_into() {
     emit_warning "Glob pattern '${ep}' expanded to zero files on ${ref}; manifest may be stale."
   done
 }
+
+# Read the two parallel arrays FILES_ALL (paths) and
+# FILES_ALL_EXCLUDE_LISTS (each element is a comma-separated string of
+# branch names that this entry is excluded from -- empty string when
+# the entry applies to every rel branch) from a manifest file.
+#
+# Signature: read_manifest_entries <manifest_path> <paths_var> <excludes_var>
+# Both output arrays are populated by parallel index, so the caller
+# can iterate one and look up exclusions in the other.
+#
+# Handles both entry shapes accepted in .github/byte-identical.yml:
+#   - simple string:   `- path/to/file`
+#   - object form:     `- path: path/to/file`
+#                      `  exclude-branches: [rel-800, rel-704]`
+#
+# Uses Mike Farah yq (v4+). The `.path // .` expression returns the
+# object's `path` field when the entry is an object and the entry
+# itself when it's a scalar string.
+read_manifest_entries() {
+  local manifest="${1}" paths_var="${2}" excludes_var="${3}"
+  # shellcheck disable=SC2178  # nameref
+  local -n paths_arr="${paths_var}"
+  # shellcheck disable=SC2178  # nameref
+  local -n excludes_arr="${excludes_var}"
+
+  local paths_raw excludes_raw
+  paths_raw="$(yq -r '.files[] | (.path // .)' "${manifest}")"
+  excludes_raw="$(yq -r '.files[] | (.["exclude-branches"] // [] | join(","))' "${manifest}")"
+
+  mapfile -t paths_arr <<<"${paths_raw}"
+  mapfile -t excludes_arr <<<"${excludes_raw}"
+
+  # yq emits one blank line per entry even when the array is empty;
+  # normalize to a truly-empty array in that edge case.
+  if [[ ${#paths_arr[@]} -eq 1 && -z "${paths_arr[0]}" ]]; then
+    paths_arr=()
+    # shellcheck disable=SC2034  # nameref -- consumed by caller
+    excludes_arr=()
+  fi
+}
+
+# Filter a (path, exclude-list) parallel pair down to just the entries
+# that apply to a given target rel branch. Signature:
+#   filter_by_branch <target_branch> <in_paths_var> <in_excl_var> <out_paths_var>
+# Entries whose exclude-list contains target_branch are dropped from
+# the output.
+filter_by_branch() {
+  local target="${1}" in_paths_var="${2}" in_excl_var="${3}" out_var="${4}"
+  # shellcheck disable=SC2178  # nameref
+  local -n in_paths="${in_paths_var}"
+  # shellcheck disable=SC2178  # nameref
+  local -n in_excl="${in_excl_var}"
+  # shellcheck disable=SC2034,SC2178  # nameref -- consumed by caller
+  local -n out_arr="${out_var}"
+
+  # shellcheck disable=SC2034  # populated below then copied out
+  local -a _fbb_out=()
+  local i excl
+  for i in "${!in_paths[@]}"; do
+    excl="${in_excl[i]:-}"
+    if [[ -n "${excl}" ]]; then
+      local -a excl_arr
+      IFS=',' read -ra excl_arr <<<"${excl}"
+      local skip=0
+      local e
+      for e in "${excl_arr[@]}"; do
+        if [[ "${e}" == "${target}" ]]; then
+          skip=1
+          break
+        fi
+      done
+      if [[ ${skip} -eq 1 ]]; then
+        continue
+      fi
+    fi
+    _fbb_out+=("${in_paths[i]}")
+  done
+  # shellcheck disable=SC2034  # nameref -- consumed by caller
+  out_arr=("${_fbb_out[@]}")
+}

--- a/.github/scripts/sync-byte-identical.sh
+++ b/.github/scripts/sync-byte-identical.sh
@@ -101,34 +101,47 @@ mkdir -p "${output_dir}"
 
 # Read the FILES_ALL set from master's config file. Even if the rel branch
 # has its own copy, master is the source of truth -- we never sync FROM a
-# rel branch's view. Each subprocess invocation is captured separately to
-# avoid SC2312 (pipeline return values being masked by mapfile process
-# substitution).
-config_contents=$(git show master:.github/byte-identical.yml)
-files_yq_output=$(echo "${config_contents}" | yq -r '.files[]')
-mapfile -t FILES_ALL <<<"${files_yq_output}"
-# When the yq output is empty, mapfile produces a single empty element;
-# normalize to an empty array so the length-zero check below is honest.
-if [[ ${#FILES_ALL[@]} -eq 1 && -z "${FILES_ALL[0]}" ]]; then
-  FILES_ALL=()
-fi
+# rel branch's view. read_manifest_entries needs a file so we materialize
+# master's copy into a temp path first.
+master_manifest=$(mktemp)
+trap 'rm -f "${master_manifest}"' EXIT
+git show master:.github/byte-identical.yml > "${master_manifest}"
 
-if [[ ${#FILES_ALL[@]} -eq 0 ]]; then
+declare -a MASTER_FILES_ALL_RAW=()
+# shellcheck disable=SC2034  # nameref -- populated by read_manifest_entries
+declare -a MASTER_FILES_ALL_EXCLUDES=()
+read_manifest_entries "${master_manifest}" MASTER_FILES_ALL_RAW MASTER_FILES_ALL_EXCLUDES
+
+if [[ ${#MASTER_FILES_ALL_RAW[@]} -eq 0 ]]; then
   emit_error "No files in master's byte-identical.yml; refusing to sync (an empty list would propagate 'delete every synced file' to every rel branch)."
   exit 1
 fi
 
-# Reject duplicates -- idempotent in practice, but a config bug worth surfacing.
-dupes=$(printf '%s\n' "${FILES_ALL[@]}" | sort | uniq -d)
+# Reject duplicates in the raw path list -- idempotent in practice, but a config bug worth surfacing.
+dupes=$(printf '%s\n' "${MASTER_FILES_ALL_RAW[@]}" | sort | uniq -d)
 if [[ -n "${dupes}" ]]; then
   dupes_one_line=$(echo "${dupes}" | tr '\n' ' ')
   emit_error "Duplicate entries in byte-identical.yml files: ${dupes_one_line}"
   exit 1
 fi
 
+# Filter master's manifest for the target rel branch. Entries whose
+# exclude-branches list contains target_branch are dropped -- those
+# files stay per-branch-drifting (e.g. release-mechanism surface on
+# rel-800/rel-704 which predate the mechanism).
+declare -a FILES_ALL=()
+filter_by_branch "${target_branch}" MASTER_FILES_ALL_RAW MASTER_FILES_ALL_EXCLUDES FILES_ALL
+
+if [[ ${#FILES_ALL[@]} -eq 0 ]]; then
+  echo "No FILES_ALL entries apply to ${target_branch} after exclude-branches filtering; nothing to sync."
+  : > "${output_dir}/changes.txt"  # truly empty; `echo "" > ...` would write a newline
+  git rev-parse master > "${output_dir}/master-sha.txt"
+  exit 0
+fi
+
 master_sha=$(git rev-parse master)
 echo "Syncing master (${master_sha}) -> ${target_branch}"
-echo "Patterns in master's FILES_ALL: ${#FILES_ALL[@]}"
+echo "Patterns applicable to ${target_branch}: ${#FILES_ALL[@]} (of ${#MASTER_FILES_ALL_RAW[@]} total)"
 
 # Expand master's FILES_ALL against BOTH refs. A path may exist only on
 # master (add), only on rel (delete), on both (identical/update), or --
@@ -221,12 +234,24 @@ done
 # in the diff and needs a silent skip. Glob entries only emit
 # existing paths, so case 3 doesn't apply to them.
 if git cat-file -e "HEAD:.github/byte-identical.yml" 2>/dev/null; then
-  rel_config_contents=$(git show "HEAD:.github/byte-identical.yml")
-  rel_files_yq_output=$(echo "${rel_config_contents}" | yq -r '.files[]')
-  mapfile -t REL_FILES_ALL <<<"${rel_files_yq_output}"
-  if [[ ${#REL_FILES_ALL[@]} -eq 1 && -z "${REL_FILES_ALL[0]}" ]]; then
-    REL_FILES_ALL=()
-  fi
+  # Materialize rel's manifest into a temp file so read_manifest_entries
+  # can process both entry shapes (string + object with exclude-branches).
+  rel_manifest=$(mktemp)
+  # shellcheck disable=SC2064  # expand-now on purpose
+  trap "rm -f '${rel_manifest}' '${master_manifest}'" EXIT
+  git show "HEAD:.github/byte-identical.yml" > "${rel_manifest}"
+
+  # shellcheck disable=SC2034  # nameref -- populated by read_manifest_entries
+  declare -a REL_FILES_ALL_RAW=()
+  # shellcheck disable=SC2034  # nameref -- populated by read_manifest_entries
+  declare -a REL_FILES_ALL_EXCLUDES=()
+  read_manifest_entries "${rel_manifest}" REL_FILES_ALL_RAW REL_FILES_ALL_EXCLUDES
+
+  # Filter rel's manifest for target_branch too -- if rel's manifest
+  # says a path is excluded from itself, that path isn't part of rel's
+  # managed set.
+  declare -a REL_FILES_ALL=()
+  filter_by_branch "${target_branch}" REL_FILES_ALL_RAW REL_FILES_ALL_EXCLUDES REL_FILES_ALL
 
   if [[ ${#REL_FILES_ALL[@]} -gt 0 ]]; then
     # Expand rel's own patterns against rel HEAD to get concrete paths

--- a/.github/scripts/validate-byte-identical.sh
+++ b/.github/scripts/validate-byte-identical.sh
@@ -113,48 +113,59 @@ command -v yq >/dev/null 2>&1 || {
 # fetches master's copy of each entry). Its check moves into the
 # master-context branch below.
 
-# Read FILES_ALL (needed in both contexts). The subprocess is captured
-# separately so SC2312 (return-value masking via process substitution)
-# does not bite.
-files_yq_output=$(yq -r '.files[]' .github/byte-identical.yml)
-mapfile -t FILES_ALL <<<"${files_yq_output}"
-if [[ ${#FILES_ALL[@]} -eq 1 && -z "${FILES_ALL[0]}" ]]; then
-  FILES_ALL=()
-fi
+# Read the manifest as two parallel arrays: paths + per-entry exclude
+# lists. String entries produce empty-string exclude, object-form
+# entries produce a comma-joined list. See read_manifest_entries in
+# lib/glob-expand.sh.
+declare -a FILES_ALL_RAW=()
+# shellcheck disable=SC2034  # nameref -- populated by read_manifest_entries
+declare -a FILES_ALL_EXCLUDES=()
+read_manifest_entries .github/byte-identical.yml FILES_ALL_RAW FILES_ALL_EXCLUDES
 
-if [[ ${#FILES_ALL[@]} -eq 0 ]]; then
-  # Fail closed: an empty FILES_ALL would silently disable the canary.
+if [[ ${#FILES_ALL_RAW[@]} -eq 0 ]]; then
+  # Fail closed: an empty manifest would silently disable the canary.
   emit_error "No files listed in byte-identical.yml; refusing to skip drift validation."
   exit 1
 fi
 
-# Reject duplicate entries -- harmless in this loop but indicates a
-# config bug worth surfacing.
-dupes=$(printf '%s\n' "${FILES_ALL[@]}" | sort | uniq -d)
+# Reject duplicate paths in the raw manifest -- catches config bugs
+# like listing the same path twice with different exclude lists.
+dupes=$(printf '%s\n' "${FILES_ALL_RAW[@]}" | sort | uniq -d)
 if [[ -n "${dupes}" ]]; then
   dupes_one_line=$(echo "${dupes}" | tr '\n' ' ')
   emit_error "Duplicate entries in byte-identical.yml files: ${dupes_one_line}"
   exit 1
 fi
 
-# Expand FILES_ALL into concrete paths. Glob patterns (e.g. `tools/release/**`)
-# are expanded against HEAD via `git ls-tree`; literal path entries pass
-# through verbatim (existence gets checked in the main loops below).
-declare -a FILES_ALL_EXPANDED=()
-expand_patterns_into HEAD FILES_ALL FILES_ALL_EXPANDED
+# expand_files_for_branch <branch> <out_expanded_var>
+# Filter FILES_ALL_RAW for entries applicable to <branch>, expand
+# them against HEAD, and populate <out_expanded_var> with the
+# concrete paths. Per-branch empty results are fine (no fail here);
+# the full-scope no-filter empty check below catches truly-empty
+# manifests.
+expand_files_for_branch() {
+  local target="${1}" out_var="${2}"
+  # shellcheck disable=SC2034  # nameref -- populated by filter_by_branch
+  local -a filtered=()
+  filter_by_branch "${target}" FILES_ALL_RAW FILES_ALL_EXCLUDES filtered
+  # shellcheck disable=SC2178  # nameref
+  local -n out_ref="${out_var}"
+  # shellcheck disable=SC2034,SC2178
+  out_ref=()
+  expand_patterns_into HEAD filtered "${out_var}"
+}
 
-if [[ ${#FILES_ALL_EXPANDED[@]} -eq 0 ]]; then
-  # Every entry expanded to zero paths -- either every pattern is stale
-  # or the manifest is entirely glob-only and matched nothing. Fail
-  # closed so we don't silently skip validation.
+# Full-scope expansion (all raw entries, no branch filter) for
+# initial fail-closed checks. Empty full expansion means every
+# pattern is stale or the manifest is entirely glob-only + matched
+# nothing -- a config bug worth failing on.
+declare -a FULL_EXPANDED=()
+expand_patterns_into HEAD FILES_ALL_RAW FULL_EXPANDED
+if [[ ${#FULL_EXPANDED[@]} -eq 0 ]]; then
   emit_error "byte-identical.yml patterns expanded to zero paths on HEAD; refusing to skip drift validation."
   exit 1
 fi
-
-# Reject duplicates in the expanded set too -- a glob pattern overlapping
-# a literal entry would produce duplicates post-expansion; catch that as
-# a config bug even though the pre-expansion set was unique.
-dupes_expanded=$(printf '%s\n' "${FILES_ALL_EXPANDED[@]}" | sort | uniq -d)
+dupes_expanded=$(printf '%s\n' "${FULL_EXPANDED[@]}" | sort | uniq -d)
 if [[ -n "${dupes_expanded}" ]]; then
   dupes_expanded_one_line=$(echo "${dupes_expanded}" | tr '\n' ' ')
   emit_error "Duplicate paths after glob expansion (glob overlaps literal or another glob): ${dupes_expanded_one_line}"
@@ -206,12 +217,14 @@ if [[ "${CONTEXT_BRANCH}" == "master" ]]; then
     exit 0
   fi
 
-  # Master context: master is canonical. Every FILES_ALL_EXPANDED entry
-  # must exist on master; missing ones are a config bug. For glob
-  # entries this is tautological (expansion only emits existing paths),
-  # so this catches literal-path entries pointing at a missing file.
+  # Master context: master is canonical. Every RAW entry (regardless
+  # of exclude-branches) must exist on master; missing ones are a
+  # config bug. Exclusions only scope which REL BRANCHES the file is
+  # checked against, not whether it's expected on master. Reuse the
+  # FULL_EXPANDED set already computed above for the empty-manifest
+  # check.
   missing=()
-  for FILE in "${FILES_ALL_EXPANDED[@]}"; do
+  for FILE in "${FULL_EXPANDED[@]}"; do
     [[ -f "${FILE}" ]] || missing+=("${FILE}")
   done
   if [[ ${#missing[@]} -gt 0 ]]; then
@@ -230,6 +243,11 @@ if [[ "${CONTEXT_BRANCH}" == "master" ]]; then
 
   for BRANCH in "${REL_BRANCHES[@]}"; do
     echo "::group::Compare ${BRANCH} to master"
+    # Per-branch expansion: skip entries whose exclude-branches list
+    # contains this branch (e.g. release-mechanism files aren't
+    # expected on rel-800 / rel-704).
+    declare -a FILES_ALL_EXPANDED=()
+    expand_files_for_branch "${BRANCH}" FILES_ALL_EXPANDED
     for FILE in "${FILES_ALL_EXPANDED[@]}"; do
       LOCAL_SHA=$(sha256sum "${FILE}" | cut -d' ' -f1)
       URL="${RAW_FETCH_BASE_URL}/${BRANCH}/${FILE}"
@@ -268,6 +286,10 @@ else
   # local file is always either a destructive PR or a hand-edit config
   # bug -- either way, fail.
   echo "Comparing ${CONTEXT_BRANCH} (LOCAL) to master HEAD (REMOTE)."
+  # Expand only the entries applicable to THIS rel branch, honouring
+  # per-entry exclude-branches lists.
+  declare -a FILES_ALL_EXPANDED=()
+  expand_files_for_branch "${CONTEXT_BRANCH}" FILES_ALL_EXPANDED
   for FILE in "${FILES_ALL_EXPANDED[@]}"; do
     if [[ ! -f "${FILE}" ]]; then
       emit_error_file "${FILE}" "${FILE} listed in FILES_ALL but missing from ${CONTEXT_BRANCH}."

--- a/tests/bats/ci-scripts/sync-byte-identical/sync.bats
+++ b/tests/bats/ci-scripts/sync-byte-identical/sync.bats
@@ -396,3 +396,85 @@ teardown() {
     [[ ! -s "$OUTPUT_DIR/changes.txt" ]]
     [[ "$output" == *"WARNING"*"nonexistent/**"*"expanded to zero files"* ]]
 }
+
+# --- exclude-branches (per-entry rel-branch exclusion) ---
+#
+# Manifest entries may be object-shaped with an `exclude-branches:` list.
+# Sync must skip those entries when the target branch is in the list,
+# leaving the file untouched on that branch. Motivating case: release-
+# mechanism PHP surface on rel-800 / rel-704 which predate the mechanism
+# and would fail phpstan + isolated tests + composer-require-checker.
+
+@test "exclude-branches: entry excluded from target branch is not synced" {
+    write_on_branch master src/shared.txt "master-content"
+    write_on_branch master src/rel820-only.txt "master-content"
+    write_files_all_raw 'files:
+- src/shared.txt
+- path: src/rel820-only.txt
+  exclude-branches:
+  - rel-810
+'
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ -f src/shared.txt ]]                     # unexcluded entry synced
+    [[ ! -f src/rel820-only.txt ]]              # excluded entry NOT synced
+    grep -qxF "add: src/shared.txt" "$OUTPUT_DIR/changes.txt"
+    ! grep -qF "src/rel820-only.txt" "$OUTPUT_DIR/changes.txt"
+}
+
+@test "exclude-branches: entry included for a non-excluded target still syncs" {
+    # setup_test_repo created rel-810 from the seed commit; add rel-820
+    # from the same seed so it starts EMPTY. Branching from master AFTER
+    # the writes below would put rel-820 at master's HEAD and the sync
+    # would see no changes needed.
+    git branch rel-820 rel-810
+    write_on_branch master src/shared.txt "master-content"
+    write_on_branch master src/rel820-only.txt "master-content"
+    write_files_all_raw 'files:
+- src/shared.txt
+- path: src/rel820-only.txt
+  exclude-branches:
+  - rel-810
+'
+    git checkout -q rel-820
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-820
+
+    [[ $status -eq 0 ]]
+    [[ -f src/shared.txt ]]
+    [[ -f src/rel820-only.txt ]]
+    grep -qxF "add: src/shared.txt" "$OUTPUT_DIR/changes.txt"
+    grep -qxF "add: src/rel820-only.txt" "$OUTPUT_DIR/changes.txt"
+}
+
+@test "exclude-branches: every entry excluded for target -> no-op sync succeeds" {
+    write_on_branch master src/only-for-others.txt "master-content"
+    write_files_all_raw 'files:
+- path: src/only-for-others.txt
+  exclude-branches:
+  - rel-810
+'
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ ! -f src/only-for-others.txt ]]
+    [[ ! -s "$OUTPUT_DIR/changes.txt" ]]
+    [[ "$output" == *"nothing to sync"* ]]
+}
+
+@test "exclude-branches: multiple branches in exclude list -- each honored" {
+    write_on_branch master src/only-for-820.txt "master-content"
+    write_files_all_raw 'files:
+- path: src/only-for-820.txt
+  exclude-branches:
+  - rel-810
+  - rel-800
+  - rel-704
+'
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+    [[ $status -eq 0 ]]
+    [[ ! -f src/only-for-820.txt ]]
+}


### PR DESCRIPTION
## Summary

**Hotfix for #12910's fallout.** #12910 added the release-mechanism PHP surface (`tools/release/**`, `src/Common/Command/ReleasePrep/**`, etc.) to `.github/byte-identical.yml`. The auto-sync workflow then tried to propagate those files to rel-800 + rel-704 (closed as #12912/#12913), where they fail phpstan + isolated tests + composer-require-checker — those older rel branches predate the release mechanism entirely and lack the composer autoload for `OpenEMR/Release/*` and `ReleasePrep/*`.

Adds a per-entry `exclude-branches:` field to the manifest schema so the release-mechanism entries can be scoped to master + rel-820 only. rel-800 + rel-704 stay unchanged.

## Manifest schema

Two entry shapes now accepted:

**String form** (unchanged, applies to master + every rel branch):

```yaml
files:
- .github/workflows/docker-build-release.yml
```

**Object form with optional exclusions:**

```yaml
files:
- path: tools/release/**
  exclude-branches:
  - rel-800
  - rel-704
```

All twelve release-mechanism entries added in #12910 now use the object form with `exclude-branches: [rel-800, rel-704]`. Docker orchestration entries stay as simple strings.

## Shared lib

Two new helpers in `lib/glob-expand.sh`:

- `read_manifest_entries <manifest> <paths_var> <excludes_var>` — reads both entry shapes into parallel arrays
- `filter_by_branch <target> <paths_var> <excludes_var> <out_var>` — drops entries whose exclude list contains target

## Validate script

- **Master context:** iterate rel branches, per-branch filter + expand. Master's own file-existence check uses the raw unfiltered expansion (exclusions only scope which rel branches see a file, not whether master should carry it).
- **Rel context:** filter for CONTEXT_BRANCH before expanding.

## Sync script

- Master's manifest is read once, filtered for `target_branch`.
- Empty filtered set → graceful no-op exit 0 with informative log message.
- Rel-only sweep also filters rel's own config for `target_branch` (so a rel branch that lists an entry excluded-from-itself in its own config doesn't get spurious rename-sweep hits).

## Tests

**Four new BATS cases in sync.bats:**

- Entry excluded from target branch is not synced
- Entry included for non-excluded target still syncs
- Every entry excluded → no-op sync succeeds (verifies graceful-exit path)
- Multiple branches in exclude list — each honored

**43/43 tests pass locally. Shellcheck clean.**

## Bugs caught during implementation

**Nameref shadow:** `filter_by_branch`'s internal accumulator was originally called `filtered`, which shadowed a caller's variable of the same name via bash namerefs. Renamed to `_fbb_out` (function-prefix internal name).

**Pre-existing sync-script bug now visible:** the graceful-exit path was writing `echo "" > changes.txt`, which produces a 1-byte file (a newline), not empty. Changed to `: > changes.txt` for truly-empty output. Test 3 pins this.

## Post-merge behavior

Next sync workflow run (auto-fires on merge) will produce:

- rel-820 sync PR: **empty** (rel-820 is not excluded, but the manifest already matched pre-#12910; only difference now is the object-form entries, but master and rel-820 have byte-identical manifests to compare against — canary sees no drift).
- rel-800 sync PR: **manifest-only update** (adds the object-form entries, but excludes the release-mechanism PHP files from rel-800's set, so nothing else propagates).
- rel-704 sync PR: same as rel-800.

## Test plan

- [x] Local BATS: 43/43 pass
- [x] Local shellcheck clean
- [ ] CI: `test-byte-identical-scripts.yml` runs BATS (23 sync + 16 validate + 4 exclude = 43)
- [ ] CI: `validate-byte-identical.yml` canary runs — should stay warning-level on master PR context
- [ ] After merge: three sync PRs open, rel-800/rel-704 diffs contain ONLY manifest updates + no release-mechanism PHP additions