### PR TITLE
refactor: allowlist attributes in CCDA/CCD/QRDA preview stylesheets

### DIFF
--- a/interface/modules/zend_modules/public/xsl/_narrative-block-attrs.xsl
+++ b/interface/modules/zend_modules/public/xsl/_narrative-block-attrs.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Attribute allowlist for CDA R2 narrative-block elements.
+
+  Sourced from HL7's normative NarrativeBlock.xsd
+  (github.com/HL7/CDA-core-2.0/tree/master/schema/normative/processable/coreschemas).
+  Union across every StrucDoc.* complexType in that schema.
+
+  Attributes copied from input CDA XML into the rendered HTML preview are
+  filtered against this list. Anything not on the list is dropped rather
+  than copied, which blocks event-handler injection (onmouseover, onclick,
+  onfocus, ...) and other non-narrative HTML attributes.
+
+  XML attribute names are case-sensitive; note `ID` is uppercase per spec.
+  A lowercase `id` submitted in input CDA would not match and would be
+  dropped, which matches spec behavior (only `ID` is legal on narrative
+  elements).
+
+  Imported by cda.xsl, ccd.xsl, and qrda.xsl. Single source of truth: when
+  extending the allowlist, edit `$narrative-block-attr-allowlist` here and
+  every consumer picks it up automatically.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+  <!--
+    Space-delimited allowlist. Space-padded so `contains()` membership
+    checks are whole-token: contains(' A B C ', concat(' ', $name, ' ')).
+    That prevents e.g. `nameEqualsSomething` accidentally matching `name`.
+  -->
+  <xsl:variable name="narrative-block-attr-allowlist"
+    select="' ID abbr align axis border cellpadding cellspacing char charoff colspan frame headers href language listType mediaType name referencedObject rel rev revised rowspan rules scope span styleCode summary title valign width '"/>
+
+  <!--
+    Iterate every attribute on the context element and emit a copy of
+    each one whose local-name is on the allowlist. Non-allowlisted
+    attributes are silently dropped.
+
+    Use from ccd.xsl / qrda.xsl in place of `<xsl:copy-of select="@*"/>`.
+  -->
+  <xsl:template name="safe-copy-narrative-attrs">
+    <xsl:for-each select="@*">
+      <xsl:if test="contains($narrative-block-attr-allowlist,
+                             concat(' ', local-name(.), ' '))">
+        <xsl:copy-of select="."/>
+      </xsl:if>
+    </xsl:for-each>
+  </xsl:template>
+</xsl:stylesheet>

--- a/interface/modules/zend_modules/public/xsl/ccd.xsl
+++ b/interface/modules/zend_modules/public/xsl/ccd.xsl
@@ -20,6 +20,9 @@
   You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:n1="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <!-- Shared allowlist template for narrative-block attribute copying. -->
+   <xsl:import href="_narrative-block-attrs.xsl"/>
+
    <xsl:output method="html" indent="yes" version="4.01" encoding="ISO-8859-1" doctype-system="http://www.w3.org/TR/html4/strict.dtd" doctype-public="-//W3C//DTD HTML 4.01//EN"/>
    <!-- global variable title -->
    <xsl:variable name="title">
@@ -1223,61 +1226,61 @@
    <!--  Tables   -->
    <xsl:template match="n1:table/@*|n1:thead/@*|n1:tfoot/@*|n1:tbody/@*|n1:colgroup/@*|n1:col/@*|n1:tr/@*|n1:th/@*|n1:td/@*">
       <xsl:copy>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </xsl:copy>
    </xsl:template>
    <xsl:template match="n1:table">
       <table class="narr_table">
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </table>
    </xsl:template>
    <xsl:template match="n1:thead">
       <thead>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </thead>
    </xsl:template>
    <xsl:template match="n1:tfoot">
       <tfoot>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </tfoot>
    </xsl:template>
    <xsl:template match="n1:tbody">
       <tbody>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </tbody>
    </xsl:template>
    <xsl:template match="n1:colgroup">
       <colgroup>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </colgroup>
    </xsl:template>
    <xsl:template match="n1:col">
       <col>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </col>
    </xsl:template>
    <xsl:template match="n1:tr">
       <tr class="narr_tr">
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </tr>
    </xsl:template>
    <xsl:template match="n1:th">
       <th class="narr_th">
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </th>
    </xsl:template>
    <xsl:template match="n1:td">
       <td>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </td>
    </xsl:template>

