### PR TITLE
docs: fix missing trailing periods in README.md section links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,19 @@ Report these on the [Issue Tracker](https://github.com/openemr/openemr/issues). 
 
 ### Reporting Security Vulnerabilities
 
-Check out [SECURITY.md](.github/SECURITY.md)
+Check out [SECURITY.md](.github/SECURITY.md).
 
 ### API
 
-Check out [API_README.md](API_README.md)
+Check out [API_README.md](API_README.md).
 
 ### Docker
 
-Check out [DOCKER_README.md](DOCKER_README.md)
+Check out [DOCKER_README.md](DOCKER_README.md).
 
 ### FHIR
 
-Check out [FHIR_README.md](FHIR_README.md)
+Check out [FHIR_README.md](FHIR_README.md).
 
 ### For Developers
 


### PR DESCRIPTION
## Description
This PR fixes sentence trailing periods for section references in `README.md`.

## Details
Added trailing periods to section link descriptions under Security, API, Docker, and FHIR sections.