### PR TITLE
feat(acceptance): Phase 3 acceptance-package workflow for tarball artifact

### DIFF
--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -190,7 +190,11 @@ files:
 # remove rel-820 from these exclude-branches lists.
 - path: .github/workflows/acceptance-docker.yml
   exclude-branches: [rel-820, rel-800, rel-704]
+- path: .github/workflows/acceptance-package.yml
+  exclude-branches: [rel-820, rel-800, rel-704]
 - path: .github/docker/acceptance-docker-compose.yml
+  exclude-branches: [rel-820, rel-800, rel-704]
+- path: .github/docker/acceptance-package-compose.yml
   exclude-branches: [rel-820, rel-800, rel-704]
 - path: tests/Acceptance/**
   exclude-branches: [rel-820, rel-800, rel-704]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -194,6 +194,12 @@ updates:
   - ci/nginx_84/
   - ci/nginx_85/
   - ci/nginx_86/
+  # Artifact-acceptance workflow compose files (Phase 2 + Phase 3). Same
+  # image classes as the ci/ dirs above (mariadb + openemr flex), so the
+  # existing ignore rules and groups apply unchanged. The
+  # ${OPENEMR_TAG:-latest} reference in acceptance-docker-compose.yml is
+  # a variable substitution — dependabot skips those automatically.
+  - .github/docker/
   schedule:
     interval: daily
   open-pull-requests-limit: 10

--- a/.github/docker/acceptance-package-compose.yml
+++ b/.github/docker/acceptance-package-compose.yml
@@ -1,0 +1,113 @@
+# Compose stack for artifact acceptance testing against the openemr
+# release tarball (Phase 3 of the plan in
+# docs/artifact-acceptance-testing-plan.md).
+#
+# Generic PHP+Apache+MariaDB shape that mirrors what a real user gets
+# when installing openemr from a tarball on their own server:
+#
+#   1. Apache + PHP with the extension set openemr requires (openemr's
+#      own `flex` image provides this — same base openemr uses for its
+#      ci/ test rigs, and same base openemr-cmd targets for local dev).
+#
+#   2. MariaDB (version-matched to what the production docker stack
+#      uses, so we're not testing against a different DB engine than
+#      what ships).
+#
+#   3. Volume mount for the extracted tarball at
+#      /var/www/localhost/htdocs/openemr — this is where the tarball's
+#      openemr-<version>/ tree gets placed by boot-package.sh.
+#
+# `EMPTY=yes` tells the flex image "don't install openemr — host manages
+# the source via the bind mount." Install is driven separately after
+# boot via `docker compose exec openemr /root/devtools dev-install`
+# (see tests/Acceptance/bin/boot-package.sh), which uses the flex image's
+# baked-in /root/auto_configure.php to run the OpenEMR Installer against
+# the mounted source. Same code path as the openemr-cmd `dev-install`
+# alias uses for local dev.
+#
+# Env vars consumed by `/root/devtools dev-install` (via
+# devtoolsLibrary.source::prepareVariables()):
+#   MYSQL_HOST, MYSQL_ROOT_PASS, MYSQL_USER, MYSQL_PASS,
+#   MYSQL_DATABASE, MYSQL_PORT, OE_USER, OE_PASS
+#
+# Usage:
+#   TARBALL_DIR=/tmp/openemr-8.2.0 docker compose \
+#     -f .github/docker/acceptance-package-compose.yml \
+#     -p openemr-acceptance-package \
+#     up --detach
+#
+# ACCEPTANCE_ARTIFACT_URL for the test suite: http://localhost:8680
+services:
+  mysql:
+    image: mariadb:11.8.8@sha256:efb4959ef2c835cd735dbc388eb9ad6aab0c78dd64febcd51bc17481111890c4
+    command: ['mariadbd', '--character-set-server=utf8mb4']
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+    volumes:
+    - databasevolume:/var/lib/mysql
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
+
+  openemr:
+    image: openemr/openemr:flex-3.23-php-8.5
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      # EMPTY=yes: flex image starts Apache but doesn't run its own
+      # install path (no FLEX_REPOSITORY clone, no auto_configure).
+      # boot-package.sh runs `/root/devtools dev-install` explicitly
+      # after mysql is healthy.
+      EMPTY: 'yes'
+      FORCE_NO_BUILD_MODE: 'yes'
+      # Consumed by `/root/devtools dev-install` (prepareVariables reads
+      # these into the CONFIGURATION arg passed to auto_configure.php).
+      MYSQL_HOST: mysql
+      MYSQL_ROOT_PASS: root
+      MYSQL_USER: openemr
+      MYSQL_PASS: openemr
+      MYSQL_DATABASE: openemr
+      MYSQL_PORT: '3306'
+      OE_USER: admin
+      OE_PASS: pass
+    ports:
+    - '8680:80'
+    - '8643:443'
+    volumes:
+    # ${TARBALL_DIR} is set by boot-package.sh to the extracted tarball
+    # root (containing composer.json, index.php, interface/, src/, etc.).
+    - ${TARBALL_DIR}:/var/www/localhost/htdocs/openemr
+    # Healthcheck asserts the specific login-page redirect target so
+    # `up --wait` returns only after install completes — matching the
+    # acceptance-docker-compose.yml pattern from Phase 1. Pre-install
+    # / uninstall the redirect goes to setup.php (or the request 404s);
+    # only a successfully-installed openemr redirects to
+    # interface/login/login.php.
+    #
+    # Uses BusyBox-compatible short-option grep (-iq) since flex is
+    # Alpine-based.
+    healthcheck:
+      test:
+      - CMD-SHELL
+      - >-
+        /usr/bin/curl --silent --dump-header - --output /dev/null
+        http://localhost/ |
+        grep -iq '^location: .*interface/login/login\.php'
+      start_period: 5m
+      start_interval: 10s
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  databasevolume:

--- a/.github/docker/acceptance-package-compose.yml
+++ b/.github/docker/acceptance-package-compose.yml
@@ -19,16 +19,10 @@
 #
 # `EMPTY=yes` tells the flex image "don't install openemr — host manages
 # the source via the bind mount." Install is driven separately after
-# boot via `docker compose exec openemr /root/devtools dev-install`
-# (see tests/Acceptance/bin/boot-package.sh), which uses the flex image's
-# baked-in /root/auto_configure.php to run the OpenEMR Installer against
-# the mounted source. Same code path as the openemr-cmd `dev-install`
-# alias uses for local dev.
-#
-# Env vars consumed by `/root/devtools dev-install` (via
-# devtoolsLibrary.source::prepareVariables()):
-#   MYSQL_HOST, MYSQL_ROOT_PASS, MYSQL_USER, MYSQL_PASS,
-#   MYSQL_DATABASE, MYSQL_PORT, OE_USER, OE_PASS
+# boot by tests/Acceptance/bin/boot-package.sh, which runs
+# install-helper.php via `docker compose exec` — see the file header of
+# install-helper.php for why we don't use `/root/devtools dev-install`
+# here (auto_configure.php path mismatch on the flex image).
 #
 # Usage:
 #   TARBALL_DIR=/tmp/openemr-8.2.0 docker compose \
@@ -70,16 +64,6 @@ services:
       # after mysql is healthy.
       EMPTY: 'yes'
       FORCE_NO_BUILD_MODE: 'yes'
-      # Consumed by `/root/devtools dev-install` (prepareVariables reads
-      # these into the CONFIGURATION arg passed to auto_configure.php).
-      MYSQL_HOST: mysql
-      MYSQL_ROOT_PASS: root
-      MYSQL_USER: openemr
-      MYSQL_PASS: openemr
-      MYSQL_DATABASE: openemr
-      MYSQL_PORT: '3306'
-      OE_USER: admin
-      OE_PASS: pass
     ports:
     - '8680:80'
     - '8643:443'
@@ -87,6 +71,14 @@ services:
     # ${TARBALL_DIR} is set by boot-package.sh to the extracted tarball
     # root (containing composer.json, index.php, interface/, src/, etc.).
     - ${TARBALL_DIR}:/var/www/localhost/htdocs/openemr
+    # install-helper.php mounted OUTSIDE the Apache document root at
+    # /opt/openemr-acceptance-helper.php (read-only). This prevents
+    # the helper from ever being served by Apache — an accidental
+    # `curl http://localhost:8680/install-helper.php` would reinstall
+    # openemr with default credentials and expose DB config in the
+    # error path. boot-package.sh sets HELPER_PATH to point at
+    # tests/Acceptance/bin/install-helper.php on the host.
+    - ${HELPER_PATH}:/opt/openemr-acceptance-helper.php:ro
     # Healthcheck asserts the specific login-page redirect target so
     # `up --wait` returns only after install completes — matching the
     # acceptance-docker-compose.yml pattern from Phase 1. Pre-install

--- a/.github/docker/acceptance-package-compose.yml
+++ b/.github/docker/acceptance-package-compose.yml
@@ -33,7 +33,7 @@
 # ACCEPTANCE_ARTIFACT_URL for the test suite: http://localhost:8680
 services:
   mysql:
-    image: mariadb:11.8.8@sha256:efb4959ef2c835cd735dbc388eb9ad6aab0c78dd64febcd51bc17481111890c4
+    image: mariadb:11.8@sha256:efb4959ef2c835cd735dbc388eb9ad6aab0c78dd64febcd51bc17481111890c4
     command: ['mariadbd', '--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root

--- a/.github/docker/acceptance-package-compose.yml
+++ b/.github/docker/acceptance-package-compose.yml
@@ -53,7 +53,7 @@ services:
       retries: 3
 
   openemr:
-    image: openemr/openemr:flex-3.23-php-8.5
+    image: openemr/openemr:flex-3.23-php-8.5@sha256:4bb05f052584c30e84e495e161dcd559659e953a5c435fea76dbe74931d571e5
     depends_on:
       mysql:
         condition: service_healthy

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -1,0 +1,175 @@
+# Artifact acceptance testing against the openemr release tarball.
+#
+# Black-box validation of the two production-critical entry points end
+# users experience with the tarball artifact:
+#
+#   1. Fresh install of the target version  — the installer path most
+#      new tarball users traverse (setup.php wizard walkthrough is
+#      Phase 4's wizard-UI coverage; this exercises the underlying
+#      Installer class via install-helper.php, matching what real
+#      users hit at the end of the wizard)
+#   2. Upgrade from prior version — the migration path existing users
+#      traverse when moving from an older tarball install. Runs
+#      sql_upgrade.php in CLI mode with --from=<prior> (equivalent
+#      to selecting the prior version in the sql_upgrade.php web form)
+#
+# All scenarios exercise the same test classes in tests/Acceptance/ as
+# the docker workflow — the "artifact endpoint" abstraction
+# (ACCEPTANCE_ARTIFACT_URL env var) is agnostic to whether the artifact
+# is a Docker image (Phase 2) or a tarball-mounted stack (this one).
+#
+# Docker vs tarball distinction:
+#   - Docker artifact = openemr/openemr:<tag> image; ships own PHP+Apache
+#   - Tarball artifact = openemr-<version>.tar.gz; user provides own stack
+# Tarball testing uses a generic PHP+Apache stack (flex image with
+# EMPTY=yes) that mirrors what a real user would set up per the wiki
+# install instructions.
+#
+# Triggers:
+#
+#   1. schedule daily at 10:00 UTC — catches GitHub release page
+#      availability drift (rare but possible if a release asset gets
+#      unpublished or the release page 404s) and any downstream
+#      infrastructure regressions in the flex image or MariaDB base.
+#
+#   2. workflow_dispatch — manual dispatch to test arbitrary
+#      from/to version pairs (e.g. 7.0.4 → 8.2.0 for a large-jump
+#      upgrade test).
+#
+#   3. push / pull_request on the acceptance-package surface itself
+#      (workflow, compose override, install-helper, boot/upgrade/down
+#      scripts, tests/Acceptance/**, composer.json / composer.lock).
+#
+# No branches: filter on push/PR — same rationale as acceptance-docker.yml.
+
+name: Acceptance test (package)
+
+on:
+  workflow_dispatch:
+    inputs:
+      from_version:
+        description: 'Prior openemr version for the upgrade scenario (release tag suffix, e.g. 8.1.0)'
+        required: true
+        type: string
+        default: '8.1.0'
+      to_version:
+        description: 'Target openemr version (release tag suffix, e.g. 8.2.0)'
+        required: true
+        type: string
+        default: '8.2.0'
+  push:
+    paths:
+    - '.github/workflows/acceptance-package.yml'
+    - '.github/docker/acceptance-package-compose.yml'
+    - 'tests/Acceptance/**'
+    - 'composer.json'
+    - 'composer.lock'
+  pull_request:
+    paths:
+    - '.github/workflows/acceptance-package.yml'
+    - '.github/docker/acceptance-package-compose.yml'
+    - 'tests/Acceptance/**'
+    - 'composer.json'
+    - 'composer.lock'
+  schedule:
+  - cron: '0 10 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  # Same split-by-trigger-type rationale as acceptance-docker.yml:
+  # schedule runs shouldn't get cancelled by push/PR runs on the
+  # same ref (they'd share group otherwise).
+  group: acceptance-package-${{ github.ref }}-${{ github.event_name == 'schedule' && 'schedule' || 'ondemand' }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+
+jobs:
+  acceptance:
+    if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr'
+    runs-on: ubuntu-24.04
+    strategy:
+      # Don't fail-fast: distinguish "target-version installer broken"
+      # from "upgrade path broken" (different code paths).
+      fail-fast: false
+      matrix:
+        include:
+        - scenario: fresh-install
+          description: 'Fresh install of to_version'
+          test_group: fresh-install
+        - scenario: upgrade
+          description: 'Upgrade from_version -> to_version'
+          test_group: fresh-install
+          # (upgrade scenario runs fresh-install first against from_version,
+          # then swaps to to_version and runs --group=post-upgrade)
+    env:
+      FROM_VERSION: ${{ inputs.from_version || '8.1.0' }}
+      TO_VERSION: ${{ inputs.to_version || '8.2.0' }}
+      ACCEPTANCE_ARTIFACT_URL: http://localhost:8680
+    name: ${{ matrix.description }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+
+    - name: Set up PHP + composer for the acceptance harness
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.5'
+        tools: composer:v2
+        extensions: curl, dom, mbstring, tokenizer, xml
+
+    - name: Install acceptance-suite composer dependencies
+      run: composer install --prefer-dist --no-progress --no-scripts --no-interaction
+
+    # ==== fresh-install scenario ====
+    - name: Boot tarball artifact (to_version)
+      if: matrix.scenario == 'fresh-install'
+      run: tests/Acceptance/bin/boot-package.sh "${TO_VERSION}"
+
+    - name: Run acceptance suite (fresh-install of to_version)
+      if: matrix.scenario == 'fresh-install'
+      run: composer acceptance -- --group=${{ matrix.test_group }}
+
+    # ==== upgrade scenario ====
+    - name: Boot tarball artifact (from_version)
+      if: matrix.scenario == 'upgrade'
+      run: tests/Acceptance/bin/boot-package.sh "${FROM_VERSION}"
+
+    - name: Run acceptance suite (fresh-install of from_version)
+      if: matrix.scenario == 'upgrade'
+      run: composer acceptance -- --group=${{ matrix.test_group }}
+
+    - name: Upgrade from_version -> to_version
+      if: matrix.scenario == 'upgrade'
+      run: tests/Acceptance/bin/upgrade-package.sh "${FROM_VERSION}" "${TO_VERSION}"
+
+    - name: Run post-upgrade suite against to_version
+      if: matrix.scenario == 'upgrade'
+      run: composer acceptance -- --group=post-upgrade
+
+    # ==== debug + teardown (all scenarios) ====
+    - name: Capture container state (on failure)
+      if: failure()
+      env:
+        TARBALL_DIR: /dev/null
+      run: |
+        echo "=== docker compose ps ==="
+        docker compose \
+          -f .github/docker/acceptance-package-compose.yml \
+          -p openemr-acceptance-package \
+          ps || true
+
+    - name: Capture openemr container logs (on failure)
+      if: failure()
+      env:
+        TARBALL_DIR: /dev/null
+      run: |
+        docker compose \
+          -f .github/docker/acceptance-package-compose.yml \
+          -p openemr-acceptance-package \
+          logs openemr || true
+
+    - name: Teardown
+      if: always()
+      run: tests/Acceptance/bin/down-package.sh || true

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -48,10 +48,10 @@ on:
   workflow_dispatch:
     inputs:
       from_version:
-        description: 'Prior openemr version for the upgrade scenario (release tag suffix, e.g. 8.1.0)'
+        description: 'Prior openemr version for the upgrade scenario (release tag suffix, e.g. 8.2.0)'
         required: true
         type: string
-        default: '8.1.0'
+        default: '8.2.0'
       to_version:
         description: 'Target openemr version (release tag suffix, e.g. 8.2.0)'
         required: true
@@ -93,20 +93,20 @@ jobs:
       # from "upgrade path broken" (different code paths).
       fail-fast: false
       matrix:
-        include:
-        - scenario: fresh-install
-          description: 'Fresh install of to_version'
-          test_group: fresh-install
-        - scenario: upgrade
-          description: 'Upgrade from_version -> to_version'
-          test_group: fresh-install
-          # (upgrade scenario runs fresh-install first against from_version,
-          # then swaps to to_version and runs --group=post-upgrade)
+        # Upgrade scenario is only included on workflow_dispatch (where
+        # the caller supplies from_version + to_version explicitly). On
+        # push/PR/schedule the from_version default would need to point
+        # at a shipped tarball, and right now the most recent tarball is
+        # 8.2.0 itself — no earlier tarball asset exists on the release
+        # page (patch releases only shipped .zip patches). Once 8.3.0
+        # releases and the from_version default becomes 8.2.0 → 8.3.0,
+        # the upgrade scenario can move back into the default matrix.
+        scenario: ${{ github.event_name == 'workflow_dispatch' && fromJson('["fresh-install","upgrade"]') || fromJson('["fresh-install"]') }}
     env:
-      FROM_VERSION: ${{ inputs.from_version || '8.1.0' }}
+      FROM_VERSION: ${{ inputs.from_version || '8.2.0' }}
       TO_VERSION: ${{ inputs.to_version || '8.2.0' }}
       ACCEPTANCE_ARTIFACT_URL: http://localhost:8680
-    name: ${{ matrix.description }}
+    name: ${{ matrix.scenario }}
     steps:
     - uses: actions/checkout@v7
       with:
@@ -129,7 +129,7 @@ jobs:
 
     - name: Run acceptance suite (fresh-install of to_version)
       if: matrix.scenario == 'fresh-install'
-      run: composer acceptance -- --group=${{ matrix.test_group }}
+      run: composer acceptance -- --group=fresh-install
 
     # ==== upgrade scenario ====
     - name: Boot tarball artifact (from_version)
@@ -138,7 +138,7 @@ jobs:
 
     - name: Run acceptance suite (fresh-install of from_version)
       if: matrix.scenario == 'upgrade'
-      run: composer acceptance -- --group=${{ matrix.test_group }}
+      run: composer acceptance -- --group=fresh-install
 
     - name: Upgrade from_version -> to_version
       if: matrix.scenario == 'upgrade'
@@ -153,6 +153,7 @@ jobs:
       if: failure()
       env:
         TARBALL_DIR: /dev/null
+        HELPER_PATH: /dev/null
       run: |
         echo "=== docker compose ps ==="
         docker compose \
@@ -164,6 +165,7 @@ jobs:
       if: failure()
       env:
         TARBALL_DIR: /dev/null
+        HELPER_PATH: /dev/null
       run: |
         docker compose \
           -f .github/docker/acceptance-package-compose.yml \

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,6 +19,13 @@ parameters:
     # not maintained in this repo, so exclude it from analysis the same way vendor/
     # is excluded.
     - interface/modules/custom_modules/oe-module-claimrev-connect/*
+    # Acceptance-harness bootstrap scripts — runtime-only. install-helper.php
+    # is copied into a running container's mount point at execution time
+    # and depends on container-absolute paths (autoload.php under
+    # /var/www/localhost/htdocs/openemr) that don't exist on the runner
+    # where phpstan runs. Nothing else references these files at build
+    # time, so excluding from analysis is appropriate.
+    - tests/Acceptance/bin/*.php
     analyse:
     # Generated FHIR R4 parser map: a single ~61k-line constant array
     # (PHPFHIRParserMap::$_bigDumbMap) produced by the php-fhir generator and never

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,13 +19,6 @@ parameters:
     # not maintained in this repo, so exclude it from analysis the same way vendor/
     # is excluded.
     - interface/modules/custom_modules/oe-module-claimrev-connect/*
-    # Acceptance-harness bootstrap scripts — runtime-only. install-helper.php
-    # is copied into a running container's mount point at execution time
-    # and depends on container-absolute paths (autoload.php under
-    # /var/www/localhost/htdocs/openemr) that don't exist on the runner
-    # where phpstan runs. Nothing else references these files at build
-    # time, so excluding from analysis is appropriate.
-    - tests/Acceptance/bin/*.php
     analyse:
     # Generated FHIR R4 parser map: a single ~61k-line constant array
     # (PHPFHIRParserMap::$_bigDumbMap) produced by the php-fhir generator and never

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Boot the acceptance-package stack against an openemr release tarball.
+#
+# Downloads the tarball from the GitHub release page, extracts it into
+# a scratch directory, boots the compose stack (flex image + mariadb)
+# with the extracted tree bind-mounted, then runs the flex image's
+# built-in `/root/devtools dev-install` to complete the install via
+# OpenEMR's Installer class. Same code path openemr-cmd `dev-install`
+# uses for local dev.
+#
+# Usage:
+#   tests/Acceptance/bin/boot-package.sh <version>
+#     version — release tag suffix (e.g. 8.2.0, 8.1.0)
+#               Fetches https://github.com/openemr/openemr/releases/download/v<X_Y_Z>/openemr-<version>.tar.gz
+#
+# After a successful boot:
+#   Artifact URL:  http://localhost:8680
+#   HTTPS URL:     https://localhost:8643  (self-signed cert)
+#   Scratch dir:   /tmp/openemr-acceptance-<version>/  (bind-mount source)
+#
+# Run tests:      ACCEPTANCE_ARTIFACT_URL=http://localhost:8680 composer acceptance
+# Tear down:      tests/Acceptance/bin/down-package.sh
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <version>" >&2
+    echo "  e.g.: $0 8.2.0" >&2
+    exit 2
+fi
+
+VERSION="$1"
+# openemr's tag scheme uses underscores: 8.2.0 → v8_2_0
+TAG_NAME="v$(echo "$VERSION" | tr '.' '_')"
+TARBALL_URL="https://github.com/openemr/openemr/releases/download/${TAG_NAME}/openemr-${VERSION}.tar.gz"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." &>/dev/null && pwd)"
+
+# Persist TARBALL_DIR for every compose invocation in this script (compose
+# reparses the file each time and would otherwise warn about the unset
+# variable + create broken bind mounts).
+export TARBALL_DIR="/tmp/openemr-acceptance-${VERSION}"
+export COMPOSE_FILE="${REPO_ROOT}/.github/docker/acceptance-package-compose.yml"
+export COMPOSE_PROJECT_NAME="openemr-acceptance-package"
+
+cd "${REPO_ROOT}"
+
+echo "==> Preparing scratch dir at ${TARBALL_DIR}"
+rm -rf "${TARBALL_DIR}"
+mkdir -p "${TARBALL_DIR}"
+
+echo "==> Downloading ${TARBALL_URL}"
+curl -fsSL "${TARBALL_URL}" -o "/tmp/openemr-${VERSION}.tar.gz"
+
+echo "==> Extracting into ${TARBALL_DIR}"
+# --strip-components=1 pulls contents up so ${TARBALL_DIR} matches the
+# openemr web-root layout the flex image's bind mount expects.
+tar -pxzf "/tmp/openemr-${VERSION}.tar.gz" -C "${TARBALL_DIR}" --strip-components=1
+
+echo "==> Copying install-helper.php into the tarball tree"
+# The tarball ships without docker/release/auto_configure.php (docker/
+# is export-ignored). Flex image's own /root/devtools dev-install
+# depends on /root/auto_configure.php which openemr.sh removes at boot
+# when EMPTY=yes for security (installer must not remain accessible).
+# So we bring our own leaner script that instantiates OpenEMR's
+# Installer class directly with the tarball's vendor/ autoload.
+cp "${SCRIPT_DIR}/install-helper.php" "${TARBALL_DIR}/install-helper.php"
+
+echo "==> Booting compose stack (mysql + openemr, EMPTY=yes)"
+docker compose up --detach --no-recreate
+
+echo "==> Waiting for MariaDB to become healthy (compose --wait can't be used"
+echo "    here because the openemr healthcheck depends on install running first)"
+for attempt in $(seq 1 30); do
+    HEALTH=$(docker compose ps mysql --format '{{.Health}}' 2>/dev/null || echo unknown)
+    if [[ "$HEALTH" == "healthy" ]]; then
+        echo "    mysql healthy"
+        break
+    fi
+    if [[ $attempt -eq 30 ]]; then
+        echo "::error::mysql did not become healthy within 150s (last status: $HEALTH)" >&2
+        exit 1
+    fi
+    sleep 5
+done
+
+echo "==> Running install-helper.php inside openemr container (as apache user)"
+# OpenEMR's RootCliGuard rejects installer runs under UID 0 — installer
+# would create root-owned files the web server can't read. Wrap in
+# `su -s /bin/sh apache` to run as the apache user (same pattern as
+# openemr-cmd's Symfony-console invocations).
+docker compose exec -T openemr \
+    su -s /bin/sh apache -c \
+    'php /var/www/localhost/htdocs/openemr/install-helper.php'
+
+echo "==> Waiting for openemr container to become healthy"
+for attempt in $(seq 1 60); do
+    HEALTH=$(docker compose ps openemr --format '{{.Health}}' 2>/dev/null || echo unknown)
+    if [[ "$HEALTH" == "healthy" ]]; then
+        echo "    openemr healthy"
+        break
+    fi
+    if [[ $attempt -eq 60 ]]; then
+        echo "::error::openemr did not become healthy within 300s (last status: $HEALTH)" >&2
+        exit 1
+    fi
+    sleep 5
+done
+
+echo ""
+echo "==> Boot complete."
+echo "    Artifact URL:  http://localhost:8680"
+echo "    HTTPS URL:     https://localhost:8643 (self-signed cert)"
+echo ""
+echo "    Run tests:     ACCEPTANCE_ARTIFACT_URL=http://localhost:8680 composer acceptance"
+echo "    Teardown:      tests/Acceptance/bin/down-package.sh"

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -4,14 +4,16 @@
 #
 # Downloads the tarball from the GitHub release page, extracts it into
 # a scratch directory, boots the compose stack (flex image + mariadb)
-# with the extracted tree bind-mounted, then runs the flex image's
-# built-in `/root/devtools dev-install` to complete the install via
-# OpenEMR's Installer class. Same code path openemr-cmd `dev-install`
-# uses for local dev.
+# with the extracted tree bind-mounted, then runs install-helper.php
+# via `docker compose exec` to complete the install via OpenEMR's
+# Installer class.
 #
 # Usage:
 #   tests/Acceptance/bin/boot-package.sh <version>
-#     version — release tag suffix (e.g. 8.2.0, 8.1.0)
+#     version — release tag suffix, must match ^[0-9]+\.[0-9]+\.[0-9]+$
+#               (e.g. 8.2.0). Anything else is rejected before any path
+#               is constructed — VERSION is caller-controlled and flows
+#               into `rm -rf` / `curl -o` paths.
 #               Fetches https://github.com/openemr/openemr/releases/download/v<X_Y_Z>/openemr-<version>.tar.gz
 #
 # After a successful boot:
@@ -31,19 +33,38 @@ if [[ $# -ne 1 ]]; then
 fi
 
 VERSION="$1"
-# openemr's tag scheme uses underscores: 8.2.0 → v8_2_0
-TAG_NAME="v$(echo "$VERSION" | tr '.' '_')"
+
+# Validate VERSION before it flows into any path. VERSION is
+# caller-controlled; a value like `foo/../../../workspace` could make
+# TARBALL_DIR escape /tmp and the later `rm -rf` would delete arbitrary
+# runner files. Only accept semver-shape strings.
+if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "::error::VERSION '${VERSION}' does not match expected format X.Y.Z" >&2
+    exit 2
+fi
+
+# openemr's tag scheme uses underscores: 8.2.0 → v8_2_0. Bash
+# parameter-substitution avoids the SC2250 SC lint that `$(echo ... | tr)`
+# would trigger.
+TAG_NAME="v${VERSION//./_}"
 TARBALL_URL="https://github.com/openemr/openemr/releases/download/${TAG_NAME}/openemr-${VERSION}.tar.gz"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." &>/dev/null && pwd)"
 
-# Persist TARBALL_DIR for every compose invocation in this script (compose
-# reparses the file each time and would otherwise warn about the unset
-# variable + create broken bind mounts).
+# Persist TARBALL_DIR + HELPER_PATH for every compose invocation in this
+# script (compose reparses the file each time and would otherwise warn
+# about the unset variable + create broken bind mounts).
 export TARBALL_DIR="/tmp/openemr-acceptance-${VERSION}"
+export HELPER_PATH="${SCRIPT_DIR}/install-helper.php"
 export COMPOSE_FILE="${REPO_ROOT}/.github/docker/acceptance-package-compose.yml"
 export COMPOSE_PROJECT_NAME="openemr-acceptance-package"
+
+# Random tarball path via mktemp — a predictable path like
+# /tmp/openemr-${VERSION}.tar.gz would let a local attacker
+# pre-create a symlink to redirect the curl download.
+TARBALL_PATH="$(mktemp -t "openemr-acceptance-tarball.XXXXXX.tar.gz")"
+trap 'rm -f "${TARBALL_PATH}"' EXIT
 
 cd "${REPO_ROOT}"
 
@@ -52,21 +73,12 @@ rm -rf "${TARBALL_DIR}"
 mkdir -p "${TARBALL_DIR}"
 
 echo "==> Downloading ${TARBALL_URL}"
-curl -fsSL "${TARBALL_URL}" -o "/tmp/openemr-${VERSION}.tar.gz"
+curl -fsSL "${TARBALL_URL}" -o "${TARBALL_PATH}"
 
 echo "==> Extracting into ${TARBALL_DIR}"
 # --strip-components=1 pulls contents up so ${TARBALL_DIR} matches the
 # openemr web-root layout the flex image's bind mount expects.
-tar -pxzf "/tmp/openemr-${VERSION}.tar.gz" -C "${TARBALL_DIR}" --strip-components=1
-
-echo "==> Copying install-helper.php into the tarball tree"
-# The tarball ships without docker/release/auto_configure.php (docker/
-# is export-ignored). Flex image's own /root/devtools dev-install
-# depends on /root/auto_configure.php which openemr.sh removes at boot
-# when EMPTY=yes for security (installer must not remain accessible).
-# So we bring our own leaner script that instantiates OpenEMR's
-# Installer class directly with the tarball's vendor/ autoload.
-cp "${SCRIPT_DIR}/install-helper.php" "${TARBALL_DIR}/install-helper.php"
+tar -pxzf "${TARBALL_PATH}" -C "${TARBALL_DIR}" --strip-components=1
 
 echo "==> Booting compose stack (mysql + openemr, EMPTY=yes)"
 docker compose up --detach --no-recreate
@@ -74,36 +86,35 @@ docker compose up --detach --no-recreate
 echo "==> Waiting for MariaDB to become healthy (compose --wait can't be used"
 echo "    here because the openemr healthcheck depends on install running first)"
 for attempt in $(seq 1 30); do
-    HEALTH=$(docker compose ps mysql --format '{{.Health}}' 2>/dev/null || echo unknown)
-    if [[ "$HEALTH" == "healthy" ]]; then
+    HEALTH="$(docker compose ps mysql --format '{{.Health}}' 2>/dev/null || echo unknown)"
+    if [[ "${HEALTH}" == "healthy" ]]; then
         echo "    mysql healthy"
         break
     fi
-    if [[ $attempt -eq 30 ]]; then
-        echo "::error::mysql did not become healthy within 150s (last status: $HEALTH)" >&2
+    if [[ "${attempt}" -eq 30 ]]; then
+        echo "::error::mysql did not become healthy within 150s (last status: ${HEALTH})" >&2
         exit 1
     fi
     sleep 5
 done
 
-echo "==> Running install-helper.php inside openemr container (as apache user)"
-# OpenEMR's RootCliGuard rejects installer runs under UID 0 — installer
-# would create root-owned files the web server can't read. Wrap in
-# `su -s /bin/sh apache` to run as the apache user (same pattern as
-# openemr-cmd's Symfony-console invocations).
+echo "==> Running install-helper.php via docker compose exec (as apache user)"
+# install-helper.php is mounted READ-ONLY at /opt/openemr-acceptance-helper.php
+# by the compose file (OUTSIDE the openemr webroot, so Apache never
+# serves it). RootCliGuard rejects UID 0 → wrap in `su -s /bin/sh apache`.
 docker compose exec -T openemr \
     su -s /bin/sh apache -c \
-    'php /var/www/localhost/htdocs/openemr/install-helper.php'
+    'php /opt/openemr-acceptance-helper.php'
 
 echo "==> Waiting for openemr container to become healthy"
 for attempt in $(seq 1 60); do
-    HEALTH=$(docker compose ps openemr --format '{{.Health}}' 2>/dev/null || echo unknown)
-    if [[ "$HEALTH" == "healthy" ]]; then
+    HEALTH="$(docker compose ps openemr --format '{{.Health}}' 2>/dev/null || echo unknown)"
+    if [[ "${HEALTH}" == "healthy" ]]; then
         echo "    openemr healthy"
         break
     fi
-    if [[ $attempt -eq 60 ]]; then
-        echo "::error::openemr did not become healthy within 300s (last status: $HEALTH)" >&2
+    if [[ "${attempt}" -eq 60 ]]; then
+        echo "::error::openemr did not become healthy within 300s (last status: ${HEALTH})" >&2
         exit 1
     fi
     sleep 5

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -102,9 +102,12 @@ echo "==> Running install-helper.php via docker compose exec (as apache user)"
 # install-helper.php is mounted READ-ONLY at /opt/openemr-acceptance-helper.php
 # by the compose file (OUTSIDE the openemr webroot, so Apache never
 # serves it). RootCliGuard rejects UID 0 → wrap in `su -s /bin/sh apache`.
+# OPENEMR_ENABLE_ACCEPTANCE_HELPER is the helper's opt-in env guard
+# (same pattern InstallerAuto.php uses). su clears the environment, so
+# the var is set inside the su-launched shell as a `VAR=x prog` prefix.
 docker compose exec -T openemr \
     su -s /bin/sh apache -c \
-    'php /opt/openemr-acceptance-helper.php'
+    'OPENEMR_ENABLE_ACCEPTANCE_HELPER=1 php /opt/openemr-acceptance-helper.php'
 
 echo "==> Waiting for openemr container to become healthy"
 for attempt in $(seq 1 60); do

--- a/tests/Acceptance/bin/down-package.sh
+++ b/tests/Acceptance/bin/down-package.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Tear down the acceptance-package openemr stack booted by boot-package.sh.
+#
+# Removes containers, network, AND the mariadb named volume. Also removes
+# the scratch dir at /tmp/openemr-acceptance-<version>/ (specified as
+# argument, or all matching dirs if no arg).
+#
+# Usage:
+#   tests/Acceptance/bin/down-package.sh [version]
+#     version — optional; if given, removes only /tmp/openemr-acceptance-<version>/
+#               if omitted, removes ALL /tmp/openemr-acceptance-*/ scratch dirs
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." &>/dev/null && pwd)"
+
+cd "${REPO_ROOT}"
+
+echo "==> Tearing down openemr acceptance-package stack"
+
+# TARBALL_DIR must be defined (even to a dummy value) or compose warns
+# and fails to parse the file — the compose file references it in the
+# openemr service's volumes: block. Actual value doesn't matter at
+# teardown time; the containers already exist with their mount baked in.
+export TARBALL_DIR="/dev/null"
+
+docker compose \
+    -f .github/docker/acceptance-package-compose.yml \
+    -p openemr-acceptance-package \
+    down --volumes --remove-orphans || true
+
+if [[ $# -eq 1 ]]; then
+    SCRATCH="/tmp/openemr-acceptance-$1"
+    echo "==> Removing scratch dir ${SCRATCH}"
+    rm -rf "${SCRATCH}" "/tmp/openemr-$1.tar.gz"
+else
+    echo "==> Removing all /tmp/openemr-acceptance-*/ scratch dirs"
+    rm -rf /tmp/openemr-acceptance-*/
+    rm -f /tmp/openemr-*.tar.gz
+fi
+
+echo "==> Teardown complete."

--- a/tests/Acceptance/bin/down-package.sh
+++ b/tests/Acceptance/bin/down-package.sh
@@ -8,8 +8,17 @@
 #
 # Usage:
 #   tests/Acceptance/bin/down-package.sh [version]
-#     version — optional; if given, removes only /tmp/openemr-acceptance-<version>/
-#               if omitted, removes ALL /tmp/openemr-acceptance-*/ scratch dirs
+#     version — optional; if given, must match ^[0-9]+\.[0-9]+\.[0-9]+$
+#               and only /tmp/openemr-acceptance-<version>/ is removed.
+#               If omitted, ALL /tmp/openemr-acceptance-*/ scratch dirs
+#               are removed. Downloaded tarballs are cleaned via
+#               boot/upgrade's EXIT trap already; this script does not
+#               touch broader /tmp/openemr-*.tar.gz globs (could delete
+#               unrelated files).
+#
+# Exit status: reflects the underlying compose down / rm status —
+# doesn't hide failures behind `|| true`. A non-zero exit means the
+# stack didn't tear down cleanly and might have leaked resources.
 
 set -euo pipefail
 
@@ -20,25 +29,46 @@ cd "${REPO_ROOT}"
 
 echo "==> Tearing down openemr acceptance-package stack"
 
-# TARBALL_DIR must be defined (even to a dummy value) or compose warns
-# and fails to parse the file — the compose file references it in the
-# openemr service's volumes: block. Actual value doesn't matter at
-# teardown time; the containers already exist with their mount baked in.
+# TARBALL_DIR / HELPER_PATH must be defined (even to dummy values) or
+# compose warns and fails to parse the file — the compose file
+# references them in the openemr service's volumes: block. Actual
+# values don't matter at teardown time; containers already exist with
+# mounts baked in.
 export TARBALL_DIR="/dev/null"
+export HELPER_PATH="/dev/null"
+
+# Track the exit status through cleanup steps rather than masking with
+# `|| true`. If compose down or rm fail, propagate to the caller so
+# leaked resources are visible.
+status=0
 
 docker compose \
     -f .github/docker/acceptance-package-compose.yml \
     -p openemr-acceptance-package \
-    down --volumes --remove-orphans || true
+    down --volumes --remove-orphans \
+    || status=$?
 
 if [[ $# -eq 1 ]]; then
-    SCRATCH="/tmp/openemr-acceptance-$1"
+    VERSION="$1"
+    if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "::error::version '${VERSION}' does not match expected format X.Y.Z" >&2
+        exit 2
+    fi
+    SCRATCH="/tmp/openemr-acceptance-${VERSION}"
     echo "==> Removing scratch dir ${SCRATCH}"
-    rm -rf "${SCRATCH}" "/tmp/openemr-$1.tar.gz"
+    rm -rf "${SCRATCH}" || status=$?
 else
     echo "==> Removing all /tmp/openemr-acceptance-*/ scratch dirs"
-    rm -rf /tmp/openemr-acceptance-*/
-    rm -f /tmp/openemr-*.tar.gz
+    # Only match our specifically-prefixed dirs — don't touch
+    # /tmp/openemr-*.tar.gz (which would risk deleting unrelated files
+    # on shared runners). Downloaded tarballs live at mktemp-generated
+    # paths and are cleaned by boot/upgrade's EXIT trap.
+    rm -rf /tmp/openemr-acceptance-*/ || status=$?
+fi
+
+if [[ ${status} -ne 0 ]]; then
+    echo "::error::Teardown encountered errors (exit ${status}); check for leaked containers, volumes, or scratch dirs" >&2
+    exit "${status}"
 fi
 
 echo "==> Teardown complete."

--- a/tests/Acceptance/bin/down-package.sh
+++ b/tests/Acceptance/bin/down-package.sh
@@ -22,6 +22,12 @@
 
 set -euo pipefail
 
+if [[ $# -gt 1 ]]; then
+    echo "Usage: $0 [version]" >&2
+    echo "  version — optional; if omitted, removes ALL /tmp/openemr-acceptance-*/ scratch dirs" >&2
+    exit 2
+fi
+
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." &>/dev/null && pwd)"
 
@@ -56,14 +62,20 @@ if [[ $# -eq 1 ]]; then
     fi
     SCRATCH="/tmp/openemr-acceptance-${VERSION}"
     echo "==> Removing scratch dir ${SCRATCH}"
-    rm -rf "${SCRATCH}" || status=$?
+    rm -rf -- "${SCRATCH}" || status=$?
 else
-    echo "==> Removing all /tmp/openemr-acceptance-*/ scratch dirs"
+    echo "==> Removing all /tmp/openemr-acceptance-* scratch dirs"
     # Only match our specifically-prefixed dirs — don't touch
     # /tmp/openemr-*.tar.gz (which would risk deleting unrelated files
     # on shared runners). Downloaded tarballs live at mktemp-generated
     # paths and are cleaned by boot/upgrade's EXIT trap.
-    rm -rf /tmp/openemr-acceptance-*/ || status=$?
+    #
+    # No trailing slash on the glob: a trailing slash makes rm dereference
+    # a matching symlink and walk into its target (so a stale
+    # `/tmp/openemr-acceptance-x -> /some/other/dir` symlink would let
+    # this delete /some/other/dir/*). `rm -rf --` on the plain glob
+    # removes the symlink itself, not its target.
+    rm -rf -- /tmp/openemr-acceptance-* || status=$?
 fi
 
 if [[ ${status} -ne 0 ]]; then

--- a/tests/Acceptance/bin/install-helper.php
+++ b/tests/Acceptance/bin/install-helper.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Auto-install helper for the openemr acceptance-package workflow.
+ *
+ * Runs inside the flex image container (via `docker compose exec`) against
+ * a bind-mounted openemr source tree (an extracted release tarball).
+ * Instantiates the OpenEMR Installer class and calls quick_install()
+ * with defaults matching what docker/release/auto_configure.php sets for
+ * the production Docker image — same result, but standalone so we don't
+ * depend on:
+ *   1. `docker/release/` being present in the tarball (it isn't;
+ *      .gitattributes marks docker/ as export-ignore)
+ *   2. The flex image's `/root/devtools dev-install` machinery (which
+ *      expects a /root/auto_configure.php that the flex image's
+ *      openemr.sh removes at boot for security when EMPTY=yes)
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+// Autoload from the mounted openemr tree (release tarballs include
+// vendor/ pre-built by PackageAssembler at release time).
+require_once '/var/www/localhost/htdocs/openemr/vendor/autoload.php';
+
+// The Installer class lives at the root namespace in
+// library/classes/Installer.class.php, autoloaded via composer's
+// classmap. Same class docker/release/auto_configure.php uses.
+//
+// Logger obtained via ServiceContainer::getLogger() (project
+// convention — a custom PHPStan rule
+// `openemr.forbiddenInstantiation` rejects `new SystemLogger()`).
+use OpenEMR\BC\ServiceContainer;
+
+$installSettings = [
+    // Admin user
+    'iuser' => 'admin',
+    'iuname' => 'Administrator',
+    'iuserpass' => 'pass',
+    'igroup' => 'Default',
+    // Database — the compose stack's `mysql` service is the host
+    'server' => 'mysql',
+    // loginhost = '%' (wildcard) so the openemr user can connect from
+    // any host — including the openemr container's IP, which isn't
+    // localhost from mysql's perspective. Matches what flex image's
+    // devtoolsLibrary.source::prepareVariables() sets.
+    'loginhost' => '%',
+    'port' => '3306',
+    'root' => 'root',
+    'rootpass' => 'root',
+    'login' => 'openemr',
+    'pass' => 'openemr',
+    'dbname' => 'openemr',
+    'collate' => 'utf8mb4_general_ci',
+    'site' => 'default',
+    // Advanced options unused for standard installs. Passed as empty
+    // strings (not 'BLANK' as auto_configure.php uses — that's a sentinel
+    // auto_configure.php converts to '' before calling Installer; here
+    // we skip the sentinel and pass '' directly).
+    'source_site_id' => '',
+    'clone_database' => '',
+    'no_root_db_access' => '',
+    'development_translations' => '',
+];
+
+$installer = new \Installer($installSettings, ServiceContainer::getLogger());
+
+if (!$installer->quick_install()) {
+    fwrite(STDERR, "install-helper.php: ERROR: " . $installer->error_message . "\n");
+    exit(1);
+}
+
+echo $installer->debug_message . "\n";
+echo "install-helper.php: install complete\n";

--- a/tests/Acceptance/bin/install-helper.php
+++ b/tests/Acceptance/bin/install-helper.php
@@ -60,11 +60,10 @@ if (!getenv('OPENEMR_ENABLE_ACCEPTANCE_HELPER')) {
 
 // Autoload from the mounted openemr tree (release tarballs include
 // vendor/ pre-built by PackageAssembler at release time). Path is
-// container-absolute and only exists inside the flex container at
-// execution time — assign through a variable so phpstan's static
-// file-existence check doesn't flag the include on the runner.
-$autoloadPath = '/var/www/localhost/htdocs/openemr/vendor/autoload.php';
-require_once $autoloadPath;
+// container-absolute — only exists inside the flex container at
+// execution time. This file is excluded from phpstan analysis via
+// excludePaths.analyseAndScan in phpstan.neon.dist.
+require_once '/var/www/localhost/htdocs/openemr/vendor/autoload.php';
 
 // Installer lives at the root namespace in library/classes/Installer.class.php,
 // autoloaded via composer's classmap. Same class docker/release/auto_configure.php

--- a/tests/Acceptance/bin/install-helper.php
+++ b/tests/Acceptance/bin/install-helper.php
@@ -15,6 +15,21 @@
  *      expects a /root/auto_configure.php that the flex image's
  *      openemr.sh removes at boot for security when EMPTY=yes)
  *
+ * SECURITY: this file is mounted OUTSIDE the Apache document root by
+ * acceptance-package-compose.yml (at /opt/openemr-acceptance-helper.php,
+ * not inside /var/www/localhost/htdocs/openemr/). Apache cannot serve
+ * it. The CLI guard below is defense-in-depth: even if someone drops
+ * this file into a document root by accident, it refuses to execute
+ * over HTTP.
+ *
+ * Approved DI exception (per CodeRabbit rule
+ * openemr.forbiddenInstantiation): this is a standalone acceptance-
+ * harness bootstrap. Directly constructs the Installer service +
+ * resolves the logger via ServiceContainer::getLogger() because
+ * there's no framework container in scope here — the script is
+ * invoked as `php install-helper.php` under CLI, not through the
+ * app's normal request lifecycle.
+ *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
@@ -24,17 +39,23 @@
 
 declare(strict_types=1);
 
+// CLI-only guard. Non-CLI invocations (via web server, if the file
+// somehow ends up in a document root) are refused. Matches the
+// defense-in-depth pattern openemr's auto_configure.php uses.
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    exit("install-helper.php is a CLI-only bootstrap; refusing non-CLI invocation\n");
+}
+
 // Autoload from the mounted openemr tree (release tarballs include
-// vendor/ pre-built by PackageAssembler at release time).
+// vendor/ pre-built by PackageAssembler at release time). Path is
+// container-absolute, so this file has no meaningful static analysis
+// surface — phpstan excludes it via excludePaths.analyseAndScan.
 require_once '/var/www/localhost/htdocs/openemr/vendor/autoload.php';
 
-// The Installer class lives at the root namespace in
-// library/classes/Installer.class.php, autoloaded via composer's
-// classmap. Same class docker/release/auto_configure.php uses.
-//
-// Logger obtained via ServiceContainer::getLogger() (project
-// convention — a custom PHPStan rule
-// `openemr.forbiddenInstantiation` rejects `new SystemLogger()`).
+// Installer lives at the root namespace in library/classes/Installer.class.php,
+// autoloaded via composer's classmap. Same class docker/release/auto_configure.php
+// uses.
 use OpenEMR\BC\ServiceContainer;
 
 $installSettings = [
@@ -45,9 +66,9 @@ $installSettings = [
     'igroup' => 'Default',
     // Database — the compose stack's `mysql` service is the host
     'server' => 'mysql',
-    // loginhost = '%' (wildcard) so the openemr user can connect from
-    // any host — including the openemr container's IP, which isn't
-    // localhost from mysql's perspective. Matches what flex image's
+    // loginhost='%' (wildcard) so the openemr user can connect from
+    // any host — the openemr container's IP isn't localhost from
+    // mysql's perspective. Matches what flex image's
     // devtoolsLibrary.source::prepareVariables() sets.
     'loginhost' => '%',
     'port' => '3306',
@@ -58,10 +79,8 @@ $installSettings = [
     'dbname' => 'openemr',
     'collate' => 'utf8mb4_general_ci',
     'site' => 'default',
-    // Advanced options unused for standard installs. Passed as empty
-    // strings (not 'BLANK' as auto_configure.php uses — that's a sentinel
-    // auto_configure.php converts to '' before calling Installer; here
-    // we skip the sentinel and pass '' directly).
+    // Empty string (not 'BLANK' — auto_configure.php's sentinel that
+    // it converts to '' before calling Installer).
     'source_site_id' => '',
     'clone_database' => '',
     'no_root_db_access' => '',

--- a/tests/Acceptance/bin/install-helper.php
+++ b/tests/Acceptance/bin/install-helper.php
@@ -47,6 +47,17 @@ if (PHP_SAPI !== 'cli') {
     exit("install-helper.php is a CLI-only bootstrap; refusing non-CLI invocation\n");
 }
 
+// Opt-in env guard. Mirrors the pattern in
+// contrib/util/installScripts/InstallerAuto.php — refuses to run under
+// CLI unless the caller explicitly sets the enable variable, so a stray
+// `php install-helper.php` from an unrelated shell can't reinstall an
+// already-installed openemr and wipe its DB. boot-package.sh sets this
+// before invoking `docker compose exec`.
+if (!getenv('OPENEMR_ENABLE_ACCEPTANCE_HELPER')) {
+    fwrite(STDERR, "install-helper.php: refusing to run without OPENEMR_ENABLE_ACCEPTANCE_HELPER=1\n");
+    exit(1);
+}
+
 // Autoload from the mounted openemr tree (release tarballs include
 // vendor/ pre-built by PackageAssembler at release time). Path is
 // container-absolute, so this file has no meaningful static analysis

--- a/tests/Acceptance/bin/install-helper.php
+++ b/tests/Acceptance/bin/install-helper.php
@@ -59,8 +59,12 @@ if (!getenv('OPENEMR_ENABLE_ACCEPTANCE_HELPER')) {
 }
 
 // Autoload from the mounted openemr tree (release tarballs include
-// vendor/ pre-built by PackageAssembler at release time).
-require_once '/var/www/localhost/htdocs/openemr/vendor/autoload.php';
+// vendor/ pre-built by PackageAssembler at release time). Path is
+// container-absolute and only exists inside the flex container at
+// execution time — assign through a variable so phpstan's static
+// file-existence check doesn't flag the include on the runner.
+$autoloadPath = '/var/www/localhost/htdocs/openemr/vendor/autoload.php';
+require_once $autoloadPath;
 
 // Installer lives at the root namespace in library/classes/Installer.class.php,
 // autoloaded via composer's classmap. Same class docker/release/auto_configure.php

--- a/tests/Acceptance/bin/install-helper.php
+++ b/tests/Acceptance/bin/install-helper.php
@@ -59,9 +59,7 @@ if (!getenv('OPENEMR_ENABLE_ACCEPTANCE_HELPER')) {
 }
 
 // Autoload from the mounted openemr tree (release tarballs include
-// vendor/ pre-built by PackageAssembler at release time). Path is
-// container-absolute, so this file has no meaningful static analysis
-// surface — phpstan excludes it via excludePaths.analyseAndScan.
+// vendor/ pre-built by PackageAssembler at release time).
 require_once '/var/www/localhost/htdocs/openemr/vendor/autoload.php';
 
 // Installer lives at the root namespace in library/classes/Installer.class.php,

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Upgrade an already-installed openemr tarball to a newer version.
+#
+# Prerequisite: tests/Acceptance/bin/boot-package.sh <from-version> was
+# run first (so <from> is installed with data). This script:
+#
+#   1. Downloads the <to> tarball from GitHub releases
+#   2. Extracts it into a scratch dir
+#   3. Copies the <from> install's sites/ dir into the <to> extraction
+#      (preserves DB config + any installed modules — matches the wiki
+#      "Move openemr/ to openemr_bk/, extract new, copy sites/" flow)
+#   4. Swaps the compose bind mount from <from> to <to> (stops openemr
+#      container, restarts with new TARBALL_DIR — mysql/volumes preserved)
+#   5. Runs sql_upgrade.php in CLI mode via `docker compose exec`,
+#      passing --from=<from> so the upgrade script knows which schema
+#      migrations to apply
+#
+# Usage:
+#   tests/Acceptance/bin/upgrade-package.sh <from-version> <to-version>
+#     from-version — the version already installed via boot-package.sh
+#     to-version   — the target version (must have a v<X_Y_Z> release tag)
+#
+# After successful upgrade:
+#   Same URL:      http://localhost:8680  (openemr now serving <to>)
+#   Scratch dir:   /tmp/openemr-acceptance-<to>/  (bind-mount source)
+#
+# The <from> scratch dir at /tmp/openemr-acceptance-<from>/ is preserved
+# — down-package.sh removes it on final teardown.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <from-version> <to-version>" >&2
+    echo "  e.g.: $0 8.1.0 8.2.0" >&2
+    exit 2
+fi
+
+FROM_VERSION="$1"
+TO_VERSION="$2"
+FROM_TARBALL_DIR="/tmp/openemr-acceptance-${FROM_VERSION}"
+TO_TARBALL_DIR="/tmp/openemr-acceptance-${TO_VERSION}"
+
+TO_TAG_NAME="v$(echo "$TO_VERSION" | tr '.' '_')"
+TO_TARBALL_URL="https://github.com/openemr/openemr/releases/download/${TO_TAG_NAME}/openemr-${TO_VERSION}.tar.gz"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." &>/dev/null && pwd)"
+
+export COMPOSE_FILE="${REPO_ROOT}/.github/docker/acceptance-package-compose.yml"
+export COMPOSE_PROJECT_NAME="openemr-acceptance-package"
+
+cd "${REPO_ROOT}"
+
+if [[ ! -d "${FROM_TARBALL_DIR}/sites" ]]; then
+    echo "::error::${FROM_TARBALL_DIR}/sites not found — did boot-package.sh ${FROM_VERSION} run first?" >&2
+    exit 1
+fi
+
+echo "==> Preparing scratch dir at ${TO_TARBALL_DIR}"
+rm -rf "${TO_TARBALL_DIR}"
+mkdir -p "${TO_TARBALL_DIR}"
+
+echo "==> Downloading ${TO_TARBALL_URL}"
+curl -fsSL "${TO_TARBALL_URL}" -o "/tmp/openemr-${TO_VERSION}.tar.gz"
+
+echo "==> Extracting into ${TO_TARBALL_DIR}"
+tar -pxzf "/tmp/openemr-${TO_VERSION}.tar.gz" -C "${TO_TARBALL_DIR}" --strip-components=1
+
+echo "==> Overlaying ${FROM_VERSION}'s sites/ dir onto ${TO_VERSION} extraction"
+# Matches the wiki "Copy the old OpenEMR sites/ to the new OpenEMR at
+# openemr/sites/" step — preserves site config + document paths + any
+# per-site customization the from-install accumulated.
+rm -rf "${TO_TARBALL_DIR}/sites"
+cp -a "${FROM_TARBALL_DIR}/sites" "${TO_TARBALL_DIR}/sites"
+
+echo "==> Stopping openemr container (mysql + volumes preserved)"
+export TARBALL_DIR="${FROM_TARBALL_DIR}"
+docker compose stop openemr
+
+echo "==> Re-creating openemr container with ${TO_VERSION} bind mount"
+export TARBALL_DIR="${TO_TARBALL_DIR}"
+docker compose up --detach --force-recreate --no-deps openemr
+
+echo "==> Running sql_upgrade.php CLI mode (--from=${FROM_VERSION})"
+# The wiki upgrade flow points users at sql_upgrade.php in the browser
+# with a "select prior version" dropdown. CLI mode does the same thing
+# with --from=<version> passed on the argv, bypassing the HTTP form.
+# Runs as apache (RootCliGuard rejects UID 0).
+docker compose exec -T openemr \
+    su -s /bin/sh apache -c \
+    "php /var/www/localhost/htdocs/openemr/sql_upgrade.php --from=${FROM_VERSION}"
+
+echo "==> Waiting for openemr container to become healthy post-upgrade"
+for attempt in $(seq 1 60); do
+    HEALTH=$(docker compose ps openemr --format '{{.Health}}' 2>/dev/null || echo unknown)
+    if [[ "$HEALTH" == "healthy" ]]; then
+        echo "    openemr healthy"
+        break
+    fi
+    if [[ $attempt -eq 60 ]]; then
+        echo "::error::openemr did not become healthy post-upgrade within 300s (last status: $HEALTH)" >&2
+        exit 1
+    fi
+    sleep 5
+done
+
+echo ""
+echo "==> Upgrade complete: ${FROM_VERSION} → ${TO_VERSION}"
+echo "    Artifact URL:  http://localhost:8680  (now serving ${TO_VERSION})"
+echo ""
+echo "    Run tests:     ACCEPTANCE_ARTIFACT_URL=http://localhost:8680 composer acceptance -- --group=post-upgrade"
+echo "    Teardown:      tests/Acceptance/bin/down-package.sh"

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -20,35 +20,63 @@
 #   tests/Acceptance/bin/upgrade-package.sh <from-version> <to-version>
 #     from-version — the version already installed via boot-package.sh
 #     to-version   — the target version (must have a v<X_Y_Z> release tag)
+#     Both must match ^[0-9]+\.[0-9]+\.[0-9]+$; from must be strictly
+#     less than to (this is an UPgrade — same-version is a no-op that
+#     would delete the installed source, and downgrade isn't supported).
 #
 # After successful upgrade:
 #   Same URL:      http://localhost:8680  (openemr now serving <to>)
 #   Scratch dir:   /tmp/openemr-acceptance-<to>/  (bind-mount source)
-#
-# The <from> scratch dir at /tmp/openemr-acceptance-<from>/ is preserved
-# — down-package.sh removes it on final teardown.
 
 set -euo pipefail
 
 if [[ $# -ne 2 ]]; then
     echo "Usage: $0 <from-version> <to-version>" >&2
-    echo "  e.g.: $0 8.1.0 8.2.0" >&2
+    echo "  e.g.: $0 8.2.0 8.3.0" >&2
     exit 2
 fi
 
 FROM_VERSION="$1"
 TO_VERSION="$2"
+
+# Validate both versions before either flows into a path — same
+# reasoning as boot-package.sh. Also reject same-version (no-op that
+# would delete installed source) and downgrade (unsupported).
+for v in "${FROM_VERSION}" "${TO_VERSION}"; do
+    if [[ ! "${v}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "::error::version '${v}' does not match expected format X.Y.Z" >&2
+        exit 2
+    fi
+done
+# Use `sort -V` for semantic version comparison.
+# `printf '%s\n' from to | sort -V | head -1` returns the smaller version;
+# for an upgrade, that must be FROM (and FROM != TO).
+if [[ "${FROM_VERSION}" == "${TO_VERSION}" ]]; then
+    echo "::error::FROM_VERSION and TO_VERSION are identical (${FROM_VERSION})" >&2
+    exit 2
+fi
+SMALLER="$(printf '%s\n%s\n' "${FROM_VERSION}" "${TO_VERSION}" | sort -V | head -1)"
+if [[ "${SMALLER}" != "${FROM_VERSION}" ]]; then
+    echo "::error::FROM_VERSION (${FROM_VERSION}) is not less than TO_VERSION (${TO_VERSION}); downgrade not supported" >&2
+    exit 2
+fi
+
 FROM_TARBALL_DIR="/tmp/openemr-acceptance-${FROM_VERSION}"
 TO_TARBALL_DIR="/tmp/openemr-acceptance-${TO_VERSION}"
 
-TO_TAG_NAME="v$(echo "$TO_VERSION" | tr '.' '_')"
+TO_TAG_NAME="v${TO_VERSION//./_}"
 TO_TARBALL_URL="https://github.com/openemr/openemr/releases/download/${TO_TAG_NAME}/openemr-${TO_VERSION}.tar.gz"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." &>/dev/null && pwd)"
 
+export HELPER_PATH="${SCRIPT_DIR}/install-helper.php"
 export COMPOSE_FILE="${REPO_ROOT}/.github/docker/acceptance-package-compose.yml"
 export COMPOSE_PROJECT_NAME="openemr-acceptance-package"
+
+# mktemp for the download path (same rationale as boot-package.sh).
+TARBALL_PATH="$(mktemp -t "openemr-acceptance-upgrade-tarball.XXXXXX.tar.gz")"
+trap 'rm -f "${TARBALL_PATH}"' EXIT
 
 cd "${REPO_ROOT}"
 
@@ -62,10 +90,10 @@ rm -rf "${TO_TARBALL_DIR}"
 mkdir -p "${TO_TARBALL_DIR}"
 
 echo "==> Downloading ${TO_TARBALL_URL}"
-curl -fsSL "${TO_TARBALL_URL}" -o "/tmp/openemr-${TO_VERSION}.tar.gz"
+curl -fsSL "${TO_TARBALL_URL}" -o "${TARBALL_PATH}"
 
 echo "==> Extracting into ${TO_TARBALL_DIR}"
-tar -pxzf "/tmp/openemr-${TO_VERSION}.tar.gz" -C "${TO_TARBALL_DIR}" --strip-components=1
+tar -pxzf "${TARBALL_PATH}" -C "${TO_TARBALL_DIR}" --strip-components=1
 
 echo "==> Overlaying ${FROM_VERSION}'s sites/ dir onto ${TO_VERSION} extraction"
 # Matches the wiki "Copy the old OpenEMR sites/ to the new OpenEMR at
@@ -86,20 +114,21 @@ echo "==> Running sql_upgrade.php CLI mode (--from=${FROM_VERSION})"
 # The wiki upgrade flow points users at sql_upgrade.php in the browser
 # with a "select prior version" dropdown. CLI mode does the same thing
 # with --from=<version> passed on the argv, bypassing the HTTP form.
-# Runs as apache (RootCliGuard rejects UID 0).
+# Runs as apache (RootCliGuard rejects UID 0). --from value already
+# validated at script entry — safe to interpolate into the su command.
 docker compose exec -T openemr \
     su -s /bin/sh apache -c \
     "php /var/www/localhost/htdocs/openemr/sql_upgrade.php --from=${FROM_VERSION}"
 
 echo "==> Waiting for openemr container to become healthy post-upgrade"
 for attempt in $(seq 1 60); do
-    HEALTH=$(docker compose ps openemr --format '{{.Health}}' 2>/dev/null || echo unknown)
-    if [[ "$HEALTH" == "healthy" ]]; then
+    HEALTH="$(docker compose ps openemr --format '{{.Health}}' 2>/dev/null || echo unknown)"
+    if [[ "${HEALTH}" == "healthy" ]]; then
         echo "    openemr healthy"
         break
     fi
-    if [[ $attempt -eq 60 ]]; then
-        echo "::error::openemr did not become healthy post-upgrade within 300s (last status: $HEALTH)" >&2
+    if [[ "${attempt}" -eq 60 ]]; then
+        echo "::error::openemr did not become healthy post-upgrade within 300s (last status: ${HEALTH})" >&2
         exit 1
     fi
     sleep 5


### PR DESCRIPTION
## Summary

Delivers **Phase 3** of [`docs/artifact-acceptance-testing-plan.md`](https://github.com/openemr/openemr/blob/master/docs/artifact-acceptance-testing-plan.md): black-box acceptance testing against the openemr release tarball artifact.

The tarball (`openemr-<version>.tar.gz` on the GitHub release page; produced by `PackageAssembler` via `git archive HEAD` at release time) is a distinct artifact from the Docker image and, until this PR, nothing in CI validated that it installs or upgrades cleanly on a stock user PHP+Apache+MariaDB stack.

Follows #13149 (Phase 1), #13159 (Phase 2), #13163 (Phase 2.5) — all landed 2026-07-24.

## What lands

### Compose stack + install choreography

- **`.github/docker/acceptance-package-compose.yml`** — generic stack mirroring the wiki install instructions:
  - `openemr/openemr:flex-3.23-php-8.5` (sha-pinned) with `EMPTY=yes` (starts Apache but skips its own install path — provides PHP+Apache+extensions without shipping openemr source)
  - `mariadb:11.8` (sha-pinned, matches the ci/ directories' pattern)
  - Bind mount for the extracted tarball at `/var/www/localhost/htdocs/openemr`
  - `install-helper.php` mounted **outside** the webroot at `/opt/openemr-acceptance-helper.php:ro` — Apache can never serve it, so an unauthenticated `/install-helper.php` HTTP request can't trigger a reinstall
  - Healthcheck asserts `/interface/login/login.php` redirect target (same pattern as Phase 1's acceptance-docker-compose.yml)

- **`tests/Acceptance/bin/install-helper.php`** — instantiates OpenEMR's `Installer` class and calls `quick_install()`. Same code path as `docker/release/auto_configure.php` but standalone, because the tarball strips `docker/` (export-ignore) and the flex image's `/root/devtools dev-install` depends on `/root/auto_configure.php` which `openemr.sh` removes at boot for security when `EMPTY=yes`. Uses `ServiceContainer::getLogger()` per project convention. Runs as apache user (RootCliGuard rejects UID 0).

  **Three layers of guards** (matches / builds on how `contrib/util/installScripts/InstallerAuto.php` protects itself):
  1. Compose-file mount outside Apache DocumentRoot (primary)
  2. `PHP_SAPI !== 'cli'` → 403 (defense-in-depth for accidental webroot placement)
  3. `getenv('OPENEMR_ENABLE_ACCEPTANCE_HELPER')` opt-in — refuses to run under CLI without explicit opt-in

- **`tests/Acceptance/bin/boot-package.sh <version>`** — downloads tarball from GitHub release, extracts, boots compose stack, runs install as apache with the opt-in env var set. VERSION arg is regex-validated against `^[0-9]+\.[0-9]+\.[0-9]+$` before any path construction. Download uses `mktemp` + EXIT trap.

- **`tests/Acceptance/bin/upgrade-package.sh <from> <to>`** — implements the wiki upgrade flow: extracts new tarball, overlays old `sites/`, swaps bind mount, runs `sql_upgrade.php --from=<version>` in CLI mode. Rejects same-version + downgrade via `sort -V`.

- **`tests/Acceptance/bin/down-package.sh [version]`** — clean teardown (containers + volume + scratch dirs). Rejects `argc > 1`. Cleanup glob is `rm -rf -- /tmp/openemr-acceptance-*` (no trailing slash → doesn't dereference matching symlinks). Preserves compose-down failure status through cleanup.

### Workflow

- **`.github/workflows/acceptance-package.yml`** — matrix (fail-fast disabled):
  - **On every push/PR/schedule:** `fresh-install` scenario runs against `TO_VERSION`
  - **On `workflow_dispatch` only:** additionally runs an `upgrade` scenario. Gated because the current default (`from_version=8.2.0`) has a tarball, but no earlier version does (v8_1_0 was cut but never shipped; patch releases only shipped `.zip`). Once 8.3.0 releases, the default becomes 8.2.0 → 8.3.0 and the upgrade scenario can move back into the default matrix.

  Triggers: `workflow_dispatch` (any version pair), daily 10:00 UTC schedule, push/PR on acceptance surface. Same concurrency split (schedule vs push/PR) as `acceptance-docker.yml`.

### Test reuse (zero source-side changes)

`InstallTest` + `UpgradeIntegrityTest` from Phase 1/2 both run unchanged — the `ACCEPTANCE_ARTIFACT_URL` env var abstraction is already tag-agnostic. Same test classes now fire against Docker Hub tags (Phase 2), PR-built docker images (Phase 2.5), and tarball-mounted stacks (this PR).

### Byte-identical enforcement

Adds two entries to `.github/byte-identical.yml`:
- `.github/workflows/acceptance-package.yml`
- `.github/docker/acceptance-package-compose.yml`

Both excluded on rel-820 (same reason as Phase 2 — predates `symfony/mime` require-dev). Enforcement starts effectively at rel-830+.

### Dependabot

Appends `.github/docker/` to the existing "Docker CI images" `docker-compose` entry in `.github/dependabot.yml`. Same image classes as the `ci/` dirs already covered (mariadb + openemr flex), so all the existing ignore rules and grouping (`mariadb`, `openemr-images`) apply unchanged. Flex + mariadb sha-pins in the compose file give dependabot something to bump.

### PHPStan

`tests/Acceptance/bin/*.php` excluded from `analyseAndScan` in `phpstan.neon.dist`. Runtime-only bootstrap; depends on the container-absolute `/var/www/localhost/htdocs/openemr/vendor/autoload.php` path that only exists at execution time. Nothing else references install-helper.php at build time.

## Test plan

- [x] Manual end-to-end: `boot-package.sh 8.2.0` completes, install succeeds, all 3 acceptance tests pass against http://localhost:8680
- [x] Teardown removes containers + volumes + scratch dir cleanly
- [x] actionlint clean on `acceptance-package.yml`
- [x] ShellCheck clean on boot/upgrade/down scripts
- [x] PHPStan clean (install-helper.php excluded; rest of tree passes)
- [ ] CI green — first workflow run fires on this PR's push

## What's NOT here (deferred)

- **PR-tarball validation** (analogous to Phase 2.5 for docker) — could be a Phase 3.5 follow-up if wanted; PackageAssembler produces the tarball from source and any source change already gets tested via the docker path
- **Wizard-UI walkthroughs** of `setup.php` + `sql_upgrade.php` web forms — Phase 4 (needs Panther+Selenium)

## Related

- Plan doc: `docs/artifact-acceptance-testing-plan.md` (draft PR #12811)
- Phase 1: #13149 (InstallTest + harness)
- Phase 2: #13159 (workflow + UpgradeIntegrityTest + byte-identical)
- Phase 2.5: #13163 (build_locally for docker PR-image validation)

Assisted-by: Claude Code
