### PR TITLE
feat(release): copy PackageAssembler + PreflightChecker from openemr-devops (Phase 2 PR 1)

### DIFF
--- a/tests/Tests/Isolated/Release/PackageAssemblerTest.php
+++ b/tests/Tests/Isolated/Release/PackageAssemblerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release;
+
+use OpenEMR\Release\PackageAssembler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Process\Process;
+
+final class PackageAssemblerTest extends TestCase
+{
+    private string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/openemr-package-assembler-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->tmpDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->tmpDir);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tmpDir)) {
+            (new Process(['rm', '-rf', $this->tmpDir]))->run();
+        }
+    }
+
+    public function testMissingOpenemrDirReturnsError(): void
+    {
+        $output = new BufferedOutput();
+        $assembler = new PackageAssembler('8.1.0', $this->tmpDir . '/does-not-exist', $this->tmpDir, $output);
+
+        self::assertSame(1, $assembler->assemble());
+        self::assertStringContainsString('OpenEMR directory not found', $output->fetch());
+    }
+
+    public function testMissingBuildXmlReturnsError(): void
+    {
+        $output = new BufferedOutput();
+        $assembler = new PackageAssembler('8.1.0', $this->tmpDir, $this->tmpDir, $output);
+
+        self::assertSame(1, $assembler->assemble());
+        self::assertStringContainsString('build.xml not found', $output->fetch());
+    }
+
+    public function testDirtyCheckoutReturnsError(): void
+    {
+        $repo = $this->tmpDir . '/openemr';
+        mkdir($repo, 0700, true);
+        $this->git($repo, ['init', '-q']);
+        $this->git($repo, ['config', 'user.email', 'test@example.com']);
+        $this->git($repo, ['config', 'user.name', 'Test']);
+        file_put_contents("{$repo}/build.xml", "<project/>\n");
+        $this->git($repo, ['add', 'build.xml']);
+        $this->git($repo, ['commit', '-qm', 'init']);
+        // Leave an uncommitted change, mimicking an uncommitted version bump.
+        file_put_contents("{$repo}/build.xml", "<project name=\"dirty\"/>\n");
+
+        $output = new BufferedOutput();
+        $assembler = new PackageAssembler('8.1.0', $repo, $this->tmpDir . '/out', $output);
+
+        self::assertSame(1, $assembler->assemble());
+        self::assertStringContainsString('dirty checkout', $output->fetch());
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    private function git(string $cwd, array $args): void
+    {
+        (new Process(['git', ...$args], $cwd))->mustRun();
+    }
+}

--- a/tools/release/bin/package-assemble.php
+++ b/tools/release/bin/package-assemble.php
@@ -42,6 +42,15 @@ use Symfony\Component\Console\SingleCommandApplication;
             $output->writeln('<error>--release-version is required</error>');
             return 1;
         }
+        // Parse at the boundary: the version string flows into staging
+        // paths and temp-file names inside PackageAssembler (see the
+        // `openemr-<version>` staging dir), so validate the shape here
+        // rather than downstream. OpenEMR release versions are strict
+        // N.N.N — dev/pre-release suffixes never reach this CLI.
+        if (preg_match('/^\d+\.\d+\.\d+$/', $versionOption) !== 1) {
+            $output->writeln("<error>--release-version must be N.N.N (got: {$versionOption})</error>");
+            return 1;
+        }
         if (!is_string($openemrDirOption) || $openemrDirOption === '') {
             $output->writeln('<error>--openemr-dir is required</error>');
             return 1;

--- a/tools/release/bin/package-assemble.php
+++ b/tools/release/bin/package-assemble.php
@@ -1,0 +1,60 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Build the full distribution tarball + zip for an official OpenEMR release.
+ *
+ * Thin CLI wrapper around OpenEMR\Release\PackageAssembler; see that class for
+ * the build steps and rationale.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+use OpenEMR\Release\PackageAssembler;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('package-assemble')
+    ->setDescription('Build the full distribution tarball + zip for an official release')
+    // `--release-version`, not `--version`: Symfony Console reserves `--version`
+    // as a global flag that prints the app name and exits 0 before the command
+    // runs, so `--version=8.1.0` would silently no-op.
+    ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g., 8.1.0)')
+    ->addOption('openemr-dir', null, InputOption::VALUE_REQUIRED, 'Path to the checked-out openemr release branch')
+    ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Output directory', './release-output')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $versionOption = $input->getOption('release-version');
+        $openemrDirOption = $input->getOption('openemr-dir');
+        $outputDirOption = $input->getOption('output-dir');
+
+        if (!is_string($versionOption) || $versionOption === '') {
+            $output->writeln('<error>--release-version is required</error>');
+            return 1;
+        }
+        if (!is_string($openemrDirOption) || $openemrDirOption === '') {
+            $output->writeln('<error>--openemr-dir is required</error>');
+            return 1;
+        }
+        $outputDir = is_string($outputDirOption) && $outputDirOption !== ''
+            ? rtrim($outputDirOption, '/')
+            : './release-output';
+
+        return (new PackageAssembler(
+            $versionOption,
+            rtrim($openemrDirOption, '/'),
+            $outputDir,
+            $output,
+        ))->assemble();
+    })
+    ->run();

