### PR TITLE
feat(acceptance): Phase 1 InstallTest against openemr Docker artifact

### DIFF
--- a/.github/docker/acceptance-docker-compose.yml
+++ b/.github/docker/acceptance-docker-compose.yml
@@ -28,17 +28,22 @@ services:
     ports:
     - '8580:80'
     - '8543:443'
+    # Healthcheck asserts the specific redirect target `interface/login/login.php`
+    # rather than just following redirects — otherwise `curl --fail --location`
+    # would succeed both when the auto-install completed (302 → login.php) AND
+    # when the container is still serving the pre-install setup wizard (302 →
+    # setup.php). Acceptance tests should fire only after the installer has
+    # actually finished; require the login-page redirect target as proof.
+    #
+    # Uses BusyBox-compatible short-option grep (`-iq`) since the openemr
+    # image is Alpine-based and its grep doesn't support GNU long options.
     healthcheck:
       test:
-      - CMD
-      - /usr/bin/curl
-      - --fail
-      - --insecure
-      - --location
-      - --silent
-      - --output
-      - /dev/null
-      - http://localhost/
+      - CMD-SHELL
+      - >-
+        /usr/bin/curl --silent --dump-header - --output /dev/null
+        http://localhost/ |
+        grep -iq '^location: .*interface/login/login\.php'
       start_period: 3m
       start_interval: 10s
       interval: 30s

--- a/.github/docker/acceptance-docker-compose.yml
+++ b/.github/docker/acceptance-docker-compose.yml
@@ -1,0 +1,46 @@
+# Compose override for artifact acceptance testing against a Docker Hub
+# openemr image (or a locally-built image, for PR validation — Phase 2.5).
+#
+# Layers on top of docker/production/docker-compose.yml — same production
+# stack shape end users deploy, with three overrides:
+#
+#   1. `image:` — replaces the sha-pinned prod ref with an env-driven
+#      tag. Defaults to `latest` for laptop convenience.
+#
+#   2. Ports rebound to high numbers so multiple stacks (dev + prod +
+#      acceptance) can coexist on one host without root or collisions.
+#
+#   3. `healthcheck:` — swapped to hit `/` instead of `/meta/health/readyz`
+#      so older images (pre-8.0 didn't have readyz) still pass. Same
+#      overall startup budget.
+#
+# Usage:
+#   OPENEMR_TAG=latest docker compose \
+#     -f docker/production/docker-compose.yml \
+#     -f .github/docker/acceptance-docker-compose.yml \
+#     -p openemr-acceptance \
+#     up --detach --wait --wait-timeout 900
+#
+# ACCEPTANCE_ARTIFACT_URL for the test suite: http://localhost:8580
+services:
+  openemr:
+    image: openemr/openemr:${OPENEMR_TAG:-latest}
+    ports:
+    - '8580:80'
+    - '8543:443'
+    healthcheck:
+      test:
+      - CMD
+      - /usr/bin/curl
+      - --fail
+      - --insecure
+      - --location
+      - --silent
+      - --output
+      - /dev/null
+      - http://localhost/
+      start_period: 3m
+      start_interval: 10s
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/composer.json
+++ b/composer.json
@@ -157,6 +157,7 @@
         "shipmonk/phpstan-baseline-per-identifier": "^2.3",
         "slevomat/coding-standard": "^8.28",
         "squizlabs/php_codesniffer": "^4.0",
