### PR TITLE
refactor: use attr() instead of text() in HTML attribute contexts

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -4213,7 +4213,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
-    'count' => 257,
+    'count' => 258,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -4258,7 +4258,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
-    'count' => 349,
+    'count' => 348,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -4423,7 +4423,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
-    'count' => 3,
+    'count' => 5,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/report.php',
 ];
 $ignoreErrors[] = [
@@ -4438,7 +4438,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
-    'count' => 304,
+    'count' => 302,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/report.php',
 ];
 $ignoreErrors[] = [
@@ -5128,12 +5128,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
-    'count' => 4,
+    'count' => 8,
     'path' => __DIR__ . '/../../interface/forms/functional_cognitive_status/new.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
-    'count' => 6,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/functional_cognitive_status/new.php',
 ];
 $ignoreErrors[] = [
@@ -6158,7 +6158,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
-    'count' => 2,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/forms/transfer_summary/new.php',
 ];
 $ignoreErrors[] = [
@@ -6168,7 +6168,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
-    'count' => 8,
+    'count' => 7,
     'path' => __DIR__ . '/../../interface/forms/transfer_summary/new.php',
 ];
 $ignoreErrors[] = [
@@ -14643,7 +14643,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
-    'count' => 11,
+    'count' => 14,
     'path' => __DIR__ . '/../../interface/patient_file/pos_checkout_ippf.php',
 ];
 $ignoreErrors[] = [
@@ -14693,7 +14693,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
-    'count' => 34,
+    'count' => 31,
     'path' => __DIR__ . '/../../interface/patient_file/pos_checkout_ippf.php',
 ];
 $ignoreErrors[] = [
@@ -16103,12 +16103,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/patient_file/summary/pnotes_fragment.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/patient_file/summary/pnotes_fragment.php',
 ];
 $ignoreErrors[] = [

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -6773,7 +6773,7 @@ function display_refractive_data($encounter_data): void
               <td><?php echo text($OSLT); ?></td>
               <td><?php echo text($OSW2W); ?></td>
               <td><?php echo text($OSECL); ?></td>
-              <!--  <td><input type=text id="pend" name="pend" value="<?php echo text($pend); ?>"></td> -->
+              <!--  <td><input type=text id="pend" name="pend" value="<?php echo attr($pend); ?>"></td> -->
             </tr>
           </table>
           </td>

--- a/interface/forms/eye_mag/report.php
+++ b/interface/forms/eye_mag/report.php
@@ -1440,7 +1440,7 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full'): void
                                 <td><?php echo text($ODLT); ?></td>
                                 <td><?php echo text($ODW2W); ?></td>
                                 <td><?php echo text($ODECL); ?></td>
-                                <!-- <td><input type=text id="pend" name="pend"  value="<?php echo text($pend); ?>"></td> -->
+                                <!-- <td><input type=text id="pend" name="pend"  value="<?php echo attr($pend); ?>"></td> -->
                             </tr>
                             <tr>
                                 <td><b><?php echo xlt('OS{{left eye}}'); ?>:</b></td>
@@ -1450,7 +1450,7 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full'): void
                                 <td><?php echo text($OSLT); ?></td>
                                 <td><?php echo text($OSW2W); ?></td>
                                 <td><?php echo text($OSECL); ?></td>
-                                <!--  <td><input type=text id="pend" name="pend" value="<?php echo text($pend); ?>"></td> -->
+                                <!--  <td><input type=text id="pend" name="pend" value="<?php echo attr($pend); ?>"></td> -->
                             </tr>
                         </table>
                     </td>

--- a/interface/forms/functional_cognitive_status/new.php
+++ b/interface/forms/functional_cognitive_status/new.php
@@ -154,9 +154,9 @@ $check_res = $formid ? $check_res : [];
                                     <div class="form-row">
                                         <div class="forms col-md-2">
                                             <label for="code_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Code'); ?>:</label>
-                                            <input type="text" id="code_<?php echo attr($key) + 1; ?>"  name="code[]" class="form-control code" value="<?php echo text($obj["code"]); ?>"  onclick='sel_code(this.parentElement.parentElement.parentElement.id);'>
+                                            <input type="text" id="code_<?php echo attr($key) + 1; ?>"  name="code[]" class="form-control code" value="<?php echo attr($obj["code"]); ?>"  onclick='sel_code(this.parentElement.parentElement.parentElement.id);'>
                                             <span id="displaytext_<?php echo attr($key) + 1; ?>"  class="displaytext help-block"></span>
-                                            <input type="hidden" id="codetext_<?php echo attr($key) + 1; ?>" name="codetext[]" class="codetext" value="<?php echo text($obj["codetext"]); ?>">
+                                            <input type="hidden" id="codetext_<?php echo attr($key) + 1; ?>" name="codetext[]" class="codetext" value="<?php echo attr($obj["codetext"]); ?>">
                                         </div>
                                         <div class="forms col-md-2">
                                             <label for="code_date_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Date'); ?>:</label>
@@ -186,9 +186,9 @@ $check_res = $formid ? $check_res : [];
                                 <div class="form-row">
                                         <div class="forms col-md-2">
                                             <label for="code_1" class="h5"><?php echo xlt('Code'); ?>:</label>
-                                            <input type="text" id="code_1"  name="code[]" class="form-control code" value="<?php echo text($obj["code"] ?? ''); ?>"  onclick='sel_code(this.parentElement.parentElement.parentElement.id);'>
+                                            <input type="text" id="code_1"  name="code[]" class="form-control code" value="<?php echo attr($obj["code"] ?? ''); ?>"  onclick='sel_code(this.parentElement.parentElement.parentElement.id);'>
                                             <span id="displaytext_1"  class="displaytext help-block"></span>
-                                            <input type="hidden" id="codetext_1" name="codetext[]" class="codetext" value="<?php echo text($obj["codetext"] ?? ''); ?>">
+                                            <input type="hidden" id="codetext_1" name="codetext[]" class="codetext" value="<?php echo attr($obj["codetext"] ?? ''); ?>">
                                         </div>
                                         <div class="forms col-md-2">
                                             <label for="code_date_1" class="h5"><?php echo xlt('Date'); ?>:</label>

--- a/interface/forms/transfer_summary/new.php
+++ b/interface/forms/transfer_summary/new.php
@@ -100,7 +100,7 @@ echo "<form method='post' name='my_form' " .
 
      <td class="forms">
          <input type="text" name="transfer_to" id="transfer_to"
-        value="<?php echo text($obj["transfer_to"] ?? '');?>"></td>
+        value="<?php echo attr($obj["transfer_to"] ?? '');?>"></td>
 
         <td align="left" class="forms"><?php echo xlt('Transfer date'); ?>:</td>
         <td class="forms">

--- a/interface/patient_file/pos_checkout_ippf.php
+++ b/interface/patient_file/pos_checkout_ippf.php
@@ -967,11 +967,11 @@ function ippf_generate_receipt($patient_id, $encounter = 0): void
                     <tr>
                         <td><b><?php echo xlt('Date'); ?></b></td>
                         <td colspan='2'><b><?php echo xlt('Checkout Receipt Ref'); ?></b></td>
-                        <td colspan="<?php echo text($rcpt_num_method_columns); ?>"
+                        <td colspan="<?php echo attr($rcpt_num_method_columns); ?>"
                         align='left'><b><?php echo xlt('Payment Method'); ?></b></td>
-                        <td colspan="<?php echo text($rcpt_num_ref_columns); ?>"
+                        <td colspan="<?php echo attr($rcpt_num_ref_columns); ?>"
                         align='left'><b><?php echo xlt('Ref No'); ?></b></td>
-                        <td colspan='<?php echo text($rcpt_num_amount_columns); ?>'
+                        <td colspan='<?php echo attr($rcpt_num_amount_columns); ?>'
                         align='right'><b><?php echo xlt('Amount'); ?></b></td>
                     </tr>
 

--- a/interface/patient_file/summary/pnotes_fragment.php
+++ b/interface/patient_file/summary/pnotes_fragment.php
@@ -89,7 +89,7 @@ if (isset($_GET['docUpdateId'])) {
                 $body = $iter['body'];
                 $body = preg_replace('/(\d{4}-\d{2}-\d{2} \d{2}:\d{2}\s\([^)(]+\s)(to)(\s[^)(]+\))/', '', (string) $body);
                 $body = preg_replace('/(\sto\s)-patient-(\))/', '${1}' . $patientname . '${2}', (string) $body);
-                echo " <tr class='text' id=" . text($iter['id']) . ">\n";
+                echo " <tr class='text' id='" . attr($iter['id']) . "'>\n";
 
                 // Modified 6/2009 by BM to incorporate the patient notes into the list_options listings
                 echo "<td class='text'>" . text($iter['user']) . "</td>\n";

--- a/interface/patient_file/summary/stats_full.php
+++ b/interface/patient_file/summary/stats_full.php
@@ -380,7 +380,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                         <button type="button" class="btn btn-outline-text btn-sm collapsed" data-toggle="collapse" data-target="#details_<?php echo attr($row['id']); ?>" aria-expanded="false" aria-controls="details_<?php echo attr($row['id']); ?>"><span aria-hidden="true" class="fa fa-fw fa-chevron-right"></span></button>
                                         <button type="button" class="btn btn-outline-text btn-sm editenc" data-issue-id="<?php echo attr($row['id']); ?>"><span aria-hidden="true" class="fa fa-fw fa-link"></span></button>
                                     </div>
-                                    <a href="#" data-issue-id="<?php echo attr($row['id']); ?>" class="font-weight-bold issue_title" data-toggle="tooltip" data-placement="right" title="<?php echo text(($diag ?? '') . ": " . ($codedesc ?? '')); ?>">
+                                    <a href="#" data-issue-id="<?php echo attr($row['id']); ?>" class="font-weight-bold issue_title" data-toggle="tooltip" data-placement="right" title="<?php echo attr(($diag ?? '') . ": " . ($codedesc ?? '')); ?>">
                                         <?php echo text($disptitle); ?>
                                     </a>&nbsp;(<?php echo $statusCompute; ?><?php echo (!$resolved && $outcome) ? ", $outcome" : ""; ?>)
                                     <?php
@@ -413,7 +413,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                         <?php if ($row['begdate']) : ?>
                                             <div class="pr-3">
                                                 <div class="font-weight-bold "><?php echo xlt("Start Date"); ?></div>
-                                                <div class="" title="<?php echo text($fullBegDate); ?>"><?php echo text($shortBegDate); ?></div>
+                                                <div class="" title="<?php echo attr($fullBegDate); ?>"><?php echo text($shortBegDate); ?></div>
                                             </div>
                                         <?php endif; ?>
                                         <?php if ($row['enddate']) : ?>


### PR DESCRIPTION
`library/htmlspecialchars.inc.php` documents `text()` as an HTML-text-node escape (`ENT_NOQUOTES`) and `attr()` as an HTML-attribute escape (`ENT_QUOTES`). Switched every `text()` call whose output lands inside a quoted HTML attribute value to `attr()` — 14 sites across 6 files.

The `pnotes_fragment.php` site also gained quotes around a previously unquoted `<tr>` `id` attribute.

Three of the sites are in commented-out code; flipped only for pattern consistency should the code ever be un-commented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)