### PR TITLE
feat(acceptance): Phase 4b — Panther plumbing + E2eCriticalPathTest

### DIFF
--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -345,17 +345,22 @@ jobs:
         # but naming them keeps failure modes obvious).
         extensions: curl, dom, mbstring, tokenizer, xml
 
-    # Chrome for the E2eCriticalPathTest — Panther launches a headless
-    # subprocess Chrome bound to the mapped artifact port. The runner's
-    # apt-provided chromium works too, but setup-chrome pins to a
-    # tested-with-Panther release channel and installs the matching
-    # ChromeDriver alongside so Panther's driver-version-detection just
-    # works.
-    - name: Set up Chrome for Panther-driven acceptance tests
-      uses: browser-actions/setup-chrome@v1
-      with:
-        chrome-version: stable
-        install-chromedriver: true
+    # ChromeDriver for the E2eCriticalPathTest — Panther launches a
+    # headless subprocess Chrome bound to the mapped artifact port.
+    # ubuntu-24.04 runners ship with google-chrome pre-installed
+    # (/opt/google/chrome/chrome); nanasess/setup-chromedriver@v2
+    # detects that version and installs the exactly-matching
+    # ChromeDriver from Chrome-for-Testing so Panther's
+    # driver-version-detection succeeds.
+    #
+    # Do NOT swap this for browser-actions/setup-chrome@v1 with
+    # install-chromedriver: true — that action pulls Chrome from
+    # Google's Linux repo and ChromeDriver from CfT with independent
+    # release cadences, and drifts a mismatched pair through
+    # (Chrome 150 + ChromeDriver 151 was the concrete example that
+    # first bit this test).
+    - name: Set up matching ChromeDriver for Panther-driven acceptance tests
+      uses: nanasess/setup-chromedriver@v2
 
     - name: Install acceptance-suite composer dependencies
       # `--no-scripts` skips OpenEMR's post-install scripts (they assume

--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -345,6 +345,18 @@ jobs:
         # but naming them keeps failure modes obvious).
         extensions: curl, dom, mbstring, tokenizer, xml
 
+    # Chrome for the E2eCriticalPathTest — Panther launches a headless
+    # subprocess Chrome bound to the mapped artifact port. The runner's
+    # apt-provided chromium works too, but setup-chrome pins to a
+    # tested-with-Panther release channel and installs the matching
+    # ChromeDriver alongside so Panther's driver-version-detection just
+    # works.
+    - name: Set up Chrome for Panther-driven acceptance tests
+      uses: browser-actions/setup-chrome@v1
+      with:
+        chrome-version: stable
+        install-chromedriver: true
+
     - name: Install acceptance-suite composer dependencies
       # `--no-scripts` skips OpenEMR's post-install scripts (they assume
       # the full app runtime context; acceptance only needs vendor/).

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -119,13 +119,12 @@ jobs:
         tools: composer:v2
         extensions: curl, dom, mbstring, tokenizer, xml
 
-    # Chrome for the E2eCriticalPathTest — see acceptance-docker.yml
-    # for the rationale on setup-chrome vs apt chromium.
-    - name: Set up Chrome for Panther-driven acceptance tests
-      uses: browser-actions/setup-chrome@v1
-      with:
-        chrome-version: stable
-        install-chromedriver: true
+    # ChromeDriver for the E2eCriticalPathTest — see acceptance-docker.yml
+    # for the rationale on nanasess/setup-chromedriver over
+    # browser-actions/setup-chrome (avoids Chrome/ChromeDriver version
+    # drift from independent release channels).
+    - name: Set up matching ChromeDriver for Panther-driven acceptance tests
+      uses: nanasess/setup-chromedriver@v2
 
     - name: Install acceptance-suite composer dependencies
       run: composer install --prefer-dist --no-progress --no-scripts --no-interaction

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -119,6 +119,14 @@ jobs:
         tools: composer:v2
         extensions: curl, dom, mbstring, tokenizer, xml
 
+    # Chrome for the E2eCriticalPathTest — see acceptance-docker.yml
+    # for the rationale on setup-chrome vs apt chromium.
+    - name: Set up Chrome for Panther-driven acceptance tests
+      uses: browser-actions/setup-chrome@v1
+      with:
+        chrome-version: stable
+        install-chromedriver: true
+
     - name: Install acceptance-suite composer dependencies
       run: composer install --prefer-dist --no-progress --no-scripts --no-interaction
 

