### PR TITLE
fix(menu): use xlt() instead of text() for patient menu labels

### DIFF
--- a/src/Menu/PatientMenuRole.php
+++ b/src/Menu/PatientMenuRole.php
@@ -197,13 +197,13 @@ class PatientMenuRole extends MenuRole
             if (!empty($value->children)) {
                 // create dropdown if there are children (bootstrap3 horizontal nav bar with dropdown)
                 $class = $value->class ?? '';
-                $list = '<li class="dropdown"><a href="#"  id="' . attr($value->menu_id ?? $value->label) . '" class="nav-link dropdown-toggle text-body ' . attr($class) . '" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">' . text($value->label) . ' <span class="caret"></span></a>';
+                $list = '<li class="dropdown"><a href="#"  id="' . attr($value->menu_id ?? $value->label) . '" class="nav-link dropdown-toggle text-body ' . attr($class) . '" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">' . xlt($value->label) . ' <span class="caret"></span></a>';
                 $list .= '<ul class="dropdown-menu">';
                 foreach ($value->children as $children_value) {
                     $link = ($children_value->pid != "true") ? $children_value->url : $children_value->url . attr($pid);
                     $class = $children_value->class ?? '';
                     $list .= '<li class="nav-item ' . attr($class) . '" id="' . attr($children_value->menu_id) . '">';
-                    $list .= '<a class="nav-link text-dark"  href="' . attr($link) . '" onclick="' . $children_value->on_click . '"> ' . text($children_value->label) . ' </a>';
+                    $list .= '<a class="nav-link text-dark"  href="' . attr($link) . '" onclick="' . $children_value->on_click . '"> ' . xlt($children_value->label) . ' </a>';
                     $list .= '</li>';
                 }
                 $list .= '</ul>';
@@ -211,7 +211,7 @@ class PatientMenuRole extends MenuRole
                 $link = ($value->pid != "true") ? $value->url : $value->url . attr($pid);
                 $class = $value->class ?? '';
                 $list = '<li class="nav-item ' . attr($class) . '" id="' . attr($value->menu_id) . '">';
-                $list .= '<a class="nav-link text-dark" href="' . attr($link) . '" onclick="' . $value->on_click . '"> ' . text($value->label) . ' </a>';
+                $list .= '<a class="nav-link text-dark" href="' . attr($link) . '" onclick="' . $value->on_click . '"> ' . xlt($value->label) . ' </a>';
                 $list .= '</li>';
             }
             echo $list . "\r\n";


### PR DESCRIPTION
## Summary
- Replace `text()` with `xlt()` in `PatientMenuRole.php` for three menu label outputs (lines 200, 206, 214)
- `text()` only escapes output; `xlt()` escapes **and** translates — these labels were not being translated in non-English locales

## Test plan
- [ ] Switch OpenEMR to a non-English locale (e.g., Spanish)
- [ ] Open a patient's demographics page
- [ ] Verify that the patient menu bar labels are now translated

🤖 Generated with [Claude Code](https://claude.com/claude-code)