### PR TITLE
fix(php86): drop return statements from constructors

### DIFF
--- a/.phpstan/baseline/return.void.php
+++ b/.phpstan/baseline/return.void.php
@@ -11,4 +11,5 @@ $ignoreErrors[] = [
     'count' => 1,
     'path' => __DIR__ . '/../../src/Events/UserInterface/BaseActionButtonHelper.php',
 ];
+
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/return.void.php
+++ b/.phpstan/baseline/return.void.php
@@ -2,16 +2,6 @@
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Billing\\\\EdiHistory\\\\X12File\\:\\:__construct\\(\\) with return type void returns mixed but should not return anything\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/EdiHistory/X12File.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Billing\\\\EdiHistory\\\\X12File\\:\\:__construct\\(\\) with return type void returns true but should not return anything\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/EdiHistory/X12File.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Events\\\\Core\\\\TemplatePageEvent\\:\\:setTwigVariables\\(\\) with return type void returns \\$this\\(OpenEMR\\\\Events\\\\Core\\\\TemplatePageEvent\\) but should not return anything\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Events/Core/TemplatePageEvent.php',
@@ -21,10 +11,4 @@ $ignoreErrors[] = [
     'count' => 1,
     'path' => __DIR__ . '/../../src/Events/UserInterface/BaseActionButtonHelper.php',
 ];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Gacl\\\\Gacl\\:\\:__construct\\(\\) with return type void returns true but should not return anything\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Gacl/Gacl.php',
-];
-
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/src/Billing/EdiHistory/X12File.php
+++ b/src/Billing/EdiHistory/X12File.php
@@ -103,7 +103,7 @@ class X12File
     function __construct($file_path = '', $mk_segs = true, $text = false)
     {
         if ($file_path === '') {
-            return true;
+            return;
         }
 
         if (is_file($file_path) && is_readable($file_path)) {
@@ -142,7 +142,6 @@ class X12File
         }
 
         $this->constructing = false;
-        return $this->valid;
     }
 
     /*

--- a/src/Gacl/Gacl.php
+++ b/src/Gacl/Gacl.php
@@ -178,8 +178,6 @@ class Gacl {
             ];
             $this->Cache_Lite = new Hashed_Cache_Lite($cache_options);
         }
-
-        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary

PHP 8.6 nightly recently added *"Returning a value from a constructor is deprecated"* (RFC just landed). Three places in the codebase trigger it:

- `src/Billing/EdiHistory/X12File.php:106` — `return true` early-out on empty `\$file_path` → `return;`
- `src/Billing/EdiHistory/X12File.php:145` — trailing `return \$this->valid` → removed (callers still reach `\$this->valid` via the property)
- `src/Gacl/Gacl.php:182` — trailing `return true` → removed

Also drops the three now-unmatched entries in `.phpstan/baseline/return.void.php` that reported the same three constructor returns as void-return violations.

## Why this shows up as red CI on unrelated PRs today

`phpunit-isolated.xml` sets `failOnDeprecation="true"`, so those three deprecations exit-1 the PHP 8.6 Isolated Tests job. `.github/workflows/isolated-tests.yml` has no `fail-fast: false` in its matrix strategy, so GitHub cancels PHP 8.2/8.3/8.4/8.5 too. Result: dependabot-batch PRs and the like show four or five red "Isolated Tests" checks that all trace back to one PHP 8.6 nightly change. Fixing these three sites clears the whole matrix.

Separately (not this PR) — worth adding `fail-fast: false` to `isolated-tests.yml` and `test-all.yml` matrices so a single PHP-version regression doesn't cancel the others. Happy to do that as a follow-up.

## Behavior change

None. PHP has always ignored constructor return values; `new Foo()` yields the object, never the constructor's return. The change is purely cosmetic modulo the deprecation.

## Test plan

- [ ] `openemr-cmd pit` — isolated tests green on the local (8.4) container
- [ ] CI PHP 8.6 Isolated Tests goes from red → green; matrix cancellation stops
- [ ] Sanity check billing/gacl paths still work (I did not exercise these — no functional change makes it safe, but worth a smoke test)