### PR TITLE
feat(release): build-release + build-release-on-tag + build-patch workflows (Phase 2 PR 2b)

### DIFF
--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -135,6 +135,10 @@ files:
   exclude-branches: [rel-800, rel-704]
 - path: .github/workflows/release-permissions-check.yml
   exclude-branches: [rel-800, rel-704]
+- path: .github/workflows/build-release.yml
+  exclude-branches: [rel-800, rel-704]
+- path: .github/workflows/build-patch.yml
+  exclude-branches: [rel-800, rel-704]
 - path: .github/actions/setup-php-composer/action.yml
   exclude-branches: [rel-800, rel-704]
 - path: .github/PULL_REQUEST_TEMPLATE/release-prep.md

--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -15,7 +15,7 @@ run-name: "Build Patch Release ${{ inputs.version }}${{ inputs.dry_run && ' (dry
 # extracts the patch zip on top of an existing install.
 #
 # Migrated from openemr/openemr-devops in workstream 7 Phase 2 (PR 2b).
-# Four devops-side steps dropped at migration time:
+# Three devops-side steps dropped at migration time:
 #
 #   1. `task release:version-bump MODE=patch` (Bump version.php) +
 #   2. Commit and push version bump
@@ -27,17 +27,25 @@ run-name: "Build Patch Release ${{ inputs.version }}${{ inputs.dry_run && ' (dry
 #      This workflow packages the resulting patch; it doesn't own the
 #      version-bump.
 #
-#   3. `task release:changelog` (Generate changelog) +
-#   4. `task release:changelog-pr` (Create CHANGELOG PRs)
-#      Those tasks were retired from devops's Taskfile in
-#      openemr/openemr-devops#857 (2026-07-13) + #858 (2026-07-13)
-#      when ChangelogMutator became authoritative and build-release
-#      switched to section-extract. build-patch invocations were never
-#      updated on the devops side and had been broken since #857
-#      landed. Patch-time changelog generation is a separate design
-#      decision -- patches historically ran their own changelog from
-#      git log because the mutator-driven CHANGELOG.md flow covers
-#      only main-line releases. Not carrying forward broken references.
+#   3. `task release:changelog-pr` (Create CHANGELOG PRs)
+#      Retired from devops's Taskfile in openemr/openemr-devops#857
+#      (2026-07-13) when ChangelogMutator became authoritative for
+#      main-release CHANGELOG.md writes. build-patch's invocation had
+#      been broken since #857 landed. Patches don't rewrite the
+#      canonical CHANGELOG.md (that's mutator territory for main
+#      releases only); the patch-time git-log-derived changelog now
+#      lives in the standalone `changelog.md` artifact produced below.
+#
+# The `Generate changelog` step below reactivates patch-time changelog
+# generation using openemr's `bin/changelog.php` (same PHP CLI that
+# feeds ChangelogMutator for main releases) via the `changelog` task,
+# producing a standalone `changelog.md` alongside the patch zip. The
+# devops-side `task release:changelog` invocation was broken since
+# openemr/openemr-devops#858 retired the task; this replacement wires
+# to the openemr-side CLI directly. changelog.md gets attached to the
+# release + included in the dry-run artifact so the maintainer can
+# paste it into forum/announcement posts without a manual walk of
+# git log.
 #
 # Two devops-side inputs also dropped to fit under GitHub's 10-input
 # workflow_dispatch cap:
@@ -197,6 +205,24 @@ jobs:
         OPENEMR_DIR="$GITHUB_WORKSPACE"
         COPY_STYLES="$COPY_STYLES"
 
+    # Generate a git-log-derived changelog for the patch. Patches don't
+    # rewrite CHANGELOG.md (ChangelogMutator covers main releases only),
+    # so this step produces a standalone changelog.md the maintainer
+    # can paste into the GitHub Release body or the forum announcement.
+    # Uploaded alongside the patch zip so both are in one artifact.
+    - name: Generate changelog
+      working-directory: tools/release
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        VERSION_START: ${{ inputs.version_start }}
+        VERSION_BRANCH: ${{ inputs.version_branch }}
+        RELEASE_VERSION: ${{ inputs.version }}
+      run: >-
+        task changelog
+        BASE="$VERSION_START"
+        HEAD="$VERSION_BRANCH"
+        TITLE="$RELEASE_VERSION"
+
     - name: Generate checksums
       working-directory: tools/release
       env:
@@ -239,6 +265,7 @@ jobs:
           tools/release/release-output/${{ inputs.patch_filename }}.md5
           tools/release/release-output/${{ inputs.patch_filename }}.sha256
           tools/release/release-output/${{ inputs.patch_filename }}.sha512
+          tools/release/release-output/changelog.md
         retention-days: 7
 
     - name: Create annotated tag and GitHub release
@@ -267,6 +294,7 @@ jobs:
           gh release create "$tag" \
             --repo openemr/openemr \
             --title "$tag" \
+            --notes-file "${output_dir}/changelog.md" \
             --verify-tag
         fi
 
@@ -276,4 +304,5 @@ jobs:
           "${output_dir}/${PATCH_FILENAME}.md5" \
           "${output_dir}/${PATCH_FILENAME}.sha256" \
           "${output_dir}/${PATCH_FILENAME}.sha512" \
+          "${output_dir}/changelog.md" \
           --clobber

--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -101,6 +101,10 @@ jobs:
   build-patch:
     runs-on: ubuntu-24.04
     name: Build Patch
+    # Cap runtime. Patch assembly + tag/release is under 10 min in
+    # normal runs; the GitHub-default 6h ceiling would let a hung
+    # git/gh/npm step burn runner minutes if something wedged.
+    timeout-minutes: 30
     steps:
     - name: Validate inputs
       if: "!inputs.dry_run && inputs.release_tag == ''"
