### PR TITLE
chore(edihistory): remove dead code in edih_errseg_parse and segment renderers

### DIFF
--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -15082,11 +15082,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function edih_errseg_parse\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function edih_277_csv_data\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_parse.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -31147,11 +31147,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_segments.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'err\' on mixed\\.$#',
-    'count' => 3,
-    'path' => __DIR__ . '/../../library/edihistory/edih_segments.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'gsn\' on mixed\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../library/edihistory/edih_segments.php',
@@ -31168,7 +31163,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'trace\' on mixed\\.$#',
-    'count' => 4,
+    'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_segments.php',
 ];
 $ignoreErrors[] = [

--- a/library/edihistory/edih_csv_inc.php
+++ b/library/edihistory/edih_csv_inc.php
@@ -1011,10 +1011,9 @@ function csv_newfile_list($type)
  * Simple analysis, but the idea is just to identify the bad segment
  *
  * @param string $err_seg error segment from edih_997_csv_data()
- * @param bool $id true if only the 1st segmentID is wanted
- * return array|string
+ * @return array{trace?: string, id?: list<string>, err?: list<string>}
  */
-function edih_errseg_parse($err_seg, $id = false)
+function edih_errseg_parse($err_seg): array
 {
     // ['err_seg'] = '|IK3*segID*segpos*loop*errcode*bht03syn|CTX-IK3*transID*segID*segpos*elempos
     //                |IK4*elempos*errcode*elem*|CTX-IK4*segID*segpos*elempos

--- a/library/edihistory/edih_csv_inc.php
+++ b/library/edihistory/edih_csv_inc.php
@@ -1029,32 +1029,9 @@ function edih_errseg_parse($err_seg): array
     //'|IK3*segID*segpos*loop*errcode*bht03syn|CTX-IK3*segID*segPos*loopLS*elemPos:compositePos:repPos
     // revised: 123456789004*IK3*segID*segpos[*segID*segpos*segID*segpos]
     $ik = explode('*', (string) $err_seg);
-    foreach ($ik as $i => $k) {
-        switch ($i) {
-            case 0:
-                $ret_ar['trace'] = $k;
-                break;
-            case 1:
-                break;  // IK3
-            case 2:
-                $ret_ar['id'][] = $k;
-                break;   // segment ID
-            case 3:
-                $ret_ar['err'][] = $k;
-                break;  // segment position
-            case 4:
-                $ret_ar['id'][] = $k;
-                break;
-            case 5:
-                $ret_ar['err'][] = $k;
-                break;
-            case 6:
-                $ret_ar['id'][] = $k;
-                break;
-            case 7:
-                $ret_ar['err'][] = $k;
-                break;
-        }
+    $ret_ar['trace'] = $ik[0];
+    foreach (array_slice($ik, 2) as $i => $k) {
+        $ret_ar[$i & 1 ? 'err' : 'id'][] = $k;
     }
 
     //

--- a/library/edihistory/edih_segments.php
+++ b/library/edihistory/edih_segments.php
@@ -360,7 +360,7 @@ function edih_271_text($segments, $delimiter, $err_seg = '')
     //
     if ($err_seg) {
         $er = edih_errseg_parse($err_seg);
-        if (is_array($er) && count($er)) {
+        if (count($er) > 0) {
             $err_ar = $er;
         }
     }

--- a/library/edihistory/edih_segments.php
+++ b/library/edihistory/edih_segments.php
@@ -58,7 +58,6 @@ function edih_837_text($segments, $delimiter, $err_seg = '')
 {
     //
     $str_html = '';
-    $err_ar = [];
     //
     if (!is_array($segments) || !count($segments) || strlen($delimiter) != 1) {
         // debug
@@ -355,14 +354,6 @@ function edih_271_text($segments, $delimiter, $err_seg = '')
     } else {
         $erstn = '';
         $erseg = [];
-    }
-
-    //
-    if ($err_seg) {
-        $er = edih_errseg_parse($err_seg);
-        if (count($er) > 0) {
-            $err_ar = $er;
-        }
     }
 
     //
@@ -832,7 +823,6 @@ function edih_278_text($segments, $delimiter, $err_seg = '')
     $loopid = "0";
     $lx_ct = 0;
     $hasst = false;
-    $err_ar = [];
     $idx = 0;
     $stsegct = 0;
     $stn = '';


### PR DESCRIPTION
Three related cleanups in `edih_errseg_parse` and its callers in `edih_segments.php`:

**`edih_errseg_parse` (edih_csv_inc.php)**
- Remove the never-used `$id = false` parameter — documented as "true if only the 1st segmentID is wanted" but never read in the body and never passed by any of the four callers.
- Replace the malformed `return array|string` comment with a proper `@return array{trace?: string, id?: list<string>, err?: list<string>}` PHPDoc and a native `: array` declaration.
- Replace the 8-case positional `switch` with a direct trace assignment and a `$i & 1` bit-index append loop — even positions are segment IDs (`id`), odd positions are error codes (`err`).

**`edih_segments.php` callers**
- `edih_837_text` and `edih_278_text`: remove dead `$err_ar = []` initializers that were never written or read.
- `edih_271_text`: remove a duplicate `edih_errseg_parse` call that assigned its result to `$err_ar` (also never read); the first call, which populates `$erstn`/`$erseg` used in the render loop, is sufficient.

**Baseline**: the typed return lets PHPStan narrow `$er` from `mixed` to the array shape in callers, resolving 12 stale entries across three baseline files.