### PR TITLE
fix(ci): sync-byte-identical rename-sweep must skip main-loop-handled paths

### DIFF
--- a/.github/scripts/sync-byte-identical.sh
+++ b/.github/scripts/sync-byte-identical.sh
@@ -259,11 +259,29 @@ if git cat-file -e "HEAD:.github/byte-identical.yml" 2>/dev/null; then
     declare -a REL_PATHS_UNDER_REL_CONFIG=()
     expand_patterns_into HEAD REL_FILES_ALL REL_PATHS_UNDER_REL_CONFIG
 
-    # Set difference (rel-managed - master-managed). Both are already
-    # sorted by expand_patterns_into.
+    # Set difference: paths rel's manifest sees that the main loop did NOT
+    # already handle. "Already handled" is anything in FILES_TO_CHECK
+    # (MASTER_PATHS ∪ REL_PATHS_UNDER_MASTER_CONFIG) -- the main loop
+    # processed each of those exactly once. Subtracting just MASTER_PATHS
+    # here would miss the "shared glob catches old-name file on rel"
+    # case: when master's and rel's manifests both list e.g. `tools/**`
+    # and rel's tree still carries an old-name file master's tree dropped,
+    # master's glob expansion against HEAD picks it up via
+    # REL_PATHS_UNDER_MASTER_CONFIG, the main loop deletes it, and the
+    # sweep would then re-encounter the same path (still present at
+    # HEAD's commit, even though the main loop `git rm`'d it from the
+    # index) and try to `git rm` an already-removed file -- exit 128
+    # with "pathspec did not match any files". Concrete trip: Phase 3b
+    # renamed tools/release/src/DocsRefreshResult.php ->
+    # DownstreamRefreshResult.php while both master's and rel-820's
+    # manifests list `tools/release/**`.
+    #
+    # Both operand lists are already sorted (FILES_TO_CHECK by `sort -u`
+    # at construction, REL_PATHS_UNDER_REL_CONFIG by expand_patterns_into's
+    # contract), so comm(1)'s sort precondition is satisfied.
     rel_only=$(comm -23 \
       <(printf '%s\n' "${REL_PATHS_UNDER_REL_CONFIG[@]}") \
-      <(printf '%s\n' "${MASTER_PATHS[@]}"))
+      <(printf '%s\n' "${FILES_TO_CHECK[@]}"))
 
     if [[ -n "${rel_only}" ]]; then
       while IFS= read -r STALE; do

--- a/tests/bats/ci-scripts/sync-byte-identical/sync.bats
+++ b/tests/bats/ci-scripts/sync-byte-identical/sync.bats
@@ -478,3 +478,41 @@ teardown() {
     [[ $status -eq 0 ]]
     [[ ! -f src/only-for-820.txt ]]
 }
+
+@test "shared-glob rename: master + rel both list the same glob and rel tree has an old-name file master dropped -> single delete, no double-processing" {
+    # Regression for the sync-byte-identical failure that hit rel-820 after
+    # Phase 3b renamed tools/release/src/DocsRefreshResult.php ->
+    # DownstreamRefreshResult.php. Both master and rel-820 carried
+    # `tools/release/**` in their manifests; the old name still existed on
+    # rel-820, so master's pattern-against-HEAD expansion picked it up via
+    # REL_PATHS_UNDER_MASTER_CONFIG and the main loop deleted it. The
+    # rel-only sweep then re-encountered the same path and tried a second
+    # `git rm`, which fails with "pathspec did not match any files"
+    # because the path is already staged for deletion.
+    write_on_branch master  src/new.txt "shared-content"
+    write_on_branch rel-810 src/new.txt "shared-content"
+    write_on_branch rel-810 src/old.txt "shared-content"
+
+    # Both manifests list the same glob.
+    write_files_all_raw 'files:
+- src/**
+'
+    git checkout -q rel-810
+    mkdir -p .github
+    printf 'files:\n- src/**\n' > .github/byte-identical.yml
+    git add .github/byte-identical.yml
+    git commit -q -m "rel manifest"
+
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ ! -f src/old.txt ]]                                         # deleted (once)
+    [[ -f src/new.txt ]]                                           # kept (identical to master)
+    grep -qxF "delete: src/old.txt" "$OUTPUT_DIR/changes.txt"
+    # Delete recorded exactly once, not twice.
+    delete_count=$(grep -cxF "delete: src/old.txt" "$OUTPUT_DIR/changes.txt")
+    [[ "$delete_count" -eq 1 ]]
+    # And no rename-sweep re-delete attempt printed.
+    ! grep -qF "delete: master removed this path entirely" <(echo "${output}")
+}


### PR DESCRIPTION
## Summary

- Root-cause fix in `.github/scripts/sync-byte-identical.sh`: the rename-sweep at the bottom of the script computed `rel_only = REL_PATHS_UNDER_REL_CONFIG - MASTER_PATHS`. When both master's and a rel branch's manifests list the same glob (e.g. `tools/release/**`), master's pattern-against-HEAD expansion already surfaces rel-only files to the main loop, which deletes them and stages the deletion in the index. The sweep then re-encountered the same path (still present at HEAD's commit) and tried a second \`git rm\`, which fails with \`pathspec did not match any files\` — exit 128 aborts the job.
- Fix: subtract \`FILES_TO_CHECK\` (\`MASTER_PATHS ∪ REL_PATHS_UNDER_MASTER_CONFIG\`, the full set the main loop already handled) instead of just \`MASTER_PATHS\`. The sweep still fires for its designed case (paths in rel's manifest that master's manifest doesn't cover at all — literal entries dropped from master's config, no shared glob).
- Adds a BATS regression test that reproduces the shared-glob rename case (verified to fail on the buggy code and pass with the fix).

## Why

The Phase 3b sync run failed on rel-820 (and would have failed on rel-810) after #13098 landed. #13098 renamed \`tools/release/src/DocsRefreshResult.php → DownstreamRefreshResult.php\`. Both master's and rel-820's byte-identical manifests list \`tools/release/**\`, and rel-820's tree still has the old name. Master's glob against rel-820 HEAD caught the old path, main loop deleted it, sweep tried to delete it again, sync failed. Consequence: no auto-sync PR was opened for rel-820/rel-810 to bring in Phase 3b.

**Failed run:** [#29855034422](https://github.com/openemr/openemr/actions/runs/29855034422)

## Follow-up after merge

Re-fire \`sync-byte-identical.yml\` via workflow_dispatch to open the Phase 3b sync PRs against rel-820 + rel-810 that never got created.

## Test plan

- [x] All 28 tests in \`tests/bats/ci-scripts/sync-byte-identical/\` pass (including the new regression case).
- [x] Confirmed regression test fails on unpatched script (exit 128 on the double \`git rm\`) and passes with the fix.
- [x] Sibling BATS suites (validate-byte-identical, list-manifest-paths) still pass.
- [ ] After merge, dispatch \`sync-byte-identical.yml\` and confirm rel-820 + rel-810 auto-sync PRs open cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)