### PR TITLE
feat(release): invert canonical/vendored for cross-repo contracts (Phase 5.1)

### DIFF
--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -74,6 +74,19 @@
 #                                                  dead weight
 #   .github/scripts/sync-byte-identical.sh         same rationale as the
 #                                                  workflow above
+#   .github/workflows/check-vendored-contracts.yml master-only-firing
+#                                                  (workflow_call reusable
+#                                                  invoked by external
+#                                                  consumers via @master;
+#                                                  rel-branch copies never
+#                                                  execute). Supporting PHP
+#                                                  under tools/release/**
+#                                                  IS synced -- the glob
+#                                                  entry below covers it --
+#                                                  which is harmless on rel
+#                                                  branches (no local caller)
+#                                                  and keeps the sync canary
+#                                                  green.
 #   .github/release-targets.yml                    master-authoritative; see
 #                                                  the file's own header
 #                                                  comment for the rationale

--- a/.github/workflows/check-vendored-contracts.yml
+++ b/.github/workflows/check-vendored-contracts.yml
@@ -54,8 +54,16 @@ jobs:
     name: vendored contracts
     runs-on: ubuntu-24.04
     steps:
+    # Both checkouts are read-only — the workflow reads consumer + canonical
+    # trees and hands them to check-vendored.php's file comparator. No git
+    # push, no authenticated fetches afterward. Suppress the default token
+    # persistence so the caller's GITHUB_TOKEN doesn't linger in workspace
+    # .git/config where a compromised later step could read it. Same
+    # defense-in-depth pattern used by ship-release.yml.
     - name: Checkout consumer
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Checkout canonical openemr
       uses: actions/checkout@v7
@@ -63,6 +71,7 @@ jobs:
         repository: openemr/openemr
         ref: ${{ inputs.canonical_ref }}
         path: _canonical-openemr
+        persist-credentials: false
         # Sparse checkout of just tools/release + composer manifests so we
         # can install the deps check-vendored.php needs (Symfony Console)
         # without pulling openemr's full ~1GB tree.

--- a/.github/workflows/check-vendored-contracts.yml
+++ b/.github/workflows/check-vendored-contracts.yml
@@ -1,42 +1,91 @@
 name: Check Vendored Contracts
 
-# Drift-check this repo's vendored copies of the cross-repo release
-# contracts against the canonical sources in openemr/openemr-devops.
+# Reusable workflow for consumer repos to drift-check their vendored copies
+# of cross-repo release contracts (dispatch.schema.json, TagVerifier,
+# TagVerificationResult) against the canonical sources here. Fails the
+# calling job on drift.
 #
-# Vendored files (under tools/release/):
-#   - contracts/dispatch.schema.json
-#   - src/TagVerifier.php
-#   - src/TagVerificationResult.php
+# See tools/release/src/VendoredFileChecker.php for the canonical file list.
+# See tools/release/contracts/dispatch.schema.json and
+# tools/release/src/TagVerifier.php for the contracts themselves.
 #
-# Calls the reusable workflow in openemr/openemr-devops which knows the
-# canonical paths and fails this job on any drift. See that workflow's
-# header for the full file list + override semantics.
+# Caller example (in a consumer repo's PR workflow):
 #
-# Trigger: PRs that touch either a vendored file or this workflow itself.
-# A PR touching only unrelated files skips the drift check entirely, since
-# nothing's changed that could introduce drift.
+#   jobs:
+#     drift:
+#       uses: openemr/openemr/.github/workflows/check-vendored-contracts.yml@master
+#       with:
+#         consumer_subpath: tools/release
 #
-# This caller is short-lived in the release-mechanism migration sense:
-# Phase 5 of the migration (docs/release-mechanism-migration-from-devops.md)
-# inverts canonical/vendored ownership — this repo becomes canonical, and
-# this caller either disappears or flips direction. Wiring it now defuses
-# a real silent-drift bug today and gives Phase 5 a clean before/after to
-# swap.
+# website-openemr (which vendored into a non-canonical layout) passes overrides:
+#
+#       with:
+#         consumer_subpath: tools/release-docs
+#         path_overrides: |
+#           src/TagVerifier.php=src/Release/TagVerifier.php
+#           src/TagVerificationResult.php=src/Release/TagVerificationResult.php
 
 on:
