### PR TITLE
feat(acceptance): Phase 2 workflow + UpgradeIntegrityTest + byte-identical wiring

### DIFF
--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -166,3 +166,31 @@ files:
   exclude-branches: [rel-800, rel-704]
 - path: tests/Tests/Isolated/Release/**
   exclude-branches: [rel-800, rel-704]
+
+# Artifact acceptance surface (added 2026-07-24 -- see
+# docs/artifact-acceptance-testing-plan.md for the full architecture
+# and phased plan. This block is Phase 2's byte-identical wiring).
+#
+# Files below fire from rel branches (acceptance-docker.yml runs on
+# push/PR against its paths + a daily schedule) OR are read by other
+# rel-branch-executing code (the compose override + tests/Acceptance/**
+# are consumed by the workflow).
+#
+# All entries in this block exclude rel-820 in addition to rel-800 +
+# rel-704: rel-820 was cut BEFORE Phase 1 (openemr/openemr#13149,
+# landed 2026-07-24) added `symfony/mime` to require-dev for
+# BrowserKit's POST-body path. Syncing tests/Acceptance/** onto
+# rel-820 would produce a branch where the acceptance suite can't
+# actually run (the login-form POST throws LogicException about
+# symfony/mime missing). Enforcement starts effectively at rel-830+
+# (not yet cut; will be cut from a master that already has the
+# dep in composer.json).
+#
+# Not permanent: once rel-820 is EOL (post-next-next release),
+# remove rel-820 from these exclude-branches lists.
+- path: .github/workflows/acceptance-docker.yml
+  exclude-branches: [rel-820, rel-800, rel-704]
+- path: .github/docker/acceptance-docker-compose.yml
+  exclude-branches: [rel-820, rel-800, rel-704]
+- path: tests/Acceptance/**
+  exclude-branches: [rel-820, rel-800, rel-704]

--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -1,0 +1,231 @@
+# Artifact acceptance testing against the openemr Docker image.
+#
+# Black-box validation of the two production-critical entry points end
+# users experience with the Docker artifact:
+#
+#   1. Fresh install (of `latest`) -- the currently-shipped installer path
+#   2. Fresh install (of `next`)   -- the target-version installer path
+#      (a different code path than the auto-upgrade one -- new users
+#      installing the target version run setup.php, not fsupgrade-<N>.sh)
+#   3. Upgrade (from_tag -> to_tag) -- the auto-upgrade path that existing
+#      installations traverse (fsupgrade-<N>.sh + sql_upgrade.php)
+#
+# All three scenarios exercise the same test classes in tests/Acceptance/
+# with different artifact endpoints + PHPUnit `--group` filters:
+#
+#   fresh-install of X   -> boot X, run --group=fresh-install (InstallTest)
+#   upgrade from_tag ->
+#     to_tag             -> boot from_tag, run --group=fresh-install,
+#                           down --preserve-volumes, boot to_tag (auto-upgrade
+#                           fires), run --group=post-upgrade
+#                           (UpgradeIntegrityTest)
+#
+# Scenarios run as parallel matrix jobs so failure modes are isolated
+# (a fresh-install failure on `next` doesn't obscure whether the upgrade
+# path is also broken).
+#
+# The InstallTest / UpgradeIntegrityTest classes are tag-agnostic: they
+# don't know which openemr version they're testing. ACCEPTANCE_ARTIFACT_URL
+# decides. Same classes work against Docker Hub tags, locally-built PR
+# images (Phase 2.5, coming), and tarball-mounted stacks (Phase 3, coming).
+#
+# Triggers:
+#
+#   1. schedule daily at 09:00 UTC -- catches Docker Hub tag drift
+#      independent of this repo (e.g. base-image regression breaking
+#      `latest`, orchestrator misfires publishing a broken `next`).
+#
+#   2. workflow_dispatch -- manual dispatch to test arbitrary tag pairs
+#      (e.g. 7.0.4 -> 8.0.0.3 for a two-release skip test).
+#
+#   3. push / pull_request on the acceptance surface itself -- workflow,
+#      compose override, tests/Acceptance/**, and the acceptance-suite
+#      dep changes in composer.json. Validates that changes to the
+#      harness itself don't break the pattern.
+#
+# No branches: filter on push/PR triggers. Branch scoping is implicit --
+# the workflow file lives on master + every rel-* (via byte-identical
+# enforcement, once wired). Push/PR events use the workflow at the pushed
+# ref, so each branch's copy fires only for events on its own branch.
+# Same pattern as docker-test-release.yml.
+
+name: Acceptance test (docker)
+
+on:
+  workflow_dispatch:
+    inputs:
+      from_tag:
+        description: 'Prior openemr Docker Hub tag (fresh + upgrade source)'
+        required: true
+        type: string
+        default: 'latest'
+      to_tag:
+        description: 'Target openemr Docker Hub tag (fresh + upgrade target)'
+        required: true
+        type: string
+        default: 'next'
+  push:
+    paths:
+    - '.github/workflows/acceptance-docker.yml'
+    - '.github/docker/acceptance-docker-compose.yml'
+    - 'tests/Acceptance/**'
+    - 'composer.json'
+    - 'composer.lock'
+  pull_request:
+    paths:
+    - '.github/workflows/acceptance-docker.yml'
+    - '.github/docker/acceptance-docker-compose.yml'
+    - 'tests/Acceptance/**'
+    - 'composer.json'
+    - 'composer.lock'
+  schedule:
+  - cron: '0 9 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  # Cancel in-flight runs for the same ref on push/PR; keep scheduled
+  # runs queued so drift-detection cycles aren't stomped by feature-branch
+  # activity.
+  group: acceptance-docker-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+
+jobs:
+  acceptance:
+    if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr'
+    runs-on: ubuntu-24.04
+    strategy:
+      # Don't fail-fast: if fresh-install on `next` breaks, we still
+      # want the upgrade scenario's result to distinguish "target
+      # installer broken" from "upgrade path broken" (different code).
+      fail-fast: false
+      matrix:
+        include:
+        - scenario: fresh-install-from
+          description: 'Fresh install of from_tag'
+          image_tag: ${{ inputs.from_tag || 'latest' }}
+          test_group: fresh-install
+        - scenario: fresh-install-to
+          description: 'Fresh install of to_tag'
+          image_tag: ${{ inputs.to_tag || 'next' }}
+          test_group: fresh-install
+        - scenario: upgrade
+          description: 'Upgrade from_tag -> to_tag'
+          image_tag: ${{ inputs.from_tag || 'latest' }}
+          # test_group runs first against from_tag, then repeats
+          # against to_tag with the post-upgrade group after the
+          # image swap.
+          test_group: fresh-install
+    env:
+      FROM_TAG: ${{ inputs.from_tag || 'latest' }}
+      TO_TAG: ${{ inputs.to_tag || 'next' }}
+      # Pin project name so `docker compose down` preserves named
+      # volumes reliably across the from_tag -> to_tag swap in the
+      # upgrade scenario.
+      COMPOSE_PROJECT_NAME: openemr-acceptance
+      ACCEPTANCE_ARTIFACT_URL: http://localhost:8580
+    name: ${{ matrix.description }}
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up PHP + composer for the acceptance harness
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.5'
+        tools: composer:v2
+        # Extensions the acceptance harness needs (BrowserKit +
+        # http-client + symfony/mime pull most of these transitively,
+        # but naming them keeps failure modes obvious).
+        extensions: curl, dom, mbstring, tokenizer, xml
+
+    - name: Install acceptance-suite composer dependencies
+      # `--no-scripts` skips OpenEMR's post-install scripts (they assume
+      # the full app runtime context; acceptance only needs vendor/).
+      # Cache-friendly via composer.lock hash.
+      run: composer install --prefer-dist --no-progress --no-scripts --no-interaction
+
+    - name: Boot artifact (${{ matrix.image_tag }})
+      env:
+        OPENEMR_TAG: ${{ matrix.image_tag }}
+      run: |
+        echo "==> Booting openemr/openemr:${OPENEMR_TAG} for scenario '${{ matrix.scenario }}'"
+        docker compose \
+          -f docker/production/docker-compose.yml \
+          -f .github/docker/acceptance-docker-compose.yml \
+          up --detach --wait --wait-timeout 900
+
+    - name: Run acceptance suite (--group=${{ matrix.test_group }}) against ${{ matrix.image_tag }}
+      run: composer acceptance -- --group=${{ matrix.test_group }}
+
+    # ==== Upgrade-scenario-only steps (image swap + post-upgrade suite) ====
+    - name: Stop containers (preserve named volumes)
+      if: matrix.scenario == 'upgrade'
+      run: |
+        # `down` without --volumes preserves databasevolume + sitevolume
+        # + logvolume01 -- the target artifact needs to see the existing
+        # installation on boot so its entrypoint runs the auto-upgrade
+        # path (fsupgrade-<N>.sh + sql_upgrade.php).
+        docker compose \
+          -f docker/production/docker-compose.yml \
+          -f .github/docker/acceptance-docker-compose.yml \
+          down
+
+    - name: Confirm volumes persist post-down
+      if: matrix.scenario == 'upgrade'
+      run: |
+        docker volume ls | grep "${COMPOSE_PROJECT_NAME}" || {
+          echo "::error::Named volumes were unexpectedly removed by docker compose down"
+          exit 1
+        }
+
+    - name: Boot target artifact (${{ env.TO_TAG }}) -- auto-upgrade path runs
+      if: matrix.scenario == 'upgrade'
+      env:
+        OPENEMR_TAG: ${{ env.TO_TAG }}
+      run: |
+        # `up --wait` blocks until healthy. The acceptance healthcheck
+        # asserts the specific `interface/login/login.php` redirect
+        # target, so it only passes after auto-upgrade completed --
+        # if fsupgrade-<N>.sh or sql_upgrade.php fail, the container
+        # stays unhealthy and --wait times out.
+        # Extended timeout (1200s vs 900s) because upgrade includes
+        # both the boot + the migration passes.
+        docker compose \
+          -f docker/production/docker-compose.yml \
+          -f .github/docker/acceptance-docker-compose.yml \
+          up --detach --wait --wait-timeout 1200
+
+    - name: Run post-upgrade suite (--group=post-upgrade) against ${{ env.TO_TAG }}
+      if: matrix.scenario == 'upgrade'
+      run: composer acceptance -- --group=post-upgrade
+
+    # ==== Debug capture on failure (all scenarios) ====
+    - name: Capture container state (on failure)
+      if: failure()
+      run: |
+        echo "=== docker compose ps ==="
+        docker compose \
+          -f docker/production/docker-compose.yml \
+          -f .github/docker/acceptance-docker-compose.yml \
+          ps || true
+        echo ""
+        echo "=== openemr container image ID ==="
+        docker inspect --format '{{ .Image }}' \
+          "$(docker compose -f docker/production/docker-compose.yml -f .github/docker/acceptance-docker-compose.yml ps -q openemr)" || true
+
+    - name: Capture openemr container logs (on failure)
+      if: failure()
+      run: |
+        docker compose \
+          -f docker/production/docker-compose.yml \
+          -f .github/docker/acceptance-docker-compose.yml \
+          logs openemr || true
+
+    - name: Teardown
+      if: always()
+      run: |
+        docker compose \
+          -f docker/production/docker-compose.yml \
+          -f .github/docker/acceptance-docker-compose.yml \
+          down --volumes --remove-orphans || true

--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -85,10 +85,14 @@ permissions:
   contents: read
 
 concurrency:
-  # Cancel in-flight runs for the same ref on push/PR; keep scheduled
-  # runs queued so drift-detection cycles aren't stomped by feature-branch
-  # activity.
-  group: acceptance-docker-${{ github.ref }}
+  # Split the concurrency group by trigger type: a scheduled run on
+  # master shouldn't share a group with push/PR runs on master, or a
+  # push landing during the scheduled run would cancel it (the
+  # push's cancel-in-progress=true wins over the schedule's
+  # cancel-in-progress=false when they share a group). Separate keys
+  # mean push/PR still cancels its own in-flight runs, but never
+  # kills a schedule run.
+  group: acceptance-docker-${{ github.ref }}-${{ github.event_name == 'schedule' && 'schedule' || 'ondemand' }}
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
@@ -128,6 +132,12 @@ jobs:
     name: ${{ matrix.description }}
     steps:
     - uses: actions/checkout@v7
+      with:
+        # No git operations after checkout (composer install + docker
+        # compose only), so no reason to persist the GITHUB_TOKEN as
+        # a git credential in the local checkout. Reduces incidental
+        # credential exposure surface.
+        persist-credentials: false
 
     - name: Set up PHP + composer for the acceptance harness
       uses: shivammathur/setup-php@v2

--- a/tests/Acceptance/InstallTest.php
+++ b/tests/Acceptance/InstallTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Acceptance;
 
 use OpenEMR\Tests\Acceptance\Support\ArtifactBrowser;
+use OpenEMR\Tests\Acceptance\Support\ResponseHeaders;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
@@ -51,7 +52,7 @@ final class InstallTest extends TestCase
         $response = $browser->getResponse();
 
         self::assertSame(302, $response->getStatusCode(), 'GET / should redirect (302) on an installed artifact');
-        $location = $this->locationHeader($response);
+        $location = ResponseHeaders::location($response);
         // openemr's redirect target is relative ("interface/login/login.php?..."),
         // no leading slash. Assert on the trailing path fragment.
         self::assertStringContainsString(
@@ -88,7 +89,7 @@ final class InstallTest extends TestCase
             'Login POST should return 302 with the authenticated-landing redirect; 200 with the login form re-rendered = credentials rejected',
         );
 
-        $location = $this->locationHeader($response);
+        $location = ResponseHeaders::location($response);
         self::assertStringContainsString(
             '/interface/main/tabs/main.php',
             $location,
@@ -116,21 +117,5 @@ final class InstallTest extends TestCase
             $landingResponse->getStatusCode(),
             'GET on the authenticated landing URL must return 200; 401/403 would indicate the session was rejected despite the login redirect',
         );
-    }
-
-    /**
-     * Symfony BrowserKit's Response::getHeader() returns array|string|null
-     * depending on the header's arity and presence. Normalize to a plain
-     * string here (empty when absent) so assertions can operate on it
-     * without narrowing dance at every call site.
-     */
-    private function locationHeader(\Symfony\Component\BrowserKit\Response $response): string
-    {
-        /** @var array<int, string>|string|null $value */
-        $value = $response->getHeader('Location');
-        if (is_array($value)) {
-            return $value[0] ?? '';
-        }
-        return $value ?? '';
     }
 }

