### PR TITLE
chore(edihistory): remove unused edih_change_loop

### DIFF
--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -2143,7 +2143,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 78,
+    'count' => 74,
     'path' => __DIR__ . '/../../library/edihistory/edih_segments.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -22007,16 +22007,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_segments.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function edih_change_loop\\(\\) has parameter \\$lptest with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_segments.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function edih_change_loop\\(\\) has parameter \\$lpval with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_segments.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function edih_ziptoarray\\(\\) has parameter \\$single with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_uploads.php',

--- a/.phpstan/baseline/openemr.noGlobalNsFunctions.php
+++ b/.phpstan/baseline/openemr.noGlobalNsFunctions.php
@@ -4857,11 +4857,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_segments.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function edih_change_loop may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_segments.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function edih_display_text may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_segments.php',

--- a/library/edihistory/edih_segments.php
+++ b/library/edihistory/edih_segments.php
@@ -13,24 +13,6 @@
 
 
 /**
- * increment loop values ($lpval is a reference)
- *
- * @param $lptest   the prospective loop value
- * @param &$lpval    the present loop value -- reassigned here
- * @return int value from strcmp()
- */
-function edih_change_loop($lptest, &$lpval)
-{
-    // strcmp($str1,$str2) Returns < 0 if str1 is less than str2; > 0 if str1 is greater than str2, and 0 if they are equal.
-    if (strcmp((string) $lptest, (string) $lpval) > 0) {
-        //echo "$lptest greater than $lpval" .PHP_EOL;
-        $lpval = $lptest;
-    }
-
-    return strcmp((string) $lptest, (string) $lpval);
-}
-
-/**
  * format segments for display of x12 edi files
  *
  * @param array  $segments
@@ -735,7 +717,7 @@ function edih_277_text($segments, $delimiter, $stpos = '')
             switch ((string)$loopid) {
                 case '2000A':
                     $loopid = '2100A';
-                    break;     // edih_change_loop($lptest, &$lpval)
+                    break;
                 case '2000B':
                     $loopid = '2100B';
                     break;


### PR DESCRIPTION
`edih_change_loop()` in `library/edihistory/edih_segments.php` has no callers anywhere in the codebase — its only non-definition reference was a stale trailing comment on a `switch` case. It was dead code (a pre-PHP-8-era `strcmp`-based loop-value helper).

## Changes
- Remove the `edih_change_loop()` function and its docblock.
- Drop its now-obsolete PHPStan baseline entries (2× `missingType.parameter`, 1× `openemr.noGlobalNsFunctions`) and decrement the shared `Cannot cast mixed to string` count for this file (78 → 74; the function had four `(string)`-on-`mixed` casts).
- Remove the dangling `// edih_change_loop(...)` comment that annotated one `case` branch, matching its sibling branches.

## Verification
- `php -l` clean on all changed files.
- Full pre-commit suite passes, including PHPStan at level 10 with the adjusted baseline — confirming every baseline count is exact after the removal.