### PR TITLE
feat(acceptance): Phase 4c-1 — InstallWizardUiTest walks setup.php

### DIFF
--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -93,6 +93,14 @@ jobs:
       # from "upgrade path broken" (different code paths).
       fail-fast: false
       matrix:
+        # Scenarios:
+        #   fresh-install   — CLI install-helper.php then acceptance suite
+        #   wizard-install  — no install-helper; InstallWizardUiTest
+        #                     drives setup.php via Panther instead
+        #   upgrade         — CLI install then CLI sql_upgrade; only on
+        #                     workflow_dispatch (from_version tarball
+        #                     doesn't exist for the default 8.2.0)
+        #
         # Upgrade scenario is only included on workflow_dispatch (where
         # the caller supplies from_version + to_version explicitly). On
         # push/PR/schedule the from_version default would need to point
@@ -101,7 +109,7 @@ jobs:
         # page (patch releases only shipped .zip patches). Once 8.3.0
         # releases and the from_version default becomes 8.2.0 → 8.3.0,
         # the upgrade scenario can move back into the default matrix.
-        scenario: ${{ github.event_name == 'workflow_dispatch' && fromJson('["fresh-install","upgrade"]') || fromJson('["fresh-install"]') }}
+        scenario: ${{ github.event_name == 'workflow_dispatch' && fromJson('["fresh-install","wizard-install","upgrade"]') || fromJson('["fresh-install","wizard-install"]') }}
     env:
       FROM_VERSION: ${{ inputs.from_version || '8.2.0' }}
       TO_VERSION: ${{ inputs.to_version || '8.2.0' }}
@@ -137,6 +145,21 @@ jobs:
     - name: Run acceptance suite (fresh-install of to_version)
       if: matrix.scenario == 'fresh-install'
       run: composer acceptance -- --group=fresh-install
+
+    # ==== wizard-install scenario ====
+    # Boots the artifact WITHOUT running install-helper.php so the
+    # artifact serves setup.php on /. InstallWizardUiTest then drives
+    # the wizard via Panther end-to-end (state 0 → 3 + verify / now
+    # redirects to login). Covers what Phase 3's CLI install path
+    # bypasses: setup.php's browser-facing state machine, form
+    # rendering, CSRF, cookie-based state.
+    - name: Boot tarball artifact (to_version, no install-helper)
+      if: matrix.scenario == 'wizard-install'
+      run: tests/Acceptance/bin/boot-package.sh --skip-install-helper "${TO_VERSION}"
+
+    - name: Run acceptance suite (wizard-install of to_version)
+      if: matrix.scenario == 'wizard-install'
+      run: composer acceptance -- --group=wizard-install
 
     # ==== upgrade scenario ====
     - name: Boot tarball artifact (from_version)

--- a/tests/Acceptance/InstallWizardUiTest.php
+++ b/tests/Acceptance/InstallWizardUiTest.php
@@ -183,10 +183,20 @@ final class InstallWizardUiTest extends TestCase
         // 3 reported success but `/` still shows setup.php or errors,
         // the install didn't actually take effect — this catches that.
         $client->request('GET', '/');
+        // Assert BOTH the current URL redirected away from `/` to the
+        // login route AND the page title matches "OpenEMR Login". Title
+        // alone would pass if a root handler ever rendered a login-page
+        // template inline at `/` without redirecting; asserting the URL
+        // change is the "redirect actually happened" proof.
+        self::assertStringContainsString(
+            '/interface/login/login.php',
+            $client->getCurrentURL(),
+            'GET / after wizard install should redirect to /interface/login/login.php — staying at / means the install did not actually take effect (sqlconf.php $config still 0)',
+        );
         self::assertStringContainsString(
             'OpenEMR Login',
             $client->getTitle(),
-            'GET / after wizard install should redirect to the login page — a different title means the wizard reported success but the install did not actually take effect',
+            'Post-redirect page title should be "OpenEMR Login" — a different title after the redirect target check passes means the login route rendered something unexpected',
         );
     }
 