@@ -136,7 +140,9 @@ jobs:
         fetch-depth: 1
 
     - name: Fetch start tag
-      run: git fetch --filter=blob:none --depth=1 origin tag '${{ inputs.version_start }}'
+      env:
+        VERSION_START: ${{ inputs.version_start }}
+      run: git fetch --filter=blob:none --depth=1 origin tag "$VERSION_START"
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer
@@ -153,12 +159,17 @@ jobs:
       if: 'inputs.milestone != '''' || !inputs.skip_ghsa_check'
       working-directory: tools/release
       env:
+        # Route inputs through env so shell-metachars in operator-
+        # provided values can't break out of task-argument quoting.
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        MILESTONE: ${{ inputs.milestone }}
+        SKIP_MILESTONE: ${{ inputs.milestone == '' && '1' || '' }}
+        SKIP_GHSA: ${{ inputs.skip_ghsa_check && '1' || '' }}
       run: >-
         task preflight
-        MILESTONE='${{ inputs.milestone }}'
-        SKIP_MILESTONE='${{ inputs.milestone == '' && '1' || '' }}'
-        SKIP_GHSA='${{ inputs.skip_ghsa_check && '1' || '' }}'
+        MILESTONE="$MILESTONE"
+        SKIP_MILESTONE="$SKIP_MILESTONE"
+        SKIP_GHSA="$SKIP_GHSA"
 
     - name: Build theme styles
       if: inputs.copy_styles
@@ -173,33 +184,49 @@ jobs:
 
     - name: Assemble patch
       working-directory: tools/release
+      env:
+        VERSION_START: ${{ inputs.version_start }}
+        VERSION_BRANCH: ${{ inputs.version_branch }}
+        PATCH_FILENAME: ${{ inputs.patch_filename }}
+        COPY_STYLES: ${{ inputs.copy_styles }}
       run: >-
         task patch:assemble
-        START_TAG='${{ inputs.version_start }}'
-        BRANCH='${{ inputs.version_branch }}'
-        FILENAME='${{ inputs.patch_filename }}'
-        OPENEMR_DIR='${{ github.workspace }}'
-        COPY_STYLES='${{ inputs.copy_styles }}'
+        START_TAG="$VERSION_START"
+        BRANCH="$VERSION_BRANCH"
+        FILENAME="$PATCH_FILENAME"
+        OPENEMR_DIR="$GITHUB_WORKSPACE"
+        COPY_STYLES="$COPY_STYLES"
 
     - name: Generate checksums
       working-directory: tools/release
+      env:
+        PATCH_FILENAME: ${{ inputs.patch_filename }}
       run: >-
         task checksum
-        FILE='${{ inputs.patch_filename }}'
+        FILE="$PATCH_FILENAME"
 
     - name: Build summary
       working-directory: tools/release
+      env:
+        MILESTONE: ${{ inputs.milestone }}
+        VERSION_START: ${{ inputs.version_start }}
+        VERSION_BRANCH: ${{ inputs.version_branch }}
+        PATCH_FILENAME: ${{ inputs.patch_filename }}
+        PATCH_NUMBER: ${{ inputs.patch_number }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        COPY_STYLES: ${{ inputs.copy_styles }}
       run: >-
         task summary
         TYPE=patch
-        MILESTONE='${{ inputs.milestone }}'
-        START_TAG='${{ inputs.version_start }}'
-        VERSION_BRANCH='${{ inputs.version_branch }}'
-        PATCH_FILENAME='${{ inputs.patch_filename }}'
-        PATCH_NUMBER='${{ inputs.patch_number }}'
-        RELEASE_TAG='${{ inputs.release_tag }}'
-        DRY_RUN='${{ inputs.dry_run }}'
-        COPY_STYLES='${{ inputs.copy_styles }}'
+        MILESTONE="$MILESTONE"
+        START_TAG="$VERSION_START"
+        VERSION_BRANCH="$VERSION_BRANCH"
+        PATCH_FILENAME="$PATCH_FILENAME"
+        PATCH_NUMBER="$PATCH_NUMBER"
+        RELEASE_TAG="$RELEASE_TAG"
+        DRY_RUN="$DRY_RUN"
+        COPY_STYLES="$COPY_STYLES"
 
     - name: Upload workflow artifact (dry run)
       if: inputs.dry_run
@@ -218,9 +245,12 @@ jobs:
       if: '!inputs.dry_run'
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+        VERSION_BRANCH: ${{ inputs.version_branch }}
+        PATCH_FILENAME: ${{ inputs.patch_filename }}
       run: |
-        tag='${{ inputs.release_tag }}'
-        output_dir='${{ github.workspace }}/tools/release/release-output'
+        tag="$RELEASE_TAG"
+        output_dir="$GITHUB_WORKSPACE/tools/release/release-output"
 
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
@@ -228,7 +258,7 @@ jobs:
         if git rev-parse "$tag" > /dev/null 2>&1; then
           echo "Tag $tag already exists, skipping tag creation"
         else
-          git tag -a -m "Patch release $tag" "$tag" '${{ inputs.version_branch }}'
+          git tag -a -m "Patch release $tag" "$tag" "$VERSION_BRANCH"
           git push origin "$tag"
         fi
 
@@ -242,8 +272,8 @@ jobs:
 
         gh release upload "$tag" \
           --repo openemr/openemr \
-          "${output_dir}/${{ inputs.patch_filename }}" \
-          "${output_dir}/${{ inputs.patch_filename }}.md5" \
-          "${output_dir}/${{ inputs.patch_filename }}.sha256" \
-          "${output_dir}/${{ inputs.patch_filename }}.sha512" \
+          "${output_dir}/${PATCH_FILENAME}" \
+          "${output_dir}/${PATCH_FILENAME}.md5" \
+          "${output_dir}/${PATCH_FILENAME}.sha256" \
+          "${output_dir}/${PATCH_FILENAME}.sha512" \
           --clobber

--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -1,0 +1,249 @@
+name: Build Patch Release
+run-name: "Build Patch Release ${{ inputs.version }}${{ inputs.dry_run && ' (dry run)' || '' }}"
+
+# Manual workflow_dispatch — emergent-patch escape hatch for zero-day-
+# style hotfixes that ship without a full release-cycle prep. Maintainer
+# picks the rel branch + patch parameters, workflow assembles a
+# cumulative patch zip from the diff between the previous tag and the
+# rel branch tip, then (optionally) creates the tag + GitHub Release +
+# uploads the patch as an asset.
+#
+# Intentionally parallel to the automated release flow (no
+# openemr-tag dispatch consumer, no cascade). Patch release cadence is
+# irregular and maintainer-driven, so this path is expected to be run
+# by hand when the situation calls for it. Distribution model: user
+# extracts the patch zip on top of an existing install.
+#
+# Migrated from openemr/openemr-devops in workstream 7 Phase 2 (PR 2b).
+# Four devops-side steps dropped at migration time:
+#
+#   1. `task release:version-bump MODE=patch` (Bump version.php) +
+#   2. Commit and push version bump
+#      Prereq: maintainer bumps `$v_realpatch` in `version.php` and
+#      pushes to the rel branch before invoking this workflow. That
+#      push fires the workstream-6 `patch-prep-automation.yml`, which
+#      handles the mutator-side release-targets + docker-scaffolding
+#      updates via a coordinated 2-PR flow (openemr/openemr#12697).
+#      This workflow packages the resulting patch; it doesn't own the
+#      version-bump.
+#
+#   3. `task release:changelog` (Generate changelog) +
+#   4. `task release:changelog-pr` (Create CHANGELOG PRs)
+#      Those tasks were retired from devops's Taskfile in
+#      openemr/openemr-devops#857 (2026-07-13) + #858 (2026-07-13)
+#      when ChangelogMutator became authoritative and build-release
+#      switched to section-extract. build-patch invocations were never
+#      updated on the devops side and had been broken since #857
+#      landed. Patch-time changelog generation is a separate design
+#      decision -- patches historically ran their own changelog from
+#      git log because the mutator-driven CHANGELOG.md flow covers
+#      only main-line releases. Not carrying forward broken references.
+#
+# Two devops-side inputs also dropped to fit under GitHub's 10-input
+# workflow_dispatch cap:
+#
+#   * `validate_token` -- release-permissions-check.yml is the tool
+#     for testing token permissions; validate_token was a duplicative
+#     safety net that predated it.
+#   * `skip_milestone_check` -- the existing preflight-check gate
+#     already skips the milestone check when milestone is empty. The
+#     explicit skip switch was rarely used when set with a non-empty
+#     milestone.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_start:
+        description: Start tag (e.g., v8_2_0)
+        required: true
+        type: string
+      version_branch:
+        description: Release branch (e.g., rel-820)
+        required: true
+        type: string
+      patch_filename:
+        description: Patch zip filename (e.g., 8-2-0-Patch-1.zip)
+        required: true
+        type: string
+      version:
+        description: Human-readable version (e.g., 8.2.0.1)
+        required: true
+        type: string
+      milestone:
+        description: GitHub milestone name for preflight check (e.g., 8.2.0.1)
+        required: false
+        type: string
+      patch_number:
+        description: Patch number to set in version.php $v_realpatch (e.g., 1)
+        required: true
+        type: string
+      release_tag:
+        description: GitHub release tag to upload to (e.g., v8_2_0_1). Required unless dry run.
+        required: false
+        type: string
+      dry_run:
+        description: Dry run — build and upload as workflow artifact only, skip GitHub release
+        type: boolean
+        default: true
+      copy_styles:
+        description: Build and include compiled theme styles
+        type: boolean
+        default: false
+      skip_ghsa_check:
+        description: Skip unpublished GHSA check
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-patch:
+    runs-on: ubuntu-24.04
+    name: Build Patch
+    steps:
+    - name: Validate inputs
+      if: "!inputs.dry_run && inputs.release_tag == ''"
+      run: |
+        printf '::error::release_tag is required when dry_run is false\n'
+        exit 1
+
+    - name: Generate app token
+      if: '!inputs.dry_run'
+      id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: openemr
+
+    - name: Verify app token
+      if: '!inputs.dry_run'
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      run: |
+        echo "Checking app token can access openemr/openemr milestones..."
+        gh api repos/openemr/openemr/milestones --jq '.[].title' | head -5
+        echo 'App token verified.'
+
+    - name: Checkout openemr release branch
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.version_branch }}
+        token: ${{ steps.app-token.outputs.token || github.token }}
+        filter: blob:none
+        fetch-depth: 1
+
+    - name: Fetch start tag
+      run: git fetch --filter=blob:none --depth=1 origin tag '${{ inputs.version_start }}'
+
+    - name: Setup PHP and Composer
+      uses: ./.github/actions/setup-php-composer
+      with:
+        php-version: '8.5'
+
+    - name: Install Taskfile
+      uses: arduino/setup-task@v3
+      with:
+        version: 3.x
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Preflight checks
+      if: 'inputs.milestone != '''' || !inputs.skip_ghsa_check'
+      working-directory: tools/release
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+      run: >-
+        task preflight
+        MILESTONE='${{ inputs.milestone }}'
+        SKIP_MILESTONE='${{ inputs.milestone == '' && '1' || '' }}'
+        SKIP_GHSA='${{ inputs.skip_ghsa_check && '1' || '' }}'
+
+    - name: Build theme styles
+      if: inputs.copy_styles
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+    - name: Install npm and build styles
+      if: inputs.copy_styles
+      run: |
+        npm ci
+        npm run build
+
+    - name: Assemble patch
+      working-directory: tools/release
+      run: >-
+        task patch:assemble
+        START_TAG='${{ inputs.version_start }}'
+        BRANCH='${{ inputs.version_branch }}'
+        FILENAME='${{ inputs.patch_filename }}'
+        OPENEMR_DIR='${{ github.workspace }}'
+        COPY_STYLES='${{ inputs.copy_styles }}'
+
+    - name: Generate checksums
+      working-directory: tools/release
+      run: >-
+        task checksum
+        FILE='${{ inputs.patch_filename }}'
+
+    - name: Build summary
+      working-directory: tools/release
+      run: >-
+        task summary
+        TYPE=patch
+        MILESTONE='${{ inputs.milestone }}'
+        START_TAG='${{ inputs.version_start }}'
+        VERSION_BRANCH='${{ inputs.version_branch }}'
+        PATCH_FILENAME='${{ inputs.patch_filename }}'
+        PATCH_NUMBER='${{ inputs.patch_number }}'
+        RELEASE_TAG='${{ inputs.release_tag }}'
+        DRY_RUN='${{ inputs.dry_run }}'
+        COPY_STYLES='${{ inputs.copy_styles }}'
+
+    - name: Upload workflow artifact (dry run)
+      if: inputs.dry_run
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.patch_filename }}
+        compression-level: 0
+        path: |
+          tools/release/release-output/${{ inputs.patch_filename }}
+          tools/release/release-output/${{ inputs.patch_filename }}.md5
+          tools/release/release-output/${{ inputs.patch_filename }}.sha256
+          tools/release/release-output/${{ inputs.patch_filename }}.sha512
+        retention-days: 7
+
+    - name: Create annotated tag and GitHub release
+      if: '!inputs.dry_run'
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+      run: |
+        tag='${{ inputs.release_tag }}'
+        output_dir='${{ github.workspace }}/tools/release/release-output'
+
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+        if git rev-parse "$tag" > /dev/null 2>&1; then
+          echo "Tag $tag already exists, skipping tag creation"
+        else
+          git tag -a -m "Patch release $tag" "$tag" '${{ inputs.version_branch }}'
+          git push origin "$tag"
+        fi
+
+        if ! gh release view "$tag" --repo openemr/openemr > /dev/null 2>&1; then
+          echo "Creating release $tag"
+          gh release create "$tag" \
+            --repo openemr/openemr \
+            --title "$tag" \
+            --verify-tag
+        fi
+
+        gh release upload "$tag" \
+          --repo openemr/openemr \
+          "${output_dir}/${{ inputs.patch_filename }}" \
+          "${output_dir}/${{ inputs.patch_filename }}.md5" \
+          "${output_dir}/${{ inputs.patch_filename }}.sha256" \
+          "${output_dir}/${{ inputs.patch_filename }}.sha512" \
+          --clobber

