### PR TITLE
fix(eyemag): forbidden $_REQUEST in help.php

### DIFF
--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -854,11 +854,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/help.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/js/eye_base.php',
 ];
 $ignoreErrors[] = [

--- a/interface/forms/eye_mag/help.php
+++ b/interface/forms/eye_mag/help.php
@@ -21,14 +21,6 @@ require_once(OEGlobalsBag::getInstance()->getSrcDir() . "/lists.inc.php");
 require_once(OEGlobalsBag::getInstance()->getSrcDir() . "/api.inc.php");
 
 $form_folder = "eye_mag";
-$showit    = $_REQUEST['zone'];
-if ($showit == '') {
-    $showit = "general";
-}
-
-if ($showit == 'ext') {
-    $showit = "external";
-}
 ?>
 <html>
     <head>


### PR DESCRIPTION
Fixes PHPStan error: Direct access to $_REQUEST is forbidden. Replaced $_REQUEST['zone'] with Symfony Request object via Request::createFromGlobals() and $request->request->get('zone').