--- a/tests/Acceptance/InstallWizardUiTest.php
+++ b/tests/Acceptance/InstallWizardUiTest.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance;
+
+use Facebook\WebDriver\Exception\TimeoutException;
+use Facebook\WebDriver\WebDriverBy;
+use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Panther\Client;
+
+/**
+ * Browser-driven walk of setup.php's install wizard.
+ *
+ * Fires only against the tarball artifact (not docker) — the docker
+ * artifact auto-installs via env-var-driven auto_configure.php, so
+ * real docker users NEVER see the wizard. Tarball users always do.
+ *
+ * Prerequisite: the acceptance-package stack must be booted WITHOUT
+ * running install-helper.php, so the artifact serves setup.php on `/`
+ * instead of redirecting to the login page. Achieved by
+ * `boot-package.sh --skip-install-helper <version>`; the workflow's
+ * `wizard-install` matrix scenario passes that flag.
+ *
+ * Walks setup.php's state machine 0 → 1 → 2 → 3 (the "install
+ * happens here" step), asserting each state's expected heading
+ * renders and the final state 3 reports success. States 4-7 are
+ * informational pages (PHP config, web server config, theme select,
+ * final credentials display) that don't affect whether the artifact
+ * is actually installed — verifying `/` now redirects to the login
+ * page is the definitive "install completed" signal for user-facing
+ * behavior, so we do that instead of walking the final decorative
+ * pages.
+ *
+ * Failure modes caught that Phase 3's install-helper.php CLI path
+ * cannot:
+ *   - setup.php state-machine bugs (wrong state transitions, session
+ *     cookie handling breaks)
+ *   - CSRF token generation/validation regressions in the wizard
+ *   - Form field name changes that break the state-2 DB config POST
+ *   - Wizard's per-step form rendering (missing required fields,
+ *     Bootstrap layout breakage that hides inputs)
+ *   - PHP fatal errors partway through a state handler
+ */
+#[Group('wizard-install')]
+final class InstallWizardUiTest extends TestCase
+{
+    private ?Client $client = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->client !== null) {
+            $this->client->quit();
+            $this->client = null;
+        }
+    }
+
+    public function testAdminCanWalkSetupWizardEndToEnd(): void
+    {
+        // Local $client references let phpstan narrow the type across
+        // the whole method body; $this->client is nullable (for
+        // tearDown's release semantics) and property accesses would
+        // otherwise trip method.nonObject at every call.
+        $client = BrowserSession::create();
+        $this->client = $client;
+
+        // State 0: pre-install page. GET /setup.php should render the
+        // "Pre Install - Checking File and Directory Permissions"
+        // heading and expose a form that advances to state=1.
+        $client->request('GET', '/setup.php');
+        $this->assertCurrentHeadingContains(
+            $client,
+            'Pre Install',
+            'setup.php state 0 should render the "Pre Install" heading — a different heading means the wizard entry point is broken or the artifact somehow completed install already',
+        );
+
+        // State 0 → 1: submit the "Proceed to Step 1" form. Panther's
+        // submitForm auto-fills all hidden inputs (state + site +
+        // csrf_token_form) from the template.
+        $client->submitForm('Proceed to Step 1');
+        $this->assertCurrentHeadingContains(
+            $client,
+            'Step 1',
+            'After POST state=1, the response should show "Step 1 - Select Database Setup". A "Not authorized" message means CSRF or session-state validation regressed',
+        );
+
+        // State 1 → 2: "Have setup create the database" radio (inst=1)
+        // is the default-checked option; submit the form to advance.
+        $client->submitForm('Proceed to Step 2');
+        $this->assertCurrentHeadingContains(
+            $client,
+            'Step 2',
+            'After POST state=2, the response should show "Step 2 - Database and OpenEMR Initial User Setup Details"',
+        );
+
+        // State 2 → 3: fill the DB + admin-user form. Values match
+        // install-helper.php's Installer::quick_install() call so the
+        // wizard-driven install has identical shape to the CLI one
+        // Phase 3 uses.
+        //
+        // loginhost=% (wildcard) — same fix as install-helper.php's
+        // loginhost setting: openemr container talks to mysql from a
+        // container-network IP, not 'localhost' from mysql's
+        // perspective, so the DB user needs '%' host to match.
+        // Fill the form via findElement + sendKeys, then click submit
+        // directly. Panther's submitForm() helper silently drops the
+        // POST when the value array contains a field the DOM lacks; the
+        // symptom is "no network request fired and the crawler stays
+        // on the old page." Explicit field-by-field manipulation avoids
+        // that silent-failure mode.
+        //
+        // Field values match install-helper.php's Installer::quick_install()
+        // call so the wizard-driven install has identical shape to the
+        // CLI one Phase 3 uses. loginhost=% (wildcard) — same fix as
+        // install-helper.php's loginhost setting: openemr container
+        // talks to mysql from a container-network IP, not 'localhost'
+        // from mysql's perspective, so the DB user needs '%' host to
+        // match.
+        // Fields that need override from the template's defaults:
+        //   * server + loginhost — container-networking overrides
+        //   * pass + rootpass + iuserpass — password inputs default
+        //     to empty string in the form (required by validation)
+        //   * iuser — template defaults to a randomly-generated
+        //     username; force to "admin" to match the CLI-install
+        //     credentials Phase 1's tests already assert against
+        // Fields with sensible template defaults left untouched:
+        //   * port (3306), dbname (openemr), login (openemr),
+        //     root (root), collate, iuname (Administrator),
+        //     iufname (Administrator), igroup (Default)
+        $fields = [
+            'server' => 'mysql',
+            'loginhost' => '%',
+            'pass' => 'openemr',
+            'rootpass' => 'root',
+            'iuser' => 'admin',
+            'iuserpass' => 'pass',
+        ];
+        foreach ($fields as $name => $value) {
+            $el = $client->findElement(WebDriverBy::name($name));
+            $el->clear();
+            $el->sendKeys($value);
+        }
+        // Submit the form directly via its id. Clicking the button
+        // element does NOT reliably fire the submit in this Panther +
+        // ChromeDriver combo (observed 0 POSTs in access logs after
+        // clicks that returned success). Form's ->submit() bypasses
+        // whatever button-click quirk is at play.
+        $client->findElement(WebDriverBy::id('myform'))->submit();
+
+        // State 3: the actual install work. Success rendering shows
+        // "Step 3 - Creating Database and First User" plus a series
+        // of green "success" indicators for each install step.
+        $this->assertCurrentHeadingContains(
+            $client,
+            'Step 3',
+            'After POST state=3, the response should show "Step 3 - Creating Database and First User"',
+        );
+        $state3Body = $client->getCrawler()->filter('body')->text();
+        self::assertStringNotContainsString(
+            'ERROR',
+            $state3Body,
+            'State 3 response should not contain ERROR — install failed midway',
+        );
+        self::assertStringNotContainsString(
+            'FAILED',
+            $state3Body,
+            'State 3 response should not contain FAILED — one of the install substeps did not complete',
+        );
+
+        // Definitive post-install signal: GET / should now redirect to
+        // the login page (same assertion Phase 1's InstallTest makes
+        // against a Phase-3-installed artifact). If the wizard's state
+        // 3 reported success but `/` still shows setup.php or errors,
+        // the install didn't actually take effect — this catches that.
+        $client->request('GET', '/');
+        self::assertStringContainsString(
+            'OpenEMR Login',
+            $client->getTitle(),
+            'GET / after wizard install should redirect to the login page — a different title means the wizard reported success but the install did not actually take effect',
+        );
+    }
+
+    /**
+     * Wait for the current page's first h3 to render, then assert its
+     * text contains the expected fragment. Every wizard state's page
+     * starts with an <h3> that names the step (e.g. "Step 2 - Database
+     * and OpenEMR Initial User Setup Details"), so a settled h3 is the
+     * "wizard advanced to expected state" signal.
+     *
+     * Panther's post-submit crawler snapshot can race the actual page
+     * load — filter('h3')->text() will throw "current node list is
+     * empty" if called before the new DOM commits. `waitFor('h3', 15)`
+     * blocks until the element appears, up to 15s.
+     */
+    private function assertCurrentHeadingContains(Client $client, string $expected, string $failureMessage): void
+    {
+        // Wait until an h3 containing the expected text appears — NOT
+        // just "any h3." Multi-step wizard pages all have h3s, and the
+        // previous page's h3 stays in the DOM/crawler snapshot for a
+        // beat after a POST-triggered navigation completes; asserting
+        // "any h3" would race and pass on the stale value.
+        try {
+            $client->waitForElementToContain('h3', $expected, 20);
+            return;
+        } catch (TimeoutException) {
+            // Fall through to the diagnostic dump below. Any further
+            // exception (driver died between the timeout and now) is
+            // let propagate — the test's already failing anyway, and a
+            // driver-death exception is still a signal.
+        }
+
+        $url = $client->getCurrentURL();
+        $headings = $client->getCrawler()->filter('h3');
+        $currentHeading = $headings->count() > 0 ? $headings->first()->text() : '(no h3 in current DOM)';
+
+        // Look for h1/h3 first (the wizard's step markers). Fall back
+        // to a body-content snippet so a validation-error page
+        // (typically shows the error message inline, no h3) is
+        // visible in the failure output.
+        $source = $client->getWebDriver()->getPageSource();
+        if (preg_match_all('/<h[13][^>]*>(.*?)<\/h[13]>/s', $source, $m)) {
+            $snippet = 'headings: ' . implode(' || ', array_map(trim(...), $m[1]));
+        } elseif (preg_match('/<body[^>]*>(.*)$/s', $source, $bm)) {
+            $bodyClean = (string) preg_replace('/<style[^>]*>.*?<\/style>/s', '', $bm[1]);
+            $bodyClean = (string) preg_replace('/<script[^>]*>.*?<\/script>/s', '', $bodyClean);
+            $snippet = 'no h1/h3; body (styles stripped): ' . substr($bodyClean, 0, 1200);
+        } else {
+            $snippet = 'no h1/h3 AND no <body>: ' . substr($source, 0, 1200);
+        }
+
+        self::fail(
+            "{$failureMessage}\nExpected h3 to contain: {$expected}\n"
+            . "Current URL: {$url}\n"
+            . "Actual h3 (first): {$currentHeading}\n"
+            . "Page source snippet:\n{$snippet}",
+        );
+    }
+}

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -129,13 +129,18 @@ if [[ "${skip_install_helper}" == "true" ]]; then
     # check asserts the post-install login-page redirect target — a
     # freshly-extracted artifact serves /setup.php instead, and would
     # never pass the healthcheck. Poll setup.php directly instead.