--- a/.github/workflows/build-release-on-tag.yml
+++ b/.github/workflows/build-release-on-tag.yml
@@ -1,0 +1,84 @@
+name: Build Release on Tag
+
+# Consumer of the intra-repo `openemr-tag` repository_dispatch. When a
+# release-prep PR merges, the conductor in release-prep.yml's `finalize`
+# job mints an annotated tag on the rel branch and fans out
+# `openemr-tag` to owner repos including this one. This workflow derives
+# the build inputs from the dispatch payload and calls the reusable
+# build-release.yml to produce the distribution packages and GitHub
+# Release that the manual workflow_dispatch path already produces.
+#
+# Migrated from openemr/openemr-devops in workstream 7 Phase 2 (PR 2b).
+# Under the pre-migration shape the dispatch crossed the
+# openemr/openemr → openemr/openemr-devops boundary; the post-migration
+# shape keeps the dispatch (release-prep.yml on merge still sends
+# `openemr-tag`) but targets openemr/openemr, so it fires here. The
+# dispatch shape and consumer semantics are unchanged — the release-me
+# PR's mutator content (CHANGELOG etc.) still lands *before* the tag
+# exists, which is why the dispatch invariant is preserved rather than
+# collapsed to `push: tags: ['v*']` or `workflow_run`.
+
+on:
+  repository_dispatch:
+    types: [openemr-tag]
+
+permissions:
+  contents: read
+
+concurrency:
+  # Distinct from the reusable build-release.yml group on purpose. This
+  # only collapses duplicate openemr-tag dispatches for the same tag.
+  # Serializing the actual build against a manual build-release.yml run
+  # is build-release.yml's own concurrency group's job — both entry
+  # paths run through it. Sharing its group here would deadlock: this
+  # run holds the group while waiting on the called workflow, which
+  # would queue behind it.
+  group: build-release-on-tag-${{ github.event.client_payload.data.tag }}
+  cancel-in-progress: false
+
+jobs:
+  derive:
+    name: Derive build inputs
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.inputs.outputs.version }}
+      version_branch: ${{ steps.inputs.outputs.version_branch }}
+      release_tag: ${{ steps.inputs.outputs.release_tag }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Setup PHP and Composer
+      uses: ./.github/actions/setup-php-composer
+      with:
+        php-version: '8.5'
+
+    - name: Install Taskfile
+      uses: arduino/setup-task@v3
+      with:
+        version: 3.x
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Derive build inputs
+      id: inputs
+      working-directory: tools/release
+      env:
+        CLIENT_PAYLOAD: ${{ toJSON(github.event.client_payload) }}
+      run: |
+        printf '%s' "${CLIENT_PAYLOAD}" \
+            | task derive-build-inputs PAYLOAD_FILE='-' \
+            >> "${GITHUB_OUTPUT}"
+
+  build:
+    name: Build release
+    needs: derive
+    uses: ./.github/workflows/build-release.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.derive.outputs.version }}
+      version_branch: ${{ needs.derive.outputs.version_branch }}
+      release_tag: ${{ needs.derive.outputs.release_tag }}
+      dry_run: false
+      milestone: ''
+      skip_milestone_check: true
+      skip_ghsa_check: false

