### PR TITLE
fix(edih): correct STC composite comparison and field indexing

### DIFF
--- a/.phpstan/baseline/booleanAnd.rightAlwaysTrue.php
+++ b/.phpstan/baseline/booleanAnd.rightAlwaysTrue.php
@@ -33,11 +33,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Right side of && is always true\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../library/edihistory/edih_277_html.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Right side of && is always true\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/patient/fwk/libs/util/parsecsv.lib.php',
 ];

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -301,7 +301,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                 $stc10 = "";
                 if (isset($sar[10]) && $sar[10]) {     // claim status category : claim status : entity identifier
                     if (strpos($sar[10], (string) $ds)) {
-                        $scda = explode($ds, $sar[1]);
+                        $scda = explode($ds, $sar[10]);
                         $sc201 = ( isset($scda[0]) && $scda[0]) ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
                         $sc202 = ( isset($scda[1]) && $scda[1]) ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
                         $sc203 = ( isset($scda[2]) && $scda[2]) ? $cd27x->get_271_code('NM101', $scda[2]) : "";
@@ -314,14 +314,14 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                 //
                 $stc11 = "";
                 if (isset($sar[11]) && $sar[11]) {     // claim status category : claim status : entity identifier
-                    if (strpos($sar[10], (string) $ds)) {
-                        $scda = explode($ds, $sar[1]);
+                    if (strpos($sar[11], (string) $ds)) {
+                        $scda = explode($ds, $sar[11]);
                         $sc301 = ( isset($scda[0]) && $scda[0]) ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
                         $sc302 = ( isset($scda[1]) && $scda[1]) ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
                         $sc303 = ( isset($scda[2]) && $scda[2]) ? $cd27x->get_271_code('NM101', $scda[2]) : "";
                         $sc304 = ( isset($scda[3]) && $scda[3] === 'RA') ? "Rx Reject/Payment Codes" : "";
                     } else {
-                        $stc11 = $sar[10];
+                        $stc11 = $sar[11];
                     }
                 }
 

--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -305,7 +305,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         $sc201 = ( isset($scda[0]) && $scda[0]) ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
                         $sc202 = ( isset($scda[1]) && $scda[1]) ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
                         $sc203 = ( isset($scda[2]) && $scda[2]) ? $cd27x->get_271_code('NM101', $scda[2]) : "";
-                        $sc204 = ( isset($scda[3]) && $scda[3] = 'RA') ? "Rx Reject/Payment Codes" : "";
+                        $sc204 = ( isset($scda[3]) && $scda[3] === 'RA') ? "Rx Reject/Payment Codes" : "";
                     } else {
                         $stc10 = $sar[10];
                     }
@@ -319,7 +319,7 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
                         $sc301 = ( isset($scda[0]) && $scda[0]) ? $cd27x->get_271_code('HCCSCC', $scda[0]) : "";
                         $sc302 = ( isset($scda[1]) && $scda[1]) ? $cd27x->get_271_code('HCCSC', $scda[1]) : "";
                         $sc303 = ( isset($scda[2]) && $scda[2]) ? $cd27x->get_271_code('NM101', $scda[2]) : "";
-                        $sc304 = ( isset($scda[3]) && $scda[3] = 'RA') ? "Rx Reject/Payment Codes" : "";
+                        $sc304 = ( isset($scda[3]) && $scda[3] === 'RA') ? "Rx Reject/Payment Codes" : "";
                     } else {
                         $stc11 = $sar[10];
                     }


### PR DESCRIPTION
Two related fixes in the 277 claim-status renderer's STC segment handling (`edih_277_transaction_html`).

## Accidental assignment → comparison

The extra "Rx Reject/Payment Codes" label used `$scda[3] = 'RA'` (assignment, always truthy) instead of `$scda[3] === 'RA'`, so the label was emitted unconditionally. Fixed for both the second (`$sc204`) and third (`$sc304`) composites.

## Wrong STC composite fields

An STC segment can carry multiple status composites — `$sar[1]` (first), `$sar[10]` (second), `$sar[11]` (third). The second- and third-composite blocks were splitting `$sar[1]` (the first composite) instead of their own field, and the third block additionally tested `strpos($sar[10], …)` and fell back to `$stc11 = $sar[10]`. They now read `$sar[10]` and `$sar[11]` respectively. (Caught in review by CodeRabbit.)

## Baseline cleanup

Removes the now-obsolete `booleanAnd.rightAlwaysTrue` PHPStan baseline entry for this file — the assignment fix resolved the "Right side of && is always true" error it suppressed.