### PR TITLE
refactor(edihistory): extract edih_277 segment renderers into a testable class

### DIFF
--- a/.phpstan/baseline/assignOp.invalid.php
+++ b/.phpstan/baseline/assignOp.invalid.php
@@ -1442,11 +1442,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_271_html.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\.\\=" between mixed and non\\-falsy\\-string results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\.\\=" between \'\' and mixed results in an error\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../library/edihistory/edih_278_html.php',

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -10272,21 +10272,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_271_html.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'edih_277_html\\: PER…\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'AAA\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_278_html.php',

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -10272,61 +10272,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_271_html.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'AMT\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'BHT\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'DTP\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'HL\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'NM1\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'PER\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'QTY\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'REF\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'STC\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'SVC\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'TRN\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'edih_277_html\\: PER…\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -2098,7 +2098,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 26,
+    'count' => 4,
     'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -2098,11 +2098,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 56,
     'path' => __DIR__ . '/../../library/edihistory/edih_278_html.php',
 ];

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -1972,11 +1972,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/codes/edih_835_code_class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$fn \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$elem04 \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_278_html.php',

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -1603,7 +1603,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -1603,11 +1603,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../library/edihistory/edih_278_html.php',
 ];

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -1603,7 +1603,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/if.alwaysTrue.php
+++ b/.phpstan/baseline/if.alwaysTrue.php
@@ -254,11 +254,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^If condition is always true\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^If condition is always true\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_archive.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/isset.offset.php
+++ b/.phpstan/baseline/isset.offset.php
@@ -18,11 +18,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Offset 0 on non\\-empty\\-list\\<string\\> in isset\\(\\) always exists and is not nullable\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset 0 on non\\-empty\\-list\\<string\\> in isset\\(\\) always exists and is not nullable\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../library/edihistory/edih_278_html.php',
 ];

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -3313,7 +3313,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method edih_delimiters\\(\\) on mixed\\.$#',
-    'count' => 3,
+    'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -3313,21 +3313,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method edih_delimiters\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method edih_filename\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method edih_x12_transaction\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method edih_delimiters\\(\\) on mixed\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../library/edihistory/edih_278_html.php',
 ];

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -21897,11 +21897,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function edih_277_transaction_html\\(\\) has parameter \\$accordion with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function edih_278_transaction_html\\(\\) has parameter \\$bht03 with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_278_html.php',

--- a/.phpstan/baseline/notIdentical.alwaysTrue.php
+++ b/.phpstan/baseline/notIdentical.alwaysTrue.php
@@ -74,11 +74,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Strict comparison using \\!\\=\\= between string and false will always evaluate to true\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Strict comparison using \\!\\=\\= between string and false will always evaluate to true\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_278_html.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -30382,23 +30382,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'e\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'icn\' on mixed\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'r\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'s\' on mixed\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -30362,32 +30362,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_271_html.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'GS\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'ST\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'bht03\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'date\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'icn\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'sender\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -30362,16 +30362,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_271_html.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ST\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'bht03\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'GS\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_278_html.php',

--- a/.phpstan/baseline/parameter.notFound.php
+++ b/.phpstan/baseline/parameter.notFound.php
@@ -172,11 +172,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/clinical_rules.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^PHPDoc tag @param references unknown parameter\\: \\$clm01$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
     'message' => '#^PHPDoc tag @param references unknown parameter\\: \\$out_str$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',

