### PR TITLE
feat(acceptance): Phase 4a — FhirSmokeTest + LoginFlow extraction

### DIFF
--- a/tests/Acceptance/FhirSmokeTest.php
+++ b/tests/Acceptance/FhirSmokeTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance;
+
+use OpenEMR\Tests\Acceptance\Support\ArtifactBrowser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * FHIR discovery-endpoint smoke test.
+ *
+ * Both endpoints exercised here are REQUIRED to be publicly accessible
+ * per their governing specs (FHIR R4 + SMART-on-FHIR) — no OAuth token,
+ * no session cookie, nothing. Purpose: prove the artifact's FHIR routing
+ * infrastructure is intact end-to-end. If /apis/default/fhir/* returns a
+ * 404 or 5xx here, no FHIR-consuming client can even discover the server
+ * exists.
+ *
+ * Fires in both fresh-install and post-upgrade scenarios: a schema
+ * migration bug can break FHIR discovery just as easily as an
+ * install-time misconfiguration, and either failure mode blocks every
+ * downstream FHIR interaction.
+ *
+ * Authenticated FHIR resource access (Patient, Observation, etc.)
+ * lands in Phase 4a-2, which introduces the OAuth2 dynamic-client-
+ * registration + authorization-code helper.
+ */
+#[Group('fresh-install')]
+#[Group('post-upgrade')]
+final class FhirSmokeTest extends TestCase
+{
+    public function testMetadataEndpointReturnsCapabilityStatement(): void
+    {
+        // Per FHIR spec (https://hl7.org/fhir/http.html#capabilities),
+        // `GET [base]/metadata` returns a CapabilityStatement resource
+        // and must be accessible without authentication so clients can
+        // discover the server's capabilities before initiating auth.
+        $browser = ArtifactBrowser::create();
+        $browser->request(
+            'GET',
+            ArtifactBrowser::baseUrl() . '/apis/default/fhir/metadata',
+        );
+        $response = $browser->getResponse();
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            'FHIR /metadata must return 200 without auth per FHIR spec — 401/403 means the routing added an auth check',
+        );
+
+        $body = json_decode($response->getContent(), true);
+        self::assertIsArray(
+            $body,
+            'FHIR /metadata should return a JSON object; a non-JSON body means the response is an HTML error page',
+        );
+        self::assertSame(
+            'CapabilityStatement',
+            $body['resourceType'] ?? null,
+            'Response resourceType must be CapabilityStatement per the FHIR /metadata contract',
+        );
+        self::assertSame(
+            '4.0.1',
+            $body['fhirVersion'] ?? null,
+            'FHIR version should be R4 (4.0.1) — mismatch here means the FhirMetaDataRestController is emitting the wrong version and clients will refuse to interoperate',
+        );
+    }
+
+    public function testSmartConfigurationEndpointDiscoverable(): void
+    {
+        // Per SMART-on-FHIR conformance
+        // (https://hl7.org/fhir/smart-app-launch/conformance.html),
+        // .well-known/smart-configuration carries the OAuth endpoint
+        // URLs SMART clients need. Must be unauthenticated (it's the
+        // discovery step BEFORE any auth handshake).
+        $browser = ArtifactBrowser::create();
+        $browser->request(
+            'GET',
+            ArtifactBrowser::baseUrl() . '/apis/default/fhir/.well-known/smart-configuration',
+        );
+        $response = $browser->getResponse();
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            'SMART .well-known/smart-configuration must return 200 without auth per the SMART conformance spec',
+        );
+
+        $body = json_decode($response->getContent(), true);
+        self::assertIsArray(
+            $body,
+            'SMART well-known should return a JSON object',
+        );
+        // authorization_endpoint + token_endpoint are the minimum
+        // signals a SMART client uses to bootstrap the auth flow. If
+        // either is missing, no SMART client can proceed.
+        self::assertArrayHasKey(
+            'authorization_endpoint',
+            $body,
+            'SMART config must expose authorization_endpoint — clients can discover the server but cannot start auth without it',
+        );
+        self::assertArrayHasKey(
+            'token_endpoint',
+            $body,
+            'SMART config must expose token_endpoint — clients cannot exchange codes for tokens without it',
+        );
+        self::assertIsString($body['authorization_endpoint']);
+        self::assertIsString($body['token_endpoint']);
+    }
+}