--- a/.github/workflows/build-release-on-tag.yml
+++ b/.github/workflows/build-release-on-tag.yml
@@ -40,6 +40,10 @@ jobs:
   derive:
     name: Derive build inputs
     runs-on: ubuntu-24.04
+    # Cap runtime. This job just resolves the tag envelope into
+    # version/branch/release_tag lines (composer install + a single
+    # PHP CLI); anything past a few minutes indicates something wedged.
+    timeout-minutes: 10
     outputs:
       version: ${{ steps.inputs.outputs.version }}
       version_branch: ${{ steps.inputs.outputs.version_branch }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,294 @@
+name: Build Release
+run-name: "Build Release ${{ inputs.version }}${{ inputs.dry_run && ' (dry run)' || '' }}"
+
+# Distribution package build + GitHub Release publish for an official
+# OpenEMR release. Two entry paths:
+#
+#   1. `workflow_dispatch` — manual invocation for one-off rebuilds
+#      (or dry-run testing) by a maintainer.
+#   2. `workflow_call` — called by build-release-on-tag.yml after the
+#      release-prep conductor fans out the `openemr-tag`
+#      repository_dispatch on release-me PR merge.
+#
+# The workflow assumes CHANGELOG.md is already populated for the target
+# version — ChangelogMutator + CompatibilityMutator write it during the
+# release-prep + release-finalize partner PRs, so the section is in
+# place by the time this workflow fires post-tag. See
+# openemr/openemr#12925 + openemr/openemr#12928 for the mutator
+# framework, and RELEASE_PROCESS.md for the ship runbook.
+#
+# Migrated from openemr/openemr-devops in workstream 7 Phase 2 (PR 2b).
+# Dropped from the devops shape:
+#
+#   * `version-bump MODE=full` fallback (Detect existing prep + Version
+#     bump + Commit + Push steps). The conductor's `VersionPhpMutator`
+#     (rel-scope) already clears -dev before the tag exists; by the
+#     time this workflow consumes the openemr-tag dispatch, `$v_tag`
+#     is clean. Manual mid-cycle dry-run niche is available via
+#     release-prep or a temporarily-mutated local checkout.
+#
+#   * `validate_token` input + the "even during dry_run, generate +
+#     verify the app token" gate it drove. `release-permissions-check.yml`
+#     is the tool for testing token permissions; validate_token was a
+#     duplicative safety net that predated it.
+#
+#   * `upload_sourceforge` + `docker_prep` + `update_website` inputs
+#     and their "not yet implemented" no-op steps. Dead scope for
+#     months. Also gets total workflow_dispatch inputs under GitHub's
+#     10-input cap (was 11).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_branch:
+        description: Release branch (e.g., rel-820)
+        required: true
+        type: string
+      version:
+        description: Human-readable version (e.g., 8.2.0)
+        required: true
+        type: string
+      release_tag:
+        description: Git tag (e.g., v8_2_0). Required unless dry run.
+        required: false
+        type: string
+      milestone:
+        description: GitHub milestone name for preflight check (e.g., 8.2.0)
+        required: false
+        type: string
+      dry_run:
+        description: Dry run — build only, skip release
+        type: boolean
+        default: true
+      skip_milestone_check:
+        description: Skip milestone open-items check
+        type: boolean
+        default: false
+      skip_ghsa_check:
+        description: Skip unpublished GHSA check
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      version_branch:
+        description: Release branch (e.g., rel-820)
+        required: true
+        type: string
+      version:
+        description: Human-readable version (e.g., 8.2.0)
+        required: true
+        type: string
+      release_tag:
+        description: Git tag (e.g., v8_2_0). Required unless dry run.
+        required: false
+        type: string
+      milestone:
+        description: GitHub milestone name for preflight check (e.g., 8.2.0)
+        required: false
+        type: string
+      dry_run:
+        description: Dry run — build only, skip release
+        type: boolean
+        default: true
+      skip_milestone_check:
+        description: Skip milestone open-items check
+        type: boolean
+        default: false
+      skip_ghsa_check:
+        description: Skip unpublished GHSA check
+        type: boolean
+        default: false
+
+concurrency:
+  group: build-release-${{ inputs.release_tag || inputs.version }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-release:
+    runs-on: ubuntu-24.04
+    name: Build Release
+    steps:
+    - name: Validate inputs
+      if: "!inputs.dry_run && inputs.release_tag == ''"
+      run: |
+        printf '::error::release_tag is required when dry_run is false\n'
+        exit 1
+
+    - name: Generate app token
+      if: '!inputs.dry_run'
+      id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: openemr
+
+    - name: Verify app token
+      if: '!inputs.dry_run'
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      run: |
+        echo "Checking app token can access openemr/openemr milestones..."
+        gh api repos/openemr/openemr/milestones --jq '.[].title' | head -5
+        echo 'App token verified.'
+
+    - name: Checkout openemr release branch
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.version_branch }}
+        token: ${{ steps.app-token.outputs.token || github.token }}
+        filter: blob:none
+        fetch-depth: 1
+
+    - name: Setup PHP and Composer
+      uses: ./.github/actions/setup-php-composer
+      with:
+        php-version: '8.5'
+
+    - name: Install Taskfile
+      uses: arduino/setup-task@v3
+      with:
+        version: 3.x
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Preflight checks
+      if: '(!inputs.skip_milestone_check && inputs.milestone != '''') || !inputs.skip_ghsa_check'
+      working-directory: tools/release
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+      run: >-
+        task preflight
+        MILESTONE='${{ inputs.milestone }}'
+        SKIP_MILESTONE='${{ (inputs.skip_milestone_check || inputs.milestone == '') && '1' || '' }}'
+        SKIP_GHSA='${{ inputs.skip_ghsa_check && '1' || '' }}'
+
+    # Extract the target version's section from CHANGELOG.md for the
+    # GitHub Release body + release-notes asset. Content is pre-computed
+    # by ChangelogMutator + CompatibilityMutator during the release-prep
+    # + release-finalize partner PRs (openemr/openemr#12925 +
+    # openemr/openemr#12928) — both the noise-filtered PR list and the
+    # Minimum-supported-versions block are already in place on the rel
+    # branch's CHANGELOG.md by the time this workflow runs post-tag.
+    - name: Extract CHANGELOG section
+      working-directory: tools/release
+      env:
+        # Route through env so a shell-metachar in inputs.version cannot
+        # break out of the task-argument quoting. Task itself calls
+        # shellQuote on the value again; belt + suspenders.
+        RELEASE_VERSION: ${{ inputs.version }}
+      run: >-
+        task changelog:extract
+        VERSION="$RELEASE_VERSION"
+        OPENEMR_DIR='${{ github.workspace }}'
+
+    # Build and checksum the package before creating the tag/release. If
+    # any build step fails, the job aborts before a release exists —
+    # never publish a release that has no distribution assets attached.
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+
+    - name: Build distribution package
+      working-directory: tools/release
+      run: >-
+        task package:assemble
+        VERSION='${{ inputs.version }}'
+        OPENEMR_DIR='${{ github.workspace }}'
+
+    - name: Generate checksums
+      working-directory: tools/release
+      run: |
+        task checksum FILE="openemr-${{ inputs.version }}.tar.gz"
+        task checksum FILE="openemr-${{ inputs.version }}.zip"
+
+    - name: Create annotated tag and GitHub release
+      if: '!inputs.dry_run'
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+      run: |
+        tag='${{ inputs.release_tag }}'
+        output_dir='${{ github.workspace }}/tools/release/release-output'
+
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+        # Check the remote, not the local checkout: the checkout step
+        # uses fetch-depth: 1 and does not fetch tags, so a local
+        # rev-parse always misses an already-published tag. That made
+        # `git push origin "$tag"` fail with "tag already exists in the
+        # remote" when re-firing after the openemr/openemr conductor
+        # had already tagged via its finalize job.
+        #
+        # `git ls-remote --exit-code` returns 0 when the tag exists and 2
+        # when it does not. Any other status is a real lookup failure
+        # (auth, transport) and must abort rather than fall through to a
+        # tag push that would mask the underlying error.
+        tag_lookup_status=0
+        git ls-remote --tags --exit-code origin "refs/tags/$tag" > /dev/null 2>&1 || tag_lookup_status=$?
+        case "$tag_lookup_status" in
+          0)
+            echo "Tag $tag already exists on origin, skipping tag creation"
+            ;;
+          2)
+            git tag -a -m "Release $tag" "$tag" '${{ inputs.version_branch }}'
+            git push origin "$tag"
+            ;;
+          *)
+            echo "::error::Failed to query origin for tag $tag (git ls-remote exit $tag_lookup_status)" >&2
+            exit "$tag_lookup_status"
+            ;;
+        esac
+
+        if ! gh release view "$tag" --repo openemr/openemr > /dev/null 2>&1; then
+          echo "Creating release $tag"
+          gh release create "$tag" \
+            --repo openemr/openemr \
+            --title "OpenEMR ${{ inputs.version }}" \
+            --notes-file "${output_dir}/changelog.md" \
+            --verify-tag
+        fi
+
+    - name: Upload package and checksums to release
+      if: '!inputs.dry_run'
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+      run: |
+        tag='${{ inputs.release_tag }}'
+        output_dir='${{ github.workspace }}/tools/release/release-output'
+
+        gh release upload "$tag" \
+          --repo openemr/openemr \
+          --clobber \
+          "${output_dir}/openemr-${{ inputs.version }}.tar.gz" \
+          "${output_dir}/openemr-${{ inputs.version }}.zip" \
+          "${output_dir}"/*.md5 \
+          "${output_dir}"/*.sha256 \
+          "${output_dir}"/*.sha512 \
+          "${output_dir}/changelog.md"
+
+    - name: Build summary
+      working-directory: tools/release
+      run: >-
+        task summary
+        TYPE=full
+        MILESTONE='${{ inputs.milestone }}'
+        VERSION_BRANCH='${{ inputs.version_branch }}'
+        RELEASE_TAG='${{ inputs.release_tag }}'
+        DRY_RUN='${{ inputs.dry_run }}'
+
+    - name: Upload artifacts (dry run)
+      if: inputs.dry_run
+      uses: actions/upload-artifact@v7
+      with:
+        name: release-${{ inputs.version }}
+        path: |
+          tools/release/release-output/changelog.md
+          tools/release/release-output/*.md5
+          tools/release/release-output/*.sha256
+          tools/release/release-output/*.sha512
+        retention-days: 7

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -110,6 +110,10 @@ jobs:
   build-release:
     runs-on: ubuntu-24.04
     name: Build Release
+    # Cap runtime. Package assembly + tag/release is under 15 min in
+    # normal runs; the GitHub-default 6h ceiling would let a hung
+    # composer/npm/git step burn runner minutes if something wedged.
+    timeout-minutes: 30
     steps:
     - name: Validate inputs
       if: "!inputs.dry_run && inputs.release_tag == ''"
@@ -159,12 +163,19 @@ jobs:
       if: '(!inputs.skip_milestone_check && inputs.milestone != '''') || !inputs.skip_ghsa_check'
       working-directory: tools/release
       env:
