### PR TITLE
fix(edihistory): reset STC status codes so they don't leak across segments

### DIFF
--- a/library/edihistory/edih_277_html.php
+++ b/library/edihistory/edih_277_html.php
@@ -263,6 +263,13 @@ function edih_277_transaction_html($obj277, $bht03, $accordion = false)
             //
             if (strncmp('STC' . $de, (string) $seg, 4) === 0) {
                 $sar = explode($de, (string) $seg);
+                // reset composite-derived status codes so a prior STC's codes do
+                // not leak into a segment that omits its own STC01/STC10/STC11
+                // composite elements (the rows below are gated on isset()/truthiness)
+                $sc101 = $sc102 = $sc103 = null;
+                $sc201 = $sc202 = $sc203 = null;
+                $sc301 = $sc302 = $sc303 = null;
+                $sc204 = $sc304 = "";
                 //
                 if (isset($sar[1])) {
                     if (strpos($sar[1], (string) $ds)) {       // claim status category : claim status : entity identifier


### PR DESCRIPTION
## Problem

`edih_277_transaction_html()` decodes the composite claim-status codes (`$sc101`..`$sc303`) only inside the `STC01`/`STC10`/`STC11` branches, then renders each row with an `isset()`/truthiness check. Those variables are **never reset between STC segments**, so a 277 claim-status response whose subscriber or dependent `STC` omits its own composites re-displays the codes decoded from an earlier `STC` (typically the information receiver's).

The result is a claim status that shows another entity's status codes — wrong data attributed to the wrong subscriber/dependent. Because the variables are function-scoped, the leak also persists across every transaction in the file once any `STC` has populated them.

## Fix

Reset the composite-derived codes at the top of each `STC` block so a segment renders only its own codes:

```php
$sc101 = $sc102 = $sc103 = null;
$sc201 = $sc202 = $sc203 = null;
$sc301 = $sc302 = $sc303 = null;
$sc204 = $sc304 = "";
```

`isset(null)` is `false`, so the existing render gates now correctly suppress rows for composites the current segment doesn't carry.

## Verification

Rendered a broad 277/277CA stream (source, receiver, provider, subscriber, dependent loops; QTY/AMT; STC10/STC11 composites) through the current `master` code and the fixed code and diffed the HTML. The **only** difference is that the receiver's leaked `STC10`/`STC11` codes no longer appear in the subscriber and dependent sections — every other row is byte-identical. `php -l` clean; full pre-commit suite (PHPStan level 10, Rector, phpcs) passes.