### PR TITLE
feat(release): migrate ship-release orchestrator + workflow (Phase 3a)

### DIFF
--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -69,11 +69,25 @@ jobs:
         repositories: |
           openemr
           website-openemr
+        # Explicit permission grants (least-privilege). Ship-release
+        # needs: read PR state (pull-requests:read via metadata), merge
+        # PRs (pull-requests:write), post commit statuses on PR heads
+        # (statuses:write), read repo contents (contents:read). The
+        # App itself may be installed with broader permissions; scoping
+        # the minted token narrows what a compromised runner can do.
+        permission-contents: read
+        permission-metadata: read
+        permission-pull-requests: write
+        permission-statuses: write
 
     - name: Checkout
       uses: actions/checkout@v7
       with:
         token: ${{ steps.app-token.outputs.token }}
+        # ship-release orchestrates via `gh` CLI (which uses GH_TOKEN env);
+        # it never pushes to git. Persisting credentials in the checkout
+        # would leak them to any subsequent step. Defense-in-depth.
+        persist-credentials: false
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer

--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -1,0 +1,104 @@
+name: Ship Release
+
+# Manually-triggered orchestration for the two-PR release flow (#705):
+# merges conductor → docs in strict order, skipping any already merged
+# (so the same trigger handles partial-merge recovery), and refusing to merge
+# anything if any unmerged PR is not ready. Mints one App token with PR-write
+# on both repos and posts a release/ship-approved commit status on each
+# PR head before merging it (so branch protection can require it later).
+#
+# **Operator convention: dispatch from master.** The workflow orchestrates PR
+# merges via `gh` CLI against branches specified in the inputs (rel_branch +
+# derived docs/finalize branches). It never touches the workflow's own git
+# state, so it doesn't need to be dispatched from a rel branch. Standardizing
+# on master-dispatch keeps the mental model clean (ship-release is an
+# orchestrator, not tied to any specific rel branch) and avoids the need for
+# .github/byte-identical.yml sync — the master copy is authoritative and the
+# only one that ever fires.
+#
+# Migrated from openemr/openemr-devops in workstream 7 Phase 3 (~2026-07-21).
+# See docs/release-mechanism-migration-from-devops.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 8.2.0) — picks website-openemr branch release-docs/<version>'
+        required: true
+        type: string
+      rel_branch:
+        description: 'Release branch (e.g. rel-820) — picks openemr/openemr branch release-prep/<rel_branch>'
+        required: true
+        type: string
+      dry_run:
+        description: 'Check readiness only — do not merge or post statuses'
+        required: false
+        type: boolean
+        default: false
+      timeout_seconds:
+        description: 'Max seconds to wait for docs PR to update after conductor merge'
+        required: false
+        type: string
+        default: '600'
+
+permissions: {}
+
+concurrency:
+  group: ship-release
+  cancel-in-progress: false
+
+jobs:
+  ship:
+    name: Merge release PRs in order
+    runs-on: ubuntu-24.04
+    env:
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+    - name: Mint release App token
+      id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        # ship-release merges 2 PRs: conductor in openemr, docs in
+        # website-openemr. openemr-devops dropped from token scope in
+        # Phase 3 (was: openemr,openemr-devops,website-openemr) --
+        # devops's ship-release.yml was retired when this workflow
+        # moved here; no dispatch or merge action targets it anymore.
+        owner: openemr
+        repositories: |
+          openemr
+          website-openemr
+
+    - name: Checkout
+      uses: actions/checkout@v7
+      with:
+        token: ${{ steps.app-token.outputs.token }}
+
+    - name: Setup PHP and Composer
+      uses: ./.github/actions/setup-php-composer
+      with:
+        php-version: '8.5'
+
+    - name: Install Task
+      uses: arduino/setup-task@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Ship release
+      working-directory: tools/release
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        VERSION: ${{ inputs.version }}
+        REL_BRANCH: ${{ inputs.rel_branch }}
+        TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+        DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+        STATUS_TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: >-
+        task ship-release
+        VERSION="${VERSION}"
+        REL_BRANCH="${REL_BRANCH}"
+        TIMEOUT_SECONDS="${TIMEOUT_SECONDS}"
+        STATUS_TARGET_URL="${STATUS_TARGET_URL}"
+        SUMMARY_FILE="${GITHUB_STEP_SUMMARY}"
+        DRY_RUN="${DRY_RUN}"

--- a/tests/Tests/Isolated/Release/Fakes/FailingMergeApi.php
+++ b/tests/Tests/Isolated/Release/Fakes/FailingMergeApi.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * FakePullRequestApi variant that throws on squashMerge for one specific PR.
+ * Used to verify the orchestrator catches gh failures per-step.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release\Fakes;
+
+final class FailingMergeApi extends FakePullRequestApi
+{
+    public function __construct(
+        private readonly string $failRepo,
+        private readonly int $failNumber,
+        private readonly string $failMessage,
+    ) {
+    }
+
+    public function squashMerge(string $repo, int $number, string $expectedHeadSha): string
+    {
+        if ($repo === $this->failRepo && $number === $this->failNumber) {
+            throw new \RuntimeException($this->failMessage);
+        }
+        return parent::squashMerge($repo, $number, $expectedHeadSha);
+    }
+}

--- a/tests/Tests/Isolated/Release/Fakes/FakeClock.php
+++ b/tests/Tests/Isolated/Release/Fakes/FakeClock.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Deterministic Clock for orchestrator tests.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release\Fakes;
+
+use OpenEMR\Release\Clock;
+
+final class FakeClock implements Clock
+{
+    private \DateTimeImmutable $current;
+
+    public int $totalSlept = 0;
+
+    public function __construct(?\DateTimeImmutable $start = null)
+    {
+        $this->current = $start ?? new \DateTimeImmutable('2026-01-01T00:00:00Z');
+    }
+
+    public function now(): \DateTimeImmutable
+    {
+        return $this->current;
+    }
+
+    public function sleep(int $seconds): void
+    {
+        $this->totalSlept += $seconds;
+        $this->current = $this->current->modify("+{$seconds} seconds");
+    }
+}

--- a/tests/Tests/Isolated/Release/Fakes/FakePullRequestApi.php
+++ b/tests/Tests/Isolated/Release/Fakes/FakePullRequestApi.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * In-memory PullRequestApi for orchestrator tests.
+ *
+ * Readiness and merge SHAs are keyed by "repo#number" so PR-number collisions
+ * across repos (entirely possible — PR numbers are per-repo on GitHub) don't
+ * silently mask cross-repo bugs in the orchestrator.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release\Fakes;
+
+use OpenEMR\Release\PullRequestApi;
+use OpenEMR\Release\PullRequestReadiness;
+use OpenEMR\Release\PullRequestSnapshot;
+
+class FakePullRequestApi implements PullRequestApi
+{
+    /** @var array<string, ?PullRequestSnapshot> */
+    private array $snapshotsByKey = [];
+
+    /** @var array<string, PullRequestReadiness> keyed by "repo#number" */
+    private array $readinessByPr = [];
+
+    /** @var array<string, list<PullRequestReadiness>> per-PR queue, consumed left-to-right */
+    private array $readinessQueue = [];
+
+    /** @var array<string, string> merge SHAs by "repo#number" */
+    private array $mergeShas = [];
+
+    /** @var list<array{repo: string, sha: string, context: string, state: string}> */
+    public array $postedStatuses = [];
+
+    /** @var list<array{repo: string, number: int, expected: string}> */
+    public array $merges = [];
+
+    /** @var array<string, PullRequestSnapshot> snapshots installed by setSnapshotAfterFinds() */
+    private array $snapshotAfterFind = [];
+
+    /** @var array<string, int> */
+    private array $findCalls = [];
+
+    public function setSnapshot(string $repo, string $branch, ?PullRequestSnapshot $snapshot): void
+    {
+        $this->snapshotsByKey[$this->branchKey($repo, $branch)] = $snapshot;
+    }
+
+    /**
+     * After the Nth call to findByHead for this repo+branch, swap to a new snapshot.
+     * Used to simulate the docs PR being re-rendered by the conductor merge.
+     */
+    public function setSnapshotAfterFinds(
+        string $repo,
+        string $branch,
+        int $afterNCalls,
+        PullRequestSnapshot $snapshot,
+    ): void {
+        $this->snapshotAfterFind[$this->branchKey($repo, $branch) . '|' . $afterNCalls] = $snapshot;
+    }
+
+    public function setReadiness(string $repo, int $number, PullRequestReadiness $readiness): void
+    {
+        $this->readinessByPr[$this->prKey($repo, $number)] = $readiness;
+    }
+
+    /**
+     * Each call to getReadiness() for $repo#$number consumes one entry. Once exhausted,
+     * the last entry is returned for subsequent calls.
+     *
+     * @param list<PullRequestReadiness> $sequence
+     */
+    public function setReadinessSequence(string $repo, int $number, array $sequence): void
+    {
+        $this->readinessQueue[$this->prKey($repo, $number)] = $sequence;
+    }
+
+    public function setMergeSha(string $repo, int $number, string $sha): void
+    {
+        $this->mergeShas[$this->prKey($repo, $number)] = $sha;
+    }
+
+    public function findByHead(string $repo, string $branch): ?PullRequestSnapshot
+    {
+        $key = $this->branchKey($repo, $branch);
+        $this->findCalls[$key] = ($this->findCalls[$key] ?? 0) + 1;
+        $swap = $this->snapshotAfterFind[$key . '|' . $this->findCalls[$key]] ?? null;
+        if ($swap !== null) {
+            $this->snapshotsByKey[$key] = $swap;
+        }
+        return $this->snapshotsByKey[$key] ?? null;
+    }
+
+    public function getReadiness(string $repo, int $number): PullRequestReadiness
+    {
+        $key = $this->prKey($repo, $number);
+        if (isset($this->readinessQueue[$key]) && $this->readinessQueue[$key] !== []) {
+            $next = array_shift($this->readinessQueue[$key]);
+            $this->readinessByPr[$key] = $next;
+            return $next;
+        }
+        if (!isset($this->readinessByPr[$key])) {
+            throw new \RuntimeException("No readiness configured for {$key}");
+        }
+        return $this->readinessByPr[$key];
+    }
+
+    public function postCommitStatus(
+        string $repo,
+        string $sha,
+        string $context,
+        string $state,
+        string $description,
+        string $targetUrl,
+    ): void {
+        $this->postedStatuses[] = [
+            'repo' => $repo,
+            'sha' => $sha,
+            'context' => $context,
+            'state' => $state,
+        ];
+    }
+
+    public function squashMerge(string $repo, int $number, string $expectedHeadSha): string
+    {
+        $this->merges[] = ['repo' => $repo, 'number' => $number, 'expected' => $expectedHeadSha];
+        return $this->mergeShas[$this->prKey($repo, $number)] ?? "merge-sha-{$number}";
+    }
+
+    private function branchKey(string $repo, string $branch): string
+    {
+        return $repo . '|' . $branch;
+    }
+
+    private function prKey(string $repo, int $number): string
+    {
+        return $repo . '#' . $number;
+    }
+}

