### PR TITLE
chore: pre-auth cleanups

### DIFF
--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -3983,7 +3983,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 33,
+    'count' => 30,
     'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -633,7 +633,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 32,
+    'count' => 30,
     'path' => __DIR__ . '/../../interface/globals.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -1383,7 +1383,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) instead of sqlQueryNoLog\\(\\)\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/globals.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -6733,7 +6733,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) instead of sqlQueryNoLog\\(\\)\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenInstantiation.php
+++ b/.phpstan/baseline/openemr.forbiddenInstantiation.php
@@ -138,7 +138,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Http\\\\Psr17Factory is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:get\\{PsrType\\}Factory\\(\\) instead\\.$#',
-    'count' => 7,
+    'count' => 6,
     'path' => __DIR__ . '/../../src/RestControllers/AuthorizationController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -1293,7 +1293,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/globals.php',
 ];
 $ignoreErrors[] = [

--- a/admin.php
+++ b/admin.php
@@ -13,6 +13,33 @@
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+/**
+ * DISABLED BY DEFAULT — set OPENEMR_ADMIN_PHP_ENABLED=1 as an environment
+ * variable to enable.
+ *
+ *   Apache (vhost or .htaccess):
+ *     SetEnv OPENEMR_ADMIN_PHP_ENABLED 1
+ *
+ *   PHP-FPM (pool config):
+ *     env[OPENEMR_ADMIN_PHP_ENABLED] = 1
+ *
+ *   Shell:
+ *     export OPENEMR_ADMIN_PHP_ENABLED=1
+ *
+ * When enabled, restrict access via network controls — this script performs
+ * no user authentication.
+ */
+
+if (
+    filter_input(INPUT_SERVER, 'OPENEMR_ADMIN_PHP_ENABLED') !== '1'
+    && (getenv('OPENEMR_ADMIN_PHP_ENABLED') ?: '') !== '1'
+) {
+    http_response_code(403);
+    header('Content-Type: text/plain');
+    echo "admin.php is disabled by default. See the header comment in this file to enable.\n";
+    exit;
+}
+
 // Checks if the server's PHP version is compatible with OpenEMR:
 require_once(__DIR__ . "/src/Common/Compatibility/Checker.php");
 $response = OpenEMR\Common\Compatibility\Checker::checkPhpVersion();

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -419,19 +419,9 @@ if (!empty($glrow)) {
     // Collect user specific settings from user_settings table.
     //
     $gl_user = [];
-    // Collect the user id first
     $temp_authuserid = '';
     if (!empty($session->get('authUserID'))) {
-        //Set the user id from the session variable
         $temp_authuserid = $session->get('authUserID');
-    } else {
-        if (!empty($_POST['authUser'])) {
-            $temp_sql_ret = sqlQueryNoLog("SELECT `id` FROM `users` WHERE BINARY `username` = ?", [$_POST['authUser']]);
-            if (!empty($temp_sql_ret['id'])) {
-                //Set the user id from the login variable
-                $temp_authuserid = $temp_sql_ret['id'];
-            }
-        }
     }
 
     if (!empty($temp_authuserid)) {

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -1462,19 +1462,16 @@ class AuthorizationController
             $token_parts = explode('.', $id_token);
             $id_payload = $this->decodeToken($token_parts[1]);
 
-            $client_id = $id_payload['aud'];
+            $client_id = is_string($id_payload['aud'] ?? null) ? $id_payload['aud'] : '';
             $user = $id_payload['sub'];
             $id_nonce = $id_payload['nonce'] ?? '';
             $trustedUser = $this->trustedUser($client_id, $user);
             if (empty($trustedUser['id'])) {
                 $message = xlt("You are currently not signed in.");
-                if (!empty($post_logout_url)) {
-                    $client = QueryUtils::querySingleRow("SELECT logout_redirect_uris as valid FROM `oauth_clients` WHERE `client_id` = ? AND `logout_redirect_uris` = ?", [$client_id, $post_logout_url], false);
-                    if (is_array($client) && ($client['valid'] ?? '') !== '') {
-                        $this->session->invalidate();
-                        return (new Psr17Factory())->createResponse(Response::HTTP_TEMPORARY_REDIRECT)
-                            ->withHeader('Location', $post_logout_url . "?state=$state");
-                    }
+                $redirectResponse = $this->buildLogoutRedirectIfAllowlisted($client_id, $post_logout_url, $state);
+                if ($redirectResponse !== null) {
+                    $this->session->invalidate();
+                    return $redirectResponse;
                 }
                 $this->session->invalidate();
                 throw new HttpException(Response::HTTP_UNAUTHORIZED, $message);
@@ -1486,24 +1483,43 @@ class AuthorizationController
             }
             // clear the users session
             $this->trustedUserService->deleteTrustedUserById($trustedUser['id']);
-            $client = sqlQueryNoLog("SELECT logout_redirect_uris as valid FROM `oauth_clients` WHERE `client_id` = ? AND `logout_redirect_uris` = ?", [$client_id, $post_logout_url]);
-            if (!empty($post_logout_url) && !empty($client['valid'])) {
+            $redirectResponse = $this->buildLogoutRedirectIfAllowlisted($client_id, $post_logout_url, $state);
+            if ($redirectResponse !== null) {
                 $this->session->invalidate();
-                return (new Psr17Factory())->createResponse(Response::HTTP_TEMPORARY_REDIRECT)
-                    ->withHeader('Location', $post_logout_url . "?state=$state");
-            } else {
-                $message = xlt("You have been signed out. Thank you.");
-                $this->session->invalidate();
-                $factory = new Psr17Factory();
-                return $factory->createResponse(Response::HTTP_OK)
-                    ->withHeader("Content-Type", "text/plain; charset=UTF-8")
-                    ->withBody($factory->createStream($message));
+                return $redirectResponse;
             }
+            $message = xlt("You have been signed out. Thank you.");
+            $this->session->invalidate();
+            $factory = new Psr17Factory();
+            return $factory->createResponse(Response::HTTP_OK)
+                ->withHeader("Content-Type", "text/plain; charset=UTF-8")
+                ->withBody($factory->createStream($message));
         } catch (OAuthServerException $exception) {
             $this->getSystemLogger()->error("OAuth error for client {client_id}: " . $exception->getMessage(), ['client_id' => $client_id]);
             $this->session->invalidate();
             return $exception->generateHttpResponse($response);
         }
+    }
+
+    private function buildLogoutRedirectIfAllowlisted(string $client_id, string $post_logout_url, string $state): ?ResponseInterface
+    {
+        if ($post_logout_url === '') {
+            return null;
+        }
+        $client = QueryUtils::querySingleRow(
+            "SELECT logout_redirect_uris FROM `oauth_clients` WHERE `client_id` = ?",
+            [$client_id],
+            false
+        );
+        $stored = is_array($client) ? ($client['logout_redirect_uris'] ?? '') : '';
+        $registeredUris = is_string($stored) ? explode('|', $stored) : [];
+        if (!in_array($post_logout_url, $registeredUris, true)) {
+            return null;
+        }
+        $stateQuery = http_build_query(['state' => $state], '', '&', PHP_QUERY_RFC3986);
+        $separator = str_contains($post_logout_url, '?') ? '&' : '?';
+        return (new Psr17Factory())->createResponse(Response::HTTP_TEMPORARY_REDIRECT)
+            ->withHeader('Location', $post_logout_url . $separator . $stateQuery);
     }
 
     public function tokenIntrospection(HttpRestRequest $request): ResponseInterface

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -1467,16 +1467,17 @@ class AuthorizationController
             $id_nonce = $id_payload['nonce'] ?? '';
             $trustedUser = $this->trustedUser($client_id, $user);
             if (empty($trustedUser['id'])) {
-                // not logged in so just continue as if were.
                 $message = xlt("You are currently not signed in.");
                 if (!empty($post_logout_url)) {
-                    $this->session->invalidate();
-                    return (new Psr17Factory())->createResponse(Response::HTTP_TEMPORARY_REDIRECT)
-                        ->withHeader('Location', $post_logout_url . "?state=$state");
-                } else {
-                    $this->session->invalidate();
-                    throw new HttpException(Response::HTTP_UNAUTHORIZED, $message);
+                    $client = QueryUtils::querySingleRow("SELECT logout_redirect_uris as valid FROM `oauth_clients` WHERE `client_id` = ? AND `logout_redirect_uris` = ?", [$client_id, $post_logout_url], false);
+                    if (is_array($client) && ($client['valid'] ?? '') !== '') {
+                        $this->session->invalidate();
+                        return (new Psr17Factory())->createResponse(Response::HTTP_TEMPORARY_REDIRECT)
+                            ->withHeader('Location', $post_logout_url . "?state=$state");
+                    }
                 }
+                $this->session->invalidate();
+                throw new HttpException(Response::HTTP_UNAUTHORIZED, $message);
             }
             $session_nonce = (json_decode((string) $trustedUser['session_cache'], true)['nonce']) ?? '';
             // this should be enough to confirm valid id

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -1516,10 +1516,14 @@ class AuthorizationController
         if (!in_array($post_logout_url, $registeredUris, true)) {
             return null;
         }
-        $stateQuery = http_build_query(['state' => $state], '', '&', PHP_QUERY_RFC3986);
-        $separator = str_contains($post_logout_url, '?') ? '&' : '?';
+        $location = $post_logout_url;
+        if ($state !== '') {
+            $stateQuery = http_build_query(['state' => $state], '', '&', PHP_QUERY_RFC3986);
+            $separator = str_contains($post_logout_url, '?') ? '&' : '?';
+            $location .= $separator . $stateQuery;
+        }
         return (new Psr17Factory())->createResponse(Response::HTTP_TEMPORARY_REDIRECT)
-            ->withHeader('Location', $post_logout_url . $separator . $stateQuery);
+            ->withHeader('Location', $location);
     }
 
     public function tokenIntrospection(HttpRestRequest $request): ResponseInterface

--- a/tests/Tests/Api/AuthorizationLogoutFullFlowTest.php
+++ b/tests/Tests/Api/AuthorizationLogoutFullFlowTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * Full OIDC RP-initiated logout end-to-end test
+ *
+ * Exercises: DCR client registration → OAuth login → consent → authorization
+ * code exchange → logout with the real signed id_token. Verifies the logout
+ * endpoint redirects to the client's registered post_logout_redirect_uri with
+ * the state parameter preserved.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Api;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+use OpenEMR\Common\Database\QueryUtils;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
+
+class AuthorizationLogoutFullFlowTest extends TestCase
+{
+    private const REDIRECT_URI = 'https://client.example/cb';
+    private const LOGOUT_URI = 'https://client.example/logged-out';
+    private const STATE = 'testflow-state-abc';
+    private const NONCE = 'testflow-nonce-xyz';
+
+    private string $baseUrl;
+    private ?string $originalSiteAddrOath = null;
+    private ?string $clientId = null;
+
+    protected function setUp(): void
+    {
+        $this->baseUrl = getenv('OPENEMR_BASE_URL_API', true) ?: 'https://localhost';
+
+        $current = QueryUtils::querySingleRow(
+            'SELECT gl_value FROM `globals` WHERE gl_name = ?',
+            ['site_addr_oath']
+        );
+        $glValue = is_array($current) ? ($current['gl_value'] ?? null) : null;
+        $this->originalSiteAddrOath = is_string($glValue) ? $glValue : null;
+
+        if ($this->originalSiteAddrOath !== $this->baseUrl) {
+            QueryUtils::sqlStatementThrowException(
+                'UPDATE `globals` SET gl_value = ? WHERE gl_name = ?',
+                [$this->baseUrl, 'site_addr_oath']
+            );
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        try {
+            if ($this->clientId !== null) {
+                QueryUtils::sqlStatementThrowException(
+                    'DELETE FROM `oauth_clients` WHERE `client_id` = ?',
+                    [$this->clientId]
+                );
+                QueryUtils::sqlStatementThrowException(
+                    'DELETE FROM `oauth_trusted_user` WHERE `client_id` = ?',
+                    [$this->clientId]
+                );
+            }
+        } finally {
+            if ($this->originalSiteAddrOath !== null && $this->originalSiteAddrOath !== $this->baseUrl) {
+                QueryUtils::sqlStatementThrowException(
+                    'UPDATE `globals` SET gl_value = ? WHERE gl_name = ?',
+                    [$this->originalSiteAddrOath, 'site_addr_oath']
+                );
+            }
+        }
+    }
+
+    #[Test]
+    public function testFullGrantToLogoutFlow(): void
+    {
+        $http = $this->buildClient();
+
+        $reg = $http->post($this->baseUrl . '/oauth2/default/registration', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'json' => [
+                'application_type' => 'private',
+                'redirect_uris' => [self::REDIRECT_URI],
+                'post_logout_redirect_uris' => [self::LOGOUT_URI],
+                'client_name' => 'AuthorizationLogoutFullFlowTest',
+                'token_endpoint_auth_method' => 'client_secret_post',
+                'contacts' => ['e2e@test.example'],
+                'scope' => 'openid fhirUser',
+            ],
+        ]);
+        $this->assertSame(200, $reg->getStatusCode(), 'DCR registration should succeed');
+        $clientData = json_decode((string) $reg->getBody(), true);
+        $this->assertIsArray($clientData);
+        $this->assertArrayHasKey('client_id', $clientData);
+        $this->assertArrayHasKey('client_secret', $clientData);
+        $this->assertIsString($clientData['client_id']);
+        $this->assertIsString($clientData['client_secret']);
+        $this->clientId = $clientData['client_id'];
+        $clientSecret = $clientData['client_secret'];
+
+        $authUrl = '/oauth2/default/authorize?' . http_build_query([
+            'client_id' => $this->clientId,
+            'redirect_uri' => self::REDIRECT_URI,
+            'response_type' => 'code',
+            'scope' => 'openid fhirUser',
+            'state' => self::STATE,
+            'nonce' => self::NONCE,
+        ]);
+        $loginPage = $http->get($this->baseUrl . $authUrl);
+        $this->assertSame(200, $loginPage->getStatusCode(), 'Authorize should redirect to login page');
+        [$loginCsrf, $loginAction] = $this->parseLoginForm(
+            new Crawler((string) $loginPage->getBody()),
+            'login page'
+        );
+
+        $postLogin = $http->post($this->baseUrl . $loginAction, [
+            'form_params' => [
+                'csrf_token_form' => $loginCsrf,
+                'username' => 'admin',
+                'password' => 'pass',
+                'email' => '',
+                'persist_login' => '0',
+                'user_role' => 'api',
+            ],
+        ]);
+        $this->assertSame(200, $postLogin->getStatusCode());
+        $consentCrawler = new Crawler((string) $postLogin->getBody());
+        $this->assertGreaterThan(
+            0,
+            $consentCrawler->filterXPath('//*[@name="proceed"]')->count(),
+            'After login, the consent page (with proceed button) should render'
+        );
+        [$consentCsrf, $consentAction] = $this->parseLoginForm($consentCrawler, 'consent page');
+
+        $postConsent = $http->post($this->baseUrl . $consentAction, [
+            'form_params' => [
+                'csrf_token_form' => $consentCsrf,
+                'proceed' => '1',
+                'scope' => ['openid' => 'openid', 'fhirUser' => 'fhirUser'],
+            ],
+            'allow_redirects' => false,
+        ]);
+        $this->assertSame(302, $postConsent->getStatusCode(), 'Consent POST should redirect back to client');
+        $callbackUrl = $postConsent->getHeaderLine('Location');
+        $this->assertStringStartsWith(self::REDIRECT_URI, $callbackUrl, 'Callback should be at registered redirect_uri');
+        $callbackQueryString = parse_url($callbackUrl, PHP_URL_QUERY);
+        $this->assertIsString($callbackQueryString);
+        parse_str($callbackQueryString, $callbackQuery);
+        $this->assertArrayHasKey('code', $callbackQuery, 'Callback URL should contain authorization code');
+        $this->assertSame(self::STATE, $callbackQuery['state'] ?? '', 'Callback should preserve state');
+        $this->assertIsString($callbackQuery['code']);
+        $code = $callbackQuery['code'];
+
+        $tokenResp = $http->post($this->baseUrl . '/oauth2/default/token', [
+            'form_params' => [
+                'grant_type' => 'authorization_code',
+                'code' => $code,
+                'redirect_uri' => self::REDIRECT_URI,
+                'client_id' => $this->clientId,
+                'client_secret' => $clientSecret,
+            ],
+        ]);
+        $this->assertSame(200, $tokenResp->getStatusCode(), 'Token exchange should succeed');
+        $tokens = json_decode((string) $tokenResp->getBody(), true);
+        $this->assertIsArray($tokens);
+        $this->assertArrayHasKey('id_token', $tokens, 'Token response should include id_token when openid scope is granted');
+        $this->assertIsString($tokens['id_token']);
+        $idToken = $tokens['id_token'];
+
+        $tokenParts = explode('.', $idToken);
+        $this->assertCount(3, $tokenParts, 'id_token should be a JWT with three segments');
+        $payload = json_decode((string) base64_decode(strtr($tokenParts[1], '-_', '+/'), true), true);
+        $this->assertIsArray($payload);
+        $this->assertSame($this->clientId, $payload['aud'] ?? '', 'id_token aud should match client_id');
+        $this->assertSame(self::NONCE, $payload['nonce'] ?? '', 'id_token nonce should match the value sent to /authorize');
+
+        $logoutResp = $http->get($this->baseUrl . '/oauth2/default/logout?' . http_build_query([
+            'id_token_hint' => $idToken,
+            'post_logout_redirect_uri' => self::LOGOUT_URI,
+            'state' => self::STATE,
+        ]), [
+            'allow_redirects' => false,
+        ]);
+        $this->assertSame(307, $logoutResp->getStatusCode(), 'Logout with valid id_token + registered URI should redirect');
+        $this->assertSame(
+            self::LOGOUT_URI . '?state=' . rawurlencode(self::STATE),
+            $logoutResp->getHeaderLine('Location'),
+            'Logout Location should be the registered post_logout_redirect_uri with state preserved'
+        );
+    }
+
+    private function buildClient(): Client
+    {
+        return new Client([
+            'verify' => false,
+            'http_errors' => false,
+            'cookies' => new CookieJar(),
+            'allow_redirects' => [
+                'max' => 10,
+                'strict' => true,
+                'referer' => true,
+                'protocols' => ['http', 'https'],
+            ],
+            'timeout' => 15,
+        ]);
+    }
+
+    /**
+     * @return array{string, string} [csrf_token_form value, form action URL]
+     */
+    private function parseLoginForm(Crawler $crawler, string $where): array
+    {
+        $csrfInputs = $crawler->filterXPath('//input[@name="csrf_token_form"]');
+        $this->assertGreaterThan(0, $csrfInputs->count(), "No csrf_token_form input found on $where");
+        $csrf = (string) $csrfInputs->first()->attr('value');
+        $this->assertNotSame('', $csrf, "Empty csrf_token_form value on $where");
+
+        $forms = $crawler->filterXPath('//form[@id="userLogin"]');
+        $this->assertGreaterThan(0, $forms->count(), "No <form id=\"userLogin\"> on $where");
+        $action = (string) $forms->first()->attr('action');
+        $this->assertNotSame('', $action, "Empty form action on $where");
+
+        return [$csrf, $action];
+    }
+}

--- a/tests/Tests/Api/AuthorizationLogoutFullFlowTest.php
+++ b/tests/Tests/Api/AuthorizationLogoutFullFlowTest.php
@@ -35,6 +35,7 @@ class AuthorizationLogoutFullFlowTest extends TestCase
 
     private string $baseUrl;
     private ?string $originalSiteAddrOath = null;
+    private bool $siteAddrOathWasInserted = false;
     private ?string $clientId = null;
 
     protected function setUp(): void
@@ -54,14 +55,21 @@ class AuthorizationLogoutFullFlowTest extends TestCase
             'SELECT gl_value FROM `globals` WHERE gl_name = ?',
             ['site_addr_oath']
         );
-        $glValue = is_array($current) ? ($current['gl_value'] ?? null) : null;
-        $this->originalSiteAddrOath = is_string($glValue) ? $glValue : null;
-
-        if ($this->originalSiteAddrOath !== $this->baseUrl) {
+        if (is_array($current)) {
+            $glValue = $current['gl_value'] ?? null;
+            $this->originalSiteAddrOath = is_string($glValue) ? $glValue : null;
+            if ($this->originalSiteAddrOath !== $this->baseUrl) {
+                QueryUtils::sqlStatementThrowException(
+                    'UPDATE `globals` SET gl_value = ? WHERE gl_name = ?',
+                    [$this->baseUrl, 'site_addr_oath']
+                );
+            }
+        } else {
             QueryUtils::sqlStatementThrowException(
-                'UPDATE `globals` SET gl_value = ? WHERE gl_name = ?',
-                [$this->baseUrl, 'site_addr_oath']
+                'INSERT INTO `globals` (`gl_name`, `gl_index`, `gl_value`) VALUES (?, 0, ?)',
+                ['site_addr_oath', $this->baseUrl]
             );
+            $this->siteAddrOathWasInserted = true;
         }
     }
 
@@ -79,7 +87,12 @@ class AuthorizationLogoutFullFlowTest extends TestCase
                 );
             }
         } finally {
-            if ($this->originalSiteAddrOath !== null && $this->originalSiteAddrOath !== $this->baseUrl) {
+            if ($this->siteAddrOathWasInserted) {
+                QueryUtils::sqlStatementThrowException(
+                    'DELETE FROM `globals` WHERE gl_name = ?',
+                    ['site_addr_oath']
+                );
+            } elseif ($this->originalSiteAddrOath !== null && $this->originalSiteAddrOath !== $this->baseUrl) {
                 QueryUtils::sqlStatementThrowException(
                     'UPDATE `globals` SET gl_value = ? WHERE gl_name = ?',
                     [$this->originalSiteAddrOath, 'site_addr_oath']

--- a/tests/Tests/Api/AuthorizationLogoutFullFlowTest.php
+++ b/tests/Tests/Api/AuthorizationLogoutFullFlowTest.php
@@ -41,6 +41,15 @@ class AuthorizationLogoutFullFlowTest extends TestCase
     {
         $this->baseUrl = getenv('OPENEMR_BASE_URL_API', true) ?: 'https://localhost';
 
+        $probe = $this->buildClient()->get($this->baseUrl . '/');
+        if ($probe->getHeaderLine('Server') === '') {
+            $this->markTestSkipped(
+                'OAuth flow requires a webserver that carries session cookies with the Secure flag'
+                . ' (Apache/nginx). Server did not respond with a Server header, so this looks like'
+                . ' PHP\'s built-in webserver (php -S) or similar stripped-down setup.'
+            );
+        }
+
         $current = QueryUtils::querySingleRow(
             'SELECT gl_value FROM `globals` WHERE gl_name = ?',
             ['site_addr_oath']

--- a/tests/Tests/Api/AuthorizationLogoutTest.php
+++ b/tests/Tests/Api/AuthorizationLogoutTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * OIDC RP-Initiated Logout regression tests
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Api;
+
+use GuzzleHttp\Client;
+use OpenEMR\Common\Database\QueryUtils;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class AuthorizationLogoutTest extends TestCase
+{
+    private const LOGOUT_ENDPOINT = '/oauth2/default/logout';
+    private const TEST_CLIENT_ID = 'test_logout_regression_client';
+    private const LOGOUT_URI_ONE = 'https://client1.example';
+    private const LOGOUT_URI_TWO = 'https://client2.example';
+    private const LOGOUT_URI_WITH_QUERY = 'https://has-query.example?extra=1';
+
+    private Client $http;
+
+    protected function setUp(): void
+    {
+        $baseUrl = getenv('OPENEMR_BASE_URL_API', true) ?: 'https://localhost';
+        $this->http = new Client([
+            'base_uri' => $baseUrl,
+            'verify' => false,
+            'allow_redirects' => false,
+            'http_errors' => false,
+        ]);
+
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `oauth_clients` WHERE `client_id` = ?',
+            [self::TEST_CLIENT_ID]
+        );
+        $allowlist = self::LOGOUT_URI_ONE . '|' . self::LOGOUT_URI_TWO . '|' . self::LOGOUT_URI_WITH_QUERY;
+        QueryUtils::sqlStatementThrowException(
+            'INSERT INTO `oauth_clients` '
+            . '(`client_id`, `client_name`, `client_role`, `client_secret`, `logout_redirect_uris`, `register_date`, `is_enabled`) '
+            . 'VALUES (?, ?, ?, ?, ?, NOW(), 1)',
+            [self::TEST_CLIENT_ID, 'Logout Regression Test', 'users', 'sec', $allowlist]
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `oauth_clients` WHERE `client_id` = ?',
+            [self::TEST_CLIENT_ID]
+        );
+    }
+
+    #[Test]
+    public function testLogoutRejectsUnregisteredUri(): void
+    {
+        $response = $this->http->get(self::LOGOUT_ENDPOINT, [
+            'query' => [
+                'id_token_hint' => $this->makeUnsignedJwt(),
+                'post_logout_redirect_uri' => 'https://evil.example',
+                'state' => 'abc',
+            ],
+        ]);
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertFalse($response->hasHeader('Location'));
+    }
+
+    #[Test]
+    public function testLogoutRedirectsToRegisteredUri(): void
+    {
+        $response = $this->http->get(self::LOGOUT_ENDPOINT, [
+            'query' => [
+                'id_token_hint' => $this->makeUnsignedJwt(),
+                'post_logout_redirect_uri' => self::LOGOUT_URI_ONE,
+                'state' => 'abc',
+            ],
+        ]);
+        $this->assertSame(307, $response->getStatusCode());
+        $this->assertSame(
+            self::LOGOUT_URI_ONE . '?state=abc',
+            $response->getHeaderLine('Location')
+        );
+    }
+
+    #[Test]
+    public function testLogoutMatchesLaterUriInPipeDelimitedAllowlist(): void
+    {
+        $response = $this->http->get(self::LOGOUT_ENDPOINT, [
+            'query' => [
+                'id_token_hint' => $this->makeUnsignedJwt(),
+                'post_logout_redirect_uri' => self::LOGOUT_URI_TWO,
+                'state' => 'abc',
+            ],
+        ]);
+        $this->assertSame(307, $response->getStatusCode());
+        $this->assertSame(
+            self::LOGOUT_URI_TWO . '?state=abc',
+            $response->getHeaderLine('Location')
+        );
+    }
+
+    #[Test]
+    public function testLogoutUsesAmpersandSeparatorWhenUriContainsQueryString(): void
+    {
+        $response = $this->http->get(self::LOGOUT_ENDPOINT, [
+            'query' => [
+                'id_token_hint' => $this->makeUnsignedJwt(),
+                'post_logout_redirect_uri' => self::LOGOUT_URI_WITH_QUERY,
+                'state' => 'abc',
+            ],
+        ]);
+        $this->assertSame(307, $response->getStatusCode());
+        $this->assertSame(
+            self::LOGOUT_URI_WITH_QUERY . '&state=abc',
+            $response->getHeaderLine('Location')
+        );
+    }
+
+    #[Test]
+    public function testLogoutUrlEncodesStateWithSpecialChars(): void
+    {
+        $response = $this->http->get(self::LOGOUT_ENDPOINT, [
+            'query' => [
+                'id_token_hint' => $this->makeUnsignedJwt(),
+                'post_logout_redirect_uri' => self::LOGOUT_URI_ONE,
+                'state' => 'foo&bar=baz',
+            ],
+        ]);
+        $this->assertSame(307, $response->getStatusCode());
+        $this->assertSame(
+            self::LOGOUT_URI_ONE . '?state=foo%26bar%3Dbaz',
+            $response->getHeaderLine('Location')
+        );
+    }
+
+    private function makeUnsignedJwt(): string
+    {
+        $header = $this->b64url('{"alg":"none","typ":"JWT"}');
+        $payload = $this->b64url((string) json_encode([
+            'aud' => self::TEST_CLIENT_ID,
+            'sub' => 'nobody',
+            'nonce' => '',
+        ]));
+        return $header . '.' . $payload . '.sig';
+    }
+
+    private function b64url(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+}

--- a/tests/Tests/Api/AuthorizationLogoutTest.php
+++ b/tests/Tests/Api/AuthorizationLogoutTest.php
@@ -142,6 +142,22 @@ class AuthorizationLogoutTest extends TestCase
         );
     }
 
+    #[Test]
+    public function testLogoutOmitsStateWhenNotProvided(): void
+    {
+        $response = $this->http->get(self::LOGOUT_ENDPOINT, [
+            'query' => [
+                'id_token_hint' => $this->makeUnsignedJwt(),
+                'post_logout_redirect_uri' => self::LOGOUT_URI_ONE,
+            ],
+        ]);
+        $this->assertSame(307, $response->getStatusCode());
+        $this->assertSame(
+            self::LOGOUT_URI_ONE,
+            $response->getHeaderLine('Location')
+        );
+    }
+
     private function makeUnsignedJwt(): string
     {
         $header = $this->b64url('{"alg":"none","typ":"JWT"}');

--- a/tests/Tests/E2e/AaLoginTest.php
+++ b/tests/Tests/E2e/AaLoginTest.php
@@ -23,6 +23,7 @@ use OpenEMR\Tests\E2e\Login\LoginTestData;
 use OpenEMR\Tests\E2e\Login\LoginTrait;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Panther\PantherTestCase;
+use Symfony\Component\Process\Process;
 
 class AaLoginTest extends PantherTestCase
 {
@@ -82,18 +83,54 @@ class AaLoginTest extends PantherTestCase
     }
 
     #[Test]
-    public function testAdminPageLoads(): void
+    public function testAdminPageDisabledByDefault(): void
     {
         $this->base();
         try {
-            $this->crawler = $this->client->request('GET', '/admin.php');
+            $this->client->request('GET', '/admin.php');
+            $source = $this->client->getPageSource();
+            $this->assertStringContainsString(
+                'admin.php is disabled by default',
+                $source,
+                'admin.php should return the disabled-by-default message when no env var is set'
+            );
             $title = $this->client->getTitle();
-            $this->assertSame('OpenEMR Site Administration', $title, 'FAILED to load admin.php');
+            $this->assertNotSame(
+                'OpenEMR Site Administration',
+                $title,
+                'admin.php dashboard should NOT render without the enable env var'
+            );
         } catch (\Throwable $e) {
             $this->client->quit();
             throw $e;
         }
         $this->client->quit();
+    }
+
+    #[Test]
+    public function testAdminPageEnabledWithEnvVar(): void
+    {
+        $process = new Process(
+            ['php', 'admin.php'],
+            '/var/www/localhost/htdocs/openemr',
+            ['OPENEMR_ADMIN_PHP_ENABLED' => '1']
+        );
+        $process->run();
+        $this->assertTrue(
+            $process->isSuccessful(),
+            'php admin.php CLI invocation should succeed'
+        );
+        $output = $process->getOutput();
+        $this->assertStringContainsString(
+            'OpenEMR Site Administration',
+            $output,
+            'admin.php dashboard should render when OPENEMR_ADMIN_PHP_ENABLED=1 is set'
+        );
+        $this->assertStringNotContainsString(
+            'disabled by default',
+            $output,
+            'admin.php should not emit the disabled-by-default message when env var is set'
+        );
     }
 
     private function loginPage(): void

--- a/tests/Tests/E2e/AaLoginTest.php
+++ b/tests/Tests/E2e/AaLoginTest.php
@@ -110,9 +110,10 @@ class AaLoginTest extends PantherTestCase
     #[Test]
     public function testAdminPageEnabledWithEnvVar(): void
     {
+        $openemrRoot = dirname(__DIR__, 3);
         $process = new Process(
-            ['php', 'admin.php'],
-            '/var/www/localhost/htdocs/openemr',
+            ['php', $openemrRoot . '/admin.php'],
+            null,
             ['OPENEMR_ADMIN_PHP_ENABLED' => '1']
         );
         $process->run();


### PR DESCRIPTION
Small cleanups in pre-authentication request paths:

- OIDC logout: unify `logout_redirect_uris` allowlist across both branches of `userSessionLogout()`. Supersedes #12768 by @munzzyy — same root-cause fix (allowlist gate applied to both branches, pipe-delimited multi-URI handling). This PR extends it with URL-encoding of state, ?/& separator handling, refactor to a shared helper, and regression + full-flow test coverage.
- admin.php: gate behind opt-in `OPENEMR_ADMIN_PHP_ENABLED` env var
  (matches existing Docker + wiki guidance).
- interface/globals.php: remove unused `$_POST['authUser']` fallback in
  the user_settings lookup (grep-confirmed no downstream consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)