### PR TITLE
refactor(ci): extract byte-identical manifest parsing into a shared script + BATS coverage

### DIFF
--- a/.github/scripts/list-manifest-paths.sh
+++ b/.github/scripts/list-manifest-paths.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Print the byte-identical manifest paths applicable to a given rel
+# branch, one per line. Object-form entries whose `exclude-branches:`
+# list contains the target branch are filtered out.
+#
+# Usage:
+#   list-manifest-paths.sh <manifest-file> <target-branch>
+#
+# Example:
+#   list-manifest-paths.sh .github/byte-identical.yml rel-820
+#
+# Rationale: sync-byte-identical.yml's "Compute add-paths input for
+# peter-evans" step needs the same filter the sync script itself uses
+# (`read_manifest_entries` + `filter_by_branch` in lib/glob-expand.sh).
+# Before this script existed the workflow had its own inline yq
+# expression that got the filter wrong twice (#12916 then #12920).
+# Sharing the logic through the lib eliminates that class of bug.
+#
+# This script is master-only-firing (only invoked from
+# sync-byte-identical.yml, which is master-only). Not in the byte-
+# identical set. If a rel-branch copy of this script drifts from
+# master's, no consumer cares -- master's version is materialized
+# fresh into RUNNER_TEMP at workflow run time.
+#
+# Exit codes
+#   0   normal completion (with or without paths printed)
+#   2   precondition error: missing args, missing yq, missing manifest
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "ERROR: usage: list-manifest-paths.sh <manifest-file> <target-branch>" >&2
+  exit 2
+fi
+manifest="$1"
+target="$2"
+
+command -v yq >/dev/null 2>&1 || {
+  echo "ERROR: yq not found on PATH (need Mike Farah's Go-based yq)." >&2
+  exit 2
+}
+[[ -f "${manifest}" ]] || {
+  echo "ERROR: manifest not found: ${manifest}" >&2
+  exit 2
+}
+
+# lib/glob-expand.sh's expand_patterns_into calls emit_warning on
+# stale-glob patterns. This script doesn't expand globs (it only
+# reads + filters the raw entries), so emit_warning is never called
+# here -- but the lib file expects the symbol to exist at source
+# time, so provide a silent stub.
+emit_warning() { :; }
+
+# shellcheck source=lib/glob-expand.sh
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/lib/glob-expand.sh"
+
+# shellcheck disable=SC2034  # populated via nameref by read_manifest_entries
+declare -a paths=()
+# shellcheck disable=SC2034  # populated via nameref by read_manifest_entries
+declare -a excludes=()
+read_manifest_entries "${manifest}" paths excludes
+
+declare -a filtered=()
+filter_by_branch "${target}" paths excludes filtered
+
+if [[ ${#filtered[@]} -gt 0 ]]; then
+  printf '%s\n' "${filtered[@]}"
+fi

--- a/.github/workflows/sync-byte-identical.yml
+++ b/.github/workflows/sync-byte-identical.yml
@@ -218,7 +218,15 @@ jobs:
         # (script + sibling lib/).
         git show master:.github/scripts/list-manifest-paths.sh > "$RUNNER_TEMP/list-manifest-paths.sh"
         git show master:.github/byte-identical.yml > "$RUNNER_TEMP/manifest.yml"
-        mapfile -t FILES_ALL < <(bash "$RUNNER_TEMP/list-manifest-paths.sh" "$RUNNER_TEMP/manifest.yml" "$TARGET_BRANCH")
+        # Two-step invocation (write to file, then mapfile from file)
+        # rather than `mapfile < <(bash ...)` process-substitution: the
+        # latter swallows the script's exit code, so a failure of
+        # list-manifest-paths.sh (missing manifest, missing yq, etc.)
+        # would silently yield an empty paths input to peter-evans,
+        # which would then open a PR with the wrong (or missing) file
+        # set. Splitting into two commands lets `set -e` propagate.
+        bash "$RUNNER_TEMP/list-manifest-paths.sh" "$RUNNER_TEMP/manifest.yml" "$TARGET_BRANCH" > "$RUNNER_TEMP/paths.txt"
+        mapfile -t FILES_ALL < "$RUNNER_TEMP/paths.txt"
         {
           echo "paths<<EOF"
           printf '%s\n' "${FILES_ALL[@]}"

--- a/.github/workflows/sync-byte-identical.yml
+++ b/.github/workflows/sync-byte-identical.yml
@@ -206,20 +206,19 @@ jobs:
         # (e.g. composer.lock drift from a running container, or our own
         # /tmp body file if it ended up here).
         #
-        # Manifest supports two entry shapes since #12915:
-        #   - simple string: `- path/to/file`
-        #   - object form:   `- path: path/to/file\n  exclude-branches: [...]`
+        # Uses master's copy of list-manifest-paths.sh, which shares the
+        # same manifest-parsing + exclude-branches filtering as the sync
+        # script (via lib/glob-expand.sh's read_manifest_entries +
+        # filter_by_branch). Eliminates the workflow-vs-script yq
+        # duplication that produced #12916 and #12920.
         #
-        # Apply the per-entry exclude-branches filter for the target rel
-        # branch AND extract the path. Without the filter, peter-evans
-        # would be asked to `git add` paths that don't exist on this rel
-        # branch (e.g. release-mechanism files on rel-800 / rel-704 which
-        # are excluded from those branches per the manifest), and
-        # git-add would fail with "pathspec did not match any files."
-        mapfile -t FILES_ALL < <(
-          git show master:.github/byte-identical.yml \
-            | yq -r '.files[] | select((.["exclude-branches"] // []) | contains([env(TARGET_BRANCH)]) | not) | (.path // .)'
-        )
+        # lib/glob-expand.sh was already materialized to $RUNNER_TEMP/lib/
+        # by the Apply step above; list-manifest-paths.sh source-loads it
+        # by relative path, so RUNNER_TEMP's layout matches master's
+        # (script + sibling lib/).
+        git show master:.github/scripts/list-manifest-paths.sh > "$RUNNER_TEMP/list-manifest-paths.sh"
+        git show master:.github/byte-identical.yml > "$RUNNER_TEMP/manifest.yml"
+        mapfile -t FILES_ALL < <(bash "$RUNNER_TEMP/list-manifest-paths.sh" "$RUNNER_TEMP/manifest.yml" "$TARGET_BRANCH")
         {
           echo "paths<<EOF"
           printf '%s\n' "${FILES_ALL[@]}"

--- a/.github/workflows/test-byte-identical-scripts.yml
+++ b/.github/workflows/test-byte-identical-scripts.yml
@@ -46,3 +46,4 @@ jobs:
       run: |
         bats tests/bats/ci-scripts/sync-byte-identical/
         bats tests/bats/ci-scripts/validate-byte-identical/
+        bats tests/bats/ci-scripts/list-manifest-paths/

--- a/tests/bats/ci-scripts/list-manifest-paths/helpers.bash
+++ b/tests/bats/ci-scripts/list-manifest-paths/helpers.bash
@@ -1,0 +1,26 @@
+# Helpers for BATS tests of .github/scripts/list-manifest-paths.sh.
+#
+# Follows the same pattern as tests/bats/ci-scripts/validate-byte-identical/
+# and tests/bats/ci-scripts/sync-byte-identical/: script path resolved at
+# load time, temp dir per test, small write_manifest helper.
+
+__HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034  # referenced from .bats files
+LIST_MANIFEST_PATHS_SCRIPT="$(cd "${__HELPERS_DIR}/../../../.." && pwd)/.github/scripts/list-manifest-paths.sh"
+
+setup_test_dir() {
+    CWD=$(mktemp -d -t list-manifest-paths-test-XXXX)
+    # shellcheck disable=SC2034  # referenced from .bats files
+    MANIFEST="${CWD}/manifest.yml"
+    cd "${CWD}" || exit 1
+}
+
+teardown_test_dir() {
+    cd /
+    rm -rf "${CWD}"
+}
+
+# Write raw YAML manifest content.
+write_manifest() {
+    echo "$1" > "${MANIFEST}"
+}

--- a/tests/bats/ci-scripts/list-manifest-paths/list-manifest-paths.bats
+++ b/tests/bats/ci-scripts/list-manifest-paths/list-manifest-paths.bats
@@ -1,0 +1,139 @@
+# BATS tests for .github/scripts/list-manifest-paths.sh
+#
+# The script is the workflow-side entry point for byte-identical
+# manifest parsing -- shares the same read_manifest_entries +
+# filter_by_branch logic as the sync script via lib/glob-expand.sh.
+# Pre-#12924, sync-byte-identical.yml had its own inline yq expression
+# that duplicated (and got wrong twice: #12916 and #12920) the same
+# filter. Coverage here catches the class of drift-between-workflow-
+# and-script bugs that duplication invites.
+
+load 'helpers'
+
+setup() {
+    setup_test_dir
+}
+
+teardown() {
+    teardown_test_dir
+}
+
+@test "usage: missing manifest arg exits 2" {
+    run bash "$LIST_MANIFEST_PATHS_SCRIPT"
+    [[ $status -eq 2 ]]
+    [[ "$output" == *"manifest-file"* || "$output" == *"usage"* ]]
+}
+
+@test "usage: missing target branch arg exits 2" {
+    write_manifest 'files:
+- foo.txt
+'
+    run bash "$LIST_MANIFEST_PATHS_SCRIPT" "$MANIFEST"
+    [[ $status -eq 2 ]]
+    [[ "$output" == *"target-branch"* || "$output" == *"usage"* ]]
+}
+
+@test "precondition: missing manifest file exits 2 with clear message" {
+    run bash "$LIST_MANIFEST_PATHS_SCRIPT" /does/not/exist.yml rel-820
+    [[ $status -eq 2 ]]
+    [[ "$output" == *"manifest not found"* ]]
+}
+
+@test "string-only manifest: all paths printed for any target" {
+    write_manifest 'files:
+- foo.txt
+- bar/baz.yml
+- nested/dir/file.sh
+'
+    run bash "$LIST_MANIFEST_PATHS_SCRIPT" "$MANIFEST" rel-820
+    [[ $status -eq 0 ]]
+    [[ "${lines[0]}" == "foo.txt" ]]
+    [[ "${lines[1]}" == "bar/baz.yml" ]]
+    [[ "${lines[2]}" == "nested/dir/file.sh" ]]
+    [[ ${#lines[@]} -eq 3 ]]
+}
+
+@test "object-form manifest: entry excluded from target is filtered out" {
+    write_manifest 'files:
+- shared.txt
+- path: only-for-820.txt
+  exclude-branches:
+  - rel-800
+  - rel-704
+'
+    run bash "$LIST_MANIFEST_PATHS_SCRIPT" "$MANIFEST" rel-800
+    [[ $status -eq 0 ]]
+    [[ "${lines[0]}" == "shared.txt" ]]
+    [[ ${#lines[@]} -eq 1 ]]
+}
+
+@test "object-form manifest: entry included for non-excluded target still prints" {
+    write_manifest 'files:
+- shared.txt
+- path: only-for-820.txt
+  exclude-branches:
+  - rel-800
+  - rel-704
+'
+    run bash "$LIST_MANIFEST_PATHS_SCRIPT" "$MANIFEST" rel-820
+    [[ $status -eq 0 ]]
+    [[ "${lines[0]}" == "shared.txt" ]]
+    [[ "${lines[1]}" == "only-for-820.txt" ]]
+    [[ ${#lines[@]} -eq 2 ]]
+}
+
+@test "mixed string + object entries: both shapes coexist correctly" {
+    write_manifest 'files:
+- string-a.txt
+- path: object-a.txt
+- string-b.txt
+- path: object-b.txt
+  exclude-branches:
+  - rel-704
+- string-c.txt
+'
+    # rel-820: all 5 entries
+    run bash "$LIST_MANIFEST_PATHS_SCRIPT" "$MANIFEST" rel-820
+    [[ $status -eq 0 ]]
+    [[ ${#lines[@]} -eq 5 ]]
+
+    # rel-704: 4 entries (object-b.txt filtered)
+    run bash "$LIST_MANIFEST_PATHS_SCRIPT" "$MANIFEST" rel-704
+    [[ $status -eq 0 ]]
+    [[ ${#lines[@]} -eq 4 ]]
+    ! printf '%s\n' "${lines[@]}" | grep -qxF "object-b.txt"
+}
+
+@test "empty manifest: exit 0, no output" {
+    write_manifest 'files: []
+'
+    run bash "$LIST_MANIFEST_PATHS_SCRIPT" "$MANIFEST" rel-820
+    [[ $status -eq 0 ]]
+    [[ -z "$output" ]]
+}
+
+@test "all entries excluded for target: exit 0, no output" {
+    write_manifest 'files:
+- path: excluded-a.txt
+  exclude-branches: [rel-800]
+- path: excluded-b.txt
+  exclude-branches: [rel-800]
+'
+    run bash "$LIST_MANIFEST_PATHS_SCRIPT" "$MANIFEST" rel-800
+    [[ $status -eq 0 ]]
+    [[ -z "$output" ]]
+}
+
+@test "target branch not in any exclude list: all entries printed" {
+    write_manifest 'files:
+- path: entry-1.txt
+  exclude-branches: [rel-800]
+- path: entry-2.txt
+  exclude-branches: [rel-704]
+- entry-3.txt
+'
+    # rel-820 isn't excluded from anything -- all 3 print.
+    run bash "$LIST_MANIFEST_PATHS_SCRIPT" "$MANIFEST" rel-820
+    [[ $status -eq 0 ]]
+    [[ ${#lines[@]} -eq 3 ]]
+}


### PR DESCRIPTION
## Summary

Consolidates the three-way duplication of manifest-parsing logic that produced #12916 (first workflow yq bug) and #12920 (second workflow yq bug). Both were the same class of bug: the workflow's inline yq expression drifted from the sync script's `read_manifest_entries` + `filter_by_branch` (in `lib/glob-expand.sh`) because they were maintained independently.

Now there's **one source of truth**: the shared lib. Both scripts and the workflow use it. Test coverage for the workflow's manifest-parsing extends naturally.

## What changed

**New script** `.github/scripts/list-manifest-paths.sh <manifest> <target-branch>` — reads the manifest via `read_manifest_entries`, filters via `filter_by_branch`, prints one path per line. Under 70 lines including comments. No new logic; just wires existing lib helpers into a callable driver.

**`sync-byte-identical.yml`** — replaces the inline yq in the "Compute add-paths input for peter-evans" step with a bash invocation of the new script. Materializes master's copy of both the script + manifest into RUNNER_TEMP (Apply step already materializes `lib/glob-expand.sh` alongside sync-byte-identical.sh; layout works because list-manifest-paths.sh source-loads by relative path).

**`test-byte-identical-scripts.yml`** — adds the new BATS suite directory to the CI run.

**New BATS suite** (10 cases in `tests/bats/ci-scripts/list-manifest-paths/`):

- Usage: missing manifest arg → exit 2
- Usage: missing target-branch arg → exit 2
- Precondition: missing manifest file → exit 2 with clear message
- String-only manifest: all paths printed
- Object-form entry excluded from target filtered out
- Object-form entry included for non-excluded target still printed
- Mixed string + object entries both shapes coexist correctly
- Empty manifest → exit 0, no output
- All entries excluded for target → exit 0, no output
- Target not in any exclude list → all entries printed

## Results

- **53/53 BATS pass locally** (10 new list-manifest-paths + 27 sync + 16 validate).
- Shellcheck clean on all three scripts.

## Why not in the byte-identical set

Like `sync-byte-identical.sh` and `sync-byte-identical.yml`, the new script is master-only-firing (only invoked from sync-byte-identical.yml, which is master-only). RUNNER_TEMP materialization always uses master's copy fresh at workflow-run time, so rel-branch drift doesn't affect execution.

## Cost analysis

−12 lines from the workflow, +67 lines new script + tests. Net add. Every future manifest-schema change now touches ONE place (the lib) that has BATS coverage, instead of three places where two were untested. Given we hit that class of bug twice in the last day, the ratio is favorable.

## Follow-ups deferred

- Similar treatment for the RUNNER_TEMP-extraction pattern in the Apply step could reduce coupling further. Not urgent — that step just materializes known files, doesn't parse anything.
- Workflow-level test coverage via actionlint or nektos/act. Big lift, low return until we see a workflow-shape bug that isn't already covered by scripts.

## Test plan

- [ ] `test-byte-identical-scripts.yml` runs all three suites (53 tests total)
- [ ] `validate-byte-identical.yml` canary still green
- [ ] After merge: sync workflow re-fires cleanly, produces sync PRs against three rel branches (rel-820 = small; rel-800/rel-704 = manifest-only-ish, no orphan release-mechanism paths)