--- a/tests/Tests/Isolated/Release/Fakes/FakePullRequestApi.php
+++ b/tests/Tests/Isolated/Release/Fakes/FakePullRequestApi.php
@@ -36,7 +36,7 @@ class FakePullRequestApi implements PullRequestApi
     /** @var array<string, string> merge SHAs by "repo#number" */
     private array $mergeShas = [];
 
-    /** @var list<array{repo: string, sha: string, context: string, state: string}> */
+    /** @var list<array{repo: string, sha: string, context: string, state: string, description: string, targetUrl: string}> */
     public array $postedStatuses = [];
 
     /** @var list<array{repo: string, number: int, expected: string}> */
@@ -125,6 +125,8 @@ class FakePullRequestApi implements PullRequestApi
             'sha' => $sha,
             'context' => $context,
             'state' => $state,
+            'description' => $description,
+            'targetUrl' => $targetUrl,
         ];
     }
 

--- a/tests/Tests/Isolated/Release/GhPullRequestApiTest.php
+++ b/tests/Tests/Isolated/Release/GhPullRequestApiTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Unit tests for the pure helpers on GhPullRequestApi. The shell-touching
+ * methods are exercised end-to-end through the orchestrator with a fake API.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release;
+
+use OpenEMR\Release\GhPullRequestApi;
+use OpenEMR\Release\ShipReleaseOrchestrator;
+use PHPUnit\Framework\TestCase;
+
+final class GhPullRequestApiTest extends TestCase
+{
+    public function testRollupSkipsOwnContextEvenWhenItIsFailure(): void
+    {
+        // Regression: a prior ship-release run that failed left
+        // release/ship-approved=failure on the head SHA. The next preflight
+        // must not treat that as a blocking external check.
+        $rollup = [
+            ['context' => 'ci/build', 'state' => 'SUCCESS'],
+            ['context' => ShipReleaseOrchestrator::STATUS_CONTEXT, 'state' => 'FAILURE'],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertSame([], $reasons);
+    }
+
+    public function testRollupBlocksOnFailingExternalCheck(): void
+    {
+        $rollup = [
+            ['context' => 'ci/build', 'state' => 'FAILURE'],
+            ['context' => ShipReleaseOrchestrator::STATUS_CONTEXT, 'state' => 'SUCCESS'],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertCount(1, $reasons);
+        self::assertStringContainsString('ci/build', $reasons[0]);
+        self::assertStringContainsString('FAILURE', $reasons[0]);
+    }
+
+    public function testRollupBlocksOnPendingCheckRun(): void
+    {
+        $rollup = [
+            ['name' => 'phpstan', 'status' => 'IN_PROGRESS', 'conclusion' => null],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertCount(1, $reasons);
+        self::assertStringContainsString('phpstan', $reasons[0]);
+        self::assertStringContainsString('IN_PROGRESS', $reasons[0]);
+    }
+
+    public function testRollupAllowsNeutralAndSkippedConclusions(): void
+    {
+        $rollup = [
+            ['name' => 'optional-job', 'status' => 'COMPLETED', 'conclusion' => 'NEUTRAL'],
+            ['name' => 'skipped-job', 'status' => 'COMPLETED', 'conclusion' => 'SKIPPED'],
+            ['name' => 'green-job', 'status' => 'COMPLETED', 'conclusion' => 'SUCCESS'],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertSame([], $reasons);
+    }
+
+    public function testRollupBlocksOnLegacyExpectedState(): void
+    {
+        $rollup = [
+            ['context' => 'required/check', 'state' => 'EXPECTED'],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertCount(1, $reasons);
+        self::assertStringContainsString('EXPECTED', $reasons[0]);
+    }
+}

--- a/tests/Tests/Isolated/Release/PullRequestTargetTest.php
+++ b/tests/Tests/Isolated/Release/PullRequestTargetTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release;
+
+use OpenEMR\Release\PullRequestTarget;
+use OpenEMR\Release\RoleLabel;
+use PHPUnit\Framework\TestCase;
+
+final class PullRequestTargetTest extends TestCase
+{
+    public function testForReleaseProducesConductorDocsInOrder(): void
+    {
+        $targets = PullRequestTarget::forRelease('8.1.0', 'rel-810');
+
+        self::assertCount(2, $targets);
+        self::assertSame(RoleLabel::Conductor, $targets[0]->roleLabel);
+        self::assertSame('openemr/openemr', $targets[0]->repo);
+        self::assertSame('release-prep/rel-810', $targets[0]->branch);
+        self::assertSame('rel-810', $targets[0]->expectedBase);
+        self::assertSame(1, $targets[0]->mergeOrder);
+
+        self::assertSame(RoleLabel::Docs, $targets[1]->roleLabel);
+        self::assertSame('openemr/website-openemr', $targets[1]->repo);
+        self::assertSame('release-docs/8.1.0', $targets[1]->branch);
+        self::assertSame('master', $targets[1]->expectedBase);
+        self::assertSame(2, $targets[1]->mergeOrder);
+    }
+}

--- a/tests/Tests/Isolated/Release/ShipReleaseOrchestratorTest.php
+++ b/tests/Tests/Isolated/Release/ShipReleaseOrchestratorTest.php
@@ -1,0 +1,424 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release;
+
+use OpenEMR\Release\PullRequestReadiness;
+use OpenEMR\Release\PullRequestSnapshot;
+use OpenEMR\Release\PullRequestState;
+use OpenEMR\Release\PullRequestTarget;
+use OpenEMR\Release\RoleLabel;
+use OpenEMR\Release\ShipReleaseOrchestrator;
+use OpenEMR\Release\ShipReleaseStepResult;
+use OpenEMR\Release\ShipReleaseStepStatus;
+use OpenEMR\Tests\Isolated\Release\Fakes\FailingMergeApi;
+use OpenEMR\Tests\Isolated\Release\Fakes\FakeClock;
+use OpenEMR\Tests\Isolated\Release\Fakes\FakePullRequestApi;
+use PHPUnit\Framework\TestCase;
+
+final class ShipReleaseOrchestratorTest extends TestCase
+{
+    private const CONDUCTOR_REPO = 'openemr/openemr';
+    private const CONDUCTOR_BRANCH = 'release-prep/rel-810';
+    private const CONDUCTOR_BASE = 'rel-810';
+    private const DOCS_REPO = 'openemr/website-openemr';
+    private const DOCS_BRANCH = 'release-docs/8.1.0';
+
+    /**
+     * @return list<PullRequestTarget>
+     */
+    private function targets(): array
+    {
+        return PullRequestTarget::forRelease('8.1.0', 'rel-810');
+    }
+
+    private function ready(string $headSha): PullRequestReadiness
+    {
+        return new PullRequestReadiness($headSha, []);
+    }
+
+    private function open(int $number, string $head, string $base = 'master'): PullRequestSnapshot
+    {
+        return new PullRequestSnapshot($number, $head, $base, PullRequestState::Open);
+    }
+
+    private function merged(int $number, string $head, string $base = 'master'): PullRequestSnapshot
+    {
+        return new PullRequestSnapshot($number, $head, $base, PullRequestState::Merged);
+    }
+
+    private function closed(int $number, string $head, string $base = 'master'): PullRequestSnapshot
+    {
+        return new PullRequestSnapshot($number, $head, $base, PullRequestState::Closed);
+    }
+
+    private function openConductor(): PullRequestSnapshot
+    {
+        return $this->open(202, 'sha-conductor', self::CONDUCTOR_BASE);
+    }
+
+    private function mergedConductor(): PullRequestSnapshot
+    {
+        return $this->merged(202, 'sha-conductor', self::CONDUCTOR_BASE);
+    }
+
+    public function testHappyPathMergesBothInOrderAndPostsApprovalStatus(): void
+    {
+        $api = new FakePullRequestApi();
+        $targets = $this->targets();
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs-old'));
+        // After conductor merge, the docs PR is re-rendered with a new head SHA.
+        $api->setSnapshotAfterFinds(
+            self::DOCS_REPO,
+            self::DOCS_BRANCH,
+            2,
+            $this->open(303, 'sha-docs-new'),
+        );
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs-new'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($targets);
+
+        self::assertTrue($result->wasSuccessful());
+        self::assertSame(
+            [ShipReleaseStepStatus::MERGED, ShipReleaseStepStatus::MERGED],
+            array_map(
+                static fn (ShipReleaseStepResult $s): ShipReleaseStepStatus => $s->status,
+                $result->steps,
+            ),
+        );
+        self::assertSame(
+            [['repo' => self::CONDUCTOR_REPO, 'number' => 202, 'expected' => 'sha-conductor'],
+                ['repo' => self::DOCS_REPO, 'number' => 303, 'expected' => 'sha-docs-new']],
+            $api->merges,
+        );
+        self::assertCount(2, $api->postedStatuses);
+        self::assertSame(ShipReleaseOrchestrator::STATUS_CONTEXT, $api->postedStatuses[0]['context']);
+        self::assertSame('sha-conductor', $api->postedStatuses[0]['sha']);
+        self::assertSame('sha-docs-new', $api->postedStatuses[1]['sha']);
+    }
+
+    public function testConductorBlockedAtPreflightMergesNothing(): void
+    {
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(
+            self::CONDUCTOR_REPO,
+            202,
+            new PullRequestReadiness('sha-conductor', ['check core-test conclusion=FAILURE']),
+        );
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[0]->status);
+        self::assertContains('check core-test conclusion=FAILURE', $result->steps[0]->reasons);
+        self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[1]->status);
+        self::assertSame([], $api->merges);
+        self::assertSame([], $api->postedStatuses);
+    }
+
+    public function testConductorReadyButDocsBlockedAtPreflightMergesNothing(): void
+    {
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, new PullRequestReadiness(
+            'sha-docs',
+            ['reviewDecision=REVIEW_REQUIRED (need APPROVED)'],
+        ));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[0]->status);
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[1]->status);
+        self::assertSame([], $api->merges);
+    }
+
+    public function testDocsFirstFatalRefusesToMergeAnything(): void
+    {
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->merged(303, 'sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertNotNull($result->fatalReason);
+        self::assertStringContainsString('docs-first', $result->fatalReason);
+        self::assertSame([], $api->merges);
+        foreach ($result->steps as $step) {
+            self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $step->status);
+        }
+    }
+
+    public function testDryRunDoesNotMergeOrPostStatuses(): void
+    {
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock(), 600, true))->ship($this->targets());
+
+        self::assertTrue($result->wasSuccessful());
+        self::assertSame([], $api->merges);
+        self::assertSame([], $api->postedStatuses);
+        foreach ($result->steps as $step) {
+            self::assertSame(ShipReleaseStepStatus::WOULD_MERGE, $step->status);
+        }
+    }
+
+    public function testConductorAlreadyMergedRefetchesDocsBeforeMerging(): void
+    {
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->mergedConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs-stale'));
+        $api->setReadinessSequence(self::DOCS_REPO, 303, [
+            $this->ready('sha-docs-stale'),
+            $this->ready('sha-docs-fresh'),
+        ]);
+        $api->setSnapshotAfterFinds(
+            self::DOCS_REPO,
+            self::DOCS_BRANCH,
+            2,
+            $this->open(303, 'sha-docs-fresh'),
+        );
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertTrue($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED, $result->steps[0]->status);
+        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[1]->status);
+        self::assertSame('sha-docs-fresh', $api->merges[0]['expected']);
+    }
+
+    public function testConductorAlreadyMergedBlocksDocsIfDownstreamStillInFlight(): void
+    {
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->mergedConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadinessSequence(self::DOCS_REPO, 303, [
+            $this->ready('sha-docs'),
+            new PullRequestReadiness('sha-docs', ['check core-test status=IN_PROGRESS']),
+        ]);
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED, $result->steps[0]->status);
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[1]->status);
+        self::assertContains('check core-test status=IN_PROGRESS', $result->steps[1]->reasons);
+        self::assertSame([], $api->merges);
+    }
+
+    public function testDownstreamWaitTimeoutBlocksDocsMerge(): void
+    {
+        // Docs PR head SHA never changes during the wait — simulates the
+        // conductor's downstream re-render workflow not firing in time.
+        // Even if readiness still looks "clean", we must NOT merge stale
+        // docs content (DRAFT→FINAL flip never happened).
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+
+        $clock = new FakeClock();
+        $result = (new ShipReleaseOrchestrator($api, $clock, 30))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertGreaterThanOrEqual(30, $clock->totalSlept);
+        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[0]->status);
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[1]->status);
+        self::assertStringContainsString('did not change after conductor merge', $result->steps[1]->reasons[0]);
+        // Only conductor merged; docs not.
+        self::assertCount(1, $api->merges);
+    }
+
+    public function testWrongBaseBranchBlocksWithoutMerging(): void
+    {
+        // Conductor PR exists but has been opened against `master` instead of
+        // the expected `rel-810`. Refuse to merge it (would ship the wrong content).
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->open(202, 'sha-conductor', 'master'));
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[0]->status);
+        self::assertStringContainsString('PR base is master, expected rel-810', $result->steps[0]->reasons[0]);
+        self::assertSame([], $api->merges);
+    }
+
+    public function testTargetsAreSortedByMergeOrderRegardlessOfInputOrder(): void
+    {
+        // Pass targets in reverse order; the orchestrator must still merge
+        // conductor → docs.
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs-old'));
+        $api->setSnapshotAfterFinds(
+            self::DOCS_REPO,
+            self::DOCS_BRANCH,
+            2,
+            $this->open(303, 'sha-docs-new'),
+        );
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs-new'));
+
+        $shuffled = $this->targets();
+        $shuffled = [$shuffled[1], $shuffled[0]]; // docs, conductor
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($shuffled);
+
+        self::assertTrue($result->wasSuccessful());
+        self::assertSame(
+            [self::CONDUCTOR_REPO, self::DOCS_REPO],
+            array_column($api->merges, 'repo'),
+        );
+    }
+
+    public function testMergeApiFailureReportsBlockedAndStopsSubsequentMerges(): void
+    {
+        // Simulate gh failing on the conductor merge (e.g. --match-head-commit
+        // mismatch from a race). Conductor reports BLOCKED with the gh error,
+        // docs is NOT_REACHED.
+        $api = new FailingMergeApi('openemr/openemr', 202, 'gh: --match-head-commit does not match');
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[0]->status);
+        self::assertStringContainsString('--match-head-commit does not match', $result->steps[0]->reasons[0]);
+        self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[1]->status);
+    }
+
+    public function testClosedWithoutMergingPrBlocks(): void
+    {
+        // A PR that was closed without merging (state=CLOSED, mergedAt=null)
+        // must not be treated as "open and ready to merge".
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(
+            self::CONDUCTOR_REPO,
+            self::CONDUCTOR_BRANCH,
+            $this->closed(202, 'sha-conductor', self::CONDUCTOR_BASE),
+        );
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[0]->status);
+        self::assertStringContainsString('CLOSED without being merged', $result->steps[0]->reasons[0]);
+        self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[1]->status);
+        self::assertSame([], $api->merges);
+    }
+
+    public function testDuplicateMergeOrderThrowsLogicException(): void
+    {
+        $api = new FakePullRequestApi();
+        $targets = [
+            new PullRequestTarget('a/x', 'b1', 'master', RoleLabel::Conductor, 1),
+            new PullRequestTarget('a/y', 'b2', 'master', RoleLabel::Docs, 1),
+        ];
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('duplicate mergeOrder');
+        (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($targets);
+    }
+
+    public function testWrongTargetCountThrowsLogicException(): void
+    {
+        // Stale callers (e.g., still passing the pre-collapse 3-PR list,
+        // or a single Conductor-only target) must fail fast rather than
+        // silently half-shipping.
+        $api = new FakePullRequestApi();
+        $targets = [
+            new PullRequestTarget('a/x', 'b1', 'master', RoleLabel::Conductor, 1),
+        ];
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('exactly 2 targets');
+        (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($targets);
+    }
+
+    public function testWrongTargetRoleSetThrowsLogicException(): void
+    {
+        // Two targets of correct count but wrong roles (e.g., two
+        // Conductors, or a Conductor + something else) violates the
+        // {Conductor, Docs} contract and must fail fast.
+        $api = new FakePullRequestApi();
+        $targets = [
+            new PullRequestTarget('a/x', 'b1', 'master', RoleLabel::Conductor, 1),
+            new PullRequestTarget('a/y', 'b2', 'master', RoleLabel::Conductor, 2),
+        ];
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('{Conductor, Docs}');
+        (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($targets);
+    }
+
+    public function testReversedMergeOrderThrowsLogicException(): void
+    {
+        // Correct role set {Conductor, Docs} with unique mergeOrder
+        // values, but Docs.mergeOrder < Conductor.mergeOrder. The
+        // role-set + dedup checks would pass, but usort would then put
+        // Docs first — silently violating the strict conductor → docs
+        // merge sequence. Must fail fast.
+        $api = new FakePullRequestApi();
+        $targets = [
+            new PullRequestTarget('a/x', 'b1', 'master', RoleLabel::Conductor, 2),
+            new PullRequestTarget('a/y', 'b2', 'master', RoleLabel::Docs, 1),
+        ];
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Conductor before Docs');
+        (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($targets);
+    }
+
+    public function testMergeFailureRetractsApprovalStatus(): void
+    {
+        // Verify the success status is followed by a failure status on the
+        // same head SHA so a stale release/ship-approved=success doesn't
+        // remain on the PR for branch protection to honor.
+        $api = new FailingMergeApi('openemr/openemr', 202, 'gh: api error');
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+
+        (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        // Statuses on conductor head: success (pre-merge) then failure (retraction).
+        $conductorStatuses = array_values(array_filter(
+            $api->postedStatuses,
+            static fn (array $s): bool => $s['sha'] === 'sha-conductor',
+        ));
+        self::assertCount(2, $conductorStatuses);
+        self::assertSame('success', $conductorStatuses[0]['state']);
+        self::assertSame('failure', $conductorStatuses[1]['state']);
+    }
+}

--- a/tests/Tests/Isolated/Release/ShipReleaseSummaryRendererTest.php
+++ b/tests/Tests/Isolated/Release/ShipReleaseSummaryRendererTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release;
+
+use OpenEMR\Release\PullRequestTarget;
+use OpenEMR\Release\RoleLabel;
+use OpenEMR\Release\ShipReleaseResult;
+use OpenEMR\Release\ShipReleaseStepResult;
+use OpenEMR\Release\ShipReleaseStepStatus;
+use OpenEMR\Release\ShipReleaseSummaryRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class ShipReleaseSummaryRendererTest extends TestCase
+{
+    public function testRendersHeaderModeAndResult(): void
+    {
+        $result = new ShipReleaseResult([
+            $this->step(RoleLabel::Conductor, 'openemr/openemr', ShipReleaseStepStatus::MERGED, 22, 'def5678'),
+            $this->step(RoleLabel::Docs, 'openemr/website-openemr', ShipReleaseStepStatus::MERGED, 33, 'aaa9999'),
+        ]);
+
+        $md = ShipReleaseSummaryRenderer::render('8.1.0', 'rel-810', false, $result);
+
+        self::assertStringContainsString('## Ship Release — 8.1.0 (rel-810)', $md);
+        self::assertStringContainsString('- **Mode:** live', $md);
+        self::assertStringContainsString('- **Result:** ✅ success', $md);
+        self::assertStringContainsString('| Role | Repo | PR | Status | Detail |', $md);
+        self::assertStringContainsString(
+            '| conductor | `openemr/openemr` '
+            . '| [#22](https://github.com/openemr/openemr/pull/22) | ✅ merged | `def5678` |',
+            $md,
+        );
+    }
+
+    public function testDryRunModeAndWouldMerge(): void
+    {
+        $result = new ShipReleaseResult([
+            $this->step(RoleLabel::Conductor, 'openemr/openemr', ShipReleaseStepStatus::WOULD_MERGE, 22, null),
+        ]);
+
+        $md = ShipReleaseSummaryRenderer::render('8.1.0', 'rel-810', true, $result);
+
+        self::assertStringContainsString('- **Mode:** dry run (no merges performed)', $md);
+        self::assertStringContainsString(
+            '| conductor | `openemr/openemr` '
+            . '| [#22](https://github.com/openemr/openemr/pull/22) | ✅ would merge | — |',
+            $md,
+        );
+    }
+
+    public function testFailureWithFatalReasonAndBlockedReasons(): void
+    {
+        $result = new ShipReleaseResult(
+            [
+                $this->step(
+                    RoleLabel::Conductor,
+                    'openemr/openemr',
+                    ShipReleaseStepStatus::BLOCKED,
+                    22,
+                    null,
+                    ['not mergeable', 'required check failing'],
+                ),
+            ],
+            'docs PR shipped FINAL with no tag',
+        );
+
+        $md = ShipReleaseSummaryRenderer::render('8.1.0', 'rel-810', false, $result);
+
+        self::assertStringContainsString('- **Result:** ❌ failure', $md);
+        self::assertStringContainsString('> ❌ **Fatal:** docs PR shipped FINAL with no tag', $md);
+        self::assertStringContainsString('❌ blocked | not mergeable<br>required check failing |', $md);
+    }
+
+    public function testMissingPrRendersDash(): void
+    {
+        $result = new ShipReleaseResult([
+            $this->step(RoleLabel::Docs, 'openemr/website-openemr', ShipReleaseStepStatus::NOT_REACHED, null, null),
+        ]);
+
+        $md = ShipReleaseSummaryRenderer::render('8.1.0', 'rel-810', false, $result);
+
+        self::assertStringContainsString('| docs | `openemr/website-openemr` | — | · not reached | — |', $md);
+    }
+
+    /**
+     * @param list<string> $reasons
+     */
+    private function step(
+        RoleLabel $role,
+        string $repo,
+        ShipReleaseStepStatus $status,
+        ?int $prNumber,
+        ?string $mergeSha,
+        array $reasons = [],
+    ): ShipReleaseStepResult {
+        return new ShipReleaseStepResult(
+            new PullRequestTarget($repo, 'branch', 'master', $role, $role->value === 'conductor' ? 1 : 2),
+            $status,
+            $prNumber,
+            $mergeSha,
+            $reasons,
+        );
+    }
+}

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -126,3 +126,17 @@ tasks:
       {{if .PATCH_NUMBER}}--patch-number={{shellQuote .PATCH_NUMBER}}{{end}}
       {{if .DRY_RUN}}--dry-run{{end}}
       {{if .COPY_STYLES}}--copy-styles{{end}}
+
+  ship-release:
+    desc: Merge the two release PRs (conductor → docs) in order
+    requires:
+      vars: [VERSION, REL_BRANCH]
+    cmds:
+    - >-
+      php bin/ship-release.php
+      --release-version={{shellQuote .VERSION}}
+      --rel-branch={{shellQuote .REL_BRANCH}}
+      {{if .TIMEOUT_SECONDS}}--timeout-seconds={{shellQuote .TIMEOUT_SECONDS}}{{end}}
+      {{if .STATUS_TARGET_URL}}--status-target-url={{shellQuote .STATUS_TARGET_URL}}{{end}}
+      {{if .SUMMARY_FILE}}--summary-file={{shellQuote .SUMMARY_FILE}}{{end}}
+      {{if eq .DRY_RUN "1"}}--dry-run{{end}}

--- a/tools/release/bin/ship-release.php
+++ b/tools/release/bin/ship-release.php
@@ -1,0 +1,88 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Merge the two release PRs (conductor → docs) in order.
+ *
+ * Authenticates via the ambient GH_TOKEN env var. The workflow mints a release
+ * App token with PR-write on both repos and exports it before invoking.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+use OpenEMR\Release\GhPullRequestApi;
+use OpenEMR\Release\PullRequestTarget;
+use OpenEMR\Release\ShipReleaseOptions;
+use OpenEMR\Release\ShipReleaseOrchestrator;
+use OpenEMR\Release\ShipReleaseRenderer;
+use OpenEMR\Release\ShipReleaseSummaryRenderer;
+use OpenEMR\Release\SystemClock;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+use Symfony\Component\Filesystem\Filesystem;
+
+(new SingleCommandApplication())
+    ->setName('ship-release')
+    ->setDescription('Merge the two release PRs in order (issue #705)')
+    // Option is `--release-version`, not `--version`: Symfony Console reserves
+    // `--version`/`-V` as a global flag that prints the app name and exits 0
+    // before the command runs, so `--version=8.1.0` would silently no-op.
+    ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g. 8.1.0)')
+    ->addOption('rel-branch', null, InputOption::VALUE_REQUIRED, 'Release branch name (e.g. rel-810)')
+    ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Check readiness without merging or posting status')
+    ->addOption(
+        'timeout-seconds',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Max seconds to wait for docs PR to update after conductor merges',
+        '600',
+    )
+    ->addOption('status-target-url', null, InputOption::VALUE_REQUIRED, 'target_url for the ship-approved status', '')
+    ->addOption('summary-file', null, InputOption::VALUE_REQUIRED, 'Write a Markdown run summary to this path', '')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $version = ShipReleaseOptions::asString($input, 'release-version');
+        $relBranch = ShipReleaseOptions::asString($input, 'rel-branch');
+        if ($version === '' || $relBranch === '') {
+            $output->writeln('<error>--release-version and --rel-branch are required</error>');
+            return 1;
+        }
+        $timeoutRaw = ShipReleaseOptions::asString($input, 'timeout-seconds');
+        if (!ctype_digit($timeoutRaw) || (int) $timeoutRaw < 1) {
+            $output->writeln('<error>--timeout-seconds must be a positive integer</error>');
+            return 1;
+        }
+
+        $orchestrator = new ShipReleaseOrchestrator(
+            new GhPullRequestApi(),
+            new SystemClock(),
+            (int) $timeoutRaw,
+            (bool) $input->getOption('dry-run'),
+            ShipReleaseOptions::asString($input, 'status-target-url'),
+        );
+        $result = $orchestrator->ship(PullRequestTarget::forRelease($version, $relBranch));
+        ShipReleaseRenderer::render($output, $result);
+
+        $summaryFile = ShipReleaseOptions::asString($input, 'summary-file');
+        if ($summaryFile !== '') {
+            $markdown = ShipReleaseSummaryRenderer::render(
+                $version,
+                $relBranch,
+                (bool) $input->getOption('dry-run'),
+                $result,
+            );
+            (new Filesystem())->appendToFile($summaryFile, $markdown);
+        }
+
+        return $result->wasSuccessful() ? 0 : 1;
+    })
+    ->run();

--- a/tools/release/src/Clock.php
+++ b/tools/release/src/Clock.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Test seam for the orchestrator's downstream-effect polling loop.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+interface Clock
+{
+    public function now(): \DateTimeImmutable;
+
+    public function sleep(int $seconds): void;
+}

--- a/tools/release/src/DocsRefreshResult.php
+++ b/tools/release/src/DocsRefreshResult.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Outcome of refreshing the docs PR snapshot + readiness right before merge.
+ *
+ * Replaces an earlier 4-tuple with overloaded null semantics. Only one of the
+ * three static factories produces a usable instance; the type system enforces
+ * which fields are populated.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class DocsRefreshResult
+{
+    /**
+     * @param list<string> $blockingReasons
+     */
+    private function __construct(
+        public ?PullRequestSnapshot $snapshot,
+        public ?PullRequestReadiness $readiness,
+        public ?string $stopReason,
+        public array $blockingReasons,
+    ) {
+    }
+
+    public static function success(PullRequestSnapshot $snapshot, PullRequestReadiness $readiness): self
+    {
+        return new self($snapshot, $readiness, null, []);
+    }
+
+    /**
+     * @param list<string> $reasons
+     */
+    public static function blocked(?PullRequestSnapshot $snapshot, string $stopReason, array $reasons): self
+    {
+        return new self($snapshot, null, $stopReason, $reasons);
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->stopReason === null;
+    }
+}

--- a/tools/release/src/GhPullRequestApi.php
+++ b/tools/release/src/GhPullRequestApi.php
@@ -1,0 +1,236 @@
+<?php
+
+/**
+ * gh-CLI implementation of PullRequestApi. Authenticates via the ambient
+ * GH_TOKEN env var (the workflow mints an App token and exports it).
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Process\Process;
+
+final readonly class GhPullRequestApi implements PullRequestApi
+{
+    public function findByHead(string $repo, string $branch): ?PullRequestSnapshot
+    {
+        $process = new Process([
+            'gh', 'pr', 'list',
+            '--repo', $repo,
+            '--head', $branch,
+            '--state', 'all',
+            '--limit', '1',
+            '--json', 'number,headRefOid,baseRefName,state',
+        ]);
+        $process->mustRun();
+
+        $output = trim($process->getOutput());
+        if ($output === '' || $output === '[]') {
+            return null;
+        }
+        /** @var list<array{number: int, headRefOid: string, baseRefName: string, state: string}> $rows */
+        $rows = $this->decodeJson($output, "gh pr list for {$repo}/{$branch}");
+        if ($rows === []) {
+            return null;
+        }
+        $row = $rows[0];
+        return new PullRequestSnapshot(
+            $row['number'],
+            $row['headRefOid'],
+            $row['baseRefName'],
+            PullRequestState::from($row['state']),
+        );
+    }
+
+    public function getReadiness(string $repo, int $number): PullRequestReadiness
+    {
+        $process = new Process([
+            'gh', 'pr', 'view', (string) $number,
+            '--repo', $repo,
+            '--json', 'isDraft,mergeable,mergeStateStatus,reviewDecision,'
+                . 'statusCheckRollup,latestReviews,headRefOid',
+        ]);
+        $process->mustRun();
+
+        /**
+         * @var array{
+         *     isDraft: bool,
+         *     mergeable: string,
+         *     mergeStateStatus: string,
+         *     reviewDecision: ?string,
+         *     statusCheckRollup: list<array<string, mixed>>,
+         *     latestReviews: list<array{state: string, author?: array{login?: string}}>,
+         *     headRefOid: string,
+         * } $data
+         */
+        $data = $this->decodeJson(trim($process->getOutput()), "gh pr view {$repo}#{$number}");
+
+        $reasons = [];
+        if ($data['isDraft']) {
+            $reasons[] = 'PR is a draft';
+        }
+        if ($data['mergeable'] !== 'MERGEABLE') {
+            $reasons[] = sprintf('mergeable=%s (need MERGEABLE)', $data['mergeable']);
+        }
+        if ($data['mergeStateStatus'] !== 'CLEAN') {
+            $reasons[] = sprintf('mergeStateStatus=%s (need CLEAN)', $data['mergeStateStatus']);
+        }
+        if (($data['reviewDecision'] ?? null) !== 'APPROVED') {
+            $reasons[] = sprintf(
+                'reviewDecision=%s (need APPROVED)',
+                $data['reviewDecision'] ?? 'null',
+            );
+        }
+        foreach ($data['latestReviews'] as $review) {
+            if ($review['state'] === 'CHANGES_REQUESTED') {
+                $reasons[] = sprintf(
+                    'CHANGES_REQUESTED review by %s',
+                    $review['author']['login'] ?? 'unknown',
+                );
+            }
+        }
+        $reasons = array_merge(
+            $reasons,
+            self::reasonsFromStatusRollup($data['statusCheckRollup'], ShipReleaseOrchestrator::STATUS_CONTEXT),
+        );
+        return new PullRequestReadiness($data['headRefOid'], $reasons);
+    }
+
+    /**
+     * Convert gh's statusCheckRollup into a list of blocking reasons. Skips
+     * any check whose context matches $ownContext — a prior ship-release run
+     * may have posted a failure status there, and the orchestrator must not
+     * gate itself on its own marker.
+     *
+     * @param  list<array<string, mixed>> $rollup
+     * @return list<string>
+     */
+    public static function reasonsFromStatusRollup(array $rollup, string $ownContext): array
+    {
+        $reasons = [];
+        foreach ($rollup as $check) {
+            if (($check['context'] ?? null) === $ownContext) {
+                continue;
+            }
+            $reasons = array_merge($reasons, self::checkBlockingReason($check));
+        }
+        return $reasons;
+    }
+
+    public function postCommitStatus(
+        string $repo,
+        string $sha,
+        string $context,
+        string $state,
+        string $description,
+        string $targetUrl,
+    ): void {
+        $argv = [
+            'gh', 'api',
+            "repos/{$repo}/statuses/{$sha}",
+            '--method', 'POST',
+            '-f', "state={$state}",
+            '-f', "context={$context}",
+            '-f', "description={$description}",
+        ];
+        if ($targetUrl !== '') {
+            $argv[] = '-f';
+            $argv[] = "target_url={$targetUrl}";
+        }
+        $process = new Process($argv);
+        $process->mustRun();
+    }
+
+    public function squashMerge(string $repo, int $number, string $expectedHeadSha): string
+    {
+        // --delete-branch=false is set explicitly so gh doesn't prompt about
+        // branch deletion when run from the workflow's non-TTY shell.
+        $merge = new Process([
+            'gh', 'pr', 'merge', (string) $number,
+            '--repo', $repo,
+            '--squash',
+            '--match-head-commit', $expectedHeadSha,
+            '--delete-branch=false',
+        ]);
+        $merge->setTimeout(300.0);
+        $merge->mustRun();
+
+        // Best-effort fetch of the resulting merge commit SHA for the report.
+        // Failure here doesn't roll back the merge — the merge succeeded if
+        // mustRun() above didn't throw — so swallow the error and report a
+        // sentinel rather than failing the whole orchestration.
+        try {
+            $view = new Process([
+                'gh', 'pr', 'view', (string) $number,
+                '--repo', $repo,
+                '--json', 'mergeCommit',
+                '--jq', '.mergeCommit.oid // ""',
+            ]);
+            $view->mustRun();
+            $sha = trim($view->getOutput());
+        } catch (\RuntimeException) {
+            return '<merge-sha-unavailable>';
+        }
+        return $sha === '' ? '<merge-sha-unavailable>' : $sha;
+    }
+
+    /**
+     * Decode JSON output from gh, raising a controlled error with the
+     * originating context instead of the bare PHP TypeError that follows
+     * indexing into a null result.
+     */
+    private function decodeJson(string $payload, string $context): mixed
+    {
+        try {
+            return json_decode($payload, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(
+                "Failed to decode JSON from {$context}: {$e->getMessage()}",
+                $e->getCode(),
+                $e,
+            );
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $check
+     * @return list<string>
+     */
+    private static function checkBlockingReason(array $check): array
+    {
+        $name = is_string($check['name'] ?? null) ? $check['name'] : 'unknown';
+        $context = is_string($check['context'] ?? null) ? $check['context'] : $name;
+
+        // Check runs use status/conclusion (conclusion may be null while in
+        // progress, so use array_key_exists, not isset). Legacy commit
+        // statuses use state.
+        if (array_key_exists('status', $check)) {
+            $status = is_string($check['status']) ? $check['status'] : '';
+            $conclusion = is_string($check['conclusion'] ?? null) ? $check['conclusion'] : '';
+            if ($status !== 'COMPLETED') {
+                return [sprintf('check %s status=%s (need COMPLETED)', $name, $status)];
+            }
+            if (!in_array($conclusion, ['SUCCESS', 'NEUTRAL', 'SKIPPED'], true)) {
+                return [sprintf('check %s conclusion=%s', $name, $conclusion)];
+            }
+            return [];
+        }
+        if (isset($check['state'])) {
+            // Legacy commit-status states: SUCCESS / FAILURE / ERROR / PENDING / EXPECTED.
+            // EXPECTED means "this status is expected but hasn't been reported yet" — treat
+            // it as blocking, same as PENDING. Only SUCCESS clears the gate.
+            $state = is_string($check['state']) ? $check['state'] : '';
+            if ($state !== 'SUCCESS') {
+                return [sprintf('status %s state=%s', $context, $state)];
+            }
+        }
+        return [];
+    }
+}

--- a/tools/release/src/PullRequestApi.php
+++ b/tools/release/src/PullRequestApi.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Cross-repo PR operations the ship-release orchestrator needs. Kept narrow on
+ * purpose so tests can substitute a fake without standing up the full gh CLI.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+interface PullRequestApi
+{
+    /**
+     * Look up the most recent PR (open or closed/merged) whose head branch
+     * matches. Returns null when no PR exists for that branch.
+     */
+    public function findByHead(string $repo, string $branch): ?PullRequestSnapshot;
+
+    /**
+     * Compute readiness from GitHub's mergeability + checks + review state.
+     */
+    public function getReadiness(string $repo, int $number): PullRequestReadiness;
+
+    /**
+     * POST a commit status to a SHA. Used to publish release/ship-approved
+     * before merge so branch protection can require it.
+     */
+    public function postCommitStatus(
+        string $repo,
+        string $sha,
+        string $context,
+        string $state,
+        string $description,
+        string $targetUrl,
+    ): void;
+
+    /**
+     * Squash-merge a PR, refusing to proceed if the PR's current head SHA has
+     * moved since $expectedHeadSha. Returns the merge commit SHA.
+     */
+    public function squashMerge(string $repo, int $number, string $expectedHeadSha): string;
+}

--- a/tools/release/src/PullRequestReadiness.php
+++ b/tools/release/src/PullRequestReadiness.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Whether a PR is ready to merge, with one human-readable reason per blocker.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class PullRequestReadiness
+{
+    /**
+     * @param list<string> $blockingReasons
+     */
+    public function __construct(
+        public string $headRefOid,
+        public array $blockingReasons,
+    ) {
+    }
+
+    public function isReady(): bool
+    {
+        return $this->blockingReasons === [];
+    }
+}

--- a/tools/release/src/PullRequestSnapshot.php
+++ b/tools/release/src/PullRequestSnapshot.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Point-in-time snapshot of a pull request.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class PullRequestSnapshot
+{
+    public function __construct(
+        public int $number,
+        public string $headRefOid,
+        public string $baseRefName,
+        public PullRequestState $state,
+    ) {
+    }
+
+    public function isMerged(): bool
+    {
+        return $this->state === PullRequestState::Merged;
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->state === PullRequestState::Closed;
+    }
+}

--- a/tools/release/src/PullRequestState.php
+++ b/tools/release/src/PullRequestState.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Lifecycle state of a pull request as reported by GitHub.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+enum PullRequestState: string
+{
+    case Open = 'OPEN';
+    case Closed = 'CLOSED';
+    case Merged = 'MERGED';
+}

--- a/tools/release/src/PullRequestTarget.php
+++ b/tools/release/src/PullRequestTarget.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * One PR slot in the ship-release orchestration: which repo, which head
+ * branch, what role it plays, and the order in which it merges.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class PullRequestTarget
+{
+    public function __construct(
+        public string $repo,
+        public string $branch,
+        public string $expectedBase,
+        public RoleLabel $roleLabel,
+        public int $mergeOrder,
+    ) {
+    }
+
+    /**
+     * Build the canonical conductor → docs target list for a release.
+     *
+     * Branch name conventions are defined in openemr-devops#705 and #664.
+     * Conductor merges into the rel-<n> branch, docs into master.
+     *
+     * @return list<self>
+     */
+    public static function forRelease(string $version, string $relBranch): array
+    {
+        return [
+            new self('openemr/openemr', "release-prep/{$relBranch}", $relBranch, RoleLabel::Conductor, 1),
+            new self('openemr/website-openemr', "release-docs/{$version}", 'master', RoleLabel::Docs, 2),
+        ];
+    }
+}

--- a/tools/release/src/RoleLabel.php
+++ b/tools/release/src/RoleLabel.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Identifier for the two sibling release PRs orchestrated by ship-release.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+enum RoleLabel: string
+{
+    case Conductor = 'conductor';
+    case Docs = 'docs';
+}

--- a/tools/release/src/ShipReleaseOptions.php
+++ b/tools/release/src/ShipReleaseOptions.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * CLI option coercion helper for bin/ship-release.php. Lives in src/ rather
+ * than the bin file because PSR1 forbids combining symbol declarations with
+ * side effects in the same file (the bin file's job is the side effect of
+ * running the SingleCommandApplication).
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+final readonly class ShipReleaseOptions
+{
+    public static function asString(InputInterface $input, string $name): string
+    {
+        $value = $input->getOption($name);
+        return is_string($value) ? $value : '';
+    }
+}

--- a/tools/release/src/ShipReleaseOrchestrator.php
+++ b/tools/release/src/ShipReleaseOrchestrator.php
@@ -1,0 +1,523 @@
+<?php
+
+/**
+ * Merges the two release PRs (conductor → docs) in strict order.
+ *
+ * Two-phase: a preflight pass evaluates every unmerged target's readiness and
+ * refuses to merge anything if any unmerged PR is not ready (issue #705 step
+ * 3 + 5: "no partial merges from the workflow itself"). PRs already merged
+ * are skipped so the same trigger handles partial-merge recovery from outside
+ * causes (e.g. an admin-overridden direct merge).
+ *
+ * Detects the one unrecoverable case — docs merged before conductor — and
+ * refuses to do anything; that recovery is documented in the runbook.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class ShipReleaseOrchestrator
+{
+    public const STATUS_CONTEXT = 'release/ship-approved';
+    public const STATUS_DESCRIPTION = 'Approved by ship-release workflow';
+    private const POLL_INTERVAL_SECONDS = 15;
+    private const STATUS_DESCRIPTION_MAX = 140;
+
+    public function __construct(
+        private PullRequestApi $api,
+        private Clock $clock,
+        private int $downstreamTimeoutSeconds = 600,
+        private bool $dryRun = false,
+        private string $statusTargetUrl = '',
+    ) {
+    }
+
+    /**
+     * @param list<PullRequestTarget> $targets conductor, docs (any order — sorted internally)
+     */
+    public function ship(array $targets): ShipReleaseResult
+    {
+        $targets = $this->sortByMergeOrder($targets);
+        $snapshots = $this->snapshotAll($targets);
+
+        $fatal = $this->detectDocsFirst($targets, $snapshots);
+        if ($fatal !== null) {
+            return new ShipReleaseResult($this->markAllNotReached($targets), $fatal);
+        }
+
+        // Preflight: evaluate every unmerged target before any merge so a later
+        // blocker can't cause earlier ones to ship as a partial merge.
+        $preflight = $this->preflight($targets, $snapshots);
+        if ($preflight['hasBlocker']) {
+            return new ShipReleaseResult($preflight['steps']);
+        }
+
+        if ($this->dryRun) {
+            return new ShipReleaseResult($this->dryRunSteps($targets, $snapshots));
+        }
+
+        return new ShipReleaseResult($this->executeMerges($targets, $snapshots, $preflight['readiness']));
+    }
+
+    /**
+     * Defensive sort + contract check. The 2-PR ship contract requires
+     * exactly the Conductor and Docs targets in any order; this method
+     * fails fast on a stale caller passing the wrong shape (e.g., an
+     * extra target, a missing one, or duplicate mergeOrder values),
+     * since the alternative is a silent half-failure deep in the
+     * downstream merge logic.
+     *
+     * @param  list<PullRequestTarget> $targets
+     * @return list<PullRequestTarget>
+     */
+    private function sortByMergeOrder(array $targets): array
+    {
+        if (count($targets) !== 2) {
+            throw new \LogicException(
+                'ship-release expects exactly 2 targets (Conductor + Docs); got ' . count($targets),
+            );
+        }
+        $roles = array_map(static fn (PullRequestTarget $t): string => $t->roleLabel->value, $targets);
+        sort($roles);
+        $expected = [RoleLabel::Conductor->value, RoleLabel::Docs->value];
+        sort($expected);
+        if ($roles !== $expected) {
+            throw new \LogicException(
+                'ship-release targets must be {Conductor, Docs}; got {' . implode(', ', $roles) . '}',
+            );
+        }
+        $orders = array_map(static fn (PullRequestTarget $t): int => $t->mergeOrder, $targets);
+        if (count(array_unique($orders)) !== count($orders)) {
+            throw new \LogicException('ship-release targets have duplicate mergeOrder values');
+        }
+        // Enforce Conductor-before-Docs at the mergeOrder level too —
+        // {Conductor, Docs} with Docs.mergeOrder < Conductor.mergeOrder
+        // would pass the role-set + dedup checks above but usort would
+        // then merge Docs first, violating the strict merge sequence.
+        $conductor = $this->findRequired($targets, RoleLabel::Conductor);
+        $docs = $this->findRequired($targets, RoleLabel::Docs);
+        if ($conductor->mergeOrder >= $docs->mergeOrder) {
+            throw new \LogicException(
+                'ship-release mergeOrder must put Conductor before Docs; got Conductor='
+                . $conductor->mergeOrder . ' Docs=' . $docs->mergeOrder,
+            );
+        }
+        usort(
+            $targets,
+            static fn (PullRequestTarget $a, PullRequestTarget $b): int => $a->mergeOrder <=> $b->mergeOrder,
+        );
+        return $targets;
+    }
+
+    /**
+     * @param  list<PullRequestTarget> $targets
+     * @return array<string, ?PullRequestSnapshot>
+     */
+    private function snapshotAll(array $targets): array
+    {
+        $out = [];
+        foreach ($targets as $target) {
+            $out[$target->roleLabel->value] = $this->api->findByHead($target->repo, $target->branch);
+        }
+        return $out;
+    }
+
+    /**
+     * Probe every unmerged target's readiness. If any is missing or blocked,
+     * return per-target step results with no merges performed.
+     *
+     * @param  list<PullRequestTarget>             $targets
+     * @param  array<string, ?PullRequestSnapshot> $snapshots
+     * @return array{
+     *     hasBlocker: bool,
+     *     steps: list<ShipReleaseStepResult>,
+     *     readiness: array<string, PullRequestReadiness>,
+     * }
+     */
+    private function preflight(array $targets, array $snapshots): array
+    {
+        $readiness = [];
+        $blocked = [];
+        foreach ($targets as $target) {
+            $key = $target->roleLabel->value;
+            $snapshot = $snapshots[$key] ?? null;
+            if ($snapshot === null) {
+                $blocked[$key] = ['no PR found for branch ' . $target->branch];
+                continue;
+            }
+            if ($snapshot->isClosed()) {
+                $blocked[$key] = [sprintf(
+                    'PR #%d is CLOSED without being merged — refusing to ship a closed PR',
+                    $snapshot->number,
+                )];
+                continue;
+            }
+            if ($snapshot->baseRefName !== $target->expectedBase) {
+                $blocked[$key] = [sprintf(
+                    'PR base is %s, expected %s — refusing to merge a PR opened against the wrong base',
+                    $snapshot->baseRefName,
+                    $target->expectedBase,
+                )];
+                continue;
+            }
+            if ($snapshot->isMerged()) {
+                continue;
+            }
+            $check = $this->api->getReadiness($target->repo, $snapshot->number);
+            $readiness[$key] = $check;
+            if (!$check->isReady()) {
+                $blocked[$key] = $check->blockingReasons;
+            }
+        }
+
+        $steps = [];
+        foreach ($targets as $target) {
+            $key = $target->roleLabel->value;
+            $snapshot = $snapshots[$key] ?? null;
+            if ($snapshot !== null && $snapshot->isMerged()) {
+                $steps[] = new ShipReleaseStepResult(
+                    $target,
+                    ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED,
+                    $snapshot->number,
+                    null,
+                    [],
+                );
+                continue;
+            }
+            if (isset($blocked[$key])) {
+                $steps[] = new ShipReleaseStepResult(
+                    $target,
+                    ShipReleaseStepStatus::BLOCKED,
+                    $snapshot?->number,
+                    null,
+                    $blocked[$key],
+                );
+                continue;
+            }
+            // Ready, but preflight failed elsewhere — we won't merge it now.
+            if ($blocked !== []) {
+                $steps[] = new ShipReleaseStepResult(
+                    $target,
+                    ShipReleaseStepStatus::NOT_REACHED,
+                    $snapshot?->number,
+                    null,
+                    ['preflight blocker on another PR — no merges performed'],
+                );
+            }
+        }
+
+        return ['hasBlocker' => $blocked !== [], 'steps' => $steps, 'readiness' => $readiness];
+    }
+
+    /**
+     * Build the dry-run report — preflight already passed, so each unmerged
+     * target is "would merge" and merged ones stay "skipped".
+     *
+     * @param  list<PullRequestTarget>             $targets
+     * @param  array<string, ?PullRequestSnapshot> $snapshots
+     * @return list<ShipReleaseStepResult>
+     */
+    private function dryRunSteps(array $targets, array $snapshots): array
+    {
+        $steps = [];
+        foreach ($targets as $target) {
+            $snapshot = $snapshots[$target->roleLabel->value] ?? null;
+            if ($snapshot !== null && $snapshot->isMerged()) {
+                $steps[] = new ShipReleaseStepResult(
+                    $target,
+                    ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED,
+                    $snapshot->number,
+                    null,
+                    [],
+                );
+                continue;
+            }
+            $steps[] = new ShipReleaseStepResult(
+                $target,
+                ShipReleaseStepStatus::WOULD_MERGE,
+                $snapshot?->number,
+                null,
+                [],
+            );
+        }
+        return $steps;
+    }
+
+    /**
+     * Real merge pass. Preflight has already validated that every unmerged
+     * target was ready at snapshot time. The docs PR gets a fresh readiness
+     * check after the conductor's downstream effect re-renders it.
+     *
+     * @param  list<PullRequestTarget>             $targets
+     * @param  array<string, ?PullRequestSnapshot> $snapshots
+     * @param  array<string, PullRequestReadiness> $readiness  preflight readiness, by role
+     * @return list<ShipReleaseStepResult>
+     */
+    private function executeMerges(array $targets, array $snapshots, array $readiness): array
+    {
+        $steps = [];
+        $stopReason = null;
+        $mergedThisRun = [];
+
+        foreach ($targets as $target) {
+            if ($stopReason !== null) {
+                $steps[] = $this->notReachedStep($target, $stopReason);
+                continue;
+            }
+
+            $snapshot = $snapshots[$target->roleLabel->value] ?? null;
+            // Preflight already filtered missing PRs.
+            if ($snapshot === null) {
+                $steps[] = $this->blockedStep($target, null, ['no PR found for branch ' . $target->branch]);
+                $stopReason = sprintf('%s PR is missing', $target->roleLabel->value);
+                continue;
+            }
+            if ($snapshot->isMerged()) {
+                $steps[] = new ShipReleaseStepResult(
+                    $target,
+                    ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED,
+                    $snapshot->number,
+                    null,
+                    [],
+                );
+                continue;
+            }
+
+            $stepReadiness = $readiness[$target->roleLabel->value] ?? null;
+            if ($target->roleLabel === RoleLabel::Docs) {
+                $refresh = $this->refreshDocsBeforeMerge($target, $snapshot, $snapshots, $mergedThisRun);
+                if ($refresh instanceof DocsRefreshResult) {
+                    if (!$refresh->isSuccess()) {
+                        $steps[] = $this->blockedStep($target, $refresh->snapshot?->number, $refresh->blockingReasons);
+                        $stopReason = $refresh->stopReason;
+                        continue;
+                    }
+                    $snapshot = $refresh->snapshot;
+                    $stepReadiness = $refresh->readiness;
+                }
+            }
+
+            if ($snapshot === null || $stepReadiness === null) {
+                throw new \LogicException(
+                    "ship-release: missing snapshot or readiness for {$target->roleLabel->value}",
+                );
+            }
+
+            try {
+                $this->api->postCommitStatus(
+                    $target->repo,
+                    $stepReadiness->headRefOid,
+                    self::STATUS_CONTEXT,
+                    'success',
+                    self::STATUS_DESCRIPTION,
+                    $this->statusTargetUrl,
+                );
+                $mergeSha = $this->api->squashMerge($target->repo, $snapshot->number, $stepReadiness->headRefOid);
+            } catch (\RuntimeException $e) {
+                // Best-effort: clear the success status we just posted so a failed
+                // run doesn't leave a release/ship-approved=success on the PR head
+                // that branch protection might honor for a subsequent manual merge.
+                $this->retractApprovalStatus($target->repo, $stepReadiness->headRefOid, $e->getMessage());
+                $steps[] = $this->blockedStep(
+                    $target,
+                    $snapshot->number,
+                    [sprintf('gh call failed: %s', $e->getMessage())],
+                );
+                $stopReason = sprintf('%s merge failed', $target->roleLabel->value);
+                continue;
+            }
+            $steps[] = new ShipReleaseStepResult(
+                $target,
+                ShipReleaseStepStatus::MERGED,
+                $snapshot->number,
+                $mergeSha,
+                [],
+            );
+            $mergedThisRun[] = $target->roleLabel;
+        }
+
+        return $steps;
+    }
+
+    /**
+     * @param list<PullRequestTarget>             $targets
+     * @param array<string, ?PullRequestSnapshot> $snapshots
+     */
+    private function detectDocsFirst(array $targets, array $snapshots): ?string
+    {
+        $docs = $snapshots[RoleLabel::Docs->value] ?? null;
+        $conductor = $snapshots[RoleLabel::Conductor->value] ?? null;
+        if ($docs === null || !$docs->isMerged()) {
+            return null;
+        }
+        if ($conductor !== null && $conductor->isMerged()) {
+            return null;
+        }
+        $conductorTarget = $this->findRequired($targets, RoleLabel::Conductor);
+        $docsTarget = $this->findRequired($targets, RoleLabel::Docs);
+        return sprintf(
+            'docs PR (%s#%d, branch %s) was merged before conductor PR (%s, branch %s).'
+            . ' This is the unrecoverable docs-first case from issue #705 — the docs page'
+            . ' shipped FINAL with no tag. See the release runbook for manual reconciliation.',
+            $docsTarget->repo,
+            $docs->number,
+            $docsTarget->branch,
+            $conductorTarget->repo,
+            $conductorTarget->branch,
+        );
+    }
+
+    /**
+     * @param list<PullRequestTarget> $targets
+     */
+    private function findRequired(array $targets, RoleLabel $role): PullRequestTarget
+    {
+        foreach ($targets as $target) {
+            if ($target->roleLabel === $role) {
+                return $target;
+            }
+        }
+        throw new \LogicException("ship-release targets list is missing role: {$role->value}");
+    }
+
+    /**
+     * Two cases need a fresh state read before merging docs:
+     *   - conductor merged in *this* run: poll until head SHA flips (or time
+     *     out), then re-check readiness against the new SHA.
+     *   - conductor was already merged when we started (recovery case): re-check
+     *     readiness right now in case the previous run's downstream re-render
+     *     is still in flight. Don't poll — if not ready, fail fast and the
+     *     operator re-runs.
+     *
+     * Returns null when no refresh is needed.
+     *
+     * @param array<string, ?PullRequestSnapshot> $snapshots
+     * @param list<RoleLabel>                     $mergedThisRun
+     */
+    private function refreshDocsBeforeMerge(
+        PullRequestTarget $target,
+        PullRequestSnapshot $current,
+        array $snapshots,
+        array $mergedThisRun,
+    ): ?DocsRefreshResult {
+        $conductorJustMerged = in_array(RoleLabel::Conductor, $mergedThisRun, true);
+        $conductorPreviouslyMerged = ($snapshots[RoleLabel::Conductor->value] ?? null)?->isMerged() ?? false;
+        if (!$conductorJustMerged && !$conductorPreviouslyMerged) {
+            return null;
+        }
+        if ($conductorJustMerged) {
+            $fresh = $this->awaitDownstreamUpdate($target, $current);
+            if ($fresh instanceof PullRequestSnapshot && $fresh->headRefOid === $current->headRefOid) {
+                $reason = sprintf(
+                    'docs PR head SHA did not change after conductor merge (timed out waiting for downstream'
+                    . ' re-render — head still %s)',
+                    $current->headRefOid,
+                );
+                return DocsRefreshResult::blocked($fresh, $reason, [$reason]);
+            }
+        } else {
+            $fresh = $this->api->findByHead($target->repo, $target->branch);
+        }
+        if (!$fresh instanceof PullRequestSnapshot) {
+            $disappeared = 'docs PR disappeared before merge';
+            return DocsRefreshResult::blocked(null, $disappeared, [$disappeared]);
+        }
+        $readiness = $this->api->getReadiness($target->repo, $fresh->number);
+        if (!$readiness->isReady()) {
+            $stopReason = $conductorJustMerged
+                ? 'docs PR not ready after conductor downstream update'
+                : 'docs PR not ready (re-checked after conductor was already merged)';
+            return DocsRefreshResult::blocked($fresh, $stopReason, $readiness->blockingReasons);
+        }
+        return DocsRefreshResult::success($fresh, $readiness);
+    }
+
+    /**
+     * Poll until the docs PR head SHA differs from the snapshot taken before
+     * the conductor merge, or until the timeout elapses. Either way, return a
+     * fresh snapshot — readiness is re-checked after this.
+     */
+    private function awaitDownstreamUpdate(
+        PullRequestTarget $target,
+        PullRequestSnapshot $before,
+    ): ?PullRequestSnapshot {
+        $deadline = $this->clock->now()->getTimestamp() + $this->downstreamTimeoutSeconds;
+        $current = $before;
+        while ($this->clock->now()->getTimestamp() < $deadline) {
+            $current = $this->api->findByHead($target->repo, $target->branch);
+            if (!$current instanceof PullRequestSnapshot) {
+                return null;
+            }
+            if ($current->headRefOid !== $before->headRefOid) {
+                return $current;
+            }
+            $this->clock->sleep(self::POLL_INTERVAL_SECONDS);
+        }
+        return $current;
+    }
+
+    /**
+     * @param  list<PullRequestTarget> $targets
+     * @return list<ShipReleaseStepResult>
+     */
+    private function markAllNotReached(array $targets): array
+    {
+        $out = [];
+        foreach ($targets as $target) {
+            $out[] = $this->notReachedStep($target, 'fatal precondition');
+        }
+        return $out;
+    }
+
+    private function retractApprovalStatus(string $repo, string $sha, string $reason): void
+    {
+        $prefix = 'ship-release failed: ';
+        $room = self::STATUS_DESCRIPTION_MAX - mb_strlen($prefix);
+        $description = $prefix . mb_substr($reason, 0, $room);
+        try {
+            $this->api->postCommitStatus(
+                $repo,
+                $sha,
+                self::STATUS_CONTEXT,
+                'failure',
+                $description,
+                $this->statusTargetUrl,
+            );
+        } catch (\RuntimeException) {
+            // Best-effort. If the retraction itself fails, we still surface
+            // the original failure via ShipReleaseStepResult.
+        }
+    }
+
+    private function notReachedStep(PullRequestTarget $target, string $reason): ShipReleaseStepResult
+    {
+        return new ShipReleaseStepResult(
+            $target,
+            ShipReleaseStepStatus::NOT_REACHED,
+            null,
+            null,
+            [$reason],
+        );
+    }
+
+    /**
+     * @param list<string> $reasons
+     */
+    private function blockedStep(PullRequestTarget $target, ?int $number, array $reasons): ShipReleaseStepResult
+    {
+        return new ShipReleaseStepResult(
+            $target,
+            ShipReleaseStepStatus::BLOCKED,
+            $number,
+            null,
+            $reasons,
+        );
+    }
+}

--- a/tools/release/src/ShipReleaseRenderer.php
+++ b/tools/release/src/ShipReleaseRenderer.php
@@ -37,29 +37,28 @@ final readonly class ShipReleaseRenderer
         string $tag,
         string $pr,
     ): void {
-        switch ($step->status) {
-            case ShipReleaseStepStatus::MERGED:
-                $output->writeln(sprintf(
-                    '<info>✓ merged</info>   %s %s → %s',
-                    $tag,
-                    $pr,
-                    $step->mergeSha ?? '?',
-                ));
-                return;
-            case ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED:
-                $output->writeln(sprintf('<comment>↷ skipped</comment> %s %s (already merged)', $tag, $pr));
-                return;
-            case ShipReleaseStepStatus::WOULD_MERGE:
-                $output->writeln(sprintf('<info>✓ ready</info>    %s %s (dry-run: would merge)', $tag, $pr));
-                return;
-            case ShipReleaseStepStatus::BLOCKED:
-                $output->writeln(sprintf('<error>✗ blocked</error>  %s %s', $tag, $pr));
-                foreach ($step->reasons as $reason) {
-                    $output->writeln('    - ' . $reason);
-                }
-                return;
-            case ShipReleaseStepStatus::NOT_REACHED:
-                $output->writeln(sprintf('<comment>· skipped</comment>  %s %s (not reached)', $tag, $pr));
+        // Exhaustive match without default so PHPStan flags new enum
+        // cases at compile time (per CLAUDE.md coding guideline).
+        $lines = match ($step->status) {
+            ShipReleaseStepStatus::MERGED => [
+                sprintf('<info>✓ merged</info>   %s %s → %s', $tag, $pr, $step->mergeSha ?? '?'),
+            ],
+            ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED => [
+                sprintf('<comment>↷ skipped</comment> %s %s (already merged)', $tag, $pr),
+            ],
+            ShipReleaseStepStatus::WOULD_MERGE => [
+                sprintf('<info>✓ ready</info>    %s %s (dry-run: would merge)', $tag, $pr),
+            ],
+            ShipReleaseStepStatus::BLOCKED => array_merge(
+                [sprintf('<error>✗ blocked</error>  %s %s', $tag, $pr)],
+                array_map(static fn (string $reason): string => '    - ' . $reason, $step->reasons),
+            ),
+            ShipReleaseStepStatus::NOT_REACHED => [
+                sprintf('<comment>· skipped</comment>  %s %s (not reached)', $tag, $pr),
+            ],
+        };
+        foreach ($lines as $line) {
+            $output->writeln($line);
         }
     }
 }