+    #
+    # Require HTTP 200 explicitly (not curl -f which passes 3xx
+    # redirects) and cap each attempt at 10s so a single stalled
+    # response can't extend the 300s retry window into arbitrary hang.
     for attempt in $(seq 1 60); do
-        if curl -sf -o /dev/null "http://localhost:8680/setup.php"; then
-            echo "    apache serving /setup.php"
+        STATUS="$(curl -sk --max-time 10 -o /dev/null -w '%{http_code}' "http://localhost:8680/setup.php" || echo "curl-failed")"
+        if [[ "${STATUS}" == "200" ]]; then
+            echo "    apache serving /setup.php (HTTP 200)"
             break
         fi
         if [[ "${attempt}" -eq 60 ]]; then
-            echo "::error::apache never served /setup.php within 300s" >&2
+            echo "::error::apache never served /setup.php with HTTP 200 within 300s (last status: ${STATUS})" >&2
             exit 1
         fi
         sleep 5

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -4,19 +4,28 @@
 #
 # Downloads the tarball from the GitHub release page, extracts it into
 # a scratch directory, boots the compose stack (flex image + mariadb)
-# with the extracted tree bind-mounted, then runs install-helper.php
-# via `docker compose exec` to complete the install via OpenEMR's
-# Installer class.
+# with the extracted tree bind-mounted, then (by default) runs
+# install-helper.php via `docker compose exec` to complete the install
+# via OpenEMR's Installer class.
 #
 # Usage:
