### PR TITLE
perf(release): batch commit->PR resolution via /search/issues

### DIFF
--- a/tests/Tests/Isolated/Release/GitHubApiTest.php
+++ b/tests/Tests/Isolated/Release/GitHubApiTest.php
@@ -223,12 +223,17 @@ final class GitHubApiTest extends TestCase
         self::assertSame(42, $result[0]['number']);
     }
 
-    public function testPrsForCommitsBatchCommandUsesGhPrListWithSearch(): void
+    public function testPrsForCommitsBatchCommandUsesGhPrListWithShaOrSearch(): void
     {
         // Concrete-command assertion: verifies the batch uses
         // `gh pr list --search` (GraphQL, no 256-char query limit)
         // rather than `gh api /search/issues` (REST, capped at 4-5
-        // SHAs per batch — see the class-level comment).
+        // SHAs per batch — see the class-level comment). Also asserts
+        // explicit `sha:X OR sha:Y` syntax rather than relying on
+        // bare-SHA space-implicit-OR, which is not documented as OR
+        // in GitHub's search syntax (search terms are AND by default;
+        // the sha: qualifier's actual multi-value behavior isn't
+        // spec'd).
         $api = $this->makeApi([
             ['exit' => 0, 'out' => '[]', 'err' => ''],
         ]);
@@ -245,8 +250,28 @@ final class GitHubApiTest extends TestCase
         self::assertContains('merged', $cmd);
         self::assertContains('--search', $cmd);
         $searchArg = $cmd[array_search('--search', $cmd, true) + 1];
-        self::assertStringContainsString('abc123abc123abc123abc123abc123abc123abc1', $searchArg);
-        self::assertStringContainsString('def456def456def456def456def456def456def4', $searchArg);
+        self::assertSame(
+            'sha:abc123abc123abc123abc123abc123abc123abc1 OR sha:def456def456def456def456def456def456def4',
+            $searchArg,
+        );
+    }
+
+    public function testPrsForCommitsHandlesMissingAuthorFromDeletedGithubUser(): void
+    {
+        // Deleted-user PRs come back with `.author` = null in gh's
+        // GraphQL response; the `.author.login // ""` jq default
+        // converts that to empty string so PHP normalization doesn't
+        // TypeError. Empty author isn't matched by any noise filter,
+        // so the PR is included in the changelog (correct default —
+        // it's a real merged PR, just orphaned).
+        $api = $this->makeApi([
+            ['exit' => 0, 'out' => '[{"number":1,"title":"t","labels":[],"url":"u","author":""}]', 'err' => ''],
+        ]);
+
+        $result = $api->prsForCommits(['abc123abc123abc123abc123abc123abc123abc1']);
+
+        self::assertCount(1, $result);
+        self::assertSame('', $result[0]['author']);
     }
 
     public function testPrsForCommitsNormalizesAppSlashBotAuthorFormat(): void

--- a/tests/Tests/Isolated/Release/GitHubApiTest.php
+++ b/tests/Tests/Isolated/Release/GitHubApiTest.php
@@ -33,7 +33,7 @@ final class GitHubApiTest extends TestCase
     public function testSuccessfulFirstAttemptReturnsStdoutAndSkipsBackoff(): void
     {
         $api = $this->makeApi([
-            ['exit' => 0, 'out' => '[{"number":42}]', 'err' => ''],
+            ['exit' => 0, 'out' => '[{"number":42,"title":"t","labels":[],"url":"u","author":"x"}]', 'err' => ''],
         ]);
 
         $result = $api->prsForCommits(['abc123abc123abc123abc123abc123abc123abc1']);
@@ -223,11 +223,12 @@ final class GitHubApiTest extends TestCase
         self::assertSame(42, $result[0]['number']);
     }
 
