### PR TITLE
fix(controllers): unify Controller::default_action() on string return

### DIFF
--- a/.phpstan/baseline/echo.nonString.php
+++ b/.phpstan/baseline/echo.nonString.php
@@ -184,11 +184,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/prior_auth/new.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/prior_auth/save.php',
 ];
 $ignoreErrors[] = [
@@ -209,22 +204,12 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/ros/new.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/ros/save.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/ros/view.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/soap/new.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
@@ -245,16 +230,6 @@ $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/vitals/growthchart/chart.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/vitals/new.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/vitals/view.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -27,11 +27,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../controllers/C_Document.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method C_Document\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_Document.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method C_Document\\:\\:document_send\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../controllers/C_Document.class.php',
@@ -58,11 +53,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method C_Document\\:\\:isReturnRetrieveKey\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_Document.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_Document\\:\\:list_action\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../controllers/C_Document.class.php',
 ];
@@ -142,11 +132,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../controllers/C_DocumentCategory.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method C_DocumentCategory\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_DocumentCategory.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method C_DocumentCategory\\:\\:delete_node_action_process\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../controllers/C_DocumentCategory.class.php',
@@ -162,24 +147,9 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../controllers/C_DocumentCategory.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method C_DocumentCategory\\:\\:list_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_DocumentCategory.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_Hl7\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_Hl7.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method C_Hl7\\:\\:default_action_process\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../controllers/C_Hl7.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_InsuranceCompany\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_InsuranceCompany.class.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method C_InsuranceCompany\\:\\:edit_action\\(\\) has no return type specified\\.$#',
@@ -192,16 +162,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../controllers/C_InsuranceCompany.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method C_InsuranceCompany\\:\\:list_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_InsuranceCompany.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_InsuranceNumbers\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_InsuranceNumbers.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method C_InsuranceNumbers\\:\\:edit_action\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../controllers/C_InsuranceNumbers.class.php',
@@ -210,21 +170,6 @@ $ignoreErrors[] = [
     'message' => '#^Method C_InsuranceNumbers\\:\\:edit_action_process\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../controllers/C_InsuranceNumbers.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_InsuranceNumbers\\:\\:list_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_InsuranceNumbers.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_PatientFinder\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_PatientFinder.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_PatientFinder\\:\\:find_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_PatientFinder.class.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method C_PatientFinder\\:\\:find_action_process\\(\\) has no return type specified\\.$#',
@@ -247,11 +192,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../controllers/C_PatientFinder.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method C_Pharmacy\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_Pharmacy.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method C_Pharmacy\\:\\:edit_action\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../controllers/C_Pharmacy.class.php',
@@ -260,16 +200,6 @@ $ignoreErrors[] = [
     'message' => '#^Method C_Pharmacy\\:\\:edit_action_process\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../controllers/C_Pharmacy.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_Pharmacy\\:\\:list_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_Pharmacy.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_PracticeSettings\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_PracticeSettings.class.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method C_PracticeSettings\\:\\:document_action\\(\\) has no return type specified\\.$#',
@@ -467,22 +397,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../controllers/C_Prescription.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method C_X12Partner\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_X12Partner.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method C_X12Partner\\:\\:edit_action\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../controllers/C_X12Partner.class.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method C_X12Partner\\:\\:edit_action_process\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../controllers/C_X12Partner.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_X12Partner\\:\\:list_action\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../controllers/C_X12Partner.class.php',
 ];
@@ -1502,11 +1422,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/newpatient/C_EncounterVisitForm.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method C_FormPriorAuth\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/prior_auth/C_FormPriorAuth.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method C_FormPriorAuth\\:\\:default_action_process\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/prior_auth/C_FormPriorAuth.class.php',
@@ -1605,11 +1520,6 @@ $ignoreErrors[] = [
     'message' => '#^Function deleteSpecimen\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/procedure_order/handle_deletions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_FormROS\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/ros/C_FormROS.class.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method C_FormROS\\:\\:default_action_process\\(\\) has no return type specified\\.$#',
@@ -3052,11 +2962,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/ros/FormROS.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method C_FormSOAP\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/soap/C_FormSOAP.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method C_FormSOAP\\:\\:default_action_process\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/soap/C_FormSOAP.class.php',
@@ -3170,11 +3075,6 @@ $ignoreErrors[] = [
     'message' => '#^Method FormSOAP\\:\\:toString\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/soap/FormSOAP.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_FormVitals\\:\\:default_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/vitals/C_FormVitals.class.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method C_FormVitals\\:\\:default_action_process\\(\\) has no return type specified\\.$#',
@@ -9158,11 +9058,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method Controller\\:\\:_link\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Controller.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method Controller\\:\\:default_action\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Controller.class.php',
 ];

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -424,7 +424,7 @@ class C_Document extends Controller
         return $this->view_action($patient_id, $n->get_foreign_id());
     }
 
-    public function default_action()
+    public function default_action(): string
     {
         return $this->list_action();
     }
@@ -1124,7 +1124,7 @@ class C_Document extends Controller
         return $this->view_action($patient_id, $document_id);
     }
 