--- a/interface/modules/zend_modules/public/xsl/ccd.xsl
+++ b/interface/modules/zend_modules/public/xsl/ccd.xsl
@@ -1224,11 +1224,16 @@
       <xsl:text>: </xsl:text>
    </xsl:template>
    <!--  Tables   -->
+   <!--
+     Attribute-node template. Not reached by current callers (parent
+     element templates handle attribute copying via safe-copy-narrative-attrs),
+     but kept and gated so any future <xsl:apply-templates select="@*"/> call
+     also respects the allowlist rather than blindly copying.
+   -->
    <xsl:template match="n1:table/@*|n1:thead/@*|n1:tfoot/@*|n1:tbody/@*|n1:colgroup/@*|n1:col/@*|n1:tr/@*|n1:th/@*|n1:td/@*">
-      <xsl:copy>
-         <xsl:call-template name="safe-copy-narrative-attrs"/>
-         <xsl:apply-templates/>
-      </xsl:copy>
+      <xsl:if test="contains($narrative-block-attr-allowlist, concat(' ', local-name(.), ' '))">
+         <xsl:copy/>
+      </xsl:if>
    </xsl:template>
    <xsl:template match="n1:table">
       <table class="narr_table">

--- a/interface/modules/zend_modules/public/xsl/cda.xsl
+++ b/interface/modules/zend_modules/public/xsl/cda.xsl
@@ -71,6 +71,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 --><xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:sdtc="urn:hl7-org:sdtc" version="1.0">
+  <!-- Shared allowlist template for narrative-block attribute copying. -->
+  <xsl:import href="_narrative-block-attrs.xsl"/>
+
   <!-- This is where all the styles are loaded -->
   
   
@@ -1730,11 +1733,15 @@ limitations under the License.
         <xsl:when test="$attr-name = 'styleCode'">
           <xsl:apply-templates select="."/>
         </xsl:when>
-        <!--<xsl:when
-          test="not(document('')/xsl:stylesheet/xsl:variable[@name = 'table-elem-attrs']/in:tableElems/in:elem[@name = $elem-name]/in:attr[@name = $attr-name])">
-          <xsl:message><xsl:value-of select="$attr-name"/> is not legal in <xsl:value-of
-              select="$elem-name"/></xsl:message>
-        </xsl:when>-->
+        <xsl:when test="not(contains($narrative-block-attr-allowlist,
+                                     concat(' ', $attr-name, ' ')))">
+          <!--
+            Drop any attribute not on the CDA R2 narrative-block allowlist
+            (see $narrative-block-attr-allowlist in
+            _narrative-block-attrs.xsl). Blocks event handlers, style,
+            srcdoc, formaction, and every other non-narrative HTML attribute.
+          -->
+        </xsl:when>
         <xsl:when test="not($source = $scrubbedSource)">
           <p>
             <xsl:value-of select="$malicious-content-warning"/>

--- a/interface/modules/zend_modules/public/xsl/cda.xsl
+++ b/interface/modules/zend_modules/public/xsl/cda.xsl
@@ -1722,6 +1722,20 @@ limitations under the License.
       <xsl:variable name="lcSource" select="translate($source, $uc, $lc)"/>
       <xsl:variable name="scrubbedSource" select="translate($source, $simple-sanitizer-match, $simple-sanitizer-replace)"/>
       <xsl:choose>
+        <xsl:when test="not(contains($narrative-block-attr-allowlist,
+                                     concat(' ', $attr-name, ' ')))">
+          <!--
+            Drop any attribute not on the CDA R2 narrative-block allowlist
+            (see $narrative-block-attr-allowlist in
+            _narrative-block-attrs.xsl). Blocks event handlers, style,
+            srcdoc, formaction, and every other non-narrative HTML attribute.
+
+            Ordered first so a non-allowlisted attribute is silently dropped
+            before its value can reach the javascript-terminate check below,
+            which would otherwise abort the whole render on malicious input
+            that would have been safely dropped anyway.
+          -->
+        </xsl:when>
         <xsl:when test="contains($lcSource, 'javascript')">
           <p>
             <xsl:value-of select="$javascript-injection-warning"/>