-  pull_request:
-    paths:
-    - 'tools/release/contracts/dispatch.schema.json'
-    - 'tools/release/src/TagVerifier.php'
-    - 'tools/release/src/TagVerificationResult.php'
-    - '.github/workflows/check-vendored-contracts.yml'
+  workflow_call:
+    inputs:
+      consumer_subpath:
+        description: 'Path within the caller repo holding the vendored copies (e.g. tools/release).'
+        required: true
+        type: string
+      canonical_ref:
+        description: 'Ref of openemr/openemr to compare against. Defaults to master.'
+        required: false
+        type: string
+        default: master
+      path_overrides:
+        description: |
+          Optional newline-delimited canonical=consumer path overrides for consumers
+          that vendored into a non-canonical layout. Example:
+            src/TagVerifier.php=src/Release/TagVerifier.php
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
 
 jobs:
-  drift:
-    name: Check vendored contracts against canonical
-    uses: openemr/openemr-devops/.github/workflows/check-vendored-contracts.yml@master
-    with:
-      consumer_subpath: tools/release
+  check:
+    name: vendored contracts
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout consumer
+      uses: actions/checkout@v7
+
+    - name: Checkout canonical openemr
+      uses: actions/checkout@v7
+      with:
+        repository: openemr/openemr
+        ref: ${{ inputs.canonical_ref }}
+        path: _canonical-openemr
+        # Sparse checkout of just tools/release + composer manifests so we
+        # can install the deps check-vendored.php needs (Symfony Console)
+        # without pulling openemr's full ~1GB tree.
+        sparse-checkout: |
+          tools/release
+          composer.json
+          composer.lock
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.5'
+        tools: composer
+
+    - name: Install canonical dependencies
+      working-directory: _canonical-openemr
+      # --no-dev suffices: bin/check-vendored.php only needs symfony/console +
+      # composer autoload from require (non-dev) entries.
+      run: composer install --no-interaction --no-progress --no-dev
+
+    - name: Check vendored contracts
+      env:
+        CONSUMER_PATH: ${{ github.workspace }}/${{ inputs.consumer_subpath }}
+        PATH_OVERRIDES: ${{ inputs.path_overrides }}
+      working-directory: _canonical-openemr
+      run: php tools/release/bin/check-vendored.php --consumer "$CONSUMER_PATH" --overrides "$PATH_OVERRIDES"

