### PR TITLE
fix(release): summary.php works with empty milestone; port missing checklist templates

### DIFF
--- a/tests/Tests/Isolated/Release/SummaryCliTest.php
+++ b/tests/Tests/Isolated/Release/SummaryCliTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+final class SummaryCliTest extends TestCase
+{
+    private const BIN = __DIR__ . '/../../../../tools/release/bin/summary.php';
+
+    private string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/openemr-summary-cli-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->tmpDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->tmpDir);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursive($this->tmpDir);
+    }
+
+    public function testEmptyMilestoneAcceptedInDryRun(): void
+    {
+        // Regression for the Phase 5.5 verification-battery failure:
+        // build-release.yml dispatches without a milestone input (it's
+        // optional), and summary.php previously rejected the empty value
+        // as `--milestone is required`. That aborted the workflow before
+        // the artifact-upload step, so operators couldn't inspect the
+        // dry-run's produced tarball/zip. See openemr/openemr#13115's
+        // Phase 5.5 findings for the surrounding context.
+        $outputPath = $this->tmpDir . '/summary.md';
+
+        $this->runBin([
+            '--type=full',
+            '--milestone=',
+            '--version-branch=rel-820',
+            '--output-dir=' . $this->tmpDir,
+            '--output=' . $outputPath,
+            '--dry-run',
+        ])->mustRun();
+
+        $out = (string) file_get_contents($outputPath);
+        self::assertStringContainsString('## Release Build Results', $out);
+        self::assertStringContainsString('rel-820', $out);
+        self::assertStringContainsString('(dry run)', $out);
+    }
+
+    public function testMilestoneOmittedAcceptedInDryRun(): void
+    {
+        // Same as the empty case but with --milestone flag entirely absent
+        // rather than set to empty. Both paths should behave identically.
+        $outputPath = $this->tmpDir . '/summary.md';
+
+        $this->runBin([
+            '--type=full',
+            '--version-branch=rel-820',
+            '--output-dir=' . $this->tmpDir,
+            '--output=' . $outputPath,
+            '--dry-run',
+        ])->mustRun();
+
+        self::assertFileExists($outputPath);
+    }
+
+    public function testMilestoneProvidedIncludedInSummary(): void
+    {
+        $outputPath = $this->tmpDir . '/summary.md';
+
+        $this->runBin([
+            '--type=full',
+            '--milestone=8.2.0',
+            '--version-branch=rel-820',
+            '--release-tag=v8_2_0',
+            '--output-dir=' . $this->tmpDir,
+            '--output=' . $outputPath,
+        ])->mustRun();
+
+        $out = (string) file_get_contents($outputPath);
+        self::assertStringContainsString('8.2.0', $out);
+        self::assertStringContainsString('v8_2_0', $out);
+    }
+
+    public function testMissingTypeRejected(): void
+    {
+        $process = $this->runBin([
+            '--milestone=8.2.0',
+            '--output-dir=' . $this->tmpDir,
+        ]);
+        $process->run();
+
+        self::assertFalse($process->isSuccessful());
+        // summary.php writes error markers via $output->writeln('<error>…</error>')
+        // which SingleCommandApplication routes to stdout with red styling,
+        // NOT to stderr. Assert against getOutput() rather than
+        // getErrorOutput() to match actual behavior.
+        self::assertStringContainsString('--type is required', $process->getOutput());
+    }
+
+    public function testInvalidTypeRejected(): void
+    {
+        $process = $this->runBin([
+            '--type=quarterly',
+            '--milestone=8.2.0',
+            '--output-dir=' . $this->tmpDir,
+        ]);
+        $process->run();
+
+        self::assertFalse($process->isSuccessful());
+        self::assertStringContainsString('must be "patch" or "full"', $process->getOutput());
+    }
+
+    public function testChecksumsAndChangelogRolledInWhenPresent(): void
+    {
+        // Populate the output dir with the sidecar files summary.php picks
+        // up via glob (matches build-release.yml's on-disk layout after
+        // package:assemble + checksum tasks run).
+        file_put_contents($this->tmpDir . '/openemr-8.2.0.tar.gz.sha256', "abc123  openemr-8.2.0.tar.gz\n");
+        file_put_contents($this->tmpDir . '/openemr-8.2.0.zip.sha256', "def456  openemr-8.2.0.zip\n");
+        file_put_contents($this->tmpDir . '/changelog.md', "## [8.2.0] - 2026-07-08\n\n### Fixed\n\n- a bug\n");
+
+        $outputPath = $this->tmpDir . '/summary.md';
+        $this->runBin([
+            '--type=full',
+            '--milestone=8.2.0',
+            '--output-dir=' . $this->tmpDir,
+            '--output=' . $outputPath,
+        ])->mustRun();
+
+        $out = (string) file_get_contents($outputPath);
+        self::assertStringContainsString('abc123', $out);
+        self::assertStringContainsString('def456', $out);
+        self::assertStringContainsString('a bug', $out);
+    }
+
+    public function testOutputAppendsRatherThanOverwrites(): void
+    {
+        // GITHUB_STEP_SUMMARY is append-mode by convention; the CLI mirrors
+        // that behavior when writing to --output. Confirm two back-to-back
+        // invocations against the same file leave both summaries intact
+        // rather than the second clobbering the first.
+        $outputPath = $this->tmpDir . '/summary.md';
+        file_put_contents($outputPath, "pre-existing marker line\n");
+
+        $this->runBin([
+            '--type=full',
+            '--milestone=8.2.0',
+            '--output-dir=' . $this->tmpDir,
+            '--output=' . $outputPath,
+        ])->mustRun();
+
+        $out = (string) file_get_contents($outputPath);
+        self::assertStringStartsWith('pre-existing marker line', $out);
+        self::assertStringContainsString('## Release Build Results', $out);
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    private function runBin(array $args): Process
+    {
+        return new Process(['php', self::BIN, ...$args]);
+    }
+
+    private function removeRecursive(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        /** @var iterable<\SplFileInfo> $items */
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tools/release/bin/summary.php
+++ b/tools/release/bin/summary.php
@@ -40,17 +40,26 @@ use Twig\Loader\FilesystemLoader;
         // Parse raw CLI input into narrowed string values at the boundary
         // rather than @var-casting downstream; PHPStan trusts the runtime
         // check, and downstream code no longer needs re-validation.
-        $required = [];
-        foreach (['type', 'milestone'] as $name) {
-            $value = $input->getOption($name);
-            if (!is_string($value) || $value === '') {
-                $output->writeln("<error>--{$name} is required</error>");
-                return 1;
-            }
-            $required[$name] = $value;
+        $typeOption = $input->getOption('type');
+        if (!is_string($typeOption) || $typeOption === '') {
+            $output->writeln('<error>--type is required</error>');
+            return 1;
         }
-        $type = $required['type'];
-        $milestone = $required['milestone'];
+        $type = $typeOption;
+
+        // --milestone is optional. build-release.yml only sets it when the
+        // operator supplied a milestone at dispatch (release-prep already
+        // determined by then whether milestone-gating applies). Treat unset
+        // and empty as equivalent -- the templates render `{{ milestone }}`
+        // as blank in that case, which matches the "no milestone context
+        // available" reality. Rejecting empty forced every dry-run dispatch
+        // to pass a dummy milestone or fail at this step.
+        $milestoneOption = $input->getOption('milestone');
+        if ($milestoneOption !== null && !is_string($milestoneOption)) {
+            $output->writeln('<error>--milestone must be a string</error>');
+            return 1;
+        }
+        $milestone = $milestoneOption ?? '';
 
         $outputDirOption = $input->getOption('output-dir');
         if (!is_string($outputDirOption) || $outputDirOption === '') {

--- a/tools/release/templates/full-checklist.md
+++ b/tools/release/templates/full-checklist.md
@@ -1,0 +1,17 @@
+### Manual steps remaining
+
+- [ ] Verify source archives on GitHub release page
+- [ ] Upload to SourceForge
+- [ ] Update Docker version files in openemr-devops
+- [ ] Trigger Docker builds
+- [ ] Update DockerHub readme
+- [ ] Update [website-openemr](https://github.com/openemr/website-openemr) download links
+- [ ] Update [Release History](https://www.open-emr.org/wiki/index.php/OpenEMR_Downloads) on wiki
+- [ ] Update demo farm
+- [ ] Announce
+  - [ ] Forums
+  - [ ] Chat
+  - [ ] Twitter
+  - [ ] Facebook
+  - [ ] LinkedIn group+company
+  - [ ] Registered users

--- a/tools/release/templates/patch-checklist.md
+++ b/tools/release/templates/patch-checklist.md
@@ -1,0 +1,14 @@
+### Manual steps remaining
+
+- [ ] Update [OpenEMR Patches](https://www.open-emr.org/wiki/index.php/OpenEMR_Patches) download page
+- [ ] Trigger Docker build in [openemr-devops](https://github.com/openemr/openemr-devops/actions) (update tags first)
+- [ ] Update DockerHub readme
+- [ ] Update [Release History](https://www.open-emr.org/wiki/index.php/OpenEMR_Downloads) on wiki
+- [ ] Point demo farm to new tag
+- [ ] Announce
+  - [ ] Forums
+  - [ ] Chat
+  - [ ] Twitter
+  - [ ] Facebook
+  - [ ] LinkedIn group+company
+  - [ ] Registered users


### PR DESCRIPTION
## Summary

Third Phase 5.5-surfaced latent bug from the Phase 2 port of \`tools/release/**\`. Same class as \`.gitignore\` missing (#13115) and the ship-release permissions block (#13115) — end-to-end dry-run was never fired between Phase 2 landing and today's Phase 5.5 verification battery, so multiple assumptions about optional inputs went unchecked.

**Two bugs fixed together** (both surface as a single \`Build summary\` step failure in \`build-release.yml\` dry-run):

### 1. \`bin/summary.php\` rejected empty \`--milestone\`

\`build-release.yml\`'s \`milestone\` input is optional (only set when the operator supplies a milestone at dispatch). Preflight tolerates the empty case (gated by \`inputs.milestone != ''\`); \`summary.php\` didn't. Every dry-run without a milestone therefore aborted at the summary step — critically, *before* the artifact upload step ran, so operators couldn't inspect the produced tarball/zip.

Fix: treat \`--milestone\` as optional, default to empty string. Twig templates render \`{{ milestone }}\` as blank when unset, which matches the "no milestone context" reality.

### 2. \`templates/full-summary.md.twig\` \`{% include 'full-checklist.md' %}\` referenced a missing file

Devops had both \`full-checklist.md\` and \`patch-checklist.md\` alongside the \`.twig\` templates; the Phase 2 port copied the \`.twig\` files but not the \`.md\` includes. Twig aborted rendering with "template not found."

Fix: copy both checklist files verbatim from devops so the include resolves.

⚠️ **Checklist content is stale** (many items are now automated post-Phase 4/5): SourceForge upload retired, docker builds automated, demo farm derived, announcements drafted by website-openemr. Follow-up content refresh tracked as a note in the commit body; this PR just gets \`summary.php\` running.

## Test coverage added

New \`tests/Tests/Isolated/Release/SummaryCliTest.php\` (7 tests):
- Empty \`--milestone\` (regression for #1)
- Omitted \`--milestone\` (same intent, different call shape)
- Provided \`--milestone\` (happy path)
- Missing \`--type\` (rejected)
- Invalid \`--type\` (rejected)
- Checksums + changelog rolled in when present in \`--output-dir\`
- Output file appends rather than overwrites (matches \`GITHUB_STEP_SUMMARY\` semantics)

Verified: tests fail on the unfixed script (2 empty-milestone tests error) and pass with the fix.

## Test plan

- [x] All 7 SummaryCliTest tests pass locally.
- [ ] After merge, refire \`build-release.yml\` with \`dry_run=true, version_branch=rel-820, version=8.2.0\` and confirm the \`Build summary\` step passes and \`Upload artifacts (dry run)\` runs, producing a downloadable artifact bundle.

## Follow-up

- Refresh checklist content post-Phase-6 to reflect current automation surface (per commit body note).
- Backfill CLI test coverage for the other bin scripts (\`dispatch.php\`, \`preflight.php\`, \`create-tag.php\`, \`verify-tag.php\`, \`ship-release.php\`, \`package-assemble.php\`, \`patch-assemble.php\`) before Phase 6 (agreed sequence in prior discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)