--- a/tests/Acceptance/FhirSmokeTest.php
+++ b/tests/Acceptance/FhirSmokeTest.php
@@ -102,7 +102,10 @@ final class FhirSmokeTest extends TestCase
         );
         // authorization_endpoint + token_endpoint are the minimum
         // signals a SMART client uses to bootstrap the auth flow. If
-        // either is missing, no SMART client can proceed.
+        // either is missing OR is not a usable URL, no SMART client
+        // can proceed. Per the SMART conformance spec both fields are
+        // string values that MUST be absolute URLs — assert not just
+        // "present" but "valid enough for a client to actually hit."
         self::assertArrayHasKey(
             'authorization_endpoint',
             $body,
@@ -114,6 +117,14 @@ final class FhirSmokeTest extends TestCase
             'SMART config must expose token_endpoint — clients cannot exchange codes for tokens without it',
         );
         self::assertIsString($body['authorization_endpoint']);
+        self::assertNotFalse(
+            filter_var($body['authorization_endpoint'], FILTER_VALIDATE_URL),
+            'authorization_endpoint must be a valid absolute URL per SMART spec — empty string or malformed value means clients cannot start the auth flow',
+        );
         self::assertIsString($body['token_endpoint']);
+        self::assertNotFalse(
+            filter_var($body['token_endpoint'], FILTER_VALIDATE_URL),
+            'token_endpoint must be a valid absolute URL per SMART spec — empty string or malformed value means clients cannot exchange codes for tokens',
+        );
     }
 }

--- a/tests/Acceptance/InstallTest.php
+++ b/tests/Acceptance/InstallTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Acceptance;
 
 use OpenEMR\Tests\Acceptance\Support\ArtifactBrowser;
+use OpenEMR\Tests\Acceptance\Support\LoginFlow;
 use OpenEMR\Tests\Acceptance\Support\ResponseHeaders;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -64,58 +65,17 @@ final class InstallTest extends TestCase
 
     public function testAdminCanLogInAndReachAuthenticatedLandingPage(): void
     {
-        // Full happy-path login: POST admin/pass to the login endpoint,
-        // assert we get the post-login redirect (302 → /interface/main/
-        // tabs/main.php?token_main=...). token_main is a per-session
-        // anti-CSRF token; its presence in the redirect URL is the
-        // definitive signal that the credentials were accepted and a
-        // session was minted.
-        $browser = ArtifactBrowser::create();
-        $browser->request(
-            'POST',
-            ArtifactBrowser::baseUrl() . '/interface/main/main_screen.php?auth=login&site=default',
-            [
-                'authUser' => 'admin',
-                'clearPass' => 'pass',
-                'languageChoice' => '1',
-                'new_login_session_management' => '1',
-            ],
-        );
-        $response = $browser->getResponse();
-
-        self::assertSame(
-            302,
-            $response->getStatusCode(),
-            'Login POST should return 302 with the authenticated-landing redirect; 200 with the login form re-rendered = credentials rejected',
-        );
-
-        $location = ResponseHeaders::location($response);
-        self::assertStringContainsString(
-            '/interface/main/tabs/main.php',
-            $location,
-            'Login should redirect to the authenticated landing page',
-        );
-        self::assertMatchesRegularExpression(
-            '/token_main=[A-Za-z0-9]+/',
-            $location,
-            'The post-login redirect must carry a per-session token_main anti-CSRF token — its presence proves the session was minted',
-        );
-
-        // Actually FOLLOW the redirect on the same BrowserKit instance
-        // (session cookie carried automatically) and verify the landing
-        // page actually loads. A 401/403 here would mean tabs/main.php
-        // rejected the session for some reason (token_main mismatch,
-        // session storage broken) — the location-header assertions alone
-        // wouldn't catch that.
-        $landingUrl = str_starts_with($location, 'http')
-            ? $location
-            : ArtifactBrowser::baseUrl() . '/' . ltrim($location, '/');
-        $browser->request('GET', $landingUrl);
-        $landingResponse = $browser->getResponse();
-        self::assertSame(
-            200,
-            $landingResponse->getStatusCode(),
-            'GET on the authenticated landing URL must return 200; 401/403 would indicate the session was rejected despite the login redirect',
+        // Full happy-path login: POST admin/pass, assert the 302 has
+        // token_main in the Location, follow the redirect, assert 200.
+        // Implementation lives in Support/LoginFlow — shared with
+        // UpgradeIntegrityTest and any future authenticated tests so
+        // the exact-form-field-shape (authUser + clearPass +
+        // languageChoice + new_login_session_management) stays in one
+        // place.
+        LoginFlow::loginAsAdmin(
+            ArtifactBrowser::create(),
+            ArtifactBrowser::baseUrl(),
+            'fresh-install',
         );
     }
 }