--- a/tests/Acceptance/Support/ResponseHeaders.php
+++ b/tests/Acceptance/Support/ResponseHeaders.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance\Support;
+
+use Symfony\Component\BrowserKit\Response;
+
+/**
+ * BrowserKit's Response::getHeader() returns array|string|null depending
+ * on the header's arity and presence. Rather than repeat the narrowing
+ * dance at every call site, funnel through these helpers.
+ *
+ * Kept as a static-method utility rather than a value object because
+ * every acceptance test needs it in the same shape; instantiating a
+ * wrapper adds ceremony without any state to hold.
+ */
+final class ResponseHeaders
+{
+    public static function location(Response $response): string
+    {
+        return self::first($response, 'Location');
+    }
+
+    public static function first(Response $response, string $name): string
+    {
+        /** @var array<int, string>|string|null $value */
+        $value = $response->getHeader($name);
+        if (is_array($value)) {
+            return $value[0] ?? '';
+        }
+        return $value ?? '';
+    }
+}

--- a/tests/Acceptance/UpgradeIntegrityTest.php
+++ b/tests/Acceptance/UpgradeIntegrityTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance;
+
+use OpenEMR\Tests\Acceptance\Support\ArtifactBrowser;
+use OpenEMR\Tests\Acceptance\Support\ResponseHeaders;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Post-upgrade acceptance test.
+ *
+ * Fires after acceptance-docker.yml's upgrade scenario has:
+ *   1. Booted the from_tag artifact (auto-installed via env vars)
+ *   2. Run --group=fresh-install successfully
+ *   3. `docker compose down` (preserved named volumes)
+ *   4. Swapped `image:` to to_tag
+ *   5. Re-booted -- the entrypoint detected the existing installation
+ *      via /var/www/localhost/htdocs/openemr/sites/ persistence and
+ *      ran the auto-upgrade path: fsupgrade-<N>.sh (filesystem
+ *      migrations) then sql_upgrade.php (schema migrations)
+ *   6. Healthcheck asserted the login-page redirect target -- so the
+ *      upgraded stack is at least serving the post-install response
+ *
+ * This test picks up from there and verifies the upgraded stack is
+ * actually functional, not just "responding to HTTP." Phase 2 MVP:
+ * admin can still log in against the upgraded artifact. That covers
+ * the load-bearing sanity path -- session storage survived the
+ * upgrade, admin credentials still work, the authenticated landing
+ * page renders. If sql_upgrade.php broke the users table or
+ * fsupgrade-<N>.sh corrupted session state, that surfaces here.
+ *
+ * Later phases expand:
+ *   - Phase 4 adds pre-upgrade data seeding (patient/encounter/user
+ *     creation via API or DB) with post-upgrade readback verification.
+ *     That requires DataSeed helpers under Support/DataSeed/ which
+ *     don't exist yet -- deferring until we actually need them.
+ *   - ApiSmokeTest / FhirSmokeTest (Phase 4) will also fire against
+ *     the post-upgrade artifact once they exist.
+ */
+#[Group('post-upgrade')]
+final class UpgradeIntegrityTest extends TestCase
+{
+    public function testAdminLoginStillWorksAfterUpgrade(): void
+    {
+        // Reuses the exact login flow InstallTest exercises against
+        // a fresh artifact. Success signal is identical: 302 to
+        // `/interface/main/tabs/main.php?token_main=<hex>`, then a
+        // GET on the landing page returns 200. If sql_upgrade.php
+        // broke the users table, sessions, or the token_main
+        // machinery, the assertions fail here.
+        $browser = ArtifactBrowser::create();
+        $browser->request(
+            'POST',
+            ArtifactBrowser::baseUrl() . '/interface/main/main_screen.php?auth=login&site=default',
+            [
+                'authUser' => 'admin',
+                'clearPass' => 'pass',
+                'languageChoice' => '1',
+                'new_login_session_management' => '1',
+            ],
+        );
+        $response = $browser->getResponse();
+
+        self::assertSame(
+            302,
+            $response->getStatusCode(),
+            'Login POST should return 302 after upgrade; 200 with login form re-rendered = users table or auth-token machinery broken by the upgrade',
+        );
+
+        $location = ResponseHeaders::location($response);
+        self::assertStringContainsString(
+            '/interface/main/tabs/main.php',
+            $location,
+            'Post-upgrade login should redirect to the authenticated landing page',
+        );
+        self::assertMatchesRegularExpression(
+            '/token_main=[A-Za-z0-9]+/',
+            $location,
+            'Post-upgrade token_main must still be minted -- absence indicates the session machinery regressed',
+        );
+
+        // Follow through: guards against the case where the redirect
+        // looks valid but the actual landing page 401s/403s due to
+        // a session-state regression the header alone wouldn't catch.
+        $landingUrl = str_starts_with($location, 'http')
+            ? $location
+            : ArtifactBrowser::baseUrl() . '/' . ltrim($location, '/');
+        $browser->request('GET', $landingUrl);
+        $landingResponse = $browser->getResponse();
+        self::assertSame(
+            200,
+            $landingResponse->getStatusCode(),
+            'GET on the authenticated landing URL must return 200 after upgrade; 401/403 = session accepted by login endpoint but rejected by main.php',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Delivers **Phase 2** of [`docs/artifact-acceptance-testing-plan.md`](https://github.com/openemr/openemr/blob/master/docs/artifact-acceptance-testing-plan.md): the `acceptance-docker.yml` workflow that runs the acceptance suite against the openemr Docker image, plus the `UpgradeIntegrityTest` for post-upgrade validation, plus byte-identical enforcement wiring so the acceptance surface stays in lock-step across rel-830+ branches.

Follows #13149 (Phase 1 InstallTest, landed 2026-07-24).

## What lands

- **`.github/workflows/acceptance-docker.yml`** — 3 parallel matrix scenarios (fail-fast disabled so failure modes stay isolated):
  - `fresh-install-from` — boots `from_tag` (default `latest`), runs `InstallTest`
  - `fresh-install-to` — boots `to_tag` (default `next`), runs `InstallTest`. Exercises the target-version installer code path (setup.php on `next`), which is a **different** code path than the auto-upgrade one — new users installing `next` fresh don't traverse `fsupgrade-<N>.sh` or `sql_upgrade.php` at all
  - `upgrade` — boots `from_tag`, runs `InstallTest`, `docker compose down` (preserves volumes), boots `to_tag` (auto-upgrade path fires), runs `UpgradeIntegrityTest`

  Triggers: `workflow_dispatch` (any tag pair), daily schedule at 09:00 UTC (Docker Hub drift detection), push/PR on the acceptance surface itself.

  Runner setup: \`shivammathur/setup-php@v2\` (PHP 8.5) + composer install for the harness. Then boot artifact via \`docker/production/docker-compose.yml\` + Phase 1's \`acceptance-docker-compose.yml\` override. \`composer acceptance -- --group=<X>\` matches the matrix scenario. Debug capture (ps + logs) on failure; full teardown on always().

- **`tests/Acceptance/UpgradeIntegrityTest.php`** — new test class grouped \`post-upgrade\`. Phase 2 MVP asserts admin login still works after upgrade — that's the load-bearing sanity path (session storage survived, users table intact, `token_main` machinery functional). Follows the redirect + asserts 200 on the landing page.

- **`tests/Acceptance/Support/ResponseHeaders.php`** — shared static helper for the BrowserKit `Response::getHeader()` narrowing dance. Extracted from InstallTest and reused in UpgradeIntegrityTest — no more copy-paste `private function locationHeader()` in every test class.

- **`.github/byte-identical.yml`** — adds the acceptance surface to the byte-identical enforcement set:
  - \`.github/workflows/acceptance-docker.yml\`
  - \`.github/docker/acceptance-docker-compose.yml\`
  - \`tests/Acceptance/**\`

  All excluded on **rel-820** (in addition to rel-800 + rel-704). rel-820 was cut before Phase 1 (#13149) added `symfony/mime` require-dev for BrowserKit's POST-body path; syncing `tests/Acceptance/**` there would produce a branch where the suite cannot run. Enforcement starts effectively at **rel-830+** (not yet cut; will be cut from a master that has the dep). Not permanent — removable once rel-820 is EOL.

## Rationale for 3 matrix scenarios (not just 2)

Prior plan sketch only exercised fresh-install of `from_tag` before the upgrade cycle. The target-version installer code path (`setup.php` on `next`) went unvalidated — that's a distinct code path from the auto-upgrade one, and matters because new users installing the target version don't traverse `fsupgrade-<N>.sh` / `sql_upgrade.php` at all. Splitting into 3 parallel scenarios both isolates failure modes (a `fresh-install-to` fail doesn't obscure whether the upgrade path also broke) and covers every user-facing entry point end users have.

## Test plan

- [x] 3 tests / 10 assertions pass end-to-end against a freshly-booted `openemr/openemr:latest` (`composer acceptance` runs in ~4.4s locally)
- [x] PHPStan clean on `tests/Acceptance/`
- [x] actionlint clean on `.github/workflows/acceptance-docker.yml`
- [x] `boot-docker.sh` + `down-docker.sh` still work with the new test class present
- [ ] CI green — this PR is the first `push` event that will fire the new workflow (against master), so all 3 matrix scenarios light up

## What's NOT here (deferred to later phases)

- No pre-upgrade data seeding / post-upgrade readback — Phase 4 brings DataSeed/ helpers when we actually need them
- No PR-built-image validation — Phase 2.5. The workflow's design is agnostic to artifact source (tag vs local build), so Phase 2.5 is workflow-only wiring, no test rewrite
- No package (tarball) acceptance — Phase 3
- No `ApiSmokeTest` / `FhirSmokeTest` / `E2eCriticalPathTest` — Phase 4

## Related

- Plan doc: `docs/artifact-acceptance-testing-plan.md` (draft PR #12811)
- Phase 1: #13149 (InstallTest + Support/ArtifactBrowser + compose override, landed 2026-07-24)
- Prior parked scaffolding: #12791 (evolved from), #12790 (Phase 5)

Assisted-by: Claude Code