+        "symfony/mime": "^7.3",
         "symfony/panther": "^2.0"
     },
     "repositories": [
@@ -196,7 +197,8 @@
     "autoload-dev": {
         "psr-4": {
             "OpenEMR\\": "tests",
-            "OpenEMR\\Release\\": "tools/release/src"
+            "OpenEMR\\Release\\": "tools/release/src",
+            "OpenEMR\\Tests\\Acceptance\\": "tests/Acceptance"
         }
     },
     "config": {
@@ -277,6 +279,7 @@
         }
     },
     "scripts": {
+        "acceptance": "phpunit -c tests/Acceptance/phpunit.acceptance.xml",
         "checks": [
             "composer validate --strict",
             "composer normalize --dry-run"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "abcbdb753c04a37ffd1eb86d90cbffa8",
+    "content-hash": "77fbd34e9a50abd8c3bdcefaae9689b8",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -18342,6 +18342,95 @@
             "time": "2026-05-20T07:20:23+00:00"
         },
         {
+            "name": "symfony/mime",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "egulias/email-validator": "~3.0.0",
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/mailer": "<6.4",
+                "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3.1|^4",
+                "league/html-to-markdown": "^5.0",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4.3|^7.0.3|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows manipulating MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-23T16:22:37+00:00"
+        },
+        {
             "name": "symfony/panther",
             "version": "v2.4.0",
             "source": {
@@ -18429,6 +18518,93 @@
                 }
             ],
             "time": "2026-01-08T05:29:21+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "symfony/polyfill-intl-normalizer": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/tests/Acceptance/InstallTest.php
+++ b/tests/Acceptance/InstallTest.php
@@ -99,6 +99,23 @@ final class InstallTest extends TestCase
             $location,
             'The post-login redirect must carry a per-session token_main anti-CSRF token — its presence proves the session was minted',
         );
+
+        // Actually FOLLOW the redirect on the same BrowserKit instance
+        // (session cookie carried automatically) and verify the landing
+        // page actually loads. A 401/403 here would mean tabs/main.php
+        // rejected the session for some reason (token_main mismatch,
+        // session storage broken) — the location-header assertions alone
+        // wouldn't catch that.
+        $landingUrl = str_starts_with($location, 'http')
+            ? $location
+            : ArtifactBrowser::baseUrl() . '/' . ltrim($location, '/');
+        $browser->request('GET', $landingUrl);
+        $landingResponse = $browser->getResponse();
+        self::assertSame(
+            200,
+            $landingResponse->getStatusCode(),
+            'GET on the authenticated landing URL must return 200; 401/403 would indicate the session was rejected despite the login redirect',
+        );
     }
 
     /**

--- a/tests/Acceptance/InstallTest.php
+++ b/tests/Acceptance/InstallTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance;
+
+use OpenEMR\Tests\Acceptance\Support\ArtifactBrowser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Phase 1 exit-criterion test: verifies the openemr artifact under test
+ * completed its install cleanly and that the default admin credentials
+ * (from OE_USER/OE_PASS env vars in docker/production/docker-compose.yml)
+ * work end-to-end through the login flow.
+ *
+ * Runs against ACCEPTANCE_ARTIFACT_URL (default http://localhost:8580).
+ * Boot the artifact first with tests/Acceptance/bin/boot-docker.sh <tag>.
+ *
+ * The test suite is intentionally tag-agnostic: it targets whatever
+ * artifact is booted, whether that's `latest`, `next`, a locally-built
+ * PR image (Phase 2.5), or a tarball-mounted stack (Phase 3). Same test
+ * class, different artifact endpoint.
+ *
+ * Group tags: `fresh-install` maps to Phase 2's matrix job that runs
+ * this test against a freshly-booted artifact (both from_tag and
+ * to_tag scenarios); no other group runs it, since the login flow
+ * assertions are only valid on a fresh install (not on a post-upgrade
+ * stack where UpgradeIntegrityTest takes over).
+ */
+#[Group('fresh-install')]
+final class InstallTest extends TestCase
+{
+    public function testHomepageRedirectsToLoginAfterInstall(): void
+    {
+        // A freshly-installed openemr artifact should serve `/` as a 302
+        // redirect to the login page. If the install didn't complete
+        // (env-var auto-install failed, container crashed, DB not
+        // reachable), the redirect target would be setup.php or a
+        // 500-class error instead — either surfaces here.
+        $browser = ArtifactBrowser::create();
+        $browser->request('GET', ArtifactBrowser::baseUrl() . '/');
+        $response = $browser->getResponse();
+
+        self::assertSame(302, $response->getStatusCode(), 'GET / should redirect (302) on an installed artifact');
+        $location = $this->locationHeader($response);
+        // openemr's redirect target is relative ("interface/login/login.php?..."),
+        // no leading slash. Assert on the trailing path fragment.
+        self::assertStringContainsString(
+            'interface/login/login.php',
+            $location,
+            'GET / should redirect to the login page; a redirect to setup.php would mean install did not complete',
+        );
+    }
+
+    public function testAdminCanLogInAndReachAuthenticatedLandingPage(): void
+    {
+        // Full happy-path login: POST admin/pass to the login endpoint,
+        // assert we get the post-login redirect (302 → /interface/main/
+        // tabs/main.php?token_main=...). token_main is a per-session
+        // anti-CSRF token; its presence in the redirect URL is the
+        // definitive signal that the credentials were accepted and a
+        // session was minted.
+        $browser = ArtifactBrowser::create();
+        $browser->request(
+            'POST',
+            ArtifactBrowser::baseUrl() . '/interface/main/main_screen.php?auth=login&site=default',
+            [
+                'authUser' => 'admin',
+                'clearPass' => 'pass',
+                'languageChoice' => '1',
+                'new_login_session_management' => '1',
+            ],
+        );
+        $response = $browser->getResponse();
+
+        self::assertSame(
+            302,
+            $response->getStatusCode(),
+            'Login POST should return 302 with the authenticated-landing redirect; 200 with the login form re-rendered = credentials rejected',
+        );
+
+        $location = $this->locationHeader($response);
+        self::assertStringContainsString(
+            '/interface/main/tabs/main.php',
+            $location,
+            'Login should redirect to the authenticated landing page',
+        );
+        self::assertMatchesRegularExpression(
+            '/token_main=[A-Za-z0-9]+/',
+            $location,
+            'The post-login redirect must carry a per-session token_main anti-CSRF token — its presence proves the session was minted',
+        );
+    }
+
+    /**
+     * Symfony BrowserKit's Response::getHeader() returns array|string|null
+     * depending on the header's arity and presence. Normalize to a plain
+     * string here (empty when absent) so assertions can operate on it
+     * without narrowing dance at every call site.
+     */
+    private function locationHeader(\Symfony\Component\BrowserKit\Response $response): string
+    {
+        /** @var array<int, string>|string|null $value */
+        $value = $response->getHeader('Location');
+        if (is_array($value)) {
+            return $value[0] ?? '';
+        }
+        return $value ?? '';
+    }
+}

