### PR TITLE
ci(release-permissions-check): probe statuses:write

### DIFF
--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -123,6 +123,32 @@ jobs:
         fi
         echo "OK: opened and closed draft PR #${pr_number}"
 
+    - name: Probe statuses:write (post commit status on throwaway commit)
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        REPO: ${{ github.repository }}
+        BRANCH: ${{ steps.probe-contents.outputs.branch }}
+        RUN_ID: ${{ github.run_id }}
+      # ship-release.yml writes a `release/ship-approved` commit status
+      # on each PR head before merging (so branch-protection can require
+      # it later). If the release App installation doesn't have
+      # statuses:write, ship-release fails at gh-app-token mint time with
+      # a generic "permissions not granted" error and no clue which scope
+      # is missing. Probe it explicitly here so the gap fails loud with
+      # the scope name. Discovered 2026-07-22 when Phase 5.5's
+      # ship-release dry-run tripped on this exact gap after every other
+      # probe in this workflow had passed.
+      run: |
+        sha=$(gh api "repos/${REPO}/git/ref/heads/${BRANCH}" --jq '.object.sha')
+        if ! gh api -X POST "repos/${REPO}/statuses/${sha}" \
+          -f 'state=success' \
+          -f "context=release-permissions-check/${RUN_ID}" \
+          -f 'description=Permissions probe — safe to ignore.' >/dev/null; then
+          echo "FAIL: statuses:write missing (cannot post commit status)" >&2
+          exit 1
+        fi
+        echo "OK: posted throwaway commit status on ${sha}"
+
     - name: Probe annotated tag creation
       id: probe-tag
       env:


### PR DESCRIPTION
## Summary

Add an explicit \`statuses:write\` probe to \`release-permissions-check.yml\` so the release App installation's Commit Statuses scope is validated ahead of ship-release firing.

## Why

\`ship-release.yml\` writes a \`release/ship-approved\` commit status on each PR head before merging (so branch protection can require it later). If the release App installation on any target repo doesn't have \`statuses:write\` granted, ship-release fails at gh-app-token mint time with a generic **"permissions not granted"** error and no clue which scope is missing.

**Discovered 2026-07-22** when Phase 5.5's ship-release dry-run tripped on this exact gap after every other probe in this workflow had passed. Ship-release requests \`permission-statuses: write\` but \`release-permissions-check.yml\` didn't probe it — coverage hole meant the gap only surfaced at production dispatch time, and the error message points at the token mint, not the underlying permission.

## What changes

New step \`Probe statuses:write (post commit status on throwaway commit)\` between \`Probe pull-requests:write\` and \`Probe annotated tag creation\`. Mirrors the existing probe pattern:
- Uses the throwaway branch's HEAD SHA (via \`gh api /git/ref/heads/${BRANCH}\`) — same technique as the existing \`Probe annotated tag creation\` step.
- POSTs a \`success\` commit status with a unique context including the run ID so successive probes don't collide.
- Fails loud with \`FAIL: statuses:write missing\` on any non-200.
- Non-destructive — commit statuses accumulate on the throwaway commit and get GC'd when the throwaway branch is deleted at the end of the run.

## Test plan

- [ ] Manual \`workflow_dispatch\` of \`release-permissions-check.yml\` after grant lands. Expect green with a new \`OK: posted throwaway commit status on <sha>\` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)