### PR TITLE
build(docker): bake pcov coverage driver into dev-php-fpm images

### DIFF
--- a/docker/library/dockers/dev-php-fpm-8-2-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-2-redis/Dockerfile
@@ -40,6 +40,7 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions \
                            intl \
                            ldap \
                            mysqli \
+                           pcov \
                            pdo_mysql \
                            redis \
                            soap \

--- a/docker/library/dockers/dev-php-fpm-8-2/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-2/Dockerfile
@@ -40,6 +40,7 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions \
                            intl \
                            ldap \
                            mysqli \
+                           pcov \
                            pdo_mysql \
                            soap \
                            sockets \

--- a/docker/library/dockers/dev-php-fpm-8-3-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-3-redis/Dockerfile
@@ -40,6 +40,7 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions \
                            intl \
                            ldap \
                            mysqli \
+                           pcov \
                            pdo_mysql \
                            redis \
                            soap \

--- a/docker/library/dockers/dev-php-fpm-8-3/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-3/Dockerfile
@@ -40,6 +40,7 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions \
                            intl \
                            ldap \
                            mysqli \
+                           pcov \
                            pdo_mysql \
                            soap \
                            sockets \

--- a/docker/library/dockers/dev-php-fpm-8-4-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-4-redis/Dockerfile
@@ -40,6 +40,7 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions \
                            intl \
                            ldap \
                            mysqli \
+                           pcov \
                            pdo_mysql \
                            redis \
                            soap \

--- a/docker/library/dockers/dev-php-fpm-8-4/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-4/Dockerfile
@@ -40,6 +40,7 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions \
                            intl \
                            ldap \
                            mysqli \
+                           pcov \
                            pdo_mysql \
                            soap \
                            sockets \

--- a/docker/library/dockers/dev-php-fpm-8-5-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-5-redis/Dockerfile
@@ -75,6 +75,7 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions \
                            intl \
                            ldap \
                            mysqli \
+                           pcov \
                            pdo_mysql \
                            soap \
                            sockets \

--- a/docker/library/dockers/dev-php-fpm-8-5/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-5/Dockerfile
@@ -58,6 +58,7 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions \
                            intl \
                            ldap \
                            mysqli \
+                           pcov \
                            pdo_mysql \
                            soap \
                            sockets \

--- a/docker/library/dockers/dev-php-fpm-8-6-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-6-redis/Dockerfile
@@ -75,6 +75,7 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions \
                            intl \
                            ldap \
                            mysqli \
+                           pcov \
                            pdo_mysql \
                            soap \
                            sockets \

--- a/docker/library/dockers/dev-php-fpm-8-6/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-6/Dockerfile
@@ -58,6 +58,7 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions \
                            intl \
                            ldap \
                            mysqli \
+                           pcov \
                            pdo_mysql \
                            soap \
                            sockets \


### PR DESCRIPTION
## Problem (fixes #13084)

The `dev-php-fpm` coverage images do not bake in a coverage driver, so `configure_coverage()` in `ci/ciLibrary.source` installs xdebug **at runtime** via `xdebug.sh` → `install-php-extensions xdebug`. On release-candidate PHP (e.g. `php:8.5-rc-fpm`) there is no prebuilt-compatible xdebug, so it compiles from **PECL source**, downloading from `pecl.php.net`. When that host returns a 504 (which it has been doing intermittently), the install fails and takes the whole test job with it:

```
### INSTALLING REMOTE MODULE xdebug ###
File https://pecl.php.net:443/channel.xml not valid (received: HTTP/1.1 504 Gateway Timeout)
...
1) No code coverage driver available
```

Every test suite does its own runtime install, so a single pecl hiccup can fail several suites in one run while others pass — a clear sign it is transient infrastructure, not a regression.

## Fix

Add `pcov` to the `install-php-extensions` list for the coverage-capable images (8.2–8.6 and their `-redis` variants). Rationale:

- Both `configure_coverage()` and `ci/auto_prepend.php` already **prefer pcov over xdebug**, so the driver check short-circuits with no runtime PECL fetch.
- pcov is coverage-only with negligible overhead when idle, so baking it in doesn't burden the dev image the way an always-loaded xdebug would.
- The on-demand `xdebug.sh` path for interactive step-debugging is left untouched.
- `convert-coverage` already ingests pcov output (`RawCodeCoverageData::fromXdebugWithoutPathCoverage`), so E2E/API coverage keeps working.

The one-time build fetch of pcov still uses PECL, but that runs in the nightly/weekly image build (retryable) rather than on every PR's test run.

## Testing

hadolint clean on the changed Dockerfiles.