--- a/tests/Acceptance/E2eCriticalPathTest.php
+++ b/tests/Acceptance/E2eCriticalPathTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance;
+
+use Facebook\WebDriver\Exception\TimeoutException;
+use Facebook\WebDriver\JavaScriptExecutor;
+use Facebook\WebDriver\WebDriverBy;
+use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Panther\Client;
+
+/**
+ * Browser-driven end-to-end acceptance test.
+ *
+ * First test in the acceptance suite that drives an actual headless
+ * Chrome via Panther/WebDriver rather than HTTP-only via BrowserKit.
+ * Every earlier acceptance test (InstallTest, UpgradeIntegrityTest,
+ * FhirSmokeTest, OAuth2SmokeTest) hits openemr as an HTTP client
+ * with no JS runtime — so those tests would still pass even if
+ * webpack builds broken bundles, if a JS asset 404s, or if Knockout
+ * bindings fail to apply. This test catches that class of regression:
+ * the full post-login SPA loads, JS runs, the Knockout-templated
+ * main menu renders.
+ *
+ * Test scope kept intentionally small for this first Panther-in-
+ * acceptance PR — one flow: admin login → wait for the main menu to
+ * render. Adding more critical-path steps (patient add, encounter
+ * start) is straightforward once the plumbing is proven in CI.
+ *
+ * Fires only on fresh-install for now; post-upgrade coverage is a
+ * follow-up (need to think about whether Knockout menu rendering is
+ * a useful upgrade-regression signal, or if it's just a duplicate
+ * of fresh-install signal since the upgrade path doesn't touch the
+ * post-login shell).
+ */
+#[Group('fresh-install')]
+final class E2eCriticalPathTest extends TestCase
+{
+    private ?Client $client = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->client !== null) {
+            // Panther leaves a Chrome subprocess + ChromeDriver session
+            // dangling if not explicitly quit. Local runs accumulate
+            // zombies; CI runners recycle so it doesn't matter there,
+            // but tearDown discipline keeps local dev clean.
+            $this->client->quit();
+            $this->client = null;
+        }
+    }
+
+    public function testAdminCanLogInAndKnockoutMainMenuRenders(): void
+    {
+        $this->client = BrowserSession::create();
+        // Panther's request() takes either an absolute URL or a path
+        // relative to `external_base_uri` (set to ACCEPTANCE_ARTIFACT_URL
+        // in the BrowserSession factory).
+        $this->client->request('GET', '/interface/login/login.php?site=default');
+
+        self::assertSame(
+            'OpenEMR Login',
+            $this->client->getTitle(),
+            'Login page title should be "OpenEMR Login" — a different title means the login route rendered something unexpected (setup wizard, error page, blank shell)',
+        );
+
+        // Fill and submit the login form. openemr's login form
+        // requires two hidden fields (languageChoice + new_login_session_management)
+        // in addition to the visible authUser/clearPass — those are
+        // pre-populated by the form template, so submitting the
+        // form element (rather than reconstructing a POST) picks
+        // them up automatically.
+        $this->client->submitForm('login-button', [
+            'authUser' => 'admin',
+            'clearPass' => 'pass',
+        ]);
+
+        // Post-login lands on /interface/main/tabs/main.php, which
+        // loads the Knockout-templated main menu asynchronously.
+        // waitForVisibility on #mainMenu confirms the DOM node
+        // exists; the executeScript check below confirms Knockout
+        // actually populated it with children (i.e. bindings
+        // applied, not just an empty shell).
+        try {
+            $this->client->waitFor('#mainMenu', 30);
+        } catch (TimeoutException) {
+            self::fail(
+                'Post-login #mainMenu element never appeared (30s timeout). '
+                . 'Landing URL: ' . $this->client->getCurrentURL() . '. '
+                . 'Title: ' . $this->client->getTitle() . '. '
+                . 'This likely means the login POST did not authenticate, or '
+                . 'the post-login shell (interface/main/tabs/main.php) never rendered.'
+            );
+        }
+
+        // Knockout-ready gate: bindings have applied, the menu template
+        // ran, so #mainMenu has child nodes. Matches the source-side
+        // BaseTrait's waitForAppReady contract. Without this check we
+        // could pass on a broken JS build that renders the SPA shell
+        // but leaves the menu empty.
+        //
+        // Type-hint the closure's $driver as JavaScriptExecutor so
+        // phpstan can resolve executeScript() (the base WebDriver
+        // interface types the callable arg as `mixed`; source-side
+        // E2E tests baseline this on principle, but we prefer to
+        // type-narrow at the source instead).
+        try {
+            $this->client->wait(30)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
+                'return document.getElementById("mainMenu")?.children.length > 0'
+            ));
+        } catch (TimeoutException) {
+            $rawDiagnostics = $this->client->executeScript(<<<'JS_WRAP'
+                return JSON.stringify({
+                    url: location.href,
+                    title: document.title,
+                    knockoutLoaded: typeof ko !== "undefined",
+                    mainMenuChildCount: document.getElementById("mainMenu")?.children.length ?? 0,
+                });
+            JS_WRAP);
+            $diagnostics = is_string($rawDiagnostics) ? $rawDiagnostics : 'unavailable';
+            self::fail(
+                'Knockout main menu never populated (30s timeout after #mainMenu appeared). '
+                . "Page state: {$diagnostics}. This means the SPA shell loaded but the "
+                . 'JS framework (Knockout) either did not load or did not apply bindings — '
+                . 'symptom of a broken webpack build, missing JS asset, or template regression.'
+            );
+        }
+
+        // At this point the app is fully booted — assert one visible
+        // menu label to prove the menu isn't just full of empty nodes.
+        // "Calendar" is the first top-level entry in the openemr menu
+        // and is essentially unrenameable (it's the landing icon in
+        // every skin). If this ever fails, the failure message points
+        // at the specific expectation being wrong rather than a vague
+        // "menu is broken."
+        $calendarMenu = $this->client->findElements(
+            WebDriverBy::xpath('//div[@id="mainMenu"]//div[text()="Calendar"]'),
+        );
+        self::assertNotEmpty(
+            $calendarMenu,
+            'The Knockout-rendered main menu should contain a "Calendar" entry — '
+            . 'a missing entry means the menu rendered but with wrong content (bad menu template, '
+            . 'localization regression, or ACL filtering the admin user out of a menu they should always see)',
+        );
+    }
+}

