### PR TITLE
chore(rector): analyze all phpstan-covered paths

### DIFF
--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -7522,11 +7522,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/therapy_groups/therapy_groups_models/therapy_groups_participants_model.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function do_visit_form\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../ippf_upgrade.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method ESign\\\\Abstract_Configuration\\:\\:getBaseUrl\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/ESign/Abstract/Configuration.php',

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -23,7 +23,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Variable \\$dbase might not be defined\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../admin.php',
 ];
 $ignoreErrors[] = [

--- a/admin.php
+++ b/admin.php
@@ -77,10 +77,10 @@ function adminSqlQuery($statement, $link)
                             die("Cannot read directory '$OE_SITES_BASE'.");
                         }
 
-                        $siteslist = array();
+                        $siteslist = [];
 
                         while (false !== ($sfname = readdir($dh))) {
-                            if (substr($sfname, 0, 1) == '.') {
+                            if (str_starts_with($sfname, '.')) {
                                 continue;
                             }
 
@@ -113,6 +113,7 @@ function adminSqlQuery($statement, $link)
 
                         // Access the site's database.
                             include "$sitedir/sqlconf.php";
+                            $dbase = is_string($dbase) ? $dbase : '';
 
                             if ($config) {
                                 $dbh = mysqli_connect("$host", "$login", "$pass", $dbase, $port);
@@ -131,7 +132,7 @@ function adminSqlQuery($statement, $link)
                             } else {
                                 // Get site name for display.
                                 $row = adminSqlQuery("SELECT gl_value FROM globals WHERE gl_name = 'openemr_name' LIMIT 1", $dbh);
-                                $openemr_name = $row ? $row['gl_value'] : '';
+                                $openemr_name = is_string($row['gl_value'] ?? null) ? $row['gl_value'] : '';
 
                                 // Get version indicators from the database.
                                 $row = adminSqlQuery("SHOW TABLES LIKE 'version'", $dbh);

--- a/ippf_upgrade.php
+++ b/ippf_upgrade.php
@@ -24,7 +24,7 @@ $insert_count = 0;
 // Create a visit form from an abortion issue.  This may be called
 // multiple times for a given issue.
 //
-function do_visit_form($irow, $encounter, $first)
+function do_visit_form($irow, $encounter, $first): void
 {
     global $insert_count, $debug, $verbose;
 
@@ -39,13 +39,13 @@ function do_visit_form($irow, $encounter, $first)
         return;
     }
 
-    $a = array(
+    $a = [
     'client_status' => $irow['client_status'],
     'in_ab_proc'    => $irow['in_ab_proc'],
     'ab_location'   => $irow['ab_location'],
     'complications' => $irow['fol_compl'],
     'contrameth'    => $irow['contrameth'],
-    );
+    ];
 
   // logic that applies only to the first related visit
     if ($first) {
@@ -118,6 +118,7 @@ function do_visit_form($irow, $encounter, $first)
                 $trow = sqlQuery("SHOW CREATE DATABASE $dbase");
                 array_shift($trow);
                 $value = array_shift($trow);
+                $value = is_string($value) ? $value : '';
                 if (!preg_match('/SET utf8/', $value)) {
                     echo "<br />Converting database to UTF-8 encoding...";
                     $tres = sqlStatement("SHOW TABLES");

--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@ use OpenEMR\Rector\Rules\OEGlobalsBagTypedGettersRector;
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
 use Rector\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector;
+use Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector;
 use Rector\CodingStyle\Rector\FuncCall\CallUserFuncArrayToVariadicRector;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
@@ -18,23 +19,39 @@ return RectorConfig::configure()
     ->withBootstrapFiles([
         __DIR__ . '/rector-bootstrap.php',
     ])
+    // Keep this list aligned with the paths in phpstan.neon.dist.
     ->withPaths([
         __DIR__ . '/Documentation',
+        __DIR__ . '/_rest_routes.inc.php',
+        __DIR__ . '/acl_upgrade.php',
+        __DIR__ . '/admin.php',
         __DIR__ . '/apis',
         __DIR__ . '/ccdaservice',
         __DIR__ . '/ccr',
+        __DIR__ . '/cli',
+        __DIR__ . '/config',
         __DIR__ . '/contrib',
+        __DIR__ . '/controller.php',
         __DIR__ . '/controllers',
         __DIR__ . '/custom',
         __DIR__ . '/gacl',
+        __DIR__ . '/index.php',
         __DIR__ . '/interface',
+        __DIR__ . '/ippf_upgrade.php',
         __DIR__ . '/library',
         __DIR__ . '/oauth2',
         __DIR__ . '/portal',
+        __DIR__ . '/setup.php',
         __DIR__ . '/sites',
         __DIR__ . '/sphere',
+        __DIR__ . '/sql_patch.php',
+        __DIR__ . '/sql_upgrade.php',
         __DIR__ . '/src',
+        __DIR__ . '/templates',
         __DIR__ . '/tests',
+        __DIR__ . '/tools/release/bin',
+        __DIR__ . '/tools/release/src',
+        __DIR__ . '/version.php',
     ])
     // oe-module-claimrev-connect is a Composer dependency
     // (claimrevolution/oe-module-claimrev-connect), relocated into this path by
@@ -43,6 +60,13 @@ return RectorConfig::configure()
     // vendor/ is skipped.
     ->withSkip([
         __DIR__ . '/interface/modules/custom_modules/oe-module-claimrev-connect',
+        // The Firehed container compiler inlines closure source code into the
+        // compiled container; first-class callables have no closure body to
+        // extract, so this rule breaks container compilation for definitions
+        // under config/.
+        ArrowFunctionDelegatingCallToFirstClassCallableRector::class => [
+            __DIR__ . '/config',
+        ],
     ])
     ->withCache(
         // ensure file system caching is used instead of in-memory

--- a/templates/super/rules/controllers/detail/view.php
+++ b/templates/super/rules/controllers/detail/view.php
@@ -39,7 +39,7 @@ $rule = $viewBean->rule ?>
                class="action_link" id="edit_summary" onclick="top.restoreSession()">(<?php echo xlt('edit'); ?>)</a>
         </p>
         <p><b><?php echo xlt($rule->title); ?></b>
-        (<?php echo Common::implode_funcs(", ", $rule->getRuleTypeLabels(), array('xlt')); ?>)
+        (<?php echo Common::implode_funcs(", ", $rule->getRuleTypeLabels(), ['xlt']); ?>)
         </p>
         <p><b><?php echo xlt('Bibliographic Citation'); ?>:</b>&nbsp;<?php echo text($rule->bibliographic_citation); ?></p>
         <p><b><?php echo xlt('Developer'); ?>:</b>&nbsp;<?php echo text($rule->developer); ?></p>

--- a/templates/super/rules/controllers/edit/action.php
+++ b/templates/super/rules/controllers/edit/action.php
@@ -55,34 +55,34 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleTemplateExtension;
         <!-- category -->
         <?php
         $change_link = '<a href="javascript:;" id="change_category" onclick="top.restoreSession();">(' . xlt('Change') . ')</a>';
-        echo RuleTemplateExtension::textfield_row(array("id" => "fld_category_lbl",
+        echo RuleTemplateExtension::textfield_row(["id" => "fld_category_lbl",
             "name" => "fld_category_lbl",
             "title" => xl("Category"),
             "value" => $action->getCategoryLabel(),
-            "render_link" => $change_link)); ?>
+            "render_link" => $change_link]); ?>
         <input type="hidden" id="fld_category" name="fld_category" value="<?php echo attr($action->category); ?>" />
 
         <!-- item -->
         <?php
         $change_link = '<a href="javascript:;" id="change_item" onclick="top.restoreSession();">(' . xlt('Change') . ')</a>';
-        echo RuleTemplateExtension::textfield_row(array("id" => "fld_item_lbl",
+        echo RuleTemplateExtension::textfield_row(["id" => "fld_item_lbl",
             "name" => "fld_item_lbl",
             "title" => xl("Item"),
             "value" => $action->getItemLabel(),
-            "render_link" => $change_link)); ?>
+            "render_link" => $change_link]); ?>
         <input type="hidden" id="fld_item" name="fld_item" value="<?php echo attr($action->item); ?>" />
 
         <!-- reminder link  -->
-        <?php echo RuleTemplateExtension::textfield_row(array("id" => "fld_link",
+        <?php echo RuleTemplateExtension::textfield_row(["id" => "fld_link",
             "name" => "fld_link",
             "title" => xl("Link"),
-            "value" => $action->reminderLink)); ?>
+            "value" => $action->reminderLink]); ?>
 
         <!-- reminder message  -->
-        <?php echo RuleTemplateExtension::textfield_row(array("id" => "fld_message",
+        <?php echo RuleTemplateExtension::textfield_row(["id" => "fld_message",
             "name" => "fld_message",
             "title" => xl("Message"),
-            "value" => $action->reminderMessage)); ?>
+            "value" => $action->reminderMessage]); ?>
 
 
         <!-- custom rules input -->

--- a/templates/super/rules/controllers/edit/age.php
+++ b/templates/super/rules/controllers/edit/age.php
@@ -25,7 +25,7 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleTemplateExtension;
 <p class="form-row">
     <span class="left_col colhead req" data-fld="fld_timeunit"><?php echo xlt('Unit');?></span>
     <span class="end_col">
-    <?php echo RuleTemplateExtension::timeunit_select(array( "context" => "rule_age_intervals", "target" => "fld_target_interval_type", "name" => "fld_target_interval_type", "value" => $criteria->timeUnit )); ?>
+    <?php echo RuleTemplateExtension::timeunit_select([ "context" => "rule_age_intervals", "target" => "fld_target_interval_type", "name" => "fld_target_interval_type", "value" => $criteria->timeUnit ]); ?>
     </span>
 </p>
 
@@ -34,4 +34,4 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleTemplateExtension;
 <br/>
 
 <!-- optional/required and inclusion/exclusion fields -->
-<?php echo RuleTemplateExtension::common_fields(array( "criteria" => $criteria)); ?>
+<?php echo RuleTemplateExtension::common_fields([ "criteria" => $criteria]); ?>

--- a/templates/super/rules/controllers/edit/bucket.php
+++ b/templates/super/rules/controllers/edit/bucket.php
@@ -28,21 +28,21 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleTemplateExtension;
 <!-- category -->
 <?php
 $change_link = '<a href="javascript:;" id="change_category" onclick="top.restoreSession();">(' . xlt('Change') . ')</a>';
-echo RuleTemplateExtension::textfield_row(array("id" => "fld_category_lbl",
+echo RuleTemplateExtension::textfield_row(["id" => "fld_category_lbl",
     "name" => "fld_category_lbl",
     "title" => xl("Category"),
     "value" => $criteria->getCategoryLabel(),
-    "render_link" => $change_link)); ?>
+    "render_link" => $change_link]); ?>
 <input type="hidden" id="fld_category" name="fld_category" value="<?php echo attr($criteria->category); ?>" />
 
 <!-- item -->
 <?php
 $change_link = '<a href="javascript:;" id="change_item" onclick="top.restoreSession();">(' . xlt('Change') . ')</a>';
-echo RuleTemplateExtension::textfield_row(array("id" => "fld_item_lbl",
+echo RuleTemplateExtension::textfield_row(["id" => "fld_item_lbl",
     "name" => "fld_item_lbl",
     "title" => xl("Item"),
     "value" => $criteria->getItemLabel(),
-    "render_link" => $change_link)); ?>
+    "render_link" => $change_link]); ?>
 <input type="hidden" id="fld_item" name="fld_item" value="<?php echo attr($criteria->item); ?>" />
 
 <!-- completed -->
@@ -80,4 +80,4 @@ echo RuleTemplateExtension::textfield_row(array("id" => "fld_item_lbl",
     <br />
 
     <!-- optional/required and inclusion/exclusion fields -->
-    <?php echo RuleTemplateExtension::common_fields(array("criteria" => $criteria)); ?>
+    <?php echo RuleTemplateExtension::common_fields(["criteria" => $criteria]); ?>

--- a/templates/super/rules/controllers/edit/custom.php
+++ b/templates/super/rules/controllers/edit/custom.php
@@ -29,11 +29,11 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleTemplateExtension;
 <p class="form-row">
     <span class="left_col colhead req" data-field="fld_table"><?php echo xlt('Table'); ?></span>
     <span class="end_col">
-        <?php echo RuleTemplateExtension::render_select(array( "id"       =>  "fld_table",
+        <?php echo RuleTemplateExtension::render_select([ "id"       =>  "fld_table",
                                          "target"   =>  "fld_table",
                                          "name"     =>  "fld_table",
                                          "options"  =>  $criteria->getTableNameOptions(),
-                                         "value"    =>  $criteria->table)); ?>
+                                         "value"    =>  $criteria->table]); ?>
     </span>
 </p>
 
@@ -41,11 +41,11 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleTemplateExtension;
 <p class="form-row">
     <span class="left_col colhead" data-field="fld_table"><?php echo xlt('Column'); ?></span>
     <span class="end_col">
-        <?php echo RuleTemplateExtension::render_select(array( "id"       =>  "fld_column",
+        <?php echo RuleTemplateExtension::render_select([ "id"       =>  "fld_column",
                                          "target"   =>  "fld_column",
                                          "name"     =>  "fld_column",
-                                         "options"  =>  array(),
-                                         "value"    =>  null )); ?>
+                                         "options"  =>  [],
+                                         "value"    =>  null ]); ?>
     </span>
 </p>
 
@@ -88,4 +88,4 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleTemplateExtension;
 <br/>
 
 <!-- optional/required and inclusion/exclusion fields -->
-<?php echo RuleTemplateExtension::common_fields(array( "criteria" => $criteria)); ?>
+<?php echo RuleTemplateExtension::common_fields([ "criteria" => $criteria]); ?>

--- a/templates/super/rules/controllers/edit/intervals.php
+++ b/templates/super/rules/controllers/edit/intervals.php
@@ -61,7 +61,7 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleTemplateExtension;
                 <input class="form-control" data-grp-tgt="<?php echo attr($type->code) ?>" type="text" name="<?php echo attr($type->code); ?>-<?php echo attr($range->code); ?>" value="<?php echo is_null($detail) ? "" : attr($detail->amount); ?>" />
             </span>
             <span class="end_col">
-            <?php echo RuleTemplateExtension::timeunit_select(array( "context" => "rule_reminder_intervals", "target" => $type->code, "name" => $type->code . "-" . $range->code . "-timeunit", "value" => $detail->timeUnit ?? null )); ?>
+            <?php echo RuleTemplateExtension::timeunit_select([ "context" => "rule_reminder_intervals", "target" => $type->code, "name" => $type->code . "-" . $range->code . "-timeunit", "value" => $detail->timeUnit ?? null ]); ?>
             </span>
         </p>
             <?php $first = false; ?>

--- a/templates/super/rules/controllers/edit/lifestyle.php
+++ b/templates/super/rules/controllers/edit/lifestyle.php
@@ -18,10 +18,10 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleTemplateExtension;
 <p class="form-row">
     <span class="left_col colhead req" data-fld="fld_lifestyle"><?php echo text($criteria->getTitle()); ?></span>
     <span class="end_col">
-    <?php echo RuleTemplateExtension::render_select(array( "target"   =>  "fld_lifestyle",
+    <?php echo RuleTemplateExtension::render_select([ "target"   =>  "fld_lifestyle",
                                      "name"     =>  "fld_lifestyle",
                                      "value"    =>  $criteria->type,
-                                     "options"  =>  $criteria->getOptions() )); ?>
+                                     "options"  =>  $criteria->getOptions() ]); ?>
     </span>
 </p>
 
@@ -47,4 +47,4 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleTemplateExtension;
 <br/>
 
 <!-- optional/required and inclusion/exclusion fields -->
-<?php echo RuleTemplateExtension::common_fields(array( "criteria" => $criteria)); ?>
+<?php echo RuleTemplateExtension::common_fields([ "criteria" => $criteria]); ?>

--- a/templates/super/rules/controllers/edit/sex.php
+++ b/templates/super/rules/controllers/edit/sex.php
@@ -18,14 +18,14 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleTemplateExtension;
 <p class="form-row">
     <span class="left_col colhead req" data-fld="fld_sex"><?php echo xlt('Sex');?></span>
     <span class="end_col">
-    <?php echo RuleTemplateExtension::render_select(array( "target"   =>  "fld_sex",
+    <?php echo RuleTemplateExtension::render_select([ "target"   =>  "fld_sex",
                                      "name"     =>  "fld_sex",
                                      "value"    =>  $criteria->value,
-                                     "options"  =>  $criteria->getOptions() )); ?>
+                                     "options"  =>  $criteria->getOptions() ]); ?>
     </span>
 </p>
 
 <br/>
 
 <!-- optional/required and inclusion/exclusion fields -->
-<?php echo RuleTemplateExtension::common_fields(array( "criteria" => $criteria)); ?>
+<?php echo RuleTemplateExtension::common_fields([ "criteria" => $criteria]); ?>

--- a/templates/super/rules/controllers/edit/simple_text_criteria.php
+++ b/templates/super/rules/controllers/edit/simple_text_criteria.php
@@ -26,4 +26,4 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleTemplateExtension;
 
 
 <!-- optional/required and inclusion/exclusion fields -->
-<?php echo RuleTemplateExtension::common_fields(array( "criteria" => $criteria)); ?>
+<?php echo RuleTemplateExtension::common_fields([ "criteria" => $criteria]); ?>


### PR DESCRIPTION
## What

Aligns `rector.php`'s `withPaths` with the path list in `phpstan.neon.dist`, adding the root-level entry-point files (`admin.php`, `index.php`, `setup.php`, …), `cli/`, `config/`, `templates/`, `tools/release/{bin,src}`, and `version.php` — then applies the resulting rector fixes.

## Why

The rector path list has been frozen since rector was introduced (#8463) and enumerates only a subset of top-level directories, even though all of these paths existed then and are analyzed by PHPStan. CI's rector job therefore never saw them and rector debt accumulated there silently. (It surfaced via the pre-commit rector hook, which passes filenames explicitly and thereby overrides `withPaths`.) A comment now ties the two path lists together.

## Notes

- `ArrowFunctionDelegatingCallToFirstClassCallableRector` is skipped for `config/`: the Firehed container compiler inlines closure source code into the compiled container, and first-class callables have no closure body to extract, so that rewrite breaks container compilation at runtime.
- Rector's `(string)` casts on `mixed` values are replaced with `is_string()` narrowing to satisfy phpstan's `cast.string`; the phpstan baseline is regenerated for the entries rector legitimately fixed (net −35 lines).

Verified locally: `composer phpstan`, `composer rector-check`, and the isolated test suite all pass.