-    public function list_action($patient_id = "")
+    public function list_action($patient_id = ""): string
     {
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
         $this->_last_node = null;

--- a/controllers/C_DocumentCategory.class.php
+++ b/controllers/C_DocumentCategory.class.php
@@ -29,12 +29,12 @@ class C_DocumentCategory extends Controller
         $this->tree = $t;
     }
 
-    function default_action()
+    function default_action(): string
     {
         return $this->list_action();
     }
 
-    function list_action()
+    function list_action(): string
     {
         //$this->tree->rebuild_tree(1,1);
 

--- a/controllers/C_Hl7.class.php
+++ b/controllers/C_Hl7.class.php
@@ -21,10 +21,11 @@ class C_Hl7 extends Controller
         $this->assign("STYLE", OEGlobalsBag::getInstance()->get('style'));
     }
 
-    function default_action()
+    function default_action(): string
     {
         return $this->fetch(OEGlobalsBag::getInstance()->get('template_dir') . "hl7/" . $this->template_mod . "_parse.html");
     }
+
     function default_action_process()
     {
         $msg = '';

--- a/controllers/C_InsuranceCompany.class.php
+++ b/controllers/C_InsuranceCompany.class.php
@@ -22,7 +22,7 @@ class C_InsuranceCompany extends Controller
         $this->InsuranceCompany = new InsuranceCompany();
     }
 
-    public function default_action()
+    public function default_action(): string
     {
         return $this->list_action();
     }
@@ -40,7 +40,7 @@ class C_InsuranceCompany extends Controller
         return $this->fetch(OEGlobalsBag::getInstance()->get('template_dir') . "insurance_companies/" . $this->template_mod . "_edit.html");
     }
 
-    public function list_action()
+    public function list_action(): string
     {
         $twig = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
 

--- a/controllers/C_InsuranceNumbers.class.php
+++ b/controllers/C_InsuranceNumbers.class.php
@@ -27,7 +27,7 @@ class C_InsuranceNumbers extends Controller
         $this->assign("STYLE", OEGlobalsBag::getInstance()->get('style'));
     }
 
-    function default_action()
+    function default_action(): string
     {
         return $this->list_action();
     }
@@ -101,7 +101,7 @@ class C_InsuranceNumbers extends Controller
         return $this->fetch(OEGlobalsBag::getInstance()->get('template_dir') . "insurance_numbers/" . $this->template_mod . "_edit.html");
     }
 
-    function list_action()
+    function list_action(): string
     {
 
         $p = new Provider();

--- a/controllers/C_PatientFinder.class.php
+++ b/controllers/C_PatientFinder.class.php
@@ -16,7 +16,7 @@ class C_PatientFinder extends Controller
         $this->assign("STYLE", OEGlobalsBag::getInstance()->get('style'));
     }
 
-    function default_action($form_id = '', $form_name = '', $pid = '')
+    function default_action($form_id = '', $form_name = '', $pid = ''): string
     {
         return $this->find_action($form_id, $form_name, $pid);
     }
@@ -25,7 +25,7 @@ class C_PatientFinder extends Controller
     * Function that will display a patient finder widget, allowing
     *   the user to input search parameters to find a patient id.
     */
-    function find_action($form_id, $form_name, $pid = null)
+    function find_action($form_id, $form_name, $pid = null): string
     {
         $isPid = false;
 

--- a/controllers/C_Pharmacy.class.php
+++ b/controllers/C_Pharmacy.class.php
@@ -31,7 +31,7 @@ class C_Pharmacy extends Controller
         $this->pageno = $this->Pharmacy->getPageno();
     }
 
-    function default_action()
+    function default_action(): string
     {
         return $this->list_action();
     }
@@ -51,11 +51,9 @@ class C_Pharmacy extends Controller
         return $this->fetch(OEGlobalsBag::getInstance()->get('template_dir') . "pharmacies/" . $this->template_mod . "_edit.html");
     }
 
-    function list_action()
+    function list_action(): string
     {
         $this->assign("pharmacies", $this->Pharmacy->pharmacies_factory());
-
-        //print_r(Prescription::prescriptions_factory($id));
         return $this->fetch(OEGlobalsBag::getInstance()->get('template_dir') . "pharmacies/" . $this->template_mod . "_list.html");
     }
 

--- a/controllers/C_PracticeSettings.class.php
+++ b/controllers/C_PracticeSettings.class.php
@@ -1,5 +1,17 @@
 <?php
 