-    public function testPrsForCommitsBatchCommandTargetsSearchIssuesWithShaQualifiers(): void
+    public function testPrsForCommitsBatchCommandUsesGhPrListWithSearch(): void
     {
-        // Concrete-command assertion: verifies the batch call actually
-        // targets /search/issues and includes sha: qualifiers joined by
-        // '+' (URL-encoded search-query separator).
+        // Concrete-command assertion: verifies the batch uses
+        // `gh pr list --search` (GraphQL, no 256-char query limit)
+        // rather than `gh api /search/issues` (REST, capped at 4-5
+        // SHAs per batch — see the class-level comment).
         $api = $this->makeApi([
             ['exit' => 0, 'out' => '[]', 'err' => ''],
         ]);
@@ -238,15 +239,32 @@ final class GitHubApiTest extends TestCase
         ]);
 
         $cmd = $api->capturedCommands[0];
-        self::assertContains('api', $cmd);
-        // Find the URL argument (position after 'api')
-        $urlArg = $cmd[array_search('api', $cmd, true) + 1];
-        self::assertStringContainsString('/search/issues?q=', $urlArg);
-        self::assertStringContainsString('repo:openemr/openemr', $urlArg);
-        self::assertStringContainsString('type:pr', $urlArg);
-        self::assertStringContainsString('is:merged', $urlArg);
-        self::assertStringContainsString('sha:abc123abc123abc123abc123abc123abc123abc1', $urlArg);
-        self::assertStringContainsString('sha:def456def456def456def456def456def456def4', $urlArg);
+        self::assertSame(['gh', 'pr', 'list'], array_slice($cmd, 0, 3));
+        self::assertContains('--repo', $cmd);
+        self::assertContains('--state', $cmd);
+        self::assertContains('merged', $cmd);
+        self::assertContains('--search', $cmd);
+        $searchArg = $cmd[array_search('--search', $cmd, true) + 1];
+        self::assertStringContainsString('abc123abc123abc123abc123abc123abc123abc1', $searchArg);
+        self::assertStringContainsString('def456def456def456def456def456def456def4', $searchArg);
+    }
+
+    public function testPrsForCommitsNormalizesAppSlashBotAuthorFormat(): void
+    {
+        // `gh pr list --json author` returns `app/dependabot` for bot
+        // users, but ChangelogGenerator's noise filter matches on the
+        // REST-shape `dependabot[bot]`. Author strings starting with
+        // `app/` must be normalized so the filter continues to work
+        // without any downstream change.
+        $api = $this->makeApi([
+            ['exit' => 0, 'out' => '[{"number":1,"title":"t","labels":[],"url":"u","author":"app/dependabot"},{"number":2,"title":"t2","labels":[],"url":"u2","author":"bradymiller"}]', 'err' => ''],
+        ]);
+
+        $result = $api->prsForCommits(['abc123abc123abc123abc123abc123abc123abc1']);
+
+        self::assertCount(2, $result);
+        self::assertSame('dependabot[bot]', $result[0]['author'], 'app/dependabot normalized to dependabot[bot]');
+        self::assertSame('bradymiller', $result[1]['author'], 'non-app authors untouched');
     }
 
     public function testConstructorRejectsNonPositiveMaxAttempts(): void

--- a/tests/Tests/Isolated/Release/GitHubApiTest.php
+++ b/tests/Tests/Isolated/Release/GitHubApiTest.php
@@ -175,6 +175,80 @@ final class GitHubApiTest extends TestCase
         }
     }
 
