### PR TITLE
chore(edihistory): remove unused edih_csv_order

### DIFF
--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -1638,7 +1638,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -2397,16 +2397,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function edih_csv_order\\(\\) has parameter \\$csvdata with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function edih_csv_order\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function edih_csv_write\\(\\) has parameter \\$csv_data with no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',

--- a/.phpstan/baseline/offsetAccess.invalidOffset.php
+++ b/.phpstan/baseline/offsetAccess.invalidOffset.php
@@ -723,7 +723,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 9,
+    'count' => 5,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -30868,7 +30868,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'type\' on mixed\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [
@@ -30892,13 +30892,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \\(int\\|string\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset mixed on mixed\\.$#',
-    'count' => 3,
+    'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.noGlobalNsFunctions.php
+++ b/.phpstan/baseline/openemr.noGlobalNsFunctions.php
@@ -4677,11 +4677,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function edih_csv_order may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function edih_csv_write may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',

--- a/.phpstan/baseline/return.unusedType.php
+++ b/.phpstan/baseline/return.unusedType.php
@@ -77,11 +77,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function edih_csv_order\\(\\) never returns bool so it can be removed from the return type\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function getBarId\\(\\) never returns null so it can be removed from the return type\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/lab.inc.php',

--- a/library/edihistory/edih_csv_inc.php
+++ b/library/edihistory/edih_csv_inc.php
@@ -1065,47 +1065,6 @@ function edih_errseg_parse($err_seg, $id = false)
 }
 
 /**
- * Order the csv data array according to the csv table heading row
- * so the data to be added to csv table rows are correctly ordered
- *  the supplied data should be in an array with this structure
- *  array['icn'] ['file'][i]['key']  ['claim'][i]['key']  ['type']['type']
- *
- * @uses csv_table_header()
- *
- * @param array $csvdata data_ar data array from edih_XXX_csv_data()
- * @return array|bool        ordered array or false on error
- */
-function edih_csv_order($csvdata)
-{
-    //
-    $wrcsv = [];
-    $order_ar = [];
-    //
-    foreach ($csvdata as $icn => $data) {
-        // [icn]['type']['file']['claim']
-        $ft = $data['type'];
-        $wrcsv[$icn]['type'] = $ft;
-        //
-        foreach ($data as $key => $val) {
-            if ($key == 'type') {
-                continue;
-            }
-
-            $order_ar[$icn][$key] = csv_table_header($ft, $key);
-            $ct = count($order_ar[$icn][$key]);
-            foreach ($val as $k => $rcrd) {
-                //
-                foreach ($order_ar[$icn][$key] as $ky => $vl) {
-                    $wrcsv[$icn][$key][$k][$ky] = $rcrd[$vl];
-                }
-            }
-        }
-    }
-
-    return $wrcsv;
-}
-
-/**
  * insert dashes in ten-digit telephone numbers
  *
  * @param string $str_val   the telephone number


### PR DESCRIPTION
`edih_csv_order()` in `library/edihistory/edih_csv_inc.php` has no callers anywhere in the codebase — its only reference is its own definition. It was dead code.

## Changes
- Remove the `edih_csv_order()` function and its docblock (~41 lines).
- Drop the now-obsolete PHPStan baseline entries that referenced it, and decrement the shared-count entries whose occurrences it contributed to (the untyped `$csvdata` parameter was the source of several `mixed`-related baseline lines).

## Verification
- `php -l` clean.
- Full pre-commit suite passes, including PHPStan at level 10 with the adjusted baseline — confirming every baseline count is exact after the removal.