--- a/tools/release/src/ShipReleaseRenderer.php
+++ b/tools/release/src/ShipReleaseRenderer.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Symfony Console rendering for ShipReleaseResult. Kept separate so the CLI
+ * file declares no helper functions (PSR1 side-effects-vs-symbols).
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+final readonly class ShipReleaseRenderer
+{
+    public static function render(OutputInterface $output, ShipReleaseResult $result): void
+    {
+        if ($result->fatalReason !== null) {
+            $output->writeln('<error>✗ fatal:</error> ' . $result->fatalReason);
+        }
+        foreach ($result->steps as $step) {
+            $tag = sprintf('[%s] %s', $step->target->roleLabel->value, $step->target->repo);
+            $pr = $step->prNumber !== null ? '#' . $step->prNumber : '(no PR)';
+            self::renderStep($output, $step, $tag, $pr);
+        }
+    }
+
+    private static function renderStep(
+        OutputInterface $output,
+        ShipReleaseStepResult $step,
+        string $tag,
+        string $pr,
+    ): void {
+        switch ($step->status) {
+            case ShipReleaseStepStatus::MERGED:
+                $output->writeln(sprintf(
+                    '<info>✓ merged</info>   %s %s → %s',
+                    $tag,
+                    $pr,
+                    $step->mergeSha ?? '?',
+                ));
+                return;
+            case ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED:
+                $output->writeln(sprintf('<comment>↷ skipped</comment> %s %s (already merged)', $tag, $pr));
+                return;
+            case ShipReleaseStepStatus::WOULD_MERGE:
+                $output->writeln(sprintf('<info>✓ ready</info>    %s %s (dry-run: would merge)', $tag, $pr));
+                return;
+            case ShipReleaseStepStatus::BLOCKED:
+                $output->writeln(sprintf('<error>✗ blocked</error>  %s %s', $tag, $pr));
+                foreach ($step->reasons as $reason) {
+                    $output->writeln('    - ' . $reason);
+                }
+                return;
+            case ShipReleaseStepStatus::NOT_REACHED:
+                $output->writeln(sprintf('<comment>· skipped</comment>  %s %s (not reached)', $tag, $pr));
+        }
+    }
+}