--- a/tests/Acceptance/Support/ArtifactBrowser.php
+++ b/tests/Acceptance/Support/ArtifactBrowser.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance\Support;
+
+use Symfony\Component\BrowserKit\HttpBrowser;
+use Symfony\Component\HttpClient\HttpClient;
+
+/**
+ * Thin factory for an HTTP client pointed at the artifact under test.
+ *
+ * Uses Symfony BrowserKit's HttpBrowser — real HTTP requests via
+ * symfony/http-client, cookie jar + form-submit convenience built in.
+ * No headless browser required, so acceptance runs on any Linux runner
+ * without Chrome/Selenium (Phase 4's E2eCriticalPathTest is when we'll
+ * need Panther-with-Selenium for JS-heavy flows).
+ *
+ * The artifact endpoint is resolved from the ACCEPTANCE_ARTIFACT_URL
+ * environment variable, defaulting to http://localhost:8580 (the port
+ * that tests/Acceptance/bin/boot-docker.sh binds by default).
+ */
+final class ArtifactBrowser
+{
+    public static function create(): HttpBrowser
+    {
+        $client = HttpClient::create([
+            // Accept the self-signed cert that the openemr image serves
+            // when we hit https. Redirect-following is toggled at the
+            // BrowserKit layer (below), not the HTTP-client layer.
+            'verify_peer' => false,
+            'verify_host' => false,
+        ]);
+        $browser = new HttpBrowser($client);
+        // Don't auto-follow redirects: the login flow's 302 IS the
+        // success signal we want to assert on, and GET / is a 302 to
+        // the login page which we also want to inspect directly rather
+        // than follow through.
+        $browser->followRedirects(false);
+        return $browser;
+    }
+
+    public static function baseUrl(): string
+    {
+        $url = getenv('ACCEPTANCE_ARTIFACT_URL');
+        return $url !== false && $url !== '' ? rtrim($url, '/') : 'http://localhost:8580';
+    }
+}

