### PR TITLE
fix(edihistory): simplify edih_format_percent, add return type

### DIFF
--- a/.phpstan/baseline/function.alreadyNarrowedType.php
+++ b/.phpstan/baseline/function.alreadyNarrowedType.php
@@ -152,11 +152,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to function is_float\\(\\) with float will always evaluate to true\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to function is_string\\(\\) with non\\-falsy\\-string will always evaluate to true\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_csv_inc.php',

--- a/library/edihistory/edih_csv_inc.php
+++ b/library/edihistory/edih_csv_inc.php
@@ -1095,12 +1095,9 @@ function edih_format_money($str_val)
  * @param string $str_val   the amount string
  * @return string           the value as a percentage
  */
-function edih_format_percent($str_val)
+function edih_format_percent($str_val): string
 {
-    $val = (float)$str_val;
-    $pct = is_float($val) ? $val * 100 . '%' : $str_val . '%';
-
-    return $pct;
+    return (float)$str_val * 100 . '%';
 }
 
 /**

--- a/library/edihistory/edih_csv_inc.php
+++ b/library/edihistory/edih_csv_inc.php
@@ -1097,7 +1097,9 @@ function edih_format_money($str_val)
  */
 function edih_format_percent($str_val): string
 {
-    return (float)$str_val * 100 . '%';
+    // Backfill: the canonical implementation lives in the autoloadable
+    // OpenEMR\Billing\EdiHistory\EdiFormat so namespaced code can reuse it.
+    return \OpenEMR\Billing\EdiHistory\EdiFormat::percent((string) $str_val);
 }
 
 /**

--- a/src/Billing/EdiHistory/EdiFormat.php
+++ b/src/Billing/EdiHistory/EdiFormat.php
@@ -6,9 +6,9 @@
  * Holds the canonical implementations of the edih_format_* routines as
  * autoloadable static methods, so namespaced code such as Claim277Renderer
  * can call them without depending on the non-autoloaded procedural include
- * library/edihistory/edih_csv_inc.php. The global edih_format_date() and
- * edih_format_money() functions delegate here as a backfill until every
- * legacy call site is migrated to the class.
+ * library/edihistory/edih_csv_inc.php. The global edih_format_date(),
+ * edih_format_money(), and edih_format_percent() functions delegate here
+ * as a backfill until every legacy call site is migrated to the class.
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
@@ -64,5 +64,18 @@ final class EdiFormat
     public static function money(string $str_val): string
     {
         return ($str_val !== '') ? sprintf('$%01.2f', $str_val) : $str_val;
+    }
+
+    /**
+     * Format an X12 percentage-as-decimal value with a % sign.
+     *
+     * Every call site passes X12 data element 954 (EB08 in 271, CLP13 and
+     * MOA01 in 835), defined as a decimal fraction — '.50' means 50%.
+     *
+     * @param string $str_val the decimal fraction, e.g. '.50'
+     */
+    public static function percent(string $str_val): string
+    {
+        return (float)$str_val * 100 . '%';
     }
 }

--- a/src/Billing/EdiHistory/EdiFormat.php
+++ b/src/Billing/EdiHistory/EdiFormat.php
@@ -76,6 +76,8 @@ final class EdiFormat
      */
     public static function percent(string $str_val): string
     {
-        return (float)$str_val * 100 . '%';
+        // %.14g matches the rendering of a bare float-to-string conversion
+        // at the default precision ini setting, without depending on it.
+        return sprintf('%.14g%%', (float)$str_val * 100);
     }
 }

--- a/tests/Tests/Isolated/Billing/EdiHistory/EdiFormatTest.php
+++ b/tests/Tests/Isolated/Billing/EdiHistory/EdiFormatTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Tests for the EDI history date/money formatting helper.
+ * Tests for the EDI history date/money/percent formatting helper.
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
@@ -84,6 +84,29 @@ final class EdiFormatTest extends TestCase
             'integer amount' => ['42', '$42.00'],
             'rounds to two places' => ['1234.567', '$1234.57'],
             'negative amount' => ['-5', '$-5.00'],
+        ];
+    }
+
+    #[DataProvider('percentProvider')]
+    public function testPercent(string $input, string $expected): void
+    {
+        self::assertSame($expected, EdiFormat::percent($input));
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function percentProvider(): array
+    {
+        return [
+            'decimal fraction' => ['.50', '50%'],
+            'leading zero' => ['0.8', '80%'],
+            'whole' => ['1', '100%'],
+            'fractional percent' => ['.125', '12.5%'],
+            'zero' => ['0', '0%'],
+            'empty string' => ['', '0%'],
         ];
     }
 


### PR DESCRIPTION
`is_float((float)$str_val)` always evaluates to true, so the else branch is dead code. All three call sites (EB08 in 271, CLP13 and MOA01 in 835) pass X12 data element 954, "Percentage as Decimal Value" — a decimal fraction like `.50` — so multiply-by-100 is the correct behavior for every caller and the dead fallback never represented a real input class.

- Remove the dead ternary and add a `: string` return type; clear the corresponding `alreadyNarrowedType` PHPStan baseline entry.
- Move the canonical implementation to `EdiFormat::percent()`, following the existing `date()`/`money()` delegation pattern, with unit tests.

Part of the ongoing edihistory cleanup series.