--- a/tools/release/src/ShipReleaseResult.php
+++ b/tools/release/src/ShipReleaseResult.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Aggregated outcome of a ship-release run.
+ *
+ * Successful when every step is MERGED, SKIPPED_ALREADY_MERGED, or WOULD_MERGE
+ * (dry-run) AND no fatal reason was recorded. A BLOCKED, NOT_REACHED, or
+ * fatalReason makes the run a failure.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class ShipReleaseResult
+{
+    /**
+     * @param list<ShipReleaseStepResult> $steps
+     */
+    public function __construct(
+        public array $steps,
+        public ?string $fatalReason = null,
+    ) {
+    }
+
+    public function wasSuccessful(): bool
+    {
+        if ($this->fatalReason !== null) {
+            return false;
+        }
+        $successful = [
+            ShipReleaseStepStatus::MERGED,
+            ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED,
+            ShipReleaseStepStatus::WOULD_MERGE,
+        ];
+        foreach ($this->steps as $step) {
+            if (!in_array($step->status, $successful, true)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/tools/release/src/ShipReleaseResult.php
+++ b/tools/release/src/ShipReleaseResult.php
@@ -34,13 +34,17 @@ final readonly class ShipReleaseResult
         if ($this->fatalReason !== null) {
             return false;
         }
-        $successful = [
-            ShipReleaseStepStatus::MERGED,
-            ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED,
-            ShipReleaseStepStatus::WOULD_MERGE,
-        ];
+        // Exhaustive match without default so PHPStan flags new enum
+        // cases at compile time (per CLAUDE.md coding guideline).
         foreach ($this->steps as $step) {
-            if (!in_array($step->status, $successful, true)) {
+            $isSuccess = match ($step->status) {
+                ShipReleaseStepStatus::MERGED,
+                ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED,
+                ShipReleaseStepStatus::WOULD_MERGE => true,
+                ShipReleaseStepStatus::BLOCKED,
+                ShipReleaseStepStatus::NOT_REACHED => false,
+            };
+            if (!$isSuccess) {
                 return false;
             }
         }

--- a/tools/release/src/ShipReleaseStepResult.php
+++ b/tools/release/src/ShipReleaseStepResult.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Per-PR outcome record produced by ShipReleaseOrchestrator.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class ShipReleaseStepResult
+{
+    /**
+     * @param list<string> $reasons
+     */
+    public function __construct(
+        public PullRequestTarget $target,
+        public ShipReleaseStepStatus $status,
+        public ?int $prNumber,
+        public ?string $mergeSha,
+        public array $reasons,
+    ) {
+    }
+}

--- a/tools/release/src/ShipReleaseStepStatus.php
+++ b/tools/release/src/ShipReleaseStepStatus.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Outcome of one step (one PR) in the ship-release orchestration.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+enum ShipReleaseStepStatus: string
+{
+    case SKIPPED_ALREADY_MERGED = 'skipped_already_merged';
+    case MERGED = 'merged';
+    case BLOCKED = 'blocked';
+    case WOULD_MERGE = 'would_merge';
+    case NOT_REACHED = 'not_reached';
+}

--- a/tools/release/src/ShipReleaseSummaryRenderer.php
+++ b/tools/release/src/ShipReleaseSummaryRenderer.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Render a GitHub-flavored Markdown run summary for a ShipReleaseResult, for
+ * writing to $GITHUB_STEP_SUMMARY. Separate from ShipReleaseRenderer, which
+ * emits Symfony Console markup for the live job log.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class ShipReleaseSummaryRenderer
+{
+    public static function render(
+        string $version,
+        string $relBranch,
+        bool $dryRun,
+        ShipReleaseResult $result,
+    ): string {
+        $lines = [];
+        $lines[] = sprintf('## Ship Release — %s (%s)', $version, $relBranch);
+        $lines[] = '';
+        $lines[] = sprintf('- **Mode:** %s', $dryRun ? 'dry run (no merges performed)' : 'live');
+        $lines[] = sprintf('- **Result:** %s', $result->wasSuccessful() ? '✅ success' : '❌ failure');
+        $lines[] = '';
+
+        if ($result->fatalReason !== null) {
+            $lines[] = sprintf('> ❌ **Fatal:** %s', $result->fatalReason);
+            $lines[] = '';
+        }
+
+        $lines[] = '| Role | Repo | PR | Status | Detail |';
+        $lines[] = '| --- | --- | --- | --- | --- |';
+        foreach ($result->steps as $step) {
+            $lines[] = self::renderRow($step);
+        }
+        $lines[] = '';
+
+        return implode("\n", $lines);
+    }
+
+    private static function renderRow(ShipReleaseStepResult $step): string
+    {
+        return sprintf(
+            '| %s | `%s` | %s | %s | %s |',
+            $step->target->roleLabel->value,
+            $step->target->repo,
+            self::prLink($step),
+            self::statusLabel($step->status),
+            self::detail($step),
+        );
+    }
+
+    private static function prLink(ShipReleaseStepResult $step): string
+    {
+        if ($step->prNumber === null) {
+            return '—';
+        }
+        return sprintf('[#%d](https://github.com/%s/pull/%d)', $step->prNumber, $step->target->repo, $step->prNumber);
+    }
+
+    private static function statusLabel(ShipReleaseStepStatus $status): string
+    {
+        return match ($status) {
+            ShipReleaseStepStatus::MERGED => '✅ merged',
+            ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED => '↷ already merged',
+            ShipReleaseStepStatus::WOULD_MERGE => '✅ would merge',
+            ShipReleaseStepStatus::BLOCKED => '❌ blocked',
+            ShipReleaseStepStatus::NOT_REACHED => '· not reached',
+        };
+    }
+
+    private static function detail(ShipReleaseStepResult $step): string
+    {
+        return match ($step->status) {
+            ShipReleaseStepStatus::MERGED => '`' . ($step->mergeSha ?? '?') . '`',
+            ShipReleaseStepStatus::BLOCKED => self::reasons($step),
+            ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED,
+            ShipReleaseStepStatus::WOULD_MERGE,
+            ShipReleaseStepStatus::NOT_REACHED => '—',
+        };
+    }
+
+    private static function reasons(ShipReleaseStepResult $step): string
+    {
+        if ($step->reasons === []) {
+            return '—';
+        }
+        return implode('<br>', $step->reasons);
+    }
+}

--- a/tools/release/src/SystemClock.php
+++ b/tools/release/src/SystemClock.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Production Clock that calls real PHP time/sleep.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class SystemClock implements Clock
+{
+    public function now(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable();
+    }
+
+    public function sleep(int $seconds): void
+    {
+        if ($seconds > 0) {
+            sleep($seconds);
+        }
+    }
+}


### PR DESCRIPTION
Phase 3a of the workstream 7 release-mechanism migration (\`docs/release-mechanism-migration-from-devops.md\`). Ports the ship-release orchestration workflow + supporting PHP classes + tests from openemr/openemr-devops. **Verbatim 2-PR shape (Conductor → Docs) matching current devops behavior.** 3-PR extension (adding release-finalize as 3rd role) follows in Phase 3b.

Ship-release has been dormant since 2026-06-01 — 8.2.0 shipped via manual click-through. The 2026-06-01 "failure" was a correct block on an incomplete pre-workstream-1 3-PR state (rotation slice included); code itself is functionally intact.

## Operator convention: dispatch from master

Documented in the workflow header. Ship-release orchestrates PR merges via \`gh\` CLI against branches specified in inputs; it never touches its own git state. Standardizing on master-dispatch keeps the mental model clean (ship-release is an orchestrator, not tied to any rel branch) and avoids byte-identical sync — master copy is authoritative and the only one that ever fires. Same treatment as \`build-release-on-tag.yml\`.

## New files

**Workflow:** \`.github/workflows/ship-release.yml\` (workflow_dispatch entry)

**Bin:** \`tools/release/bin/ship-release.php\` (Symfony Console CLI)

**Source (18 files, ~46 KB):**
- \`ShipReleaseOrchestrator\` + 6 supporting classes (Options, Result, StepResult, StepStatus, Renderer, SummaryRenderer)
- 7 \`PullRequest*\` abstraction (Api interface + \`GhPullRequestApi\` impl + Readiness, Snapshot, State, Target) + \`RoleLabel\` enum
- \`Clock\` interface + \`SystemClock\` impl
- \`DocsRefreshResult\` value object

**Tests (all isolated, 27 tests total):**
- \`ShipReleaseOrchestratorTest\` (17), \`ShipReleaseSummaryRendererTest\` (4), \`GhPullRequestApiTest\` (3), \`PullRequestTargetTest\` (3)
- Test fakes: \`FakePullRequestApi\`, \`FakeClock\`, \`FailingMergeApi\`

**Taskfile:** new \`ship-release\` task in \`tools/release/Taskfile.yml\`.

## Adjustments vs devops originals

- **ship-release.yml token scope**: dropped \`openemr-devops\` (was: \`openemr,openemr-devops,website-openemr\` → now: \`openemr,website-openemr\`). Devops's ship-release.yml is retired; no merge action targets it anymore.
- **ship-release.yml**: replaced \`task release:ship\` with \`task ship-release\` matching PR 2a's simplified Taskfile shape.
- **ship-release.yml**: swapped raw \`shivammathur/setup-php@v2\` for \`.github/actions/setup-php-composer\` composite.
- Test namespace: \`OpenEMR\\Release\\Tests[\\Fakes]\` → \`OpenEMR\\Tests\\Isolated\\Release[\\Fakes]\`.
- Bin autoload path: \`dirname(__DIR__)\` → \`dirname(__DIR__, 3)\`.
- Standard \`@package\` + license URL remap.

## Byte-identical: NOT added

Per the dispatch-from-master convention. Same rationale as \`build-release-on-tag.yml\`.

## Test plan
- [x] Full isolated suite: 3845 tests pass (was 3818 + 27 new = 3845)
- [x] Just the 4 new test files: 27/27 pass
- [x] phpstan: 4336 files, no errors
- [x] actionlint clean (with CI's 2 known-good false-positive suppressions on \`actions/create-github-app-token@v3\` \`client-id\` auth path)
- [x] \`--help\` runs on ship-release.php
- [x] Pre-commit hooks pass
- [ ] Post-merge: manual \`workflow_dispatch\` with \`dry_run=true\` against current rel-820 draft state (expected: correctly reports PRs not ready since mid-cycle)

## Not in this PR

- **Phase 3b**: 3-PR role extension (add \`RoleLabel::Finalize\`, teach orchestrator to wait for + merge the release-finalize PR after conductor + docs) + asymmetric approval-gate change (drop APPROVED requirement for Docs + Finalize, keep for Conductor).
- **Phase 3c**: add \`gh pr ready\` to website-openemr's release-docs.yml post-openemr-tag so the docs PR auto-flips (currently manual per RELEASE_PROCESS.md Automation gap step 9).
- **Phase 3d**: RELEASE_PROCESS.md updates + migration doc SHIPPED marker.
- **Phase 6**: delete devops copies of ship-release.yml + all migrated PHP classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)