--- a/tools/release/bin/patch-assemble.php
+++ b/tools/release/bin/patch-assemble.php
@@ -35,23 +35,42 @@ use Symfony\Component\Process\Process;
     ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Output directory', './release-output')
     ->addOption('copy-styles', null, InputOption::VALUE_NONE, 'Include compiled theme styles')
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
-        /** @var string $startTag */
-        $startTag = $input->getOption('start-tag');
-        /** @var string $branch */
-        $branch = $input->getOption('branch');
-        /** @var string $filename */
-        $filename = $input->getOption('filename');
-        /** @var string $openemrDir */
-        $openemrDir = $input->getOption('openemr-dir');
-        /** @var string $outputDir */
-        $outputDir = $input->getOption('output-dir');
-
-        foreach (['start-tag', 'branch', 'filename', 'openemr-dir'] as $required) {
-            if ($input->getOption($required) === null) {
-                $output->writeln("<error>--{$required} is required</error>");
+        // Parse raw CLI input into narrowed string values at the boundary
+        // rather than @var-casting downstream; PHPStan trusts the runtime
+        // check, and downstream code no longer needs re-validation.
+        $required = [];
+        foreach (['start-tag', 'branch', 'filename', 'openemr-dir'] as $name) {
+            $value = $input->getOption($name);
+            if (!is_string($value) || $value === '') {
+                $output->writeln("<error>--{$name} is required</error>");
                 return 1;
             }
+            $required[$name] = $value;
         }
+        $startTag = $required['start-tag'];
+        $branch = $required['branch'];
+        $filename = $required['filename'];
+        $openemrDir = $required['openemr-dir'];
+
+        $outputDirOption = $input->getOption('output-dir');
+        if (!is_string($outputDirOption) || $outputDirOption === '') {
+            $output->writeln('<error>--output-dir must be a non-empty string</error>');
+            return 1;
+        }
+        // Resolve to absolute before spawning zip: patch-staging is created
+        // under $outputDir and zip runs with cwd=<staging>, so a relative
+        // $outputDir would land the archive in the wrong tree. mkdir first
+        // so realpath resolves.
+        if (!is_dir($outputDirOption) && !mkdir($outputDirOption, 0o755, true) && !is_dir($outputDirOption)) {
+            $output->writeln("<error>Failed to create output directory: {$outputDirOption}</error>");
+            return 1;
+        }
+        $resolved = realpath($outputDirOption);
+        if ($resolved === false) {
+            $output->writeln("<error>Failed to resolve output directory: {$outputDirOption}</error>");
+            return 1;
+        }
+        $outputDir = $resolved;
 
         if (!is_dir($openemrDir)) {
             $output->writeln("<error>OpenEMR directory not found: {$openemrDir}</error>");
@@ -118,14 +137,17 @@ use Symfony\Component\Process\Process;
             ':!README-Isolated-Testing.md',
         ];
 
+        // `-z` gives NUL-delimited, literal (unquoted) filenames; splitting
+        // on `\n` mishandles paths with spaces or non-ASCII bytes (git
+        // otherwise renders them C-style-quoted, which `copy()` can't open).
         $diff = new Process(
-            ['git', 'diff', '--name-only', '--diff-filter=d', "{$startTag}..{$branch}", '--', '.', ...$excludes],
+            ['git', 'diff', '-z', '--name-only', '--diff-filter=d', "{$startTag}..{$branch}", '--', '.', ...$excludes],
             $openemrDir,
         );
         $diff->mustRun();
 
         $changedFiles = array_filter(
-            explode("\n", trim($diff->getOutput())),
+            explode("\0", $diff->getOutput()),
             static fn(string $line): bool => $line !== '',
         );
         file_put_contents("{$outputDir}/changed-files.txt", implode("\n", $changedFiles) . "\n");

--- a/tools/release/bin/patch-assemble.php
+++ b/tools/release/bin/patch-assemble.php
@@ -1,0 +1,181 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Build a cumulative patch zip from the diff between a start tag and release branch.
+ *
+ * The patch is an overlay archive: users extract it on top of their existing
+ * install. It can't delete files (but can empty them like setup.php) and always
+ * includes version.php and sql_patch.php.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+use Symfony\Component\Process\Process;
+
+(new SingleCommandApplication())
+    ->setName('patch-assemble')
+    ->setDescription('Build cumulative patch zip from diff between tags')
+    ->addOption('start-tag', null, InputOption::VALUE_REQUIRED, 'Base tag for diff (e.g., v8_0_0)')
+    ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Release branch (e.g., rel-800)')
+    ->addOption('filename', null, InputOption::VALUE_REQUIRED, 'Output zip filename')
+    ->addOption('openemr-dir', null, InputOption::VALUE_REQUIRED, 'Path to openemr checkout')
+    ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Output directory', './release-output')
+    ->addOption('copy-styles', null, InputOption::VALUE_NONE, 'Include compiled theme styles')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        /** @var string $startTag */
+        $startTag = $input->getOption('start-tag');
+        /** @var string $branch */
+        $branch = $input->getOption('branch');
+        /** @var string $filename */
+        $filename = $input->getOption('filename');
+        /** @var string $openemrDir */
+        $openemrDir = $input->getOption('openemr-dir');
+        /** @var string $outputDir */
+        $outputDir = $input->getOption('output-dir');
+
+        foreach (['start-tag', 'branch', 'filename', 'openemr-dir'] as $required) {
+            if ($input->getOption($required) === null) {
+                $output->writeln("<error>--{$required} is required</error>");
+                return 1;
+            }
+        }
+
+        if (!is_dir($openemrDir)) {
+            $output->writeln("<error>OpenEMR directory not found: {$openemrDir}</error>");
+            return 1;
+        }
+
+        $patchDir = "{$outputDir}/patch-staging";
+
+        if (is_dir($patchDir)) {
+            (new Process(['rm', '-rf', $patchDir]))->mustRun();
+        }
+        if (!is_dir($outputDir)) {
+            mkdir($outputDir, 0755, true);
+        }
+        mkdir($patchDir, 0755, true);
+
+        // Get changed files, excluding CI/dev/test paths
+        // Exclude CI, testing, build tooling, and Docker configuration.
+        // Keep in sync with build-patch.yml's exclude list.
+        $excludes = [
+            // Directories
+            ':(exclude).github/**',
+            ':(exclude).phpstan/**',
+            ':(exclude).git/**',
+            ':(exclude)ci/**',
+            ':(exclude)docker/**',
+            ':(exclude)tests/**',
+            ':(exclude)tools/**',
+            // Dotfiles
+            ':!.codespell*',
+            ':!.composer-require-checker.json',
+            ':!.dclintrc.yaml',
+            ':!.editorconfig',
+            ':!.gitattributes',
+            ':!.gitignore',
+            ':!.gitmodules',
+            ':!.hadolint.yaml',
+            ':!.pre-commit-config.yaml',
+            ':!.shellcheckrc',
+            ':!.stylelintignore',
+            ':!.stylelintrc.json',
+            // Build/CI config files
+            ':!build.xml',
+            ':!cloudbuild.yaml',
+            ':!codecov.yml',
+            ':!composer.json',
+            ':!composer.lock',
+            ':!eslint.config.mjs',
+            ':!gulpfile.js',
+            ':!jest.config.js',
+            ':!package.json',
+            ':!package-lock.json',
+            ':!phpcs.xml.dist',
+            ':!phpstan.neon.dist',
+            ':!phpunit*.xml',
+            ':!rector*.php',
+            ':!run-semgrep.sh',
+            ':!semgrep.yaml',
+            // Documentation
+            ':!CLAUDE.md',
+            ':!CONTRIBUTING.md',
+            ':!CODE_OF_CONDUCT.md',
+            ':!DOCKER_README.md',
+            ':!README-Isolated-Testing.md',
+        ];
+
+        $diff = new Process(
+            ['git', 'diff', '--name-only', '--diff-filter=d', "{$startTag}..{$branch}", '--', '.', ...$excludes],
+            $openemrDir,
+        );
+        $diff->mustRun();
+
+        $changedFiles = array_filter(
+            explode("\n", trim($diff->getOutput())),
+            static fn(string $line): bool => $line !== '',
+        );
+        file_put_contents("{$outputDir}/changed-files.txt", implode("\n", $changedFiles) . "\n");
+        $output->writeln(sprintf('<info>%d</info> changed files', count($changedFiles)));
+
+        // Copy each changed file preserving directory structure
+        foreach ($changedFiles as $filepath) {
+            $targetDir = "{$patchDir}/" . dirname($filepath);
+            if (!is_dir($targetDir)) {
+                mkdir($targetDir, 0755, true);
+            }
+            copy("{$openemrDir}/{$filepath}", "{$patchDir}/{$filepath}");
+        }
+
+        // Copy compiled theme styles if requested
+        $copyStyles = (bool) $input->getOption('copy-styles');
+        if ($copyStyles && is_dir("{$openemrDir}/public/themes")) {
+            $themesDir = "{$patchDir}/public/themes";
+            if (!is_dir($themesDir)) {
+                mkdir($themesDir, 0755, true);
+            }
+            (new Process(['cp', '-R', "{$openemrDir}/public/themes/.", $themesDir]))->mustRun();
+        }
+
+        // Blank out setup.php so patch doesn't re-run setup
+        file_put_contents("{$patchDir}/setup.php", '');
+
+        // Always include version.php and sql_patch.php
+        copy("{$openemrDir}/version.php", "{$patchDir}/version.php");
+        copy("{$openemrDir}/sql_patch.php", "{$patchDir}/sql_patch.php");
+
+        // Standardize permissions
+        (new Process(['find', $patchDir, '-type', 'f', '-exec', 'chmod', '0644', '{}', '+']))->mustRun();
+
+        // Count files in patch
+        $findProcess = new Process(['find', $patchDir, '-type', 'f']);
+        $findProcess->mustRun();
+        $fileCount = count(array_filter(
+            explode("\n", trim($findProcess->getOutput())),
+            static fn(string $l): bool => $l !== '',
+        ));
+        $output->writeln(sprintf('<info>%d</info> files in patch', $fileCount));
+
+        // Build zip
+        (new Process(['zip', '-r', "../{$filename}", '.'], $patchDir))->mustRun();
+
+        // Clean up staging directory
+        (new Process(['rm', '-rf', $patchDir]))->mustRun();
+
+        $output->writeln("Patch built: <info>{$outputDir}/{$filename}</info>");
+        return 0;
+    })
+    ->run();

