### PR TITLE
fix(ci): graceful-restart httpd in enable_coredumps so cores actually land

### DIFF
--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -669,6 +669,20 @@ enable_coredumps() {
     dc exec -T openemr sh -c "mkdir -p '${COREDUMP_DIR}' && chmod 1777 '${COREDUMP_DIR}'"
     sudo sysctl -w "kernel.core_pattern=${COREDUMP_DIR}/core.%e.%p.%t"
     sudo sysctl -w 'fs.suid_dumpable=2'
+    # The two sysctls above are checked at the moment a process changes UID.
+    # Apache started earlier in the compose `up` and its prefork workers
+    # already dropped root -> apache before we ran these sysctls, so those
+    # existing workers still have dumpable=0 — the kernel will silently
+    # discard their cores. This is why #12438's crash-diagnostics artifact
+    # has been reporting "No coredumps found in /var/www/coredumps" on
+    # every apache_82_118* segfault since #12445 landed: enable_coredumps
+    # ran cleanly but the workers that segfaulted were already un-dumpable.
+    #
+    # `httpd -k graceful` sends SIGUSR1 to the parent apache. The parent
+    # forks fresh workers, and those inherit dumpable=1 under
+    # fs.suid_dumpable=2, so subsequent segfaults leave usable cores.
+    dc exec -T openemr sh -c 'httpd -k graceful' \
+        || echo 'enable_coredumps: graceful restart failed; existing workers keep dumpable=0'
 }
 
 ##

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -681,6 +681,7 @@ enable_coredumps() {
     # `httpd -k graceful` sends SIGUSR1 to the parent apache. The parent
     # forks fresh workers, and those inherit dumpable=1 under
     # fs.suid_dumpable=2, so subsequent segfaults leave usable cores.
+    # shellcheck disable=SC2310  # graceful restart failure is diagnostic, not fatal
     dc exec -T openemr sh -c 'httpd -k graceful' \
         || echo 'enable_coredumps: graceful restart failed; existing workers keep dumpable=0'
 }


### PR DESCRIPTION
## Summary

`enable_coredumps` (added by #12445 in `ci/ciLibrary.source`) sets `fs.suid_dumpable=2` and `kernel.core_pattern`, but the workers that actually segfault still have `dumpable=0` because they already dropped `root` → `apache` **before** `enable_coredumps` ran. `fs.suid_dumpable` is checked at UID-change time, not at dump time. So the kernel silently discards their cores and `crash-diagnostics-*/coredumps.none.txt` reports "No coredumps found in `/var/www/coredumps`" — which is what #12438 has been observing since the capture plumbing landed on 2026-06-10 (Firehed's 2026-06-20 comment: *"the core dump additions yielded nothing"*).

The fix: `httpd -k graceful` (SIGUSR1 to the apache parent) inside `enable_coredumps`, right after the sysctls. That forks a fresh worker pool, and those new workers inherit `dumpable=1` under `fs.suid_dumpable=2`. Subsequent segfaults leave cores that `capture_coredumps` can backtrace.

## Why this matters

#12438 has been open with no diagnostic progress for a month because the coredump path has been broken end-to-end. This one-line change unblocks the whole "identify the faulting `.so`" plan the issue was built around.

## Also relevant — apparent side-effect: the segfault stops manifesting

Since 2026-07-13, the segfault has been consistently hitting the `apache_82_118_upgrade / e2e` cell too (not just `apache_82_118 / e2e` per #12438). Master had been failing this cell **6-for-6** on recent runs.

With this fix applied, three consecutive CI runs against the same cell have **passed with zero segfaults**:

| Run | Branch | segfaults | Tests |
|-----|--------|-----------|-------|
| 9804033 | debug PR #12975 | 0 | 154/334/7 pass |
| 68a06137 | debug PR #12975 (retest) | 0 | 154/334/7 pass |
| this PR (clean off master) | fix-enable-coredumps-graceful-restart | 0 | 154/334/7 pass |

Three-for-three against a 6-for-6-fail baseline is small-N but striking. The most plausible mechanism: the segfault requires accumulated state in a long-lived apache prefork worker (Firehed hypothesized "data race in session close" tied to redis extension or PHP itself on #12438). The graceful restart forks fresh workers with clean state at test-start, and those don't accumulate long enough during the ~5-minute test window to hit the crash condition. If confirmed under longer observation, this is a fortunate two-for-one — coredump capture fixed *and* the flake incidentally rescued.

Even if the flake-fix side effect turns out to be luck under longer observation, the primary framing (coredump capture actually working) stands on its own merit — that infrastructure has been broken for a month and #12438 root-cause work is blocked on it.

## Prod-risk read

This is almost certainly **CI-only**. Real production users don't use the `flex-3.22-php-8.2` test image, don't enable `OPENEMR_DEPRECATION_MODE=error` / `OPENEMR_ENABLE_CI_PHP` / coverage auto_prepend, and don't hit their app with 154 automated browser tests in 5 minutes. API/services/email test suites on the *same* image + *same* upgraded DB + *same* PHP 8.2 pass reliably — so it's not a generic "any HTTP request crashes" issue. That said, we won't know for certain until we get the first coredump backtrace and identify the faulting `.so` — which is exactly what this PR unblocks.

## Test plan

- [ ] Merge and observe the next 5-10 `PHP 8.2 - apache - mariadb 11.8.8 / e2e` and `... - Upgrade from 5.0.0 / e2e` master runs.
- [ ] If a segfault does still occur, confirm the `crash-diagnostics-*` artifact now contains a `core.httpd.<pid>.<ts>.backtrace.txt` naming the faulting `.so` (the primary goal of this PR).
- [ ] If segfaults stop occurring entirely (matching the debug PR observation), the graceful restart is doubling as a workaround — worth calling out on #12438 and considering whether to keep the restart in place long-term regardless of coredump-capture need.

Refs #12423, #12438, #12439, #12445.