+/**
+ * Practice Settings controller.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    OpenEMR contributors
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) OpenEMR contributors
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 use OpenEMR\Core\OEGlobalsBag;
 
 class C_PracticeSettings extends Controller
@@ -15,11 +27,11 @@ class C_PracticeSettings extends Controller
         $this->direction = (OEGlobalsBag::getInstance()->get('_SESSION')['language_direction'] == 'rtl') ? 'right' : 'left';
     }
 
-    function default_action($display = "")
+    function default_action($display = ""): string
     {
         $this->assign("display", $display);
         $this->assign("direction", $this->direction);
-        $this->display(OEGlobalsBag::getInstance()->get('template_dir') . "practice_settings/" . $this->template_mod . "_list.html");
+        return $this->fetch(OEGlobalsBag::getInstance()->get('template_dir') . "practice_settings/" . $this->template_mod . "_list.html");
     }
 
     function pharmacy_action($arg)
@@ -31,7 +43,7 @@ class C_PracticeSettings extends Controller
         $this->assign("direction", $this->direction);
         $display = $c->dispatch($params);
         $this->assign("ACTION_NAME", xl("Pharmacies"));
-        $this->default_action($display);
+        return $this->default_action($display);
     }
 
     function insurance_company_action($arg)
@@ -43,7 +55,7 @@ class C_PracticeSettings extends Controller
         $display = $c->dispatch($params);
         $this->assign("direction", $this->direction);
         $this->assign("ACTION_NAME", xl("Insurance Companies"));
-        $this->default_action($display);
+        return $this->default_action($display);
     }
 
     function insurance_numbers_action($arg)
@@ -55,7 +67,7 @@ class C_PracticeSettings extends Controller
         $display = $c->dispatch($params);
         $this->assign("ACTION_NAME", xl("Insurance Numbers"));
         $this->assign("direction", $this->direction);
-        $this->default_action($display);
+        return $this->default_action($display);
     }
 
     function document_action($arg)
@@ -67,7 +79,7 @@ class C_PracticeSettings extends Controller
         $display = $c->dispatch($params);
         $this->assign("ACTION_NAME", xl("Documents"));
         $this->assign("direction", $this->direction);
-        $this->default_action($display);
+        return $this->default_action($display);
     }
 
     function document_category_action($arg)
@@ -79,7 +91,7 @@ class C_PracticeSettings extends Controller
         $display = $c->dispatch($params);
         $this->assign("ACTION_NAME", xl("Documents"));
         $this->assign("direction", $this->direction);
-        $this->default_action($display);
+        return $this->default_action($display);
     }
 
     function x12_partner_action($arg)
@@ -91,7 +103,7 @@ class C_PracticeSettings extends Controller
         $display = $c->dispatch($params);
         $this->assign("ACTION_NAME", xl("X12 Partners"));
         $this->assign("direction", $this->direction);
-        $this->default_action($display);
+        return $this->default_action($display);
     }
 
 
@@ -104,6 +116,6 @@ class C_PracticeSettings extends Controller
         $display = $c->dispatch($params);
         $this->assign("ACTION_NAME", xl("HL7 Viewer"));
         $this->assign("direction", $this->direction);
-        $this->default_action($display);
+        return $this->default_action($display);
     }
 }

--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -120,7 +120,7 @@ class C_Prescription extends Controller
         }
     }
 
-    function default_action(): void
+    function default_action(): string
     {
         $prescription = $this->prescriptions[0];
         $this->assign("prescription", $prescription);
@@ -136,7 +136,7 @@ class C_Prescription extends Controller
             $vars['amcCollectReturnControlledSubstances'] = amcCollect('e_prescribe_cont_subst_amc', $prescription->patient->id, 'prescriptions', $prescription->id);
         }
         $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig();
-        echo $twig->render("prescription/" . $this->template_mod . "_edit.html.twig", $vars);
+        return $twig->render("prescription/" . $this->template_mod . "_edit.html.twig", $vars);
     }
 
     function edit_action($id = "", $patient_id = "")
@@ -170,7 +170,7 @@ class C_Prescription extends Controller
         $isNewPrescription = empty($this->prescriptions[0]->id);
         $this->assign("isNewPrescription", $isNewPrescription);
 
-        $this->default_action();
+        return $this->default_action();
     }
 
     function list_action($id, $sort = "", $printPrescriptionId = null)

--- a/controllers/C_X12Partner.class.php
+++ b/controllers/C_X12Partner.class.php
@@ -30,7 +30,7 @@ class C_X12Partner extends Controller
         $this->assign("STYLE", OEGlobalsBag::getInstance()->get('style'));
     }
 
-    function default_action()
+    function default_action(): string
     {
         return $this->list_action();
     }
@@ -56,9 +56,8 @@ class C_X12Partner extends Controller
         return $this->fetch(OEGlobalsBag::getInstance()->get('template_dir') . "x12_partners/" . $this->template_mod . "_edit.html");
     }
 
-    function list_action()
+    function list_action(): string
     {
-
         $x = new X12Partner();
         $this->assign("partners", $x->x12_partner_factory());
         return $this->fetch(OEGlobalsBag::getInstance()->get('template_dir') . "x12_partners/" . $this->template_mod . "_list.html");

--- a/interface/clickmap/C_AbstractClickmap.php
+++ b/interface/clickmap/C_AbstractClickmap.php
@@ -108,7 +108,7 @@ abstract class C_AbstractClickmap extends Controller
      * @brief generate an html document from the 'new form' template
      * @return string
      */