--- a/tools/release/bin/preflight.php
+++ b/tools/release/bin/preflight.php
@@ -30,18 +30,28 @@ use Symfony\Component\Console\SingleCommandApplication;
     ->addOption('skip-milestone', null, InputOption::VALUE_NONE, 'Skip milestone check')
     ->addOption('skip-ghsa', null, InputOption::VALUE_NONE, 'Skip GHSA check')
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
-        /** @var ?string $milestone */
-        $milestone = $input->getOption('milestone');
-        /** @var string $repo */
-        $repo = $input->getOption('repo');
+        // Parse raw CLI input into narrowed types at the boundary rather
+        // than @var-casting downstream; see PSR-based coding guidelines.
+        $milestoneOption = $input->getOption('milestone');
+        if ($milestoneOption !== null && !is_string($milestoneOption)) {
+            $output->writeln('<error>--milestone must be a string</error>');
+            return 1;
+        }
+        $milestone = $milestoneOption;
+
+        $repoOption = $input->getOption('repo');
+        if (!is_string($repoOption) || $repoOption === '') {
+            $output->writeln('<error>--repo must be a non-empty string</error>');
+            return 1;
+        }
+        $repo = $repoOption;
+
         $api = new GitHubApi($repo);
         $checker = new PreflightChecker($api, $repo);
         $failures = 0;
 