--- a/tests/Acceptance/Support/BrowserSession.php
+++ b/tests/Acceptance/Support/BrowserSession.php
@@ -81,13 +81,19 @@ final class BrowserSession
      */
     private static function createLocalClient(): Client
     {
-        // Panther's static factories accept `arguments` under the
-        // `browser_arguments` key of its options array. External base
-        // URI is the artifact URL, so tests can use relative paths
-        // (`$client->request('GET', '/interface/login/login.php')`).
-        return Client::createChromeClient(null, self::CHROME_ARGS, [
-            'external_base_uri' => ArtifactBrowser::baseUrl(),
-        ]);
+        // Signature: createChromeClient($chromeDriverBinary, $arguments,
+        // $options, $baseUri). baseUri MUST be the 4th positional arg —
+        // there's no `external_base_uri` key on $options for this
+        // factory (that key is a Panther *internal* extra_capability,
+        // and passing it via $options is silently ignored, which
+        // reports as "invalid argument" from ChromeDriver on the first
+        // relative-URL request because get() tries to load "/login...").
+        return Client::createChromeClient(
+            null,
+            self::CHROME_ARGS,
+            [],
+            ArtifactBrowser::baseUrl(),
+        );
     }
 
     /**

--- a/tests/Acceptance/Support/BrowserSession.php
+++ b/tests/Acceptance/Support/BrowserSession.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance\Support;
+
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Symfony\Component\Panther\Client;
+
+/**
+ * Panther/WebDriver client factory for acceptance tests that need a
+ * real headless browser (JS + Knockout + full asset load).
+ *
+ * Two backends, selected via env vars — same pattern as the
+ * source-side tests/Tests/E2e BaseTrait so acceptance follows the
+ * established convention:
+ *
+ *   - **local ChromeDriver** (default) — Panther launches Chrome as a
+ *     subprocess of the PHPUnit process. Requires `google-chrome` (or
+ *     `chromium`) on PATH and the matching ChromeDriver binary
+ *     (bundled with symfony/panther for common Chrome versions).
+ *     Path used in CI: the acceptance workflows install Chrome via
+ *     `browser-actions/setup-chrome` before running the suite.
+ *
+ *   - **Selenium grid** (`SELENIUM_USE_GRID=true`) — Panther drives a
+ *     remote Chrome over the WebDriver protocol. Set `SELENIUM_HOST`
+ *     to the grid hostname and `SELENIUM_BASE_URL` to the URL the
+ *     grid's browser should use for the artifact (usually a
+ *     docker-network alias, not the host-visible port). Path used
+ *     for local development: the dev-easy stack ships a selenium
+ *     container, so running acceptance from within the dev container
+ *     with SELENIUM_USE_GRID=true works out of the box.
+ *
+ * Callers should invoke `create()` in setUp() and `->quit()` in
+ * tearDown() to release the Chrome process/session.
+ */
+final class BrowserSession
+{
+    /**
+     * Sensible defaults for headless acceptance runs. Every entry
+     * here is either "required for CI runners" (no-sandbox,
+     * disable-gpu, disable-dev-shm-usage) or "avoids known flakes"
+     * (ignore-certificate-errors for the self-signed cert on
+     * artifact HTTPS ports, headless because there's no display in
+     * CI, fixed window size so viewport-dependent renders are
+     * deterministic).
+     */
+    private const CHROME_ARGS = [
+        '--headless=new',
+        '--no-sandbox',
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--ignore-certificate-errors',
+        '--window-size=1920,1080',
+    ];
+
+    public static function create(): Client
+    {
+        if (self::useGrid()) {
+            return self::createGridClient();
+        }
+        return self::createLocalClient();
+    }
+
+    private static function useGrid(): bool
+    {
+        $val = getenv('SELENIUM_USE_GRID');
+        return $val === 'true' || $val === '1';
+    }
+
+    /**
+     * Local ChromeDriver path — subprocess launched by Panther.
+     */
+    private static function createLocalClient(): Client
+    {
+        // Panther's static factories accept `arguments` under the
+        // `browser_arguments` key of its options array. External base
+        // URI is the artifact URL, so tests can use relative paths
+        // (`$client->request('GET', '/interface/login/login.php')`).
+        return Client::createChromeClient(null, self::CHROME_ARGS, [
+            'external_base_uri' => ArtifactBrowser::baseUrl(),
+        ]);
+    }
+
+    /**
+     * Selenium grid path — WebDriver session on a remote grid. Env
+     * inputs mirror what tests/Tests/E2e BaseTrait already accepts,
+     * so a dev running acceptance from inside the dev-easy openemr
+     * container just needs SELENIUM_USE_GRID=true and things work.
+     */
+    private static function createGridClient(): Client
+    {
+        $host = getenv('SELENIUM_HOST') ?: 'selenium';
+        $externalBaseUri = getenv('SELENIUM_BASE_URL') ?: 'http://openemr';
+
+        $capabilities = DesiredCapabilities::chrome();
+        $capabilities->setCapability('goog:chromeOptions', ['args' => self::CHROME_ARGS]);
+        // Auto-accept unexpected JS alerts — matches E2e BaseTrait's
+        // choice; acceptance tests shouldn't be blocked by a stray
+        // prompt they didn't ask for.
+        $capabilities->setCapability('unhandledPromptBehavior', 'accept');
+
+        return Client::createSeleniumClient(
+            "http://{$host}:4444/wd/hub",
+            $capabilities,
+            $externalBaseUri,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Third slice of **Phase 4** of [`docs/artifact-acceptance-testing-plan.md`](https://github.com/openemr/openemr/blob/master/docs/artifact-acceptance-testing-plan.md). Introduces headless browser coverage to the acceptance suite for the first time via Symfony Panther. Every earlier acceptance test (Install, UpgradeIntegrity, FhirSmoke, OAuth2Smoke) drives openemr as an HTTP-only client via BrowserKit — those tests still pass even if webpack builds a broken bundle, a JS asset 404s, or Knockout bindings never apply. Phase 4b plugs that gap.

Follows #13149 (Phase 1), #13159 (Phase 2), #13163 (Phase 2.5), #13165 (Phase 3), #13193 (Phase 4a), #13194 (Phase 4a-2).

## What lands

### `Support/BrowserSession` (new)

Panther/WebDriver client factory with two backends, selected via env vars — matches the source-side `tests/Tests/E2e/Base/BaseTrait` convention:

- **Local ChromeDriver** (default) — Panther launches Chrome as a subprocess. Requires `google-chrome` + `chromedriver` on the runner (both acceptance workflows install them via `browser-actions/setup-chrome@v1`).
- **Selenium grid** (`SELENIUM_USE_GRID=true`) — Panther drives a remote Chrome. Convenient for local development from inside the dev-easy openemr container, which already has a selenium sidecar.

Sensible Chrome defaults for both backends: `--headless=new`, `--no-sandbox`, `--disable-gpu`, `--disable-dev-shm-usage` (required in containers), `--ignore-certificate-errors` (self-signed cert on artifact HTTPS), `1920x1080` window (deterministic viewport).

### `E2eCriticalPathTest` (new)

One test — `testAdminCanLogInAndKnockoutMainMenuRenders` — that:

1. Loads `/interface/login/login.php`, submits admin/pass via Panther's `submitForm` (auto-fills the `languageChoice` + `new_login_session_management` hidden fields from the template)
2. Waits for `#mainMenu` to appear (post-login SPA shell rendered)
3. Waits for Knockout to populate `#mainMenu` with children (bindings applied — same contract as `BaseTrait::waitForAppReady`)
4. Asserts the "Calendar" menu entry exists (proves the menu is populated with real content, not just empty nodes)

**Failure modes caught that no earlier acceptance test covers:**
- Webpack build regressions that ship broken JS bundles
- Missing JS asset 404s that leave the SPA shell empty
- Menu-template regressions that render an empty menu
- ACL bugs that filter admin out of a menu they should always see

### Workflow changes

Both `.github/workflows/acceptance-{docker,package}.yml` grow a Chrome install step (`browser-actions/setup-chrome@v1`) before "Install acceptance-suite composer dependencies". Pinned to `stable` channel with `install-chromedriver: true` so Panther's driver-version detection just works.

## What's NOT here

- **`post-upgrade` group tag on `E2eCriticalPathTest`** — deferred as follow-up decision. Knockout menu rendering is essentially a duplicate signal to fresh-install since the upgrade path doesn't touch the post-login shell. Adding the tag is trivial once we decide it's worth the ~5s per matrix leg.
- **Wizard-UI tests** (`InstallWizardUiTest` + `UpgradeWizardUiTest`, tarball-only) — Phase 4c. Depends on this PR's Panther plumbing.
- **Authenticated Bearer-token access** — Phase 4a-3 (now last in rollout order per plan-doc `c46acc6a96`). Depends on Panther admin-panel automation for API-enable, which needs this PR's plumbing.
- **Additional critical-path steps** (patient add, encounter start) — deliberately excluded from this PR to keep the surface small for the first Panther introduction. Straightforward follow-ups once CI proves stable.

### phpstan-narrowness note

The `wait()->until()` closure's `$driver` arg is type-hinted as `JavaScriptExecutor` rather than left `mixed`. Source-side E2E tests baseline the "call executeScript on mixed" error dozens of times — adding baseline entries here would be against CLAUDE.md's "avoid baselines" guidance, and type-narrowing at the source is cheap.

## Test plan

- [x] Local: `composer acceptance --filter=E2eCriticalPath` against dev-easy stack via `SELENIUM_USE_GRID=true` — passes (1 test / 2 assertions)
- [x] Local: full phpstan (`.phpstan/phpstan.ci.neon`) — clean
- [ ] CI: local ChromeDriver path exercised on the runner during this PR's first push (Chrome installed by `browser-actions/setup-chrome@v1`)

## Related

- Plan doc: `docs/artifact-acceptance-testing-plan.md` (draft PR #12811) — Phase 4b + updated 4a-3 sequencing landed in `c46acc6a96`
- Phase 4a-2: #13194 (OAuth2SmokeTest safety-net gate)
- Pattern source: `tests/Tests/E2e/Base/BaseTrait.php` — the source-side E2E harness this file's `BrowserSession` factory + `waitForAppReady` contract inherits its shape from

Assisted-by: Claude Code