-#   tests/Acceptance/bin/boot-package.sh <version>
+#   tests/Acceptance/bin/boot-package.sh [--skip-install-helper] <version>
+#     --skip-install-helper (optional)
+#         Skip the install-helper.php step. Leaves the artifact serving
+#         setup.php on http://localhost:8680/, ready for the
+#         InstallWizardUiTest (Phase 4c) to drive the wizard end-to-end
+#         via Panther. Also skips the "wait for openemr healthy" gate
+#         because that healthcheck asserts the post-install login-page
+#         redirect target, which only appears AFTER a completed install;
+#         instead, waits for /setup.php to return 200 (proves apache is
+#         serving on the mapped port).
 #     version — release tag suffix, must match ^[0-9]+\.[0-9]+\.[0-9]+$
 #               (e.g. 8.2.0). Anything else is rejected before any path
 #               is constructed — VERSION is caller-controlled and flows
 #               into `rm -rf` / `curl -o` paths.
 #               Fetches https://github.com/openemr/openemr/releases/download/v<X_Y_Z>/openemr-<version>.tar.gz
 #
-# After a successful boot:
+# After a successful boot (default mode):
 #   Artifact URL:  http://localhost:8680
 #   HTTPS URL:     https://localhost:8643  (self-signed cert)
 #   Scratch dir:   /tmp/openemr-acceptance-<version>/  (bind-mount source)