@@ -1732,15 +1746,6 @@ limitations under the License.
         </xsl:when>
         <xsl:when test="$attr-name = 'styleCode'">
           <xsl:apply-templates select="."/>
-        </xsl:when>
-        <xsl:when test="not(contains($narrative-block-attr-allowlist,
-                                     concat(' ', $attr-name, ' ')))">
-          <!--
-            Drop any attribute not on the CDA R2 narrative-block allowlist
-            (see $narrative-block-attr-allowlist in
-            _narrative-block-attrs.xsl). Blocks event handlers, style,
-            srcdoc, formaction, and every other non-narrative HTML attribute.
-          -->
         </xsl:when>
         <xsl:when test="not($source = $scrubbedSource)">
           <p>

--- a/interface/modules/zend_modules/public/xsl/qrda.xsl
+++ b/interface/modules/zend_modules/public/xsl/qrda.xsl
@@ -20,6 +20,9 @@
   You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 
 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:n1="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <!-- Shared allowlist template for narrative-block attribute copying. -->
+   <xsl:import href="_narrative-block-attrs.xsl"/>
+
    <xsl:output method="html" indent="yes" version="4.01" encoding="ISO-8859-1" doctype-system="http://www.w3.org/TR/html4/strict.dtd" doctype-public="-//W3C//DTD HTML 4.01//EN"/>
    <!-- global variable title -->
    <xsl:variable name="title">
@@ -1228,61 +1231,61 @@
    <!--  Tables   -->
    <xsl:template match="n1:table/@*|n1:thead/@*|n1:tfoot/@*|n1:tbody/@*|n1:colgroup/@*|n1:col/@*|n1:tr/@*|n1:th/@*|n1:td/@*">
       <xsl:copy>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </xsl:copy>
    </xsl:template>
    <xsl:template match="n1:table">
       <table class="narr_table">
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </table>
    </xsl:template>
    <xsl:template match="n1:thead">
       <thead>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </thead>
    </xsl:template>
    <xsl:template match="n1:tfoot">
       <tfoot>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </tfoot>
    </xsl:template>
    <xsl:template match="n1:tbody">
       <tbody>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </tbody>
    </xsl:template>
    <xsl:template match="n1:colgroup">
       <colgroup>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </colgroup>
    </xsl:template>
    <xsl:template match="n1:col">
       <col>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </col>
    </xsl:template>
    <xsl:template match="n1:tr">
       <tr class="narr_tr">
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </tr>
    </xsl:template>
    <xsl:template match="n1:th">
       <th class="narr_th">
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </th>
    </xsl:template>
    <xsl:template match="n1:td">
       <td>
-         <xsl:copy-of select="@*"/>
+         <xsl:call-template name="safe-copy-narrative-attrs"/>
          <xsl:apply-templates/>
       </td>
    </xsl:template>

--- a/interface/modules/zend_modules/public/xsl/qrda.xsl
+++ b/interface/modules/zend_modules/public/xsl/qrda.xsl
@@ -1229,11 +1229,16 @@
       <xsl:text>: </xsl:text>
    </xsl:template>
    <!--  Tables   -->
+   <!--
+     Attribute-node template. Not reached by current callers (parent
+     element templates handle attribute copying via safe-copy-narrative-attrs),
+     but kept and gated so any future <xsl:apply-templates select="@*"/> call
+     also respects the allowlist rather than blindly copying.
+   -->
    <xsl:template match="n1:table/@*|n1:thead/@*|n1:tfoot/@*|n1:tbody/@*|n1:colgroup/@*|n1:col/@*|n1:tr/@*|n1:th/@*|n1:td/@*">
-      <xsl:copy>
-         <xsl:call-template name="safe-copy-narrative-attrs"/>
-         <xsl:apply-templates/>
-      </xsl:copy>
+      <xsl:if test="contains($narrative-block-attr-allowlist, concat(' ', local-name(.), ' '))">
+         <xsl:copy/>
+      </xsl:if>
    </xsl:template>
    <xsl:template match="n1:table">
       <table class="narr_table">

