### PR TITLE
fix(fax): resolve all 157 phpstan findings in fax_dispatch.php

### DIFF
--- a/.phpstan/baseline/assignOp.invalid.php
+++ b/.phpstan/baseline/assignOp.invalid.php
@@ -237,16 +237,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/eRx_xml.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\.\\=" between \'\' and mixed results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\.\\=" between string and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\+\\=" between float\\|int and mixed results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/LBF/new.php',

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -1677,41 +1677,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/eRx_xml.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/custom\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/documents/\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \'/faxcover\\.txt\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and non\\-falsy\\-string results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 6,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between string and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../interface/fax/fax_view.php',

--- a/.phpstan/baseline/cast.int.php
+++ b/.phpstan/baseline/cast.int.php
@@ -48,11 +48,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to int\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to int\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/CAMOS/report.php',
 ];

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -303,11 +303,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 12,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/fax/fax_dispatch_newpid.php',
 ];

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -343,11 +343,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 40,
     'path' => __DIR__ . '/../../interface/forms/LBF/new.php',
 ];

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -392,26 +392,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/easipro/pro.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$catstring \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$inbase \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$newid \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Part \\$srcdir \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 5,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$encounter \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/CAMOS/report.php',

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -228,11 +228,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
     'count' => 9,
     'path' => __DIR__ . '/../../interface/forms/LBF/new.php',
 ];