--- a/tests/Acceptance/Support/LoginFlow.php
+++ b/tests/Acceptance/Support/LoginFlow.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance\Support;
+
+use PHPUnit\Framework\Assert;
+use Symfony\Component\BrowserKit\HttpBrowser;
+
+/**
+ * Shared admin-login flow used by every acceptance test that needs an
+ * authenticated session against the artifact under test.
+ *
+ * Extracted from the identical implementations in InstallTest (Phase 1)
+ * and UpgradeIntegrityTest (Phase 2) so future authenticated tests
+ * (Phase 4a-2 API/FHIR OAuth-adjacent tests, wizard walkthroughs in
+ * 4c, etc.) don't hand-roll a fifth copy.
+ *
+ * The success signal is unchanged from the original inline versions:
+ * login POST returns 302 with `token_main` in the Location header,
+ * and a GET on that Location returns 200 — that combination is the
+ * definitive proof the credentials were accepted, session was minted,
+ * and the authenticated landing page renders.
+ */
+final class LoginFlow
+{
+    /**
+     * Log in as `admin`/`pass`, follow the post-login redirect on the
+     * same browser instance (session cookie carried automatically), and
+     * assert each step succeeded. Callers can immediately follow up
+     * with authenticated requests on the returned browser.
+     *
+     * `$failureContext` is prepended to every assertion message so a
+     * failure points back at the calling test's scenario ("post-upgrade
+     * login" is clearer than a bare "login failed" when both
+     * InstallTest and UpgradeIntegrityTest use the same helper).
+     */
+    public static function loginAsAdmin(
+        HttpBrowser $browser,
+        string $baseUrl,
+        string $failureContext = '',
+    ): void {
+        $prefix = $failureContext !== '' ? "[{$failureContext}] " : '';
+
+        $browser->request(
+            'POST',
+            $baseUrl . '/interface/main/main_screen.php?auth=login&site=default',
+            [
+                'authUser' => 'admin',
+                'clearPass' => 'pass',
+                'languageChoice' => '1',
+                'new_login_session_management' => '1',
+            ],
+        );
+        $response = $browser->getResponse();
+
+        Assert::assertSame(
+            302,
+            $response->getStatusCode(),
+            $prefix . 'Login POST should return 302; 200 with the login form re-rendered = credentials rejected',
+        );
+
+        $location = ResponseHeaders::location($response);
+        Assert::assertStringContainsString(
+            '/interface/main/tabs/main.php',
+            $location,
+            $prefix . 'Login should redirect to the authenticated landing page',
+        );
+        Assert::assertMatchesRegularExpression(
+            '/token_main=[A-Za-z0-9]+/',
+            $location,
+            $prefix . 'Post-login redirect must carry a per-session token_main anti-CSRF token — its absence indicates the session was not minted',
+        );
+
+        // Actually FOLLOW the redirect on the same BrowserKit instance
+        // and verify the landing page loads. Guards against the case
+        // where the 302 looks valid but the actual landing page 401s
+        // due to session-state regression that the header alone
+        // wouldn't catch.
+        $landingUrl = str_starts_with($location, 'http')
+            ? $location
+            : $baseUrl . '/' . ltrim($location, '/');
+        $browser->request('GET', $landingUrl);
+        $landingResponse = $browser->getResponse();
+        Assert::assertSame(
+            200,
+            $landingResponse->getStatusCode(),
+            $prefix . 'GET on the authenticated landing URL must return 200; 401/403 = session accepted by login endpoint but rejected by main.php',
+        );
+    }
+}