--- a/tests/Tests/Isolated/CCDA/CcdaXslAttributeFilterTest.php
+++ b/tests/Tests/Isolated/CCDA/CcdaXslAttributeFilterTest.php
@@ -1,0 +1,203 @@
+<?php
+
+/**
+ * Isolated tests for the CDA R2 narrative-block attribute allowlist.
+ *
+ * Exercises the shared `safe-copy-narrative-attrs` template in
+ * `interface/modules/zend_modules/public/xsl/_narrative-block-attrs.xsl`
+ * — the template that `ccd.xsl` and `qrda.xsl` call in place of a bare
+ * `<xsl:copy-of select="@*"/>` on table narrative elements, and that
+ * `cda.xsl`'s `output-attrs` template gates against inline.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class CcdaXslAttributeFilterTest extends TestCase
+{
+    private const XSL_DIR = __DIR__ . '/../../../../interface/modules/zend_modules/public/xsl';
+
+    /**
+     * Wrap the shared allowlist template so we can drive it directly from
+     * a test-only XSL. Uses an absolute `file://` URI for the import so
+     * the resolver doesn't need documentURI to work.
+     */
+    private static function copyAttrsViaSharedTemplate(string $attrsFragment): string
+    {
+        $sharedPath = realpath(self::XSL_DIR . '/_narrative-block-attrs.xsl');
+        self::assertNotFalse($sharedPath, 'shared XSL file must resolve');
+        $importHref = 'file://' . $sharedPath;
+
+        $wrapperXsl = <<<XSL
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="$importHref"/>
+  <xsl:output method="xml" indent="no" omit-xml-declaration="yes"/>
+  <xsl:template match="/probe">
+    <result>
+      <xsl:call-template name="safe-copy-narrative-attrs"/>
+    </result>
+  </xsl:template>
+</xsl:stylesheet>
+XSL;
+
+        $xsl = new DOMDocument();
+        $xsl->loadXML($wrapperXsl);
+
+        $xml = new DOMDocument();
+        $xml->loadXML('<probe ' . $attrsFragment . ' />');
+
+        $proc = new XSLTProcessor();
+        $proc->importStylesheet($xsl);
+        return (string) $proc->transformToXml($xml);
+    }
+
+    /**
+     * @param list<string> $expectedNames  attribute names that must appear in output
+     * @param list<string> $droppedNames   attribute names that must NOT appear in output
+     */
+    #[DataProvider('attributeCasesProvider')]
+    public function testAllowlist(string $inputAttrs, array $expectedNames, array $droppedNames): void
+    {
+        $result = self::copyAttrsViaSharedTemplate($inputAttrs);
+        foreach ($expectedNames as $name) {
+            $this->assertMatchesRegularExpression(
+                '/\b' . preg_quote($name, '/') . '=/',
+                $result,
+                "Expected `$name=` to be preserved in: $result"
+            );
+        }
+        foreach ($droppedNames as $name) {
+            $this->assertDoesNotMatchRegularExpression(
+                '/\b' . preg_quote($name, '/') . '=/',
+                $result,
+                "Expected `$name=` to be dropped from: $result"
+            );
+        }
+    }
+
+    /**
+     * @return array<string, array{string, list<string>, list<string>}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function attributeCasesProvider(): array
+    {
+        return [
+            // --- Benign spec-legal attributes preserved ---
+            'ID preserved (spec case)' => [
+                'ID="section1"',
+                ['ID'],
+                [],
+            ],
+            'width + border on table' => [
+                'width="200" border="1"',
+                ['width', 'border'],
+                [],
+            ],
+            'colspan + rowspan on cell' => [
+                'colspan="2" rowspan="3"',
+                ['colspan', 'rowspan'],
+                [],
+            ],
+            'styleCode preserved' => [
+                'styleCode="Bold"',
+                ['styleCode'],
+                [],
+            ],
+            'all-narrative sample (title, href)' => [
+                'title="tip" href="https://example.org"',
+                ['title', 'href'],
+                [],
+            ],
+
+            // --- Case sensitivity: only spec-cased names allowed ---
+            'lowercase id dropped (spec uses ID)' => [
+                'id="lowercase"',
+                [],
+                ['id'],
+            ],
+            'uppercase ID kept + lowercase id dropped side-by-side' => [
+                'ID="keep" id="drop"',
+                ['ID'],
+                ['id'],
+            ],
+
+            // --- Event handlers dropped ---
+            'onmouseover dropped' => [
+                'onmouseover="alert(1)"',
+                [],
+                ['onmouseover'],
+            ],
+            'onclick dropped' => [
+                'onclick="alert(1)"',
+                [],
+                ['onclick'],
+            ],
+            'onfocus dropped' => [
+                'onfocus="alert(1)"',
+                [],
+                ['onfocus'],
+            ],
+            'onerror dropped' => [
+                'onerror="alert(1)"',
+                [],
+                ['onerror'],
+            ],
+
+            // --- Other non-narrative dangerous attributes dropped ---
+            'style dropped' => [
+                'style="background:red"',
+                [],
+                ['style'],
+            ],
+            'srcdoc dropped' => [
+                'srcdoc="&lt;script&gt;alert(1)&lt;/script&gt;"',
+                [],
+                ['srcdoc'],
+            ],
+            'formaction dropped' => [
+                'formaction="https://evil.example"',
+                [],
+                ['formaction'],
+            ],
+
+            // --- Mixed: legitimate + malicious in same element ---
+            'legitimate colspan preserved + onmouseover dropped' => [
+                'colspan="2" onmouseover="alert(1)"',
+                ['colspan'],
+                ['onmouseover'],
+            ],
+            'legitimate ID preserved + onclick dropped' => [
+                'ID="keeper" onclick="alert(1)"',
+                ['ID'],
+                ['onclick'],
+            ],
+
+            // --- Substring/prefix matches that must NOT bypass the allowlist ---
+            'idFoo (prefix collision with ID) dropped' => [
+                'idFoo="attempt"',
+                [],
+                ['idFoo'],
+            ],
+            'nameEquals (variant of name) dropped' => [
+                'nameEquals="attempt"',
+                [],
+                ['nameEquals'],
+            ],
+            'widthy (prefix collision with width) dropped' => [
+                'widthy="attempt"',
+                [],
+                ['widthy'],
+            ],
+        ];
+    }
+}

--- a/tests/Tests/Isolated/CCDA/CcdaXslAttributeFilterTest.php
+++ b/tests/Tests/Isolated/CCDA/CcdaXslAttributeFilterTest.php
@@ -85,6 +85,54 @@ XSL;
     }
 
     /**
+     * Belt-and-suspenders coverage for the attribute-match templates in
+     * ccd.xsl/qrda.xsl that match `n1:table/@*|n1:thead/@*|...`. Not
+     * currently reached by production callers (parent element templates
+     * copy attributes via safe-copy-narrative-attrs), but gated so any
+     * future `<xsl:apply-templates select="@*"/>` respects the allowlist.
+     *
+     * Test drives that path directly against ccd.xsl and asserts drops.
+     */
+    public function testCcdAttributeMatchTemplateAppliesAllowlist(): void
+    {
+        $ccdPath = realpath(self::XSL_DIR . '/ccd.xsl');
+        self::assertNotFalse($ccdPath, 'ccd.xsl must resolve');
+
+        // Wrapper imports ccd.xsl and drives the attribute-match template by
+        // explicitly applying to @* on our synthetic root. Overrides ccd.xsl's
+        // match="/" template (import lowers priority) so we don't get pulled
+        // into CCD's full rendering pipeline for our tiny synthetic input.
+        $wrapperXsl = <<<XSL
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:n1="urn:hl7-org:v3">
+  <xsl:import href="file://$ccdPath"/>
+  <xsl:output method="xml" indent="no" omit-xml-declaration="yes"/>
+  <xsl:template match="/">
+    <result>
+      <xsl:apply-templates select="/n1:td/@*"/>
+    </result>
+  </xsl:template>
+</xsl:stylesheet>
+XSL;
+
+        $xsl = new DOMDocument();
+        $xsl->loadXML($wrapperXsl);
+        $xml = new DOMDocument();
+        $xml->loadXML('<n1:td xmlns:n1="urn:hl7-org:v3" ID="keep" colspan="2" onmouseover="alert(1)" style="x"/>');
+
+        $proc = new XSLTProcessor();
+        $proc->importStylesheet($xsl);
+        $out = (string) $proc->transformToXml($xml);
+
+        $this->assertMatchesRegularExpression('/\bID=/', $out, 'ID must survive attribute-match template');
+        $this->assertMatchesRegularExpression('/\bcolspan=/', $out, 'colspan must survive attribute-match template');
+        $this->assertDoesNotMatchRegularExpression('/\bonmouseover=/', $out, 'onmouseover must be dropped by attribute-match template');
+        $this->assertDoesNotMatchRegularExpression('/\bstyle=/', $out, 'style must be dropped by attribute-match template');
+    }
+
+    /**
      * @return array<string, array{string, list<string>, list<string>}>
      *
      * @codeCoverageIgnore Data providers run before coverage instrumentation starts.

--- a/tests/Tests/Isolated/CCDA/CcdaXslAttributeFilterTest.php
+++ b/tests/Tests/Isolated/CCDA/CcdaXslAttributeFilterTest.php
@@ -86,28 +86,34 @@ XSL;
 
     /**
      * Belt-and-suspenders coverage for the attribute-match templates in
-     * ccd.xsl/qrda.xsl that match `n1:table/@*|n1:thead/@*|...`. Not
-     * currently reached by production callers (parent element templates
+     * ccd.xsl and qrda.xsl that match `n1:table/@*|n1:thead/@*|...`.
+     * Not currently reached by production callers (parent element templates
      * copy attributes via safe-copy-narrative-attrs), but gated so any
      * future `<xsl:apply-templates select="@*"/>` respects the allowlist.
      *
-     * Test drives that path directly against ccd.xsl and asserts drops.
+     * Runs against both stylesheets since they have parallel templates —
+     * a future refactor touching one but not the other is exactly the
+     * kind of drift this test is meant to catch.
+     *
+     * @param non-empty-string $xslFile
      */
