### PR TITLE
chore(release): whitelist ChangelogMutator on rel-820 to unblock composer-require-checker

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -24,6 +24,7 @@
         "OpenEMR\\Common\\Utils\\Exception",
         "OpenEMR\\Common\\Http\\UploadedFile",
         "OpenEMR\\Gacl\\Hashed_Cache_Lite",
+        "OpenEMR\\Release\\Mutator\\ChangelogMutator",
         "Pdo\\Mysql",
         "PHPUnit\\Framework\\Attributes\\Test",
         "Psy\\Shell",


### PR DESCRIPTION
Coordinated fix for auto-sync PR #12926.

**Problem:** #12925 landed on master + auto-sync (#12926) is bringing `OpenEMR\\Release\\Mutator\\ChangelogMutator` + `ReleasePrepCommand`'s `class_exists()`-guarded FQCN reference to rel-820 as part of byte-identical enforcement of the release-mechanism surface. But `.composer-require-checker.json` is NOT in the byte-identical set (project-config file that could legitimately differ per branch), so the sync PR doesn't carry the whitelist entry that master added alongside the mutator in #12925.

Without this whitelist entry, composer-require-checker fails on rel-820 with:

```
Unknown Symbol: OpenEMR\\Release\\Mutator\\ChangelogMutator
```

**Fix:** manually port the single-line whitelist entry to rel-820.

rel-800 and rel-704 are excluded from the mutator's byte-identical entries (per the `exclude-branches: [rel-800, rel-704]` shape on `tools/release/**` and `src/Common/Command/ReleasePrep/**`), so they don't have the reference and don't need this fix.

**Landing order:**
1. This PR merges first (adds whitelist to rel-820)
2. Sync PR #12926 re-runs (or gets merged) — composer-require-checker now passes because the whitelist is present

## Test plan

- [ ] CI green
- [ ] Merge before #12926
- [ ] After merge: verify #12926 re-runs CI and composer-require-checker passes