### PR TITLE
feat(release): CompatibilityMutator + fix inject() idempotence (PR 8)

### DIFF
--- a/.codespell-ignore-words.txt
+++ b/.codespell-ignore-words.txt
@@ -112,6 +112,7 @@ cancelled
 # These require separate PRs with proper testing (see SPELLCHECK_BATCHES.md)
 cant
 collapsable
+deriver
 detatch
 durationm
 ect

--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -25,6 +25,7 @@
         "OpenEMR\\Common\\Http\\UploadedFile",
         "OpenEMR\\Gacl\\Hashed_Cache_Lite",
         "OpenEMR\\Release\\Mutator\\ChangelogMutator",
+        "OpenEMR\\Release\\Mutator\\CompatibilityMutator",
         "Pdo\\Mysql",
         "PHPUnit\\Framework\\Attributes\\Test",
         "Psy\\Shell",

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -247,10 +247,12 @@ jobs:
       if: steps.resolve.outputs.should-run != 'false'
       env:
         VERSION: ${{ steps.resolve.outputs.version }}
+        REL_BRANCH: ${{ steps.resolve.outputs.branch }}
       run: |
         php bin/console openemr:release-prep \
           --skip-globals \
           --target-version="${VERSION}" \
+          --rel-branch="${REL_BRANCH}" \
           --scope=rel
 
     # Open/update the long-lived release-prep PR via peter-evans/create-pull-request,

--- a/src/Common/Command/ReleasePrepCommand.php
+++ b/src/Common/Command/ReleasePrepCommand.php
@@ -217,24 +217,32 @@ final class ReleasePrepCommand extends Command
      * composer-require-checker does not flag the cross-boundary
      * dependency.
      *