-        /** @var bool $skipMilestone */
-        $skipMilestone = $input->getOption('skip-milestone');
-        /** @var bool $skipGhsa */
-        $skipGhsa = $input->getOption('skip-ghsa');
+        $skipMilestone = (bool) $input->getOption('skip-milestone');
+        $skipGhsa = (bool) $input->getOption('skip-ghsa');
 
         if (!$skipMilestone) {
             if ($milestone === null) {

--- a/tools/release/bin/preflight.php
+++ b/tools/release/bin/preflight.php
@@ -1,0 +1,60 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Run pre-release checks: milestone completeness and unpublished GHSAs.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+use OpenEMR\Release\GitHubApi;
+use OpenEMR\Release\PreflightChecker;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('preflight')
+    ->setDescription('Run pre-release checks')
+    ->addOption('milestone', 'm', InputOption::VALUE_REQUIRED, 'Milestone name')
+    ->addOption('repo', 'r', InputOption::VALUE_REQUIRED, 'GitHub repo', 'openemr/openemr')
+    ->addOption('skip-milestone', null, InputOption::VALUE_NONE, 'Skip milestone check')
+    ->addOption('skip-ghsa', null, InputOption::VALUE_NONE, 'Skip GHSA check')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        /** @var ?string $milestone */
+        $milestone = $input->getOption('milestone');
+        /** @var string $repo */
+        $repo = $input->getOption('repo');
+        $api = new GitHubApi($repo);
+        $checker = new PreflightChecker($api, $repo);
+        $failures = 0;
+
+        /** @var bool $skipMilestone */
+        $skipMilestone = $input->getOption('skip-milestone');
+        /** @var bool $skipGhsa */
+        $skipGhsa = $input->getOption('skip-ghsa');
+
+        if (!$skipMilestone) {
+            if ($milestone === null) {
+                $output->writeln('<error>--milestone is required (or use --skip-milestone)</error>');
+                return 1;
+            }
+            $failures += $checker->checkMilestone($milestone, $output);
+        }
+
+        if (!$skipGhsa) {
+            $failures += $checker->checkGhsa($output);
+        }
+
+        return $failures > 0 ? 1 : 0;
+    })
+    ->run();