-    function default_action()
+    function default_action(): string
     {
         $model = $this->createModel();
         $this->assign("form", $model);

--- a/interface/forms/prior_auth/C_FormPriorAuth.class.php
+++ b/interface/forms/prior_auth/C_FormPriorAuth.class.php
@@ -34,7 +34,7 @@ class C_FormPriorAuth extends Controller
         $this->assign("CSRF_TOKEN_FORM", CsrfUtils::collectCsrfToken(session: $session));
     }
 
-    function default_action()
+    function default_action(): string
     {
         $prior_auth = new FormPriorAuth();
         $this->assign("prior_auth", $prior_auth);

--- a/interface/forms/ros/C_FormROS.class.php
+++ b/interface/forms/ros/C_FormROS.class.php
@@ -39,7 +39,7 @@ class C_FormROS extends Controller
         $this->assign("CSRF_TOKEN_FORM", CsrfUtils::collectCsrfToken(session: $session));
     }
 
-    function default_action()
+    function default_action(): string
     {
         $ros = new FormROS();
         $this->assign("form", $ros);

--- a/interface/forms/soap/C_FormSOAP.class.php
+++ b/interface/forms/soap/C_FormSOAP.class.php
@@ -32,7 +32,7 @@ class C_FormSOAP extends Controller
      * @throws \Twig\Error\SyntaxError
      * @throws \Twig\Error\LoaderError
      */
-    function default_action()
+    function default_action(): string
     {
         $form = new FormSOAP();
         return $this->twig->getTwig()->render(

--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -58,7 +58,7 @@ class C_FormVitals
         $this->form_id = $form_id;
     }
 
-    public function default_action()
+    public function default_action(): string
     {
         $vitalsService = new VitalsService();
         $vitalsService->setShouldConvertVitalMeasurementsFlag(false);
@@ -387,7 +387,7 @@ class C_FormVitals
         ];
         $twig = (new TwigContainer($this->template_dir, OEGlobalsBag::getInstance()->getKernel()))->getTwig();
 
-        echo $twig->render("vitals.html.twig", $data);
+        return $twig->render("vitals.html.twig", $data);
     }
 
     private function get_interpretation_list_options()

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -85,14 +85,14 @@ class Controller extends Smarty implements ControllerInterface
          $this->_current_action = $action;
     }
 
-    public function default_action()
+    public function default_action(): string
     {
-         echo "<html><body></body></html>";
+         return "<html><body></body></html>";
     }
 
     public function process_action()
     {
-         $this->default_action();
+         echo $this->default_action();
     }
 
     public function populate_object(&$obj)


### PR DESCRIPTION
Unifies `Controller::default_action()` on a `string` return type across the entire controller hierarchy.

## Why

Most subclasses already returned their rendered HTML — the `dispatch()`/`act()` router captures the return value and echoes it. But the base `Controller`, `C_PracticeSettings`, `C_Prescription`, and `C_FormVitals` echoed internally and returned `void`. Typing the string-returning children while the base stayed `void` produced `method.childReturnType` covariance errors (a `string` override cannot narrow a `void` parent), and echoing `C_FormVitals`'s `void` result at its entry scripts produced `method.void`.

There is no native type spanning "echoes/void" and "returns string", so the hierarchy commits to the discipline the router already expects: `default_action()` returns the HTML and the caller echoes it.

## What

- The four `void` holdouts now return their rendered markup (`C_PracticeSettings` switches `display()` → `fetch()`).
- The internal non-echo callers consume the return value: `Controller::process_action()` echoes it, `C_Prescription::edit_action()` and the seven `C_PracticeSettings` sub-action delegators return it so `dispatch()` captures it.
- Baseline entries resolved by the newly typed methods are dropped.

Output is byte-for-byte identical — the internal echoes move to the callers that already echo (`controller.php`, the form entry scripts).

Verified at PHPStan level 10 on the full codebase: the `default_action` covariance and `method.void` findings are gone with no new errors introduced.