### PR TITLE
chore(phpstan): skip analysis of generated PHPFHIRParserMap.php

### DIFF
--- a/.phpstan/baseline/missingType.generics.php
+++ b/.phpstan/baseline/missingType.generics.php
@@ -182,16 +182,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Entities/ResourceScopeEntityList.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Class OpenEMR\\\\FHIR\\\\R4\\\\PHPFHIRParserMap implements generic interface ArrayAccess but does not specify its types\\: TKey, TValue$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/FHIR/R4/PHPFHIRParserMap.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Class OpenEMR\\\\FHIR\\\\R4\\\\PHPFHIRParserMap implements generic interface Iterator but does not specify its types\\: TKey, TValue$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/FHIR/R4/PHPFHIRParserMap.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Class OpenEMR\\\\Menu\\\\MenuItems extends generic class ArrayObject but does not specify its types\\: TKey, TValue$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Menu/MenuItems.php',

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -8482,11 +8482,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/FHIR/R4/PHPFHIRAutoloader.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\FHIR\\\\R4\\\\PHPFHIRParserMap\\:\\:\\$_bigDumbMap type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/FHIR/R4/PHPFHIRParserMap.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\FHIR\\\\R4\\\\PHPFHIRResponseParser\\:\\:_parseJsonObject\\(\\) has parameter \\$jsonEntry with no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/FHIR/R4/PHPFHIRResponseParser.php',

--- a/.phpstan/baseline/offsetAccess.invalidOffset.php
+++ b/.phpstan/baseline/offsetAccess.invalidOffset.php
@@ -988,11 +988,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../src/FHIR/R4/PHPFHIRParserMap.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Possibly invalid array key type mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/FHIR/SMART/ExternalClinicalDecisionSupport/DecisionSupportInterventionEntity.php',
 ];

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -7972,11 +7972,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/FHIR/R4/FHIRResourceContainer.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\FHIR\\\\R4\\\\PHPFHIRParserMap\\:\\:key\\(\\) should return string but returns int\\|string\\|null\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/FHIR/R4/PHPFHIRParserMap.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\FHIR\\\\R4\\\\PHPFHIRResponseParser\\:\\:_parseJson\\(\\) should return object but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/FHIR/R4/PHPFHIRResponseParser.php',

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,14 +10,23 @@ parameters:
   # Set tmpDir explicitly so we know what it is
   tmpDir: tmp-phpstan
   excludePaths:
-  # excluding for easy dev setups since ccdaservice is a path below
-  - ccdaservice/node_modules/*
-  # oe-module-claimrev-connect is a Composer dependency
-  # (claimrevolution/oe-module-claimrev-connect), relocated into this path by the
-  # oe-module-installer-plugin during `composer install`. It is third-party code,
-  # not maintained in this repo, so exclude it from analysis the same way vendor/
-  # is excluded.
-  - interface/modules/custom_modules/oe-module-claimrev-connect/*
+    analyseAndScan:
+    # excluding for easy dev setups since ccdaservice is a path below
+    - ccdaservice/node_modules/*
+    # oe-module-claimrev-connect is a Composer dependency
+    # (claimrevolution/oe-module-claimrev-connect), relocated into this path by the
+    # oe-module-installer-plugin during `composer install`. It is third-party code,
+    # not maintained in this repo, so exclude it from analysis the same way vendor/
+    # is excluded.
+    - interface/modules/custom_modules/oe-module-claimrev-connect/*
+    analyse:
+    # Generated FHIR R4 parser map: a single ~61k-line constant array
+    # (PHPFHIRParserMap::$_bigDumbMap) produced by the php-fhir generator and never
+    # hand-edited. Analysing it costs ~90s and ~1 GB on its own because a constant
+    # array literal with more than 256 keys degrades to a general array via an
+    # expensive value-type union. Keep scanning it so the PHPFHIRParserMap class
+    # stays discoverable for callers, but skip the (pointless) analysis.
+    - src/FHIR/R4/PHPFHIRParserMap.php
   paths:
   - Documentation
   - _rest_routes.inc.php


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Excludes the generated `src/FHIR/R4/PHPFHIRParserMap.php` from PHPStan analysis (the file is still scanned), removing ~90 s and a ~1 GB memory spike from every non-cached PHPStan run.

#### Changes proposed in this pull request:

`PHPFHIRParserMap` is generated by the php-fhir library and holds a single ~61k-line constant array (`$_bigDumbMap`). Analysing that one file costs **~90 s and ~1 GB of memory** on its own — it is the single slowest file in a full analysis.

The cost is in PHPStan's constant-array handling. A constant array literal with more than 256 keys (`ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT`) degrades to a general `array<…>` by unioning all ~890 deeply-nested value types together, which is superlinear. Measured scaling shows a sharp cliff right at that threshold:

| top-level keys | analysis time |
|---:|---:|
| 178 | 1.9 s |
| 312 | 27.7 s |
| 535 | 52.5 s |
| 891 (full) | 101.9 s |

The file is generated and never hand-edited, so there is nothing to gain from analysing it.

It is placed under `excludePaths.analyse` (not `analyseAndScan`) so PHPStan still **scans** the file — the `PHPFHIRParserMap` class and its `ArrayAccess`/`Iterator` methods stay discoverable for the FHIR code that instantiates it. Only the expensive analysis pass is skipped. No behavior change for analysed code.

#### Was an AI assistant used? Yes