--- a/tools/release/src/PackageAssembler.php
+++ b/tools/release/src/PackageAssembler.php
@@ -116,7 +116,12 @@ final readonly class PackageAssembler
         mkdir($composerHome, 0755, true);
         $composerEnv = ['COMPOSER_HOME' => $composerHome];
         $this->run(
-            ['composer', 'global', 'require', 'phing/phing', '--no-interaction', '--no-progress'],
+            // Pin to a known-good major version. Unbounded `phing/phing`
+            // would resolve to whatever's latest at build time, so a
+            // future breaking release (renamed targets, changed CLI
+            // flags) would silently break packaging without any code
+            // change here.
+            ['composer', 'global', 'require', 'phing/phing:^3.0', '--no-interaction', '--no-progress'],
             null,
             $composerEnv,
         );

--- a/tools/release/src/PackageAssembler.php
+++ b/tools/release/src/PackageAssembler.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * Build the full distribution tarball + zip for an official OpenEMR release.
+ *
+ * Ports the long-standing manual release-package process: export a checked-out
+ * release branch, install production-only dependencies, build front-end assets,
+ * prune dev/test cruft, and emit `openemr-<version>.tar.gz` and
+ * `openemr-<version>.zip` ready to attach to the GitHub release.
+ *
+ * The staging tree is produced with `git archive`, so `export-ignore` entries in
+ * openemr/openemr's .gitattributes (.github, ci, docker, tests, tools, large
+ * docs, …) are the single source of truth for what ships — no exclude list is
+ * duplicated here.
+ *
+ * Unlike PatchAssembler (a changed-files overlay), this produces a complete,
+ * standalone install that end users extract and run without composer or npm.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+final readonly class PackageAssembler
+{
+    public function __construct(
+        private string $version,
+        private string $openemrDir,
+        private string $outputDir,
+        private OutputInterface $output,
+    ) {
+    }
+
+    public function assemble(): int
+    {
+        if (!is_dir($this->openemrDir)) {
+            $this->output->writeln("<error>OpenEMR directory not found: {$this->openemrDir}</error>");
+            return 1;
+        }
+        if (!is_file("{$this->openemrDir}/build.xml")) {
+            $this->output->writeln("<error>build.xml not found in {$this->openemrDir} — wrong checkout?</error>");
+            return 1;
+        }
+
+        // `git archive HEAD` below ships the committed tree, so an uncommitted
+        // version bump would silently package stale content. Fail fast on a dirty
+        // checkout. (The workflow commits the bump locally before this step, even
+        // in dry runs, so the package validates the exact tree a release ships.)
+        $status = new Process(['git', 'status', '--porcelain'], $this->openemrDir);
+        $status->mustRun();
+        $dirty = trim($status->getOutput());
+        if ($dirty !== '') {
+            $this->output->writeln("<error>Refusing to package a dirty checkout in {$this->openemrDir}:</error>");
+            $this->output->writeln($dirty);
+            return 1;
+        }
+
+        $packageName = "openemr-{$this->version}";
+
+        // Resolve the output dir to an absolute path before any command runs.
+        // The git archive below runs with cwd = openemrDir, so a relative output
+        // path (the default ./release-output) would resolve against the openemr
+        // checkout — where the dir does not exist — and fail to open. Create the
+        // dir, then canonicalize, so every command writes here regardless of its
+        // own cwd.
+        if (!is_dir($this->outputDir)) {
+            mkdir($this->outputDir, 0755, true);
+        }
+        $outputDir = realpath($this->outputDir);
+        if ($outputDir === false) {
+            $this->output->writeln("<error>Could not resolve output directory: {$this->outputDir}</error>");
+            return 1;
+        }
+
+        $stageDir = "{$outputDir}/{$packageName}";
+
+        // Fresh staging directory.
+        if (is_dir($stageDir)) {
+            $this->run(['rm', '-rf', $stageDir]);
+        }
+
+        // Export the committed tree (honoring .gitattributes export-ignore) into
+        // a fresh openemr-<version>/ staging dir. git archive can't pipe through
+        // our no-shell Process runner, so stage via an intermediate tar. HEAD is
+        // the release commit — the dirty-checkout guard above guarantees the
+        // version bump is committed (in every run, dry included).
+        $sourceTar = "{$outputDir}/{$packageName}-source.tar";
+        $this->run(
+            ['git', 'archive', '--format=tar', '--prefix', "{$packageName}/", '-o', $sourceTar, 'HEAD'],
+            $this->openemrDir,
+        );
+        $this->run(['tar', '-xf', $sourceTar, '-C', $outputDir]);
+        unlink($sourceTar);
+
+        // Production dependencies + built front-end assets.
+        $this->run(['composer', 'install', '--no-dev', '--no-interaction', '--no-progress'], $stageDir);
+        $this->run(['npm', 'ci'], $stageDir);
+        $this->run(['npm', 'run', 'build'], $stageDir);
+
+        // Prune vendor/asset cruft via the openemr build.xml targets. Driving
+        // these through phing keeps the prune list owned by openemr/openemr
+        // (single source of truth) rather than duplicated here. Point
+        // COMPOSER_HOME at a throwaway dir so `composer global` installs phing
+        // there instead of mutating the caller's real global environment — no
+        // `remove` cleanup step that could be skipped on a clean-target failure.
+        $composerHome = "{$outputDir}/{$packageName}-composer-home";
+        mkdir($composerHome, 0755, true);
+        $composerEnv = ['COMPOSER_HOME' => $composerHome];
+        $this->run(
+            ['composer', 'global', 'require', 'phing/phing', '--no-interaction', '--no-progress'],
+            null,
+            $composerEnv,
+        );
+        // build.xml is export-ignore'd in openemr's .gitattributes, so git
+        // archive strips it from the staged tree. Its prune targets resolve
+        // ${project.basedir}/vendor and .../public/assets against the staged
+        // tree (phing runs there), so copy the buildfile in for the prune run
+        // and remove it afterward — it must not ship in the distribution.
+        $buildXml = "{$stageDir}/build.xml";
+        if (!copy("{$this->openemrDir}/build.xml", $buildXml)) {
+            $this->output->writeln("<error>Failed to stage build.xml for prune: {$buildXml}</error>");
+            return 1;
+        }
+        $phing = "{$composerHome}/vendor/bin/phing";
+        $this->run([$phing, 'vendor-clean'], $stageDir);
+        $this->run([$phing, 'assets-clean'], $stageDir);
+        // Fail hard if the staged copy can't be removed: otherwise it would ship
+        // in the archives below, defeating the export-ignore intent.
+        if (!unlink($buildXml)) {
+            $this->output->writeln("<error>Failed to remove staged build.xml; refusing to ship: {$buildXml}</error>");
+            return 1;
+        }
+        $this->run(['rm', '-rf', $composerHome]);
+
+        // Drop node_modules and regenerate the optimized production autoloader.
+        $this->run(['rm', '-rf', "{$stageDir}/node_modules"]);
+        $this->run(['composer', 'dump-autoload', '--optimize', '--no-dev'], $stageDir);
+
+        // Standardize permissions; make the install-writable paths writable.
+        $this->run(['chmod', '-R', 'u+w', $stageDir]);
+        $documentsDir = "{$stageDir}/sites/default/documents";
+        if (is_dir($documentsDir)) {
+            $this->run(['chmod', '-R', 'a+w', $documentsDir]);
+        }
+        $sqlconf = "{$stageDir}/sites/default/sqlconf.php";
+        if (is_file($sqlconf)) {
+            $this->run(['chmod', 'a+w', $sqlconf]);
+        }
+
+        // Build archives from the output dir so each unpacks to openemr-<version>/.
+        $this->run(['tar', '-zcpf', "{$packageName}.tar.gz", $packageName], $outputDir);
+        $this->run(['zip', '-r', '-q', "{$packageName}.zip", $packageName], $outputDir);
+
+        // Drop the staging tree; only the archives need to survive.
+        $this->run(['rm', '-rf', $stageDir]);
+
+        foreach (["{$packageName}.tar.gz", "{$packageName}.zip"] as $artifact) {
+            $path = "{$outputDir}/{$artifact}";
+            $size = filesize($path);
+            $this->output->writeln(sprintf(
+                '<info>Built</info> %s (%s bytes)',
+                $path,
+                is_int($size) ? number_format($size) : '?',
+            ));
+        }
+
+        return 0;
+    }
+
+    /**
+     * Run a command, streaming its output. No timeout — builds are slow.
+     *
+     * @param list<string>              $command
+     * @param array<string, string>|null $env extra environment, merged over the inherited environment
+     */
+    private function run(array $command, ?string $cwd = null, ?array $env = null): void
+    {
+        $this->output->writeln('<comment>$ ' . implode(' ', $command) . '</comment>');
+        $process = new Process($command, $cwd, $env, null, null);
+        $process->mustRun(function (string $type, string $buffer): void {
+            $this->output->write($buffer);
+        });
+    }
+}