+        # Route inputs through env so shell-metachars in operator-
+        # provided values can't break out of task-argument quoting.
+        # Task itself calls shellQuote on the value again; belt +
+        # suspenders.
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        MILESTONE: ${{ inputs.milestone }}
+        SKIP_MILESTONE: ${{ (inputs.skip_milestone_check || inputs.milestone == '') && '1' || '' }}
+        SKIP_GHSA: ${{ inputs.skip_ghsa_check && '1' || '' }}
       run: >-
         task preflight
-        MILESTONE='${{ inputs.milestone }}'
-        SKIP_MILESTONE='${{ (inputs.skip_milestone_check || inputs.milestone == '') && '1' || '' }}'
-        SKIP_GHSA='${{ inputs.skip_ghsa_check && '1' || '' }}'
+        MILESTONE="$MILESTONE"
+        SKIP_MILESTONE="$SKIP_MILESTONE"
+        SKIP_GHSA="$SKIP_GHSA"
 
     # Extract the target version's section from CHANGELOG.md for the
     # GitHub Release body + release-notes asset. Content is pre-computed
@@ -195,24 +206,31 @@ jobs:
 
     - name: Build distribution package
       working-directory: tools/release
+      env:
+        RELEASE_VERSION: ${{ inputs.version }}
       run: >-
         task package:assemble
