### PR TITLE
fix(rector): scan non-autoloaded class dirs for stable type inference

### DIFF
--- a/.phpstan/rector-scan.neon
+++ b/.phpstan/rector-scan.neon
@@ -1,0 +1,24 @@
+# Symbol discovery for rector runs that receive explicit file paths.
+#
+# Classes in these directories are not registered with the composer
+# autoloader: Laminas modules load via the module manager, and the
+# Phreeze/gacl/rulesets/ClinicalTypes classes are loaded by legacy
+# includes (rulesets is excluded from the composer classmap because it
+# contains duplicate unnamespaced class names). A full `rector process`
+# run discovers them anyway because they sit inside withPaths, but
+# hook-style runs that pass explicit filenames (pre-commit) never parse
+# these directories, so references to their classes degrade to mixed and
+# rules like NullToStrictStringFuncCallArgRector insert spurious casts.
+# Scanning keeps symbol discovery complete for any invocation shape.
+parameters:
+    scanDirectories:
+        - ../controllers
+        - ../custom
+        - ../gacl
+        - ../interface/modules/zend_modules
+        - ../library/classes/ClinicalTypes
+        - ../library/classes/rulesets
+        # Only verysimple: fwk/libs/util declares a lowercase `class thumbnail`
+        # that collides (case-insensitively) with library/classes/thumbnail's
+        # Thumbnail and corrupts type resolution when scanned.
+        - ../portal/patient/fwk/libs/verysimple

--- a/rector.php
+++ b/rector.php
@@ -74,6 +74,12 @@ return RectorConfig::configure()
         // specify a path that works locally as well as on CI job runners
         cacheDirectory: '/tmp/rector'
     )
+    // Scan non-composer-autoloaded class directories so type inference is
+    // identical whether rector analyzes the full withPaths tree or just the
+    // filenames a pre-commit hook passes. See the comment in the neon file.
+    ->withPHPStanConfigs([
+        __DIR__ . '/.phpstan/rector-scan.neon',
+    ])
     ->withCodeQualityLevel(5)
     ->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
         'allow_model_based_classes' => true,


### PR DESCRIPTION
## What

Adds `.phpstan/rector-scan.neon` with `scanDirectories` for every directory that defines classes outside the composer autoloader (`controllers`, `custom`, `gacl`, `interface/modules/zend_modules`, `library/classes/ClinicalTypes`, `library/classes/rulesets`, `portal/patient/fwk/libs/verysimple`), wired into rector via `withPHPStanConfigs()`.

## Why

The pre-commit rector hook passes explicit filenames, and in that mode rector's embedded PHPStan resolves classes only through the composer autoloader plus the passed files. References to Laminas-module and legacy-included classes degrade to `mixed`, so `NullToStrictStringFuncCallArgRector` inserts spurious `(string)` casts (e.g. `src/Services/CDADocumentService.php`, the portal Phreeze files) that the full CI `rector process --dry-run` then rejects — local hook runs and CI disagree forever. Scanning those directories makes type inference identical for any invocation shape.

## Notes

- `portal/patient/fwk` is scanned only under `libs/verysimple`: `fwk/libs/util` declares a lowercase `class thumbnail` that collides case-insensitively with `library/classes/thumbnail`'s `Thumbnail` and flipped a finding in `ThumbnailGenerator` when scanned (caught during full-run verification).
- Verified locally: cold-cache filename-scoped rector on all six previously-affected files reports no changes; full `composer rector-check`, `composer phpstan`, and the isolated suite are green (modulo the pre-existing local-env errors tracked in #13018).