--- a/tools/release/src/PreflightChecker.php
+++ b/tools/release/src/PreflightChecker.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Pre-release checks: milestone completeness and unpublished GHSAs.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+class PreflightChecker
+{
+    public function __construct(
+        private readonly GitHubApi $api,
+        private readonly string $repo,
+    ) {
+    }
+
+    /**
+     * Check that a milestone has no open issues or PRs.
+     *
+     * @return int 0 on success, 1 on failure
+     */
+    public function checkMilestone(string $milestone, OutputInterface $output): int
+    {
+        $process = new Process([
+            'gh', 'api',
+            "/search/issues?q=milestone:{$milestone}+repo:{$this->repo}+state:open",
+            '--jq', '.total_count',
+        ]);
+        $process->mustRun();
+        $count = (int) trim($process->getOutput());
+
+        if ($count === 0) {
+            $output->writeln("<info>✓</info> Milestone {$milestone}: no open items");
+            return 0;
+        }
+
+        $detail = new Process([
+            'gh', 'api',
+            "/search/issues?q=milestone:{$milestone}+repo:{$this->repo}+state:open",
+            '--jq', '.items[] | "  - #\(.number) \(.title)"',
+        ]);
+        $detail->mustRun();
+
+        $output->writeln("<error>✗</error> Milestone {$milestone}: {$count} open item(s)");
+        $output->write($detail->getOutput());
+        return 1;
+    }
+
+    /**
+     * Check for unpublished security advisories.
+     *
+     * @return int 0 on success, 1 on failure
+     */
+    public function checkGhsa(OutputInterface $output): int
+    {
+        $advisories = $this->api->paginate('/security-advisories');
+        $unpublished = array_filter(
+            $advisories,
+            static fn(array $a): bool => $a['state'] !== 'published',
+        );
+
+        if (count($unpublished) === 0) {
+            $output->writeln('<info>✓</info> No unpublished security advisories');
+            return 0;
+        }
+
+        $output->writeln(sprintf(
+            '<error>✗</error> %d unpublished security advisory/ies:',
+            count($unpublished),
+        ));
+        foreach ($unpublished as $advisory) {
+            $severity = is_string($advisory['severity'] ?? null) ? $advisory['severity'] : 'unknown';
+            $summary = is_string($advisory['summary'] ?? null) ? $advisory['summary'] : '';
+            $output->writeln("  - [{$severity}] {$summary}");
+        }
+        return 1;
+    }
+}