-        VERSION='${{ inputs.version }}'
-        OPENEMR_DIR='${{ github.workspace }}'
+        VERSION="$RELEASE_VERSION"
+        OPENEMR_DIR="$GITHUB_WORKSPACE"
 
     - name: Generate checksums
       working-directory: tools/release
+      env:
+        RELEASE_VERSION: ${{ inputs.version }}
       run: |
-        task checksum FILE="openemr-${{ inputs.version }}.tar.gz"
-        task checksum FILE="openemr-${{ inputs.version }}.zip"
+        task checksum FILE="openemr-${RELEASE_VERSION}.tar.gz"
+        task checksum FILE="openemr-${RELEASE_VERSION}.zip"
 
     - name: Create annotated tag and GitHub release
       if: '!inputs.dry_run'
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+        RELEASE_VERSION: ${{ inputs.version }}
+        VERSION_BRANCH: ${{ inputs.version_branch }}
       run: |
-        tag='${{ inputs.release_tag }}'
-        output_dir='${{ github.workspace }}/tools/release/release-output'
+        tag="$RELEASE_TAG"
+        output_dir="$GITHUB_WORKSPACE/tools/release/release-output"
 
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
@@ -235,7 +253,7 @@ jobs:
             echo "Tag $tag already exists on origin, skipping tag creation"
             ;;
           2)
