### PR TITLE
feat(encounter): add View button for forms with view.php

### DIFF
--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -956,6 +956,9 @@ if (OEGlobalsBag::getInstance()->getBoolean('google_signin_enabled') && !empty(O
             <div class='form_header_controls btn-group' role='group'>
     HTML;
 
+                // Check if form has a view.php (e.g. nursing forms)
+                $has_view_php = file_exists(__DIR__ . '/../../forms/' . $formdir . '/view.php');
+
                 // If the form is locked, it is no longer editable
                 if ($esign->isLocked()) {
                     echo "<a href='#' class='btn btn-text btn-sm form-edit-button-locked' id='form-edit-button-" . attr($formdir) . "-" . attr($iter['id']) . "'><i class='fa fa-lock fa-fw'></i>&nbsp;" . xlt('Locked') . "</a>";
@@ -978,6 +981,12 @@ if (OEGlobalsBag::getInstance()->getBoolean('google_signin_enabled') && !empty(O
                     if (!$aco_spec || AclMain::aclCheckCore($aco_spec[0], $aco_spec[1], '', 'write')) {
                         echo $esign->buttonHtml();
                     }
+                }
+
+                // View button — only for forms that provide a view.php
+                if ($has_view_php) {
+                    echo "<a href='" . attr($GLOBALS['webroot'] . '/interface/forms/' . $formdir . '/view.php?pid=' . $pid . '&encounter=' . $encounter . '&id=' . $iter['form_id']) .
+                        "' class='btn btn-text btn-sm' title='" . xla('View this form') . "' onclick='top.restoreSession()'><i class='fa fa-eye fa-fw'></i>&nbsp;" . xlt('View') . "</a>";
                 }
 
                 if (str_starts_with((string) $formdir, 'LBF')) {


### PR DESCRIPTION
## Summary

- Adds a "View" button (eye icon) in the encounter form list for any form that provides a `view.php` file
- Allows read-only access to form data without opening the edit dialog
- No impact on existing forms — the button only appears when `view.php` exists

## Files changed

- `interface/patient_file/encounter/forms.php` — 9 lines added

## How it works

1. `file_exists()` checks if the form directory contains a `view.php`
2. If it does, a View button is rendered alongside Edit/Lock/eSign buttons
3. The button links to `view.php` with the standard `pid`, `encounter`, and `id` parameters

## Test plan

- [ ] Open an encounter with standard forms (SOAP, Vitals) — no View button should appear
- [ ] Install a form that has `view.php` (e.g. nursing module forms) — View button should appear
- [ ] Click View button — form should open in read-only mode
- [ ] Verify button respects `top.restoreSession()` for session handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)