--- a/.phpstan/baseline/function.deprecated.php
+++ b/.phpstan/baseline/function.deprecated.php
@@ -59,12 +59,6 @@ $ignoreErrors[] = [
     'message' => '#^Call to deprecated function addForm\\(\\)\\:
 Use FormService\\:\\:addForm\\(\\) instead$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated function addForm\\(\\)\\:
-Use FormService\\:\\:addForm\\(\\) instead$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/LBF/new.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -2337,21 +2337,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/eRx_xml.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function getKittens\\(\\) has parameter \\$categories with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function getKittens\\(\\) has parameter \\$catid with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function getKittens\\(\\) has parameter \\$catstring with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function CAMOS_report\\(\\) has parameter \\$cols with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/CAMOS/report.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -1312,11 +1312,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/eRx_xml.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function mergeTiffs\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function startsWith\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/js/eye_base.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -3947,31 +3947,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/easipro/pro.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'count\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'date\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'name\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'parent\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset mixed on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset 0 on array\\{0\\: int, 1\\: int, 2\\: int, 3\\: int, 4\\: int, 5\\: int, 6\\: int, 7\\: int, \\.\\.\\.\\}\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/fax/faxq.php',

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -623,26 +623,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:sqlInsert\\(\\) instead of sqlInsert\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/fax/fax_dispatch_newpid.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
@@ -222,11 +222,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/eRx_xml.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use of the "global" keyword is forbidden \\(\\$faxcache\\)\\. Use dependency injection instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use of the "global" keyword is forbidden \\(\\$cell_count, \\$CPR, \\$historical_ids, \\$USING_BOOTSTRAP, \\$BS_COL_CLASS\\)\\. Use dependency injection instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/LBF/new.php',

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -658,16 +658,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 28,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/fax/fax_dispatch_newpid.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenShellExecution.php
+++ b/.phpstan/baseline/openemr.forbiddenShellExecution.php
@@ -17,11 +17,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../controllers/C_Prescription.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Shell execution function exec\\(\\) is forbidden\\. exec\\(\\) executes a shell command\\. Use Symfony\\\\Component\\\\Process\\\\Process with array arguments as a safer alternative\\.$#',
-    'count' => 12,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Shell execution function passthru\\(\\) is forbidden\\. passthru\\(\\) executes a command and passes raw output\\. Use Symfony\\\\Component\\\\Process\\\\Process with array arguments as a safer alternative\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/fax/fax_view.php',

--- a/.phpstan/baseline/openemr.noGlobalNsFunctions.php
+++ b/.phpstan/baseline/openemr.noGlobalNsFunctions.php
@@ -792,16 +792,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/eRx_xml.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function getKittens may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function mergeTiffs may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function addAppt may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/CAMOS/content_parser.php',

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -457,31 +457,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/easipro/pro.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$erow might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$srcdir might not be defined\\.$#',
-    'count' => 5,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$tmp_name might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$userauthorized might not be defined\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$webserver_root might not be defined\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/fax/fax_dispatch.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$date_init might not be defined\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/LBF/new.php',

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -49,7 +49,7 @@ return [
         'return.missing.php' => 0,
         'staticMethod.notFound.php' => 0,
         'trait.notFound.php' => 0,
-        'variable.undefined.php' => 504,
+        'variable.undefined.php' => 499,
     ],
     'confidentNonObject' => [
         'classConstant.nonObject.php' => 0,

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -24,6 +24,7 @@ use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FormService;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Process\Process;
 
 $globalsBag = OEGlobalsBag::getInstance();
@@ -39,6 +40,19 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 $request = Request::createFromGlobals();
 $filesystem = new Filesystem();
 $userauthorized = $globalsBag->getInt('userauthorized');
+
+// Stop with a real HTTP error status instead of die(): callers and proxies
+// see the failure, and the nonzero exit fails loudly outside a web SAPI.
+// Response::send() skips the status line if headers already went out.
+$abort = static function (int $statusCode, string $message): never {
+    (new Response($message, $statusCode))->send();
+    exit(1);
+};
+
+$site_id = $session->get('site_id');
+if (!is_string($site_id) || $site_id === '') {
+    $abort(Response::HTTP_UNAUTHORIZED, "Site ID is missing from the session.");
+}
 
 $fileParam = $request->query->getString('file');
 $scanParam = $request->query->getString('scan');
@@ -64,7 +78,7 @@ if ($fileParam !== '') {
 
     $filepath = $globalsBag->getString('scanner_output_directory') . '/' . $filename;
 } else {
-    die("No filename was given.");
+    $abort(Response::HTTP_BAD_REQUEST, "No filename was given.");
 }
 
 $dotPos = strrpos($filename, '.');
@@ -89,7 +103,7 @@ $processError = (static fn(Process $process): string => (string) $process->getEx
 // This merges the tiff files for the selected pages into one tiff file.
 // $images holds the form_images checkboxes to the right of the images.
 //
-$mergeTiffs = static function (array $images) use ($faxcache, $filesystem, $runProcess, $processError): string {
+$mergeTiffs = static function (array $images) use ($faxcache, $filesystem, $runProcess, $processError, $abort): string {
     $tiffNames = [];
     foreach ($images as $name) {
         if (is_string($name)) {
@@ -98,7 +112,7 @@ $mergeTiffs = static function (array $images) use ($faxcache, $filesystem, $runP
     }
 
     if (count($tiffNames) === 0) {
-        die(xlt("Internal error - no pages were selected!"));
+        $abort(Response::HTTP_BAD_REQUEST, xlt("Internal error - no pages were selected!"));
     }
 
     // Remove any merge output from a previous run so a failed tiffcp cannot
@@ -133,7 +147,7 @@ if ($request->request->getString('form_save') !== '') {
     if ($request->request->getBoolean('form_cb_copy')) {
         $patient_id = $request->request->getInt('form_pid');
         if ($patient_id === 0) {
-            die(xlt('Internal error - patient ID was not provided!'));
+            $abort(Response::HTTP_BAD_REQUEST, xlt('Internal error - patient ID was not provided!'));
         }
 
         // If copying to patient documents...
@@ -281,7 +295,7 @@ if ($request->request->getString('form_save') !== '') {
                 // we already have a jpeg for each page in faxcache.
                 $process = $runProcess(['convert', '-resize', '800', '-density', '96', $tmp_name, '-append', $imagepath]);
                 if (!$process->isSuccessful()) {
-                    die("convert returned " . text($processError($process)));
+                    $abort(Response::HTTP_INTERNAL_SERVER_ERROR, "convert returned " . text($processError($process)));
                 }
             }
 
@@ -382,7 +396,7 @@ if ($request->request->getString('form_save') !== '') {
         if ($action_taken) {
             $dh = opendir($faxcache);
             if (! $dh) {
-                die("Cannot read " . text($faxcache));
+                $abort(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
             }
 
             $form_cb_delete = '2';
@@ -411,7 +425,7 @@ if ($request->request->getString('form_save') !== '') {
         if (is_dir($faxcache)) {
             $dh = opendir($faxcache);
             if (! $dh) {
-                die("Cannot read " . text($faxcache));
+                $abort(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
             }
 
             while (($tmp = readdir($dh)) !== false) {
@@ -464,9 +478,9 @@ $using_scanned_notes = is_numeric($scannedNotesCount) && (int) $scannedNotesCoun
 if (! is_dir($faxcache)) {
     // Remove the partial cache on any failure so a later request rebuilds it
     // instead of silently serving an incomplete set of pages.
-    $failCache = static function (string $message) use ($faxcache, $filesystem): never {
+    $failCache = static function (string $message) use ($faxcache, $filesystem, $abort): never {
         $filesystem->remove($faxcache);
-        die($message);
+        $abort(Response::HTTP_INTERNAL_SERVER_ERROR, $message);
     };
 
     $filesystem->mkdir($faxcache);
@@ -926,7 +940,7 @@ $userRows = QueryUtils::fetchRecords(
 <?php
 $dh = opendir($faxcache);
 if (! $dh) {
-    die("Cannot read " . text($faxcache));
+    $abort(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
 }
 
 $jpgarray = [];
@@ -941,11 +955,6 @@ closedir($dh);
 // by filename so the display order matches the original document.
 ksort($jpgarray);
 $page = 0;
-$site_id = $session->get('site_id');
-if (!is_string($site_id)) {
-    die("Site ID is missing from the session.");
-}
-
 foreach ($jpgarray as $jfnamebase => $jfname) {
     ++$page;
     echo " <tr>\n";

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -7,153 +7,168 @@
  * @link      https://www.open-emr.org
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2006-2010 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017-2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once("../globals.php");
-require_once("$srcdir/patient.inc.php");
-require_once("$srcdir/pnotes.inc.php");
-require_once("$srcdir/forms.inc.php");
-require_once("$srcdir/options.inc.php");
-require_once("$srcdir/gprelations.inc.php");
+require_once __DIR__ . '/../globals.php';
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Services\FormService;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Process\Process;
+
+$globalsBag = OEGlobalsBag::getInstance();
+$srcdir = $globalsBag->getSrcDir();
+
+require_once "$srcdir/patient.inc.php";
+require_once "$srcdir/pnotes.inc.php";
+require_once "$srcdir/forms.inc.php";
+require_once "$srcdir/options.inc.php";
+require_once "$srcdir/gprelations.inc.php";
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
+$request = Request::createFromGlobals();
+$filesystem = new Filesystem();
+$userauthorized = $globalsBag->getInt('userauthorized');
 
-if ($_GET['file']) {
+$fileParam = $request->query->getString('file');
+$scanParam = $request->query->getString('scan');
+
+if ($fileParam !== '') {
     CsrfUtils::checkCsrfInput(INPUT_GET, dieOnFail: true);
 
     $mode = 'fax';
-    $filename = $_GET['file'];
+    $filename = $fileParam;
 
     // ensure the file variable has no illegal characters
     check_file_dir_name($filename);
 
-    $filepath = OEGlobalsBag::getInstance()->getString('hylafax_basedir') . '/recvq/' . $filename;
-} elseif ($_GET['scan']) {
+    $filepath = $globalsBag->getString('hylafax_basedir') . '/recvq/' . $filename;
+} elseif ($scanParam !== '') {
     CsrfUtils::checkCsrfInput(INPUT_GET, dieOnFail: true);
 
     $mode = 'scan';
-    $filename = $_GET['scan'];
+    $filename = $scanParam;
 
     // ensure the file variable has no illegal characters
     check_file_dir_name($filename);
 
-    $filepath = OEGlobalsBag::getInstance()->getString('scanner_output_directory') . '/' . $filename;
+    $filepath = $globalsBag->getString('scanner_output_directory') . '/' . $filename;
 } else {
     die("No filename was given.");
 }
 
-$filename = (string) $filename;
-$ext = substr($filename, strrpos($filename, '.'));
+$dotPos = strrpos($filename, '.');
+$ext = $dotPos === false ? '' : substr($filename, $dotPos);
 $filebase = basename("/$filename", $ext);
-$faxcache = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/faxcache/$mode/$filebase";
+$faxcache = $globalsBag->getString('OE_SITE_DIR') . "/faxcache/$mode/$filebase";
 
 $info_msg = "";
 
-// This function builds an array of document categories recursively.
-// Kittens are the children of cats, you know.  :-)getKittens
-//
-function getKittens($catid, $catstring, &$categories): void
-{
-    $cres = sqlStatement("SELECT id, name FROM categories " .
-    "WHERE parent = ? ORDER BY name", [$catid]);
-    $childcount = 0;
-    while ($crow = sqlFetchArray($cres)) {
-        ++$childcount;
-        getKittens($crow['id'], ($catstring ? "$catstring / " : "") .
-        ($catid ? $crow['name'] : ''), $categories);
-    }
+// Run an external command with Symfony Process so arguments are escaped
+// safely, returning the finished Process for exit-code and output checks.
+/** @param list<string> $command */
+$runProcess = static function (array $command, ?string $cwd = null): Process {
+    $process = new Process($command, $cwd);
+    $process->run();
+    return $process;
+};
 
-  // If no kitties, then this is a leaf node and should be listed.
-    if (!$childcount) {
-        $categories[$catid] = $catstring;
-    }
-}
+// Format a failed Process as "exitcode: output" for error messages.
+$processError = (static fn(Process $process): string => (string) $process->getExitCode() . ': ' . trim($process->getOutput() . ' ' . $process->getErrorOutput()));
 
 // This merges the tiff files for the selected pages into one tiff file.
+// $images holds the form_images checkboxes to the right of the images.
 //
-function mergeTiffs()
-{
-    global $faxcache;
-    $msg = '';
-    $inames = '';
-    $tmp1 = [];
-    $tmp2 = 0;
-  // form_images are the checkboxes to the right of the images.
-    foreach ($_POST['form_images'] as $inbase) {
-        check_file_dir_name($inbase);
-        $inames .= ' ' . escapeshellarg("$inbase.tif");
+$mergeTiffs = static function (array $images) use ($faxcache, $runProcess, $processError): string {
+    $tiffNames = [];
+    foreach ($images as $name) {
+        if (is_string($name)) {
+            $tiffNames[] = "$name.tif";
+        }
     }
 
-    if (!$inames) {
+    if (count($tiffNames) === 0) {
         die(xlt("Internal error - no pages were selected!"));
     }
 
-    $tmp0 = exec("cd " . escapeshellarg((string) $faxcache) . "; tiffcp $inames temp.tif", $tmp1, $tmp2);
-    if ($tmp2) {
-        $msg .= "tiffcp returned $tmp2: $tmp0 ";
+    $process = $runProcess(array_merge(['tiffcp'], $tiffNames, ['temp.tif']), $faxcache);
+    if (!$process->isSuccessful()) {
+        return 'tiffcp returned ' . $processError($process) . ' ';
     }
 
-    return $msg;
-}
+    return '';
+};
 
 // If we are submitting...
 //
-if ($_POST['form_save']) {
+if ($request->request->getString('form_save') !== '') {
     CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 
     $action_taken = false;
-    $tmp1 = [];
-    $tmp2 = 0;
 
-    if ($_POST['form_cb_copy']) {
-        $patient_id = (int) $_POST['form_pid'];
-        if (!$patient_id) {
+    // form_images are the checkboxes to the right of the images.
+    $selectedImages = [];
+    foreach ($request->request->all('form_images') as $image) {
+        if (!is_string($image)) {
+            continue;
+        }
+
+        check_file_dir_name($image);
+        $selectedImages[] = $image;
+    }
+
+    if ($request->request->getBoolean('form_cb_copy')) {
+        $patient_id = $request->request->getInt('form_pid');
+        if ($patient_id === 0) {
             die(xlt('Internal error - patient ID was not provided!'));
         }
 
         // If copying to patient documents...
         //
-        if ($_POST['form_cb_copy_type'] == 1) {
+        if ($request->request->getInt('form_cb_copy_type') === 1) {
             // Compute the document's display filename.
-            $ffname = (string) check_file_dir_name(trim((string) $_POST['form_filename']));
+            $ffname = trim($request->request->getString('form_filename'));
+            check_file_dir_name($ffname);
             $i = strrpos($ffname, '.');
-            if ($i) {
+            if ($i !== false && $i > 0) {
                 $ffname = trim(substr($ffname, 0, $i));
             }
 
-            if (!$ffname) {
+            if ($ffname === '') {
                 $ffname = $filebase;
             }
 
             $docname = "$ffname.pdf";
-            $docdate = fixDate($_POST['form_docdate']);
-            $catid = (int) $_POST['form_category'];
+            $docdate = fixDate($request->request->getString('form_docdate'));
+            $catid = $request->request->getInt('form_category');
             $newid = null;
 
             // Create the target PDF in a temporary file.  Note that we are
             // relying on the .tif files for the individual pages to already
             // exist in the faxcache directory.
             //
-            $info_msg .= mergeTiffs();
-            $tmppdf = tempnam(OEGlobalsBag::getInstance()->getString('temporary_files_dir'), 'fax');
+            $info_msg .= $mergeTiffs($selectedImages);
+            $tmppdf = tempnam($globalsBag->getString('temporary_files_dir'), 'fax');
 
             if ($tmppdf === false) {
                 $info_msg .= xl('Unable to create a temporary file for the document') . ' ';
             } else {
                 // The -j option here requires that libtiff is configured with libjpeg.
                 // It could be omitted, but the output PDFs would then be quite large.
-                $tmp0 = exec("tiff2pdf -j -p letter -o " . escapeshellarg($tmppdf) . " " . escapeshellarg($faxcache . '/temp.tif'), $tmp1, $tmp2);
+                $process = $runProcess(['tiff2pdf', '-j', '-p', 'letter', '-o', $tmppdf, $faxcache . '/temp.tif']);
 
-                if ($tmp2) {
-                    $info_msg .= "tiff2pdf returned $tmp2: $tmp0 ";
+                if (!$process->isSuccessful()) {
+                    $info_msg .= 'tiff2pdf returned ' . $processError($process) . ' ';
                 } else {
                     // Storing through the Document model keeps drive encryption,
                     // the storage path, UUID, hash and category linkage consistent
@@ -172,8 +187,9 @@ if ($_POST['form_save']) {
                             $data,
                             tmpfile: $tmppdf,
                         );
-                        $newid = $document->get_id();
-                        if (!is_numeric($newid)) {
+                        $rawDocId = $document->get_id();
+                        $newid = is_numeric($rawDocId) ? (int) $rawDocId : null;
+                        if ($newid === null) {
                             $info_msg .= ($store_msg ?: xl('Failed to store the document')) . ' ';
                         }
                     }
@@ -185,29 +201,35 @@ if ($_POST['form_save']) {
             } // end temporary file created
 
             // If we are posting a note...
-            if ($_POST['form_cb_note'] && !$info_msg) {
+            if ($request->request->getBoolean('form_cb_note') && !$info_msg) {
                 // Build note text in a way that identifies the new document.
                 // See pnotes_full.php which uses this to auto-display the document.
                 $note = $docname;
-                for ($tmp = $catid; $tmp;) {
-                    $catrow = sqlQuery("SELECT name, parent FROM categories WHERE id = ?", [$tmp]);
-                    $note = $catrow['name'] . "/$note";
-                    $tmp = $catrow['parent'];
+                for ($ancestorId = $catid; $ancestorId !== 0;) {
+                    $catrow = QueryUtils::fetchRecords('SELECT name, parent FROM categories WHERE id = ?', [$ancestorId])[0] ?? null;
+                    if ($catrow === null) {
+                        break;
+                    }
+
+                    $catName = $catrow['name'];
+                    $note = (is_string($catName) ? $catName : '') . "/$note";
+                    $catParent = $catrow['parent'];
+                    $ancestorId = is_numeric($catParent) ? (int) $catParent : 0;
                 }
 
                 $note = "New scanned document $newid: $note";
-                $form_note_message = trim((string) $_POST['form_note_message']);
+                $form_note_message = trim($request->request->getString('form_note_message'));
                 if ($form_note_message) {
                     $note .= "\n" . $form_note_message;
                 }
 
                 $noteid = addPnote(
-                    $_POST['form_pid'],
+                    $patient_id,
                     $note,
                     $userauthorized,
-                    '1',
-                    $_POST['form_note_type'],
-                    $_POST['form_note_to']
+                    1,
+                    $request->request->getString('form_note_type'),
+                    $request->request->getString('form_note_to')
                 );
                 // Link the new patient note to the document.
                 setGpRelation(1, $newid, 6, $noteid);
@@ -215,25 +237,23 @@ if ($_POST['form_save']) {
         } else { // end copy to documents
             // Otherwise creating a scanned encounter note...
             // Get desired $encounter_id.
-            $encounter_id = 0;
-            if (empty($_POST['form_copy_sn_visit'])) {
+            $encounter_id = $request->request->getInt('form_copy_sn_visit');
+            if ($encounter_id === 0) {
                 $info_msg .= "This patient has no visits! ";
-            } else {
-                $encounter_id = (int) $_POST['form_copy_sn_visit'];
             }
 
+            $tmp_name = "$faxcache/temp.tif";
             if (!$info_msg) {
                 // Merge the selected pages.
-                $info_msg .= mergeTiffs();
-                $tmp_name = "$faxcache/temp.tif";
+                $info_msg .= $mergeTiffs($selectedImages);
             }
 
             if (!$info_msg) {
                 // The following is cloned from contrib/forms/scanned_notes/new.php:
                 //
                 $query = "INSERT INTO form_scanned_notes ( notes ) VALUES ( ? )";
-                $formid = sqlInsert($query, [$_POST['form_copy_sn_comments']]);
-                addForm(
+                $formid = QueryUtils::sqlInsert($query, [$request->request->getString('form_copy_sn_comments')]);
+                (new FormService())->addForm(
                     $encounter_id,
                     "Scanned Notes",
                     $formid,
@@ -242,15 +262,11 @@ if ($_POST['form_save']) {
                     $userauthorized
                 );
                 //
-                $imagedir = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/documents/" . check_file_dir_name($patient_id) . "/encounters";
-                $imagepath = "$imagedir/" . check_file_dir_name($encounter_id) . "_" . check_file_dir_name($formid) . ".jpg";
+                $imagedir = $globalsBag->getString('OE_SITE_DIR') . "/documents/$patient_id/encounters";
+                $imagepath = "$imagedir/{$encounter_id}_$formid.jpg";
                 if (! is_dir($imagedir)) {
-                        $tmp0 = exec('mkdir -p ' . escapeshellarg($imagedir), $tmp1, $tmp2);
-                    if ($tmp2) {
-                        die("mkdir returned " . text($tmp2) . ": " . text($tmp0));
-                    }
-
-                        exec("touch " . escapeshellarg($imagedir . "/index.html"));
+                    $filesystem->mkdir($imagedir);
+                    $filesystem->touch($imagedir . "/index.html");
                 }
 
                 if (is_file($imagepath)) {
@@ -259,17 +275,28 @@ if ($_POST['form_save']) {
 
                 // TBD: There may be a faster way to create this file, given that
                 // we already have a jpeg for each page in faxcache.
-                $cmd = "convert -resize 800 -density 96 " . escapeshellarg((string) $tmp_name) . " -append " . escapeshellarg($imagepath);
-                $tmp0 = exec($cmd, $tmp1, $tmp2);
-                if ($tmp2) {
-                    die("\"" . text($cmd) . "\" returned " . text($tmp2) . ": " . text($tmp0));
+                $process = $runProcess(['convert', '-resize', '800', '-density', '96', $tmp_name, '-append', $imagepath]);
+                if (!$process->isSuccessful()) {
+                    die("convert returned " . text($processError($process)));
                 }
             }
 
             // If we are posting a patient note...
-            if ($_POST['form_cb_note'] && !$info_msg) {
-                $note = "New scanned encounter note for visit on " . substr((string) $erow['date'], 0, 10);
-                $form_note_message = trim((string) $_POST['form_note_message']);
+            if ($request->request->getBoolean('form_cb_note') && !$info_msg) {
+                $visitDate = '';
+                $erow = QueryUtils::fetchRecords(
+                    'SELECT date FROM form_encounter WHERE encounter = ? AND pid = ?',
+                    [$encounter_id, $patient_id]
+                )[0] ?? null;
+                if ($erow !== null) {
+                    $encDate = $erow['date'] ?? null;
+                    if (is_string($encDate)) {
+                        $visitDate = substr($encDate, 0, 10);
+                    }
+                }
+
+                $note = "New scanned encounter note for visit on " . $visitDate;
+                $form_note_message = trim($request->request->getString('form_note_message'));
                 if ($form_note_message) {
                     $note .= "\n" . $form_note_message;
                 }
@@ -278,9 +305,9 @@ if ($_POST['form_save']) {
                     $patient_id,
                     $note,
                     $userauthorized,
-                    '1',
-                    $_POST['form_note_type'],
-                    $_POST['form_note_to']
+                    1,
+                    $request->request->getString('form_note_type'),
+                    $request->request->getString('form_note_to')
                 );
             } // end post patient note
         }
@@ -288,53 +315,42 @@ if ($_POST['form_save']) {
         $action_taken = true;
     } // end copy to chart
 
-    if ($_POST['form_cb_forward']) {
-        $form_from     = trim((string) $_POST['form_from']);
-        $form_to       = trim((string) $_POST['form_to']);
-        $form_fax      = trim((string) $_POST['form_fax']);
-        $form_message  = trim((string) $_POST['form_message']);
-        $form_finemode = $_POST['form_finemode'] ? '-m' : '-l';
+    if ($request->request->getBoolean('form_cb_forward')) {
+        $form_from     = trim($request->request->getString('form_from'));
+        $form_to       = trim($request->request->getString('form_to'));
+        $form_fax      = trim($request->request->getString('form_fax'));
+        $form_message  = trim($request->request->getString('form_message'));
+        $form_finemode = $request->request->getBoolean('form_finemode') ? '-m' : '-l';
 
         // Generate a cover page using enscript.  This can be a cool thing
         // to do, as enscript is very powerful.
         //
-        $tmp1 = [];
-        $tmp2 = 0;
-        $tmpfn1 = tempnam("/tmp", "fax1");
-        $tmpfn2 = tempnam("/tmp", "fax2");
-        $tmph = fopen($tmpfn1, "w");
-        $cpstring = '';
-        $fh = fopen(OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . "/faxcover.txt", 'r');
-        while (!feof($fh)) {
-            $cpstring .= fread($fh, 8192);
-        }
-
-        fclose($fh);
+        $tmpfn1 = $filesystem->tempnam('/tmp', 'fax1');
+        $tmpfn2 = $filesystem->tempnam('/tmp', 'fax2');
+        $cpstring = $filesystem->readFile($globalsBag->getString('OE_SITE_DIR') . '/faxcover.txt');
         $cpstring = str_replace('{CURRENT_DATE}', date('F j, Y'), $cpstring);
         $cpstring = str_replace('{SENDER_NAME}', $form_from, $cpstring);
         $cpstring = str_replace('{RECIPIENT_NAME}', $form_to, $cpstring);
         $cpstring = str_replace('{RECIPIENT_FAX}', $form_fax, $cpstring);
         $cpstring = str_replace('{MESSAGE}', $form_message, $cpstring);
-        fwrite($tmph, $cpstring);
-        fclose($tmph);
-        $tmp0 = exec("cd " . escapeshellarg($webserver_root . '/custom') . "; " . escapeshellcmd(OPENEMR_HYLAFAX_ENSCRIPT) .
-        " -o " . escapeshellarg($tmpfn2) . " " . escapeshellarg($tmpfn1), $tmp1, $tmp2);
-        if ($tmp2) {
-              $info_msg .= "enscript returned $tmp2: $tmp0 ";
+        $filesystem->dumpFile($tmpfn1, $cpstring);
+        $process = $runProcess(
+            array_merge(explode(' ', OPENEMR_HYLAFAX_ENSCRIPT), ['-o', $tmpfn2, $tmpfn1]),
+            $globalsBag->getString('webserver_root') . '/custom'
+        );
+        if (!$process->isSuccessful()) {
+            $info_msg .= 'enscript returned ' . $processError($process) . ' ';
         }
 
         unlink($tmpfn1);
 
         // Send the fax as the cover page followed by the selected pages.
-        $info_msg .= mergeTiffs();
-        $tmp0 = exec(
-            "sendfax -A -n " . escapeshellarg($form_finemode) . " -d " .
-            escapeshellarg($form_fax) . " " . escapeshellarg($tmpfn2) . " " . escapeshellarg($faxcache . '/temp.tif'),
-            $tmp1,
-            $tmp2
+        $info_msg .= $mergeTiffs($selectedImages);
+        $process = $runProcess(
+            ['sendfax', '-A', '-n', $form_finemode, '-d', $form_fax, $tmpfn2, $faxcache . '/temp.tif']
         );
-        if ($tmp2) {
-              $info_msg .= "sendfax returned $tmp2: $tmp0 ";
+        if (!$process->isSuccessful()) {
+            $info_msg .= 'sendfax returned ' . $processError($process) . ' ';
         }
 
         unlink($tmpfn2);
@@ -342,12 +358,11 @@ if ($_POST['form_save']) {
         $action_taken = true;
     } // end forward
 
-    $form_cb_delete = $_POST['form_cb_delete'];
+    $form_cb_delete = $request->request->getString('form_cb_delete');
 
   // If deleting selected, do it and then check if any are left.
     if ($form_cb_delete == '1' && !$info_msg) {
-        foreach ($_POST['form_images'] as $inbase) {
-            check_file_dir_name($inbase);
+        foreach ($selectedImages as $inbase) {
             unlink($faxcache . "/" . $inbase . ".jpg");
             $action_taken = true;
         }
@@ -372,8 +387,9 @@ if ($_POST['form_save']) {
 
     if ($form_cb_delete == '2' && !$info_msg) {
         // Delete the tiff file, with archiving if desired.
-        if (OEGlobalsBag::getInstance()->get('hylafax_archdir') && $mode == 'fax') {
-            rename($filepath, OEGlobalsBag::getInstance()->get('hylafax_archdir') . '/' . $filename);
+        $archdir = $globalsBag->getString('hylafax_archdir');
+        if ($archdir !== '' && $mode == 'fax') {
+            rename($filepath, $archdir . '/' . $filename);
         } else {
             unlink($filepath);
         }
@@ -381,6 +397,10 @@ if ($_POST['form_save']) {
         // Erase its cache.
         if (is_dir($faxcache)) {
             $dh = opendir($faxcache);
+            if (! $dh) {
+                die("Cannot read " . text($faxcache));
+            }
+
             while (($tmp = readdir($dh)) !== false) {
                 if (is_file("$faxcache/$tmp")) {
                     unlink("$faxcache/$tmp");
@@ -416,53 +436,105 @@ if ($_POST['form_save']) {
 
 // Find out if the scanned_notes form is installed and active.
 //
-$tmp = sqlQuery("SELECT count(*) AS count FROM registry WHERE " .
-  "directory LIKE 'scanned_notes' AND state = 1 AND sql_run = 1");
-$using_scanned_notes = $tmp['count'];
+$scannedNotesCount = QueryUtils::fetchSingleValue(
+    <<<'SQL'
+    SELECT COUNT(*) AS count FROM registry
+    WHERE directory LIKE 'scanned_notes' AND state = 1 AND sql_run = 1
+    SQL,
+    'count'
+);
+$using_scanned_notes = is_numeric($scannedNotesCount) && (int) $scannedNotesCount > 0;
 
 // If the image cache does not yet exist for this fax, build it.
 // This will contain a .tif image as well as a .jpg image for each page.
 //
 if (! is_dir($faxcache)) {
-    $tmp0 = exec('mkdir -p ' . escapeshellarg($faxcache), $tmp1, $tmp2);
-    if ($tmp2) {
-        die("mkdir returned " . text($tmp2) . ": " . text($tmp0));
-    }
+    $filesystem->mkdir($faxcache);
 
     if (strtolower($ext) != '.tif') {
         // convert's default density for PDF-to-TIFF conversion is 72 dpi which is
         // not very good, so we upgrade it to "fine mode" fax quality.  It's really
         // better and faster if the scanner produces TIFFs instead of PDFs.
-        $tmp0 = exec("convert -density 203x196 " . escapeshellarg($filepath) . " " . escapeshellarg($faxcache . '/deleteme.tif'), $tmp1, $tmp2);
-        if ($tmp2) {
-            die("convert returned " . text($tmp2) . ": " . text($tmp0));
+        $process = $runProcess(['convert', '-density', '203x196', $filepath, $faxcache . '/deleteme.tif']);
+        if (!$process->isSuccessful()) {
+            die("convert returned " . text($processError($process)));
         }
 
-        $tmp0 = exec("cd " . escapeshellarg($faxcache) . "; tiffsplit 'deleteme.tif'; rm -f 'deleteme.tif'", $tmp1, $tmp2);
-        if ($tmp2) {
-            die("tiffsplit/rm returned " . text($tmp2) . ": " . text($tmp0));
+        $process = $runProcess(['tiffsplit', 'deleteme.tif'], $faxcache);
+        if (!$process->isSuccessful()) {
+            die("tiffsplit returned " . text($processError($process)));
         }
+
+        $filesystem->remove($faxcache . '/deleteme.tif');
     } else {
-        $tmp0 = exec("cd " . escapeshellarg($faxcache) . "; tiffsplit " . escapeshellarg($filepath), $tmp1, $tmp2);
-        if ($tmp2) {
-            die("tiffsplit returned " . text($tmp2) . ": " . text($tmp0));
+        $process = $runProcess(['tiffsplit', $filepath], $faxcache);
+        if (!$process->isSuccessful()) {
+            die("tiffsplit returned " . text($processError($process)));
         }
     }
 
-    $tmp0 = exec("cd " . escapeshellarg($faxcache) . "; mogrify -resize 750x970 -format jpg *.tif", $tmp1, $tmp2);
-    if ($tmp2) {
-        die("mogrify returned " . text($tmp2) . ": " . text($tmp0) . "; ext is '" . text($ext) . "'; filepath is '" . text($filepath) . "'");
+    $pageTiffs = [];
+    foreach (new FilesystemIterator($faxcache) as $pageFile) {
+        if ($pageFile instanceof SplFileInfo && strtolower($pageFile->getExtension()) === 'tif') {
+            $pageTiffs[] = $pageFile->getFilename();
+        }
+    }
+
+    sort($pageTiffs);
+    if (count($pageTiffs) > 0) {
+        $process = $runProcess(array_merge(['mogrify', '-resize', '750x970', '-format', 'jpg'], $pageTiffs), $faxcache);
+        if (!$process->isSuccessful()) {
+            die("mogrify returned " . text($processError($process)) . "; ext is '" . text($ext) . "'; filepath is '" . text($filepath) . "'");
+        }
     }
 }
 
-// Get the categories list.
+// Get the categories list: the leaf nodes of the document category tree,
+// labeled with their ancestry. Kittens are the children of cats, you know. :-)
+// Depth-first via an explicit stack; children are pushed in reverse so they
+// are visited in name order, matching the original recursive listing.
 $categories = [];
-getKittens(0, '', $categories);
+$catStack = [[0, '']];
+while (count($catStack) > 0) {
+    [$catid, $catstring] = array_pop($catStack);
+    if (!is_int($catid) || !is_string($catstring)) {
+        continue;
+    }
+
+    $crows = QueryUtils::fetchRecords('SELECT id, name FROM categories WHERE parent = ? ORDER BY name', [$catid]);
+    $children = [];
+    foreach ($crows as $crow) {
+        $childId = $crow['id'];
+        $childName = $crow['name'];
+        if (!is_numeric($childId) || !is_string($childName)) {
+            continue;
+        }
+
+        $children[] = [
+            (int) $childId,
+            ($catstring !== '' ? "$catstring / " : '') . ($catid !== 0 ? $childName : ''),
+        ];
+    }
+
+    // If no kitties, then this is a leaf node and should be listed.
+    if (count($children) === 0) {
+        $categories[$catid] = $catstring;
+        continue;
+    }
+
+    foreach (array_reverse($children) as $child) {
+        $catStack[] = $child;
+    }
+}
 
 // Get the users list.
-$ures = sqlStatement("SELECT username, fname, lname FROM users " .
-  "WHERE active = 1 AND ( info IS NULL OR info NOT LIKE '%Inactive%' ) " .
-  "ORDER BY lname, fname");
+$userRows = QueryUtils::fetchRecords(
+    <<<'SQL'
+    SELECT username, fname, lname FROM users
+    WHERE active = 1 AND ( info IS NULL OR info NOT LIKE '%Inactive%' )
+    ORDER BY lname, fname
+    SQL
+);
 ?>
 <html>
 <head>
@@ -641,7 +713,7 @@ $ures = sqlStatement("SELECT username, fname, lname FROM users " .
                         <select name='form_category' class='form-control'>
                             <?php
                             foreach ($categories as $catkey => $catname) {
-                                echo "         <option value='" . attr($catkey) . "'";
+                                echo "         <option value='" . attr((string) $catkey) . "'";
                                 echo ">" . text($catname) . "</option>";
                             }
                             ?>
@@ -716,11 +788,18 @@ $ures = sqlStatement("SELECT username, fname, lname FROM users " .
                     <div class="col-10">
                     <select name='form_note_to' class='form-control'>
                         <?php
-                        while ($urow = sqlFetchArray($ures)) {
-                            echo "         <option value='" . attr($urow['username']) . "'";
-                            echo ">" . text($urow['lname']);
-                            if ($urow['fname']) {
-                                echo ", " . text($urow['fname']);
+                        foreach ($userRows as $urow) {
+                            $username = $urow['username'];
+                            $lname = $urow['lname'];
+                            $fname = $urow['fname'];
+                            if (!is_string($username) || !is_string($lname)) {
+                                continue;
+                            }
+
+                            echo "         <option value='" . attr($username) . "'";
+                            echo ">" . text($lname);
+                            if (is_string($fname) && $fname !== '') {
+                                echo ", " . text($fname);
                             }
 
                             echo "</option>\n";
@@ -843,6 +922,10 @@ closedir($dh);
 ksort($jpgarray);
 $page = 0;
 $site_id = $session->get('site_id');
+if (!is_string($site_id)) {
+    die("Site ID is missing from the session.");
+}
+
 foreach ($jpgarray as $jfnamebase => $jfname) {
     ++$page;
     echo " <tr>\n";
@@ -851,7 +934,7 @@ foreach ($jpgarray as $jfnamebase => $jfname) {
     echo "  </td>\n";
     echo "  <td align='center' valign='top'>\n";
     echo "   <input type='checkbox' name='form_images[]' value='" . attr($jfnamebase) . "' checked />\n";
-    echo "   <br />" . text($page) . "\n";
+    echo "   <br />" . text((string) $page) . "\n";
     echo "  </td>\n";
     echo " </tr>\n";
 }

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -89,7 +89,7 @@ $processError = (static fn(Process $process): string => (string) $process->getEx
 // This merges the tiff files for the selected pages into one tiff file.
 // $images holds the form_images checkboxes to the right of the images.
 //
-$mergeTiffs = static function (array $images) use ($faxcache, $runProcess, $processError): string {
+$mergeTiffs = static function (array $images) use ($faxcache, $filesystem, $runProcess, $processError): string {
     $tiffNames = [];
     foreach ($images as $name) {
         if (is_string($name)) {
@@ -101,6 +101,9 @@ $mergeTiffs = static function (array $images) use ($faxcache, $runProcess, $proc
         die(xlt("Internal error - no pages were selected!"));
     }
 
+    // Remove any merge output from a previous run so a failed tiffcp cannot
+    // leave stale pages behind for the dependent tiff2pdf/sendfax steps.
+    $filesystem->remove($faxcache . '/temp.tif');
     $process = $runProcess(array_merge(['tiffcp'], $tiffNames, ['temp.tif']), $faxcache);
     if (!$process->isSuccessful()) {
         return 'tiffcp returned ' . $processError($process) . ' ';
@@ -157,12 +160,13 @@ if ($request->request->getString('form_save') !== '') {
             // relying on the .tif files for the individual pages to already
             // exist in the faxcache directory.
             //
-            $info_msg .= $mergeTiffs($selectedImages);
-            $tmppdf = tempnam($globalsBag->getString('temporary_files_dir'), 'fax');
+            $mergeMsg = $mergeTiffs($selectedImages);
+            $info_msg .= $mergeMsg;
+            $tmppdf = $mergeMsg === '' ? tempnam($globalsBag->getString('temporary_files_dir'), 'fax') : false;
 
-            if ($tmppdf === false) {
+            if ($mergeMsg === '' && $tmppdf === false) {
                 $info_msg .= xl('Unable to create a temporary file for the document') . ' ';
-            } else {
+            } elseif ($tmppdf !== false) {
                 // The -j option here requires that libtiff is configured with libjpeg.
                 // It could be omitted, but the output PDFs would then be quite large.
                 $process = $runProcess(['tiff2pdf', '-j', '-p', 'letter', '-o', $tmppdf, $faxcache . '/temp.tif']);
@@ -338,19 +342,26 @@ if ($request->request->getString('form_save') !== '') {
             array_merge(explode(' ', OPENEMR_HYLAFAX_ENSCRIPT), ['-o', $tmpfn2, $tmpfn1]),
             $globalsBag->getString('webserver_root') . '/custom'
         );
+        $coverMsg = '';
         if (!$process->isSuccessful()) {
-            $info_msg .= 'enscript returned ' . $processError($process) . ' ';
+            $coverMsg = 'enscript returned ' . $processError($process) . ' ';
+            $info_msg .= $coverMsg;
         }
 
         unlink($tmpfn1);
 
-        // Send the fax as the cover page followed by the selected pages.
-        $info_msg .= $mergeTiffs($selectedImages);
-        $process = $runProcess(
-            ['sendfax', '-A', '-n', $form_finemode, '-d', $form_fax, $tmpfn2, $faxcache . '/temp.tif']
-        );
-        if (!$process->isSuccessful()) {
-            $info_msg .= 'sendfax returned ' . $processError($process) . ' ';
+        // Send the fax as the cover page followed by the selected pages,
+        // but only if both the cover page and the merge succeeded — faxing
+        // after a failed merge could send stale pages from an earlier run.
+        $mergeMsg = $mergeTiffs($selectedImages);
+        $info_msg .= $mergeMsg;
+        if ($coverMsg === '' && $mergeMsg === '') {
+            $process = $runProcess(
+                ['sendfax', '-A', '-n', $form_finemode, '-d', $form_fax, $tmpfn2, $faxcache . '/temp.tif']
+            );
+            if (!$process->isSuccessful()) {
+                $info_msg .= 'sendfax returned ' . $processError($process) . ' ';
+            }
         }
 
         unlink($tmpfn2);
@@ -386,12 +397,14 @@ if ($request->request->getString('form_save') !== '') {
     } // end delete 1
 
     if ($form_cb_delete == '2' && !$info_msg) {
-        // Delete the tiff file, with archiving if desired.
+        // Delete the tiff file, with archiving if desired. The throwing
+        // Filesystem calls guarantee the cache erase below cannot run when
+        // the source file was not actually archived or deleted.
         $archdir = $globalsBag->getString('hylafax_archdir');
         if ($archdir !== '' && $mode == 'fax') {
-            rename($filepath, $archdir . '/' . $filename);
+            $filesystem->rename($filepath, $archdir . '/' . $filename, true);
         } else {
-            unlink($filepath);
+            $filesystem->remove($filepath);
         }
 
         // Erase its cache.
@@ -449,6 +462,13 @@ $using_scanned_notes = is_numeric($scannedNotesCount) && (int) $scannedNotesCoun
 // This will contain a .tif image as well as a .jpg image for each page.
 //
 if (! is_dir($faxcache)) {
+    // Remove the partial cache on any failure so a later request rebuilds it
+    // instead of silently serving an incomplete set of pages.
+    $failCache = static function (string $message) use ($faxcache, $filesystem): never {
+        $filesystem->remove($faxcache);
+        die($message);
+    };
+
     $filesystem->mkdir($faxcache);
 
     if (strtolower($ext) != '.tif') {
@@ -457,19 +477,19 @@ if (! is_dir($faxcache)) {
         // better and faster if the scanner produces TIFFs instead of PDFs.
         $process = $runProcess(['convert', '-density', '203x196', $filepath, $faxcache . '/deleteme.tif']);
         if (!$process->isSuccessful()) {
-            die("convert returned " . text($processError($process)));
+            $failCache("convert returned " . text($processError($process)));
         }
 
         $process = $runProcess(['tiffsplit', 'deleteme.tif'], $faxcache);
         if (!$process->isSuccessful()) {
-            die("tiffsplit returned " . text($processError($process)));
+            $failCache("tiffsplit returned " . text($processError($process)));
         }
 
         $filesystem->remove($faxcache . '/deleteme.tif');
     } else {
         $process = $runProcess(['tiffsplit', $filepath], $faxcache);
         if (!$process->isSuccessful()) {
-            die("tiffsplit returned " . text($processError($process)));
+            $failCache("tiffsplit returned " . text($processError($process)));
         }
     }
 
@@ -484,7 +504,7 @@ if (! is_dir($faxcache)) {
     if (count($pageTiffs) > 0) {
         $process = $runProcess(array_merge(['mogrify', '-resize', '750x970', '-format', 'jpg'], $pageTiffs), $faxcache);
         if (!$process->isSuccessful()) {
-            die("mogrify returned " . text($processError($process)) . "; ext is '" . text($ext) . "'; filepath is '" . text($filepath) . "'");
+            $failCache("mogrify returned " . text($processError($process)) . "; ext is '" . text($ext) . "'; filepath is '" . text($filepath) . "'");
         }
     }
 }

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -18,6 +18,7 @@ require_once __DIR__ . '/../globals.php';
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Http\RequestTerminator;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -41,17 +42,15 @@ $request = Request::createFromGlobals();
 $filesystem = new Filesystem();
 $userauthorized = $globalsBag->getInt('userauthorized');
 
-// Send a real HTTP error status instead of die(). Callers follow this with a
-// top-level `return`, which ends the request like exit() but keeps the script
-// includable (and therefore testable) — no process kill, no swallowed status.
-// Response::send() skips the status line if headers already went out.
-$sendError = static function (int $statusCode, string $message): void {
-    (new Response($message, $statusCode))->send();
-};
+// Error paths send a real HTTP status instead of die(), then `return` at the
+// top level — which ends the request like exit() but keeps the script
+// includable (and therefore testable). The default terminator exits nonzero
+// for error statuses; tests can inject a non-exiting one.
+$terminator = new RequestTerminator();
 
 $site_id = $session->get('site_id');
 if (!is_string($site_id) || $site_id === '') {
-    $sendError(Response::HTTP_UNAUTHORIZED, "Site ID is missing from the session.");
+    $terminator->error(Response::HTTP_UNAUTHORIZED, "Site ID is missing from the session.");
     return;
 }
 
@@ -79,7 +78,7 @@ if ($fileParam !== '') {
 
     $filepath = $globalsBag->getString('scanner_output_directory') . '/' . $filename;
 } else {
-    $sendError(Response::HTTP_BAD_REQUEST, "No filename was given.");
+    $terminator->error(Response::HTTP_BAD_REQUEST, "No filename was given.");
     return;
 }
 
@@ -149,7 +148,7 @@ if ($request->request->getString('form_save') !== '') {
     if ($request->request->getBoolean('form_cb_copy')) {
         $patient_id = $request->request->getInt('form_pid');
         if ($patient_id === 0) {
-            $sendError(Response::HTTP_BAD_REQUEST, xlt('Internal error - patient ID was not provided!'));
+            $terminator->error(Response::HTTP_BAD_REQUEST, xlt('Internal error - patient ID was not provided!'));
             return;
         }
 
@@ -298,7 +297,7 @@ if ($request->request->getString('form_save') !== '') {
                 // we already have a jpeg for each page in faxcache.
                 $process = $runProcess(['convert', '-resize', '800', '-density', '96', $tmp_name, '-append', $imagepath]);
                 if (!$process->isSuccessful()) {
-                    $sendError(Response::HTTP_INTERNAL_SERVER_ERROR, "convert returned " . text($processError($process)));
+                    $terminator->error(Response::HTTP_INTERNAL_SERVER_ERROR, "convert returned " . text($processError($process)));
                     return;
                 }
             }
@@ -400,7 +399,7 @@ if ($request->request->getString('form_save') !== '') {
         if ($action_taken) {
             $dh = opendir($faxcache);
             if (! $dh) {
-                $sendError(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
+                $terminator->error(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
                 return;
             }
 
@@ -430,7 +429,7 @@ if ($request->request->getString('form_save') !== '') {
         if (is_dir($faxcache)) {
             $dh = opendir($faxcache);
             if (! $dh) {
-                $sendError(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
+                $terminator->error(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
                 return;
             }
 
@@ -535,7 +534,7 @@ $buildFaxcache = static function () use ($ext, $filepath, $faxcache, $filesystem
 if (! is_dir($faxcache)) {
     $buildError = $buildFaxcache();
     if ($buildError !== '') {
-        $sendError(Response::HTTP_INTERNAL_SERVER_ERROR, $buildError);
+        $terminator->error(Response::HTTP_INTERNAL_SERVER_ERROR, $buildError);
         return;
     }
 }
@@ -957,7 +956,7 @@ $userRows = QueryUtils::fetchRecords(
 <?php
 $dh = opendir($faxcache);
 if (! $dh) {
-    $sendError(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
+    $terminator->error(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
     return;
 }
 

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -42,16 +42,14 @@ $request = Request::createFromGlobals();
 $filesystem = new Filesystem();
 $userauthorized = $globalsBag->getInt('userauthorized');
 
-// Error paths send a real HTTP status instead of die(), then `return` at the
-// top level — which ends the request like exit() but keeps the script
-// includable (and therefore testable). The default terminator exits nonzero
-// for error statuses; tests can inject a non-exiting one.
+// Error paths send a real HTTP status instead of die(). The default
+// terminator exits nonzero for error statuses; tests can inject a
+// throwing one.
 $terminator = new RequestTerminator();
 
 $site_id = $session->get('site_id');
 if (!is_string($site_id) || $site_id === '') {
     $terminator->error(Response::HTTP_UNAUTHORIZED, "Site ID is missing from the session.");
-    return;
 }
 
 $fileParam = $request->query->getString('file');
@@ -79,7 +77,6 @@ if ($fileParam !== '') {
     $filepath = $globalsBag->getString('scanner_output_directory') . '/' . $filename;
 } else {
     $terminator->error(Response::HTTP_BAD_REQUEST, "No filename was given.");
-    return;
 }
 
 $dotPos = strrpos($filename, '.');
@@ -149,7 +146,6 @@ if ($request->request->getString('form_save') !== '') {
         $patient_id = $request->request->getInt('form_pid');
         if ($patient_id === 0) {
             $terminator->error(Response::HTTP_BAD_REQUEST, xlt('Internal error - patient ID was not provided!'));
-            return;
         }
 
         // If copying to patient documents...
@@ -298,7 +294,6 @@ if ($request->request->getString('form_save') !== '') {
                 $process = $runProcess(['convert', '-resize', '800', '-density', '96', $tmp_name, '-append', $imagepath]);
                 if (!$process->isSuccessful()) {
                     $terminator->error(Response::HTTP_INTERNAL_SERVER_ERROR, "convert returned " . text($processError($process)));
-                    return;
                 }
             }
 
@@ -400,7 +395,6 @@ if ($request->request->getString('form_save') !== '') {
             $dh = opendir($faxcache);
             if (! $dh) {
                 $terminator->error(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
-                return;
             }
 
             $form_cb_delete = '2';
@@ -430,7 +424,6 @@ if ($request->request->getString('form_save') !== '') {
             $dh = opendir($faxcache);
             if (! $dh) {
                 $terminator->error(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
-                return;
             }
 
             while (($tmp = readdir($dh)) !== false) {
@@ -535,7 +528,6 @@ if (! is_dir($faxcache)) {
     $buildError = $buildFaxcache();
     if ($buildError !== '') {
         $terminator->error(Response::HTTP_INTERNAL_SERVER_ERROR, $buildError);
-        return;
     }
 }
 
@@ -957,7 +949,6 @@ $userRows = QueryUtils::fetchRecords(
 $dh = opendir($faxcache);
 if (! $dh) {
     $terminator->error(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
-    return;
 }
 
 $jpgarray = [];

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -41,17 +41,18 @@ $request = Request::createFromGlobals();
 $filesystem = new Filesystem();
 $userauthorized = $globalsBag->getInt('userauthorized');
 
-// Stop with a real HTTP error status instead of die(): callers and proxies
-// see the failure, and the nonzero exit fails loudly outside a web SAPI.
+// Send a real HTTP error status instead of die(). Callers follow this with a
+// top-level `return`, which ends the request like exit() but keeps the script
+// includable (and therefore testable) — no process kill, no swallowed status.
 // Response::send() skips the status line if headers already went out.
-$abort = static function (int $statusCode, string $message): never {
+$sendError = static function (int $statusCode, string $message): void {
     (new Response($message, $statusCode))->send();
-    exit(1);
 };
 
 $site_id = $session->get('site_id');
 if (!is_string($site_id) || $site_id === '') {
-    $abort(Response::HTTP_UNAUTHORIZED, "Site ID is missing from the session.");
+    $sendError(Response::HTTP_UNAUTHORIZED, "Site ID is missing from the session.");
+    return;
 }
 
 $fileParam = $request->query->getString('file');
@@ -78,7 +79,8 @@ if ($fileParam !== '') {
 
     $filepath = $globalsBag->getString('scanner_output_directory') . '/' . $filename;
 } else {
-    $abort(Response::HTTP_BAD_REQUEST, "No filename was given.");
+    $sendError(Response::HTTP_BAD_REQUEST, "No filename was given.");
+    return;
 }
 
 $dotPos = strrpos($filename, '.');
@@ -103,7 +105,7 @@ $processError = (static fn(Process $process): string => (string) $process->getEx
 // This merges the tiff files for the selected pages into one tiff file.
 // $images holds the form_images checkboxes to the right of the images.
 //
-$mergeTiffs = static function (array $images) use ($faxcache, $filesystem, $runProcess, $processError, $abort): string {
+$mergeTiffs = static function (array $images) use ($faxcache, $filesystem, $runProcess, $processError): string {
     $tiffNames = [];
     foreach ($images as $name) {
         if (is_string($name)) {
@@ -112,7 +114,7 @@ $mergeTiffs = static function (array $images) use ($faxcache, $filesystem, $runP
     }
 
     if (count($tiffNames) === 0) {
-        $abort(Response::HTTP_BAD_REQUEST, xlt("Internal error - no pages were selected!"));
+        return xl('Internal error - no pages were selected!') . ' ';
     }
 
     // Remove any merge output from a previous run so a failed tiffcp cannot
@@ -147,7 +149,8 @@ if ($request->request->getString('form_save') !== '') {
     if ($request->request->getBoolean('form_cb_copy')) {
         $patient_id = $request->request->getInt('form_pid');
         if ($patient_id === 0) {
-            $abort(Response::HTTP_BAD_REQUEST, xlt('Internal error - patient ID was not provided!'));
+            $sendError(Response::HTTP_BAD_REQUEST, xlt('Internal error - patient ID was not provided!'));
+            return;
         }
 
         // If copying to patient documents...
@@ -295,7 +298,8 @@ if ($request->request->getString('form_save') !== '') {
                 // we already have a jpeg for each page in faxcache.
                 $process = $runProcess(['convert', '-resize', '800', '-density', '96', $tmp_name, '-append', $imagepath]);
                 if (!$process->isSuccessful()) {
-                    $abort(Response::HTTP_INTERNAL_SERVER_ERROR, "convert returned " . text($processError($process)));
+                    $sendError(Response::HTTP_INTERNAL_SERVER_ERROR, "convert returned " . text($processError($process)));
+                    return;
                 }
             }
 
@@ -396,7 +400,8 @@ if ($request->request->getString('form_save') !== '') {
         if ($action_taken) {
             $dh = opendir($faxcache);
             if (! $dh) {
-                $abort(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
+                $sendError(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
+                return;
             }
 
             $form_cb_delete = '2';
@@ -425,7 +430,8 @@ if ($request->request->getString('form_save') !== '') {
         if (is_dir($faxcache)) {
             $dh = opendir($faxcache);
             if (! $dh) {
-                $abort(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
+                $sendError(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
+                return;
             }
 
             while (($tmp = readdir($dh)) !== false) {
@@ -455,7 +461,7 @@ if ($request->request->getString('form_save') !== '') {
         echo " if (!opener.closed && opener.refreshme) opener.refreshme();\n";
         echo " window.close();\n";
         echo "</script>\n</body>\n</html>\n";
-        exit();
+        return;
     }
 } // end submit logic
 
@@ -475,14 +481,11 @@ $using_scanned_notes = is_numeric($scannedNotesCount) && (int) $scannedNotesCoun
 // If the image cache does not yet exist for this fax, build it.
 // This will contain a .tif image as well as a .jpg image for each page.
 //
-if (! is_dir($faxcache)) {
-    // Remove the partial cache on any failure so a later request rebuilds it
-    // instead of silently serving an incomplete set of pages.
-    $failCache = static function (string $message) use ($faxcache, $filesystem, $abort): never {
-        $filesystem->remove($faxcache);
-        $abort(Response::HTTP_INTERNAL_SERVER_ERROR, $message);
-    };
-
+// Build the page images for the fax under $faxcache: a .tif and a .jpg per
+// page. Returns '' on success. On failure, removes the partial cache — so a
+// later request rebuilds it instead of silently serving an incomplete set of
+// pages — and returns the error message.
+$buildFaxcache = static function () use ($ext, $filepath, $faxcache, $filesystem, $runProcess, $processError): string {
     $filesystem->mkdir($faxcache);
 
     if (strtolower($ext) != '.tif') {
@@ -491,19 +494,22 @@ if (! is_dir($faxcache)) {
         // better and faster if the scanner produces TIFFs instead of PDFs.
         $process = $runProcess(['convert', '-density', '203x196', $filepath, $faxcache . '/deleteme.tif']);
         if (!$process->isSuccessful()) {
-            $failCache("convert returned " . text($processError($process)));
+            $filesystem->remove($faxcache);
+            return "convert returned " . text($processError($process));
         }
 
         $process = $runProcess(['tiffsplit', 'deleteme.tif'], $faxcache);
         if (!$process->isSuccessful()) {
-            $failCache("tiffsplit returned " . text($processError($process)));
+            $filesystem->remove($faxcache);
+            return "tiffsplit returned " . text($processError($process));
         }
 
         $filesystem->remove($faxcache . '/deleteme.tif');
     } else {
         $process = $runProcess(['tiffsplit', $filepath], $faxcache);
         if (!$process->isSuccessful()) {
-            $failCache("tiffsplit returned " . text($processError($process)));
+            $filesystem->remove($faxcache);
+            return "tiffsplit returned " . text($processError($process));
         }
     }
 
@@ -518,8 +524,19 @@ if (! is_dir($faxcache)) {
     if (count($pageTiffs) > 0) {
         $process = $runProcess(array_merge(['mogrify', '-resize', '750x970', '-format', 'jpg'], $pageTiffs), $faxcache);
         if (!$process->isSuccessful()) {
-            $failCache("mogrify returned " . text($processError($process)) . "; ext is '" . text($ext) . "'; filepath is '" . text($filepath) . "'");
+            $filesystem->remove($faxcache);
+            return "mogrify returned " . text($processError($process)) . "; ext is '" . text($ext) . "'; filepath is '" . text($filepath) . "'";
         }
+    }
+
+    return '';
+};
+
+if (! is_dir($faxcache)) {
+    $buildError = $buildFaxcache();
+    if ($buildError !== '') {
+        $sendError(Response::HTTP_INTERNAL_SERVER_ERROR, $buildError);
+        return;
     }
 }
 
@@ -940,7 +957,8 @@ $userRows = QueryUtils::fetchRecords(
 <?php
 $dh = opendir($faxcache);
 if (! $dh) {
-    $abort(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
+    $sendError(Response::HTTP_INTERNAL_SERVER_ERROR, "Cannot read " . text($faxcache));
+    return;
 }
 
 $jpgarray = [];

--- a/src/Common/Http/RequestTerminator.php
+++ b/src/Common/Http/RequestTerminator.php
@@ -23,10 +23,11 @@ use Symfony\Component\HttpFoundation\Response;
  * anything else that reads status codes. This helper sends a real Response
  * first, then hands control to a terminator that never returns.
  *
- * The default terminator exits the process: nonzero when the response status
- * is a client or server error (4xx/5xx), zero otherwise. Tests inject a throwing closure so
- * request-ending code paths remain executable under PHPUnit instead of
- * killing the test runner.
+ * The terminator receives the HTTP status code of the sent response and
+ * decides how to end the request. The default exits the process: nonzero for
+ * client and server error statuses (4xx/5xx), zero otherwise. Tests inject a
+ * throwing closure so request-ending code paths remain executable under
+ * PHPUnit instead of killing the test runner.
  *
  * This class exists to retrofit legacy procedural scripts. Do not reach for
  * it in new code — new endpoints should build and return a Response through
@@ -38,16 +39,25 @@ final readonly class RequestTerminator
     private Closure $terminator;
 
     /**
-     * @param (Closure(int): never)|null $terminator receives the intended
-     *        process exit code: 1 when the response status is 4xx/5xx, else 0
+     * @param (Closure(int): never)|null $terminator receives the HTTP status
+     *        code of the sent response and must end the request
      */
     public function __construct(?Closure $terminator = null)
     {
-        $this->terminator = $terminator ?? static function (int $exitCode): never {
+        $this->terminator = $terminator ?? static function (int $statusCode): never {
             // @codeCoverageIgnoreStart -- exiting would kill the test runner
-            exit($exitCode);
+            exit(self::defaultExitCode($statusCode));
             // @codeCoverageIgnoreEnd
         };
+    }
+
+    /**
+     * The process exit code the default terminator uses for a status code:
+     * 1 for client and server errors (4xx/5xx), 0 otherwise.
+     */
+    public static function defaultExitCode(int $statusCode): int
+    {
+        return $statusCode >= Response::HTTP_BAD_REQUEST ? 1 : 0;
     }
 
     /**
@@ -56,7 +66,7 @@ final readonly class RequestTerminator
     public function respond(Response $response): never
     {
         $response->send();
-        ($this->terminator)((int) ($response->isClientError() || $response->isServerError()));
+        ($this->terminator)($response->getStatusCode());
     }
 
     /**

--- a/src/Common/Http/RequestTerminator.php
+++ b/src/Common/Http/RequestTerminator.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
  * first, then hands control to a terminator that never returns.
  *
  * The default terminator exits the process: nonzero when the response status
- * is an error (>= 400), zero otherwise. Tests inject a throwing closure so
+ * is a client or server error (4xx/5xx), zero otherwise. Tests inject a throwing closure so
  * request-ending code paths remain executable under PHPUnit instead of
  * killing the test runner.
  *
@@ -39,7 +39,7 @@ final readonly class RequestTerminator
 
     /**
      * @param (Closure(int): never)|null $terminator receives the intended
-     *        process exit code: 1 when the response status is >= 400, else 0
+     *        process exit code: 1 when the response status is 4xx/5xx, else 0
      */
     public function __construct(?Closure $terminator = null)
     {
@@ -56,7 +56,7 @@ final readonly class RequestTerminator
     public function respond(Response $response): never
     {
         $response->send();
-        ($this->terminator)((int) ($response->getStatusCode() >= 400));
+        ($this->terminator)((int) ($response->isClientError() || $response->isServerError()));
     }
 
     /**

--- a/src/Common/Http/RequestTerminator.php
+++ b/src/Common/Http/RequestTerminator.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Ends the current request with a real HTTP response instead of die()/exit()
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Http;
+
+use Closure;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Legacy scripts end error paths with die("message"), which reports HTTP 200
+ * and process exit code 0 — invisible to browsers, proxies, monitoring, and
+ * anything else that reads status codes. This helper sends a real Response
+ * first, then hands control to a terminator.
+ *
+ * The default terminator exits the process: nonzero when the response status
+ * is an error (>= 400), zero otherwise. Tests inject their own closure
+ * (throw or record) so request-ending code paths remain executable under
+ * PHPUnit instead of killing the test runner.
+ */
+final readonly class RequestTerminator
+{
+    private Closure $terminator;
+
+    /**
+     * @param (Closure(int): void)|null $terminator receives the intended
+     *        process exit code: 1 when the response status is >= 400, else 0
+     */
+    public function __construct(?Closure $terminator = null)
+    {
+        $this->terminator = $terminator ?? static function (int $exitCode): never {
+            // @codeCoverageIgnoreStart -- exiting would kill the test runner
+            exit($exitCode);
+            // @codeCoverageIgnoreEnd
+        };
+    }
+
+    /**
+     * Send the response, then terminate the request.
+     *
+     * With the default terminator this never returns. Top-level script
+     * callers should still follow it with `return;` so control flow also
+     * ends when a test injects a non-exiting terminator.
+     */
+    public function respond(Response $response): void
+    {
+        $response->send();
+        ($this->terminator)((int) ($response->getStatusCode() >= 400));
+    }
+
+    /**
+     * Convenience wrapper for the common case: an error body with status.
+     */
+    public function error(int $statusCode, string $message): void
+    {
+        $this->respond(new Response($message, $statusCode));
+    }
+}

--- a/src/Common/Http/RequestTerminator.php
+++ b/src/Common/Http/RequestTerminator.php
@@ -21,19 +21,24 @@ use Symfony\Component\HttpFoundation\Response;
  * Legacy scripts end error paths with die("message"), which reports HTTP 200
  * and process exit code 0 — invisible to browsers, proxies, monitoring, and
  * anything else that reads status codes. This helper sends a real Response
- * first, then hands control to a terminator.
+ * first, then hands control to a terminator that never returns.
  *
  * The default terminator exits the process: nonzero when the response status
- * is an error (>= 400), zero otherwise. Tests inject their own closure
- * (throw or record) so request-ending code paths remain executable under
- * PHPUnit instead of killing the test runner.
+ * is an error (>= 400), zero otherwise. Tests inject a throwing closure so
+ * request-ending code paths remain executable under PHPUnit instead of
+ * killing the test runner.
+ *
+ * This class exists to retrofit legacy procedural scripts. Do not reach for
+ * it in new code — new endpoints should build and return a Response through
+ * a controller and let the front controller send it.
  */
 final readonly class RequestTerminator
 {
+    /** @var Closure(int): never */
     private Closure $terminator;
 
     /**
-     * @param (Closure(int): void)|null $terminator receives the intended
+     * @param (Closure(int): never)|null $terminator receives the intended
      *        process exit code: 1 when the response status is >= 400, else 0
      */
     public function __construct(?Closure $terminator = null)
@@ -47,12 +52,8 @@ final readonly class RequestTerminator
 
     /**
      * Send the response, then terminate the request.
-     *
-     * With the default terminator this never returns. Top-level script
-     * callers should still follow it with `return;` so control flow also
-     * ends when a test injects a non-exiting terminator.
      */
-    public function respond(Response $response): void
+    public function respond(Response $response): never
     {
         $response->send();
         ($this->terminator)((int) ($response->getStatusCode() >= 400));
@@ -61,7 +62,7 @@ final readonly class RequestTerminator
     /**
      * Convenience wrapper for the common case: an error body with status.
      */
-    public function error(int $statusCode, string $message): void
+    public function error(int $statusCode, string $message): never
     {
         $this->respond(new Response($message, $statusCode));
     }

--- a/tests/Tests/Isolated/Common/Http/RequestTerminatorIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Http/RequestTerminatorIsolatedTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Common\Http;
 
+use LogicException;
 use OpenEMR\Common\Http\RequestTerminator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -21,6 +22,17 @@ use Symfony\Component\HttpFoundation\Response;
 
 class RequestTerminatorIsolatedTest extends TestCase
 {
+    /**
+     * Terminators must never return, so the test double throws instead of
+     * exiting; the exception code carries the exit code it received.
+     */
+    private static function throwingTerminator(): RequestTerminator
+    {
+        return new RequestTerminator(static function (int $exitCode): never {
+            throw new LogicException('terminated', $exitCode);
+        });
+    }
+
     /**
      * @return array<string, array{int, int}>
      *
@@ -40,41 +52,19 @@ class RequestTerminatorIsolatedTest extends TestCase
     #[DataProvider('statusToExitCodeProvider')]
     public function testRespondPassesExitCodeForStatus(int $statusCode, int $expectedExitCode): void
     {
-        $received = null;
-        $terminator = new RequestTerminator(static function (int $exitCode) use (&$received): void {
-            $received = $exitCode;
-        });
-
         $this->expectOutputString('body');
-        $terminator->respond(new Response('body', $statusCode));
+        $this->expectException(LogicException::class);
+        $this->expectExceptionCode($expectedExitCode);
 
-        $this->assertSame($expectedExitCode, $received);
+        self::throwingTerminator()->respond(new Response('body', $statusCode));
     }
 
     public function testErrorSendsMessageWithStatus(): void
     {
-        $received = null;
-        $terminator = new RequestTerminator(static function (int $exitCode) use (&$received): void {
-            $received = $exitCode;
-        });
-
         $this->expectOutputString('Cannot read the fax cache.');
-        $terminator->error(Response::HTTP_INTERNAL_SERVER_ERROR, 'Cannot read the fax cache.');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionCode(1);
 
-        $this->assertSame(1, $received);
-    }
-
-    public function testControlReturnsToCallerWithInjectedTerminator(): void
-    {
-        $calls = 0;
-        $terminator = new RequestTerminator(static function (int $exitCode) use (&$calls): void {
-            $calls++;
-        });
-
-        $this->expectOutputString('firstsecond');
-        $terminator->error(Response::HTTP_BAD_REQUEST, 'first');
-        $terminator->error(Response::HTTP_BAD_REQUEST, 'second');
-
-        $this->assertSame(2, $calls);
+        self::throwingTerminator()->error(Response::HTTP_INTERNAL_SERVER_ERROR, 'Cannot read the fax cache.');
     }
 }

--- a/tests/Tests/Isolated/Common/Http/RequestTerminatorIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Http/RequestTerminatorIsolatedTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Isolated RequestTerminator Test
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Http;
+
+use OpenEMR\Common\Http\RequestTerminator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequestTerminatorIsolatedTest extends TestCase
+{
+    /**
+     * @return array<string, array{int, int}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function statusToExitCodeProvider(): array
+    {
+        return [
+            'success is exit zero' => [Response::HTTP_OK, 0],
+            'redirect is exit zero' => [Response::HTTP_FOUND, 0],
+            'client error is exit one' => [Response::HTTP_BAD_REQUEST, 1],
+            'unauthorized is exit one' => [Response::HTTP_UNAUTHORIZED, 1],
+            'server error is exit one' => [Response::HTTP_INTERNAL_SERVER_ERROR, 1],
+        ];
+    }
+
+    #[DataProvider('statusToExitCodeProvider')]
+    public function testRespondPassesExitCodeForStatus(int $statusCode, int $expectedExitCode): void
+    {
+        $received = null;
+        $terminator = new RequestTerminator(static function (int $exitCode) use (&$received): void {
+            $received = $exitCode;
+        });
+
+        $this->expectOutputString('body');
+        $terminator->respond(new Response('body', $statusCode));
+
+        $this->assertSame($expectedExitCode, $received);
+    }
+
+    public function testErrorSendsMessageWithStatus(): void
+    {
+        $received = null;
+        $terminator = new RequestTerminator(static function (int $exitCode) use (&$received): void {
+            $received = $exitCode;
+        });
+
+        $this->expectOutputString('Cannot read the fax cache.');
+        $terminator->error(Response::HTTP_INTERNAL_SERVER_ERROR, 'Cannot read the fax cache.');
+
+        $this->assertSame(1, $received);
+    }
+
+    public function testControlReturnsToCallerWithInjectedTerminator(): void
+    {
+        $calls = 0;
+        $terminator = new RequestTerminator(static function (int $exitCode) use (&$calls): void {
+            $calls++;
+        });
+
+        $this->expectOutputString('firstsecond');
+        $terminator->error(Response::HTTP_BAD_REQUEST, 'first');
+        $terminator->error(Response::HTTP_BAD_REQUEST, 'second');
+
+        $this->assertSame(2, $calls);
+    }
+}

--- a/tests/Tests/Isolated/Common/Http/RequestTerminatorIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Http/RequestTerminatorIsolatedTest.php
@@ -24,13 +24,48 @@ class RequestTerminatorIsolatedTest extends TestCase
 {
     /**
      * Terminators must never return, so the test double throws instead of
-     * exiting; the exception code carries the exit code it received.
+     * exiting; the exception code carries the status code it received.
      */
     private static function throwingTerminator(): RequestTerminator
     {
-        return new RequestTerminator(static function (int $exitCode): never {
-            throw new LogicException('terminated', $exitCode);
+        return new RequestTerminator(static function (int $statusCode): never {
+            throw new LogicException('terminated', $statusCode);
         });
+    }
+
+    /**
+     * @return array<string, array{int}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function statusCodeProvider(): array
+    {
+        return [
+            'success' => [Response::HTTP_OK],
+            'redirect' => [Response::HTTP_FOUND],
+            'client error' => [Response::HTTP_BAD_REQUEST],
+            'unauthorized' => [Response::HTTP_UNAUTHORIZED],
+            'server error' => [Response::HTTP_INTERNAL_SERVER_ERROR],
+        ];
+    }
+
+    #[DataProvider('statusCodeProvider')]
+    public function testRespondPassesStatusCodeToTerminator(int $statusCode): void
+    {
+        $this->expectOutputString('body');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionCode($statusCode);
+
+        self::throwingTerminator()->respond(new Response('body', $statusCode));
+    }
+
+    public function testErrorSendsMessageWithStatus(): void
+    {
+        $this->expectOutputString('Cannot read the fax cache.');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionCode(Response::HTTP_INTERNAL_SERVER_ERROR);
+
+        self::throwingTerminator()->error(Response::HTTP_INTERNAL_SERVER_ERROR, 'Cannot read the fax cache.');
     }
 
     /**
@@ -50,21 +85,8 @@ class RequestTerminatorIsolatedTest extends TestCase
     }
 
     #[DataProvider('statusToExitCodeProvider')]
-    public function testRespondPassesExitCodeForStatus(int $statusCode, int $expectedExitCode): void
+    public function testDefaultExitCodeForStatus(int $statusCode, int $expectedExitCode): void
     {
-        $this->expectOutputString('body');
-        $this->expectException(LogicException::class);
-        $this->expectExceptionCode($expectedExitCode);
-
-        self::throwingTerminator()->respond(new Response('body', $statusCode));
-    }
-
-    public function testErrorSendsMessageWithStatus(): void
-    {
-        $this->expectOutputString('Cannot read the fax cache.');
-        $this->expectException(LogicException::class);
-        $this->expectExceptionCode(1);
-
-        self::throwingTerminator()->error(Response::HTTP_INTERNAL_SERVER_ERROR, 'Cannot read the fax cache.');
+        $this->assertSame($expectedExitCode, RequestTerminator::defaultExitCode($statusCode));
     }
 }


### PR DESCRIPTION
Modernizes `interface/fax/fax_dispatch.php` so it passes PHPStan level 10 with zero baseline entries, and drains its 157 entries from the baseline.

## What
- Replace `$_GET`/`$_POST` access with Symfony Request typed getters
- Replace all 10 `exec()` calls with Symfony Process using array arguments (the `mogrify *.tif` shell glob now enumerates files via `FilesystemIterator`)
- Replace deprecated `sqlStatement`/`sqlQuery`/`sqlFetchArray`/`sqlInsert`/`addForm` with `QueryUtils` and `FormService`
- Replace false-returning file APIs (`fopen`/`fread`/`tempnam`) with Symfony Filesystem
- Convert the global-namespace `getKittens()`/`mergeTiffs()` functions to an iterative traversal and a closure; drop the `global` keyword
- Lower the `variable.undefined` fatal-baseline cap 505 → 500

## Why
Beyond static-analysis hygiene, this fixes a real latent bug: `$erow` was referenced but never defined, so the "New scanned encounter note for visit on …" patient note always had an empty visit date (and is an undefined-variable error on PHP 8). The date is now queried from `form_encounter` for the selected visit.

Behavior notes: process failures now report combined stdout+stderr instead of only the last stdout line; a missing `sites/<site>/faxcover.txt` now throws instead of silently faxing a blank cover page.