-            git tag -a -m "Release $tag" "$tag" '${{ inputs.version_branch }}'
+            git tag -a -m "Release $tag" "$tag" "$VERSION_BRANCH"
             git push origin "$tag"
             ;;
           *)
@@ -248,7 +266,7 @@ jobs:
           echo "Creating release $tag"
           gh release create "$tag" \
             --repo openemr/openemr \
-            --title "OpenEMR ${{ inputs.version }}" \
+            --title "OpenEMR $RELEASE_VERSION" \
             --notes-file "${output_dir}/changelog.md" \
             --verify-tag
         fi
@@ -257,15 +275,17 @@ jobs:
       if: '!inputs.dry_run'
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+        RELEASE_VERSION: ${{ inputs.version }}
       run: |
-        tag='${{ inputs.release_tag }}'
-        output_dir='${{ github.workspace }}/tools/release/release-output'
+        tag="$RELEASE_TAG"
+        output_dir="$GITHUB_WORKSPACE/tools/release/release-output"
 
         gh release upload "$tag" \
           --repo openemr/openemr \
           --clobber \
-          "${output_dir}/openemr-${{ inputs.version }}.tar.gz" \
-          "${output_dir}/openemr-${{ inputs.version }}.zip" \
+          "${output_dir}/openemr-${RELEASE_VERSION}.tar.gz" \
+          "${output_dir}/openemr-${RELEASE_VERSION}.zip" \
           "${output_dir}"/*.md5 \
           "${output_dir}"/*.sha256 \
           "${output_dir}"/*.sha512 \
@@ -273,13 +293,18 @@ jobs:
 
     - name: Build summary
       working-directory: tools/release
+      env:
+        MILESTONE: ${{ inputs.milestone }}
+        VERSION_BRANCH: ${{ inputs.version_branch }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+        DRY_RUN: ${{ inputs.dry_run }}
       run: >-
         task summary
         TYPE=full
-        MILESTONE='${{ inputs.milestone }}'
-        VERSION_BRANCH='${{ inputs.version_branch }}'
-        RELEASE_TAG='${{ inputs.release_tag }}'
-        DRY_RUN='${{ inputs.dry_run }}'
+        MILESTONE="$MILESTONE"
+        VERSION_BRANCH="$VERSION_BRANCH"
+        RELEASE_TAG="$RELEASE_TAG"
+        DRY_RUN="$DRY_RUN"
 
     - name: Upload artifacts (dry run)
       if: inputs.dry_run

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -37,6 +37,19 @@ tasks:
       --changelog={{shellQuote .OPENEMR_DIR}}/CHANGELOG.md
       --output={{shellQuote .OUTPUT_DIR}}/changelog.md
 
+  changelog:
+    desc: Generate a changelog from a commit range (patch-release use case)
+    requires:
+      vars: [BASE, HEAD, TITLE]
+    cmds:
+    - mkdir -p {{shellQuote .OUTPUT_DIR}}
+    - >-
+      php bin/changelog.php
+      --base={{shellQuote .BASE}}
+      --head={{shellQuote .HEAD}}
+      --title={{shellQuote .TITLE}}
+      --output={{shellQuote .OUTPUT_DIR}}/changelog.md
+
   preflight:
     desc: Run pre-release checks (milestone completeness + unpublished GHSAs)
     cmds:


### PR DESCRIPTION
Phase 2 PR 2b of the workstream 7 release-mechanism migration (\`docs/release-mechanism-migration-from-devops.md\`). Adds the 3 build workflows on top of the Taskfile + bin scripts landed in PR 2a (#13079). **Workflows are wired but no automated trigger fires them yet** — \`release-prep.yml\` still dispatches \`openemr-tag\` to \`openemr-devops\`. PR 2c will retarget that dispatch, at which point the intra-repo flow becomes canonical.

Devops copies stay live during the parallel-run validation window per the migration doc's phased plan; Phase 6 deletes them after one clean release cycle validates the new path.

## New workflows

- **\`.github/workflows/build-release.yml\`** — full-release packaging. \`workflow_dispatch\` (manual maintainer path) + \`workflow_call\` (invoked from build-release-on-tag.yml).
- **\`.github/workflows/build-release-on-tag.yml\`** — consumer of intra-repo \`openemr-tag\` \`repository_dispatch\`. Derives build inputs from the payload and calls build-release.yml.
- **\`.github/workflows/build-patch.yml\`** — manual patch-release escape hatch for zero-day-style hotfixes.

## Simplifications vs devops originals

- Dropped \`Checkout openemr-devops (release tools)\` sparse-checkout step — release tools now live in openemr's \`tools/release/\` (PR 1 #13062 + PR 2a #13079).
- Dropped \`Checkout openemr release branch\` cross-repo checkout in favor of a single self-checkout.
- Dropped \`DEVOPS_DIR\` + \`TOOLS_DIR\` env vars.
- Replaced \`task release:<foo>\` (working-directory: devops-tools) with \`cd tools/release && task <foo>\` (bare task names, no \`release:\` namespace prefix — matches PR 2a's simplified Taskfile shape).
- Replaced \`Install release tools\` (\`task release:setup\` running \`composer install\` in devops's module vendor) with \`.github/actions/setup-php-composer\` composite action.

## Dropped steps

- **build-release.yml**: \`Detect existing prep\` + \`Version bump (full mode)\` + \`Commit version changes\` + \`Push version changes\` — the legacy \`-dev\`-detection fallback the guard supported is superseded by the conductor's \`VersionPhpMutator\` (rel-scope).
- **build-patch.yml**: \`Bump version.php\` (MODE=patch) + \`Commit and push version bump\` — maintainer bumps \`\$v_realpatch\` and pushes to the rel branch before invoking, which fires \`patch-prep-automation.yml\` (workstream 6) for the mutator-side coordinated 2-PR flow.
- **build-patch.yml**: \`Generate changelog\` (\`task release:changelog\`) + \`Create CHANGELOG PRs\` (\`task release:changelog-pr\`) — both task targets were retired from devops's Taskfile in openemr/openemr-devops#857 (2026-07-13) + #858 (2026-07-13); build-patch invocations were never updated on the devops side and had been broken since #857 landed.

## Dropped inputs (fits under GitHub's 10-input workflow_dispatch cap)

Devops originals exceeded the cap (11 for build-release, 12 for build-patch). This trims to 7 and 10 respectively:

- **build-release.yml (11 → 7)**: \`upload_sourceforge\`, \`docker_prep\`, \`update_website\` (all "not yet implemented" no-op stubs — dead scope for months); \`validate_token\` (\`release-permissions-check.yml\` is the tool for testing token permissions).
- **build-patch.yml (12 → 10)**: \`validate_token\` (same reason); \`skip_milestone_check\` (existing preflight gate already skips when milestone is empty).

## Preserved intra-repo dispatch trigger

Per your design decision: the release-me PR's mutator output (CHANGELOG etc.) needs to land *before* the tag exists, so keep the tag-post-merge \`openemr-tag\` \`repository_dispatch\` invariant rather than collapsing to \`push: tags: ['v*']\` or \`workflow_run\`. The only change vs devops is intra-repo (openemr → openemr) instead of cross-repo (openemr → openemr-devops).

## Byte-identical sync additions

Added to \`.github/byte-identical.yml\` (with \`exclude-branches: [rel-800, rel-704]\` per the established release-mechanism-workflow pattern):

- \`build-release.yml\` — fires on \`workflow_dispatch\` + \`workflow_call\`; operator can pick rel branch.
- \`build-patch.yml\` — fires on \`workflow_dispatch\`; operator picks rel branch.

**NOT added**: \`build-release-on-tag.yml\` — \`repository_dispatch\` events run the default-branch (master) copy per GitHub Actions spec; rel-branch copies would be dead weight without behavior load.

## Test plan
- [x] actionlint clean (with CI's 2 known-good false-positive suppressions on \`actions/create-github-app-token@v3\` \`client-id\` auth path).
- [x] All 3 workflows under the 10-input workflow_dispatch cap.
- [x] Pre-commit hooks pass.
- [ ] CI green on this PR.
- [ ] Manual workflow_dispatch smoke test on build-release.yml with \`dry_run: true\` after merge (validates parallel-run path against devops's still-live copy).

## Not in this PR

- **PR 2c**: retarget \`release-prep.yml\`'s openemr-tag dispatch from \`openemr/openemr-devops\` → \`openemr/openemr\`. Atomic cutover; intra-repo flow becomes canonical at merge.
- **PR 2d**: docs updates (migration doc SHIPPED marker, gap-doc closures, RELEASE_PROCESS.md if operator-facing paths changed).
- **Phase 6**: delete devops copies of these workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)