### PR TITLE
fix(ehi-exporter): adapt ExportState to escapeTableName() backtick contract from #11297.

### DIFF
--- a/interface/modules/custom_modules/oe-module-ehi-exporter/src/Models/ExportState.php
+++ b/interface/modules/custom_modules/oe-module-ehi-exporter/src/Models/ExportState.php
@@ -243,11 +243,13 @@ class ExportState
 
     public function createTableDefinition(string $tableName)
     {
-        // need to make sure we sanitize this
-        $safeTableName = QueryUtils::escapeTableName($tableName);
-        // we are going to do our safe escaping here so we don't have to do it in the rest of the code.
-        $tableDef = $this->exportTableDefininitionFactory($safeTableName);
-        $primaryKeys = $this->xmlXPath("//table[@name='" . $safeTableName . "']/primaryKey");
+        // need to make sure we sanitize this. Since core PR #11297, escapeTableName()
+        // returns a backtick-quoted SQL fragment and throws if the input contains a
+        // backtick, so we call it purely to validate against the schema whitelist and
+        // keep using the bare name for lookups, map keys, and the XPath query below.
+        QueryUtils::escapeTableName($tableName);
+        $tableDef = $this->exportTableDefininitionFactory($tableName);
+        $primaryKeys = $this->xmlXPath("//table[@name='" . $tableName . "']/primaryKey");
         $pkBySequence = [];
         foreach ($primaryKeys as $primaryKey) {
             $columnName = (string)($primaryKey->attributes()['column']) ?? "";
@@ -259,10 +261,12 @@ class ExportState
             $tableDef->addPrimaryKey($columnName);
         }
         // this will be used to make sure we don't have any sql injection attacks
-        $safeColumnNames = QueryUtils::listTableFields($safeTableName);
+        // (listTableFields runs the name through escapeTableName internally, so it must
+        // receive the bare, un-backticked name)
+        $safeColumnNames = QueryUtils::listTableFields($tableName);
         $tableDef->setColumnNames($safeColumnNames);
         $this->dataFilterer->generateSelectQueryForTableFromMetadata($tableDef, $this->metaNode);
-        $this->tableDefinitionsMap[$safeTableName] = $tableDef;
+        $this->tableDefinitionsMap[$tableName] = $tableDef;
         return $tableDef;
     }
 


### PR DESCRIPTION

Fixes #13058

## Summary

Since #11297, `QueryUtils::escapeTableName()` returns a backtick-quoted SQL fragment and throws on input containing a backtick. That PR updated core call sites but missed oe-module-ehi-exporter, where `ExportState::createTableDefinition()` was using the return value as a plain table name — which now throws on the first table (via `listTableFields()` re-escaping the already-quoted name) and, worse, silently broke the XPath primary-key lookup, the special-case table definition factory matching, and the table definition map keys.

## Changes

One file, `src/Models/ExportState.php`:

- `escapeTableName()` is now called once purely as schema whitelist validation (return value discarded — it still throws on unknown table names, so the security intent of #11297 is preserved)
- The bare `$tableName` is used for the definition factory, the metadata XPath query, `listTableFields()`, and the `tableDefinitionsMap` key
- SQL-fragment escaping stays where it belongs — at query construction time, which `listTableFields()` and the data filterer already do internally

No core changes. The #11297 hardening is correct; the module just needed to catch up.

## Test plan

- [x] EHI export runs to completion on master (previously threw SqlQueryException on the first table definition)
- [x] Primary keys register from the EHI metadata XML again (XPath matches on bare names)
- [x] Special-cased tables (onsite messages, esign, calendar events, clinical notes, etc.) resolve to their dedicated definition classes instead of falling through to the generic one
- [x] `getTableDefinitionForTable()` lookups resolve (map keyed by bare name)
- [x] php -l / phpcs clean

Assisted-By: Claude code

<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:


#### Changes proposed in this pull request:


#### Was an AI assistant used? Yes / No

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
