### PR TITLE
chore(edihistory): remove unused edih_997_sbmtfile

### DIFF
--- a/.phpstan/baseline/openemr.noGlobalNsFunctions.php
+++ b/.phpstan/baseline/openemr.noGlobalNsFunctions.php
@@ -4447,11 +4447,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_997_error.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function edih_997_sbmtfile may not be defined in the global namespace\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_997_error.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function edih_archive_cleanup may not be defined in the global namespace\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_archive.php',

--- a/library/edihistory/edih_997_error.php
+++ b/library/edihistory/edih_997_error.php
@@ -33,33 +33,6 @@ use OpenEMR\Common\Session\SessionWrapperFactory;
 //require_once './codes/edih_997_codes.php';
 
 /**
- * Look up file name by control number
- *
- * @param string $icn
- * @param string $filetype
- *
- * @return string
- */
-function edih_997_sbmtfile($icn, $filetype)
-{
-    //
-    if (strlen((string) $icn) == 13) {
-        $bticn = substr((string) $icn, 0, 9);
-        $stn = substr((string) $icn, -4);
-    } else {
-        $bticn = $icn;
-    }
-
-    $ftp = is_numeric($filetype) ? 'f' . $filetype : $filetype;
-
-    //
-    $btfn = csv_file_by_controlnum($ftp, $bticn);
-    $bfullpath = ($btfn) ? csv_check_filepath($btfn, $ftp) : '';
-    //
-    return $bfullpath;
-}
-
-/**
  * Extract information on rejected files or transactions
  *
  * @param mixed $obj997


### PR DESCRIPTION
`edih_997_sbmtfile()` in `library/edihistory/edih_997_error.php` has no callers anywhere in the codebase — its only reference is its own definition. It was dead code (a control-number → filename lookup helper).

## Changes
- Remove the `edih_997_sbmtfile()` function and its docblock.
- Drop its single obsolete PHPStan baseline entry (`openemr.noGlobalNsFunctions`). The function's parameters were docblock-typed `string`, so its body produced no `mixed`-related errors — no shared-count baseline adjustments were needed.

## Verification
- `php -l` clean on all changed files.
- Full pre-commit suite passes, including PHPStan at level 10 with the adjusted baseline.