### PR TITLE
fix(release): remove rel-checkout before master peter-evans to prevent submodule leak

### DIFF
--- a/.github/workflows/release-amendment.yml
+++ b/.github/workflows/release-amendment.yml
@@ -314,6 +314,19 @@ jobs:
         committer: 'openemr-release-bot <release-bot@openemr.invalid>'
         delete-branch: false
 
+    # Remove rel-checkout before master steps run. rel-checkout is a
+    # sub-directory of the workflow root (master's git tree) with its
+    # own `.git/` from the rel-820 checkout. The master-scope
+    # peter-evans call runs `git add -A` at the workflow root, which
+    # treats any nested-git subdirectory as a submodule and adds a
+    # spurious `Subproject commit <sha>` entry to the amendment PR
+    # (observed in openemr/openemr#13003's first version). By this
+    # point Extract has already saved the section to $RUNNER_TEMP and
+    # rel-side peter-evans has captured its diff, so nothing else
+    # downstream reads from rel-checkout.
+    - name: Remove rel-checkout to keep it out of master's commit
+      run: rm -rf rel-checkout
+
     # --- Master amendment ----------------------------------------------
     - name: Install Composer dependencies (master)
       run: composer install --prefer-dist --no-progress --no-interaction


### PR DESCRIPTION
## Summary

First fully-successful end-to-end run of the amendment workflow ([run 29404476642](https://github.com/openemr/openemr/actions/runs/29404476642)) opened a correctly-scoped rel-side amendment PR #13002 — but the master-side sibling #13003 also picked up a spurious second file:

```
rel-checkout: +1 -0
@@ -0,0 +1 @@
+Subproject commit 6e8b26d8d555c29b7b6318c988cc1ce4219fb773
```

## Root cause

The workflow checks out rel-820 to `rel-checkout/` — a sub-directory of the workflow root, which is master's git tree. That checkout has its own `.git/`. When the master-scope peter-evans call runs `git add -A` at the workflow root, git treats any nested-git subdirectory as a submodule and adds a `Subproject commit <sha>` entry to the amendment PR.

rel-side peter-evans doesn't hit this because it uses `path: rel-checkout` which sets its git context to `rel-checkout/` itself — from there it doesn't see itself as a sibling submodule.

## Fix

`rm -rf rel-checkout` between the rel-side peter-evans call and the master-scope block. By that point:

- Extract has already saved the section to `$RUNNER_TEMP/section.md` (survives the delete)
- Rel-side peter-evans has captured its diff into the amendment branch

Nothing downstream reads from rel-checkout, so it's safe to delete.

## After landing

Re-dispatch amendment on 8.2.0/rel-820 → #13003 gets force-updated with just the `CHANGELOG.md` diff, spurious `rel-checkout` submodule entry goes away. #13002 stays no-op idempotent (already clean).

## Test plan
- [x] YAML lints (actionlint via pre-commit)
- [ ] Smoke test (openemr/openemr#13000) auto-fires on this PR — should pass; only touches workflow ordering, not the mutator invocation itself
- [ ] Post-land: re-dispatch amendment workflow, verify #13003 shows only `CHANGELOG.md` in its files list

🤖 Generated with [Claude Code](https://claude.com/claude-code)