### PR TITLE
fix(release): extract CHANGELOG section before peter-evans opens PR

### DIFF
--- a/.github/workflows/release-amendment.yml
+++ b/.github/workflows/release-amendment.yml
@@ -255,6 +255,40 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
         fi
 
+    # Extract runs HERE (not after peter-evans opens the PR) because
+    # peter-evans/create-pull-request@v8 resets the rel-checkout working
+    # tree back to rel-branch HEAD after committing the diff to the
+    # amendment branch. If Extract ran after peter-evans, it would read
+    # the pre-amendment CHANGELOG.md and set the Release body + attachment
+    # to stale content -- the exact failure mode observed in workflow run
+    # 29397657588. Extracting BEFORE peter-evans captures the amended
+    # content into $RUNNER_TEMP/section.md, which survives peter-evans's
+    # working-tree reset (it lives in the runner's temp dir, not the
+    # rel-checkout).
+    - name: Extract amended section from rel-branch CHANGELOG
+      id: extract
+      working-directory: rel-checkout
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        # Match `## [X.Y.Z]` heading (with optional link markup that
+        # ChangelogGenerator emits) and take everything up to the next
+        # `## ` heading or EOF. Escape dots in the version literal so
+        # awk doesn't treat them as regex any-char.
+        escaped_version=$(printf '%s' "${VERSION}" | sed 's/\./\\./g')
+        awk -v ver="${escaped_version}" '
+          BEGIN { in_section = 0 }
+          $0 ~ "^## \\[" ver "\\]" { in_section = 1; print; next }
+          in_section && /^## / { exit }
+          in_section { print }
+        ' CHANGELOG.md > "${RUNNER_TEMP}/section.md"
+        if [ ! -s "${RUNNER_TEMP}/section.md" ]; then
+          echo "::error::extracted section is empty; CHANGELOG.md may not contain a ## [${VERSION}] heading"
+          exit 1
+        fi
+        echo "section-path=${RUNNER_TEMP}/section.md" >> "$GITHUB_OUTPUT"
+        echo "Extracted $(wc -l < "${RUNNER_TEMP}/section.md") lines from CHANGELOG.md"
+
     - name: Open rel-side amendment PR
       if: ${{ !inputs.dry_run }}
       id: rel-pr
@@ -356,39 +390,15 @@ jobs:
         delete-branch: false
 
     # --- Release body sync ---------------------------------------------
-    # Extract the `## [X.Y.Z]` section from the freshly-mutated
-    # rel-branch CHANGELOG and update the GitHub Release body. The
-    # extraction runs against the in-workflow checkout -- doesn't wait
-    # for the amendment PRs to merge, so the Release body reflects the
-    # amended state immediately.
+    # Section already extracted BEFORE peter-evans (see the Extract step
+    # in the rel-scope block). The extraction lives in ${RUNNER_TEMP}
+    # so it survives peter-evans's working-tree reset of rel-checkout/.
+    # These steps update the Release object using that pre-captured
+    # section content; run in order: body first, then attachment.
     #
-    # If no advisories matched (rel-checkout/CHANGELOG.md unchanged from
-    # what shipped), the extracted section is byte-identical to the
-    # current Release body and gh release edit is a no-op.
-    - name: Extract amended section from rel-branch CHANGELOG
-      id: extract
-      working-directory: rel-checkout
-      env:
-        VERSION: ${{ inputs.version }}
-      run: |
-        # Match `## [X.Y.Z]` heading (with optional link markup that
-        # ChangelogGenerator emits) and take everything up to the next
-        # `## ` heading or EOF. Escape dots in the version literal so
-        # awk doesn't treat them as regex any-char.
-        escaped_version=$(printf '%s' "${VERSION}" | sed 's/\./\\./g')
-        awk -v ver="${escaped_version}" '
-          BEGIN { in_section = 0 }
-          $0 ~ "^## \\[" ver "\\]" { in_section = 1; print; next }
-          in_section && /^## / { exit }
-          in_section { print }
-        ' CHANGELOG.md > "${RUNNER_TEMP}/section.md"
-        if [ ! -s "${RUNNER_TEMP}/section.md" ]; then
-          echo "::error::extracted section is empty; CHANGELOG.md may not contain a ## [${VERSION}] heading"
-          exit 1
-        fi
-        echo "section-path=${RUNNER_TEMP}/section.md" >> "$GITHUB_OUTPUT"
-        echo "Extracted $(wc -l < "${RUNNER_TEMP}/section.md") lines from CHANGELOG.md"
-
+    # If no advisories matched (extracted section byte-identical to
+    # what shipped), gh release edit is a user-visible no-op (updatedAt
+    # bumps but body content is unchanged).
     - name: Update GitHub Release body
       if: ${{ !inputs.dry_run }}
       env:


### PR DESCRIPTION
## Summary

Real dispatch of the amendment workflow on 8.2.0/rel-820 ([run 29397657588](https://github.com/openemr/openemr/actions/runs/29397657588)) surfaced a step-ordering bug: Release body + \`changelog.md\` attachment got overwritten with **pre-amendment** content instead of the mutator's amended output.

## Root cause

\`peter-evans/create-pull-request@v8\` resets the calling checkout's working tree back to base-branch HEAD after committing the diff to the amendment branch. In the previous step order:

1. Run rel-scope mutators → amends \`rel-checkout/CHANGELOG.md\`
2. Restore date → sed on amended file
3. Capture diff → sees \`changed=true\` ✓
4. **Open rel-side amendment PR (peter-evans)** → resets \`rel-checkout/\` back to rel-820 HEAD
5–9. ...master-scope steps run in workflow root (unaffected)...
10. Extract section → reads \`rel-checkout/CHANGELOG.md\`, now back to **pre-amendment** content
11. Update Release body → writes pre-amendment content
12. Sync attachment → uploads pre-amendment content

## Damage from the earlier dispatch

**Zero user-visible impact.** Release body + attachment got overwritten with essentially byte-identical pre-amendment content (differs from the previous devops-generated body only by a trailing newline). The Release page looks the same as before the dispatch.

The two amendment PRs (#13002 rel-820, #13003 master) DO contain the correct mutator output — peter-evans captured the diff BEFORE resetting the working tree, so the commits on the amendment branches have the amended content. Merging those PRs will correctly update CHANGELOG.md on both branches.

## Fix

Move the \"Extract amended section from rel-branch CHANGELOG\" step from after the master-scope block (was line 368) to right after \"Capture rel-scope diff\" (now line 268), BEFORE any peter-evans call. Extracted content lives in \`${RUNNER_TEMP}/section.md\` which survives peter-evans's working-tree reset (temp dir, not the rel-checkout).

Added comment explaining the ordering constraint at the Extract step and updated the Release-body-sync section's comment to reflect the new flow.

## Test plan

- [x] YAML lints (actionlint)
- [ ] After landing: re-dispatch amendment workflow on 8.2.0/rel-820 (real, not dry-run). Verify Release body now shows amended content (`### Security Fixes` block + `v8_1_0...v8_2_0` compare link) and \`changelog.md\` attachment matches.

## Follow-up

The two existing amendment PRs (#13002, #13003) contain the correct mutator output and can either merge as-is (before this fix lands) or be force-updated by the re-dispatch after this lands (idempotent since branch name is stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)