### PR TITLE
test(release): isolate ChangelogMutatorTest + CompatibilityMutatorTest from developer git config

### DIFF
--- a/tests/Tests/Isolated/Release/ChangelogMutatorTest.php
+++ b/tests/Tests/Isolated/Release/ChangelogMutatorTest.php
@@ -328,6 +328,14 @@ MD);
             ['git', ...$args],
             $this->tmpDir,
             [
+                // Hermeticity: null the developer's ~/.gitconfig + system
+                // config so options like `tag.gpgsign=true` don't promote
+                // our lightweight tags to signed annotated tags (which
+                // then demand a message and fail with exit 128). CI is
+                // unaffected but local runs bite developers who sign by
+                // default. See openemr/openemr#13018.
+                'GIT_CONFIG_GLOBAL' => '/dev/null',
+                'GIT_CONFIG_SYSTEM' => '/dev/null',
                 'GIT_AUTHOR_NAME' => 'Test',
                 'GIT_AUTHOR_EMAIL' => 'test@example.com',
                 'GIT_COMMITTER_NAME' => 'Test',

--- a/tests/Tests/Isolated/Release/CompatibilityMutatorTest.php
+++ b/tests/Tests/Isolated/Release/CompatibilityMutatorTest.php
@@ -145,28 +145,26 @@ final class CompatibilityMutatorTest extends TestCase
         $originDir = sys_get_temp_dir() . '/openemr-origin-' . bin2hex(random_bytes(6));
         $checkoutDir = sys_get_temp_dir() . '/openemr-master-co-' . bin2hex(random_bytes(6));
         try {
-            (new Process(['git', 'clone', '--quiet', '--bare', $this->tmpDir, $originDir]))->mustRun();
-            (new Process([
-                'git', 'clone', '--quiet',
+            $this->git(['clone', '--quiet', '--bare', $this->tmpDir, $originDir]);
+            $this->git([
+                'clone', '--quiet',
                 '--branch', 'main', '--single-branch',
                 $originDir, $checkoutDir,
-            ]))->mustRun();
+            ]);
 
             // Verify pre-conditions: rel-820 is NOT a local branch,
             // but origin/rel-820 is a remote-tracking ref. With
             // --single-branch we need an explicit refspec to populate
             // refs/remotes/origin/rel-820 (bare `git fetch origin rel-820`
             // would only update FETCH_HEAD).
-            $fetch = new Process(
-                ['git', 'fetch', '--quiet', 'origin', 'rel-820:refs/remotes/origin/rel-820'],
-                $checkoutDir,
-            );
-            $fetch->mustRun();
-            $probeLocal = new Process(['git', 'rev-parse', '--verify', '--quiet', 'refs/heads/rel-820'], $checkoutDir);
+            $this->git(['fetch', '--quiet', 'origin', 'rel-820:refs/remotes/origin/rel-820'], $checkoutDir);
+            // Inline Process for this one call because it expects failure
+            // (probeLocal->run() != mustRun()); helper is mustRun-only.
+            // Env still hermetic via self::gitEnv().
+            $probeLocal = new Process(['git', 'rev-parse', '--verify', '--quiet', 'refs/heads/rel-820'], $checkoutDir, self::gitEnv());
             $probeLocal->run();
             self::assertFalse($probeLocal->isSuccessful(), 'rel-820 must not be a local branch in the master-style checkout');
-            $probeRemote = new Process(['git', 'rev-parse', '--verify', '--quiet', 'refs/remotes/origin/rel-820'], $checkoutDir);
-            $probeRemote->mustRun();
+            $this->git(['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/rel-820'], $checkoutDir);
 
             file_put_contents($checkoutDir . '/CHANGELOG.md', <<<'MD'
 # CHANGELOG.md
@@ -325,19 +323,37 @@ MD);
     /**
      * @param list<string> $args
      */
-    private function git(array $args): void
+    private function git(array $args, ?string $cwd = null): void
     {
         $process = new Process(
             ['git', ...$args],
-            $this->tmpDir,
-            [
-                'GIT_AUTHOR_NAME' => 'Test',
-                'GIT_AUTHOR_EMAIL' => 'test@example.com',
-                'GIT_COMMITTER_NAME' => 'Test',
-                'GIT_COMMITTER_EMAIL' => 'test@example.com',
-            ],
+            $cwd ?? $this->tmpDir,
+            self::gitEnv(),
         );
         $process->mustRun();
+    }
+
+    /**
+     * Hermetic git env: null the developer's ~/.gitconfig + system config
+     * so options like `tag.gpgsign=true` don't promote our lightweight
+     * tags to signed annotated tags (which then demand a message and fail
+     * with exit 128). CI is unaffected but local runs bite developers who
+     * sign by default. Also blocks any other future ~/.gitconfig drift
+     * (init.defaultBranch, fetch.parallel, core.pager, etc.) from making
+     * this suite non-reproducible. See openemr/openemr#13018.
+     *
+     * @return array<string, string>
+     */
+    private static function gitEnv(): array
+    {
+        return [
+            'GIT_CONFIG_GLOBAL' => '/dev/null',
+            'GIT_CONFIG_SYSTEM' => '/dev/null',
+            'GIT_AUTHOR_NAME' => 'Test',
+            'GIT_AUTHOR_EMAIL' => 'test@example.com',
+            'GIT_COMMITTER_NAME' => 'Test',
+            'GIT_COMMITTER_EMAIL' => 'test@example.com',
+        ];
     }
 
     private function removeRecursive(string $path): void


### PR DESCRIPTION
Closes #13018.

## Summary

Both `ChangelogMutatorTest` and `CompatibilityMutatorTest` shell out to `git` in a temp repo via Symfony `Process`. The env array they supply covered author/committer identity but did **not** null the developer's `~/.gitconfig` or system git config. Symfony `Process` merges the provided env with the parent PHP process's env by default, so `HOME` propagates through and git finds `~/.gitconfig`.

On developer machines with `tag.gpgsign = true` set globally, `git tag v8_1_0` (lightweight) is promoted to a signed annotated tag, demands a message, and fails with exit 128 (\"fatal: no tag message?\") — **8 test errors on an otherwise clean checkout** (per @kojiromike's #13018 report). CI is unaffected — GitHub runners have no such config — so this only bites `composer phpunit-isolated` runs on developer machines.

## Prior art

Sibling tests in the same directory (`BranchVersionResolverTest.php:266`, `TagVerifierTest.php:122`) already use the hermetic env pattern — they set `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_SYSTEM=/dev/null` in the Process env array. This PR propagates that proven pattern to the two files that missed it.

## Changes

**`ChangelogMutatorTest.php`** — added `GIT_CONFIG_GLOBAL=/dev/null` + `GIT_CONFIG_SYSTEM=/dev/null` to the `git()` helper's env array (matches the shape used by `BranchVersionResolverTest` + `TagVerifierTest`).

**`CompatibilityMutatorTest.php`** — same env addition to its `git()` helper, plus:
- Extracted the env array into a shared `gitEnv()` static method so the one intentional inline `Process` call (line 165, `probeLocal->run()` — expects failure, can't use the `mustRun()`-only helper) also gets hermetic env.
- Added an optional `?string $cwd = null` parameter to `git()` so the 4 inline calls that operated in `$originDir` / `$checkoutDir` can route through the helper instead of re-inlining Process directly.

## Broader protection

`tag.gpgsign` is one of many `~/.gitconfig` options that can break tests non-hermetically. Others in the same failure class: `commit.gpgsign=true`, `user.signingKey`, `core.pager=less` without `-F`, `init.defaultBranch`, `fetch.parallel`, git aliases. The hermetic env vars close the whole category rather than just this one case, so future developer-config drift can't cause new breakage.

## Audit scope

Grepped `tests/Tests/Isolated/**` for `git` subprocess shellouts. Four files touch git; two already had the correct env pattern (`BranchVersionResolverTest`, `TagVerifierTest`), two didn't (this PR fixes them). No other files in the tree do subprocess git operations.

## Test plan

- [x] `openemr-cmd pit` — all 3794 isolated tests pass after the change. No new failures. Warnings in output are pre-existing and unrelated (Encounter/Immunization/Auth validators).
- [ ] Developer with `git config --global tag.gpgsign true`: `composer phpunit-isolated` should pass instead of failing 8 tests. (Not reproducible on a stock CI runner; if @kojiromike wants to validate on his machine that would be ideal.)

Assisted-by: Claude Code