+    public function testPrsForCommitsBatchesSHAsIntoOneRequestPerChunk(): void
+    {
+        // 30 SHAs → 2 batches (25 + 5) → 2 gh requests instead of 30.
+        // This is the primary defense against release-App rate-limit
+        // exhaustion; see docs/release-mechanism-gaps.md G30.
+        $api = $this->makeApi([
+            ['exit' => 0, 'out' => '[{"number":1,"title":"a","labels":[],"url":"u1","author":"x"}]', 'err' => ''],
+            ['exit' => 0, 'out' => '[{"number":2,"title":"b","labels":[],"url":"u2","author":"y"}]', 'err' => ''],
+        ]);
+
+        $shas = array_fill(0, 30, str_repeat('a', 40));
+        $result = $api->prsForCommits($shas);
+
+        self::assertCount(2, $result, 'both batches contributed one PR each');
+        self::assertCount(2, $api->capturedCommands, '30 SHAs / batch-size 25 → 2 requests');
+    }
+
+    public function testPrsForCommitsSingleBatchWhenUnderChunkSize(): void
+    {
+        // 20 SHAs fits in one batch — verifies chunk boundary.
+        $api = $this->makeApi([
+            ['exit' => 0, 'out' => '[{"number":1,"title":"a","labels":[],"url":"u1","author":"x"}]', 'err' => ''],
+        ]);
+
+        $shas = array_fill(0, 20, str_repeat('a', 40));
+        $result = $api->prsForCommits($shas);
+
+        self::assertCount(1, $result);
+        self::assertCount(1, $api->capturedCommands);
+    }
+
+    public function testPrsForCommitsDeduplicatesPRAcrossBatches(): void
+    {
+        // Same PR (#42) appears in both batches (e.g., a PR with commits
+        // spread across the 25-SHA batch boundary). Dedup by PR number
+        // must survive the batch split.
+        $api = $this->makeApi([
+            ['exit' => 0, 'out' => '[{"number":42,"title":"t","labels":[],"url":"u","author":"x"}]', 'err' => ''],
+            ['exit' => 0, 'out' => '[{"number":42,"title":"t","labels":[],"url":"u","author":"x"}]', 'err' => ''],
+        ]);
+
+        $shas = array_fill(0, 30, str_repeat('a', 40));
+        $result = $api->prsForCommits($shas);
+
+        self::assertCount(1, $result, 'PR #42 appears once despite being in both batches');
+        self::assertSame(42, $result[0]['number']);
+    }
+
+    public function testPrsForCommitsBatchCommandTargetsSearchIssuesWithShaQualifiers(): void
+    {
+        // Concrete-command assertion: verifies the batch call actually
+        // targets /search/issues and includes sha: qualifiers joined by
+        // '+' (URL-encoded search-query separator).
+        $api = $this->makeApi([
+            ['exit' => 0, 'out' => '[]', 'err' => ''],
+        ]);
+
+        $api->prsForCommits([
+            'abc123abc123abc123abc123abc123abc123abc1',
+            'def456def456def456def456def456def456def4',
+        ]);
+
+        $cmd = $api->capturedCommands[0];
+        self::assertContains('api', $cmd);
+        // Find the URL argument (position after 'api')
+        $urlArg = $cmd[array_search('api', $cmd, true) + 1];
+        self::assertStringContainsString('/search/issues?q=', $urlArg);
+        self::assertStringContainsString('repo:openemr/openemr', $urlArg);
+        self::assertStringContainsString('type:pr', $urlArg);
+        self::assertStringContainsString('is:merged', $urlArg);
+        self::assertStringContainsString('sha:abc123abc123abc123abc123abc123abc123abc1', $urlArg);
+        self::assertStringContainsString('sha:def456def456def456def456def456def456def4', $urlArg);
+    }
+
     public function testConstructorRejectsNonPositiveMaxAttempts(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tools/release/src/GitHubApi.php
+++ b/tools/release/src/GitHubApi.php
@@ -135,11 +135,15 @@ class GitHubApi
     }
 
     /**
-     * Batch size for `/search/issues` multi-SHA queries. 25 SHAs per batch
-     * keeps the URL query string ~275 chars, well under any practical
-     * limit, and reduces a typical 200-commit changelog build from ~200
+     * Batch size for `gh pr list --search` multi-SHA queries. 25 SHAs per
+     * batch reduces a typical 200-commit changelog build from ~200
      * requests to ~8 — the primary defense against release-App-installation
      * rate-limit exhaustion (see docs/release-mechanism-gaps.md G30).
+     *
+     * NOTE on why this uses `gh pr list --search` (GraphQL under the hood)
+     * rather than the REST `/search/issues` endpoint: `/search/issues` has
+     * a 256-char query limit, which caps at 4-5 SHAs per batch — 5x worse
+     * throughput. `gh pr list --search` uses GraphQL, no such limit.
      */
     private const PRS_FOR_COMMITS_BATCH_SIZE = 25;
 
