### PR TITLE
fix(release): pass GH_TOKEN to release-amendment mutator steps

### DIFF
--- a/.github/workflows/release-amendment.yml
+++ b/.github/workflows/release-amendment.yml
@@ -187,6 +187,12 @@ jobs:
       env:
         VERSION: ${{ inputs.version }}
         REL_BRANCH: ${{ inputs.rel_branch }}
+        # ChangelogMutator shells out to `gh api` for commit + PR walking.
+        # `gh` looks for GH_TOKEN / GITHUB_TOKEN and errors otherwise;
+        # without persist-credentials it can't fall back on .git/config
+        # auth either. Explicit token here keeps the mutator step self-
+        # contained.
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       # All mutators except ChangelogMutator + CompatibilityMutator are
       # already idempotent no-ops on a shipped release (version.php has
       # $v_tag='', release-targets.yml is post-rotation, etc.). The two
@@ -282,6 +288,8 @@ jobs:
       env:
         VERSION: ${{ inputs.version }}
         REL_BRANCH: ${{ inputs.rel_branch }}
+        # Same GH_TOKEN requirement as the rel-scope mutator run above.
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         php bin/console openemr:release-prep \
           --skip-globals \


### PR DESCRIPTION
## Summary

Dry-run dispatch of \`.github/workflows/release-amendment.yml\` on \`8.2.0\` / \`rel-820\` (my run [29392343714](https://github.com/openemr/openemr/actions/runs/29392343714)) failed at the \"Run release-prep mutators (rel scope)\" step:

\`\`\`
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
\`\`\`

Root cause: \`ChangelogMutator\` shells out to \`gh api\` via \`ChangelogGenerator::commitsBetweenRefs()\` to walk the release range. The \`gh\` CLI looks for \`GH_TOKEN\` / \`GITHUB_TOKEN\` in env; without \`persist-credentials\` it also can't fall back on \`.git/config\` auth. The mutator steps didn't set \`GH_TOKEN\` — they only had \`VERSION\` and \`REL_BRANCH\` — so \`gh\` errored immediately when the mutator's PHP tried to shell out.

Fix: add \`GH_TOKEN: \${{ steps.app-token.outputs.token }}\` to the env block of both mutator steps (rel + master scopes). Preserves the least-privilege app-token pattern (rather than injecting the ambient \`GITHUB_TOKEN\`).

## Latent issue in release-prep.yml

Same missing \`GH_TOKEN\` on release-prep.yml's mutator steps, but it happens to work today because release-prep.yml uses the default \`actions/checkout\` (no \`persist-credentials: false\`), so \`gh\` picks up the ambient \`GITHUB_TOKEN\` from \`.git/config\` extra-header. That's fragile and uses the wrong token (scoped-down GITHUB_TOKEN instead of the app token that other steps use for API calls). Worth a separate audit/hardening PR — not fixing here.

## Test plan
- [x] YAML lints (actionlint)
- [ ] Re-dispatch amendment workflow dry-run on 8.2.0/rel-820 once this lands; should reach "Extract amended section from rel-branch CHANGELOG" step this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)