--- a/tools/release/src/PreflightChecker.php
+++ b/tools/release/src/PreflightChecker.php
@@ -32,9 +32,16 @@ class PreflightChecker
      */
     public function checkMilestone(string $milestone, OutputInterface $output): int
     {
+        // URL-encode the search query: `+` as space-substitute only works
+        // for single-word milestones, and a multi-word milestone
+        // ("Fixed in 8.2.0") or one containing `&`/`?` would silently
+        // corrupt the query. Quote the milestone value so GitHub search
+        // treats it as one term.
+        $query = urlencode(sprintf('milestone:"%s" repo:%s state:open', $milestone, $this->repo));
+
         $process = new Process([
             'gh', 'api',
-            "/search/issues?q=milestone:{$milestone}+repo:{$this->repo}+state:open",
+            "/search/issues?q={$query}",
             '--jq', '.total_count',
         ]);
         $process->mustRun();
@@ -47,13 +54,15 @@ class PreflightChecker
 
         $detail = new Process([
             'gh', 'api',
-            "/search/issues?q=milestone:{$milestone}+repo:{$this->repo}+state:open",
+            "/search/issues?q={$query}",
             '--jq', '.items[] | "  - #\(.number) \(.title)"',
         ]);
         $detail->mustRun();
 
         $output->writeln("<error>✗</error> Milestone {$milestone}: {$count} open item(s)");
-        $output->write($detail->getOutput());
+        // OUTPUT_RAW: issue titles are external text and can contain `<`/`>`
+        // that Symfony Console would otherwise try to parse as style tags.
+        $output->write($detail->getOutput(), false, OutputInterface::OUTPUT_RAW);
         return 1;
     }
 
