### PR TITLE
fix(release): unblock dry-run build path (Phase 5.5 findings)

### DIFF
--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -203,6 +203,16 @@ jobs:
     name: Dry-run build (artifacts only, no publish)
     needs: ship
     if: ${{ needs.ship.result == 'success' && (inputs.mode == 'dry-run' || inputs.dry_run) }}
+    # Per-job override of the workflow-level `permissions: {}`. build-release.yml
+    # (called via workflow_call below) declares `permissions: contents: read`
+    # at its own workflow level. GitHub's startup validation rejects the
+    # dispatch when the caller grants strictly less than what the callee
+    # requests -- the empty workflow-level default would block dry-run-build
+    # from launching at all. Granting the exact `contents: read` the callee
+    # needs (for its actions/checkout step) keeps the `ship` job's default-
+    # deny intact and matches least-privilege.
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-release.yml
     with:
       version_branch: release-prep/${{ inputs.rel_branch }}

--- a/tools/release/.gitignore
+++ b/tools/release/.gitignore
@@ -1,0 +1,5 @@
+/vendor/
+/release-output/
+/.phpunit.cache/
+/.phpunit.result.cache
+/.task/


### PR DESCRIPTION
## Summary

Two latent bugs surfaced by the Phase 5.5 verification battery (fired against master today after Phase 5.1 landed). Both were present since earlier phases landed; neither had been exercised end-to-end until we ran the battery.

**1. Add \`tools/release/.gitignore\`** (mirrors openemr-devops's copy)

\`build-release.yml\`'s dry-run path — fired via workflow_dispatch or from ship-release's dry-run-build sub-workflow — failed with:

\`\`\`
Refusing to package a dirty checkout in /home/runner/work/openemr/openemr:
?? tools/release/release-output/
\`\`\`

\`changelog:extract\` writes \`changelog.md\` into \`tools/release/release-output/\` before \`package:assemble\` runs, and \`package:assemble.php\` refuses to archive a dirty tree. Devops's port of \`tools/release/\` carried a \`.gitignore\` that suppresses the flag; the Phase 2 port (#13087) didn't bring it along. Failure surfaced today via the Phase 5.5 verification battery.

Fix mirrors devops verbatim (5 entries: \`/vendor/\`, \`/release-output/\`, \`/.phpunit.cache/\`, \`/.phpunit.result.cache\`, \`/.task/\`). Only \`/release-output/\` is load-bearing today; the rest are defensive parity for paths that might get exercised if we ever composer-install or run \`task\` with \`working-directory: tools/release\`.

**2. Grant \`permissions: contents: read\` to \`ship-release.yml\`'s \`dry-run-build\` job**

\`ship-release.yml\` declares \`permissions: {}\` at workflow level. The \`dry-run-build\` job calls \`build-release.yml\` via \`workflow_call\`; \`build-release.yml\` declares \`permissions: contents: read\` at ITS workflow level. GitHub's startup validation rejects the dispatch when the caller grants strictly less than what the callee needs: the empty workflow-level default blocked \`dry-run-build\` from launching at all (result: \`startup_failure\` with zero jobs run).

Fix is a per-job override that grants exactly \`contents: read\` (what \`build-release.yml\`'s \`actions/checkout\` needs) while keeping the \`ship\` job's workflow-level default-deny intact. Latent from Phase 3b-2 (#13099) which introduced \`dry-run-build\` but never dispatched it.

## Verification battery results (Phase 5.5, pre-fix)

| # | Workflow | Result |
|---|----------|--------|
| 1 | \`release-permissions-check\` | ✅ |
| 2 | \`release-mechanism-smoketest\` | ✅ |
| 3 | \`build-release\` (dry-run, 8.2.0) | ❌ fixed by change 1 |
| 4 | \`ship-release\` (dry-run) | ❌ fixed by change 2 |

## Test plan

- [ ] After merge, refire \`build-release.yml\` with \`dry_run=true, version_branch=rel-820, version=8.2.0\` and confirm green with artifact bundle.
- [ ] After merge, refire \`ship-release.yml\` with \`mode=dry-run\` and confirm the \`dry-run-build\` job launches (may fail on preflight due to missing release-prep PR for 8.2.1 — that's diagnostic, not blocker).
- [ ] Phase 6 (openemr-devops release-mechanism wholesale delete) unblocked once both above green.

## Byte-identical impact

- \`tools/release/.gitignore\` gets propagated to rel-820 by sync-byte-identical (covered by the \`tools/release/**\` glob). Harmless on rel branches (they don't build releases via this path).
- \`ship-release.yml\` is intentionally NOT in byte-identical (see its header comment); no rel-branch propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)