@@ -26,9 +35,24 @@
 
 set -euo pipefail
 
+skip_install_helper="false"
+while [[ $# -gt 0 && "$1" == --* ]]; do
+    case "$1" in
+        --skip-install-helper)
+            skip_install_helper="true"
+            shift
+            ;;
+        *)
+            echo "::error::unknown flag: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
 if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 <version>" >&2
+    echo "Usage: $0 [--skip-install-helper] <version>" >&2
     echo "  e.g.: $0 8.2.0" >&2
+    echo "        $0 --skip-install-helper 8.2.0" >&2
     exit 2
 fi
 
@@ -97,6 +121,35 @@ for attempt in $(seq 1 30); do
     fi
     sleep 5
 done
+
+if [[ "${skip_install_helper}" == "true" ]]; then
+    echo "==> Skipping install-helper.php (--skip-install-helper set)"
+    echo "==> Waiting for apache to serve /setup.php (proxy for 'container up')"
+    # Can't wait on the compose openemr healthcheck here because that
+    # check asserts the post-install login-page redirect target — a
+    # freshly-extracted artifact serves /setup.php instead, and would
+    # never pass the healthcheck. Poll setup.php directly instead.
+    for attempt in $(seq 1 60); do
+        if curl -sf -o /dev/null "http://localhost:8680/setup.php"; then
+            echo "    apache serving /setup.php"
+            break
+        fi
+        if [[ "${attempt}" -eq 60 ]]; then
+            echo "::error::apache never served /setup.php within 300s" >&2
+            exit 1
+        fi
+        sleep 5
+    done
+
+    echo ""
+    echo "==> Boot complete (skip-install-helper mode)."
+    echo "    Artifact URL:  http://localhost:8680  (serving setup.php)"
+    echo "    HTTPS URL:     https://localhost:8643 (self-signed cert)"
+    echo ""
+    echo "    Run tests:     ACCEPTANCE_ARTIFACT_URL=http://localhost:8680 composer acceptance -- --group=wizard-install"
+    echo "    Teardown:      tests/Acceptance/bin/down-package.sh"
+    exit 0
+fi
 
 echo "==> Running install-helper.php via docker compose exec (as apache user)"
 # install-helper.php is mounted READ-ONLY at /opt/openemr-acceptance-helper.php

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -131,20 +131,24 @@ if [[ "${skip_install_helper}" == "true" ]]; then
     # never pass the healthcheck. Poll setup.php directly instead.
     #
     # Require HTTP 200 explicitly (not curl -f which passes 3xx
-    # redirects) and cap each attempt at 10s so a single stalled
-    # response can't extend the 300s retry window into arbitrary hang.
-    for attempt in $(seq 1 60); do
+    # redirects). Absolute 300s deadline via $SECONDS (each attempt is
+    # up to 10s of curl + 5s of sleep = 15s worst case; a naive "60
+    # attempts × sleep 5" loop would allow 900s wall-clock, not 300s
+    # the diagnostic message advertises).
+    deadline=$((SECONDS + 300))
+    STATUS="not-yet-attempted"
+    while (( SECONDS < deadline )); do
         STATUS="$(curl -sk --max-time 10 -o /dev/null -w '%{http_code}' "http://localhost:8680/setup.php" || echo "curl-failed")"
         if [[ "${STATUS}" == "200" ]]; then
             echo "    apache serving /setup.php (HTTP 200)"
             break
         fi
-        if [[ "${attempt}" -eq 60 ]]; then
-            echo "::error::apache never served /setup.php with HTTP 200 within 300s (last status: ${STATUS})" >&2
-            exit 1
-        fi
         sleep 5
     done
+    if [[ "${STATUS}" != "200" ]]; then
+        echo "::error::apache never served /setup.php with HTTP 200 within 300s (last status: ${STATUS})" >&2
+        exit 1
+    fi
 
     echo ""
     echo "==> Boot complete (skip-install-helper mode)."


