### PR TITLE
fix(ci): sync workflow parses object-form manifest entries

### DIFF
--- a/.github/workflows/sync-byte-identical.yml
+++ b/.github/workflows/sync-byte-identical.yml
@@ -203,7 +203,13 @@ jobs:
         # entries, not any other files that happen to be in the workspace
         # (e.g. composer.lock drift from a running container, or our own
         # /tmp body file if it ended up here).
-        mapfile -t FILES_ALL < <(git show master:.github/byte-identical.yml | yq -r '.files[]')
+        # Extract just the path from each entry. Manifest supports two
+        # shapes since #12915:
+        #   - simple string: `- path/to/file`
+        #   - object form:   `- path: path/to/file\n  exclude-branches: [...]`
+        # The `.path // .` expression returns the object's .path field
+        # when present, else the entry itself (string).
+        mapfile -t FILES_ALL < <(git show master:.github/byte-identical.yml | yq -r '.files[] | (.path // .)')
         {
           echo "paths<<EOF"
           printf '%s\n' "${FILES_ALL[@]}"


### PR DESCRIPTION
## Summary

**Second-order fallout from #12915.** `sync-byte-identical.yml`'s "Compute add-paths input for peter-evans" step uses `yq -r '.files[]'` which dumps the whole object tree (path + exclude-branches + comments) as a multi-line splat for object-form entries. `peter-evans/create-pull-request` then tries to `git add` those splatted YAML fragments as file paths, which fails with `Unexpected error`.

## Fix

One-line change to the yq expression:

```diff
- mapfile -t FILES_ALL < <(git show master:.github/byte-identical.yml | yq -r '.files[]')
+ mapfile -t FILES_ALL < <(git show master:.github/byte-identical.yml | yq -r '.files[] | (.path // .)')
```

`.path // .` returns the object's `.path` field when present, else the entry itself when string-shaped. Same expression the sync script's `read_manifest_entries` (in `lib/glob-expand.sh`) already uses.

## How this got missed in #12915

- `sync-byte-identical.yml` runs on master-push only, isn't in the byte-identical set, and doesn't get exercised in local BATS.
- My PR 2 (#12904) BATS suite tests the sync SCRIPT, not the WORKFLOW's inline path-computation step.
- I updated `read_manifest_entries` in the shared lib but forgot to check whether the workflow file also parses the manifest independently (it does).

## Deferring workflow-level test coverage

Adding a workflow-level test would need actionlint's manifest-shape check or a full workflow-runner harness. Deferring as a follow-up — for now the manual test plan below suffices.

## Impact of not fixing

Sync workflow stays broken; auto-sync of #12915's manifest changes to rel branches never lands. Failed sync runs pile up on the master push queue (concurrency lock).

## Test plan

- [ ] CI green on this PR
- [ ] After merge: sync workflow re-fires (master push), completes with three sync PRs opened (one per rel branch, each carrying just the manifest update — no orphan splatted YAML in the diff)