### PR TITLE
fix(php86): drop return statements from constructors

### DIFF
--- a/.phpstan/baseline/return.void.php
+++ b/.phpstan/baseline/return.void.php
@@ -2,16 +2,6 @@
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Billing\\\\EdiHistory\\\\X12File\\:\\:__construct\\(\\) with return type void returns mixed but should not return anything\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/EdiHistory/X12File.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Billing\\\\EdiHistory\\\\X12File\\:\\:__construct\\(\\) with return type void returns true but should not return anything\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/EdiHistory/X12File.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Events\\\\Core\\\\TemplatePageEvent\\:\\:setTwigVariables\\(\\) with return type void returns \\$this\\(OpenEMR\\\\Events\\\\Core\\\\TemplatePageEvent\\) but should not return anything\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Events/Core/TemplatePageEvent.php',
@@ -20,11 +10,6 @@ $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Events\\\\UserInterface\\\\BaseActionButtonHelper\\:\\:getHref\\(\\) with return type void returns mixed but should not return anything\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Events/UserInterface/BaseActionButtonHelper.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Gacl\\\\Gacl\\:\\:__construct\\(\\) with return type void returns true but should not return anything\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Gacl/Gacl.php',
 ];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/src/Billing/EdiHistory/X12File.php
+++ b/src/Billing/EdiHistory/X12File.php
@@ -103,7 +103,7 @@ class X12File
     function __construct($file_path = '', $mk_segs = true, $text = false)
     {
         if ($file_path === '') {
-            return true;
+            return;
         }
 
         if (is_file($file_path) && is_readable($file_path)) {
@@ -142,7 +142,6 @@ class X12File
         }
 
         $this->constructing = false;
-        return $this->valid;
     }
 
     /*

--- a/src/Gacl/Gacl.php
+++ b/src/Gacl/Gacl.php
@@ -178,8 +178,6 @@ class Gacl {
             ];
             $this->Cache_Lite = new Hashed_Cache_Lite($cache_options);
         }
-
-        return true;
     }
 
     /**


### PR DESCRIPTION
Cherry-pick of #12973 to `rel-820`.

Backports the PHP 8.6 constructor-return fix that landed on master in 1c0d77361f.

See #12973 for the full description. Cherry-pick applied clean; patch-id verified byte-equal to the master merge before push.

## Test plan

- [ ] Same acceptance path as #12973.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)