### PR TITLE
chore(edihistory): remove unused csv_array_flatten

### DIFF
--- a/.phpstan/baseline/function.alreadyNarrowedType.php
+++ b/.phpstan/baseline/function.alreadyNarrowedType.php
@@ -163,7 +163,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#',
-    'count' => 9,
+    'count' => 8,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -2342,16 +2342,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function csv_array_flatten\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function csv_array_flatten\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function csv_denied_by_file\\(\\) return type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',

--- a/.phpstan/baseline/openemr.noGlobalNsFunctions.php
+++ b/.phpstan/baseline/openemr.noGlobalNsFunctions.php
@@ -4542,11 +4542,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function csv_array_flatten may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function csv_assoc_array may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -1617,11 +1617,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function csv_array_flatten\\(\\) should return array but returns false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function csv_check_filepath\\(\\) should return string but returns string\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',

--- a/library/edihistory/edih_csv_inc.php
+++ b/library/edihistory/edih_csv_inc.php
@@ -1474,32 +1474,6 @@ function csv_assoc_array($file_type, $csv_type)
 
 
 /**
- * A multidimensional array will be flattened to a single row.
- *
- * @param array $array array to be flattened
- * @return array
- */
-function csv_array_flatten($array)
-{
-    //
-    if (!is_array($array)) {
-        return false;
-    }
-
-    $result = [];
-    foreach ($array as $key => $value) {
-        if (is_array($value)) {
-            $result = array_merge($result, csv_array_flatten($value));
-        } else {
-            $result[$key] = $value;
-        }
-    }
-
-    return $result;
-}
-
-
-/**
  * Write parsed data from edi x12 files to csv file
  *
  * @uses csv_parameters()


### PR DESCRIPTION
`csv_array_flatten()` has no callers anywhere in the codebase — the only references were its own definition and its recursive self-call, so it was dead code.

Remove the function along with its PHPStan baseline entries, and decrement the file's `is_array()`-always-true count by one (the function's own `@param array` + `is_array($array)` guard was one of those occurrences).

Pure dead-code removal, no behavior change. `php -l` clean and the full pre-commit suite (PHP_CodeSniffer, PHPStan level max, Rector) passes.