--- a/tests/Tests/Isolated/Release/VendoredFileCheckerTest.php
+++ b/tests/Tests/Isolated/Release/VendoredFileCheckerTest.php
@@ -1,0 +1,375 @@
+<?php
+
+/**
+ * @package   openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release;
+
+use OpenEMR\Release\VendoredDriftIssue;
+use OpenEMR\Release\VendoredFileChecker;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class VendoredFileCheckerTest extends TestCase
+{
+    private const CANONICAL_JSON = <<<'JSON'
+        {
+            "$schema": "https://example.test/schema",
+            "title": "test schema",
+            "required": ["event", "data"],
+            "properties": {
+                "event": { "type": "string" },
+                "data": { "type": "object" }
+            }
+        }
+        JSON;
+
+    private const CANONICAL_PHP_TEMPLATE = <<<'PHP'
+        <?php
+
+        declare(strict_types=1);
+
+        namespace %s;
+
+        final class TagVerifier
+        {
+            public function verify(string $tag): bool
+            {
+                return $tag !== '';
+            }
+        }
+        PHP;
+
+    private string $canonicalRoot = '';
+    private string $consumerDir = '';
+
+    protected function setUp(): void
+    {
+        $this->canonicalRoot = sys_get_temp_dir() . '/openemr-vendored-canon-' . bin2hex(random_bytes(8));
+        $this->consumerDir = sys_get_temp_dir() . '/openemr-vendored-consumer-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->canonicalRoot, 0700, true) || !mkdir($this->consumerDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dirs');
+        }
+        $this->writeCanonicalFixtures($this->canonicalRoot);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursive($this->canonicalRoot);
+        $this->removeRecursive($this->consumerDir);
+    }
+
+    public function testMatchingCopiesProduceNoIssues(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertSame([], $issues);
+    }
+
+    public function testJsonReorderedKeysAreEquivalent(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        $reordered = json_encode(
+            [
+                'properties' => [
+                    'data' => ['type' => 'object'],
+                    'event' => ['type' => 'string'],
+                ],
+                'required' => ['event', 'data'],
+                'title' => 'test schema',
+                '$schema' => 'https://example.test/schema',
+            ],
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+        file_put_contents($this->consumerDir . '/contracts/dispatch.schema.json', $reordered);
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertSame([], $issues, 'JSON object key order must not affect equivalence');
+    }
+
+    public function testJsonReformattedWhitespaceIsEquivalent(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        $minified = json_encode(
+            json_decode(self::CANONICAL_JSON, true, flags: JSON_THROW_ON_ERROR),
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+        file_put_contents($this->consumerDir . '/contracts/dispatch.schema.json', $minified);
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertSame([], $issues, 'JSON whitespace must not affect equivalence');
+    }
+
+    public function testJsonListReorderingIsFlagged(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        $reorderedList = json_encode(
+            [
+                '$schema' => 'https://example.test/schema',
+                'title' => 'test schema',
+                'required' => ['data', 'event'],
+                'properties' => [
+                    'event' => ['type' => 'string'],
+                    'data' => ['type' => 'object'],
+                ],
+            ],
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+        file_put_contents($this->consumerDir . '/contracts/dispatch.schema.json', $reorderedList);
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertCount(1, $issues, 'JSON list element order is semantic and must trip drift');
+        self::assertSame('contracts/dispatch.schema.json', $issues[0]->relativePath);
+        self::assertSame('drift', $issues[0]->kind);
+    }
+
+    public function testPhpWithDifferentNamespaceIsEquivalent(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        file_put_contents(
+            $this->consumerDir . '/src/TagVerifier.php',
+            sprintf(self::CANONICAL_PHP_TEMPLATE, 'OpenEMR\\ReleaseDocs\\Release'),
+        );
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertSame([], $issues, 'Different vendored namespace must not trip drift');
+    }
+
+    public function testPhpDriftBeyondNamespaceIsFlagged(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        $modified = str_replace(
+            "return \$tag !== '';",
+            "return true;",
+            sprintf(self::CANONICAL_PHP_TEMPLATE, 'OpenEMR\\Release'),
+        );
+        file_put_contents($this->consumerDir . '/src/TagVerifier.php', $modified);
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertCount(1, $issues, 'Behavior change must trip drift even with matching namespace');
+        self::assertSame('src/TagVerifier.php', $issues[0]->relativePath);
+        self::assertSame('drift', $issues[0]->kind);
+    }
+
+    public function testInvalidJsonRaisesWithPathContext(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        file_put_contents($this->consumerDir . '/contracts/dispatch.schema.json', '{not json');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('contracts/dispatch.schema.json');
+
+        (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+    }
+
+    public function testMissingConsumerCopyIsFlagged(): void
+    {
+        $copy = VendoredFileChecker::VENDORED_PATHS;
+        array_pop($copy);
+        $this->writeCanonicalFixtures($this->consumerDir, $copy);
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertCount(1, $issues);
+        self::assertSame('missing_consumer', $issues[0]->kind);
+    }
+
+    public function testMissingCanonicalIsFlagged(): void
+    {
+        unlink($this->canonicalRoot . '/contracts/dispatch.schema.json');
+        $this->writeCanonicalFixtures($this->consumerDir);
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertCount(1, $issues);
+        self::assertSame('contracts/dispatch.schema.json', $issues[0]->relativePath);
+        self::assertSame('missing_canonical', $issues[0]->kind);
+    }
+
+    public function testMultipleDriftKindsReportedTogether(): void
+    {
+        $this->writeFile(
+            $this->consumerDir,
+            'contracts/dispatch.schema.json',
+            json_encode(['unrelated' => 'value'], JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR),
+        );
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertCount(count(VendoredFileChecker::VENDORED_PATHS), $issues);
+        $kinds = array_map(static fn(VendoredDriftIssue $i): string => $i->kind, $issues);
+        self::assertContains('drift', $kinds);
+        self::assertContains('missing_consumer', $kinds);
+    }
+
+    public function testCanonicalListContainsContractAndTagFiles(): void
+    {
+        self::assertContains('contracts/dispatch.schema.json', VendoredFileChecker::VENDORED_PATHS);
+        self::assertContains('src/TagVerifier.php', VendoredFileChecker::VENDORED_PATHS);
+        self::assertContains('src/TagVerificationResult.php', VendoredFileChecker::VENDORED_PATHS);
+    }
+
+    public function testPathOverrideMapsCanonicalToConsumerLayout(): void
+    {
+        foreach (VendoredFileChecker::VENDORED_PATHS as $rel) {
+            $consumerRel = $rel === 'src/TagVerifier.php' ? 'src/Release/TagVerifier.php' : $rel;
+            $this->writeFile($this->consumerDir, $consumerRel, $this->canonicalContents($rel));
+        }
+
+        $issues = (new VendoredFileChecker(
+            $this->canonicalRoot,
+            $this->consumerDir,
+            ['src/TagVerifier.php' => 'src/Release/TagVerifier.php'],
+        ))->check();
+
+        self::assertSame([], $issues);
+    }
+
+    public function testOverriddenPathDriftReportsConsumerRelativePath(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        $this->writeFile(
+            $this->consumerDir,
+            'src/Release/TagVerifier.php',
+            sprintf(self::CANONICAL_PHP_TEMPLATE, 'OpenEMR\\Release') . "\n// extra\n",
+        );
+
+        $issues = (new VendoredFileChecker(
+            $this->canonicalRoot,
+            $this->consumerDir,
+            ['src/TagVerifier.php' => 'src/Release/TagVerifier.php'],
+        ))->check();
+
+        self::assertCount(1, $issues);
+        self::assertSame('src/Release/TagVerifier.php', $issues[0]->relativePath);
+        self::assertSame('drift', $issues[0]->kind);
+    }
+
+    public function testUnknownOverrideKeyThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new VendoredFileChecker(
+            $this->canonicalRoot,
+            $this->consumerDir,
+            ['not/a/canonical/path.php' => 'irrelevant'],
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function unsafeOverrideValueProvider(): iterable
+    {
+        yield 'absolute path' => ['/etc/passwd'];
+        yield 'parent traversal' => ['../outside.php'];
+        yield 'embedded parent traversal' => ['src/../../outside.php'];
+        yield 'trailing parent traversal' => ['src/Release/..'];
+        yield 'empty value' => [''];
+    }
+
+    #[DataProvider('unsafeOverrideValueProvider')]
+    public function testUnsafeOverrideValueThrows(string $unsafeValue): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new VendoredFileChecker(
+            $this->canonicalRoot,
+            $this->consumerDir,
+            ['src/TagVerifier.php' => $unsafeValue],
+        );
+    }
+
+    public function testNonStringOverrideValueThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new VendoredFileChecker(
+            $this->canonicalRoot,
+            $this->consumerDir,
+            ['src/TagVerifier.php' => 123],
+        );
+    }
+
+    public function testNonStringOverrideKeyThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new VendoredFileChecker(
+            $this->canonicalRoot,
+            $this->consumerDir,
+            [42 => 'src/Release/TagVerifier.php'],
+        );
+    }
+
+    /**
+     * @param list<string>|null $only restrict which paths to write
+     */
+    private function writeCanonicalFixtures(string $root, ?array $only = null): void
+    {
+        $paths = $only ?? VendoredFileChecker::VENDORED_PATHS;
+        foreach ($paths as $rel) {
+            $this->writeFile($root, $rel, $this->canonicalContents($rel));
+        }
+    }
+
+    private function canonicalContents(string $relativePath): string
+    {
+        $extension = pathinfo($relativePath, PATHINFO_EXTENSION);
+        return match ($extension) {
+            'json' => self::CANONICAL_JSON,
+            'php' => sprintf(self::CANONICAL_PHP_TEMPLATE, 'OpenEMR\\Release'),
+            default => "canonical:{$relativePath}\n",
+        };
+    }
+
+    private function writeFile(string $root, string $rel, string $contents): void
+    {
+        $abs = $root . '/' . $rel;
+        $dir = dirname($abs);
+        if (!is_dir($dir) && !mkdir($dir, 0700, true)) {
+            throw new \RuntimeException("Failed to mkdir: {$dir}");
+        }
+        file_put_contents($abs, $contents);
+    }
+
+    private function removeRecursive(string $path): void
+    {
+        if (!is_dir($path)) {
+            if (is_file($path) || is_link($path)) {
+                unlink($path);
+            }
+            return;
+        }
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        /** @var \SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $entryPath = $entry->getPathname();
+            if ($entry->isDir() && !$entry->isLink()) {
+                rmdir($entryPath);
+            } else {
+                unlink($entryPath);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tools/release/bin/check-vendored.php
+++ b/tools/release/bin/check-vendored.php
@@ -1,0 +1,139 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Fail if a consumer repo's vendored copies of cross-repo contracts have
+ * drifted from the canonical sources here.
+ *
+ * Run by CI in consumer repos (openemr/openemr-devops, openemr/website-openemr)
+ * to catch the case where the canonical contract is updated but a vendored
+ * copy is not refreshed.
+ *
+ * @package   openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+use OpenEMR\Release\VendoredFileChecker;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('check-vendored')
+    ->setDescription('Verify a consumer repo vendored copy matches the canonical contract')
+    ->addOption(
+        'canonical',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Path to the canonical tools/release/ root',
+        dirname(__DIR__),
+    )
+    ->addOption(
+        'consumer',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Path to the consumer repo dir holding the vendored copies',
+    )
+    ->addOption(
+        'override',
+        null,
+        InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+        'Map a canonical path to a different consumer-relative path '
+            . '(e.g. --override src/TagVerifier.php=src/Release/TagVerifier.php). Repeatable.',
+    )
+    ->addOption(
+        'overrides',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Same mapping as --override but as a single newline-delimited string '
+            . '(blank lines and surrounding whitespace ignored). Convenient for '
+            . 'CI inputs that arrive as multi-line strings. Combines with --override.',
+    )
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $canonical = $input->getOption('canonical');
+        if (!is_string($canonical) || $canonical === '') {
+            $output->writeln('<error>--canonical is required</error>');
+            return 1;
+        }
+        if (!is_dir($canonical)) {
+            $output->writeln(sprintf('<error>Canonical dir not found: %s</error>', $canonical));
+            return 1;
+        }
+
+        $consumer = $input->getOption('consumer');
+        if (!is_string($consumer) || $consumer === '') {
+            $output->writeln('<error>--consumer is required</error>');
+            return 1;
+        }
+        if (!is_dir($consumer)) {
+            $output->writeln(sprintf('<error>Consumer dir not found: %s</error>', $consumer));
+            return 1;
+        }
+
+        $rawOverrides = $input->getOption('override');
+        if (!is_array($rawOverrides)) {
+            $rawOverrides = [];
+        }
+        $multiline = $input->getOption('overrides');
+        if (is_string($multiline) && $multiline !== '') {
+            $lines = preg_split('/\R/', $multiline);
+            if ($lines === false) {
+                $output->writeln('<error>--overrides could not be parsed</error>');
+                return 1;
+            }
+            foreach ($lines as $line) {
+                $trimmed = trim($line);
+                if ($trimmed !== '') {
+                    $rawOverrides[] = $trimmed;
+                }
+            }
+        }
+        $overrides = [];
+        foreach ($rawOverrides as $entry) {
+            if (!is_string($entry) || !str_contains($entry, '=')) {
+                $output->writeln(sprintf(
+                    '<error>override entry expects CANONICAL=CONSUMER, got: %s</error>',
+                    is_string($entry) ? $entry : gettype($entry),
+                ));
+                return 1;
+            }
+            [$canonicalPath, $consumerPath] = explode('=', $entry, 2);
+            if ($canonicalPath === '' || $consumerPath === '') {
+                $output->writeln(sprintf('<error>override entry has empty side: %s</error>', $entry));
+                return 1;
+            }
+            $overrides[$canonicalPath] = $consumerPath;
+        }
+
+        try {
+            $checker = new VendoredFileChecker($canonical, $consumer, $overrides);
+        } catch (\InvalidArgumentException $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+            return 1;
+        }
+        $issues = $checker->check();
+        if ($issues === []) {
+            $output->writeln(sprintf(
+                '<info>✓</info> All %d vendored file(s) match canonical.',
+                count(VendoredFileChecker::VENDORED_PATHS),
+            ));
+            return 0;
+        }
+
+        $output->writeln(sprintf('<error>✗</error> Vendored drift detected (%d issue(s)):', count($issues)));
+        foreach ($issues as $issue) {
+            $output->writeln(sprintf('  %s  [%s]  %s', $issue->relativePath, $issue->kind, $issue->message));
+        }
+        $output->writeln('');
+        $output->writeln('Re-vendor each drifted file from the canonical openemr/openemr checkout.');
+        return 1;
+    })
+    ->run();

--- a/tools/release/contracts/dispatch.schema.json
+++ b/tools/release/contracts/dispatch.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/openemr/openemr-devops/blob/master/tools/release/contracts/dispatch.schema.json",
+  "$id": "https://github.com/openemr/openemr/blob/master/tools/release/contracts/dispatch.schema.json",
   "title": "OpenEMR release dispatch payload",
-  "description": "Cross-repo repository_dispatch payloads emitted between openemr/openemr (conductor) and openemr/openemr-devops, openemr/website-openemr, openemr/website-openemr-files (consumers). See openemr/openemr-devops#664. The canonical copy lives here; consumers vendor it and CI fails on drift via tools/release/bin/check-vendored.php.",
+  "description": "Cross-repo repository_dispatch payloads emitted between openemr/openemr (conductor) and openemr/openemr-devops, openemr/website-openemr, openemr/website-openemr-files (consumers). See openemr/openemr-devops#664 for the original spec (issue stays there for history; the mechanism now lives here). The canonical copy lives here; consumers vendor it and CI fails on drift via tools/release/bin/check-vendored.php.",
   "type": "object",
   "required": [
     "event",

--- a/tools/release/src/TagVerificationResult.php
+++ b/tools/release/src/TagVerificationResult.php
@@ -2,12 +2,14 @@
 
 /**
  * Result of verifying a release tag against the openemr-devops#664 spec.
+ * Spec issue lives on openemr-devops for history; the mechanism now lives
+ * here and this file is canonical.
  *
- * @package   openemr-devops
+ * @package   openemr
  * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
- * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 declare(strict_types=1);

--- a/tools/release/src/TagVerifier.php
+++ b/tools/release/src/TagVerifier.php
@@ -3,12 +3,14 @@
 /**
  * Verify a release tag is annotated and its message conforms to the
  * openemr-devops#664 spec (contains a version, ISO date, and merge SHA).
+ * Spec issue lives on openemr-devops for history; the mechanism now lives
+ * here and this file is canonical.
  *
- * @package   openemr-devops
+ * @package   openemr
  * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
- * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 declare(strict_types=1);

--- a/tools/release/src/VendoredDriftIssue.php
+++ b/tools/release/src/VendoredDriftIssue.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * One drift finding from VendoredFileChecker: a vendored copy in a consumer
+ * repo that no longer matches its canonical source here.
+ *
+ * `kind` is one of:
+ *   - `missing_canonical` — canonical file absent (registry bug, not consumer drift)
+ *   - `missing_consumer`  — consumer never vendored this file
+ *   - `drift`             — consumer copy differs from canonical (re-vendor)
+ *
+ * @package   openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class VendoredDriftIssue
+{
+    public function __construct(
+        public string $relativePath,
+        public string $kind,
+        public string $message,
+    ) {
+    }
+}

--- a/tools/release/src/VendoredFileChecker.php
+++ b/tools/release/src/VendoredFileChecker.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * Compare a consumer repo's vendored copies of cross-repo contracts against
+ * the canonical sources in this repo. Used by CI in consumer repos
+ * (openemr/openemr-devops, openemr/website-openemr) to catch silent contract
+ * drift.
+ *
+ * Layout assumption: the consumer mirrors the canonical relative paths under
+ * its vendored dir. A consumer that vendors to `vendored/openemr/` therefore
+ * has `vendored/openemr/contracts/dispatch.schema.json` and
+ * `vendored/openemr/src/TagVerifier.php`. A consumer that vendored into a
+ * different layout (e.g. `src/Release/TagVerifier.php`) can pass a
+ * `$pathOverrides` map keyed by canonical path → consumer-relative path.
+ *
+ * Equivalence is per-file-type, per the openemr-devops#664 spec (issue lives
+ * on openemr-devops for historical reasons; the mechanism now lives here):
+ *
+ *   - JSON: parse + canonical re-serialize (recursively sort object keys,
+ *     preserve list order, normalize whitespace), then string-compare.
+ *     A consumer can reformat or reorder object keys without tripping drift.
+ *   - PHP: strip the `namespace` declaration line, then string-compare.
+ *     A consumer can vendor under its own namespace (e.g.
+ *     `OpenEMR\ReleaseDocs\Release`) so long as everything else — class
+ *     structure, method signatures, behavior — is identical.
+ *   - Other: byte-for-byte sha256. Default for any file type added later.
+ *
+ * @package   openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class VendoredFileChecker
+{
+    /**
+     * Files consumers must vendor. Keep this list tight — every entry is an
+     * obligation on every consumer repo's CI.
+     */
+    public const VENDORED_PATHS = [
+        'contracts/dispatch.schema.json',
+        'src/TagVerifier.php',
+        'src/TagVerificationResult.php',
+    ];
+
+    /** @var array<string, string> */
+    private array $pathOverrides;
+
+    /**
+     * @param array<array-key, mixed> $pathOverrides Map of canonical relative
+     *     path → consumer relative path. Validated at runtime since CLI/CI
+     *     callers can produce arbitrary input: keys and values must both be
+     *     strings; unmapped entries default to the canonical path; unknown
+     *     keys (not in VENDORED_PATHS) throw, as do values that are absolute
+     *     or contain `..` segments — overrides must stay inside the
+     *     consumer dir.
+     */
+    public function __construct(
+        private string $canonicalRoot,
+        private string $consumerDir,
+        array $pathOverrides = [],
+    ) {
+        $validated = [];
+        foreach ($pathOverrides as $key => $value) {
+            if (!is_string($key) || !is_string($value)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Override entries must be string=>string, got %s=>%s',
+                    get_debug_type($key),
+                    get_debug_type($value),
+                ));
+            }
+            if (!in_array($key, self::VENDORED_PATHS, true)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Unknown override key %s; must be one of: %s',
+                    $key,
+                    implode(', ', self::VENDORED_PATHS),
+                ));
+            }
+            if ($value === '' || $value[0] === '/' || preg_match('#(^|/)\.\.(/|$)#', $value) === 1) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Override value for %s must be a relative path inside the consumer dir, got: %s',
+                    $key,
+                    $value,
+                ));
+            }
+            $validated[$key] = $value;
+        }
+        $this->pathOverrides = $validated;
+    }
+
+    /**
+     * @return list<VendoredDriftIssue>
+     */
+    public function check(): array
+    {
+        $issues = [];
+        foreach (self::VENDORED_PATHS as $rel) {
+            $canonicalAbs = $this->canonicalRoot . '/' . $rel;
+            $consumerRel = $this->pathOverrides[$rel] ?? $rel;
+            $consumerAbs = $this->consumerDir . '/' . $consumerRel;
+
+            if (!is_file($canonicalAbs)) {
+                $issues[] = new VendoredDriftIssue(
+                    $rel,
+                    'missing_canonical',
+                    'Canonical file not found: ' . $canonicalAbs,
+                );
+                continue;
+            }
+            if (!is_file($consumerAbs)) {
+                $issues[] = new VendoredDriftIssue(
+                    $consumerRel,
+                    'missing_consumer',
+                    'Consumer copy missing — vendor it from canonical at ' . $canonicalAbs,
+                );
+                continue;
+            }
+            if (!$this->equivalent($rel, $canonicalAbs, $consumerAbs)) {
+                $issues[] = new VendoredDriftIssue(
+                    $consumerRel,
+                    'drift',
+                    'Consumer copy differs from canonical — re-vendor from ' . $canonicalAbs,
+                );
+            }
+        }
+        return $issues;
+    }
+
+    private function equivalent(string $relativePath, string $canonicalAbs, string $consumerAbs): bool
+    {
+        $extension = pathinfo($relativePath, PATHINFO_EXTENSION);
+        return match ($extension) {
+            'json' => $this->canonicalJson($canonicalAbs) === $this->canonicalJson($consumerAbs),
+            'php' => $this->stripNamespace($this->readFile($canonicalAbs))
+                === $this->stripNamespace($this->readFile($consumerAbs)),
+            default => hash_file('sha256', $canonicalAbs) === hash_file('sha256', $consumerAbs),
+        };
+    }
+
+    private function canonicalJson(string $path): string
+    {
+        $contents = $this->readFile($path);
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException('Invalid JSON in ' . $path . ': ' . $e->getMessage(), 0, $e);
+        }
+        $this->sortObjectKeys($decoded);
+        return json_encode(
+            $decoded,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+        );
+    }
+
+    /**
+     * Recursively sort object (associative array) keys to make JSON
+     * comparison insensitive to key order. List order stays intact —
+     * arrays in JSON Schema (`enum`, `oneOf`, `required`) carry semantic
+     * meaning that reordering would silently change.
+     */
+    private function sortObjectKeys(mixed &$value): void
+    {
+        if (!is_array($value)) {
+            return;
+        }
+        if (!array_is_list($value)) {
+            ksort($value);
+        }
+        foreach ($value as &$child) {
+            $this->sortObjectKeys($child);
+        }
+    }
+
+    /**
+     * Strip the single `namespace …;` declaration line from a PHP source
+     * string. Removes the line itself but leaves surrounding whitespace
+     * intact — both canonical and consumer files have the same
+     * surrounding whitespace, so byte-comparing the post-strip strings
+     * is sufficient.
+     */
+    private function stripNamespace(string $contents): string
+    {
+        $stripped = preg_replace('/^namespace\s+[\w\\\\]+;\s*$/m', '', $contents);
+        return $stripped ?? $contents;
+    }
+
+    private function readFile(string $path): string
+    {
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            throw new \RuntimeException('Cannot read ' . $path);
+        }
+        return $contents;
+    }
+}