+     * Ordering matters: CompatibilityMutator must run AFTER
+     * ChangelogMutator because it injects into the `## [X.Y.Z]` heading
+     * ChangelogMutator writes.
+     *
      * @param list<MutatorInterface> $mutators
      */
     private function appendOptionalReleaseMutators(array &$mutators): void
     {
-        // FQCN via ::class: composer-require-checker sees the reference
-        // (which is why the class name is whitelisted in
+        // FQCNs via ::class: composer-require-checker sees the reference
+        // (which is why the class names are whitelisted in
         // .composer-require-checker.json), but autoload is not triggered
         // by the reference itself — only by the guarded new below. Under
-        // a production `composer install --no-dev` the class is not
+        // a production `composer install --no-dev` the classes are not
         // autoloadable, class_exists() returns false, and the mutator is
         // silently skipped. Kept as ::class (rather than a plain string
         // literal) so an IDE can refactor the FQCN alongside the file if
         // it ever moves.
-        $changelogMutator = \OpenEMR\Release\Mutator\ChangelogMutator::class;
-        if (!class_exists($changelogMutator)) {
-            return;
+        $optionalMutators = [
+            \OpenEMR\Release\Mutator\ChangelogMutator::class,
+            \OpenEMR\Release\Mutator\CompatibilityMutator::class,
+        ];
+        foreach ($optionalMutators as $mutator) {
+            if (class_exists($mutator)) {
+                $mutators[] = new $mutator();
+            }
         }
-        $mutators[] = new $changelogMutator();
     }
 
     private function defaultProjectDir(): string

--- a/tests/Tests/Isolated/Release/CompatibilityMutatorTest.php
+++ b/tests/Tests/Isolated/Release/CompatibilityMutatorTest.php
@@ -1,0 +1,239 @@
+<?php
+
+/**
+ * Isolated tests for CompatibilityMutator.
+ *
+ * Each test spins up a temp git repo with a checked-in `ci/` scaffold
+ * + a rel-820 branch, then invokes the real mutator against it. Uses
+ * the real CompatibilityDeriver + Renderer (both are `final readonly`
+ * so no mocking; the test fixture provides the inputs deriver reads).
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release;
+
+use OpenEMR\Common\Command\ReleasePrep\MutatorContext;
+use OpenEMR\Release\Mutator\CompatibilityMutator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+final class CompatibilityMutatorTest extends TestCase
+{
+    private string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/openemr-compat-mut-test-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->tmpDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->tmpDir);
+        }
+        $this->git(['init', '-q', '-b', 'main']);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursive($this->tmpDir);
+    }
+
+    public function testRelBranchRequired(): void
+    {
+        $this->seedCi(['nginx_82_1011' => 'mariadb:10.11.0']);
+        file_put_contents($this->tmpDir . '/CHANGELOG.md', "# CHANGELOG.md\n\n");
+        $this->commit();
+
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.2.1');
+        $mutator = new CompatibilityMutator();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/relBranch is required/');
+        $mutator->apply($context);
+    }
+
+    public function testInjectsMinimumSupportedVersionsAfterVersionHeading(): void
+    {
+        $this->seedCi([
+            'nginx_82_1011' => 'mariadb:10.11.0',
+            'nginx_83_1108' => 'mariadb:11.8.6',
+            'nginx_82_57'     => 'mysql:5.7.44',
+        ]);
+        $this->seedChangelog();
+        $this->commit();
+        $this->git(['branch', 'rel-820']);
+
+        $result = $this->apply();
+        self::assertTrue($result->changed());
+        $updated = (string) file_get_contents($this->tmpDir . '/CHANGELOG.md');
+
+        self::assertStringContainsString('### Minimum supported versions', $updated);
+        // Minimum of {8.2, 8.3} = 8.2 (php)
+        self::assertStringContainsString('- **PHP** 8.2+', $updated);
+        // Minimum of {10.11, 11.8} = 10.11 (mariadb)
+        self::assertStringContainsString('- **MariaDB** 10.11+', $updated);
+        // Only one mysql entry → 5.7
+        self::assertStringContainsString('- **MySQL** 5.7+', $updated);
+        self::assertLessThan(
+            strpos($updated, '### Fixed'),
+            strpos($updated, '### Minimum supported versions'),
+            'compat block appears before Fixed',
+        );
+    }
+
+    public function testMatrixUrlUsesRelBranch(): void
+    {
+        $this->seedCi(['nginx_82_1011' => 'mariadb:10.11.0']);
+        $this->seedChangelog();
+        $this->commit();
+        $this->git(['branch', 'rel-820']);
+
+        $this->apply();
+        $updated = (string) file_get_contents($this->tmpDir . '/CHANGELOG.md');
+
+        self::assertStringContainsString(
+            '[tested CI matrix](https://github.com/openemr/openemr/tree/rel-820/ci)',
+            $updated,
+        );
+    }
+
+    public function testRerunIsNoOpWhenSameCiState(): void
+    {
+        $this->seedCi(['nginx_82_1011' => 'mariadb:10.11.0']);
+        $this->seedChangelog();
+        $this->commit();
+        $this->git(['branch', 'rel-820']);
+
+        $first = $this->apply();
+        self::assertTrue($first->changed());
+
+        $second = $this->apply();
+        self::assertFalse($second->changed(), 'idempotent rerun');
+    }
+
+    public function testResultShapeCarriesChangelogPathAndDerivedMinimums(): void
+    {
+        $this->seedCi(['nginx_82_1011' => 'mariadb:10.11.0']);
+        $this->seedChangelog();
+        $this->commit();
+        $this->git(['branch', 'rel-820']);
+
+        $result = $this->apply();
+        self::assertSame(['CHANGELOG.md'], $result->changedFiles);
+        self::assertCount(1, $result->messages);
+        self::assertStringContainsString('rel-820', $result->messages[0]);
+        self::assertStringContainsString('php=8.2', $result->messages[0]);
+        self::assertStringContainsString('mariadb=10.11', $result->messages[0]);
+    }
+
+    public function testMasterScopeExtractsRelBranchCiNotMasterCi(): void
+    {
+        // rel-820 has PHP 8.2 in its ci/; master has drifted to PHP 8.3.
+        // Mutator on master scope must derive from rel-820's ci/, not master's.
+        $this->seedCi(['nginx_82_1011' => 'mariadb:10.11.0']);
+        $this->seedChangelog();
+        $this->commit();
+        $this->git(['branch', 'rel-820']);
+
+        // Drift master's ci/ to a newer PHP
+        $this->removeRecursive($this->tmpDir . '/ci');
+        $this->seedCi(['nginx_83_1108' => 'mariadb:11.8.6']);
+        $this->git(['add', '.']);
+        $this->git(['commit', '-q', '-m', 'master drift']);
+        // Now master has php83, rel-820 has php82
+
+        // apply() runs against master's checkout, but passes relBranch=rel-820
+        $result = $this->apply();
+        self::assertTrue($result->changed());
+        $updated = (string) file_get_contents($this->tmpDir . '/CHANGELOG.md');
+
+        // Should reflect rel-820's ci/ (PHP 8.2), NOT master's ci/ (PHP 8.3)
+        self::assertStringContainsString('- **PHP** 8.2+', $updated);
+        self::assertStringNotContainsString('- **PHP** 8.3+', $updated);
+    }
+
+    /**
+     * @param array<string, string> $dirs Map of ci-subdir → mysql-image value
+     */
+    private function seedCi(array $dirs): void
+    {
+        mkdir($this->tmpDir . '/ci', 0700, true);
+        foreach ($dirs as $subdir => $image) {
+            $path = $this->tmpDir . '/ci/' . $subdir;
+            mkdir($path, 0700, true);
+            file_put_contents(
+                $path . '/docker-compose.yml',
+                "services:\n  mysql:\n    image: {$image}\n",
+            );
+        }
+    }
+
+    private function seedChangelog(): void
+    {
+        file_put_contents($this->tmpDir . '/CHANGELOG.md', <<<'MD'
+# CHANGELOG.md
+
+## [8.2.1](https://github.com/openemr/openemr/compare/v8_2_0...v8_2_1) - 2026-08-01
+
+### Fixed
+
+  - stuff ([#1](https://github.com/openemr/openemr/pull/1))
+
+MD);
+    }
+
+    private function commit(): void
+    {
+        $this->git(['add', '.']);
+        $this->git(['commit', '-q', '-m', 'seed']);
+    }
+
+    private function apply(): \OpenEMR\Common\Command\ReleasePrep\MutatorResult
+    {
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.2.1', 'rel-820');
+        $mutator = new CompatibilityMutator();
+        return $mutator->apply($context);
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    private function git(array $args): void
+    {
+        $process = new Process(
+            ['git', ...$args],
+            $this->tmpDir,
+            [
+                'GIT_AUTHOR_NAME' => 'Test',
+                'GIT_AUTHOR_EMAIL' => 'test@example.com',
+                'GIT_COMMITTER_NAME' => 'Test',
+                'GIT_COMMITTER_EMAIL' => 'test@example.com',
+            ],
+        );
+        $process->mustRun();
+    }
+
+    private function removeRecursive(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        /** @var iterable<\SplFileInfo> $items */
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/Tests/Isolated/Release/CompatibilityMutatorTest.php
+++ b/tests/Tests/Isolated/Release/CompatibilityMutatorTest.php
@@ -130,6 +130,129 @@ final class CompatibilityMutatorTest extends TestCase
         self::assertStringContainsString('mariadb=10.11', $result->messages[0]);
     }
 
+    public function testResolvesRelBranchViaOriginRemoteTrackingRefWhenLocalBranchAbsent(): void
+    {
+        // Simulate the master-scope workflow shape: a separate
+        // `master-checkout` cloned with --branch master --single-branch.
+        // The rel-820 branch is not locally reachable; only origin/rel-820
+        // exists as a remote-tracking ref.
+        $this->seedCi(['nginx_82_1011' => 'mariadb:10.11.0']);
+        $this->seedChangelog();
+        $this->commit();
+        $this->git(['branch', 'rel-820']);
+
+        // Set up a bare "origin" and clone --single-branch master
+        $originDir = sys_get_temp_dir() . '/openemr-origin-' . bin2hex(random_bytes(6));
+        $checkoutDir = sys_get_temp_dir() . '/openemr-master-co-' . bin2hex(random_bytes(6));
+        try {
+            (new Process(['git', 'clone', '--quiet', '--bare', $this->tmpDir, $originDir]))->mustRun();
+            (new Process([
+                'git', 'clone', '--quiet',
+                '--branch', 'main', '--single-branch',
+                $originDir, $checkoutDir,
+            ]))->mustRun();
+
+            // Verify pre-conditions: rel-820 is NOT a local branch,
+            // but origin/rel-820 is a remote-tracking ref. With
+            // --single-branch we need an explicit refspec to populate
+            // refs/remotes/origin/rel-820 (bare `git fetch origin rel-820`
+            // would only update FETCH_HEAD).
+            $fetch = new Process(
+                ['git', 'fetch', '--quiet', 'origin', 'rel-820:refs/remotes/origin/rel-820'],
+                $checkoutDir,
+            );
+            $fetch->mustRun();
+            $probeLocal = new Process(['git', 'rev-parse', '--verify', '--quiet', 'refs/heads/rel-820'], $checkoutDir);
+            $probeLocal->run();
+            self::assertFalse($probeLocal->isSuccessful(), 'rel-820 must not be a local branch in the master-style checkout');
+            $probeRemote = new Process(['git', 'rev-parse', '--verify', '--quiet', 'refs/remotes/origin/rel-820'], $checkoutDir);
+            $probeRemote->mustRun();
+
+            file_put_contents($checkoutDir . '/CHANGELOG.md', <<<'MD'
+# CHANGELOG.md
+
+## [8.2.1](https://github.com/openemr/openemr/compare/v8_2_0...v8_2_1) - 2026-08-01
+
+### Fixed
+
+  - new bugfix ([#1](https://github.com/openemr/openemr/pull/1))
+
+MD);
+            $context = MutatorContext::fromVersionString($checkoutDir, '8.2.1', 'rel-820');
+            $result = (new CompatibilityMutator())->apply($context);
+
+            self::assertTrue($result->changed());
+            $updated = (string) file_get_contents($checkoutDir . '/CHANGELOG.md');
+            self::assertStringContainsString('- **MariaDB** 10.11+', $updated);
+        } finally {
+            $this->removeRecursive($checkoutDir);
+            $this->removeRecursive($originDir);
+        }
+    }
+
+    public function testResolveRelBranchThrowsWhenNeitherLocalNorRemoteRefExists(): void
+    {
+        $this->seedCi(['nginx_82_1011' => 'mariadb:10.11.0']);
+        $this->seedChangelog();
+        $this->commit();
+        // rel-820 NOT created
+
+        $context = MutatorContext::fromVersionString($this->tmpDir, '8.2.1', 'rel-820');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/neither rel-820 nor origin\/rel-820/');
+        (new CompatibilityMutator())->apply($context);
+    }
+
+    public function testInjectPreservesOlderReleasesCompatBlock(): void
+    {
+        // Multi-heading CHANGELOG: prior release already has its own compat
+        // block. The mutator should inject into the NEW top section and
+        // leave the older release's block intact.
+        $this->seedCi(['nginx_82_1011' => 'mariadb:10.11.0']);
+        file_put_contents($this->tmpDir . '/CHANGELOG.md', <<<'MD'
+# CHANGELOG.md
+
+## [8.2.1](https://github.com/openemr/openemr/compare/v8_2_0...v8_2_1) - 2026-08-01
+
+### Fixed
+
+  - new bugfix ([#200](https://github.com/openemr/openemr/pull/200))
+
+## [8.2.0](https://github.com/openemr/openemr/compare/v8_1_0...v8_2_0) - 2026-07-08
+
+### Minimum supported versions
+
+- **PHP** 8.2+
+
+See the [tested CI matrix](https://github.com/openemr/openemr/tree/rel-820/ci) for all tested version combinations.
+
+### Fixed
+
+  - old bugfix ([#100](https://github.com/openemr/openemr/pull/100))
+
+MD);
+        $this->commit();
+        $this->git(['branch', 'rel-820']);
+
+        $this->apply();
+        $updated = (string) file_get_contents($this->tmpDir . '/CHANGELOG.md');
+
+        // 8.2.1 gets its new compat block (mariadb 10.11 from seedCi)
+        self::assertStringContainsString('- **MariaDB** 10.11+', $updated);
+        // 8.2.0's original compat block is untouched (still PHP 8.2 + no MariaDB entry)
+        self::assertMatchesRegularExpression(
+            '/## \[8\.2\.0\].*?### Minimum supported versions.*?- \*\*PHP\*\* 8\.2\+/s',
+            $updated,
+        );
+        // Exactly two compat sections now (one per release)
+        self::assertSame(
+            2,
+            substr_count($updated, '### Minimum supported versions'),
+            'top section gets new compat block, older section keeps its own',
+        );
+    }
+
     public function testMasterScopeExtractsRelBranchCiNotMasterCi(): void
     {
         // rel-820 has PHP 8.2 in its ci/; master has drifted to PHP 8.3.

--- a/tests/Tests/Isolated/Release/CompatibilityNotesRendererTest.php
+++ b/tests/Tests/Isolated/Release/CompatibilityNotesRendererTest.php
@@ -122,6 +122,53 @@ MD;
         self::assertStringContainsString('#123', $out);
     }
 
+    public function testInjectDoesNotStripCompatBlocksFromOlderReleaseSections(): void
+    {
+        // CHANGELOG with two prior release entries -- the OLDER one has a
+        // compat block from its own release-prep run. When we inject into
+        // the NEW top section, the older release's compat block must be
+        // preserved.
+        $notes = <<<'MD'
+## [8.2.1](https://github.com/openemr/openemr/compare/v8_2_0...v8_2_1) - 2026-08-01
+
+### Fixed
+
+  - new bugfix ([#200](https://github.com/openemr/openemr/pull/200))
+
+## [8.2.0](https://github.com/openemr/openemr/compare/v8_1_0...v8_2_0) - 2026-07-08
+
+### Minimum supported versions
+
+- **PHP** 8.2+
+- **MariaDB** 10.6+
+
+See the [tested CI matrix](https://github.com/openemr/openemr/tree/rel-820/ci) for all tested version combinations.
+
+### Fixed
+
+  - old bugfix ([#100](https://github.com/openemr/openemr/pull/100))
+
+MD;
+        $section = $this->renderer->render(
+            ['php' => '8.3', 'mariadb' => '11.4'],
+            'https://github.com/openemr/openemr/tree/rel-821/ci',
+        );
+
+        $out = $this->renderer->inject($notes, $section);
+
+        // The new 8.2.1 compat block is added
+        self::assertStringContainsString('- **PHP** 8.3+', $out);
+        // The older 8.2.0 compat block is preserved
+        self::assertStringContainsString('- **PHP** 8.2+', $out);
+        self::assertStringContainsString('- **MariaDB** 10.6+', $out);
+        // Exactly two headings now (one per release)
+        self::assertSame(
+            2,
+            substr_count($out, '### Minimum supported versions'),
+            'top section gets a new compat block, older section keeps its own',
+        );
+    }
+
     public function testInjectReplacesStaleSectionWithNewValues(): void
     {
         $notes = <<<'MD'

--- a/tests/Tests/Isolated/Release/CompatibilityNotesRendererTest.php
+++ b/tests/Tests/Isolated/Release/CompatibilityNotesRendererTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Isolated tests for OpenEMR\Release\CompatibilityNotesRenderer,
+ * focused on the inject() idempotence fix introduced alongside
+ * CompatibilityMutator (PR 8). CompatibilityMutator is the first live
+ * consumer of inject(); a rerun with the same section must be a
+ * no-op rather than duplicating the "### Minimum supported versions"
+ * block.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release;
+
+use OpenEMR\Release\CompatibilityNotesRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class CompatibilityNotesRendererTest extends TestCase
+{
+    private CompatibilityNotesRenderer $renderer;
+
+    protected function setUp(): void
+    {
+        $this->renderer = new CompatibilityNotesRenderer();
+    }
+
+    public function testRenderProducesExpectedSectionShape(): void
+    {
+        $out = $this->renderer->render(
+            ['php' => '8.2', 'mariadb' => '10.6', 'mysql' => '5.7'],
+            'https://github.com/openemr/openemr/tree/rel-820/ci',
+        );
+
+        self::assertStringStartsWith("### Minimum supported versions\n", $out);
+        self::assertStringContainsString('- **PHP** 8.2+', $out);
+        self::assertStringContainsString('- **MariaDB** 10.6+', $out);
+        self::assertStringContainsString('- **MySQL** 5.7+', $out);
+        self::assertStringContainsString(
+            '[tested CI matrix](https://github.com/openemr/openemr/tree/rel-820/ci)',
+            $out,
+        );
+    }
+
+    public function testInjectAfterFirstVersionHeadingPreservesTrailingSections(): void
+    {
+        $notes = <<<'MD'
+## [8.2.1](https://github.com/openemr/openemr/compare/v8_2_0...v8_2_1) - 2026-08-01
+
+### Fixed
+
+  - some bugfix ([#123](https://github.com/openemr/openemr/pull/123))
+
+MD;
+        $section = $this->renderer->render(
+            ['php' => '8.2'],
+            'https://github.com/openemr/openemr/tree/rel-820/ci',
+        );
+
+        $out = $this->renderer->inject($notes, $section);
+
+        self::assertStringContainsString('### Minimum supported versions', $out);
+        self::assertStringContainsString('### Fixed', $out);
+        self::assertLessThan(
+            strpos($out, '### Fixed'),
+            strpos($out, '### Minimum supported versions'),
+            'compat section appears before Fixed',
+        );
+        // Preserve the version-heading + blank-line prefix
+        self::assertStringStartsWith("## [8.2.1]", $out);
+    }
+
+    public function testInjectPrependsWhenNoVersionHeadingExists(): void
+    {
+        $notes = "just body content\n\nno heading\n";
+        $section = $this->renderer->render(
+            ['php' => '8.2'],
+            'https://github.com/openemr/openemr/tree/rel-820/ci',
+        );
+
+        $out = $this->renderer->inject($notes, $section);
+        self::assertStringStartsWith('### Minimum supported versions', $out);
+    }
+
+    public function testInjectIsIdempotentWhenSectionAlreadyPresent(): void
+    {
+        $notes = <<<'MD'
+## [8.2.1](https://github.com/openemr/openemr/compare/v8_2_0...v8_2_1) - 2026-08-01
+
+### Minimum supported versions
+
+- **PHP** 8.2+
+
+See the [tested CI matrix](https://github.com/openemr/openemr/tree/rel-820/ci) for all tested version combinations.
+
+### Fixed
+
+  - some bugfix ([#123](https://github.com/openemr/openemr/pull/123))
+
+MD;
+        $section = $this->renderer->render(
+            ['php' => '8.2'],
+            'https://github.com/openemr/openemr/tree/rel-820/ci',
+        );
+
+        $out = $this->renderer->inject($notes, $section);
+
+        // Exactly one instance of the heading
+        self::assertSame(
+            1,
+            substr_count($out, '### Minimum supported versions'),
+            'existing block was stripped before reinjection — no duplicate',
+        );
+        // Fixed section still present
+        self::assertStringContainsString('### Fixed', $out);
+        self::assertStringContainsString('#123', $out);
+    }
+
+    public function testInjectReplacesStaleSectionWithNewValues(): void
+    {
+        $notes = <<<'MD'
+## [8.2.1](https://github.com/openemr/openemr/compare/v8_2_0...v8_2_1) - 2026-08-01
+
+### Minimum supported versions
+
+- **PHP** 7.4+
+
+See the [tested CI matrix](https://github.com/openemr/openemr/tree/rel-820/ci) for all tested version combinations.
+
+### Fixed
+
+  - a bug ([#1](https://github.com/openemr/openemr/pull/1))
+
+MD;
+        // Rerender with updated minimums
+        $section = $this->renderer->render(
+            ['php' => '8.2', 'mariadb' => '10.6'],
+            'https://github.com/openemr/openemr/tree/rel-820/ci',
+        );
+
+        $out = $this->renderer->inject($notes, $section);
+
+        self::assertStringContainsString('- **PHP** 8.2+', $out);
+        self::assertStringContainsString('- **MariaDB** 10.6+', $out);
+        self::assertStringNotContainsString('- **PHP** 7.4+', $out);
+        self::assertStringContainsString('### Fixed', $out);
+    }
+}

--- a/tools/release/src/CompatibilityNotesRenderer.php
+++ b/tools/release/src/CompatibilityNotesRenderer.php
@@ -56,41 +56,62 @@ final readonly class CompatibilityNotesRenderer
      * the blank line that conventionally follows it). If the notes have no such
      * heading, prepend the section instead.
      *
-     * Idempotent: if the notes already contain a "### Minimum supported
-     * versions" block (bounded by the heading and the next `##`-prefixed
-     * heading of any depth or EOF), that block is removed first so a rerun
-     * with the same section produces the same output rather than a duplicate.
+     * Idempotent: if the FIRST `## ` section already contains a
+     * "### Minimum supported versions" block, that block is stripped in place
+     * before the new section is inserted. Only the first `## ` section's
+     * contents are considered — older release sections further down the file
+     * (which have their own compat blocks from earlier release-prep runs) are
+     * left untouched.
      */
     public function inject(string $notes, string $section): string
     {
-        // Strip any existing Minimum-supported-versions block first so a
-        // second inject() call with the same section is a no-op instead of
-        // producing a duplicate section. The block runs from the heading
-        // to the next `##`-prefixed heading of any depth (### or ##) or
-        // EOF, so we anchor on the following heading in a lookahead.
+        $lines = explode("\n", $notes);
+
+        $headingIndex = null;
+        foreach ($lines as $index => $line) {
+            if (str_starts_with($line, '## ')) {
+                $headingIndex = $index;
+                break;
+            }
+        }
+
+        if ($headingIndex === null) {
+            return $section . "\n" . $notes;
+        }
+
+        // Bound the first section: heading -> next `## ` heading or EOF.
+        // Only strip existing compat blocks inside THIS scope so older
+        // release sections keep their own Minimum-supported-versions blocks.
+        $sectionEnd = count($lines);
+        for ($i = $headingIndex + 1, $n = count($lines); $i < $n; $i++) {
+            if (str_starts_with($lines[$i], '## ')) {
+                $sectionEnd = $i;
+                break;
+            }
+        }
+        $targetBlock = implode("\n", array_slice($lines, $headingIndex, $sectionEnd - $headingIndex));
+        // Strip an existing compat block bounded by its heading and the next
+        // `##`-prefixed heading of any depth (### or ##) or the section end.
         $stripped = preg_replace(
             '/^### Minimum supported versions.*?(?=^##|\z)/ms',
             '',
-            $notes,
+            $targetBlock,
             1,
         );
         if ($stripped === null) {
             throw new \RuntimeException('CompatibilityNotesRenderer::inject regex failure');
         }
-        $notes = $stripped;
+        array_splice(
+            $lines,
+            $headingIndex,
+            $sectionEnd - $headingIndex,
+            explode("\n", $stripped),
+        );
 
-        $lines = explode("\n", $notes);
-        foreach ($lines as $index => $line) {
-            if (!str_starts_with($line, '## ')) {
-                continue;
-            }
-            $insertAt = isset($lines[$index + 1]) && trim($lines[$index + 1]) === ''
-                ? $index + 2
-                : $index + 1;
-            array_splice($lines, $insertAt, 0, [rtrim($section, "\n"), '']);
-            return implode("\n", $lines);
-        }
-
-        return $section . "\n" . $notes;
+        $insertAt = isset($lines[$headingIndex + 1]) && trim($lines[$headingIndex + 1]) === ''
+            ? $headingIndex + 2
+            : $headingIndex + 1;
+        array_splice($lines, $insertAt, 0, [rtrim($section, "\n"), '']);
+        return implode("\n", $lines);
     }
 }

--- a/tools/release/src/CompatibilityNotesRenderer.php
+++ b/tools/release/src/CompatibilityNotesRenderer.php
@@ -55,9 +55,30 @@ final readonly class CompatibilityNotesRenderer
      * Insert a section into notes just after the first `## ` heading line (and
      * the blank line that conventionally follows it). If the notes have no such
      * heading, prepend the section instead.
+     *
+     * Idempotent: if the notes already contain a "### Minimum supported
+     * versions" block (bounded by the heading and the next `##`-prefixed
+     * heading of any depth or EOF), that block is removed first so a rerun
+     * with the same section produces the same output rather than a duplicate.
      */
     public function inject(string $notes, string $section): string
     {
+        // Strip any existing Minimum-supported-versions block first so a
+        // second inject() call with the same section is a no-op instead of
+        // producing a duplicate section. The block runs from the heading
+        // to the next `##`-prefixed heading of any depth (### or ##) or
+        // EOF, so we anchor on the following heading in a lookahead.
+        $stripped = preg_replace(
+            '/^### Minimum supported versions.*?(?=^##|\z)/ms',
+            '',
+            $notes,
+            1,
+        );
+        if ($stripped === null) {
+            throw new \RuntimeException('CompatibilityNotesRenderer::inject regex failure');
+        }
+        $notes = $stripped;
+
         $lines = explode("\n", $notes);
         foreach ($lines as $index => $line) {
             if (!str_starts_with($line, '## ')) {

--- a/tools/release/src/Mutator/CompatibilityMutator.php
+++ b/tools/release/src/Mutator/CompatibilityMutator.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * Inject the "### Minimum supported versions" section into the target
+ * version's `## [X.Y.Z]` block in CHANGELOG.md. The section is derived
+ * from the rel branch's `ci/` matrix via `CompatibilityDeriver`
+ * (mirrors ci/parse_docker_dir.sh) and rendered via
+ * `CompatibilityNotesRenderer`.
+ *
+ * Runs AFTER `ChangelogMutator` on both scopes so the target-version
+ * heading exists when this mutator injects into it. The order is
+ * enforced by `ReleasePrepCommand::appendOptionalReleaseMutators()`.
+ *
+ * CI-directory sourcing
+ *   On both rel and master scopes the mutator materializes the rel
+ *   branch's `ci/` compose files into a temp dir via `git ls-tree` +
+ *   `git show` (per-file blob reads). Master scope needs this because
+ *   master's `ci/` can diverge from rel-820's during the release window.
+ *   Rel scope also uses it (rather than reading `$projectDir/ci/`
+ *   directly) so the two paths behave identically -- one code path,
+ *   tested once. `git archive` was considered but `.gitattributes` has
+ *   `ci/ export-ignore` (correctly, since ci configs shouldn't ship in
+ *   release tarballs), which silently produces an empty archive.
+ *
+ * Idempotence
+ *   Rerun with the same target version + rel branch produces no diff.
+ *   `CompatibilityNotesRenderer::inject()` was fixed alongside this
+ *   mutator to strip an existing Minimum-supported-versions block
+ *   before injecting the new one (rather than duplicating).
+ *
+ * External-tool dependence
+ *   Shells out to `git ls-tree` + `git show` via Symfony Process. Both
+ *   are always available with git. No network calls (unlike
+ *   ChangelogMutator's gh api dependency).
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Mutator;
+
+use OpenEMR\Common\Command\ReleasePrep\MutatorContext;
+use OpenEMR\Common\Command\ReleasePrep\MutatorInterface;
+use OpenEMR\Common\Command\ReleasePrep\MutatorResult;
+use OpenEMR\Release\CompatibilityDeriver;
+use OpenEMR\Release\CompatibilityNotesRenderer;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+
+final readonly class CompatibilityMutator implements MutatorInterface
+{
+    private const RELATIVE_PATH = 'CHANGELOG.md';
+    private const CI_RELATIVE_PATH = 'ci';
+    private const REPO = 'openemr/openemr';
+
+    public function __construct(
+        private ?CompatibilityDeriver $deriver = null,
+        private ?CompatibilityNotesRenderer $renderer = null,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'CHANGELOG.md (inject Minimum supported versions section)';
+    }
+
+    public function apply(MutatorContext $context): MutatorResult
+    {
+        if ($context->relBranch === null) {
+            throw new \RuntimeException(
+                'CompatibilityMutator: relBranch is required; the release-prep'
+                . ' workflow passes --rel-branch on both rel and master scope.',
+            );
+        }
+
+        $path = $context->projectDir . '/' . self::RELATIVE_PATH;
+        $existing = file_get_contents($path);
+        if ($existing === false) {
+            throw new \RuntimeException('Cannot read ' . $path);
+        }
+
+        [$ciDir, $cleanup] = $this->materializeCiDir($context);
+
+        try {
+            $deriver = $this->deriver ?? new CompatibilityDeriver($ciDir);
+            $minimums = $deriver->derive();
+
+            $matrixUrl = sprintf(
+                'https://github.com/%s/tree/%s/%s',
+                self::REPO,
+                $context->relBranch,
+                self::CI_RELATIVE_PATH,
+            );
+            $renderer = $this->renderer ?? new CompatibilityNotesRenderer();
+            $section = $renderer->render($minimums, $matrixUrl);
+            $updated = $renderer->inject($existing, $section);
+
+            if ($updated === $existing) {
+                return MutatorResult::noop();
+            }
+
+            if (file_put_contents($path, $updated) === false) {
+                throw new \RuntimeException('Cannot write ' . $path);
+            }
+
+            return new MutatorResult(
+                [self::RELATIVE_PATH],
+                [sprintf(
+                    'CHANGELOG.md: injected Minimum supported versions from %s/ci (%s)',
+                    $context->relBranch,
+                    implode(', ', array_map(
+                        static fn (string $k, string $v): string => "{$k}={$v}",
+                        array_keys($minimums),
+                        array_values($minimums),
+                    )),
+                )],
+            );
+        } finally {
+            $cleanup();
+        }
+    }
+
+    /**
+     * Materialize rel branch's docker-compose.yml files under `ci/`
+     * into a temp dir via `git ls-tree` + `git show` per file.
+     * CompatibilityDeriver iterates ci-subdirs and reads each subdir's
+     * docker-compose.yml, so only compose files need materializing
+     * (other files in ci/ -- READMEs, dockerfiles -- are unused).
+     *
+     * Uses per-blob reads rather than `git archive` because
+     * `.gitattributes` marks `ci/` as export-ignore (correctly, since
+     * ci configs shouldn't ship in release tarballs); `git archive`
+     * silently produces an empty archive.
+     *
+     * @return array{string, callable(): void} Tuple of the extracted
+     *                                          ci dir path + a cleanup
+     *                                          callable that removes the
+     *                                          temp dir.
+     */
+    private function materializeCiDir(MutatorContext $context): array
+    {
+        $tempDir = sys_get_temp_dir() . '/openemr-compat-mut-' . bin2hex(random_bytes(6));
+        if (!mkdir($tempDir . '/' . self::CI_RELATIVE_PATH, 0700, true)) {
+            throw new \RuntimeException("Cannot create temp dir: {$tempDir}");
+        }
+        $cleanup = static function () use ($tempDir): void {
+            (new Filesystem())->remove($tempDir);
+        };
+
+        try {
+            $ls = new Process(
+                [
+                    'git', 'ls-tree', '-r', '--name-only',
+                    (string) $context->relBranch, '--',
+                    self::CI_RELATIVE_PATH . '/',
+                ],
+                $context->projectDir,
+            );
+            $ls->mustRun();
+
+            foreach (explode("\n", trim($ls->getOutput())) as $file) {
+                if (!str_ends_with($file, '/docker-compose.yml')) {
+                    continue;
+                }
+                $show = new Process(
+                    ['git', 'show', $context->relBranch . ':' . $file],
+                    $context->projectDir,
+                );
+                $show->mustRun();
+
+                $destPath = $tempDir . '/' . $file;
+                $destDir = dirname($destPath);
+                if (!is_dir($destDir) && !mkdir($destDir, 0700, true)) {
+                    throw new \RuntimeException("Cannot create dir: {$destDir}");
+                }
+                if (file_put_contents($destPath, $show->getOutput()) === false) {
+                    throw new \RuntimeException("Cannot write: {$destPath}");
+                }
+            }
+        } catch (\Throwable $e) {
+            $cleanup();
+            throw $e;
+        }
+
+        return [$tempDir . '/' . self::CI_RELATIVE_PATH, $cleanup];
+    }
+}

--- a/tools/release/src/Mutator/CompatibilityMutator.php
+++ b/tools/release/src/Mutator/CompatibilityMutator.php
@@ -153,11 +153,12 @@ final readonly class CompatibilityMutator implements MutatorInterface
         };
 
         try {
+            $ref = $this->resolveRelBranchRef($context);
+
             $ls = new Process(
                 [
                     'git', 'ls-tree', '-r', '--name-only',
-                    (string) $context->relBranch, '--',
-                    self::CI_RELATIVE_PATH . '/',
+                    $ref, '--', self::CI_RELATIVE_PATH . '/',
                 ],
                 $context->projectDir,
             );
@@ -168,7 +169,7 @@ final readonly class CompatibilityMutator implements MutatorInterface
                     continue;
                 }
                 $show = new Process(
-                    ['git', 'show', $context->relBranch . ':' . $file],
+                    ['git', 'show', $ref . ':' . $file],
                     $context->projectDir,
                 );
                 $show->mustRun();
@@ -188,5 +189,38 @@ final readonly class CompatibilityMutator implements MutatorInterface
         }
 
         return [$tempDir . '/' . self::CI_RELATIVE_PATH, $cleanup];
+    }
+
+    /**
+     * Resolve the rel-branch name to a ref reachable from the current
+     * checkout. On rel scope the checkout is on the rel branch and the
+     * bare branch name resolves via refs/heads/. On master scope the
+     * workflow uses a separate `master-checkout` cloned with
+     * --branch master --single-branch, where only refs/remotes/origin/
+     * <relBranch> exists (if it was fetched); fall back to that form.
+     * Throws if neither resolves, with a clear message pointing at the
+     * workflow-side fetch that would fix it.
+     */
+    private function resolveRelBranchRef(MutatorContext $context): string
+    {
+        $relBranch = (string) $context->relBranch;
+        foreach ([$relBranch, 'origin/' . $relBranch] as $candidate) {
+            $probe = new Process(
+                ['git', 'rev-parse', '--verify', '--quiet', $candidate . '^{commit}'],
+                $context->projectDir,
+            );
+            $probe->run();
+            if ($probe->isSuccessful()) {
+                return $candidate;
+            }
+        }
+        throw new \RuntimeException(sprintf(
+            'CompatibilityMutator: neither %s nor origin/%s is a resolvable ref in %s;'
+            . ' fetch the rel branch (e.g. `git fetch --depth=1 origin %s`) before invoking.',
+            $relBranch,
+            $relBranch,
+            $context->projectDir,
+            $relBranch,
+        ));
     }
 }


### PR DESCRIPTION
PR 8 of the "Changelog surface early-migration slice" (see `docs/release-mechanism-migration-from-devops.md`).

**Sequencing note (resequenced 2026-07-13):** originally slotted as a non-blocking follow-up, but promoted to land **before PR 5** to close the compat-gap window. Without this, PR 5's section-extract would pull an entry missing the "### Minimum supported versions" block for 8.2.1+, since ChangelogMutator alone doesn't produce that section.

## New mutator

`tools/release/src/Mutator/CompatibilityMutator.php` under namespace `OpenEMR\\Release\\Mutator` — same autoload-dev placement as `ChangelogMutator`, alongside its `CompatibilityDeriver` + `CompatibilityNotesRenderer` deps.

**Wired AFTER ChangelogMutator** on both rel + master scopes via the same `class_exists()`-guarded FQCN pattern. Ordering matters — CompatibilityMutator injects into the `## [X.Y.Z]` heading that ChangelogMutator writes.

`appendOptionalReleaseMutators()` refactored to loop over an array of FQCNs (was one hardcoded entry).

## CI-directory sourcing

On both scopes the mutator materializes rel branch's `ci/*/docker-compose.yml` files via `git ls-tree` + `git show` per file (not `git archive` — `.gitattributes` marks `ci/` as `export-ignore`, correctly, since ci configs shouldn't ship in release tarballs, but that means `git archive` silently produces an empty tarball).

Master scope needs this materialization because master's `ci/` can diverge from rel-820's during the release window (master accepts newer CI additions the release wasn't tested against). Rel scope uses the same code path for uniformity — one code path, tested once.

## `inject()` idempotence fix

CR round-2 finding on PR 4 (openemr/openemr#12925): `CompatibilityNotesRenderer::inject()` was non-idempotent — a second call on already-injected notes duplicated the section by blindly splicing after the first `## ` heading. This PR is the first live consumer, so we own the behavior.

Fix: strips any existing `### Minimum supported versions` block (bounded by heading + next `##`-prefixed heading of any depth or EOF) before injecting. Rerun with same section → no diff. Rerun with different minimums → stale block replaced instead of duplicated.

## Latent bug in ChangelogMutator (fixed here)

Noticed while planning PR 8: `release-prep.yml`'s **rel-scope** invocation did NOT pass `--rel-branch`, so `$context->relBranch` was null on rel scope. ChangelogMutator's `resolveRangeHead()` throws when target tag doesn't exist AND relBranch is null — exactly the pre-tag release-prep-PR-open case. **Would have blown up on the first real 8.2.1 release-prep run.**

Fix: pass `--rel-branch` on rel scope too (workflow already computes `steps.resolve.outputs.branch`). CompatibilityMutator needs the same input for its git-tree reads + matrix URL.

## Whitelist

`.composer-require-checker.json` gets a second whitelist entry (`OpenEMR\\Release\\Mutator\\CompatibilityMutator`) alongside `ChangelogMutator`, same "documented cross-boundary" reason.

## Tests

At `tests/Tests/Isolated/Release/`:

- **`CompatibilityMutatorTest`** — 6 cases exercising real `CompatibilityDeriver` + `Renderer` against a scratch git repo with seeded `ci/` dirs + `rel-820` branch: relBranch required, injection ordering (compat before Fixed), matrixUrl uses rel-branch, rerun idempotence, master-scope reads rel branch's `ci/` (not master's `ci/` after intentional drift), MutatorResult shape.
- **`CompatibilityNotesRendererTest`** — 5 cases covering render shape, injection after version heading, prepend when no heading, idempotence (rerun no diff), and stale-section replacement.

Isolated suite: 3756 tests, all pass. PHPStan clean. Composer-require-checker clean.

## Live smoke test

Ran the mutator against real rel-820's `ci/` via git ls-tree + git show. Output:

```
## [8.2.99](https://github.com/openemr/openemr/compare/v8_2_0...v8_2_99) - 2026-07-13

### Minimum supported versions

- **PHP** 8.2+
- **MariaDB** 10.6+
- **MySQL** 5.7+

See the [tested CI matrix](https://github.com/openemr/openemr/tree/rel-820/ci) for all tested version combinations.
```

Exactly the shape 8.2.0's committed CHANGELOG entry has today.

## Coordinated

**Coordinated rel-820 companion PR** (opening after this one merges) to add the `OpenEMR\\Release\\Mutator\\CompatibilityMutator` whitelist entry to rel-820's `.composer-require-checker.json`. Same shape as #12927 was for ChangelogMutator's whitelist, since `.composer-require-checker.json` isn't in the byte-identical set.

## Test plan

- [ ] CI green
- [ ] After merge: open rel-820 companion PR for whitelist
- [ ] After both land: sync workflow re-fires cleanly against rel-820 (byte-identical picks up the new mutator + wiring + renderer fix)
- [ ] Next real release cycle (probably 8.2.1) is the acceptance test end-to-end