--- a/tests/Acceptance/UpgradeIntegrityTest.php
+++ b/tests/Acceptance/UpgradeIntegrityTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Acceptance;
 
 use OpenEMR\Tests\Acceptance\Support\ArtifactBrowser;
-use OpenEMR\Tests\Acceptance\Support\ResponseHeaders;
+use OpenEMR\Tests\Acceptance\Support\LoginFlow;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
@@ -53,55 +53,16 @@ final class UpgradeIntegrityTest extends TestCase
 {
     public function testAdminLoginStillWorksAfterUpgrade(): void
     {
-        // Reuses the exact login flow InstallTest exercises against
-        // a fresh artifact. Success signal is identical: 302 to
-        // `/interface/main/tabs/main.php?token_main=<hex>`, then a
-        // GET on the landing page returns 200. If sql_upgrade.php
-        // broke the users table, sessions, or the token_main
-        // machinery, the assertions fail here.
-        $browser = ArtifactBrowser::create();
-        $browser->request(
-            'POST',
-            ArtifactBrowser::baseUrl() . '/interface/main/main_screen.php?auth=login&site=default',
-            [
-                'authUser' => 'admin',
-                'clearPass' => 'pass',
-                'languageChoice' => '1',
-                'new_login_session_management' => '1',
-            ],
-        );
-        $response = $browser->getResponse();
-
-        self::assertSame(
-            302,
-            $response->getStatusCode(),
-            'Login POST should return 302 after upgrade; 200 with login form re-rendered = users table or auth-token machinery broken by the upgrade',
-        );
-
-        $location = ResponseHeaders::location($response);
-        self::assertStringContainsString(
-            '/interface/main/tabs/main.php',
-            $location,
-            'Post-upgrade login should redirect to the authenticated landing page',
-        );
-        self::assertMatchesRegularExpression(
-            '/token_main=[A-Za-z0-9]+/',
-            $location,
-            'Post-upgrade token_main must still be minted -- absence indicates the session machinery regressed',
-        );
-
-        // Follow through: guards against the case where the redirect
-        // looks valid but the actual landing page 401s/403s due to
-        // a session-state regression the header alone wouldn't catch.
-        $landingUrl = str_starts_with($location, 'http')
-            ? $location
-            : ArtifactBrowser::baseUrl() . '/' . ltrim($location, '/');
-        $browser->request('GET', $landingUrl);
-        $landingResponse = $browser->getResponse();
-        self::assertSame(
-            200,
-            $landingResponse->getStatusCode(),
-            'GET on the authenticated landing URL must return 200 after upgrade; 401/403 = session accepted by login endpoint but rejected by main.php',
+        // Same happy-path login as InstallTest — shared implementation
+        // in Support/LoginFlow keeps both scenarios in lockstep on the
+        // exact login form contract. The failure-context prefix routes
+        // any assertion failure back at the post-upgrade scenario so
+        // it's clear this is an upgrade regression, not a fresh-install
+        // regression.
+        LoginFlow::loginAsAdmin(
+            ArtifactBrowser::create(),
+            ArtifactBrowser::baseUrl(),
+            'post-upgrade',
         );
     }
 }


### PR DESCRIPTION
## Summary

First slice of **Phase 4** of [`docs/artifact-acceptance-testing-plan.md`](https://github.com/openemr/openemr/blob/master/docs/artifact-acceptance-testing-plan.md). Focuses on the two changes with the smallest new surface area: adding a FHIR discovery smoke test that needs no auth, and extracting the login flow that Phase 1 + Phase 2 both hand-rolled.

Follows #13149 (Phase 1), #13159 (Phase 2), #13163 (Phase 2.5), #13165 (Phase 3).

## What lands

### `FhirSmokeTest` (new)

Two unauthenticated GET assertions against the FHIR routing surface:

- **`GET /apis/default/fhir/metadata`** → 200 with JSON `resourceType: CapabilityStatement`, `fhirVersion: 4.0.1`. Per [FHIR spec](https://hl7.org/fhir/http.html#capabilities), the metadata endpoint MUST be accessible without auth so clients can discover the server before initiating any OAuth handshake.
- **`GET /apis/default/fhir/.well-known/smart-configuration`** → 200 with JSON carrying at minimum `authorization_endpoint` + `token_endpoint`. Per [SMART conformance](https://hl7.org/fhir/smart-app-launch/conformance.html), this is the discovery step SMART clients hit before any auth handshake — must be unauthenticated.

Tagged with both `#[Group('fresh-install')]` and `#[Group('post-upgrade')]` so it fires in every scenario of every acceptance workflow (docker + package). A schema-migration bug can break FHIR discovery just as easily as an install-time misconfiguration, so both scenarios exercise it.

### `Support/LoginFlow` (extraction, no behavior change)

`InstallTest` and `UpgradeIntegrityTest` each hand-rolled the same ~50-line admin-login flow:

- POST `authUser`/`clearPass`/`languageChoice`/`new_login_session_management`
- assert 302 with `token_main` in Location header
- follow the redirect on the same browser, assert 200

Now shared in `Support/LoginFlow::loginAsAdmin(...)`. `$failureContext` param prepends every assertion message with the calling scenario (`fresh-install` vs `post-upgrade`), so a shared-code failure still points back at which test invoked it.

Retrofitting: both existing tests now call the helper. Exact same HTTP calls + assertions.

## What's NOT here

- **`ApiSmokeTest` (authenticated `/api/version` GET)** — deferred to Phase 4a-2. Needs an OAuth2 helper (`Support/OAuth2/DcrClient.php`) that ports the dynamic-client-registration + authorization-code flow pattern shown in #13175's `AuthorizationLogoutFullFlowTest`. Non-trivial (DCR + login-form scrape + consent + code-exchange) — worth its own PR because the resulting helper becomes the foundation for every future authenticated acceptance test (data seeders, wizard-tests reading state via API, etc.).
- **Panther + `E2eCriticalPathTest`** — Phase 4b (introduces headless browser to acceptance).
- **Wizard-UI tests** (`InstallWizardUiTest`, `UpgradeWizardUiTest`) — Phase 4c (depends on 4b's Panther plumbing; tarball-only).

## Test plan

- [x] `composer acceptance` against local dev stack: **5 tests / 20 assertions pass** (was 3 tests / 15 assertions)
- [x] `phpstan analyze -c .phpstan/phpstan.ci.neon` (full codebase, CI config): **clean**
- [ ] CI green on this PR's first run

## Related

- Plan doc: `docs/artifact-acceptance-testing-plan.md` (draft PR #12811)
- Phase 3: #13165 (package/tarball acceptance workflow)
- OAuth flow pattern reference: #13175 (`AuthorizationLogoutFullFlowTest`)

Assisted-by: Claude Code