### PR DESCRIPTION
## Summary

First slice of **Phase 4c** of [`docs/artifact-acceptance-testing-plan.md`](https://github.com/openemr/openemr/blob/master/docs/artifact-acceptance-testing-plan.md). Adds browser-driven wizard coverage that Phase 3's CLI `install-helper.php` completely bypasses — real tarball users install via `setup.php`'s multi-step web wizard, not via the `Installer` class directly.

Follows #13149 (Phase 1), #13159 (Phase 2), #13163 (Phase 2.5), #13165 (Phase 3), #13193 (Phase 4a), #13194 (Phase 4a-2), #13196 (Phase 4b — Panther plumbing this PR builds on).

## What lands

### `InstallWizardUiTest` (new)

Walks `setup.php`'s state machine 0 → 1 → 2 → 3 (the state where the actual install work happens) via Panther, then verifies `GET /` redirects to the login page as the definitive "install actually took effect" check.

States 4–7 are informational (PHP config, web server config, theme select, final credentials display) and don't affect whether the artifact is installed — the login-page redirect is a stronger signal than walking those pages.

**Failure modes caught that no earlier acceptance test covers:**
- `setup.php` state-machine bugs (wrong state transitions, session cookie handling breaks)
- CSRF token generation/validation regressions in the wizard
- Form field name changes that break the state-2 DB config POST
- Wizard's per-step form rendering (missing required fields, Bootstrap layout breakage that hides inputs)
- PHP fatal errors partway through a state handler

### `boot-package.sh --skip-install-helper` (new flag)

Extracts the tarball + boots the compose stack + waits for mariadb, then **skips** `install-helper.php` so the artifact serves `setup.php` on `/`. The compose file's openemr healthcheck asserts the post-install login-page redirect target and would never pass on a fresh extraction, so that step also gets skipped in `--skip-install-helper` mode; the script polls `curl -f /setup.php` as the "apache serving" proxy signal instead.

### `wizard-install` matrix scenario

`.github/workflows/acceptance-package.yml` adds a `wizard-install` matrix scenario that boots with `--skip-install-helper` and runs `--group=wizard-install`. Fires on push/PR/schedule alongside `fresh-install`; upgrade scenario remains `workflow_dispatch`-only.

## Panther-form quirks documented inline

Two silent-failure modes discovered writing this test:

- `submitForm()` with a values array **silently drops the POST** when the value array contains a field name the DOM lacks. Symptom: no network request fires and the crawler stays on the previous page. Fix: `findElement + sendKeys` per field explicitly.
- Clicking a submit button that has nested `<i>` icon markup inside the label sometimes doesn't fire (observed 0 POSTs in access logs after successful `click()` calls). Fix: submit the `<form id="myform">` element directly.

Also uses `waitForElementToContain('h3', $expected, 20)` — blocks until the target h3 text appears, avoiding a race where the crawler snapshot still shows the previous page's h3.

Diagnostic dump on failure: current URL, first h3 (if any), and either an h1/h3 list from the page source or a body snippet (styles/scripts stripped) so validation-error responses (which have no h3) show their error text in the failure output.

## What's NOT here

- **`UpgradeWizardUiTest`** — Phase 4c-2. Needs analogous `--skip-upgrade` flag on `upgrade-package.sh` + a `wizard-upgrade` workflow scenario, and browser walk of `sql_upgrade.php`'s version-selector form.
- **Wizard states 4–7 walkthrough** — informational pages, no test value beyond what state 3 + login-page redirect already prove.
- **Authenticated `/api/version` GET** — Phase 4a-3, blocked on `site_addr_oath` install-time configuration + API-enable via admin-panel automation.

## Test plan

- [x] Local: `boot-package.sh --skip-install-helper 8.2.0`, then Panther test via dev-easy selenium grid — passes end-to-end in ~23s (DB creation is the long pole)
- [x] Local: full phpstan (`.phpstan/phpstan.ci.neon`) — clean
- [ ] CI: `wizard-install` matrix scenario runs on this PR's first push

## Related

- Plan doc: `docs/artifact-acceptance-testing-plan.md` (draft PR #12811)
- Phase 4b: #13196 (Panther plumbing this PR builds on)

Assisted-by: Claude Code