--- a/.phpstan/baseline/ternary.alwaysTrue.php
+++ b/.phpstan/baseline/ternary.alwaysTrue.php
@@ -44,11 +44,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Ternary operator condition is always true\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Ternary operator condition is always true\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_835_html.php',
 ];
 $ignoreErrors[] = [

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -299,17 +299,25 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
 
                     $stc12 = ($sar[12] ?? '') ?: "";    // message
 
-                    $stc_html = (isset($sc101)) ? "<tr class='" . $cls . "'><td>" . text($stc03) . "</td><td colspan=2>" . text($sc101) . "</td><td>" . text($stc02 . " " . $stc04) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= (isset($sc102)) ? "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($sc102) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= ($sc103 ?? '') ? "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc103) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= ($stc05 || $stc06 || $stc08 || $stc09) ? "<tr class='" . $cls . "'><td><em>Payment</em></td><td colspan=3>" . text($stc05 . " " . $stc06 . " " . $stc08 . " " . $stc09) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= (isset($sc201)) ?  "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($sc201 . " " . $sc204) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= (isset($sc202)) ?  "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($sc202) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= ($sc203 ?? '') ?    "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc203) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= (isset($sc301)) ?  "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($sc301 . " " . $sc304) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= (isset($sc302)) ?  "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($sc302) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= ($sc303 ?? '') ?    "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc303) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= ($stc12) ? "<tr class='" . $cls . "'><td><em>Message</em></td><td colspan=3>" . text($stc12) . "</td></tr>" . PHP_EOL : "";
+                    // repeated STC row templates: a plain detail row, an "Entity" row, and a labeled row
+                    $row = fn(string $inner): string => "<tr class='$cls'><td>&gt;</td><td colspan=3>$inner</td></tr>";
+                    $entity = fn(string $inner): string => "<tr class='$cls'><td>&gt;</td><td colspan=3><em>Entity</em> $inner</td></tr>";
+                    $labeled = fn(string $label, string $inner): string => "<tr class='$cls'><td><em>$label</em></td><td colspan=3>$inner</td></tr>";
+
+                    $stc03Text = text($stc03);
+                    $sc101Text = text($sc101 ?? '');
+                    $stcAmtText = text($stc02 . " " . $stc04);
+                    $stc_html = (isset($sc101)) ? "<tr class='$cls'><td>$stc03Text</td><td colspan=2>$sc101Text</td><td>$stcAmtText</td></tr>" : "";
+                    $stc_html .= (isset($sc102)) ? $row(text($sc102)) : "";
+                    $stc_html .= ($sc103 ?? '') ? $entity(text($sc103)) : "";
+                    $stc_html .= ($stc05 || $stc06 || $stc08 || $stc09) ? $labeled('Payment', text($stc05 . " " . $stc06 . " " . $stc08 . " " . $stc09)) : "";
+                    $stc_html .= (isset($sc201)) ? $row(text($sc201 . " " . $sc204)) : "";
+                    $stc_html .= (isset($sc202)) ? $row(text($sc202)) : "";
+                    $stc_html .= ($sc203 ?? '') ? $entity(text($sc203)) : "";
+                    $stc_html .= (isset($sc301)) ? $row(text($sc301 . " " . $sc304)) : "";
+                    $stc_html .= (isset($sc302)) ? $row(text($sc302)) : "";
+                    $stc_html .= ($sc303 ?? '') ? $entity(text($sc303)) : "";
+                    $stc_html .= ($stc12) ? $labeled('Message', text($stc12)) : "";
 
                     $section = match ($loopid) {
                         '2200B' => 'rcv',

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -21,6 +21,8 @@
  * MA 02110-1301, USA.
  */
 
+use OpenEMR\Billing\EdiHistory\Claim277Renderer;
+
 /**
  * Produce an html display of information in
  * the x12 edi 271 eligibility report for a particular patient
@@ -39,22 +41,27 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
     // get the transaction segments
     $trans = $obj277->edih_x12_transaction($bht03);
 
-    // get other necessary items
-    $de = $obj277->edih_delimiters()['e'];
-    $ds = $obj277->edih_delimiters()['s'];
-    $dr = $obj277->edih_delimiters()['r'];
-    $fn = $obj277->edih_filename();
+    // get other necessary items: narrow the delimiters to non-empty strings at
+    // the source so the segment renderers receive honestly-typed values
+    $delimiters = $obj277->edih_delimiters();
+    $de = is_array($delimiters) ? ($delimiters['e'] ?? '') : '';
+    $ds = is_array($delimiters) ? ($delimiters['s'] ?? '') : '';
+    $dr = is_array($delimiters) ? ($delimiters['r'] ?? '') : '';
+    $fnRaw = $obj277->edih_filename();
+    $fn = is_string($fnRaw) ? $fnRaw : '';
 
     if (!is_array($trans) || !count($trans)) {
-        $str_html = "<p>Did not find transaction " . text($bht03) . " in " . attr($fn) . "</p>" . PHP_EOL;
-        return $str_html;
+        return "<p>Did not find transaction " . text($bht03) . " in " . attr($fn) . "</p>" . PHP_EOL;
+    }
+    if (!is_string($de) || $de === '' || !is_string($ds) || $ds === '') {
+        csv_edihist_log("edih_277_transaction_html: invalid x12 delimiters $fn");
+        return "<p>Did not find transaction " . text($bht03) . " in " . attr($fn) . "</p>" . PHP_EOL;
     }
 
     $cd27x = new edih_271_codes($ds, $dr);
 
     $h3_lbl = '';
     $str_html = "";
-    $hdr_html = "";
 
     $bht03Attr = attr($bht03);
     $fnText = text($fn);
@@ -67,6 +74,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
         <tbody>
         HTML;
 
+    // one accumulator per HL section, emitted in a fixed order at the end
     $html = [
         'src' => '',
         'rcv' => '',
@@ -76,95 +84,53 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
         'sbr_stc' => '',
         'dep_stc' => '',
     ];
-    $cls = '';
+
+    // state carried across segments: the loop cursor, the accordion label,
+    // and the QTY prefix consumed by the next AMT (277CA)
     $loopid = '';
     $bht = '';
     $qtystr = '';
-    $sc204 = '';
-    $sc304 = '';
 
     foreach ($trans as $transaction) {
         $segments = is_array($transaction) ? array_filter($transaction, is_string(...)) : [];
         foreach ($segments as $seg) {
-
-            $idtype = '';
-            $name = '';
-
-            $var = '';
-            $rej_reason = '';
-            $follow = '';
-            $addr = '';
-
             // dispatch on the segment id: the token before the first element delimiter
             $sar = explode($de, $seg);
             $segid = $sar[0];
+            // the row class is fixed by the current loop, derived from its id
+            $cls = Claim277Renderer::rowClass($loopid);
+
             switch ($segid) {
                 case 'BHT':
                     $loopid = 'Heading';
-                    $elem01 = match ($sar[1] ?? null) {
-                        '0010' => 'Src, Rcv, Prv, Sbr, Dep',
-                        '0085' => 'Src, Rcv, Prv, Pt',
-                        null => '',
-                        default => "Not determined ({$sar[1]})",
-                    };
-
-
-                    $elem02 = ($sar[2] ?? false) !== false ? $cd27x->get_271_code('BHT02', $sar[2]) : "";
-                    $elem03 = ($sar[3] ?? '') ?: "";
-                    $elem04 = ($sar[4] ?? '') ? edih_format_date($sar[4]) : "";
-                    $elem06 = ($sar[6] ?? '') ? $cd27x->get_271_code('BHT06', $sar[6]) : "";
-
-                    $e01Text = text($elem01);
-                    $e02Text = text($elem02);
-                    $e03Text = text($elem03);
-                    $e04Text = text($elem04);
-                    $hdr_html .= <<<HTML
-                        <tr><td colspan=2><em>Reference:</em> {$e03Text}</td><td colspan=2><em>Sequence:</em> {$e01Text}</td></tr>
-                        <tr><td colspan=2><em>Date:</em> {$e04Text}</td><td colspan=2><em>Type:</em> {$e02Text}</td>
-                        HTML;
-                    $hdr_html .= ($elem06) ? "<tr><td>&gt;</td><td colspan=3><em>Type:</em> " . text($elem06) . "</td></tr>" : "";
-
-                    $bht = $elem03;
-                break;
-
+                    $bhtRow = Claim277Renderer::bht($sar, $cd27x);
+                    $hdr_html .= $bhtRow['html'];
+                    $bht = $bhtRow['ref'];
+                    break;
 
                 case 'HL':
-                    $elem03 = $sar[3] ?? "";
-                    // HL level code => [loopid, $cls, section accumulator, section heading]
-                    $hl = match ($elem03) {
-                        '20' => ['2000A', 'src', 'src', 'Information Source'],
-                        '21' => ['2000B', 'rcv', 'rcv', 'Information Receiver'],
-                        '19' => ['2000C', 'prv', 'prv', 'Provider'],
-                        '22' => ['2000D', 'sbr', 'sbr_nm1', 'Subscriber'],
-                        'PT' => ['2000D', 'sbr', 'sbr_nm1', 'Patient'],  // patient in 277CA
-                        '23' => ['2000E', 'dep', 'dep_nm1', 'Dependent'],
+                    // HL level code => [loopid, section accumulator, section heading]
+                    $hl = match ($sar[3] ?? '') {
+                        '20' => ['2000A', 'src', 'Information Source'],
+                        '21' => ['2000B', 'rcv', 'Information Receiver'],
+                        '19' => ['2000C', 'prv', 'Provider'],
+                        '22' => ['2000D', 'sbr_nm1', 'Subscriber'],
+                        'PT' => ['2000D', 'sbr_nm1', 'Patient'],  // patient in 277CA
+                        '23' => ['2000E', 'dep_nm1', 'Dependent'],
                         default => null,
                     };
                     if ($hl === null) {
                         csv_edihist_log("edih_277_transaction_html: HL segment error $fn");
                     } else {
-                        [$loopid, $cls, $section, $heading] = $hl;
-                        $html[$section] .= "<tr class='$cls'><td colspan=4><b>$heading</b></td></tr>" . PHP_EOL;
+                        [$loopid, $section, $heading] = $hl;
+                        $cls = Claim277Renderer::rowClass($loopid);
+                        $html[$section] .= "<tr class='$cls'><td colspan=4><b>$heading</b></td></tr>";
                     }
 
-
                     $qtystr = '';  // reset for QTY and AMT segments in 277CA
-                break;
-
+                    break;
 
                 case 'NM1':
-
-                    $nm101 = $sar[1] ?? '';
-                    $descr = ($nm101) ? $cd27x->get_271_code('NM101', $nm101) : "";
-
-                    $name = ($sar[3] ?? '') ?: "";
-                    $name .= ($sar[7] ?? '') ? " {$sar[7]}" : "";
-                    $name .= ($sar[4] ?? '') ? ", {$sar[4]}" : "";
-                    $name .= ($sar[5] ?? '') ? " {$sar[5]}" : "";
-                    $nm109 = ($sar[9] ?? '') ?: "";
-
-                    $nm108 = ($sar[8] ?? '') ? $cd27x->get_271_code('NM108', $sar[8]) : "";
-
                     $nm1 = match ($loopid) {
                         '2000A' => ['src', '2100A', false],
                         '2000B' => ['rcv', '2100B', false],
@@ -175,46 +141,23 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     };
                     if ($nm1 !== null) {
                         [$section, $loopid, $setLabel] = $nm1;
-                        $html[$section] .= "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                        $html[$section] .= "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
+                        $nm1Row = Claim277Renderer::nm1($sar, $cls, $cd27x);
+                        $html[$section] .= $nm1Row['html'];
                         if ($setLabel) {
-                            $h3_lbl = $name;
+                            $h3_lbl = $nm1Row['name'];
                         }
                     }
-
-
-                break;
-
+                    break;
 
                 case 'PER':
-
-                    $elem01 = $sar[1] ?? '';
-                    $elem02 = $sar[2] ?? '';
-                    $elem03 = (isset($sar[3])) ? $cd27x->get_271_code('PER03', $sar[3]) : "";
-                    $elem04 = $sar[4] ?? '';
-                    $elem05 = (isset($sar[5])) ? $cd27x->get_271_code('PER03', $sar[5]) : "";
-                    $elem06 = $sar[6] ?? '';
-                    $elem07 = (isset($sar[7])) ? $cd27x->get_271_code('PER03', $sar[7]) : "";
-                    $elem08 = $sar[8] ?? '';
-                    $elem09 = $sar[9] ?? '';
-
                     if ($loopid == '2100A') {
-                        $html['src'] .= "<tr class='" . $cls . "'><td colspan=2>" . text($elem02) . "</td><td colspan=2 title='" . attr($elem03 . " " . $elem05 . " " . $elem07) . "'>" . text($elem04 . " " . $elem06 . " " . $elem08) . "</td></tr>" . PHP_EOL;
+                        $html['src'] .= Claim277Renderer::per($sar, $cls, $cd27x);
                     } else {
                         csv_edihist_log('edih_277_html: PER segment not in 2100A loop ' . $fn);
                     }
-
-
-                break;
-
+                    break;
 
                 case 'TRN':
-
-                    $elem01 = ($sar[1] ?? '') == "1" ? "Transaction Ref" : "Trace";
-                    $elem02 = $sar[2] ?? '';
-                    $elem03 = $sar[3] ?? '';
-                    $elem04 = $sar[4] ?? '';
-
                     $trn = match ($loopid) {
                         '2100B' => ['rcv', '2200B', false],
                         '2100C' => ['prv', '2200C', false],
@@ -224,101 +167,15 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     };
                     if ($trn !== null) {
                         [$section, $loopid, $appendLabel] = $trn;
-                        $html[$section] .= "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
+                        $trnRow = Claim277Renderer::trn($sar, $cls);
+                        $html[$section] .= $trnRow['html'];
                         if ($appendLabel) {
-                            $h3_lbl = ($h3_lbl) ? $h3_lbl . ' ' . $elem02 : $h3_lbl;
+                            $h3_lbl = ($h3_lbl) ? $h3_lbl . ' ' . $trnRow['ref'] : $h3_lbl;
                         }
                     }
-
-
-                break;
-
+                    break;
 
                 case 'STC':
-                    // reset composite-derived status codes so a prior STC's codes do
-                    // not leak into a segment that omits its own STC01/STC10/STC11
-                    // composite elements (the rows below are gated on isset()/truthiness)
-                    $sc101 = $sc102 = $sc103 = null;
-                    $sc201 = $sc202 = $sc203 = null;
-                    $sc301 = $sc302 = $sc303 = null;
-                    $sc204 = $sc304 = "";
-                    //
-                    if (isset($sar[1])) {
-                        if (strpos($sar[1], (string) $ds)) {       // claim status category : claim status : entity identifier
-                            $scda = explode($ds, $sar[1]);
-                            $sc101 = $scda[0] ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
-                            $sc102 = ($scda[1] ?? '') ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
-                            $sc103 = ($scda[2] ?? '') ? $cd27x->get_271_code('NM101', $scda[2]) : "";
-                        }
-                    }
-
-                    $stc02 = ($sar[2] ?? '') ? edih_format_date($sar[2]) : "";  // status information date
-                    $stc03 = match ($sar[3] ?? null) {                                           // action code
-                        'WQ' => 'Accepted',
-                        'F' => 'Final',
-                        '15' => 'Correct/Resubmit',
-                        'U' => 'Rejected',
-                        null => '',
-                        default => $sar[3],
-                    };
-
-                    $stc04 = ($sar[4] ?? '') ? edih_format_money($sar[4]) : "";  // billed amount
-                    $stc05 = ($sar[5] ?? '') ? edih_format_money($sar[5]) : "";  // paid amount
-                    $stc06 = ($sar[6] ?? '') ? edih_format_date($sar[6]) : "";   // payment date
-                //$stc07  not used
-                    $stc08 = ($sar[8] ?? '') ? edih_format_date($sar[8]) : "";   // check issue date
-                    $stc09 = ($sar[9] ?? '') ?: "";                        // check or eft number
-
-                    $stc10 = "";
-                    if ($sar[10] ?? false) {     // claim status category : claim status : entity identifier
-                        if (strpos($sar[10], (string) $ds)) {
-                            $scda = explode($ds, $sar[10]);
-                            $sc201 = $scda[0] ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
-                            $sc202 = ($scda[1] ?? '') ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
-                            $sc203 = ($scda[2] ?? '') ? $cd27x->get_271_code('NM101', $scda[2]) : "";
-                            $sc204 = ($scda[3] ?? '') === 'RA' ? "Rx Reject/Payment Codes" : "";
-                        } else {
-                            $stc10 = $sar[10];
-                        }
-                    }
-
-
-                    $stc11 = "";
-                    if ($sar[11] ?? false) {     // claim status category : claim status : entity identifier
-                        if (strpos($sar[11], (string) $ds)) {
-                            $scda = explode($ds, $sar[11]);
-                            $sc301 = $scda[0] ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
-                            $sc302 = ($scda[1] ?? '') ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
-                            $sc303 = ($scda[2] ?? '') ? $cd27x->get_271_code('NM101', $scda[2]) : "";
-                            $sc304 = ($scda[3] ?? '') === 'RA' ? "Rx Reject/Payment Codes" : "";
-                        } else {
-                            $stc11 = $sar[11];
-                        }
-                    }
-
-
-                    $stc12 = ($sar[12] ?? '') ?: "";    // message
-
-                    // repeated STC row templates: a plain detail row, an "Entity" row, and a labeled row
-                    $row = fn(string $inner): string => "<tr class='$cls'><td>&gt;</td><td colspan=3>$inner</td></tr>";
-                    $entity = fn(string $inner): string => "<tr class='$cls'><td>&gt;</td><td colspan=3><em>Entity</em> $inner</td></tr>";
-                    $labeled = fn(string $label, string $inner): string => "<tr class='$cls'><td><em>$label</em></td><td colspan=3>$inner</td></tr>";
-
-                    $stc03Text = text($stc03);
-                    $sc101Text = text($sc101 ?? '');
-                    $stcAmtText = text($stc02 . " " . $stc04);
-                    $stc_html = (isset($sc101)) ? "<tr class='$cls'><td>$stc03Text</td><td colspan=2>$sc101Text</td><td>$stcAmtText</td></tr>" : "";
-                    $stc_html .= (isset($sc102)) ? $row(text($sc102)) : "";
-                    $stc_html .= ($sc103 ?? '') ? $entity(text($sc103)) : "";
-                    $stc_html .= ($stc05 || $stc06 || $stc08 || $stc09) ? $labeled('Payment', text($stc05 . " " . $stc06 . " " . $stc08 . " " . $stc09)) : "";
-                    $stc_html .= (isset($sc201)) ? $row(text($sc201 . " " . $sc204)) : "";
-                    $stc_html .= (isset($sc202)) ? $row(text($sc202)) : "";
-                    $stc_html .= ($sc203 ?? '') ? $entity(text($sc203)) : "";
-                    $stc_html .= (isset($sc301)) ? $row(text($sc301 . " " . $sc304)) : "";
-                    $stc_html .= (isset($sc302)) ? $row(text($sc302)) : "";
-                    $stc_html .= ($sc303 ?? '') ? $entity(text($sc303)) : "";
-                    $stc_html .= ($stc12) ? $labeled('Message', text($stc12)) : "";
-
                     $section = match ($loopid) {
                         '2200B' => 'rcv',
                         '2200C' => 'prv',
@@ -327,33 +184,17 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         default => null,
                     };
                     if ($section !== null) {
-                        $html[$section] .= $stc_html;
+                        $html[$section] .= Claim277Renderer::stc($sar, $ds, $cls, $cd27x);
                     }
+                    break;
 
-
-                break;
-
-            // in 277CA, expect QTY followed by AMT
-            // do not expect QTY or AMT in regular 277
+                // in 277CA, expect QTY followed by AMT
+                // do not expect QTY or AMT in regular 277
                 case 'QTY':
-                    $qtystr = match ($sar[1] ?? null) {
-                        '90' => 'Acknowledged Quantity ',
-                        'AA' => 'Unacknowledged Quantity ',
-                        'QA' => 'Quantity Approved ',
-                        'QC' => 'Quantity Disapproved ',
-                        null => '',
-                        default => 'Quantity ',
-                    };
-
-                    $qtystr .= ($sar[2] ?? '') ?: "";
-                break;
-
+                    $qtystr = Claim277Renderer::qtyString($sar);
+                    break;
 
                 case 'AMT':
-                    // 277CA
-                    $amtstr = ($sar[1] ?? '') == 'YU' ? "Amt " : "Amt Rej ";
-                    $amtstr .= ($sar[2] ?? '') ? edih_format_money($sar[2]) : "";
-
                     $section = match ($loopid) {
                         '2200B' => 'rcv',
                         '2200C' => 'prv',
@@ -362,21 +203,12 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         default => null,
                     };
                     if ($section !== null) {
-                        $html[$section] .= "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
+                        $html[$section] .= Claim277Renderer::amt($sar, $cls, $qtystr);
                     }
-
-                    $amtstr = '';
                     $qtystr = '';
-
-                break;
-
+                    break;
 
                 case 'REF':
-
-                    $elem01 = (isset($sar[1])) ? $cd27x->get_271_code('REF', $sar[1]) : '';
-                    $elem02 = $sar[2] ?? '';
-                    $elem03 = $sar[3] ?? '';
-
                     $section = match ($loopid) {
                         '2200B' => 'rcv',
                         '2200C' => 'prv',
@@ -385,71 +217,22 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         default => null,
                     };
                     if ($section !== null) {
-                        $html[$section] .= "<tr class='" . $cls . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
+                        $html[$section] .= Claim277Renderer::ref($sar, $cls, $cd27x);
                     }
-
-
-                break;
-
+                    break;
 
                 case 'DTP':
-
-                    $var = '';
-
-                    $elem01 = ($sar[1] ?? '') ? $cd27x->get_271_code('DTP', $sar[1]) : "";
-                    $elem02 = $sar[2] ?? '';
-                    $elem03 = $sar[3] ?? '';
-
-                    $idtype = ($elem01) ? $cd27x->get_271_code('DTP', $elem01) : "";
-                    if ($elem02 == 'D8' && $elem03) {
-                        $var = edih_format_date($elem03);
-                    } elseif ($elem02 == 'RD8' && $elem03) {
-                        $var = edih_format_date(substr($elem03, 0, 8));
-                        $var .= ' - ' . edih_format_date(substr($elem03, -8));
-                    }
-
-
                     $section = match ($loopid) {
                         '2200D', '2220D' => 'sbr_stc',
                         '2200E', '2220E' => 'dep_stc',
                         default => null,
                     };
                     if ($section !== null) {
-                        $html[$section] .= "<tr class='" . $cls . "'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>" . PHP_EOL;
+                        $html[$section] .= Claim277Renderer::dtp($sar, $cls, $cd27x);
                     }
-
-
-                break;
-
+                    break;
 
                 case 'SVC':
-
-                    $elem01 = '';                           // composite procedure code source:code:modifier:modifier
-                    if ($sar[1] ?? false) {
-                        // construct a code source code modifier string
-                        if (strpos($sar[1], (string) $ds)) {
-                            $scda = explode($ds, $sar[1]);
-                            reset($scda);
-                            foreach ($scda as $key => $val) {
-                                if ($key == 0 && $val) {
-                                    $elem01 = $cd27x->get_271_code('EB13', $val);
-                                } else {
-                                    $elem01 .= " " . $val;
-                                }
-                            }
-                        } else {
-                            $elem01 = $sar[1];
-                        }
-                    }
-
-
-                    $elem02 = ($sar[2] ?? '') ? edih_format_money($sar[2]) : "";  // billed amount
-                    $elem03 = ($sar[3] ?? '') ? edih_format_money($sar[3]) : "";  // paid amount
-                    $elem04 = ($sar[4] ?? '') ?: "";                   // revenue code
-                    $elem05 = ($sar[5] ?? '') ?: "";                   // quantity
-                    // $elem06 not used
-                    $elem07 = ($sar[7] ?? '') ?: "";                   // original unis of service
-
                     $section = match ($loopid) {
                         '2200B' => 'rcv',
                         '2200D', '2220D' => 'sbr_stc',
@@ -457,23 +240,15 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         default => null,
                     };
                     if ($section !== null) {
-                        $html[$section] .= ($section === 'rcv')
-                            ? "<tr class='" . $cls . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td>" . text($elem02) . "</td><td>" . text($elem04) . "</td></tr>" . PHP_EOL
-                            : "<tr class='" . $cls . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>" . PHP_EOL;
-                        $html[$section] .= ($elem03 || $elem04) ? "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
+                        $html[$section] .= Claim277Renderer::svc($sar, $ds, $cls, $section === 'rcv', $cd27x);
                     }
-
-
-                break;
+                    break;
             }
-
-
         }
 
-
         if ($accordion) {
-            $str_html .= "<h3>" . text($bht . " " . $h3_lbl) . "</h3>" . PHP_EOL;
-            $str_html .= "<div id='ac_" . attr($bht) . "'>" . PHP_EOL;
+            $str_html .= "<h3>" . text($bht . " " . $h3_lbl) . "</h3>";
+            $str_html .= "<div id='ac_" . attr($bht) . "'>";
         }
 
         $str_html .= $hdr_html ?: "";
@@ -484,15 +259,15 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
         $str_html .= $html['sbr_stc'] ?: "";
         $str_html .= $html['dep_nm1'] ?: "";
         $str_html .= $html['dep_stc'] ?: "";
-        $str_html .= "<tr><td colspan=4>&nbsp;</td></tr>" . PHP_EOL;
-        $str_html .= "</tbody>" . PHP_EOL . "</table>" . PHP_EOL;
+        $str_html .= "<tr><td colspan=4>&nbsp;</td></tr>";
+        $str_html .= "</tbody>" . "</table>";
 
         if ($accordion) {
-            $str_html .= "</div>" . PHP_EOL;
+            $str_html .= "</div>";
         }
     }
 
-    return  $str_html;
+    return $str_html;
 }
 
 /**

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -69,13 +69,15 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
     $hdr_html .= "<tr><th>Reference</th><th>Information</th><th colspan=2>" . text($fn) . "</th></tr>" . PHP_EOL; //
     $hdr_html .= "</thead>" . PHP_EOL . "<tbody>" . PHP_EOL;
     //
-    $src_html = "";
-    $rcv_html = "";
-    $prv_html = "";
-    $sbr_nm1_html = "";
-    $dep_nm1_html = "";
-    $sbr_stc_html = "";
-    $dep_stc_html = "";
+    $html = [
+        'src' => '',
+        'rcv' => '',
+        'prv' => '',
+        'sbr_nm1' => '',
+        'dep_nm1' => '',
+        'sbr_stc' => '',
+        'dep_stc' => '',
+    ];
     $cls = '';
     $loopid = '';
     $bht = '';
@@ -126,33 +128,21 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
             //
                 case 'HL':
                     $elem03 = $sar[3] ?? "";
-                    if ($elem03 == '20') {                     // level code
-                        $loopid = '2000A';                      // info source (payer)
-                        $cls = "src";
-                        $src_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Information Source</b></td></tr>" . PHP_EOL;
-                    } elseif ($elem03 == '21') {
-                        $loopid = '2000B';                      // info receiver (clinic)
-                        $cls = "rcv";
-                        $rcv_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Information Receiver</b></td></tr>" . PHP_EOL;
-                    } elseif ($elem03 == '19') {
-                        $loopid = '2000C';                      // provider
-                        $cls = "prv";
-                        $has_eb = false;
-                        $prv_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Provider</b></td></tr>" . PHP_EOL;
-                    } elseif ($elem03 == '22') {
-                        $loopid = '2000D';                      // subscriber
-                        $cls = "sbr";
-                        $sbr_nm1_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Subscriber</b></td></tr>" . PHP_EOL;
-                    } elseif ($elem03 == 'PT') {
-                        $loopid = '2000D';                      // patient in 277CA
-                        $cls = "sbr";
-                        $sbr_nm1_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Patient</b></td></tr>" . PHP_EOL;
-                    } elseif ($elem03 == '23') {
-                        $loopid = '2000E';                      // dependent
-                        $cls = "dep";
-                        $dep_nm1_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Dependent</b></td></tr>" . PHP_EOL;
-                    } else {
+                    // HL level code => [loopid, $cls, section accumulator, section heading]
+                    $hl = match ($elem03) {
+                        '20' => ['2000A', 'src', 'src', 'Information Source'],
+                        '21' => ['2000B', 'rcv', 'rcv', 'Information Receiver'],
+                        '19' => ['2000C', 'prv', 'prv', 'Provider'],
+                        '22' => ['2000D', 'sbr', 'sbr_nm1', 'Subscriber'],
+                        'PT' => ['2000D', 'sbr', 'sbr_nm1', 'Patient'],  // patient in 277CA
+                        '23' => ['2000E', 'dep', 'dep_nm1', 'Dependent'],
+                        default => null,
+                    };
+                    if ($hl === null) {
                         csv_edihist_log("edih_277_transaction_html: HL segment error $fn");
+                    } else {
+                        [$loopid, $cls, $section, $heading] = $hl;
+                        $html[$section] .= "<tr class='$cls'><td colspan=4><b>$heading</b></td></tr>" . PHP_EOL;
                     }
 
                     //
@@ -174,25 +164,25 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     $nm108 = ($sar[8] ?? '') ? $cd27x->get_271_code('NM108', $sar[8]) : "";
                     //
                     if ($loopid == '2000A') {
-                        $src_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                        $src_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
+                        $html['src'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
+                        $html['src'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
                         $loopid = '2100A';
                     } elseif ($loopid == '2000B') {
-                        $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                        $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
+                        $html['rcv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
+                        $html['rcv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
                         $loopid = '2100B';
                     } elseif ($loopid == '2000C') {
-                        $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                        $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
+                        $html['prv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
+                        $html['prv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
                         $loopid = '2100C';
                     } elseif ($loopid == '2000D') {
-                        $sbr_nm1_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                        $sbr_nm1_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
+                        $html['sbr_nm1'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
+                        $html['sbr_nm1'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
                         $h3_lbl = $name;
                         $loopid = '2100D';
                     } elseif ($loopid == '2000E') {
-                        $dep_nm1_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                        $dep_nm1_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
+                        $html['dep_nm1'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
+                        $html['dep_nm1'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
                         $h3_lbl = $name;
                         $loopid = '2100E';
                     }
@@ -214,7 +204,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     $elem09 = $sar[9] ?? '';
                     //
                     if ($loopid == '2100A') {
-                        $src_html .= "<tr class='" . attr($cls) . "'><td colspan=2>" . text($elem02) . "</td><td colspan=2 title='" . attr($elem03 . " " . $elem05 . " " . $elem07) . "'>" . text($elem04 . " " . $elem06 . " " . $elem08) . "</td></tr>" . PHP_EOL;
+                        $html['src'] .= "<tr class='" . attr($cls) . "'><td colspan=2>" . text($elem02) . "</td><td colspan=2 title='" . attr($elem03 . " " . $elem05 . " " . $elem07) . "'>" . text($elem04 . " " . $elem06 . " " . $elem08) . "</td></tr>" . PHP_EOL;
                     } else {
                         csv_edihist_log('edih_277_html: PER segment not in 2100A loop ' . $fn);
                     }
@@ -231,17 +221,17 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     $elem04 = $sar[4] ?? '';
                     //
                     if ($loopid == '2100B') {
-                        $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
+                        $html['rcv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
                         $loopid = '2200B';
                     } elseif ($loopid == '2100C') {
-                        $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
+                        $html['prv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
                         $loopid = '2200C';
                     } elseif ($loopid == '2100D') {
-                        $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
+                        $html['sbr_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
                         $h3_lbl = ($h3_lbl) ? $h3_lbl . ' ' . $elem02 : $h3_lbl;
                         $loopid = '2200D';
                     } elseif ($loopid == '2100E') {
-                        $dep_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
+                        $html['dep_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
                         $h3_lbl = ($h3_lbl) ? $h3_lbl . ' ' . $elem02 : $h3_lbl;
                         $loopid = '2200E';
                     }
@@ -328,13 +318,13 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     $stc_html .= ($stc12) ? "<tr class='" . attr($cls) . "'><td><em>Message</em></td><td colspan=3>" . text($stc12) . "</td></tr>" . PHP_EOL : "";
                 //
                     if ($loopid == '2200B') {
-                        $rcv_html .= $stc_html;
+                        $html['rcv'] .= $stc_html;
                     } elseif ($loopid == '2200C') {
-                        $prv_html .= $stc_html;
+                        $html['prv'] .= $stc_html;
                     } elseif ($loopid == '2200D') {
-                        $sbr_stc_html .= $stc_html;
+                        $html['sbr_stc'] .= $stc_html;
                     } elseif ($loopid == '2200E') {
-                        $dep_stc_html .= $stc_html;
+                        $html['dep_stc'] .= $stc_html;
                     }
 
                 //
@@ -362,13 +352,13 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     $amtstr .= ($sar[2] ?? '') ? edih_format_money($sar[2]) : "";
                     //
                     if ($loopid == '2200B') {
-                        $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
+                        $html['rcv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
                     } elseif ($loopid == '2200C') {
-                        $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
+                        $html['prv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
                     } elseif ($loopid == '2200D') {
-                        $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
+                        $html['sbr_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
                     } elseif ($loopid == '2200E') {
-                        $dep_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
+                        $html['dep_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
                     }
 
                     $amtstr = '';
@@ -384,13 +374,13 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     $elem03 = $sar[3] ?? '';
                     //
                     if ($loopid == '2200B') {
-                        $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
+                        $html['rcv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
                     } elseif ($loopid == '2200C') {
-                        $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
+                        $html['prv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
                     } elseif ($loopid == '2200D' || $loopid == '2220D') {
-                        $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
+                        $html['sbr_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
                     } elseif ($loopid == '2200E' || $loopid == '2220E') {
-                        $dep_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
+                        $html['dep_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
                     }
 
                     //
@@ -415,9 +405,9 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
 
                     //
                     if ($loopid == '2200D' || $loopid == '2220D') {
-                        $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>" . PHP_EOL;
+                        $html['sbr_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>" . PHP_EOL;
                     } elseif ($loopid == '2200E' || $loopid == '2220E') {
-                        $dep_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>" . PHP_EOL;
+                        $html['dep_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>" . PHP_EOL;
                     }
 
                     //
@@ -453,14 +443,14 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     $elem07 = ($sar[7] ?? '') ?: "";                   // original unis of service
                     //
                     if ($loopid == '2200B') {
-                        $rcv_html .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td>" . text($elem02) . "</td><td>" . text($elem04) . "</td></tr>" . PHP_EOL;
-                        $rcv_html .= ($elem03 || $elem04) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
+                        $html['rcv'] .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td>" . text($elem02) . "</td><td>" . text($elem04) . "</td></tr>" . PHP_EOL;
+                        $html['rcv'] .= ($elem03 || $elem04) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
                     } elseif ($loopid == '2200D' || $loopid == '2220D') {
-                        $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>" . PHP_EOL;
-                        $sbr_stc_html .= ($elem03 || $elem04) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
+                        $html['sbr_stc'] .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>" . PHP_EOL;
+                        $html['sbr_stc'] .= ($elem03 || $elem04) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
                     } elseif ($loopid == '2200E' || $loopid == '2220E') {
-                        $dep_stc_html .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>" . PHP_EOL;
-                        $dep_stc_html .= ($elem03 || $elem04) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
+                        $html['dep_stc'] .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>" . PHP_EOL;
+                        $html['dep_stc'] .= ($elem03 || $elem04) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
                     }
 
                     //
@@ -477,13 +467,13 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
         }
 
         $str_html .= $hdr_html ?: "";
-        $str_html .= $src_html ?: "";
-        $str_html .= $rcv_html ?: "";
-        $str_html .= $prv_html ?: "";
-        $str_html .= $sbr_nm1_html ?: "";
-        $str_html .= $sbr_stc_html ?: "";
-        $str_html .= $dep_nm1_html ?: "";
-        $str_html .= $dep_stc_html ?: "";
+        $str_html .= $html['src'] ?: "";
+        $str_html .= $html['rcv'] ?: "";
+        $str_html .= $html['prv'] ?: "";
+        $str_html .= $html['sbr_nm1'] ?: "";
+        $str_html .= $html['sbr_stc'] ?: "";
+        $str_html .= $html['dep_nm1'] ?: "";
+        $str_html .= $html['dep_stc'] ?: "";
         $str_html .= "<tr><td colspan=4>&nbsp;</td></tr>" . PHP_EOL;
         $str_html .= "</tbody>" . PHP_EOL . "</table>" . PHP_EOL;
         //

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -32,11 +32,12 @@ use OpenEMR\Billing\EdiHistory\Claim277Renderer;
  * @uses edih_format_date()
  * @uses edih_format_percent()
  *
- * @param mixed $obj277 edih_x12_file type 271
+ * @param edih_x12_file $obj277 the parsed 277 / 277CA x12 file object
  * @param string $bht03 bht03 or clm01 reference for transaction
+ * @param bool $accordion wrap each transaction in its own accordion section
  * @return string
  */
-function edih_277_transaction_html($obj277, $bht03, $accordion = false)
+function edih_277_transaction_html($obj277, string $bht03, bool $accordion = false)
 {
     // segment dispatch maps, defined once up front so each case below is a
     // declarative lookup rather than an inline match
@@ -70,8 +71,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
     $svcSection = ['2200B' => 'rcv', '2200D' => 'sbr_stc', '2220D' => 'sbr_stc', '2200E' => 'dep_stc', '2220E' => 'dep_stc'];
 
     // keep only the transaction rows that are arrays of segments
-    $transRaw = $obj277->edih_x12_transaction($bht03);
-    $trans = is_array($transRaw) ? array_filter($transRaw, is_array(...)) : [];
+    $trans = array_filter($obj277->edih_x12_transaction($bht03), is_array(...));
 
     // narrow the x12 delimiters to strings at the source so the renderers
     // receive honestly-typed values
@@ -130,7 +130,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
         $segments = array_filter($transaction, is_string(...));
         foreach ($segments as $seg) {
             // dispatch on the segment id: the token before the first element delimiter
-            $sar = explode($de, $seg);
+            $sar = explode($de, (string) $seg);
             $segid = $sar[0];
             // the row class is fixed by the current loop, derived from its id
             $cls = Claim277Renderer::rowClass($loopid);
@@ -239,7 +239,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
             $str_html .= "<div id='ac_{$bhtAttr}'>";
         }
 
-        $str_html .= $hdr_html ?: "";
+        $str_html .= $hdr_html;
         $str_html .= $html['src'] ?: "";
         $str_html .= $html['rcv'] ?: "";
         $str_html .= $html['prv'] ?: "";
@@ -264,58 +264,44 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
  * @uses csv_check_x12_obj()
  * @uses edih_277_transaction_html()
  *
- * @param string  $filename the filename
- * @param string  $clm01 identifier from 837 CLM of BHT segment
+ * @param string $filename the filename
  *
  * @return string  either an error message or a table with the information from the response
  */
 function edih_277_html($filename, $bht03 = '')
 {
     // create a display for an individual 277 response
-    $html_str = '';
-
-    if ($filename) {
-        $fn = $filename;
-    } else {
+    if ($filename === '') {
         csv_edihist_log("edih_277_html: called with no file arguments");
-        $html_str .= "Error, no file given<br />" . PHP_EOL;
-        return $html_str;
+        return "Error, no file given<br />" . PHP_EOL;
     }
 
-    if ($fn) {
-        $obj277 = csv_check_x12_obj($fn, 'f277');
-        if ($obj277 !== false) {
-            if ($bht03) {
-                // particular transaction
-                $html_str .= edih_277_transaction_html($obj277, $bht03);
-            } else {
-                // file contents
-                $env_ar = $obj277->edih_envelopes();
-                if (!isset($env_ar['ST'])) {
-                    $html_str .= "<p>edih_277_html: file parse error, envelope error</p>" . PHP_EOL;
-                    $html_str .= text($obj277->edih_message());
-                    return $html_str;
-                }
+    $obj277 = csv_check_x12_obj($filename, 'f277');
+    if ($obj277 === false) {
+        return "<p>" . text($filename) . " : file parse error</p>" . PHP_EOL;
+    }
 
-                $html_str .= "<div id='accordion'>" . PHP_EOL;
+    // a specific bht03/clm01 reference renders just that transaction
+    if (is_string($bht03) && $bht03 !== '') {
+        return edih_277_transaction_html($obj277, $bht03);
+    }
 
-                foreach ($env_ar['ST'] as $st) {
-                    // get each transaction
-                    foreach ($st['bht03'] as $bht) {
-                        $html_str .= edih_277_transaction_html($obj277, $bht, true);
-                    }
-                }
+    // otherwise render every transaction in the file
+    $env_ar = $obj277->edih_envelopes();
+    if (!is_array($env_ar) || !isset($env_ar['ST']) || !is_array($env_ar['ST'])) {
+        return "<p>edih_277_html: file parse error, envelope error</p>" . PHP_EOL . text($obj277->edih_message());
+    }
 
-                $html_str .= "</div>" . PHP_EOL;
+    $html_str = "<div id='accordion'>" . PHP_EOL;
+    foreach ($env_ar['ST'] as $st) {
+        $bht03_list = (is_array($st) && isset($st['bht03']) && is_array($st['bht03'])) ? $st['bht03'] : [];
+        foreach ($bht03_list as $bht) {
+            if (is_string($bht)) {
+                $html_str .= edih_277_transaction_html($obj277, $bht, true);
             }
-        } else {
-            $html_str .= "<p>" . text($filename) . " : file parse error</p>" . PHP_EOL;
         }
-    } else {
-        $html_str .= "Error with file name or file parsing <br />" . PHP_EOL;
-        csv_edihist_log("edih_277_html: error in retrieving file object");
-        return $html_str;
     }
+    $html_str .= "</div>" . PHP_EOL;
 
     return $html_str;
 }

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -63,11 +63,16 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
     $str_html = "";
     $hdr_html = "";
     //
-    $hdr_html = "<table id=" . attr($bht03) . " class='h277' columns=4>";
-    $hdr_html .= "<caption>Claim Status</caption>" . PHP_EOL;
-    $hdr_html .= "<thead>" . PHP_EOL;
-    $hdr_html .= "<tr><th>Reference</th><th>Information</th><th colspan=2>" . text($fn) . "</th></tr>" . PHP_EOL; //
-    $hdr_html .= "</thead>" . PHP_EOL . "<tbody>" . PHP_EOL;
+    $bht03Attr = attr($bht03);
+    $fnText = text($fn);
+    $hdr_html = <<<HTML
+        <table id={$bht03Attr} class='h277' columns=4>
+        <caption>Claim Status</caption>
+        <thead>
+        <tr><th>Reference</th><th>Information</th><th colspan=2>{$fnText}</th></tr>
+        </thead>
+        <tbody>
+        HTML;
     //
     $html = [
         'src' => '',
@@ -118,9 +123,15 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     $elem04 = ($sar[4] ?? '') ? edih_format_date($sar[4]) : "";
                     $elem06 = ($sar[6] ?? '') ? $cd27x->get_271_code('BHT06', $sar[6]) : "";
                 //
-                    $hdr_html .= "<tr><td colspan=2><em>Reference:</em> " . text($elem03) . "</td><td colspan=2><em>Sequence:</em> " . text($elem01) . "</td></tr>" . PHP_EOL;
-                    $hdr_html .= "<tr><td colspan=2><em>Date:</em> " . text($elem04) . "</td><td colspan=2><em>Type:</em> " . text($elem02) . "</td>" . PHP_EOL;
-                    $hdr_html .= ($elem06) ? "<tr><td>&gt;</td><td colspan=3><em>Type:</em> " . text($elem06) . "</td></tr>" . PHP_EOL : "";
+                    $e01Text = text($elem01);
+                    $e02Text = text($elem02);
+                    $e03Text = text($elem03);
+                    $e04Text = text($elem04);
+                    $hdr_html .= <<<HTML
+                        <tr><td colspan=2><em>Reference:</em> {$e03Text}</td><td colspan=2><em>Sequence:</em> {$e01Text}</td></tr>
+                        <tr><td colspan=2><em>Date:</em> {$e04Text}</td><td colspan=2><em>Type:</em> {$e02Text}</td>
+                        HTML;
+                    $hdr_html .= ($elem06) ? "<tr><td>&gt;</td><td colspan=3><em>Type:</em> " . text($elem06) . "</td></tr>" : "";
                 //
                     $bht = $elem03;
                 break;

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -182,8 +182,8 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         [$section, $loopid, $appendLabel] = $trn;
                         $trnRow = Claim277Renderer::trn($sar, $cls);
                         $html[$section] .= $trnRow['html'];
-                        if ($appendLabel) {
-                            $h3_lbl = ($h3_lbl) ? $h3_lbl . ' ' . $trnRow['ref'] : $h3_lbl;
+                        if ($appendLabel && $h3_lbl) {
+                            $h3_lbl .= " {$trnRow['ref']}";
                         }
                     }
                     break;
@@ -313,12 +313,7 @@ function edih_277_html($filename, $bht03 = '')
 
                     // get each transaction
                     foreach ($st['bht03'] as $bht) {
-                        //$html_str .= "<h3>$bht Claim Status <em>Date</em> $gs_date <em>Source</em> $gs_sender</h3>".PHP_EOL;
-                        //$html_str .= "<div id='ac_$bht'>".PHP_EOL;
-
                         $html_str .= edih_277_transaction_html($obj277, $bht, true);
-
-                        //$html_str .= "</div>".PHP_EOL;
                     }
                 }
 

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -266,8 +266,6 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                             $sc102 = ($scda[1] ?? '') ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
                             $sc103 = ($scda[2] ?? '') ? $cd27x->get_271_code('NM101', $scda[2]) : "";
                         }
-                    } else {
-                        $stc01 = $sar[1];
                     }
 
                     $stc02 = ($sar[2] ?? '') ? edih_format_date($sar[2]) : "";  // status information date
@@ -383,7 +381,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     //
                     $elem01 = (isset($sar[1])) ? $cd27x->get_271_code('REF', $sar[1]) : '';
                     $elem02 = $sar[2] ?? '';
-                    $elem03 = (isset($sar[3])) ? $sar[2] : '';
+                    $elem03 = $sar[3] ?? '';
                     //
                     if ($loopid == '2200B') {
                         $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -38,24 +38,59 @@ use OpenEMR\Billing\EdiHistory\Claim277Renderer;
  */
 function edih_277_transaction_html($obj277, $bht03, $accordion = false)
 {
-    // get the transaction segments
-    $trans = $obj277->edih_x12_transaction($bht03);
+    // segment dispatch maps, defined once up front so each case below is a
+    // declarative lookup rather than an inline match
+    // HL level code => [loopid, section accumulator, section heading]
+    $hlMap = [
+        '20' => ['2000A', 'src', 'Information Source'],
+        '21' => ['2000B', 'rcv', 'Information Receiver'],
+        '19' => ['2000C', 'prv', 'Provider'],
+        '22' => ['2000D', 'sbr_nm1', 'Subscriber'],
+        'PT' => ['2000D', 'sbr_nm1', 'Patient'],  // patient in 277CA
+        '23' => ['2000E', 'dep_nm1', 'Dependent'],
+    ];
+    // NM1/TRN loopid => [section accumulator, next loopid, whether to set the h3 label]
+    $nm1Map = [
+        '2000A' => ['src', '2100A', false],
+        '2000B' => ['rcv', '2100B', false],
+        '2000C' => ['prv', '2100C', false],
+        '2000D' => ['sbr_nm1', '2100D', true],
+        '2000E' => ['dep_nm1', '2100E', true],
+    ];
+    $trnMap = [
+        '2100B' => ['rcv', '2200B', false],
+        '2100C' => ['prv', '2200C', false],
+        '2100D' => ['sbr_stc', '2200D', true],
+        '2100E' => ['dep_stc', '2200E', true],
+    ];
+    // loopid => section accumulator, for the claim-status detail segments
+    $stcSection = ['2200B' => 'rcv', '2200C' => 'prv', '2200D' => 'sbr_stc', '2200E' => 'dep_stc'];
+    $refSection = ['2200B' => 'rcv', '2200C' => 'prv', '2200D' => 'sbr_stc', '2220D' => 'sbr_stc', '2200E' => 'dep_stc', '2220E' => 'dep_stc'];
+    $dtpSection = ['2200D' => 'sbr_stc', '2220D' => 'sbr_stc', '2200E' => 'dep_stc', '2220E' => 'dep_stc'];
+    $svcSection = ['2200B' => 'rcv', '2200D' => 'sbr_stc', '2220D' => 'sbr_stc', '2200E' => 'dep_stc', '2220E' => 'dep_stc'];
 
-    // get other necessary items: narrow the delimiters to non-empty strings at
-    // the source so the segment renderers receive honestly-typed values
+    // keep only the transaction rows that are arrays of segments
+    $transRaw = $obj277->edih_x12_transaction($bht03);
+    $trans = is_array($transRaw) ? array_filter($transRaw, is_array(...)) : [];
+
+    // narrow the x12 delimiters to strings at the source so the renderers
+    // receive honestly-typed values
     $delimiters = $obj277->edih_delimiters();
-    $de = is_array($delimiters) ? ($delimiters['e'] ?? '') : '';
-    $ds = is_array($delimiters) ? ($delimiters['s'] ?? '') : '';
-    $dr = is_array($delimiters) ? ($delimiters['r'] ?? '') : '';
+    $delimiters = is_array($delimiters) ? $delimiters : [];
+    $de = isset($delimiters['e']) && is_string($delimiters['e']) ? $delimiters['e'] : '';
+    $ds = isset($delimiters['s']) && is_string($delimiters['s']) ? $delimiters['s'] : '';
+    $dr = isset($delimiters['r']) && is_string($delimiters['r']) ? $delimiters['r'] : '';
     $fnRaw = $obj277->edih_filename();
     $fn = is_string($fnRaw) ? $fnRaw : '';
 
-    if (!is_array($trans) || !count($trans)) {
-        return "<p>Did not find transaction " . text($bht03) . " in " . attr($fn) . "</p>" . PHP_EOL;
+    $bht03Text = text($bht03);
+    $fnAttr = attr($fn);
+    if (count($trans) === 0) {
+        return "<p>Did not find transaction {$bht03Text} in {$fnAttr}</p>";
     }
-    if (!is_string($de) || $de === '' || !is_string($ds) || $ds === '') {
+    if ($de === '' || $ds === '') {
         csv_edihist_log("edih_277_transaction_html: invalid x12 delimiters $fn");
-        return "<p>Did not find transaction " . text($bht03) . " in " . attr($fn) . "</p>" . PHP_EOL;
+        return "<p>Did not find transaction {$bht03Text} in {$fnAttr}</p>";
     }
 
     $cd27x = new edih_271_codes($ds, $dr);
@@ -92,7 +127,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
     $qtystr = '';
 
     foreach ($trans as $transaction) {
-        $segments = is_array($transaction) ? array_filter($transaction, is_string(...)) : [];
+        $segments = array_filter($transaction, is_string(...));
         foreach ($segments as $seg) {
             // dispatch on the segment id: the token before the first element delimiter
             $sar = explode($de, $seg);
@@ -109,36 +144,20 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     break;
 
                 case 'HL':
-                    // HL level code => [loopid, section accumulator, section heading]
-                    $hl = match ($sar[3] ?? '') {
-                        '20' => ['2000A', 'src', 'Information Source'],
-                        '21' => ['2000B', 'rcv', 'Information Receiver'],
-                        '19' => ['2000C', 'prv', 'Provider'],
-                        '22' => ['2000D', 'sbr_nm1', 'Subscriber'],
-                        'PT' => ['2000D', 'sbr_nm1', 'Patient'],  // patient in 277CA
-                        '23' => ['2000E', 'dep_nm1', 'Dependent'],
-                        default => null,
-                    };
-                    if ($hl === null) {
-                        csv_edihist_log("edih_277_transaction_html: HL segment error $fn");
-                    } else {
+                    $hl = $hlMap[$sar[3] ?? ''] ?? null;
+                    if ($hl !== null) {
                         [$loopid, $section, $heading] = $hl;
                         $cls = Claim277Renderer::rowClass($loopid);
-                        $html[$section] .= "<tr class='$cls'><td colspan=4><b>$heading</b></td></tr>";
+                        $html[$section] .= "<tr class='{$cls}'><td colspan=4><b>{$heading}</b></td></tr>";
+                    } else {
+                        csv_edihist_log("edih_277_transaction_html: HL segment error $fn");
                     }
 
                     $qtystr = '';  // reset for QTY and AMT segments in 277CA
                     break;
 
                 case 'NM1':
-                    $nm1 = match ($loopid) {
-                        '2000A' => ['src', '2100A', false],
-                        '2000B' => ['rcv', '2100B', false],
-                        '2000C' => ['prv', '2100C', false],
-                        '2000D' => ['sbr_nm1', '2100D', true],
-                        '2000E' => ['dep_nm1', '2100E', true],
-                        default => null,
-                    };
+                    $nm1 = $nm1Map[$loopid] ?? null;
                     if ($nm1 !== null) {
                         [$section, $loopid, $setLabel] = $nm1;
                         $nm1Row = Claim277Renderer::nm1($sar, $cls, $cd27x);
@@ -150,7 +169,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     break;
 
                 case 'PER':
-                    if ($loopid == '2100A') {
+                    if ($loopid === '2100A') {
                         $html['src'] .= Claim277Renderer::per($sar, $cls, $cd27x);
                     } else {
                         csv_edihist_log('edih_277_html: PER segment not in 2100A loop ' . $fn);
@@ -158,13 +177,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     break;
 
                 case 'TRN':
-                    $trn = match ($loopid) {
-                        '2100B' => ['rcv', '2200B', false],
-                        '2100C' => ['prv', '2200C', false],
-                        '2100D' => ['sbr_stc', '2200D', true],
-                        '2100E' => ['dep_stc', '2200E', true],
-                        default => null,
-                    };
+                    $trn = $trnMap[$loopid] ?? null;
                     if ($trn !== null) {
                         [$section, $loopid, $appendLabel] = $trn;
                         $trnRow = Claim277Renderer::trn($sar, $cls);
@@ -176,13 +189,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     break;
 
                 case 'STC':
-                    $section = match ($loopid) {
-                        '2200B' => 'rcv',
-                        '2200C' => 'prv',
-                        '2200D' => 'sbr_stc',
-                        '2200E' => 'dep_stc',
-                        default => null,
-                    };
+                    $section = $stcSection[$loopid] ?? null;
                     if ($section !== null) {
                         $html[$section] .= Claim277Renderer::stc($sar, $ds, $cls, $cd27x);
                     }
@@ -195,13 +202,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     break;
 
                 case 'AMT':
-                    $section = match ($loopid) {
-                        '2200B' => 'rcv',
-                        '2200C' => 'prv',
-                        '2200D' => 'sbr_stc',
-                        '2200E' => 'dep_stc',
-                        default => null,
-                    };
+                    $section = $stcSection[$loopid] ?? null;
                     if ($section !== null) {
                         $html[$section] .= Claim277Renderer::amt($sar, $cls, $qtystr);
                     }
@@ -209,36 +210,21 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     break;
 
                 case 'REF':
-                    $section = match ($loopid) {
-                        '2200B' => 'rcv',
-                        '2200C' => 'prv',
-                        '2200D', '2220D' => 'sbr_stc',
-                        '2200E', '2220E' => 'dep_stc',
-                        default => null,
-                    };
+                    $section = $refSection[$loopid] ?? null;
                     if ($section !== null) {
                         $html[$section] .= Claim277Renderer::ref($sar, $cls, $cd27x);
                     }
                     break;
 
                 case 'DTP':
-                    $section = match ($loopid) {
-                        '2200D', '2220D' => 'sbr_stc',
-                        '2200E', '2220E' => 'dep_stc',
-                        default => null,
-                    };
+                    $section = $dtpSection[$loopid] ?? null;
                     if ($section !== null) {
                         $html[$section] .= Claim277Renderer::dtp($sar, $cls, $cd27x);
                     }
                     break;
 
                 case 'SVC':
-                    $section = match ($loopid) {
-                        '2200B' => 'rcv',
-                        '2200D', '2220D' => 'sbr_stc',
-                        '2200E', '2220E' => 'dep_stc',
-                        default => null,
-                    };
+                    $section = $svcSection[$loopid] ?? null;
                     if ($section !== null) {
                         $html[$section] .= Claim277Renderer::svc($sar, $ds, $cls, $section === 'rcv', $cd27x);
                     }
@@ -247,8 +233,10 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
         }
 
         if ($accordion) {
-            $str_html .= "<h3>" . text($bht . " " . $h3_lbl) . "</h3>";
-            $str_html .= "<div id='ac_" . attr($bht) . "'>";
+            $h3Text = text($bht . ' ' . $h3_lbl);
+            $bhtAttr = attr($bht);
+            $str_html .= "<h3>{$h3Text}</h3>";
+            $str_html .= "<div id='ac_{$bhtAttr}'>";
         }
 
         $str_html .= $hdr_html ?: "";
@@ -260,7 +248,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
         $str_html .= $html['dep_nm1'] ?: "";
         $str_html .= $html['dep_stc'] ?: "";
         $str_html .= "<tr><td colspan=4>&nbsp;</td></tr>";
-        $str_html .= "</tbody>" . "</table>";
+        $str_html .= "</tbody></table>";
 
         if ($accordion) {
             $str_html .= "</div>";

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * edih_277_html.php.php
  *
  * Copyright 2016 Kevin McCormick <kevin@kt61p>
@@ -19,13 +19,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  * MA 02110-1301, USA.
- *
- *
  */
-
-//
-// require_once("$srcdir/edihistory/codes/edih_271_code_class.php");
-//
 
 /**
  * Produce an html display of information in
@@ -50,19 +44,18 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
     $ds = $obj277->edih_delimiters()['s'];
     $dr = $obj277->edih_delimiters()['r'];
     $fn = $obj277->edih_filename();
-    //
+
     if (!is_array($trans) || !count($trans)) {
         $str_html = "<p>Did not find transaction " . text($bht03) . " in " . attr($fn) . "</p>" . PHP_EOL;
         return $str_html;
     }
 
-    //
     $cd27x = new edih_271_codes($ds, $dr);
-    //
+
     $h3_lbl = '';
     $str_html = "";
     $hdr_html = "";
-    //
+
     $bht03Attr = attr($bht03);
     $fnText = text($fn);
     $hdr_html = <<<HTML
@@ -73,7 +66,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
         </thead>
         <tbody>
         HTML;
-    //
+
     $html = [
         'src' => '',
         'rcv' => '',
@@ -89,11 +82,11 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
     $qtystr = '';
     $sc204 = '';
     $sc304 = '';
-    //
+
     foreach ($trans as $transaction) {
         $segments = is_array($transaction) ? array_filter($transaction, is_string(...)) : [];
         foreach ($segments as $seg) {
-            //
+
             $idtype = '';
             $name = '';
 
@@ -101,9 +94,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
             $rej_reason = '';
             $follow = '';
             $addr = '';
-            // debug
-            // echo "$i loop: $loopid Segment: $seg".PHP_EOL;
-            //
+
             // dispatch on the segment id: the token before the first element delimiter
             $sar = explode($de, $seg);
             $segid = $sar[0];
@@ -117,12 +108,12 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         default => "Not determined ({$sar[1]})",
                     };
 
-                //
+
                     $elem02 = ($sar[2] ?? false) !== false ? $cd27x->get_271_code('BHT02', $sar[2]) : "";
                     $elem03 = ($sar[3] ?? '') ?: "";
                     $elem04 = ($sar[4] ?? '') ? edih_format_date($sar[4]) : "";
                     $elem06 = ($sar[6] ?? '') ? $cd27x->get_271_code('BHT06', $sar[6]) : "";
-                //
+
                     $e01Text = text($elem01);
                     $e02Text = text($elem02);
                     $e03Text = text($elem03);
@@ -132,11 +123,11 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         <tr><td colspan=2><em>Date:</em> {$e04Text}</td><td colspan=2><em>Type:</em> {$e02Text}</td>
                         HTML;
                     $hdr_html .= ($elem06) ? "<tr><td>&gt;</td><td colspan=3><em>Type:</em> " . text($elem06) . "</td></tr>" : "";
-                //
+
                     $bht = $elem03;
                 break;
 
-            //
+
                 case 'HL':
                     $elem03 = $sar[3] ?? "";
                     // HL level code => [loopid, $cls, section accumulator, section heading]
@@ -156,54 +147,47 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         $html[$section] .= "<tr class='$cls'><td colspan=4><b>$heading</b></td></tr>" . PHP_EOL;
                     }
 
-                    //
+
                     $qtystr = '';  // reset for QTY and AMT segments in 277CA
                 break;
 
-            //
+
                 case 'NM1':
-                    //
+
                     $nm101 = $sar[1] ?? '';
                     $descr = ($nm101) ? $cd27x->get_271_code('NM101', $nm101) : "";
-                    //
+
                     $name = ($sar[3] ?? '') ?: "";
                     $name .= ($sar[7] ?? '') ? " {$sar[7]}" : "";
                     $name .= ($sar[4] ?? '') ? ", {$sar[4]}" : "";
                     $name .= ($sar[5] ?? '') ? " {$sar[5]}" : "";
                     $nm109 = ($sar[9] ?? '') ?: "";
-                    //
+
                     $nm108 = ($sar[8] ?? '') ? $cd27x->get_271_code('NM108', $sar[8]) : "";
-                    //
-                    if ($loopid == '2000A') {
-                        $html['src'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                        $html['src'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
-                        $loopid = '2100A';
-                    } elseif ($loopid == '2000B') {
-                        $html['rcv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                        $html['rcv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
-                        $loopid = '2100B';
-                    } elseif ($loopid == '2000C') {
-                        $html['prv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                        $html['prv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
-                        $loopid = '2100C';
-                    } elseif ($loopid == '2000D') {
-                        $html['sbr_nm1'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                        $html['sbr_nm1'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
-                        $h3_lbl = $name;
-                        $loopid = '2100D';
-                    } elseif ($loopid == '2000E') {
-                        $html['dep_nm1'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                        $html['dep_nm1'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
-                        $h3_lbl = $name;
-                        $loopid = '2100E';
+
+                    $nm1 = match ($loopid) {
+                        '2000A' => ['src', '2100A', false],
+                        '2000B' => ['rcv', '2100B', false],
+                        '2000C' => ['prv', '2100C', false],
+                        '2000D' => ['sbr_nm1', '2100D', true],
+                        '2000E' => ['dep_nm1', '2100E', true],
+                        default => null,
+                    };
+                    if ($nm1 !== null) {
+                        [$section, $loopid, $setLabel] = $nm1;
+                        $html[$section] .= "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
+                        $html[$section] .= "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
+                        if ($setLabel) {
+                            $h3_lbl = $name;
+                        }
                     }
 
-                    //
+
                 break;
 
-            //                              //
+
                 case 'PER':
-                    //
+
                     $elem01 = $sar[1] ?? '';
                     $elem02 = $sar[2] ?? '';
                     $elem03 = (isset($sar[3])) ? $cd27x->get_271_code('PER03', $sar[3]) : "";
@@ -213,44 +197,43 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     $elem07 = (isset($sar[7])) ? $cd27x->get_271_code('PER03', $sar[7]) : "";
                     $elem08 = $sar[8] ?? '';
                     $elem09 = $sar[9] ?? '';
-                    //
+
                     if ($loopid == '2100A') {
-                        $html['src'] .= "<tr class='" . attr($cls) . "'><td colspan=2>" . text($elem02) . "</td><td colspan=2 title='" . attr($elem03 . " " . $elem05 . " " . $elem07) . "'>" . text($elem04 . " " . $elem06 . " " . $elem08) . "</td></tr>" . PHP_EOL;
+                        $html['src'] .= "<tr class='" . $cls . "'><td colspan=2>" . text($elem02) . "</td><td colspan=2 title='" . attr($elem03 . " " . $elem05 . " " . $elem07) . "'>" . text($elem04 . " " . $elem06 . " " . $elem08) . "</td></tr>" . PHP_EOL;
                     } else {
                         csv_edihist_log('edih_277_html: PER segment not in 2100A loop ' . $fn);
                     }
 
-                    //
+
                 break;
 
-            //
+
                 case 'TRN':
-                    //
+
                     $elem01 = ($sar[1] ?? '') == "1" ? "Transaction Ref" : "Trace";
                     $elem02 = $sar[2] ?? '';
                     $elem03 = $sar[3] ?? '';
                     $elem04 = $sar[4] ?? '';
-                    //
-                    if ($loopid == '2100B') {
-                        $html['rcv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
-                        $loopid = '2200B';
-                    } elseif ($loopid == '2100C') {
-                        $html['prv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
-                        $loopid = '2200C';
-                    } elseif ($loopid == '2100D') {
-                        $html['sbr_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
-                        $h3_lbl = ($h3_lbl) ? $h3_lbl . ' ' . $elem02 : $h3_lbl;
-                        $loopid = '2200D';
-                    } elseif ($loopid == '2100E') {
-                        $html['dep_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
-                        $h3_lbl = ($h3_lbl) ? $h3_lbl . ' ' . $elem02 : $h3_lbl;
-                        $loopid = '2200E';
+
+                    $trn = match ($loopid) {
+                        '2100B' => ['rcv', '2200B', false],
+                        '2100C' => ['prv', '2200C', false],
+                        '2100D' => ['sbr_stc', '2200D', true],
+                        '2100E' => ['dep_stc', '2200E', true],
+                        default => null,
+                    };
+                    if ($trn !== null) {
+                        [$section, $loopid, $appendLabel] = $trn;
+                        $html[$section] .= "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
+                        if ($appendLabel) {
+                            $h3_lbl = ($h3_lbl) ? $h3_lbl . ' ' . $elem02 : $h3_lbl;
+                        }
                     }
 
-                    //
+
                 break;
 
-            //
+
                 case 'STC':
                     // reset composite-derived status codes so a prior STC's codes do
                     // not leak into a segment that omits its own STC01/STC10/STC11
@@ -285,7 +268,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                 //$stc07  not used
                     $stc08 = ($sar[8] ?? '') ? edih_format_date($sar[8]) : "";   // check issue date
                     $stc09 = ($sar[9] ?? '') ?: "";                        // check or eft number
-                //
+
                     $stc10 = "";
                     if ($sar[10] ?? false) {     // claim status category : claim status : entity identifier
                         if (strpos($sar[10], (string) $ds)) {
@@ -299,7 +282,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         }
                     }
 
-                //
+
                     $stc11 = "";
                     if ($sar[11] ?? false) {     // claim status category : claim status : entity identifier
                         if (strpos($sar[11], (string) $ds)) {
@@ -313,32 +296,33 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         }
                     }
 
-                //
+
                     $stc12 = ($sar[12] ?? '') ?: "";    // message
-                //
-                    $stc_html = (isset($sc101)) ? "<tr class='" . attr($cls) . "'><td>" . text($stc03) . "</td><td colspan=2>" . text($sc101) . "</td><td>" . text($stc02 . " " . $stc04) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= (isset($sc102)) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc102) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= ($sc103 ?? '') ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc103) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= ($stc05 || $stc06 || $stc08 || $stc09) ? "<tr class='" . attr($cls) . "'><td><em>Payment</em></td><td colspan=3>" . text($stc05 . " " . $stc06 . " " . $stc08 . " " . $stc09) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= (isset($sc201)) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc201 . " " . $sc204) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= (isset($sc202)) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc202) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= ($sc203 ?? '') ?    "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc203) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= (isset($sc301)) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc301 . " " . $sc304) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= (isset($sc302)) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc302) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= ($sc303 ?? '') ?    "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc303) . "</td></tr>" . PHP_EOL : "";
-                    $stc_html .= ($stc12) ? "<tr class='" . attr($cls) . "'><td><em>Message</em></td><td colspan=3>" . text($stc12) . "</td></tr>" . PHP_EOL : "";
-                //
-                    if ($loopid == '2200B') {
-                        $html['rcv'] .= $stc_html;
-                    } elseif ($loopid == '2200C') {
-                        $html['prv'] .= $stc_html;
-                    } elseif ($loopid == '2200D') {
-                        $html['sbr_stc'] .= $stc_html;
-                    } elseif ($loopid == '2200E') {
-                        $html['dep_stc'] .= $stc_html;
+
+                    $stc_html = (isset($sc101)) ? "<tr class='" . $cls . "'><td>" . text($stc03) . "</td><td colspan=2>" . text($sc101) . "</td><td>" . text($stc02 . " " . $stc04) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= (isset($sc102)) ? "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($sc102) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= ($sc103 ?? '') ? "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc103) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= ($stc05 || $stc06 || $stc08 || $stc09) ? "<tr class='" . $cls . "'><td><em>Payment</em></td><td colspan=3>" . text($stc05 . " " . $stc06 . " " . $stc08 . " " . $stc09) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= (isset($sc201)) ?  "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($sc201 . " " . $sc204) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= (isset($sc202)) ?  "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($sc202) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= ($sc203 ?? '') ?    "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc203) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= (isset($sc301)) ?  "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($sc301 . " " . $sc304) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= (isset($sc302)) ?  "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($sc302) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= ($sc303 ?? '') ?    "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc303) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= ($stc12) ? "<tr class='" . $cls . "'><td><em>Message</em></td><td colspan=3>" . text($stc12) . "</td></tr>" . PHP_EOL : "";
+
+                    $section = match ($loopid) {
+                        '2200B' => 'rcv',
+                        '2200C' => 'prv',
+                        '2200D' => 'sbr_stc',
+                        '2200E' => 'dep_stc',
+                        default => null,
+                    };
+                    if ($section !== null) {
+                        $html[$section] .= $stc_html;
                     }
 
-                //
+
                 break;
 
             // in 277CA, expect QTY followed by AMT
@@ -356,56 +340,58 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                     $qtystr .= ($sar[2] ?? '') ?: "";
                 break;
 
-            //
+
                 case 'AMT':
                     // 277CA
                     $amtstr = ($sar[1] ?? '') == 'YU' ? "Amt " : "Amt Rej ";
                     $amtstr .= ($sar[2] ?? '') ? edih_format_money($sar[2]) : "";
-                    //
-                    if ($loopid == '2200B') {
-                        $html['rcv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
-                    } elseif ($loopid == '2200C') {
-                        $html['prv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
-                    } elseif ($loopid == '2200D') {
-                        $html['sbr_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
-                    } elseif ($loopid == '2200E') {
-                        $html['dep_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
+
+                    $section = match ($loopid) {
+                        '2200B' => 'rcv',
+                        '2200C' => 'prv',
+                        '2200D' => 'sbr_stc',
+                        '2200E' => 'dep_stc',
+                        default => null,
+                    };
+                    if ($section !== null) {
+                        $html[$section] .= "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
                     }
 
                     $amtstr = '';
                     $qtystr = '';
-                    //
+
                 break;
 
-            //
+
                 case 'REF':
-                    //
+
                     $elem01 = (isset($sar[1])) ? $cd27x->get_271_code('REF', $sar[1]) : '';
                     $elem02 = $sar[2] ?? '';
                     $elem03 = $sar[3] ?? '';
-                    //
-                    if ($loopid == '2200B') {
-                        $html['rcv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
-                    } elseif ($loopid == '2200C') {
-                        $html['prv'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
-                    } elseif ($loopid == '2200D' || $loopid == '2220D') {
-                        $html['sbr_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
-                    } elseif ($loopid == '2200E' || $loopid == '2220E') {
-                        $html['dep_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
+
+                    $section = match ($loopid) {
+                        '2200B' => 'rcv',
+                        '2200C' => 'prv',
+                        '2200D', '2220D' => 'sbr_stc',
+                        '2200E', '2220E' => 'dep_stc',
+                        default => null,
+                    };
+                    if ($section !== null) {
+                        $html[$section] .= "<tr class='" . $cls . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
                     }
 
-                    //
+
                 break;
 
-            //
+
                 case 'DTP':
-                    //
+
                     $var = '';
-                    //
+
                     $elem01 = ($sar[1] ?? '') ? $cd27x->get_271_code('DTP', $sar[1]) : "";
                     $elem02 = $sar[2] ?? '';
                     $elem03 = $sar[3] ?? '';
-                    //
+
                     $idtype = ($elem01) ? $cd27x->get_271_code('DTP', $elem01) : "";
                     if ($elem02 == 'D8' && $elem03) {
                         $var = edih_format_date($elem03);
@@ -414,19 +400,22 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         $var .= ' - ' . edih_format_date(substr($elem03, -8));
                     }
 
-                    //
-                    if ($loopid == '2200D' || $loopid == '2220D') {
-                        $html['sbr_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>" . PHP_EOL;
-                    } elseif ($loopid == '2200E' || $loopid == '2220E') {
-                        $html['dep_stc'] .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>" . PHP_EOL;
+
+                    $section = match ($loopid) {
+                        '2200D', '2220D' => 'sbr_stc',
+                        '2200E', '2220E' => 'dep_stc',
+                        default => null,
+                    };
+                    if ($section !== null) {
+                        $html[$section] .= "<tr class='" . $cls . "'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>" . PHP_EOL;
                     }
 
-                    //
+
                 break;
 
-            //
+
                 case 'SVC':
-                    //
+
                     $elem01 = '';                           // composite procedure code source:code:modifier:modifier
                     if ($sar[1] ?? false) {
                         // construct a code source code modifier string
@@ -445,33 +434,35 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         }
                     }
 
-                    //
+
                     $elem02 = ($sar[2] ?? '') ? edih_format_money($sar[2]) : "";  // billed amount
                     $elem03 = ($sar[3] ?? '') ? edih_format_money($sar[3]) : "";  // paid amount
                     $elem04 = ($sar[4] ?? '') ?: "";                   // revenue code
                     $elem05 = ($sar[5] ?? '') ?: "";                   // quantity
                     // $elem06 not used
                     $elem07 = ($sar[7] ?? '') ?: "";                   // original unis of service
-                    //
-                    if ($loopid == '2200B') {
-                        $html['rcv'] .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td>" . text($elem02) . "</td><td>" . text($elem04) . "</td></tr>" . PHP_EOL;
-                        $html['rcv'] .= ($elem03 || $elem04) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
-                    } elseif ($loopid == '2200D' || $loopid == '2220D') {
-                        $html['sbr_stc'] .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>" . PHP_EOL;
-                        $html['sbr_stc'] .= ($elem03 || $elem04) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
-                    } elseif ($loopid == '2200E' || $loopid == '2220E') {
-                        $html['dep_stc'] .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>" . PHP_EOL;
-                        $html['dep_stc'] .= ($elem03 || $elem04) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
+
+                    $section = match ($loopid) {
+                        '2200B' => 'rcv',
+                        '2200D', '2220D' => 'sbr_stc',
+                        '2200E', '2220E' => 'dep_stc',
+                        default => null,
+                    };
+                    if ($section !== null) {
+                        $html[$section] .= ($section === 'rcv')
+                            ? "<tr class='" . $cls . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td>" . text($elem02) . "</td><td>" . text($elem04) . "</td></tr>" . PHP_EOL
+                            : "<tr class='" . $cls . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>" . PHP_EOL;
+                        $html[$section] .= ($elem03 || $elem04) ? "<tr class='" . $cls . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
                     }
 
-                    //
+
                 break;
             }
 
-            //
+
         }
 
-        //
+
         if ($accordion) {
             $str_html .= "<h3>" . text($bht . " " . $h3_lbl) . "</h3>" . PHP_EOL;
             $str_html .= "<div id='ac_" . attr($bht) . "'>" . PHP_EOL;
@@ -487,7 +478,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
         $str_html .= $html['dep_stc'] ?: "";
         $str_html .= "<tr><td colspan=4>&nbsp;</td></tr>" . PHP_EOL;
         $str_html .= "</tbody>" . PHP_EOL . "</table>" . PHP_EOL;
-        //
+
         if ($accordion) {
             $str_html .= "</div>" . PHP_EOL;
         }
@@ -511,7 +502,7 @@ function edih_277_html($filename, $bht03 = '')
 {
     // create a display for an individual 277 response
     $html_str = '';
-    //
+
     if ($filename) {
         $fn = $filename;
     } else {
@@ -548,14 +539,14 @@ function edih_277_html($filename, $bht03 = '')
                         }
                     }
 
-                    //
+
                     // get each transaction
                     foreach ($st['bht03'] as $bht) {
                         //$html_str .= "<h3>$bht Claim Status <em>Date</em> $gs_date <em>Source</em> $gs_sender</h3>".PHP_EOL;
                         //$html_str .= "<div id='ac_$bht'>".PHP_EOL;
-                        //
+
                         $html_str .= edih_277_transaction_html($obj277, $bht, true);
-                        //
+
                         //$html_str .= "</div>".PHP_EOL;
                     }
                 }
@@ -571,6 +562,5 @@ function edih_277_html($filename, $bht03 = '')
         return $html_str;
     }
 
-    //
     return $html_str;
 }

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -83,9 +83,9 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
     $sc204 = '';
     $sc304 = '';
     //
-    $trns_ct = count($trans);
-    for ($i = 0; $i < $trns_ct; $i++) {
-        foreach ($trans[$i] as $seg) {
+    foreach ($trans as $transaction) {
+        $segments = is_array($transaction) ? array_filter($transaction, is_string(...)) : [];
+        foreach ($segments as $seg) {
             //
             $idtype = '';
             $name = '';
@@ -97,412 +97,376 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
             // debug
             // echo "$i loop: $loopid Segment: $seg".PHP_EOL;
             //
-            if (strncmp('BHT' . $de, (string) $seg, 4) === 0) {
-                $loopid = 'Heading';
-                $sar = explode($de, (string) $seg);
-                if (isset($sar[1])) {
-                    if ($sar[1] == '0010') {
-                        $elem01 = "Src, Rcv, Prv, Sbr, Dep";
-                    } elseif ($sar[1] == '0085') {
-                        $elem01 = "Src, Rcv, Prv, Pt";
+            // dispatch on the segment id: the token before the first element delimiter
+            $sar = explode($de, $seg);
+            $segid = $sar[0];
+            switch ($segid) {
+                case 'BHT':
+                    $loopid = 'Heading';
+                    $elem01 = match ($sar[1] ?? null) {
+                        '0010' => 'Src, Rcv, Prv, Sbr, Dep',
+                        '0085' => 'Src, Rcv, Prv, Pt',
+                        null => '',
+                        default => "Not determined ({$sar[1]})",
+                    };
+
+                //
+                    $elem02 = ($sar[2] ?? false) !== false ? $cd27x->get_271_code('BHT02', $sar[2]) : "";
+                    $elem03 = ($sar[3] ?? '') ?: "";
+                    $elem04 = ($sar[4] ?? '') ? edih_format_date($sar[4]) : "";
+                    $elem06 = ($sar[6] ?? '') ? $cd27x->get_271_code('BHT06', $sar[6]) : "";
+                //
+                    $hdr_html .= "<tr><td colspan=2><em>Reference:</em> " . text($elem03) . "</td><td colspan=2><em>Sequence:</em> " . text($elem01) . "</td></tr>" . PHP_EOL;
+                    $hdr_html .= "<tr><td colspan=2><em>Date:</em> " . text($elem04) . "</td><td colspan=2><em>Type:</em> " . text($elem02) . "</td>" . PHP_EOL;
+                    $hdr_html .= ($elem06) ? "<tr><td>&gt;</td><td colspan=3><em>Type:</em> " . text($elem06) . "</td></tr>" . PHP_EOL : "";
+                //
+                    $bht = $elem03;
+                break;
+
+            //
+                case 'HL':
+                    $elem03 = $sar[3] ?? "";
+                    if ($elem03 == '20') {                     // level code
+                        $loopid = '2000A';                      // info source (payer)
+                        $cls = "src";
+                        $src_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Information Source</b></td></tr>" . PHP_EOL;
+                    } elseif ($elem03 == '21') {
+                        $loopid = '2000B';                      // info receiver (clinic)
+                        $cls = "rcv";
+                        $rcv_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Information Receiver</b></td></tr>" . PHP_EOL;
+                    } elseif ($elem03 == '19') {
+                        $loopid = '2000C';                      // provider
+                        $cls = "prv";
+                        $has_eb = false;
+                        $prv_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Provider</b></td></tr>" . PHP_EOL;
+                    } elseif ($elem03 == '22') {
+                        $loopid = '2000D';                      // subscriber
+                        $cls = "sbr";
+                        $sbr_nm1_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Subscriber</b></td></tr>" . PHP_EOL;
+                    } elseif ($elem03 == 'PT') {
+                        $loopid = '2000D';                      // patient in 277CA
+                        $cls = "sbr";
+                        $sbr_nm1_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Patient</b></td></tr>" . PHP_EOL;
+                    } elseif ($elem03 == '23') {
+                        $loopid = '2000E';                      // dependent
+                        $cls = "dep";
+                        $dep_nm1_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Dependent</b></td></tr>" . PHP_EOL;
                     } else {
-                        $elem01 = "Not determined ({$sar[1]})";
+                        csv_edihist_log("edih_277_transaction_html: HL segment error $fn");
                     }
-                } else {
-                    $elem01 = '';
-                }
 
-                //
-                $elem02 = ( isset($sar[2]) && $sar[2] !== false) ? $cd27x->get_271_code('BHT02', $sar[2]) : "";
-                $elem03 = ( isset($sar[3]) && $sar[3]) ? $sar[3] : "";
-                $elem04 = ( isset($sar[4]) && $sar[4]) ? edih_format_date($sar[4]) : "";
-                $elem06 = ( isset($sar[6]) && $sar[6]) ? $cd27x->get_271_code('BHT06', $sar[6]) : "";
-                //
-                $hdr_html .= "<tr><td colspan=2><em>Reference:</em> " . text($elem03) . "</td><td colspan=2><em>Sequence:</em> " . text($elem01) . "</td></tr>" . PHP_EOL;
-                $hdr_html .= "<tr><td colspan=2><em>Date:</em> " . text($elem04) . "</td><td colspan=2><em>Type:</em> " . text($elem02) . "</td>" . PHP_EOL;
-                $hdr_html .= ($elem06) ? "<tr><td>&gt;</td><td colspan=3><em>Type:</em> " . text($elem06) . "</td></tr>" . PHP_EOL : "";
-                //
-                $bht = $elem03;
-                continue;
-            }
+                    //
+                    $qtystr = '';  // reset for QTY and AMT segments in 277CA
+                break;
 
             //
-            if (strncmp('HL' . $de, (string) $seg, 3) === 0) {
-                $sar = explode($de, (string) $seg);
-                $elem03 = $sar[3] ?? "";
-                if ($elem03 == '20') {                     // level code
-                    $loopid = '2000A';                      // info source (payer)
-                    $cls = "src";
-                    $src_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Information Source</b></td></tr>" . PHP_EOL;
-                } elseif ($elem03 == '21') {
-                    $loopid = '2000B';                      // info receiver (clinic)
-                    $cls = "rcv";
-                    $rcv_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Information Receiver</b></td></tr>" . PHP_EOL;
-                } elseif ($elem03 == '19') {
-                    $loopid = '2000C';                      // provider
-                    $cls = "prv";
-                    $has_eb = false;
-                    $prv_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Provider</b></td></tr>" . PHP_EOL;
-                } elseif ($elem03 == '22') {
-                    $loopid = '2000D';                      // subscriber
-                    $cls = "sbr";
-                    $sbr_nm1_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Subscriber</b></td></tr>" . PHP_EOL;
-                } elseif ($elem03 == 'PT') {
-                    $loopid = '2000D';                      // patient in 277CA
-                    $cls = "sbr";
-                    $sbr_nm1_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Patient</b></td></tr>" . PHP_EOL;
-                } elseif ($elem03 == '23') {
-                    $loopid = '2000E';                      // dependent
-                    $cls = "dep";
-                    $dep_nm1_html .= "<tr class='" . attr($cls) . "'><td colspan=4><b>Dependent</b></td></tr>" . PHP_EOL;
-                } else {
-                    csv_edihist_log("edih_277_transaction_html: HL segment error $fn");
-                }
+                case 'NM1':
+                    //
+                    $nm101 = $sar[1] ?? '';
+                    $descr = ($nm101) ? $cd27x->get_271_code('NM101', $nm101) : "";
+                    //
+                    $name = ($sar[3] ?? '') ?: "";
+                    $name .= ($sar[7] ?? '') ? " {$sar[7]}" : "";
+                    $name .= ($sar[4] ?? '') ? ", {$sar[4]}" : "";
+                    $name .= ($sar[5] ?? '') ? " {$sar[5]}" : "";
+                    $nm109 = ($sar[9] ?? '') ?: "";
+                    //
+                    $nm108 = ($sar[8] ?? '') ? $cd27x->get_271_code('NM108', $sar[8]) : "";
+                    //
+                    if ($loopid == '2000A') {
+                        $src_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
+                        $src_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
+                        $loopid = '2100A';
+                    } elseif ($loopid == '2000B') {
+                        $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
+                        $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
+                        $loopid = '2100B';
+                    } elseif ($loopid == '2000C') {
+                        $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
+                        $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
+                        $loopid = '2100C';
+                    } elseif ($loopid == '2000D') {
+                        $sbr_nm1_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
+                        $sbr_nm1_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
+                        $h3_lbl = $name;
+                        $loopid = '2100D';
+                    } elseif ($loopid == '2000E') {
+                        $dep_nm1_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
+                        $dep_nm1_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
+                        $h3_lbl = $name;
+                        $loopid = '2100E';
+                    }
 
-                //
-                $qtystr = '';  // reset for QTY and AMT segments in 277CA
-                continue;
-            }
-
-            //
-            if (strncmp('NM1' . $de, (string) $seg, 4) === 0) {
-                $sar = explode($de, (string) $seg);
-                //
-                $nm101 = $sar[1] ?? '';
-                $descr = ($nm101) ? $cd27x->get_271_code('NM101', $nm101) : "";
-                //
-                $name = (isset($sar[3]) && $sar[3] ) ? $sar[3] : "";
-                $name .= (isset($sar[7]) && $sar[7]) ? " {$sar[7]}" : "";
-                $name .= (isset($sar[4]) && $sar[4]) ? ", {$sar[4]}" : "";
-                $name .= (isset($sar[5]) &&  $sar[5]) ? " {$sar[5]}" : "";
-                $nm109 = (isset($sar[9]) &&  $sar[9]) ? $sar[9] : "";
-                //
-                $nm108 = (isset($sar[8]) && $sar[8] ) ? $cd27x->get_271_code('NM108', $sar[8]) : "";
-                //
-                if ($loopid == '2000A') {
-                    $src_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                    $src_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
-                    $loopid = '2100A';
-                } elseif ($loopid == '2000B') {
-                    $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                    $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
-                    $loopid = '2100B';
-                } elseif ($loopid == '2000C') {
-                    $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                    $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
-                    $loopid = '2100C';
-                } elseif ($loopid == '2000D') {
-                    $sbr_nm1_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                    $sbr_nm1_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
-                    $h3_lbl = $name;
-                    $loopid = '2100D';
-                } elseif ($loopid == '2000E') {
-                    $dep_nm1_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'>" . text($name) . "</td></tr>" . PHP_EOL;
-                    $dep_nm1_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3 title='" . attr($descr) . "'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>" . PHP_EOL;
-                    $h3_lbl = $name;
-                    $loopid = '2100E';
-                }
-
-                //
-                continue;
-            }
+                    //
+                break;
 
             //                              //
-            if (strncmp('PER' . $de, (string) $seg, 4) === 0) {
-                $sar = explode($de, (string) $seg);
-                //
-                $elem01 = $sar[1] ?? '';
-                $elem02 = $sar[2] ?? '';
-                $elem03 = (isset($sar[3])) ? $cd27x->get_271_code('PER03', $sar[3]) : "";
-                $elem04 = $sar[4] ?? '';
-                $elem05 = (isset($sar[5])) ? $cd27x->get_271_code('PER03', $sar[5]) : "";
-                $elem06 = $sar[6] ?? '';
-                $elem07 = (isset($sar[7])) ? $cd27x->get_271_code('PER03', $sar[7]) : "";
-                $elem08 = $sar[8] ?? '';
-                $elem09 = $sar[9] ?? '';
-                //
-                if ($loopid == '2100A') {
-                    $src_html .= "<tr class='" . attr($cls) . "'><td colspan=2>" . text($elem02) . "</td><td colspan=2 title='" . attr($elem03 . " " . $elem05 . " " . $elem07) . "'>" . text($elem04 . " " . $elem06 . " " . $elem08) . "</td></tr>" . PHP_EOL;
-                } else {
-                    csv_edihist_log('edih_277_html: PER segment not in 2100A loop ' . $fn);
-                }
-
-                //
-                continue;
-            }
-
-            //
-            if (strncmp('TRN' . $de, (string) $seg, 4) === 0) {
-                $sar = explode($de, (string) $seg);
-                //
-                $elem01 = ( isset($sar[1]) && $sar[1] == "1" ) ? "Transaction Ref" : "Trace";
-                $elem02 = $sar[2] ?? '';
-                $elem03 = $sar[3] ?? '';
-                $elem04 = $sar[4] ?? '';
-                //
-                if ($loopid == '2100B') {
-                    $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
-                    $loopid = '2200B';
-                } elseif ($loopid == '2100C') {
-                    $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
-                    $loopid = '2200C';
-                } elseif ($loopid == '2100D') {
-                    $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
-                    $h3_lbl = ($h3_lbl) ? $h3_lbl . ' ' . $elem02 : $h3_lbl;
-                    $loopid = '2200D';
-                } elseif ($loopid == '2100E') {
-                    $dep_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
-                    $h3_lbl = ($h3_lbl) ? $h3_lbl . ' ' . $elem02 : $h3_lbl;
-                    $loopid = '2200E';
-                }
-
-                //
-                continue;
-            }
-
-            //
-            if (strncmp('STC' . $de, (string) $seg, 4) === 0) {
-                $sar = explode($de, (string) $seg);
-                // reset composite-derived status codes so a prior STC's codes do
-                // not leak into a segment that omits its own STC01/STC10/STC11
-                // composite elements (the rows below are gated on isset()/truthiness)
-                $sc101 = $sc102 = $sc103 = null;
-                $sc201 = $sc202 = $sc203 = null;
-                $sc301 = $sc302 = $sc303 = null;
-                $sc204 = $sc304 = "";
-                //
-                if (isset($sar[1])) {
-                    if (strpos($sar[1], (string) $ds)) {       // claim status category : claim status : entity identifier
-                        $scda = explode($ds, $sar[1]);
-                        $sc101 = ( isset($scda[0]) && $scda[0]) ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
-                        $sc102 = ( isset($scda[1]) && $scda[1]) ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
-                        $sc103 = ( isset($scda[2]) && $scda[2]) ? $cd27x->get_271_code('NM101', $scda[2]) : "";
-                    }
-                } else {
-                    $stc01 = $sar[1];
-                }
-
-                $stc02 = (isset($sar[2]) && $sar[2]) ? edih_format_date($sar[2]) : "";  // status information date
-                $stc03 = "";                                                                // action code
-                if (isset($sar[3])) {
-                    if ($sar[3] == 'WQ') {
-                        $stc03 = "Accepted";
-                    } elseif ($sar[3] == 'F') {
-                        $stc03 = "Final";
-                    } elseif ($sar[3] == '15') {
-                        $stc03 = "Correct/Resubmit";
-                    } elseif ($sar[3] == 'U') {
-                        $stc03 = "Rejected";
+                case 'PER':
+                    //
+                    $elem01 = $sar[1] ?? '';
+                    $elem02 = $sar[2] ?? '';
+                    $elem03 = (isset($sar[3])) ? $cd27x->get_271_code('PER03', $sar[3]) : "";
+                    $elem04 = $sar[4] ?? '';
+                    $elem05 = (isset($sar[5])) ? $cd27x->get_271_code('PER03', $sar[5]) : "";
+                    $elem06 = $sar[6] ?? '';
+                    $elem07 = (isset($sar[7])) ? $cd27x->get_271_code('PER03', $sar[7]) : "";
+                    $elem08 = $sar[8] ?? '';
+                    $elem09 = $sar[9] ?? '';
+                    //
+                    if ($loopid == '2100A') {
+                        $src_html .= "<tr class='" . attr($cls) . "'><td colspan=2>" . text($elem02) . "</td><td colspan=2 title='" . attr($elem03 . " " . $elem05 . " " . $elem07) . "'>" . text($elem04 . " " . $elem06 . " " . $elem08) . "</td></tr>" . PHP_EOL;
                     } else {
-                        $stc03 = $sar[3];
+                        csv_edihist_log('edih_277_html: PER segment not in 2100A loop ' . $fn);
                     }
-                }
 
-                $stc04 = (isset($sar[4]) && $sar[4]) ? edih_format_money($sar[4]) : "";  // billed amount
-                $stc05 = (isset($sar[5]) && $sar[5]) ? edih_format_money($sar[5]) : "";  // paid amount
-                $stc06 = (isset($sar[6]) && $sar[6]) ? edih_format_date($sar[6]) : "";   // payment date
+                    //
+                break;
+
+            //
+                case 'TRN':
+                    //
+                    $elem01 = ($sar[1] ?? '') == "1" ? "Transaction Ref" : "Trace";
+                    $elem02 = $sar[2] ?? '';
+                    $elem03 = $sar[3] ?? '';
+                    $elem04 = $sar[4] ?? '';
+                    //
+                    if ($loopid == '2100B') {
+                        $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
+                        $loopid = '2200B';
+                    } elseif ($loopid == '2100C') {
+                        $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
+                        $loopid = '2200C';
+                    } elseif ($loopid == '2100D') {
+                        $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
+                        $h3_lbl = ($h3_lbl) ? $h3_lbl . ' ' . $elem02 : $h3_lbl;
+                        $loopid = '2200D';
+                    } elseif ($loopid == '2100E') {
+                        $dep_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>" . PHP_EOL;
+                        $h3_lbl = ($h3_lbl) ? $h3_lbl . ' ' . $elem02 : $h3_lbl;
+                        $loopid = '2200E';
+                    }
+
+                    //
+                break;
+
+            //
+                case 'STC':
+                    // reset composite-derived status codes so a prior STC's codes do
+                    // not leak into a segment that omits its own STC01/STC10/STC11
+                    // composite elements (the rows below are gated on isset()/truthiness)
+                    $sc101 = $sc102 = $sc103 = null;
+                    $sc201 = $sc202 = $sc203 = null;
+                    $sc301 = $sc302 = $sc303 = null;
+                    $sc204 = $sc304 = "";
+                    //
+                    if (isset($sar[1])) {
+                        if (strpos($sar[1], (string) $ds)) {       // claim status category : claim status : entity identifier
+                            $scda = explode($ds, $sar[1]);
+                            $sc101 = $scda[0] ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
+                            $sc102 = ($scda[1] ?? '') ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
+                            $sc103 = ($scda[2] ?? '') ? $cd27x->get_271_code('NM101', $scda[2]) : "";
+                        }
+                    } else {
+                        $stc01 = $sar[1];
+                    }
+
+                    $stc02 = ($sar[2] ?? '') ? edih_format_date($sar[2]) : "";  // status information date
+                    $stc03 = match ($sar[3] ?? null) {                                           // action code
+                        'WQ' => 'Accepted',
+                        'F' => 'Final',
+                        '15' => 'Correct/Resubmit',
+                        'U' => 'Rejected',
+                        null => '',
+                        default => $sar[3],
+                    };
+
+                    $stc04 = ($sar[4] ?? '') ? edih_format_money($sar[4]) : "";  // billed amount
+                    $stc05 = ($sar[5] ?? '') ? edih_format_money($sar[5]) : "";  // paid amount
+                    $stc06 = ($sar[6] ?? '') ? edih_format_date($sar[6]) : "";   // payment date
                 //$stc07  not used
-                $stc08 = (isset($sar[8]) && $sar[8]) ? edih_format_date($sar[8]) : "";   // check issue date
-                $stc09 = (isset($sar[9]) && $sar[9]) ? $sar[9] : "";                        // check or eft number
+                    $stc08 = ($sar[8] ?? '') ? edih_format_date($sar[8]) : "";   // check issue date
+                    $stc09 = ($sar[9] ?? '') ?: "";                        // check or eft number
                 //
-                $stc10 = "";
-                if (isset($sar[10]) && $sar[10]) {     // claim status category : claim status : entity identifier
-                    if (strpos($sar[10], (string) $ds)) {
-                        $scda = explode($ds, $sar[10]);
-                        $sc201 = ( isset($scda[0]) && $scda[0]) ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
-                        $sc202 = ( isset($scda[1]) && $scda[1]) ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
-                        $sc203 = ( isset($scda[2]) && $scda[2]) ? $cd27x->get_271_code('NM101', $scda[2]) : "";
-                        $sc204 = ( isset($scda[3]) && $scda[3] === 'RA') ? "Rx Reject/Payment Codes" : "";
-                    } else {
-                        $stc10 = $sar[10];
+                    $stc10 = "";
+                    if ($sar[10] ?? false) {     // claim status category : claim status : entity identifier
+                        if (strpos($sar[10], (string) $ds)) {
+                            $scda = explode($ds, $sar[10]);
+                            $sc201 = $scda[0] ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
+                            $sc202 = ($scda[1] ?? '') ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
+                            $sc203 = ($scda[2] ?? '') ? $cd27x->get_271_code('NM101', $scda[2]) : "";
+                            $sc204 = ($scda[3] ?? '') === 'RA' ? "Rx Reject/Payment Codes" : "";
+                        } else {
+                            $stc10 = $sar[10];
+                        }
                     }
-                }
 
                 //
-                $stc11 = "";
-                if (isset($sar[11]) && $sar[11]) {     // claim status category : claim status : entity identifier
-                    if (strpos($sar[11], (string) $ds)) {
-                        $scda = explode($ds, $sar[11]);
-                        $sc301 = ( isset($scda[0]) && $scda[0]) ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
-                        $sc302 = ( isset($scda[1]) && $scda[1]) ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
-                        $sc303 = ( isset($scda[2]) && $scda[2]) ? $cd27x->get_271_code('NM101', $scda[2]) : "";
-                        $sc304 = ( isset($scda[3]) && $scda[3] === 'RA') ? "Rx Reject/Payment Codes" : "";
-                    } else {
-                        $stc11 = $sar[11];
+                    $stc11 = "";
+                    if ($sar[11] ?? false) {     // claim status category : claim status : entity identifier
+                        if (strpos($sar[11], (string) $ds)) {
+                            $scda = explode($ds, $sar[11]);
+                            $sc301 = $scda[0] ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
+                            $sc302 = ($scda[1] ?? '') ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
+                            $sc303 = ($scda[2] ?? '') ? $cd27x->get_271_code('NM101', $scda[2]) : "";
+                            $sc304 = ($scda[3] ?? '') === 'RA' ? "Rx Reject/Payment Codes" : "";
+                        } else {
+                            $stc11 = $sar[11];
+                        }
                     }
-                }
 
                 //
-                $stc12 =  ( isset($sar[12]) && $sar[12]) ? $sar[12] : "";    // message
+                    $stc12 = ($sar[12] ?? '') ?: "";    // message
                 //
-                $stc_html = (isset($sc101)) ? "<tr class='" . attr($cls) . "'><td>" . text($stc03) . "</td><td colspan=2>" . text($sc101) . "</td><td>" . text($stc02 . " " . $stc04) . "</td></tr>" . PHP_EOL : "";
-                $stc_html .= (isset($sc102)) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc102) . "</td></tr>" . PHP_EOL : "";
-                $stc_html .= (isset($sc103) && $sc103) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc103) . "</td></tr>" . PHP_EOL : "";
-                $stc_html .= ($stc05 || $stc06 || $stc08 || $stc09) ? "<tr class='" . attr($cls) . "'><td><em>Payment</em></td><td colspan=3>" . text($stc05 . " " . $stc06 . " " . $stc08 . " " . $stc09) . "</td></tr>" . PHP_EOL : "";
-                $stc_html .= (isset($sc201)) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc201 . " " . $sc204) . "</td></tr>" . PHP_EOL : "";
-                $stc_html .= (isset($sc202)) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc202) . "</td></tr>" . PHP_EOL : "";
-                $stc_html .= (isset($sc203) && $sc203) ?    "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc203) . "</td></tr>" . PHP_EOL : "";
-                $stc_html .= (isset($sc301)) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc301 . " " . $sc304) . "</td></tr>" . PHP_EOL : "";
-                $stc_html .= (isset($sc302)) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc302) . "</td></tr>" . PHP_EOL : "";
-                $stc_html .= (isset($sc303) && $sc303) ?    "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc303) . "</td></tr>" . PHP_EOL : "";
-                $stc_html .= ($stc12) ? "<tr class='" . attr($cls) . "'><td><em>Message</em></td><td colspan=3>" . text($stc12) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html = (isset($sc101)) ? "<tr class='" . attr($cls) . "'><td>" . text($stc03) . "</td><td colspan=2>" . text($sc101) . "</td><td>" . text($stc02 . " " . $stc04) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= (isset($sc102)) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc102) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= ($sc103 ?? '') ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc103) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= ($stc05 || $stc06 || $stc08 || $stc09) ? "<tr class='" . attr($cls) . "'><td><em>Payment</em></td><td colspan=3>" . text($stc05 . " " . $stc06 . " " . $stc08 . " " . $stc09) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= (isset($sc201)) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc201 . " " . $sc204) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= (isset($sc202)) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc202) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= ($sc203 ?? '') ?    "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc203) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= (isset($sc301)) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc301 . " " . $sc304) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= (isset($sc302)) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($sc302) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= ($sc303 ?? '') ?    "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3><em>Entity</em> " . text($sc303) . "</td></tr>" . PHP_EOL : "";
+                    $stc_html .= ($stc12) ? "<tr class='" . attr($cls) . "'><td><em>Message</em></td><td colspan=3>" . text($stc12) . "</td></tr>" . PHP_EOL : "";
                 //
-                if ($loopid == '2200B') {
-                    $rcv_html .= $stc_html;
-                } elseif ($loopid == '2200C') {
-                    $prv_html .= $stc_html;
-                } elseif ($loopid == '2200D') {
-                    $sbr_stc_html .= $stc_html;
-                } elseif ($loopid == '2200E') {
-                    $dep_stc_html .= $stc_html;
-                }
+                    if ($loopid == '2200B') {
+                        $rcv_html .= $stc_html;
+                    } elseif ($loopid == '2200C') {
+                        $prv_html .= $stc_html;
+                    } elseif ($loopid == '2200D') {
+                        $sbr_stc_html .= $stc_html;
+                    } elseif ($loopid == '2200E') {
+                        $dep_stc_html .= $stc_html;
+                    }
 
                 //
-                continue;
-            }
+                break;
 
             // in 277CA, expect QTY followed by AMT
             // do not expect QTY or AMT in regular 277
-            if (strncmp('QTY' . $de, (string) $seg, 4) === 0) {
-                $sar = explode($de, (string) $seg);
-                if (isset($sar[1])) {
-                    if ($sar[1] == '90') {
-                        $qtystr = "Acknowledged Quantity ";
-                    } elseif ($sar[1] == 'AA') {
-                        $qtystr = "Unacknowledged Quantity ";
-                    } elseif ($sar[1] == 'QA') {
-                        $qtystr = "Quantity Approved ";
-                    } elseif ($sar[1] == 'QC') {
-                        $qtystr = "Quantity Disapproved ";
-                    } else {
-                        $qtystr = "Quantity ";
+                case 'QTY':
+                    $qtystr = match ($sar[1] ?? null) {
+                        '90' => 'Acknowledged Quantity ',
+                        'AA' => 'Unacknowledged Quantity ',
+                        'QA' => 'Quantity Approved ',
+                        'QC' => 'Quantity Disapproved ',
+                        null => '',
+                        default => 'Quantity ',
+                    };
+
+                    $qtystr .= ($sar[2] ?? '') ?: "";
+                break;
+
+            //
+                case 'AMT':
+                    // 277CA
+                    $amtstr = ($sar[1] ?? '') == 'YU' ? "Amt " : "Amt Rej ";
+                    $amtstr .= ($sar[2] ?? '') ? edih_format_money($sar[2]) : "";
+                    //
+                    if ($loopid == '2200B') {
+                        $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
+                    } elseif ($loopid == '2200C') {
+                        $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
+                    } elseif ($loopid == '2200D') {
+                        $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
+                    } elseif ($loopid == '2200E') {
+                        $dep_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
                     }
-                } else {
-                    $qtystr = "";
-                }
 
-                $qtystr .= (isset($sar[2]) && $sar[2]) ? $sar[2] : "";
-            }
-
-            //
-            if (strncmp('AMT' . $de, (string) $seg, 4) === 0) {
-                $sar = explode($de, (string) $seg);
-                // 277CA
-                $amtstr = (isset($sar[1])  && $sar[1] == 'YU') ? "Amt " : "Amt Rej ";
-                $amtstr .= (isset($sar[2])  && $sar[2]) ? edih_format_money($sar[2]) : "";
-                //
-                if ($loopid == '2200B') {
-                    $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
-                } elseif ($loopid == '2200C') {
-                    $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
-                } elseif ($loopid == '2200D') {
-                    $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
-                } elseif ($loopid == '2200E') {
-                    $dep_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>" . PHP_EOL;
-                }
-
-                $amtstr = '';
-                $qtystr = '';
-                //
-                continue;
-            }
+                    $amtstr = '';
+                    $qtystr = '';
+                    //
+                break;
 
             //
-            if (strncmp('REF' . $de, (string) $seg, 4) === 0) {
-                $sar = explode($de, (string) $seg);
-                //
-                //
-                $elem01 = (isset($sar[1])) ? $cd27x->get_271_code('REF', $sar[1]) : '';
-                $elem02 = $sar[2] ?? '';
-                $elem03 = (isset($sar[3])) ? $sar[2] : '';
-                //
-                if ($loopid == '2200B') {
-                    $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
-                } elseif ($loopid == '2200C') {
-                    $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
-                } elseif ($loopid == '2200D' || $loopid == '2220D') {
-                    $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
-                } elseif ($loopid == '2200E' || $loopid == '2220E') {
-                    $dep_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
-                }
+                case 'REF':
+                    //
+                    $elem01 = (isset($sar[1])) ? $cd27x->get_271_code('REF', $sar[1]) : '';
+                    $elem02 = $sar[2] ?? '';
+                    $elem03 = (isset($sar[3])) ? $sar[2] : '';
+                    //
+                    if ($loopid == '2200B') {
+                        $rcv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
+                    } elseif ($loopid == '2200C') {
+                        $prv_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
+                    } elseif ($loopid == '2200D' || $loopid == '2220D') {
+                        $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
+                    } elseif ($loopid == '2200E' || $loopid == '2220E') {
+                        $dep_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>" . PHP_EOL;
+                    }
 
-                //
-                continue;
-            }
+                    //
+                break;
 
             //
-            if (strncmp('DTP' . $de, (string) $seg, 4) === 0) {
-                //
-                $sar = explode($de, (string) $seg);
-                $var = '';
-                //
-                $elem01 = (isset($sar[1]) && $sar[1]) ? $cd27x->get_271_code('DTP', $sar[1]) : "";
-                $elem02 = $sar[2] ?? '';
-                $elem03 = $sar[3] ?? '';
-                //
-                $idtype = ($elem01) ? $cd27x->get_271_code('DTP', $elem01) : "";
-                if ($elem02 == 'D8' && $elem03) {
-                    $var = edih_format_date($elem03);
-                } elseif ($elem02 == 'RD8' && $elem03) {
-                    $var = edih_format_date(substr($elem03, 0, 8));
-                    $var .= ' - ' . edih_format_date(substr($elem03, -8));
-                }
+                case 'DTP':
+                    //
+                    $var = '';
+                    //
+                    $elem01 = ($sar[1] ?? '') ? $cd27x->get_271_code('DTP', $sar[1]) : "";
+                    $elem02 = $sar[2] ?? '';
+                    $elem03 = $sar[3] ?? '';
+                    //
+                    $idtype = ($elem01) ? $cd27x->get_271_code('DTP', $elem01) : "";
+                    if ($elem02 == 'D8' && $elem03) {
+                        $var = edih_format_date($elem03);
+                    } elseif ($elem02 == 'RD8' && $elem03) {
+                        $var = edih_format_date(substr($elem03, 0, 8));
+                        $var .= ' - ' . edih_format_date(substr($elem03, -8));
+                    }
 
-                //
-                if ($loopid == '2200D' || $loopid == '2220D') {
-                    $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>" . PHP_EOL;
-                } elseif ($loopid == '2200E' || $loopid == '2220E') {
-                    $dep_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>" . PHP_EOL;
-                }
+                    //
+                    if ($loopid == '2200D' || $loopid == '2220D') {
+                        $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>" . PHP_EOL;
+                    } elseif ($loopid == '2200E' || $loopid == '2220E') {
+                        $dep_stc_html .= "<tr class='" . attr($cls) . "'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>" . PHP_EOL;
+                    }
 
-                //
-                continue;
-            }
+                    //
+                break;
 
             //
-            if (strncmp('SVC' . $de, (string) $seg, 4) === 0) {
-                //
-                $sar = explode($de, (string) $seg);
-                //
-                $elem01 = '';                           // composite procedure code source:code:modifier:modifier
-                if (isset($sar[1]) && $sar[1]) {
-                    // construct a code source code modifier string
-                    if (strpos($sar[1], (string) $ds)) {
-                        $scda = explode($ds, $sar[1]);
-                        reset($scda);
-                        foreach ($scda as $key => $val) {
-                            if ($key == 0 && $val) {
-                                $elem01 = $cd27x->get_271_code('EB13', $val);
-                            } else {
-                                $elem01 .= " " . $val;
+                case 'SVC':
+                    //
+                    $elem01 = '';                           // composite procedure code source:code:modifier:modifier
+                    if ($sar[1] ?? false) {
+                        // construct a code source code modifier string
+                        if (strpos($sar[1], (string) $ds)) {
+                            $scda = explode($ds, $sar[1]);
+                            reset($scda);
+                            foreach ($scda as $key => $val) {
+                                if ($key == 0 && $val) {
+                                    $elem01 = $cd27x->get_271_code('EB13', $val);
+                                } else {
+                                    $elem01 .= " " . $val;
+                                }
                             }
+                        } else {
+                            $elem01 = $sar[1];
                         }
-                    } else {
-                        $elem01 = $sar[1];
                     }
-                }
 
-                //
-                $elem02 = (isset($sar[2]) && $sar[2]) ? edih_format_money($sar[2]) : "";  // billed amount
-                $elem03 = (isset($sar[3]) && $sar[3]) ? edih_format_money($sar[3]) : "";  // paid amount
-                $elem04 = (isset($sar[4]) && $sar[4]) ? $sar[4] : "";                   // revenue code
-                $elem05 = (isset($sar[5]) && $sar[5]) ? $sar[5] : "";                   // quantity
-                // $elem06 not used
-                $elem07 = (isset($sar[7]) && $sar[7]) ? $sar[7] : "";                   // original unis of service
-                //
-                if ($loopid == '2200B') {
-                    $rcv_html .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td>" . text($elem02) . "</td><td>" . text($elem04) . "</td></tr>" . PHP_EOL;
-                    $rcv_html .= ($elem03 || $elem04) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
-                } elseif ($loopid == '2200D' || $loopid == '2220D') {
-                    $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>" . PHP_EOL;
-                    $sbr_stc_html .= ($elem03 || $elem04) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
-                } elseif ($loopid == '2200E' || $loopid == '2220E') {
-                    $dep_stc_html .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>" . PHP_EOL;
-                    $dep_stc_html .= ($elem03 || $elem04) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
-                }
+                    //
+                    $elem02 = ($sar[2] ?? '') ? edih_format_money($sar[2]) : "";  // billed amount
+                    $elem03 = ($sar[3] ?? '') ? edih_format_money($sar[3]) : "";  // paid amount
+                    $elem04 = ($sar[4] ?? '') ?: "";                   // revenue code
+                    $elem05 = ($sar[5] ?? '') ?: "";                   // quantity
+                    // $elem06 not used
+                    $elem07 = ($sar[7] ?? '') ?: "";                   // original unis of service
+                    //
+                    if ($loopid == '2200B') {
+                        $rcv_html .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td>" . text($elem02) . "</td><td>" . text($elem04) . "</td></tr>" . PHP_EOL;
+                        $rcv_html .= ($elem03 || $elem04) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
+                    } elseif ($loopid == '2200D' || $loopid == '2220D') {
+                        $sbr_stc_html .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>" . PHP_EOL;
+                        $sbr_stc_html .= ($elem03 || $elem04) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
+                    } elseif ($loopid == '2200E' || $loopid == '2220E') {
+                        $dep_stc_html .= "<tr class='" . attr($cls) . "'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>" . PHP_EOL;
+                        $dep_stc_html .= ($elem03 || $elem04) ?  "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" . PHP_EOL : "";
+                    }
 
-                //
-                continue;
+                    //
+                break;
             }
 
             //

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -295,22 +295,11 @@ function edih_277_html($filename, $bht03 = '')
                     $html_str .= "<p>edih_277_html: file parse error, envelope error</p>" . PHP_EOL;
                     $html_str .= text($obj277->edih_message());
                     return $html_str;
-                } else {
-                    $html_str .= "<div id='accordion'>" . PHP_EOL;
                 }
 
+                $html_str .= "<div id='accordion'>" . PHP_EOL;
+
                 foreach ($env_ar['ST'] as $st) {
-                    foreach ($env_ar['GS'] as $gs) {
-                        if ($gs['icn'] != $st['icn']) {
-                            continue;
-                        } else {
-                            $gs_date = edih_format_date($gs['date']);
-                            $gs_sender = $gs['sender'];
-                            break;
-                        }
-                    }
-
-
                     // get each transaction
                     foreach ($st['bht03'] as $bht) {
                         $html_str .= edih_277_transaction_html($obj277, $bht, true);

--- a/library/edihistory/edih_csv_inc.php
+++ b/library/edihistory/edih_csv_inc.php
@@ -1093,27 +1093,9 @@ function edih_format_telephone($str_val)
  */
 function edih_format_date($str_val, $pref = "Y-m-d")
 {
-    $strdt = (string)$str_val;
-    $strdt = preg_replace('/\D/', '', $strdt);
-    $dt = '';
-    if (strlen((string) $strdt) == 6) {
-        $tdy = date('Ymd');
-        if ($pref == "US") {
-            // assume mmddyy
-            $strdt = substr($tdy, 0, 2) . substr((string) $strdt, -2) . substr((string) $strdt, 0, 4);
-        } else {
-            // assume yymmdd
-            $strdt = substr($tdy, 0, 2) . $strdt;
-        }
-    }
-
-    if ($pref == "US") {
-        $dt = substr($strdt, 4, 2) . "/" . substr($strdt, 6) . "/" . substr($strdt, 0, 4);
-    } else {
-        $dt = substr($strdt, 0, 4) . "-" . substr($strdt, 4, 2) . "-" . substr($strdt, 6);
-    }
-
-    return $dt;
+    // Backfill: the canonical implementation lives in the autoloadable
+    // OpenEMR\Billing\EdiHistory\EdiFormat so namespaced code can reuse it.
+    return \OpenEMR\Billing\EdiHistory\EdiFormat::date((string) $str_val, (string) $pref);
 }
 
 /**
@@ -1125,10 +1107,9 @@ function edih_format_date($str_val, $pref = "Y-m-d")
  */
 function edih_format_money($str_val)
 {
-    //
-    $mny = $str_val || $str_val === '0' ? sprintf("$%01.2f", $str_val) : $str_val;
-
-    return $mny;
+    // Backfill: the canonical implementation lives in the autoloadable
+    // OpenEMR\Billing\EdiHistory\EdiFormat so namespaced code can reuse it.
+    return \OpenEMR\Billing\EdiHistory\EdiFormat::money((string) $str_val);
 }
 
 /**

--- a/src/Billing/EdiHistory/Claim277Renderer.php
+++ b/src/Billing/EdiHistory/Claim277Renderer.php
@@ -1,0 +1,350 @@
+<?php
+
+/**
+ * Segment renderers for the EDI 277 / 277CA claim-status HTML display.
+ *
+ * Each method turns one parsed X12 segment (already split on the element
+ * delimiter) into the HTML rows it contributes, so the procedural
+ * edih_277_transaction_html() loop stays thin state-machine glue. The
+ * renderers hold no state of their own: every value a segment needs is
+ * passed in, and everything it produces is returned, which keeps each
+ * branch independently testable.
+ *
+ * Lifted from the case bodies of library/edihistory/edih_277_html.php.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Kevin McCormick
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2016 Kevin McCormick
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Billing\EdiHistory;
+
+use edih_271_codes;
+
+final class Claim277Renderer
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Narrow a legacy 271-code lookup to a string.
+     *
+     * edih_271_codes::get_271_code() is untyped and so returns mixed; a code
+     * lookup is always a string in practice, so anything else collapses to ''.
+     */
+    private static function code(edih_271_codes $cd, string $set, string $value): string
+    {
+        $result = $cd->get_271_code($set, $value);
+        return is_string($result) ? $result : '';
+    }
+
+    /**
+     * CSS row class for the loop the current segment belongs to.
+     *
+     * The class is fixed for the duration of an HL hierarchy loop and is a
+     * pure function of the loop id's family letter (2000A / 2100A / 2200A ->
+     * src, and so on), so it never needs to be carried as separate state.
+     *
+     * @param string $loopid current loop id, e.g. '2000A', '2200D', 'Heading'
+     * @return string one of src|rcv|prv|sbr|dep, or '' outside an HL loop
+     */
+    public static function rowClass(string $loopid): string
+    {
+        return match (substr($loopid, -1)) {
+            'A' => 'src',
+            'B' => 'rcv',
+            'C' => 'prv',
+            'D' => 'sbr',
+            'E' => 'dep',
+            default => '',
+        };
+    }
+
+    /**
+     * Render the heading rows for a BHT (transaction header) segment.
+     *
+     * @param list<string> $sar segment split on the element delimiter
+     * @return array{html: string, ref: string} rows plus the BHT03 reference
+     */
+    public static function bht(array $sar, edih_271_codes $cd): array
+    {
+        $bht01 = $sar[1] ?? null;
+        $elem01 = match ($bht01) {
+            '0010' => 'Src, Rcv, Prv, Sbr, Dep',
+            '0085' => 'Src, Rcv, Prv, Pt',
+            null => '',
+            default => "Not determined ({$bht01})",
+        };
+        $elem02 = ($sar[2] ?? false) !== false ? self::code($cd,'BHT02', $sar[2]) : "";
+        $elem03 = ($sar[3] ?? '') ?: "";
+        $elem04 = ($sar[4] ?? '') ? EdiFormat::date($sar[4]) : "";
+        $elem06 = ($sar[6] ?? '') ? self::code($cd,'BHT06', $sar[6]) : "";
+
+        $e01Text = text($elem01);
+        $e02Text = text($elem02);
+        $e03Text = text($elem03);
+        $e04Text = text($elem04);
+        $e06Text = text($elem06);
+        $e06Html = $elem06 ? "<tr><td>&gt;</td><td colspan=3><em>Type:</em> {$e06Text}</td></tr>" : '';
+        $html = <<<HTML
+            <tr><td colspan=2><em>Reference:</em> {$e03Text}</td><td colspan=2><em>Sequence:</em> {$e01Text}</td></tr>
+            <tr><td colspan=2><em>Date:</em> {$e04Text}</td><td colspan=2><em>Type:</em> {$e02Text}</td>
+            {$e06Html}
+            HTML;
+
+        return ['html' => $html, 'ref' => $elem03];
+    }
+
+    /**
+     * Render the two identity rows for an NM1 segment.
+     *
+     * @param list<string> $sar
+     * @return array{html: string, name: string} rows plus the assembled entity name
+     */
+    public static function nm1(array $sar, string $cls, edih_271_codes $cd): array
+    {
+        $nm101 = $sar[1] ?? '';
+        $descr = ($nm101) ? self::code($cd,'NM101', $nm101) : "";
+
+        $name = ($sar[3] ?? '') ?: "";
+        $name .= ($sar[7] ?? '') ? " {$sar[7]}" : "";
+        $name .= ($sar[4] ?? '') ? ", {$sar[4]}" : "";
+        $name .= ($sar[5] ?? '') ? " {$sar[5]}" : "";
+        $nm109 = ($sar[9] ?? '') ?: "";
+        $nm108 = ($sar[8] ?? '') ? self::code($cd,'NM108', $sar[8]) : "";
+
+        $descrAttr = attr($descr);
+        $html  = "<tr class='$cls'><td>&gt;</td><td colspan=3 title='$descrAttr'>" . text($name) . "</td></tr>";
+        $html .= "<tr class='$cls'><td>&gt;</td><td colspan=3 title='$descrAttr'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>";
+
+        return ['html' => $html, 'name' => $name];
+    }
+
+    /**
+     * Render the contact row for a PER segment (2100A information-source contact).
+     *
+     * @param list<string> $sar
+     */
+    public static function per(array $sar, string $cls, edih_271_codes $cd): string
+    {
+        $elem02 = $sar[2] ?? '';
+        $elem03 = (isset($sar[3])) ? self::code($cd,'PER03', $sar[3]) : "";
+        $elem04 = $sar[4] ?? '';
+        $elem05 = (isset($sar[5])) ? self::code($cd,'PER03', $sar[5]) : "";
+        $elem06 = $sar[6] ?? '';
+        $elem07 = (isset($sar[7])) ? self::code($cd,'PER03', $sar[7]) : "";
+        $elem08 = $sar[8] ?? '';
+
+        return "<tr class='$cls'><td colspan=2>" . text($elem02) . "</td><td colspan=2 title='" . attr($elem03 . " " . $elem05 . " " . $elem07) . "'>" . text($elem04 . " " . $elem06 . " " . $elem08) . "</td></tr>";
+    }
+
+    /**
+     * Render the trace row for a TRN segment.
+     *
+     * @param list<string> $sar
+     * @return array{html: string, ref: string} row plus TRN02 (appended to the label)
+     */
+    public static function trn(array $sar, string $cls): array
+    {
+        $elem01 = ($sar[1] ?? '') == "1" ? "Transaction Ref" : "Trace";
+        $elem02 = $sar[2] ?? '';
+        $html = "<tr class='$cls'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>";
+
+        return ['html' => $html, 'ref' => $elem02];
+    }
+
+    /**
+     * Render the claim-status rows for an STC segment.
+     *
+     * All STC-local scratch (the composite sc1xx/sc2xx/sc3xx codes) stays
+     * local to this call, so codes never leak into a later STC that lacks
+     * that composite.
+     *
+     * @param list<string> $sar
+     * @param non-empty-string $ds sub-element (composite) delimiter
+     */
+    public static function stc(array $sar, string $ds, string $cls, edih_271_codes $cd): string
+    {
+        // STC01 composite: claim status category : claim status : entity identifier
+        $sc101 = $sc102 = $sc103 = null;
+        if (isset($sar[1]) && strpos($sar[1], $ds)) {
+            $scda = explode($ds, $sar[1]);
+            $sc101 = $scda[0] ? self::code($cd,'HCCSCC', $scda[0]) : "";
+            $sc102 = ($scda[1] ?? '') ? self::code($cd,'HCCSC', $scda[1]) : "";
+            $sc103 = ($scda[2] ?? '') ? self::code($cd,'NM101', $scda[2]) : "";
+        }
+
+        $stc02 = ($sar[2] ?? '') ? EdiFormat::date($sar[2]) : "";  // status information date
+        $stc03 = match ($sar[3] ?? null) {                          // action code
+            'WQ' => 'Accepted',
+            'F' => 'Final',
+            '15' => 'Correct/Resubmit',
+            'U' => 'Rejected',
+            null => '',
+            default => $sar[3],
+        };
+        $stc04 = ($sar[4] ?? '') ? EdiFormat::money($sar[4]) : "";  // billed amount
+        $stc05 = ($sar[5] ?? '') ? EdiFormat::money($sar[5]) : "";  // paid amount
+        $stc06 = ($sar[6] ?? '') ? EdiFormat::date($sar[6]) : "";   // payment date
+        // $stc07 not used
+        $stc08 = ($sar[8] ?? '') ? EdiFormat::date($sar[8]) : "";   // check issue date
+        $stc09 = ($sar[9] ?? '') ?: "";                              // check or eft number
+
+        // STC10 composite
+        $sc201 = $sc202 = $sc203 = null;
+        $sc204 = '';
+        if (($sar[10] ?? false) && strpos($sar[10], $ds)) {
+            $scda = explode($ds, $sar[10]);
+            $sc201 = $scda[0] ? self::code($cd,'HCCSCC', $scda[0]) : "";
+            $sc202 = ($scda[1] ?? '') ? self::code($cd,'HCCSC', $scda[1]) : "";
+            $sc203 = ($scda[2] ?? '') ? self::code($cd,'NM101', $scda[2]) : "";
+            $sc204 = ($scda[3] ?? '') === 'RA' ? "Rx Reject/Payment Codes" : "";
+        }
+
+        // STC11 composite
+        $sc301 = $sc302 = $sc303 = null;
+        $sc304 = '';
+        if (($sar[11] ?? false) && strpos($sar[11], $ds)) {
+            $scda = explode($ds, $sar[11]);
+            $sc301 = $scda[0] ? self::code($cd,'HCCSCC', $scda[0]) : "";
+            $sc302 = ($scda[1] ?? '') ? self::code($cd,'HCCSC', $scda[1]) : "";
+            $sc303 = ($scda[2] ?? '') ? self::code($cd,'NM101', $scda[2]) : "";
+            $sc304 = ($scda[3] ?? '') === 'RA' ? "Rx Reject/Payment Codes" : "";
+        }
+
+        $stc12 = ($sar[12] ?? '') ?: "";    // message
+
+        // repeated STC row templates: a plain detail row, an "Entity" row, and a labeled row
+        $row = fn(string $inner): string => "<tr class='$cls'><td>&gt;</td><td colspan=3>$inner</td></tr>";
+        $entity = fn(string $inner): string => "<tr class='$cls'><td>&gt;</td><td colspan=3><em>Entity</em> $inner</td></tr>";
+        $labeled = fn(string $label, string $inner): string => "<tr class='$cls'><td><em>$label</em></td><td colspan=3>$inner</td></tr>";
+
+        $html  = ($sc101 !== null) ? "<tr class='$cls'><td>" . text($stc03) . "</td><td colspan=2>" . text($sc101) . "</td><td>" . text($stc02 . " " . $stc04) . "</td></tr>" : "";
+        $html .= ($sc102 !== null) ? $row(text($sc102)) : "";
+        $html .= ($sc103) ? $entity(text($sc103)) : "";
+        $html .= ($stc05 || $stc06 || $stc08 || $stc09) ? $labeled('Payment', text($stc05 . " " . $stc06 . " " . $stc08 . " " . $stc09)) : "";
+        $html .= ($sc201 !== null) ? $row(text($sc201 . " " . $sc204)) : "";
+        $html .= ($sc202 !== null) ? $row(text($sc202)) : "";
+        $html .= ($sc203) ? $entity(text($sc203)) : "";
+        $html .= ($sc301 !== null) ? $row(text($sc301 . " " . $sc304)) : "";
+        $html .= ($sc302 !== null) ? $row(text($sc302)) : "";
+        $html .= ($sc303) ? $entity(text($sc303)) : "";
+        $html .= ($stc12) ? $labeled('Message', text($stc12)) : "";
+
+        return $html;
+    }
+
+    /**
+     * Build the acknowledged/approved quantity prefix from a QTY segment.
+     *
+     * @param list<string> $sar
+     */
+    public static function qtyString(array $sar): string
+    {
+        $qtystr = match ($sar[1] ?? null) {
+            '90' => 'Acknowledged Quantity ',
+            'AA' => 'Unacknowledged Quantity ',
+            'QA' => 'Quantity Approved ',
+            'QC' => 'Quantity Disapproved ',
+            null => '',
+            default => 'Quantity ',
+        };
+
+        return $qtystr . (($sar[2] ?? '') ?: "");
+    }
+
+    /**
+     * Render the amount row for an AMT segment (277CA), prefixed with the
+     * carried QTY string.
+     *
+     * @param list<string> $sar
+     * @param string $qtystr quantity prefix carried from the preceding QTY segment
+     */
+    public static function amt(array $sar, string $cls, string $qtystr): string
+    {
+        $amtstr = ($sar[1] ?? '') == 'YU' ? "Amt " : "Amt Rej ";
+        $amtstr .= ($sar[2] ?? '') ? EdiFormat::money($sar[2]) : "";
+
+        return "<tr class='$cls'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>";
+    }
+
+    /**
+     * Render the reference row for a REF segment.
+     *
+     * @param list<string> $sar
+     */
+    public static function ref(array $sar, string $cls, edih_271_codes $cd): string
+    {
+        $elem01 = (isset($sar[1])) ? self::code($cd,'REF', $sar[1]) : '';
+        $elem02 = $sar[2] ?? '';
+        $elem03 = $sar[3] ?? '';
+
+        return "<tr class='$cls'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>";
+    }
+
+    /**
+     * Render the date row for a DTP segment.
+     *
+     * @param list<string> $sar
+     */
+    public static function dtp(array $sar, string $cls, edih_271_codes $cd): string
+    {
+        $elem01 = ($sar[1] ?? '') ? self::code($cd,'DTP', $sar[1]) : "";
+        $elem02 = $sar[2] ?? '';
+        $elem03 = $sar[3] ?? '';
+        $var = match (true) {
+            $elem02 == 'D8' && $elem03 => EdiFormat::date($elem03),
+            $elem02 == 'RD8' && $elem03 => EdiFormat::date(substr($elem03, 0, 8)) . ' - ' . EdiFormat::date(substr($elem03, -8)),
+            default => '',
+        };
+
+        return "<tr class='$cls'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>";
+    }
+
+    /**
+     * Render the service rows for an SVC segment.
+     *
+     * @param list<string> $sar
+     * @param non-empty-string $ds sub-element (composite) delimiter
+     * @param bool $isRcv true in the 2200B receiver loop, which uses a 4-column row
+     */
+    public static function svc(array $sar, string $ds, string $cls, bool $isRcv, edih_271_codes $cd): string
+    {
+        $elem01 = '';                           // composite procedure code source:code:modifier:modifier
+        if ($sar[1] ?? false) {
+            // construct a code source code modifier string
+            if (strpos($sar[1], $ds)) {
+                $scda = explode($ds, $sar[1]);
+                reset($scda);
+                foreach ($scda as $key => $val) {
+                    if ($key == 0 && $val) {
+                        $elem01 = self::code($cd,'EB13', $val);
+                    } else {
+                        $elem01 .= " " . $val;
+                    }
+                }
+            } else {
+                $elem01 = $sar[1];
+            }
+        }
+
+        $elem02 = ($sar[2] ?? '') ? EdiFormat::money($sar[2]) : "";  // billed amount
+        $elem03 = ($sar[3] ?? '') ? EdiFormat::money($sar[3]) : "";  // paid amount
+        $elem04 = ($sar[4] ?? '') ?: "";                              // revenue code
+        // $elem05, $elem06 and $elem07 are not used
+
+        $html = $isRcv
+            ? "<tr class='$cls'><td><em>Service</em></td><td>" . text($elem01) . "</td><td>" . text($elem02) . "</td><td>" . text($elem04) . "</td></tr>"
+            : "<tr class='$cls'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>";
+        $html .= ($elem03 || $elem04) ? "<tr class='$cls'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" : "";
+
+        return $html;
+    }
+}

--- a/src/Billing/EdiHistory/Claim277Renderer.php
+++ b/src/Billing/EdiHistory/Claim277Renderer.php
@@ -121,8 +121,11 @@ final class Claim277Renderer
         $nm108 = ($sar[8] ?? '') ? self::code($cd,'NM108', $sar[8]) : "";
 
         $descrAttr = attr($descr);
-        $html  = "<tr class='$cls'><td>&gt;</td><td colspan=3 title='$descrAttr'>" . text($name) . "</td></tr>";
-        $html .= "<tr class='$cls'><td>&gt;</td><td colspan=3 title='$descrAttr'><em>" . text($nm108) . "</em> " . text($nm109) . "</td></tr>";
+        $nameText = text($name);
+        $nm108Text = text($nm108);
+        $nm109Text = text($nm109);
+        $html  = "<tr class='{$cls}'><td>&gt;</td><td colspan=3 title='{$descrAttr}'>{$nameText}</td></tr>";
+        $html .= "<tr class='{$cls}'><td>&gt;</td><td colspan=3 title='{$descrAttr}'><em>{$nm108Text}</em> {$nm109Text}</td></tr>";
 
         return ['html' => $html, 'name' => $name];
     }
@@ -142,7 +145,11 @@ final class Claim277Renderer
         $elem07 = (isset($sar[7])) ? self::code($cd,'PER03', $sar[7]) : "";
         $elem08 = $sar[8] ?? '';
 
-        return "<tr class='$cls'><td colspan=2>" . text($elem02) . "</td><td colspan=2 title='" . attr($elem03 . " " . $elem05 . " " . $elem07) . "'>" . text($elem04 . " " . $elem06 . " " . $elem08) . "</td></tr>";
+        $elem02Text = text($elem02);
+        $titleAttr = attr($elem03 . ' ' . $elem05 . ' ' . $elem07);
+        $contactText = text($elem04 . ' ' . $elem06 . ' ' . $elem08);
+
+        return "<tr class='{$cls}'><td colspan=2>{$elem02Text}</td><td colspan=2 title='{$titleAttr}'>{$contactText}</td></tr>";
     }
 
     /**
@@ -155,7 +162,9 @@ final class Claim277Renderer
     {
         $elem01 = ($sar[1] ?? '') == "1" ? "Transaction Ref" : "Trace";
         $elem02 = $sar[2] ?? '';
-        $html = "<tr class='$cls'><td>&gt;</td><td colspan=3><em>" . text($elem01) . "</em> " . text($elem02) . "</td></tr>";
+        $elem01Text = text($elem01);
+        $elem02Text = text($elem02);
+        $html = "<tr class='{$cls}'><td>&gt;</td><td colspan=3><em>{$elem01Text}</em> {$elem02Text}</td></tr>";
 
         return ['html' => $html, 'ref' => $elem02];
     }
@@ -226,7 +235,10 @@ final class Claim277Renderer
         $entity = fn(string $inner): string => "<tr class='$cls'><td>&gt;</td><td colspan=3><em>Entity</em> $inner</td></tr>";
         $labeled = fn(string $label, string $inner): string => "<tr class='$cls'><td><em>$label</em></td><td colspan=3>$inner</td></tr>";
 
-        $html  = ($sc101 !== null) ? "<tr class='$cls'><td>" . text($stc03) . "</td><td colspan=2>" . text($sc101) . "</td><td>" . text($stc02 . " " . $stc04) . "</td></tr>" : "";
+        $stc03Text = text($stc03);
+        $sc101Text = text($sc101 ?? '');
+        $stcHeadText = text($stc02 . ' ' . $stc04);
+        $html  = ($sc101 !== null) ? "<tr class='{$cls}'><td>{$stc03Text}</td><td colspan=2>{$sc101Text}</td><td>{$stcHeadText}</td></tr>" : "";
         $html .= ($sc102 !== null) ? $row(text($sc102)) : "";
         $html .= ($sc103) ? $entity(text($sc103)) : "";
         $html .= ($stc05 || $stc06 || $stc08 || $stc09) ? $labeled('Payment', text($stc05 . " " . $stc06 . " " . $stc08 . " " . $stc09)) : "";
@@ -271,8 +283,9 @@ final class Claim277Renderer
     {
         $amtstr = ($sar[1] ?? '') == 'YU' ? "Amt " : "Amt Rej ";
         $amtstr .= ($sar[2] ?? '') ? EdiFormat::money($sar[2]) : "";
+        $amtText = text($qtystr . ' ' . $amtstr);
 
-        return "<tr class='$cls'><td>&gt;</td><td colspan=3>" . text($qtystr . " " . $amtstr) . "</td></tr>";
+        return "<tr class='{$cls}'><td>&gt;</td><td colspan=3>{$amtText}</td></tr>";
     }
 
     /**
@@ -285,8 +298,11 @@ final class Claim277Renderer
         $elem01 = (isset($sar[1])) ? self::code($cd,'REF', $sar[1]) : '';
         $elem02 = $sar[2] ?? '';
         $elem03 = $sar[3] ?? '';
+        $elem01Text = text($elem01);
+        $elem02Text = text($elem02);
+        $elem03Text = text($elem03);
 
-        return "<tr class='$cls'><td>&gt;</td><td colspan=2><em>" . text($elem01) . "</em> " . text($elem02) . "</td><td>" . text($elem03) . "</td></tr>";
+        return "<tr class='{$cls}'><td>&gt;</td><td colspan=2><em>{$elem01Text}</em> {$elem02Text}</td><td>{$elem03Text}</td></tr>";
     }
 
     /**
@@ -304,8 +320,10 @@ final class Claim277Renderer
             $elem02 == 'RD8' && $elem03 => EdiFormat::date(substr($elem03, 0, 8)) . ' - ' . EdiFormat::date(substr($elem03, -8)),
             default => '',
         };
+        $elem01Text = text($elem01);
+        $varText = text($var);
 
-        return "<tr class='$cls'><td>&gt;</td><td>" . text($elem01) . "</td><td colspan=2>" . text($var) . "</td></tr>";
+        return "<tr class='{$cls}'><td>&gt;</td><td>{$elem01Text}</td><td colspan=2>{$varText}</td></tr>";
     }
 
     /**
@@ -340,10 +358,15 @@ final class Claim277Renderer
         $elem04 = ($sar[4] ?? '') ?: "";                              // revenue code
         // $elem05, $elem06 and $elem07 are not used
 
+        $elem01Text = text($elem01);
+        $elem02Text = text($elem02);
+        $elem04Text = text($elem04);
+        $svcText = text($elem02 . ' ' . $elem04);
         $html = $isRcv
-            ? "<tr class='$cls'><td><em>Service</em></td><td>" . text($elem01) . "</td><td>" . text($elem02) . "</td><td>" . text($elem04) . "</td></tr>"
-            : "<tr class='$cls'><td><em>Service</em></td><td>" . text($elem01) . "</td><td colspan=2>" . text($elem02 . " " . $elem04) . "</td></tr>";
-        $html .= ($elem03 || $elem04) ? "<tr class='$cls'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04) . "</td></tr>" : "";
+            ? "<tr class='{$cls}'><td><em>Service</em></td><td>{$elem01Text}</td><td>{$elem02Text}</td><td>{$elem04Text}</td></tr>"
+            : "<tr class='{$cls}'><td><em>Service</em></td><td>{$elem01Text}</td><td colspan=2>{$svcText}</td></tr>";
+        $paidText = text($elem03 . ' ' . $elem04);
+        $html .= ($elem03 || $elem04) ? "<tr class='{$cls}'><td>&gt;</td><td colspan=3>{$paidText}</td></tr>" : "";
 
         return $html;
     }

--- a/src/Billing/EdiHistory/EdiFormat.php
+++ b/src/Billing/EdiHistory/EdiFormat.php
@@ -63,6 +63,6 @@ final class EdiFormat
      */
     public static function money(string $str_val): string
     {
-        return ($str_val !== '') ? sprintf('$%01.2f', (float) $str_val) : $str_val;
+        return ($str_val !== '') ? sprintf('$%01.2f', $str_val) : $str_val;
     }
 }

--- a/src/Billing/EdiHistory/EdiFormat.php
+++ b/src/Billing/EdiHistory/EdiFormat.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Formatting helpers for the EDI history (edihistory) X12 display code.
+ *
+ * Holds the canonical implementations of the edih_format_* routines as
+ * autoloadable static methods, so namespaced code such as Claim277Renderer
+ * can call them without depending on the non-autoloaded procedural include
+ * library/edihistory/edih_csv_inc.php. The global edih_format_date() and
+ * edih_format_money() functions delegate here as a backfill until every
+ * legacy call site is migrated to the class.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Kevin McCormick
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2016 Kevin McCormick
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Billing\EdiHistory;
+
+final class EdiFormat
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Order the digits of an X12 date and insert separators.
+     *
+     * A six-digit value is expanded to eight digits using the current
+     * century. US preference yields MM/DD/YYYY; anything else yields the
+     * general YYYY-MM-DD.
+     *
+     * @param string $str_val the date digits (six or eight)
+     * @param string $pref    'US' for MM/DD/YYYY, otherwise YYYY-MM-DD
+     */
+    public static function date(string $str_val, string $pref = 'Y-m-d'): string
+    {
+        $strdt = preg_replace('/\D/', '', $str_val) ?? '';
+        if (strlen($strdt) === 6) {
+            $tdy = date('Ymd');
+            $strdt = ($pref === 'US')
+                ? substr($tdy, 0, 2) . substr($strdt, -2) . substr($strdt, 0, 4)
+                : substr($tdy, 0, 2) . $strdt;
+        }
+
+        return ($pref === 'US')
+            ? substr($strdt, 4, 2) . '/' . substr($strdt, 6) . '/' . substr($strdt, 0, 4)
+            : substr($strdt, 0, 4) . '-' . substr($strdt, 4, 2) . '-' . substr($strdt, 6);
+    }
+
+    /**
+     * Format a monetary amount with a leading $ and two decimal places.
+     *
+     * The empty string passes through unchanged, matching the legacy helper.
+     *
+     * @param string $str_val the amount, e.g. '150.5'
+     */
+    public static function money(string $str_val): string
+    {
+        return ($str_val !== '') ? sprintf('$%01.2f', (float) $str_val) : $str_val;
+    }
+}

--- a/tests/Tests/Isolated/Billing/EdiHistory/Claim277RendererTest.php
+++ b/tests/Tests/Isolated/Billing/EdiHistory/Claim277RendererTest.php
@@ -1,0 +1,421 @@
+<?php
+
+/**
+ * Tests for the EDI 277 / 277CA claim-status segment renderers.
+ *
+ * The renderers are pure functions over a split X12 segment: every value a
+ * segment needs is passed in and everything it produces is returned, so each
+ * branch is exercised in isolation. The code-lookup collaborator is the real
+ * edih_271_codes class (a stateless value-lookup table), loaded here because
+ * it lives outside the PSR-4 tree and is not autoloaded.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Billing\EdiHistory;
+
+use edih_271_codes;
+use OpenEMR\Billing\EdiHistory\Claim277Renderer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class Claim277RendererTest extends TestCase
+{
+    /** Sub-element (composite) delimiter used throughout the 277 fixtures. */
+    private const DS = ':';
+
+    private edih_271_codes $cd;
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/../../../../../library/edihistory/codes/edih_271_code_class.php';
+    }
+
+    protected function setUp(): void
+    {
+        // ds = sub-element delimiter, dr = repetition delimiter.
+        $this->cd = new edih_271_codes(self::DS, '^');
+    }
+
+    #[DataProvider('rowClassProvider')]
+    public function testRowClass(string $loopId, string $expected): void
+    {
+        self::assertSame($expected, Claim277Renderer::rowClass($loopId));
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function rowClassProvider(): array
+    {
+        return [
+            // The class depends only on the loop-id's trailing family letter,
+            // so every loop in a family maps to the same class.
+            '2000A source' => ['2000A', 'src'],
+            '2100A source' => ['2100A', 'src'],
+            '2200A source' => ['2200A', 'src'],
+            '2000B receiver' => ['2000B', 'rcv'],
+            '2100C provider' => ['2100C', 'prv'],
+            '2000D subscriber' => ['2000D', 'sbr'],
+            '2100E dependent' => ['2100E', 'dep'],
+            'heading has no class' => ['Heading', ''],
+            'empty has no class' => ['', ''],
+        ];
+    }
+
+    public function testBhtRendersHeadingAndReturnsReference(): void
+    {
+        $result = Claim277Renderer::bht(
+            ['BHT', '0010', '08', 'REF123', '20240115', '', '19'],
+            $this->cd,
+        );
+
+        self::assertSame('REF123', $result['ref']);
+        self::assertStringContainsString('<em>Reference:</em> REF123', $result['html']);
+        self::assertStringContainsString('<em>Sequence:</em> Src, Rcv, Prv, Sbr, Dep', $result['html']);
+        self::assertStringContainsString('<em>Date:</em> 2024-01-15', $result['html']);
+        self::assertStringContainsString('<em>Type:</em> Status', $result['html']);
+        // BHT06 present -> the transaction-type row is appended.
+        self::assertStringContainsString('Response - further updates to follow', $result['html']);
+    }
+
+    #[DataProvider('bhtSequenceProvider')]
+    public function testBhtSequenceLabel(?string $bht01, string $expectedSequence): void
+    {
+        $sar = ['BHT'];
+        if ($bht01 !== null) {
+            $sar[1] = $bht01;
+        }
+
+        $html = Claim277Renderer::bht($sar, $this->cd)['html'];
+
+        self::assertStringContainsString('<em>Sequence:</em> ' . $expectedSequence . '</td>', $html);
+    }
+
+    /**
+     * @return array<string, array{?string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function bhtSequenceProvider(): array
+    {
+        return [
+            'code 0010' => ['0010', 'Src, Rcv, Prv, Sbr, Dep'],
+            'code 0085' => ['0085', 'Src, Rcv, Prv, Pt'],
+            'unknown code' => ['9999', 'Not determined (9999)'],
+            'missing BHT01' => [null, ''],
+        ];
+    }
+
+    public function testBhtMinimalSegmentReturnsEmptyReference(): void
+    {
+        $result = Claim277Renderer::bht(['BHT'], $this->cd);
+
+        self::assertSame('', $result['ref']);
+        // No BHT06 -> no trailing transaction-type row.
+        self::assertStringNotContainsString('<em>Type:</em> ', str_replace('<em>Type:</em> </td>', '', $result['html']));
+    }
+
+    public function testNm1AssemblesNameAndEscapesHtml(): void
+    {
+        $result = Claim277Renderer::nm1(
+            ['NM1', 'PR', '2', 'A & B <Co>'],
+            'src',
+            $this->cd,
+        );
+
+        // The returned name is the raw, unescaped value...
+        self::assertSame('A & B <Co>', $result['name']);
+        // ...but the HTML escapes it (text() uses ENT_NOQUOTES).
+        self::assertStringContainsString('A &amp; B &lt;Co&gt;', $result['html']);
+        self::assertStringContainsString("title='Payer'", $result['html']);
+    }
+
+    /**
+     * @param list<string> $sar
+     */
+    #[DataProvider('nm1NameProvider')]
+    public function testNm1NameAssembly(array $sar, string $expectedName): void
+    {
+        self::assertSame($expectedName, Claim277Renderer::nm1($sar, 'src', $this->cd)['name']);
+    }
+
+    /**
+     * @return array<string, array{list<string>, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function nm1NameProvider(): array
+    {
+        return [
+            'organization name only' => [['NM1', 'PR', '2', 'Acme Insurance'], 'Acme Insurance'],
+            // Person: last (NM103), suffix (NM107), first (NM104), middle (NM105).
+            'person full name' => [['NM1', '1P', '1', 'Smith', 'John', 'A', '', 'Jr'], 'Smith Jr, John A'],
+            'person first and last' => [['NM1', '1P', '1', 'Smith', 'John'], 'Smith, John'],
+            'empty name element' => [['NM1', 'PR', '2'], ''],
+        ];
+    }
+
+    public function testNm1IncludesIdentificationRow(): void
+    {
+        $html = Claim277Renderer::nm1(
+            ['NM1', 'PR', '2', 'Acme Insurance', '', '', '', '', 'PI', '12345'],
+            'src',
+            $this->cd,
+        )['html'];
+
+        // NM108 code translated, NM109 value appended.
+        self::assertStringContainsString('<em>Payer ID</em> 12345', $html);
+    }
+
+    public function testPer(): void
+    {
+        $html = Claim277Renderer::per(
+            ['PER', 'IC', 'Jane Doe', 'TE', '555-1212', 'FX', '555-9999'],
+            'src',
+            $this->cd,
+        );
+
+        self::assertSame(
+            "<tr class='src'><td colspan=2>Jane Doe</td>"
+            . "<td colspan=2 title='Telephone Facsimile '>555-1212 555-9999 </td></tr>",
+            $html,
+        );
+    }
+
+    #[DataProvider('trnProvider')]
+    public function testTrn(string $trn01, string $expectedLabel): void
+    {
+        $result = Claim277Renderer::trn(['TRN', $trn01, 'TRACE99'], 'src');
+
+        self::assertSame('TRACE99', $result['ref']);
+        self::assertStringContainsString("<em>{$expectedLabel}</em> TRACE99", $result['html']);
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function trnProvider(): array
+    {
+        return [
+            'trace type 1 is a transaction reference' => ['1', 'Transaction Ref'],
+            'other trace types are a trace' => ['2', 'Trace'],
+        ];
+    }
+
+    public function testStcRendersStatusRowsFromComposite(): void
+    {
+        $html = Claim277Renderer::stc(
+            ['STC', 'A1:19:PR', '20240115', 'WQ', '150.00', '100.00'],
+            self::DS,
+            'src',
+            $this->cd,
+        );
+
+        // STC03 action code -> 'Accepted'; STC01 category code translated;
+        // STC02 date and STC04 billed amount in the head row.
+        self::assertStringContainsString('<td>Accepted</td>', $html);
+        self::assertStringContainsString('The claim/encounter has been received.', $html);
+        self::assertStringContainsString('2024-01-15 $150.00', $html);
+        // STC05 paid amount surfaces in the labeled Payment row.
+        self::assertStringContainsString('<em>Payment</em>', $html);
+        self::assertStringContainsString('$100.00', $html);
+    }
+
+    public function testStcRendersAllCompositesAndMessage(): void
+    {
+        $html = Claim277Renderer::stc(
+            ['STC', 'A1:19', '20240115', 'U', '150', '', '', '', '', '', 'A2:20:PR:RA', 'A3:21::RA', 'msg here'],
+            self::DS,
+            'sbr',
+            $this->cd,
+        );
+
+        self::assertStringContainsString('<td>Rejected</td>', $html);
+        // STC10 and STC11 composites both carry the 'RA' Rx flag.
+        self::assertSame(2, substr_count($html, 'Rx Reject/Payment Codes'));
+        // STC12 free-text message row.
+        self::assertStringContainsString('<em>Message</em>', $html);
+        self::assertStringContainsString('msg here', $html);
+    }
+
+    #[DataProvider('stcActionCodeProvider')]
+    public function testStcActionCode(string $stc03, string $expected): void
+    {
+        $html = Claim277Renderer::stc(
+            ['STC', 'A1:19:PR', '20240115', $stc03],
+            self::DS,
+            'src',
+            $this->cd,
+        );
+
+        self::assertStringContainsString("<tr class='src'><td>{$expected}</td>", $html);
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function stcActionCodeProvider(): array
+    {
+        return [
+            'WQ accepted' => ['WQ', 'Accepted'],
+            'F final' => ['F', 'Final'],
+            '15 correct/resubmit' => ['15', 'Correct/Resubmit'],
+            'U rejected' => ['U', 'Rejected'],
+            'passthrough unknown code' => ['ZZ', 'ZZ'],
+        ];
+    }
+
+    public function testStcWithoutCompositesRendersNothing(): void
+    {
+        // A follow-on STC that carries no composite of its own must render
+        // nothing — the stateless renderer cannot leak a prior STC's codes.
+        self::assertSame(
+            '',
+            Claim277Renderer::stc(['STC', '', '20240115', 'WQ'], self::DS, 'src', $this->cd),
+        );
+        self::assertSame(
+            '',
+            Claim277Renderer::stc(['STC'], self::DS, 'src', $this->cd),
+        );
+    }
+
+    #[DataProvider('qtyProvider')]
+    public function testQtyString(string $qty01, string $qty02, string $expected): void
+    {
+        self::assertSame($expected, Claim277Renderer::qtyString(['QTY', $qty01, $qty02]));
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function qtyProvider(): array
+    {
+        return [
+            'acknowledged' => ['90', '5', 'Acknowledged Quantity 5'],
+            'unacknowledged' => ['AA', '3', 'Unacknowledged Quantity 3'],
+            'approved' => ['QA', '7', 'Quantity Approved 7'],
+            'disapproved' => ['QC', '2', 'Quantity Disapproved 2'],
+            'unknown qualifier' => ['ZZ', '1', 'Quantity 1'],
+        ];
+    }
+
+    public function testQtyStringWithMissingQualifier(): void
+    {
+        self::assertSame('', Claim277Renderer::qtyString(['QTY']));
+    }
+
+    #[DataProvider('amtProvider')]
+    public function testAmt(string $amt01, string $qtyPrefix, string $expectedBody): void
+    {
+        $html = Claim277Renderer::amt(['AMT', $amt01, '500.25'], 'src', $qtyPrefix);
+
+        self::assertSame(
+            "<tr class='src'><td>&gt;</td><td colspan=3>{$expectedBody}</td></tr>",
+            $html,
+        );
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function amtProvider(): array
+    {
+        return [
+            'YU amount' => ['YU', 'Quantity Approved 5', 'Quantity Approved 5 Amt $500.25'],
+            'other qualifier is a rejection' => ['ZZ', 'Q', 'Q Amt Rej $500.25'],
+        ];
+    }
+
+    public function testRef(): void
+    {
+        $html = Claim277Renderer::ref(['REF', '1K', 'CLAIM99', 'extra'], 'prv', $this->cd);
+
+        self::assertSame(
+            "<tr class='prv'><td>&gt;</td><td colspan=2><em>Payer Control Number</em> CLAIM99</td>"
+            . '<td>extra</td></tr>',
+            $html,
+        );
+    }
+
+    public function testDtpD8SingleDate(): void
+    {
+        $html = Claim277Renderer::dtp(['DTP', '472', 'D8', '20240115'], 'src', $this->cd);
+
+        self::assertSame(
+            "<tr class='src'><td>&gt;</td><td>Service</td><td colspan=2>2024-01-15</td></tr>",
+            $html,
+        );
+    }
+
+    public function testDtpRd8DateRange(): void
+    {
+        $html = Claim277Renderer::dtp(['DTP', '472', 'RD8', '20240101-20240131'], 'src', $this->cd);
+
+        self::assertStringContainsString('2024-01-01 - 2024-01-31', $html);
+    }
+
+    public function testDtpUnknownFormatRendersNoDate(): void
+    {
+        $html = Claim277Renderer::dtp(['DTP', '472', 'XX', '20240115'], 'src', $this->cd);
+
+        self::assertSame(
+            "<tr class='src'><td>&gt;</td><td>Service</td><td colspan=2></td></tr>",
+            $html,
+        );
+    }
+
+    public function testSvcSubscriberLoopUsesThreeColumnRow(): void
+    {
+        $html = Claim277Renderer::svc(['SVC', 'HC:99213', '150', '100', '0300'], self::DS, 'src', false, $this->cd);
+
+        self::assertSame(
+            "<tr class='src'><td><em>Service</em></td><td>HCPCS Codes 99213</td>"
+            . "<td colspan=2>$150.00 0300</td></tr>"
+            . "<tr class='src'><td>&gt;</td><td colspan=3>$100.00 0300</td></tr>",
+            $html,
+        );
+    }
+
+    public function testSvcReceiverLoopUsesFourColumnRow(): void
+    {
+        $html = Claim277Renderer::svc(['SVC', 'HC:99213', '150', '100', '0300'], self::DS, 'rcv', true, $this->cd);
+
+        self::assertStringContainsString(
+            "<tr class='rcv'><td><em>Service</em></td><td>HCPCS Codes 99213</td><td>$150.00</td><td>0300</td></tr>",
+            $html,
+        );
+    }
+
+    public function testSvcProcedureCodeWithoutCompositeIsPassedThrough(): void
+    {
+        $html = Claim277Renderer::svc(['SVC', '99213', '150'], self::DS, 'src', false, $this->cd);
+
+        self::assertStringContainsString('<td>99213</td>', $html);
+        // No paid amount and no revenue code -> no second row.
+        self::assertStringNotContainsString('&gt;', $html);
+    }
+
+    public function testConstructorIsPrivate(): void
+    {
+        $ctor = (new \ReflectionClass(Claim277Renderer::class))->getConstructor();
+        self::assertNotNull($ctor);
+        self::assertTrue($ctor->isPrivate());
+    }
+}

--- a/tests/Tests/Isolated/Billing/EdiHistory/EdiFormatTest.php
+++ b/tests/Tests/Isolated/Billing/EdiHistory/EdiFormatTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Tests for the EDI history date/money formatting helper.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Billing\EdiHistory;
+
+use OpenEMR\Billing\EdiHistory\EdiFormat;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class EdiFormatTest extends TestCase
+{
+    #[DataProvider('dateProvider')]
+    public function testDate(string $input, string $pref, string $expected): void
+    {
+        self::assertSame($expected, EdiFormat::date($input, $pref));
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function dateProvider(): array
+    {
+        return [
+            // Eight-digit input: reordered, no century expansion.
+            'eight-digit ISO' => ['20240115', 'Y-m-d', '2024-01-15'],
+            'eight-digit US' => ['20240115', 'US', '01/15/2024'],
+            // Six-digit input is expanded to eight using the current century
+            // (20xx until the year 2100), then reordered.
+            'six-digit ISO' => ['240115', 'Y-m-d', '2024-01-15'],
+            // Non-digit characters are stripped before formatting, so an
+            // already-separated date round-trips through the ISO path.
+            'separators stripped' => ['2024/01/15', 'Y-m-d', '2024-01-15'],
+            // Any pref other than the literal 'US' takes the ISO branch.
+            'unknown pref is ISO' => ['20240115', 'anything', '2024-01-15'],
+            // Legacy quirk preserved from the original edih_format_date():
+            // a six-digit value under the US preference expands with the
+            // wrong digit ordering. Locked here so the refactor stays
+            // behavior-preserving, not because the result is meaningful.
+            'six-digit US legacy quirk' => ['240115', 'US', '24/01/2015'],
+        ];
+    }
+
+    public function testDateDefaultPrefIsIso(): void
+    {
+        self::assertSame('2024-01-15', EdiFormat::date('20240115'));
+    }
+
+    public function testDateSixDigitUsesCurrentCentury(): void
+    {
+        $century = substr(date('Ymd'), 0, 2);
+        self::assertSame($century . '24-01-15', EdiFormat::date('240115'));
+    }
+
+    #[DataProvider('moneyProvider')]
+    public function testMoney(string $input, string $expected): void
+    {
+        self::assertSame($expected, EdiFormat::money($input));
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function moneyProvider(): array
+    {
+        return [
+            'empty passes through' => ['', ''],
+            'zero formats' => ['0', '$0.00'],
+            'one decimal place padded' => ['150.5', '$150.50'],
+            'integer amount' => ['42', '$42.00'],
+            'rounds to two places' => ['1234.567', '$1234.57'],
+            'negative amount' => ['-5', '$-5.00'],
+        ];
+    }
+
+    public function testConstructorIsPrivate(): void
+    {
+        $ctor = (new \ReflectionClass(EdiFormat::class))->getConstructor();
+        self::assertNotNull($ctor);
+        self::assertTrue($ctor->isPrivate());
+    }
+}


### PR DESCRIPTION
Refactors the 277 / 277CA claim-status HTML display so `edih_277_transaction_html()` reads as thin state-machine glue over pure, independently testable renderers.

## What

- **Dispatch by segment id.** The chain of `strncmp('BHT' . $de, (string) $seg, 4)` prefix checks became a `switch` on the segment id — the token before the first element delimiter — walking `$trans` with `foreach` and exploding each segment once at the top of the loop.
- **Extract renderers into a class.** Each `case` body moved to a `public static` method on the new autoloaded `OpenEMR\Billing\EdiHistory\Claim277Renderer`. Every renderer takes the split segment plus its collaborators and returns HTML, holding no state of its own — so a prior STC's composite status codes can no longer leak into a later segment that omits its own composites.
- **Add an `EdiFormat` helper.** The date/money formatting the renderers need moves to the autoloadable `OpenEMR\Billing\EdiHistory\EdiFormat`. The global `edih_format_date()` / `edih_format_money()` become thin backfills that delegate to it, so every existing call site keeps working unchanged until it is migrated.

## Why this is behavior-preserving

- The row CSS class — previously mutable `$cls` state fixed at each `HL` segment — is now `Claim277Renderer::rowClass($loopid)`. Every loop-id transition preserves the family letter (`2000A`, `2100A`, `2200A` all end in `A`, mapping to `src`), so recomputing it per segment is equivalent to carrying it.
- The x12 delimiters are narrowed to non-empty strings once at the top of the function, so the renderers receive honestly-typed values. This clears the corresponding `edih_277_html.php` PHPStan baseline entries — the baseline is **reduced**, with no new suppressions.
- The `EdiFormat` backfill is identical to the original for every string input the call sites pass (empty passes through, `'0'` formats to `$0.00`, date digit-ordering unchanged).

## Verification

A broad 277 / 277CA segment battery — BHT, HL 20/21/19/22/23/PT, NM1, PER, TRN, STC (with STC01/STC10/STC11 composites and a bare follow-on STC to catch code leakage), QTY/AMT, REF, DTP D8/RD8, SVC — rendered through the pre- and post-extraction implementations produces identical normalized HTML (zero semantic diff). The `EdiFormat` backfill reproduces the original formatter output across representative inputs. PHPStan level 10, phpcs, and Rector are clean.