-    public function testCcdAttributeMatchTemplateAppliesAllowlist(): void
+    #[DataProvider('stylesheetsWithAttributeMatchTemplateProvider')]
+    public function testAttributeMatchTemplateAppliesAllowlist(string $xslFile): void
     {
-        $ccdPath = realpath(self::XSL_DIR . '/ccd.xsl');
-        self::assertNotFalse($ccdPath, 'ccd.xsl must resolve');
+        $xslPath = realpath(self::XSL_DIR . '/' . $xslFile);
+        self::assertNotFalse($xslPath, $xslFile . ' must resolve');
 
-        // Wrapper imports ccd.xsl and drives the attribute-match template by
-        // explicitly applying to @* on our synthetic root. Overrides ccd.xsl's
-        // match="/" template (import lowers priority) so we don't get pulled
-        // into CCD's full rendering pipeline for our tiny synthetic input.
+        // Wrapper imports the target stylesheet and drives the attribute-match
+        // template by explicitly applying to @* on our synthetic root. The
+        // wrapper's match="/" template overrides the imported match="/" (import
+        // lowers priority) so we don't get pulled into the full rendering
+        // pipeline for our tiny synthetic input.
         $wrapperXsl = <<<XSL
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="1.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:n1="urn:hl7-org:v3">
-  <xsl:import href="file://$ccdPath"/>
+  <xsl:import href="file://$xslPath"/>
   <xsl:output method="xml" indent="no" omit-xml-declaration="yes"/>
   <xsl:template match="/">
     <result>
@@ -126,10 +132,23 @@ XSL;
         $proc->importStylesheet($xsl);
         $out = (string) $proc->transformToXml($xml);
 
-        $this->assertMatchesRegularExpression('/\bID=/', $out, 'ID must survive attribute-match template');
-        $this->assertMatchesRegularExpression('/\bcolspan=/', $out, 'colspan must survive attribute-match template');
-        $this->assertDoesNotMatchRegularExpression('/\bonmouseover=/', $out, 'onmouseover must be dropped by attribute-match template');
-        $this->assertDoesNotMatchRegularExpression('/\bstyle=/', $out, 'style must be dropped by attribute-match template');
+        $this->assertMatchesRegularExpression('/\bID=/', $out, "$xslFile: ID must survive attribute-match template");
+        $this->assertMatchesRegularExpression('/\bcolspan=/', $out, "$xslFile: colspan must survive attribute-match template");
+        $this->assertDoesNotMatchRegularExpression('/\bonmouseover=/', $out, "$xslFile: onmouseover must be dropped by attribute-match template");
+        $this->assertDoesNotMatchRegularExpression('/\bstyle=/', $out, "$xslFile: style must be dropped by attribute-match template");
+    }
+
+    /**
+     * @return array<string, array{non-empty-string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function stylesheetsWithAttributeMatchTemplateProvider(): array
+    {
+        return [
+            'ccd.xsl' => ['ccd.xsl'],
+            'qrda.xsl' => ['qrda.xsl'],
+        ];
     }
 
     /**


### PR DESCRIPTION
Introduce a shared allowlist template at `interface/modules/zend_modules/public/xsl/_narrative-block-attrs.xsl` that mirrors the CDA R2 narrative-block attribute set from HL7's normative `NarrativeBlock.xsd` ([github.com/HL7/CDA-core-2.0](https://github.com/HL7/CDA-core-2.0/tree/master/schema/normative/processable/coreschemas)). Union across every `StrucDoc.*` complexType in that schema: 30 attributes, defined once as `$narrative-block-attr-allowlist` and consumed via `contains()` in `cda.xsl`'s sanitization pipeline and via the `safe-copy-narrative-attrs` named template in `ccd.xsl` and `qrda.xsl` (10 sites each).

Attributes copied from input CDA XML into the rendered HTML preview go through the allowlist; anything outside it is silently dropped. XML attribute names are case-sensitive so `ID` matches while `id` does not — consistent with the spec.

Isolated PHPUnit coverage in `tests/Tests/Isolated/CCDA/` — 21 tests, 54 assertions.

### Render regression check — cda.xsl

Ran the existing repo fixture `tests/Tests/data/Services/Modules/CareCoordination/Model/CcdaServiceDocumentRequestor/ccda-example-response1.xml` through cda.xsl before and after the fix:

| Fixture | CDA XML | Tables / rows / td | Pre-fix render | Post-fix render | Byte-identical |
|---------|---------|--------------------|----------------|-----------------|----------------|
| `ccda-example-response1.xml` | 303,571 | 7 / 187 / 816 | 610,377 | 610,377 | ✓ |

Then generated 5 random patients via `openemr-cmd irp 5` (Synthea) and generated a CCDA per patient via `CDADocumentService::generateCCDXml`, ran each through cda.xsl before and after the fix:

| Patient | CDA XML | Tables / rows / td | Pre-fix render | Post-fix render | Byte-identical |
|---------|---------|--------------------|----------------|-----------------|----------------|
| Verlene883 Conn188 | 331,667 | 7 / 245 / 1094 | 621,115 | 621,115 | ✓ |
| Sarita454 White193 | 436,191 | 7 / 327 / 1475 | 636,440 | 636,440 | ✓ |
| Miguel Ángel46 Yáñez198 | 162,372 | 7 / 112 / 485 | 595,695 | 595,695 | ✓ |
| Jasmin506 Hyatt152 | 365,972 | 7 / 246 / 1004 | 617,245 | 617,245 | ✓ |
| Ethan766 Blick895 | 433,437 | 7 / 304 / 1315 | 630,668 | 630,668 | ✓ |

### Render regression check — qrda.xsl

Ran every QRDA fixture under `tests/Tests/ECQM/test_patient_qrda/` through qrda.xsl before and after the fix:

| Fixture | XML | Tables / rows / td | Pre-fix render | Post-fix render | Byte-identical |
|---------|-----|--------------------|----------------|-----------------|----------------|
| `BH Adult_1.xml` | 38,453 | 1 / 2 / 3 | 5,648 | 5,648 | ✓ |
| `BH Adult_2.xml` | 21,758 | 1 / 2 / 3 | 5,649 | 5,649 | ✓ |
| `Heart Adult_Z31.xml` | 26,628 | 1 / 2 / 3 | 5,654 | 5,654 | ✓ |
| `catI_doc_28.xml` | 35,262 | 1 / 2 / 3 | 5,650 | 5,650 | ✓ |
| `catI_doc_29.xml` | 22,261 | 1 / 2 / 3 | 5,660 | 5,660 | ✓ |
| `catI_gen_Heart_Adult_Z31.xml` | 40,649 | 1 / 2 / 3 | 5,708 | 5,708 | ✓ |

All 12 render byte-identical. The 30-attribute allowlist doesn't drop anything the documents actually use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)