### PR DESCRIPTION
## Summary

Workstream 7 Phase 5 first PR — flip the canonical/vendored direction for the three cross-repo release contracts and import the enforcement machinery from openemr-devops. **openemr is now canonical**; openemr-devops (and website-openemr) vendor from here.

**Flipped files** (canonical markers now point at openemr):
- \`tools/release/contracts/dispatch.schema.json\` — \`\$id\` + description
- \`tools/release/src/TagVerifier.php\` — \`@package\` + \`@license\` docblock
- \`tools/release/src/TagVerificationResult.php\` — \`@package\` + \`@license\` docblock

**Enforcement machinery imported** (adapted for openemr-as-canonical):
- \`tools/release/src/VendoredFileChecker.php\` — the checker class
- \`tools/release/src/VendoredDriftIssue.php\` — its result DTO
- \`tools/release/bin/check-vendored.php\` — CLI entry point; autoload path adapted from devops's \`tools/release/vendor/\` to openemr root \`vendor/\`
- \`tests/Tests/Isolated/Release/VendoredFileCheckerTest.php\` — 21 tests ported, namespace shifted to \`OpenEMR\\Tests\\Isolated\\Release\`

**Reusable workflow transformed** (was caller of devops's workflow → is now the reusable workflow itself):
- \`.github/workflows/check-vendored-contracts.yml\` — \`workflow_call\` trigger; sparse-checkout of openemr master to \`_canonical-openemr/\`; \`composer install --no-dev\`; invokes \`bin/check-vendored.php\`. Consumers pass \`consumer_subpath\` + optional \`path_overrides\` (same shape as devops's workflow, so consumers just update the \`uses:\` ref).

**Byte-identical coverage**: the existing \`tools/release/**\` + \`tests/Tests/Isolated/Release/**\` globs in \`.github/byte-identical.yml\` already cover all new files. Sync will propagate to rel-820 automatically.

## Why

Post-Phase-3 (ship-release + orchestrator migration to openemr), the release-mechanism home is here — the last remaining piece of the "who owns the canonical contract" story is these three files, which still point at devops via \`\$id\` and docblocks. Phase 5.1 completes the ownership move; Phase 5.2 (website-openemr caller flip) and Phase 5.3 (openemr-devops relabels its copies as vendored-from-openemr) follow. Phase 6 (delete devops's now-dead release-mechanism copies) unblocks after Phase 5 lands + a verification battery green (see planning doc PR #12598).

## Test plan

- [x] 21 new tests in \`VendoredFileCheckerTest\` pass (3872 total isolated tests, all green).
- [x] PHPStan level 10 clean across the full codebase (no new baselines).
- [x] YAML + JSON syntax validated on the transformed workflow + updated schema.
- [ ] After merge, verify the reusable workflow works end-to-end by opening Phase 5.2 (website-openemr caller flip) and confirming its CI drift-check job invokes this workflow and runs green.

## Follow-up PRs

- **5.2** (website-openemr): flip \`uses:\` from \`openemr/openemr-devops/.github/workflows/check-vendored-contracts.yml@master\` → \`openemr/openemr/...@master\`; update any \`\$id\` back-references in its vendored copies.
- **5.3** (openemr-devops): mark devops's 3 contract copies as vendored-from-openemr (docblock updates); optionally add a caller invocation of this reusable workflow so devops's still-live copies get drift-checked until Phase 6 deletes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)