### PR TITLE
fix(ci): sync workflow filters add-paths by target rel branch

### DIFF
--- a/.github/workflows/sync-byte-identical.yml
+++ b/.github/workflows/sync-byte-identical.yml
@@ -198,18 +198,28 @@ jobs:
     - name: Compute add-paths input for peter-evans
       id: paths
       if: steps.apply.outputs.has_changes == 'true'
+      env:
+        TARGET_BRANCH: ${{ matrix.branch }}
       run: |
         # Tell peter-evans/create-pull-request to commit only the FILES_ALL
         # entries, not any other files that happen to be in the workspace
         # (e.g. composer.lock drift from a running container, or our own
         # /tmp body file if it ended up here).
-        # Extract just the path from each entry. Manifest supports two
-        # shapes since #12915:
+        #
+        # Manifest supports two entry shapes since #12915:
         #   - simple string: `- path/to/file`
         #   - object form:   `- path: path/to/file\n  exclude-branches: [...]`
-        # The `.path // .` expression returns the object's .path field
-        # when present, else the entry itself (string).
-        mapfile -t FILES_ALL < <(git show master:.github/byte-identical.yml | yq -r '.files[] | (.path // .)')
+        #
+        # Apply the per-entry exclude-branches filter for the target rel
+        # branch AND extract the path. Without the filter, peter-evans
+        # would be asked to `git add` paths that don't exist on this rel
+        # branch (e.g. release-mechanism files on rel-800 / rel-704 which
+        # are excluded from those branches per the manifest), and
+        # git-add would fail with "pathspec did not match any files."
+        mapfile -t FILES_ALL < <(
+          git show master:.github/byte-identical.yml \
+            | yq -r '.files[] | select((.["exclude-branches"] // []) | contains([env(TARGET_BRANCH)]) | not) | (.path // .)'
+        )
         {
           echo "paths<<EOF"
           printf '%s\n' "${FILES_ALL[@]}"


### PR DESCRIPTION
## Summary

**Third-order fallout from #12915.** The manifest's per-entry `exclude-branches` filtering works in the sync SCRIPT (this morning's rel-800 run correctly identified only 3 files to update), but the workflow's "Compute add-paths input for peter-evans" step passes ALL 21 manifest paths to peter-evans — including the 12 release-mechanism paths excluded from rel-800 by design. `peter-evans/create-pull-request` invokes `git add <paths>` which fails on the missing pathspecs with "no changes added to commit" → "Unexpected error".

## Fix

Extend the workflow's yq expression to also apply the `exclude-branches` filter for the target rel branch:

```yaml
env:
  TARGET_BRANCH: ${{ matrix.branch }}
run: |
  mapfile -t FILES_ALL < <(
    git show master:.github/byte-identical.yml \
      | yq -r '.files[] | select((.["exclude-branches"] // []) | contains([env(TARGET_BRANCH)]) | not) | (.path // .)'
  )
```

`env(TARGET_BRANCH)` is Mike Farah yq's env-substitution operator (jq's `--arg` syntax isn't supported by yq).

Filter behavior verified locally:
- **rel-820:** 21 paths pass (no entries exclude rel-820)
- **rel-800:** 9 paths pass (12 release-mechanism entries excluded)
- **rel-704:** same as rel-800

## Root cause of missing this in #12915

The workflow's inline shell duplicates the manifest-parsing logic that the sync SCRIPT already handles via `read_manifest_entries` + `filter_by_branch` in the shared lib. BATS covers the script but not the workflow's inline step. Test coverage discussion is in flight but doesn't gate this fix — new sync PRs can't open until this lands.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: sync workflow re-fires and completes; three sync PRs open (rel-820 = tiny, rel-800/rel-704 = manifest-only-ish diff — no orphan release-mechanism paths in `git add`)