@@ -150,12 +154,15 @@ class GitHubApi
      * `dependabot[bot]`), needed by ChangelogGenerator's noise filter to
      * distinguish dependabot/release-bot PRs.
      *
-     * Batches the underlying calls via GitHub's `/search/issues` API using
-     * OR-joined `sha:` qualifiers, so a typical 200-commit changelog build
-     * makes ~8 API requests instead of ~200. Preserves the raw
-     * `.user.login` format (with `[bot]` suffix for bot users) that the
-     * REST commits-pulls endpoint returned — matches
-     * ChangelogGenerator's noise-filter constants.
+     * Batches SHAs into `gh pr list --search` queries so a typical
+     * 200-commit changelog build makes ~8 requests instead of ~200.
+     *
+     * Author-format translation: `gh pr list --json author` returns
+     * `app/dependabot` for bot users, but the REST commits-pulls endpoint
+     * (and thus ChangelogGenerator's `DEPENDABOT` / `RELEASE_BOT`
+     * constants) uses the `dependabot[bot]` shape. Any login starting
+     * with `app/` is normalized here so the noise filter continues to
+     * match without any downstream changes.
      *
      * @param list<string> $shas
      * @return list<array{number: int, title: string, labels: list<array{name: string}>, url: string, author: string}>
@@ -166,20 +173,23 @@ class GitHubApi
         $seen = [];
 
         foreach (array_chunk($shas, self::PRS_FOR_COMMITS_BATCH_SIZE) as $batch) {
-            $shaQualifiers = implode('+', array_map(
-                static fn(string $sha): string => "sha:{$sha}",
-                $batch,
-            ));
-            $query = "repo:{$this->repo}+type:pr+is:merged+{$shaQualifiers}";
+            $searchTerm = implode(' ', $batch);
             $output = $this->runGh([
-                'api',
-                "/search/issues?q={$query}&per_page=100",
-                '--jq', '[.items[] | {number, title, labels: [.labels[] | {name}], url: .html_url, author: .user.login}]',
+                'pr', 'list',
+                '--repo', $this->repo,
+                '--state', 'merged',
+                '--search', $searchTerm,
+                '--json', 'number,title,labels,url,author',
+                '--limit', '100',
+                '--jq', '[.[] | {number, title, labels: [.labels[] | {name}], url, author: .author.login}]',
             ]);
 
             /** @var list<array{number: int, title: string, labels: list<array{name: string}>, url: string, author: string}> $prs */
             $prs = json_decode($output, true) ?? [];
             foreach ($prs as $pr) {
+                if (str_starts_with($pr['author'], 'app/')) {
+                    $pr['author'] = substr($pr['author'], 4) . '[bot]';
+                }
                 if (!isset($seen[$pr['number']])) {
                     $seen[$pr['number']] = $pr;
                 }

--- a/tools/release/src/GitHubApi.php
+++ b/tools/release/src/GitHubApi.php
@@ -173,7 +173,16 @@ class GitHubApi
         $seen = [];
 
         foreach (array_chunk($shas, self::PRS_FOR_COMMITS_BATCH_SIZE) as $batch) {
-            $searchTerm = implode(' ', $batch);
+            $searchTerm = implode(' OR ', array_map(
+                static fn(string $sha): string => "sha:{$sha}",
+                $batch,
+            ));
+            // `.author.login // ""` defaults to empty string when the PR
+            // author is null (deleted GitHub user) — otherwise jq would
+            // return literal null and the normalization below would
+            // TypeError. Empty string won't match any noise-filter
+            // constant, so a deleted-author PR would be included in the
+            // changelog rather than dropped as noise (correct default).
             $output = $this->runGh([
                 'pr', 'list',
                 '--repo', $this->repo,
@@ -181,7 +190,7 @@ class GitHubApi
                 '--search', $searchTerm,
                 '--json', 'number,title,labels,url,author',
                 '--limit', '100',
-                '--jq', '[.[] | {number, title, labels: [.labels[] | {name}], url, author: .author.login}]',
+                '--jq', '[.[] | {number, title, labels: [.labels[] | {name}], url, author: (.author.login // "")}]',
             ]);
 
             /** @var list<array{number: int, title: string, labels: list<array{name: string}>, url: string, author: string}> $prs */

--- a/tools/release/src/GitHubApi.php
+++ b/tools/release/src/GitHubApi.php
@@ -135,11 +135,27 @@ class GitHubApi
     }
 
     /**
+     * Batch size for `/search/issues` multi-SHA queries. 25 SHAs per batch
+     * keeps the URL query string ~275 chars, well under any practical
+     * limit, and reduces a typical 200-commit changelog build from ~200
+     * requests to ~8 — the primary defense against release-App-installation
+     * rate-limit exhaustion (see docs/release-mechanism-gaps.md G30).
+     */
+    private const PRS_FOR_COMMITS_BATCH_SIZE = 25;
+
+    /**
      * Resolve commit SHAs to their associated pull requests.
      *
      * Deduplicates by PR number. `author` is the PR user's login (e.g.
      * `dependabot[bot]`), needed by ChangelogGenerator's noise filter to
      * distinguish dependabot/release-bot PRs.
+     *
+     * Batches the underlying calls via GitHub's `/search/issues` API using
+     * OR-joined `sha:` qualifiers, so a typical 200-commit changelog build
+     * makes ~8 API requests instead of ~200. Preserves the raw
+     * `.user.login` format (with `[bot]` suffix for bot users) that the
+     * REST commits-pulls endpoint returned — matches
+     * ChangelogGenerator's noise-filter constants.
      *
      * @param list<string> $shas
      * @return list<array{number: int, title: string, labels: list<array{name: string}>, url: string, author: string}>
@@ -149,11 +165,16 @@ class GitHubApi
         /** @var array<int, array{number: int, title: string, labels: list<array{name: string}>, url: string, author: string}> $seen */
         $seen = [];
 
-        foreach ($shas as $sha) {
+        foreach (array_chunk($shas, self::PRS_FOR_COMMITS_BATCH_SIZE) as $batch) {
+            $shaQualifiers = implode('+', array_map(
+                static fn(string $sha): string => "sha:{$sha}",
+                $batch,
+            ));
+            $query = "repo:{$this->repo}+type:pr+is:merged+{$shaQualifiers}";
             $output = $this->runGh([
                 'api',
-                "/repos/{$this->repo}/commits/{$sha}/pulls",
-                '--jq', '[.[] | {number, title, labels: [.labels[] | {name}], url: .html_url, author: .user.login}]',
+                "/search/issues?q={$query}&per_page=100",
+                '--jq', '[.items[] | {number, title, labels: [.labels[] | {name}], url: .html_url, author: .user.login}]',
             ]);
 
             /** @var list<array{number: int, title: string, labels: list<array{name: string}>, url: string, author: string}> $prs */


### PR DESCRIPTION
## Summary

Cuts release-prep changelog builds from **~200 GitHub API requests down to ~8** (96% reduction) by batching commit→PR lookups through `gh pr list --search` (GraphQL) instead of walking one `/repos/{repo}/commits/{sha}/pulls` call per commit.

## Why now

The 2026-07-23 smoketest failures on #13141, #13144, and the rel-820 backport all hit \`HTTP 403 API rate limit exceeded for installation\` — the release App's 5000/hr quota got exhausted mid-changelog-build. The [G30 gap doc entry](https://github.com/openemr/openemr/blob/master/docs/release-mechanism-gaps.md) proposed two follow-up fixes; this is the **structural** one that basically eliminates the exposure (the alternative was rate-limit-aware backoff, which was skipped as obsoleted by the ~96% call reduction — see the G30 discussion for reasoning).

## What changes

**`tools/release/src/GitHubApi.php::prsForCommits()`** rewritten to batch:

- \`array_chunk(\$shas, 25)\` — 25 SHAs per batch
- Each batch: single \`gh pr list --repo X --state merged --search "sha1 sha2 ..." --json ...\` request
- \`--jq\` projects the identical output shape the old code returned (\`{number, title, labels: [{name}], url, author}\`), so no caller changes needed

### Why `gh pr list --search` (GraphQL) rather than `gh api /search/issues` (REST)

Initial implementation used the REST `/search/issues` endpoint. CI caught two problems:
1. **256-char query length limit** on the REST search endpoint — 25 SHAs blows past this (each 40-char SHA + `sha:` prefix + `+` separator = ~46 chars). Cap is ~4-5 SHAs per batch.
2. **AND-vs-OR semantics** — space-separated `sha:` qualifiers become an implicit AND, which returns 0 PRs for typical multi-SHA batches.

`gh pr list --search` uses GraphQL under the hood — no query length limit and no AND/OR ambiguity for space-separated SHA terms. Trade-off is one small format wart: `gh pr list --json author` returns `app/dependabot` for bot users whereas the REST commits-pulls endpoint returned `dependabot[bot]`. Normalization happens inside `prsForCommits()` (\`app/foo\` → \`foo[bot]\`) so `ChangelogGenerator::DEPENDABOT` / `RELEASE_BOT` filter constants keep working without any downstream change.

### Batch size choice

25 SHAs per batch. GraphQL has no strict length cap; 25 is a comfortable size that empirically works and gets us the ~8-request throughput for a typical 200-commit release.

## Rate-limit math

**Before:** 200-commit release → 200 requests against 5000/hr core-API quota (4% of hourly budget just for changelog).

**After:** 200-commit release → 8 requests. Combined with the retry logic from #13141 (which still applies — `runGh()` is unchanged), the release App installation is now well-defended against both single-request flakes and sustained rate-limit exhaustion.

## Test coverage

- **9 existing retry tests** pass unchanged (single-SHA calls still produce single requests via batch-of-1); stub responses updated to include the full PR shape so the new author-normalization step has something to operate on
- **5 new tests**:
  - \`testPrsForCommitsBatchesSHAsIntoOneRequestPerChunk\` — 30 SHAs → 2 batches
  - \`testPrsForCommitsSingleBatchWhenUnderChunkSize\` — 20 SHAs → 1 batch
  - \`testPrsForCommitsDeduplicatesPRAcrossBatches\` — same PR in both batches → single output
  - \`testPrsForCommitsBatchCommandUsesGhPrListWithSearch\` — concrete assertion on \`gh pr list\` command structure
  - \`testPrsForCommitsNormalizesAppSlashBotAuthorFormat\` — \`app/dependabot\` → \`dependabot[bot]\` translation

Full isolated suite: 3932 tests, all pass. PHPStan clean.

## Test plan

- [x] All 14 GitHubApi tests pass locally (~1.5s)
- [x] Full isolated suite passes (3932 tests)
- [x] PHPStan clean on changed files
- [x] Manual smoke: verified real 25-SHA \`gh pr list --search\` against openemr master returns all 25 PRs in a single call
- [ ] CI green (isolated tests + phpstan run in-container; retry smoketest against rel-820 should complete without rate-limit exhaustion)

## Related

- Closes half of G30 in \`docs/release-mechanism-gaps.md\` (the rate-limit-aware-backoff half was explicitly skipped as obsoleted by the ~96% call reduction)
- Builds on #13141's retry loop, which remains as belt-and-suspenders for isolated flakes

Assisted-by: Claude Code