--- a/tests/Acceptance/Support/ArtifactBrowser.php
+++ b/tests/Acceptance/Support/ArtifactBrowser.php
@@ -32,13 +32,22 @@ final class ArtifactBrowser
 {
     public static function create(): HttpBrowser
     {
-        $client = HttpClient::create([
-            // Accept the self-signed cert that the openemr image serves
-            // when we hit https. Redirect-following is toggled at the
-            // BrowserKit layer (below), not the HTTP-client layer.
-            'verify_peer' => false,
-            'verify_host' => false,
-        ]);
+        // TLS verification stays ENABLED by default — acceptance tests
+        // submit admin credentials, and disabling verification against
+        // an arbitrary ACCEPTANCE_ARTIFACT_URL would be MITM-vulnerable
+        // over any non-loopback network. Only disable verification when
+        // the endpoint is provably local (loopback host, host-gateway
+        // container-runtime alias, or explicit ACCEPTANCE_TRUST_SELF_SIGNED=1
+        // opt-in). The Docker artifact under test serves a self-signed
+        // cert on https, so a local acceptance run needs the trust
+        // scoping to be automatic when hitting localhost.
+        $options = ['verify_peer' => true, 'verify_host' => true];
+        if (self::isLocalArtifact()) {
+            $options['verify_peer'] = false;
+            $options['verify_host'] = false;
+        }
+        $client = HttpClient::create($options);
+
         $browser = new HttpBrowser($client);
         // Don't auto-follow redirects: the login flow's 302 IS the
         // success signal we want to assert on, and GET / is a 302 to
@@ -46,6 +55,16 @@ final class ArtifactBrowser
         // than follow through.
         $browser->followRedirects(false);
         return $browser;
+    }
+
+    private static function isLocalArtifact(): bool
+    {
+        $optIn = getenv('ACCEPTANCE_TRUST_SELF_SIGNED');
+        if ($optIn === '1' || $optIn === 'true') {
+            return true;
+        }
+        $host = parse_url(self::baseUrl(), PHP_URL_HOST);
+        return in_array($host, ['localhost', '127.0.0.1', '::1', 'host.docker.internal'], true);
     }
 
     public static function baseUrl(): string

--- a/tests/Acceptance/bin/boot-docker.sh
+++ b/tests/Acceptance/bin/boot-docker.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Boot an openemr Docker image for acceptance testing on a laptop.
+#
+# Composes docker/production/docker-compose.yml with the acceptance
+# override at .github/docker/acceptance-docker-compose.yml — same
+# production stack shape end users deploy, with the image ref driven
+# by $1 (defaults to `latest`) and ports rebound to 8580/8543 so
+# nothing collides with a dev stack running alongside.
+#
+# Usage:
+#   tests/Acceptance/bin/boot-docker.sh [tag]
+#     tag  — Docker Hub tag to boot (default: latest)
+#            Examples: latest, next, dev, 8.2.0, 8.1.0-2026-06-01
+#
+# After a successful boot, the artifact is reachable at
+#   http://localhost:8580   (matches ACCEPTANCE_ARTIFACT_URL's default)
+#
+# Run the acceptance suite against it:
+#   composer acceptance
+#   # or:
+#   vendor/bin/phpunit -c tests/Acceptance/phpunit.acceptance.xml
+#
+# Tear down (preserving no state):
+#   tests/Acceptance/bin/down-docker.sh
+
+set -euo pipefail
+
+TAG="${1:-latest}"
+
+# Locate repo root regardless of where this script is invoked from
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." &>/dev/null && pwd)"
+
+cd "${REPO_ROOT}"
+
+echo "==> Booting openemr/openemr:${TAG} for acceptance testing"
+
+OPENEMR_TAG="${TAG}" docker compose \
+    -f docker/production/docker-compose.yml \
+    -f .github/docker/acceptance-docker-compose.yml \
+    -p openemr-acceptance \
+    up --detach --wait --wait-timeout 900
+
+echo ""
+echo "==> Boot complete."
+echo "    Artifact URL:  http://localhost:8580"
+echo "    HTTPS URL:     https://localhost:8543 (self-signed cert)"
+echo ""
+echo "    Run tests:     composer acceptance"
+echo "    Teardown:      tests/Acceptance/bin/down-docker.sh"

--- a/tests/Acceptance/bin/down-docker.sh
+++ b/tests/Acceptance/bin/down-docker.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Tear down the acceptance-testing openemr Docker stack booted by
+# tests/Acceptance/bin/boot-docker.sh.
+#
+# Removes containers, network, AND the named volumes (databasevolume,
+# sitevolume, logvolume01) — a fresh boot afterwards will re-run the
+# auto-install rather than picking up the prior installation.
+#
+# Usage:
+#   tests/Acceptance/bin/down-docker.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." &>/dev/null && pwd)"
+
+cd "${REPO_ROOT}"
+
+echo "==> Tearing down openemr acceptance stack (removing volumes)"
+
+docker compose \
+    -f docker/production/docker-compose.yml \
+    -f .github/docker/acceptance-docker-compose.yml \
+    -p openemr-acceptance \
+    down --volumes --remove-orphans
+
+echo "==> Teardown complete."

--- a/tests/Acceptance/bootstrap.php
+++ b/tests/Acceptance/bootstrap.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Acceptance-suite PHPUnit bootstrap.
+ *
+ * Minimal: loads composer autoload. Acceptance tests are black-box —
+ * they don't touch OpenEMR's global-state bootstrap (Kernel, session,
+ * database connection, etc.) because the artifact under test has its
+ * own bootstrap running inside its own container/stack.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';

--- a/tests/Acceptance/phpunit.acceptance.xml
+++ b/tests/Acceptance/phpunit.acceptance.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+OpenEMR acceptance tests.
+
+Runs from a GitHub Actions runner (or a developer laptop) against a
+BOOTED openemr artifact — Docker image booted from docker/production/
+docker-compose.yml + .github/docker/acceptance-docker-compose.yml
+override, or a tarball extracted into a generic PHP+Apache+MySQL stack
+(Phase 3 — not yet). Tests are BLACK-BOX: they exercise the artifact
+through its public HTTP interface (and later API + DB + browser); they
+do NOT execute any code inside the artifact.
+
+Distinct from tests/Tests/Isolated/** (pure-PHP logic, no boot) and
+tests/Tests/Unit/**+Api/**+E2e/** (source-tree white-box in the dev
+stack). Acceptance is the artifact-side layer — see
+docs/artifact-acceptance-testing-plan.md for full architecture.
+
+Prereq: an openemr artifact is booted and reachable at
+ACCEPTANCE_ARTIFACT_URL (env var; defaults to http://localhost:8580).
+Boot helper: tests/Acceptance/bin/boot-docker.sh <tag>.
+-->
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="bootstrap.php"
+         backupGlobals="false"
+         colors="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnRisky="false"
+         stopOnSkipped="false"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         failOnDeprecation="true"
+         failOnPhpunitDeprecation="true"
+         failOnPhpunitWarning="true"
+         testdox="false">
+
+  <php>
+    <env name="ENV" value="acceptance" />
+    <ini name="error_reporting" value="-1"/>
+  </php>
+
+  <testsuites>
+    <testsuite name="acceptance">
+      <directory>.</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary

Delivers **Phase 1** of [`docs/artifact-acceptance-testing-plan.md`](https://github.com/openemr/openemr/blob/master/docs/artifact-acceptance-testing-plan.md): a black-box acceptance test that boots the openemr Docker image and verifies fresh-install completed + admin login works.

Runs from a developer laptop today; Phase 2 wraps it in a GitHub Actions workflow with matrix jobs for `latest` / `next` / upgrade paths.

## What lands

- **`.github/docker/acceptance-docker-compose.yml`** — override on top of `docker/production/docker-compose.yml`. Swaps sha-pinned `image:` for an env-driven tag ref (`OPENEMR_TAG`, default `latest`), rebinds ports to 8580/8543 (no root, no collision with dev stack), relaxes healthcheck for older-image compatibility. Same shape end users deploy in production.

- **`tests/Acceptance/`** — new PSR-4 namespace `OpenEMR\Tests\Acceptance\`:
  - `phpunit.acceptance.xml` — dedicated PHPUnit config distinct from `phpunit.xml` (source-side) and `phpunit-isolated.xml` (source-side, DB-less)
  - `bootstrap.php` — minimal (composer autoload only, no OpenEMR global-state bootstrap since tests are black-box)
  - `InstallTest.php` — two tests:
    - `testHomepageRedirectsToLoginAfterInstall` — GET / expects 302 to login page (guards against setup.php redirect = install didn't complete, or 500 = container crashed)
    - `testAdminCanLogInAndReachAuthenticatedLandingPage` — POST admin/pass, expects 302 to `/interface/main/tabs/main.php` with a per-session `token_main=` anti-CSRF token in the redirect URL (token presence is the definitive signal that credentials were accepted and a session was minted)
  - `Support/ArtifactBrowser.php` — thin factory around Symfony BrowserKit's HttpBrowser (real HTTP, cookie jar, redirects not auto-followed so tests can assert on the intermediate 302)
  - `bin/boot-docker.sh <tag>` + `bin/down-docker.sh` — laptop helpers

- **`composer.json`** — adds `OpenEMR\Tests\Acceptance\` autoload-dev PSR-4 entry, `symfony/mime` require-dev (needed by BrowserKit's POST-body path; wasn't transitively installed by Panther), and `composer acceptance` script

## Design choices

**Tag-agnostic**: the InstallTest doesn't know which openemr version it's testing. `ACCEPTANCE_ARTIFACT_URL` env var decides. Same test class works against `latest`, `next`, a locally-built PR image (Phase 2.5), or a tarball-mounted stack (Phase 3) — Phase 2 wires the workflow-driven matrix without any test rewrite.

**Group tag `fresh-install`** on the class — Phase 2's matrix runs it against a freshly-booted artifact (both from_tag and to_tag scenarios). Post-upgrade validation is `UpgradeIntegrityTest`'s job in Phase 2.

**HttpBrowser (not Panther/Selenium)**: the login flow is a plain HTML form POST, no JS. BrowserKit is enough and lets acceptance run on any Linux runner without Chrome. Panther-with-Selenium comes in Phase 4 for `E2eCriticalPathTest`.

## How to run locally

\`\`\`bash
# Boot openemr:latest (~40s cold)
tests/Acceptance/bin/boot-docker.sh latest

# Run the tests
composer acceptance

# Tear down (removes volumes for clean re-boot)
tests/Acceptance/bin/down-docker.sh

# Test against a different tag (next, dev, 8.2.0, ...)
tests/Acceptance/bin/boot-docker.sh next
composer acceptance
\`\`\`

## Test plan

- [x] Boots `openemr/openemr:latest` cleanly to Healthy state
- [x] `composer acceptance` runs 2 tests / 5 assertions in ~0.3s, both pass end-to-end against real openemr:latest via the auto-installer path
- [x] PHPStan clean on `tests/Acceptance/`
- [x] composer-require-checker clean (symfony/mime declared directly)
- [x] `down-docker.sh` cleanly tears down volumes + network
- [ ] CI green (no new workflow yet — just proving the new test files pass source-side lint/phpstan/composer checks)

## What's NOT here (deferred to later phases)

- No workflow (`.github/workflows/acceptance-docker.yml`) — Phase 2. Phase 1's exit criterion is laptop-runnable.
- No `UpgradeIntegrityTest` / `ApiSmokeTest` / `FhirSmokeTest` / `E2eCriticalPathTest` — Phases 2 + 4.
- No package (tarball) acceptance — Phase 3.
- No DataSeed / Assertions Support classes — Phase 2 introduces those when `UpgradeIntegrityTest` needs pre-upgrade seeding.

## Related

- Plan doc: `docs/artifact-acceptance-testing-plan.md` (draft PR #12811)
- Prior parked scaffolding: #12791 (docker upgrade workflow — Phase 2 reference) and #12790 (Dockerfile git-archive — Phase 5)

Assisted-by: Claude Code