### PR TITLE
feat(encounters): add View button for locked or read-only forms

### DIFF
--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -957,13 +957,21 @@ if (OEGlobalsBag::getInstance()->getBoolean('google_signin_enabled') && !empty(O
     HTML;
 
                 // If the form is locked, it is no longer editable
+                $hasWriteAccess = (
+                    (!$aco_spec || AclMain::aclCheckCore($aco_spec[0], $aco_spec[1], '', 'write') and $is_group == 0 and $authPostCalendarCategoryWrite)
+                    or (((!$aco_spec || AclMain::aclCheckCore($aco_spec[0], $aco_spec[1], '', 'write')) and $is_group and AclMain::aclCheckCore("groups", "glog", false, 'write')) and $authPostCalendarCategoryWrite)
+                );
                 if ($esign->isLocked()) {
                     echo "<a href='#' class='btn btn-text btn-sm form-edit-button-locked' id='form-edit-button-" . attr($formdir) . "-" . attr($iter['id']) . "'><i class='fa fa-lock fa-fw'></i>&nbsp;" . xlt('Locked') . "</a>";
+                    // View button for locked forms
+                    echo "<a class='btn btn-text btn-sm' " .
+                        "href='#' " .
+                        "title='" . xla('View this form') . "' " .
+                        "onclick=\"return openEncounterForm(" . attr_js($formdir) . ", " .
+                        attr_js($form_name) . ", " . attr_js($iter['form_id']) . ")\">" .
+                        xlt('View') . "</a>";
                 } else {
-                    if (
-                        (!$aco_spec || AclMain::aclCheckCore($aco_spec[0], $aco_spec[1], '', 'write') and $is_group == 0 and $authPostCalendarCategoryWrite)
-                        or (((!$aco_spec || AclMain::aclCheckCore($aco_spec[0], $aco_spec[1], '', 'write')) and $is_group and AclMain::aclCheckCore("groups", "glog", false, 'write')) and $authPostCalendarCategoryWrite)
-                    ) {
+                    if ($hasWriteAccess) {
                         echo "<a class='btn btn-text btn-sm form-edit-button btn-edit' " .
                             "id='form-edit-button-" . attr($formdir) . "-" . attr($iter['id']) . "' " .
                             "href='#' " .
@@ -971,6 +979,14 @@ if (OEGlobalsBag::getInstance()->getBoolean('google_signin_enabled') && !empty(O
                             "onclick=\"return openEncounterForm(" . attr_js($formdir) . ", " .
                             attr_js($form_name) . ", " . attr_js($iter['form_id']) . ")\">";
                         echo "" . xlt('Edit') . "</a>";
+                    } else {
+                        // View button for users without write access
+                        echo "<a class='btn btn-text btn-sm' " .
+                            "href='#' " .
+                            "title='" . xla('View this form') . "' " .
+                            "onclick=\"return openEncounterForm(" . attr_js($formdir) . ", " .
+                            attr_js($form_name) . ", " . attr_js($iter['form_id']) . ")\">" .
+                            xlt('View') . "</a>";
                     }
                 }
 


### PR DESCRIPTION
## Summary
- When a form is **locked** (e-signed), only a "Locked" label was shown — users could not open the form to read its contents
- When a user has **read-only access** (no write ACL), no button was shown at all
- Adds a "View" button in both cases so users can still open and read form data

## Test plan
- [ ] Lock a form via e-sign, verify the "View" button appears next to the lock icon
- [ ] Log in as a user without write permissions on encounters, verify "View" button appears instead of "Edit"
- [ ] Click "View" in both cases, verify the form opens in read-only mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form action controls to consistently reflect the user’s editing permissions.
  * Users without write access see a **View** option instead of **Edit**.
  * Locked forms continue to display their locked status and view-only access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->