@@ -82,7 +91,9 @@ class PreflightChecker
         foreach ($unpublished as $advisory) {
             $severity = is_string($advisory['severity'] ?? null) ? $advisory['severity'] : 'unknown';
             $summary = is_string($advisory['summary'] ?? null) ? $advisory['summary'] : '';
-            $output->writeln("  - [{$severity}] {$summary}");
+            // OUTPUT_RAW: GHSA summaries are external text and can contain
+            // `<`/`>` chars that Symfony Console would parse as style tags.
+            $output->writeln("  - [{$severity}] {$summary}", OutputInterface::OUTPUT_RAW);
         }
         return 1;
     }


### PR DESCRIPTION
Phase 2 PR 1 of the workstream 7 release-mechanism migration. Copies the two remaining PHP classes + their bin-script entrypoints + PackageAssembler test from openemr-devops's \`tools/release/\`. Workflows (\`build-release.yml\`, \`build-release-on-tag.yml\`, \`build-patch.yml\`) land in a follow-up PR; devops copies stay live until Phase 6 (parallel-run validation window).

See \`docs/release-mechanism-migration-from-devops.md\` Phase 2 for context.

## Files copied

- \`tools/release/src/PackageAssembler.php\` (~180 LOC) — full distribution tarball + zip builder. Uses \`git archive\` so \`.gitattributes\` \`export-ignore\` entries are the single source of truth for what ships.
- \`tools/release/src/PreflightChecker.php\` (~50 LOC) — milestone-completeness + unpublished-GHSA preflight. Depends only on \`OpenEMR\Release\GitHubApi\` (already in this repo via the changelog-surface slice) and Symfony bits.
- \`tools/release/bin/package-assemble.php\` — Symfony Console wrapper around PackageAssembler.
- \`tools/release/bin/preflight.php\` — Symfony Console wrapper around PreflightChecker.
- \`tools/release/bin/patch-assemble.php\` — self-contained cumulative patch-zip builder (no PackageAssembler dependency, purely filesystem + git). Called by the \`build-patch.yml\` workflow that lands in PR 2.
- \`tests/Tests/Isolated/Release/PackageAssemblerTest.php\` — 3 tests covering the early-return error paths (missing openemr dir, missing build.xml, dirty checkout).

## Adjustments vs devops originals

- \`@package openemr-devops\` → \`@package OpenEMR\` and license URL retargeted from \`openemr-devops\` to \`openemr/openemr\` (author + copyright preserved).
- Bin-script autoload path: \`dirname(__DIR__)\` → \`dirname(__DIR__, 3)\` — matches the existing openemr \`tools/release/bin/*\` convention (openemr uses the top-level \`vendor/\`, not a per-module \`vendor/\` like devops does).
- Test-file namespace: \`OpenEMR\Release\Tests\` → \`OpenEMR\Tests\Isolated\Release\` — matches the \`ChangelogGeneratorTest\` pattern already in \`tests/Tests/Isolated/Release/\`.

Both PHP classes only import \`Symfony\Component\Console\Output\OutputInterface\` and \`Symfony\Component\Process\Process\` — zero devops-side infrastructure dependencies. Migration doc's original scoping considered whether \`GitHubApi\`/\`Clock\`/etc. would need to be duplicated during the parallel-run window; they don't, because the actual dependency graph is empty.

## Test plan
- [x] \`openemr-cmd pit\` — full isolated suite passes (3797 tests, 9575 assertions; pre-existing warnings/notices unchanged)
- [x] \`phpunit tests/Tests/Isolated/Release/PackageAssemblerTest.php\` — 3/3 pass
- [x] \`rector process --dry-run\` against the 6 new files — clean
- [x] \`php -l\` on all 3 bin scripts — clean
- [x] \`--help\` output from all 3 bin scripts — autoload resolves, Symfony Console parses options
- [ ] CI green on this PR (phpstan, phpcs, codespell, actionlint, etc. — no yaml files touched so most CI is a no-op)

## Not in this PR (follow-up scope)

- **PR 2:** \`build-release.yml\` + \`build-release-on-tag.yml\` + \`build-patch.yml\` land, with \`build-release-on-tag.yml\` keeping the \`openemr-tag\` \`repository_dispatch\` trigger shape (intra-repo instead of cross-repo — one-line change in \`release-prep.yml\`'s finalize job).
- **PR 3:** docs updates — mark Phase 2 shipped in migration doc, \`RELEASE_PROCESS.md\` if operator-facing changes.
- **Phase 6:** delete devops copies of these files after one clean release cycle validates the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)