### PR TITLE
chore(release): rel-820 config-file ports for #12928 (composer-require-checker + codespell)

### DIFF
--- a/.codespell-ignore-words.txt
+++ b/.codespell-ignore-words.txt
@@ -112,6 +112,7 @@ cancelled
 # These require separate PRs with proper testing (see SPELLCHECK_BATCHES.md)
 cant
 collapsable
+deriver
 detatch
 durationm
 ect

--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -25,6 +25,7 @@
         "OpenEMR\\Common\\Http\\UploadedFile",
         "OpenEMR\\Gacl\\Hashed_Cache_Lite",
         "OpenEMR\\Release\\Mutator\\ChangelogMutator",
+        "OpenEMR\\Release\\Mutator\\CompatibilityMutator",
         "Pdo\\Mysql",
         "PHPUnit\\Framework\\Attributes\\Test",
         "Psy\\Shell",


### PR DESCRIPTION
Coordinated fixes for #12928's auto-sync PR against rel-820. Two config-file ports needed because neither file is in the byte-identical set (both are project-config files that can legitimately differ per branch):

1. **`.composer-require-checker.json`** — whitelist `OpenEMR\\Release\\Mutator\\CompatibilityMutator` (same shape as #12927 was for ChangelogMutator)
2. **`.codespell-ignore-words.txt`** — whitelist \`deriver\` (CompatibilityMutator + its tests reference \`\$deriver\` as a variable name matching the CompatibilityDeriver class; codespell scans changed files in pre-commit and would flag the new files on the sync PR)

Without these two entries, the sync PR fails on rel-820 with:

- \`Unknown Symbol: OpenEMR\\Release\\Mutator\\CompatibilityMutator\` (composer-require-checker)
- \`deriver ==> derive, driver\` (codespell)

rel-800 and rel-704 are excluded from the mutator's byte-identical entries and don't need these fixes.

**Landing order:**
1. This PR merges first (adds both entries to rel-820)
2. #12928's auto-sync PR re-runs (or gets merged) — both checks now pass

## Test plan

- [ ] CI green
- [ ] Merge before the auto-sync PR
- [ ] After merge: verify the auto-sync PR re-runs CI and both composer-require-checker + codespell pass