### PR TITLE
feat(release): retarget openemr-tag dispatch to openemr (Phase 2 PR 2c)

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -410,13 +410,18 @@ jobs:
         # Scope the installation token to this repo plus the dispatch
         # targets, otherwise repository_dispatch to the consumer repos
         # returns 403 "Resource not accessible by integration".
-        # demo_farm_openemr dropped (was: ...,demo_farm_openemr) because
-        # the only dispatch in this `finalize` job is openemr-tag, and
-        # demo_farm no longer consumes it (demo_farm_openemr#141 retired
-        # bump-tag.yml; the auto-derive bot subscribes to
-        # release-targets-changed instead).
+        #
+        # After workstream 7 Phase 2 PR 2c (openemr-tag dispatch cutover
+        # from openemr-devops -> openemr), the finalize dispatch fanout
+        # is `openemr/openemr,openemr/website-openemr`. `openemr` needs
+        # to be in the token scope both as the running repo and as the
+        # dispatch target. `openemr-devops` dropped: no dispatch to it
+        # remains from this job. `demo_farm_openemr` never in scope
+        # here: bump-tag.yml was retired in demo_farm_openemr#141 in
+        # favor of the auto-derive bot subscribing to
+        # release-targets-changed instead.
         owner: ${{ github.repository_owner }}
-        repositories: openemr,openemr-devops,website-openemr
+        repositories: openemr,website-openemr
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer
@@ -505,14 +510,22 @@ jobs:
         # BranchVersionResolver::previousRelease() the sibling rel-cut/
         # update dispatches use.
         prev_release="$(php tools/release/bin/derive-prev-release.php "${VERSION}")"
-        # Demo_farm_openemr no longer consumes openemr-tag: its bump-tag.yml
-        # was retired in demo_farm_openemr#141 in favor of the auto-derive
-        # bot, which subscribes to release-targets-changed instead. Explicit
-        # --target-repos to drop demo_farm from the default list so the
-        # dispatch doesn't fire into a void.
+        # Explicit --target-repos to shape the fanout differently from
+        # dispatch.php's default list (see Dispatcher::DEFAULT_TARGET_REPOS):
+        #   * `openemr/openemr` -- intra-repo, consumed by openemr's own
+        #     build-release-on-tag.yml (workstream 7 Phase 2 PR 2b landed
+        #     the consumer; PR 2c retargeted this dispatch to it, from the
+        #     historical openemr/openemr-devops build-release-on-tag.yml).
+        #   * `openemr/website-openemr` -- consumed by release-docs.yml
+        #     for acknowledgements + release-notes markdown generation.
+        #   * Demo_farm_openemr dropped from the default list: its
+        #     bump-tag.yml was retired in demo_farm_openemr#141 in favor
+        #     of the auto-derive bot subscribing to
+        #     release-targets-changed instead. Without the explicit
+        #     --target-repos the dispatch would fire into a void there.
         php tools/release/bin/dispatch.php \
           --event=openemr-tag \
-          --target-repos=openemr/openemr-devops,openemr/website-openemr \
+          --target-repos=openemr/openemr,openemr/website-openemr \
           --sha="${MERGE_SHA}" \
           --actor='openemr-release-bot' \
           --branch="${REL_BRANCH}" \


### PR DESCRIPTION
Phase 2 PR 2c of the workstream 7 release-mechanism migration (\`docs/release-mechanism-migration-from-devops.md\`). **Atomic cutover**: \`release-prep.yml\`'s finalize-job \`openemr-tag\` dispatch now targets \`openemr/openemr\` instead of \`openemr/openemr-devops\`.

## What changed

- \`--target-repos=openemr/openemr-devops,openemr/website-openemr\` → \`--target-repos=openemr/openemr,openemr/website-openemr\`
- Finalize-job App-token permission scope (\`repositories:\` list) drops \`openemr-devops\` — no dispatch to it remains from this job.

## What this unblocks

Openemr's \`build-release-on-tag.yml\` (landed in PR 2b, #13087) is the intended consumer of the \`openemr-tag\` dispatch. Before this PR, the dispatch still went to devops's copy; this cutover routes it intra-repo. On the next real release cycle (**rel-830 cut in ~2 weeks**), the release-me PR merge fires \`openemr-tag\` which triggers openemr's \`build-release-on-tag.yml\` → \`build-release.yml\`, producing the distribution packages + GitHub Release.

## Verification I confirmed

Grepped \`openemr/openemr-devops/.github/workflows\` for consumers of \`openemr-tag\`, \`openemr-rel-cut\`, \`openemr-rel-update\`: **only** \`build-release-on-tag.yml\` consumes \`openemr-tag\` (no other devops workflow reacts to any of these events). So retargeting \`openemr-tag\` away from devops doesn't leave any devops-side handler dark that we needed to preserve.

## Devops's copy stays live for now

No consumer will fire it after this PR merges (\`openemr-tag\` no longer sent there), but Phase 6 formally deletes it after one clean release cycle validates the new path. Manual devops-side \`workflow_dispatch\` of \`build-release.yml\` remains available as a break-glass fallback if the new path misfires.

## Scope discipline

1 file, 2 edits. Deliberately narrow: this is the semantic cutover moment, and keeping the diff tiny makes the review focus on "is the retarget correct" rather than "is anything else in this PR going to break."

## Not in this PR (independent from Phase 2 scope)

- **Prep-job (rel-cut/rel-update) fanout** still targets the default list including \`openemr-devops\` + \`demo_farm_openemr\`, both of which no longer consume those events. Stale but firing-into-a-void is harmless; cleanup is a followup.
- \`release-prep.yml\` line 99's token scope still includes \`openemr-devops\` + \`demo_farm_openemr\` for the same reason.

## Byte-identical sync

\`release-prep.yml\` is already in \`.github/byte-identical.yml\` (with \`exclude-branches: [rel-800, rel-704]\`); this change auto-syncs to rel-820 + rel-810 on merge.

## Test plan
- [x] actionlint clean (with CI's 2 known-good false-positive suppressions on \`actions/create-github-app-token@v3\` \`client-id\` auth path).
- [x] Grep-verified: devops has no other \`openemr-tag\` consumers to preserve.
- [ ] CI green on this PR.
- [ ] On next real release-me PR merge, watch that \`openemr-tag\` fires openemr's \`build-release-on-tag.yml\` (not devops's).

## Not in this PR

- **PR 2d**: docs updates (migration doc SHIPPED marker on Phase 2, gap-doc closures, \`RELEASE_PROCESS.md\` if operator-facing paths changed).
- **Phase 6**: delete devops copies of \`build-release.yml\` / \`build-release-on-tag.yml\` / \`build-patch.yml\` + the supporting PHP classes + Taskfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)