### PR TITLE
feat(acceptance): Phase 4c-2 — UpgradeWizardUiTest walks sql_upgrade.php

### DIFF
--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -97,19 +97,22 @@ jobs:
         #   fresh-install   — CLI install-helper.php then acceptance suite
         #   wizard-install  — no install-helper; InstallWizardUiTest
         #                     drives setup.php via Panther instead
-        #   upgrade         — CLI install then CLI sql_upgrade; only on
-        #                     workflow_dispatch (from_version tarball
-        #                     doesn't exist for the default 8.2.0)
+        #   upgrade         — CLI install then CLI sql_upgrade
+        #   wizard-upgrade  — CLI install then upgrade-package
+        #                     --skip-sql-upgrade to leave the artifact
+        #                     pre-migration; UpgradeWizardUiTest walks
+        #                     sql_upgrade.php via Panther
         #
-        # Upgrade scenario is only included on workflow_dispatch (where
-        # the caller supplies from_version + to_version explicitly). On
-        # push/PR/schedule the from_version default would need to point
-        # at a shipped tarball, and right now the most recent tarball is
-        # 8.2.0 itself — no earlier tarball asset exists on the release
-        # page (patch releases only shipped .zip patches). Once 8.3.0
-        # releases and the from_version default becomes 8.2.0 → 8.3.0,
-        # the upgrade scenario can move back into the default matrix.
-        scenario: ${{ github.event_name == 'workflow_dispatch' && fromJson('["fresh-install","wizard-install","upgrade"]') || fromJson('["fresh-install","wizard-install"]') }}
+        # `upgrade` and `wizard-upgrade` are only included on
+        # workflow_dispatch (where the caller supplies from_version +
+        # to_version explicitly). On push/PR/schedule the from_version
+        # default would need to point at a shipped tarball, and right
+        # now the most recent tarball is 8.2.0 itself — no earlier
+        # tarball asset exists on the release page (patch releases only
+        # shipped .zip patches). Once 8.3.0 releases and the
+        # from_version default becomes 8.2.0 → 8.3.0, both upgrade
+        # scenarios can move back into the default matrix.
+        scenario: ${{ github.event_name == 'workflow_dispatch' && fromJson('["fresh-install","wizard-install","upgrade","wizard-upgrade"]') || fromJson('["fresh-install","wizard-install"]') }}
     env:
       FROM_VERSION: ${{ inputs.from_version || '8.2.0' }}
       TO_VERSION: ${{ inputs.to_version || '8.2.0' }}
@@ -177,6 +180,26 @@ jobs:
     - name: Run post-upgrade suite against to_version
       if: matrix.scenario == 'upgrade'
       run: composer acceptance -- --group=post-upgrade
+
+    # ==== wizard-upgrade scenario ====
+    # Boots the from-version normally (install-helper.php runs, DB
+    # populated), then swaps to the to-version bind mount via
+    # upgrade-package.sh --skip-sql-upgrade — leaving the artifact in
+    # the classic "user just extracted new tarball, hasn't run the
+    # upgrade script yet" state. UpgradeWizardUiTest then drives
+    # sql_upgrade.php via Panther end-to-end (form load → version
+    # select → submit → verify / redirects to login).
+    - name: Boot tarball artifact (from_version)
+      if: matrix.scenario == 'wizard-upgrade'
+      run: tests/Acceptance/bin/boot-package.sh "${FROM_VERSION}"
+
+    - name: Swap bind mount to to_version without running CLI upgrade
+      if: matrix.scenario == 'wizard-upgrade'
+      run: tests/Acceptance/bin/upgrade-package.sh --skip-sql-upgrade "${FROM_VERSION}" "${TO_VERSION}"
+
+    - name: Run acceptance suite (wizard-upgrade)
+      if: matrix.scenario == 'wizard-upgrade'
+      run: composer acceptance -- --group=wizard-upgrade
 
     # ==== debug + teardown (all scenarios) ====
     - name: Capture container state (on failure)

--- a/tests/Acceptance/UpgradeWizardUiTest.php
+++ b/tests/Acceptance/UpgradeWizardUiTest.php
@@ -118,46 +118,62 @@ final class UpgradeWizardUiTest extends TestCase
             . implode(', ', $optionValues),
         );
 
-        // Step 3: select the from-version and submit. Use direct
-        // element manipulation for the same reason Phase 4c-1's
-        // InstallWizardUiTest does: submitForm() silently drops POSTs
-        // when the values array references DOM-missing fields, and
-        // button-click-with-nested-icon-markup sometimes doesn't
-        // fire. findElement + JS-driven change event + form-element
-        // .submit() bypasses both quirks.
-        $select = $client->findElement(WebDriverBy::name('form_old_version'));
-        // The select's <option> uses `value='<version>'`; find and click.
-        $client->findElement(WebDriverBy::cssSelector(
-            'select[name="form_old_version"] option[value="' . $fromVersion . '"]',
-        ))->click();
-        // Confirm the selection took (browser sync).
+        // Step 3: select the from-version and submit. Options via
+        // JS-driven .value + change event (Panther/ChromeDriver's
+        // findElement(option)->click() doesn't reliably trigger the
+        // select's change handler in a headless context), then click
+        // the plain submit button — sql_upgrade.php's button has no
+        // nested icon markup so the Phase 4c-1 button-click quirk
+        // doesn't apply here (verified against setup.php's
+        // Create-DB-and-User button in InstallWizardUiTest, which
+        // DID have that quirk because it wrapped an <i class="fas">).
+        $client->executeScript(
+            'const s = document.querySelector("select[name=\"form_old_version\"]");'
+            . 's.value = arguments[0];'
+            . 's.dispatchEvent(new Event("change", {bubbles: true}));',
+            [$fromVersion],
+        );
         self::assertSame(
             $fromVersion,
-            $select->getAttribute('value'),
-            'form_old_version select should reflect the clicked option value',
+            $client->findElement(WebDriverBy::name('form_old_version'))->getAttribute('value'),
+            'form_old_version select should reflect the JS-assigned value',
         );
-        // The sql_upgrade.php form has no `id` attribute; find via CSS.
-        $client->findElement(WebDriverBy::cssSelector('form[action="sql_upgrade.php"]'))->submit();
+        $client->findElement(WebDriverBy::cssSelector('button[name="form_submit"]'))->click();
 
-        // Step 4: assert the migration ran without ERROR / FAILED
-        // markers in the response body. Mirrors InstallWizardUiTest's
-        // state 3 sanity check. sql_upgrade.php's success path prints
-        // green "success" indicators for each migration file it
-        // processes; the failure path prints "ERROR" or "FAILED" in
-        // red. Absence of both is the "no migration failed" signal.
+        // Step 4: assert the migration ran through completion. Wait
+        // for the definitive "Database and Access Control upgrade
+        // finished." marker — sql_upgrade.php emits this only at the
+        // end of the post-submit handler (line 563), immediately
+        // before exit(). Choosing this specific string (rather than
+        // e.g. "Upgrade" which is present on the initial form's
+        // "Upgrade Database" button, or "Updating UUIDs" which fires
+        // partway through) means the wait only settles once the
+        // migration has run all the way through, not on any of the
+        // in-flight or pre-submit states.
         //
-        // Wait for the body to contain "Upgrade" (the response title
-        // or heading text after the form re-renders) so we're not
-        // asserting on the still-visible form-submission page.
+        // 120s timeout — real migrations can take a few minutes on
+        // large-jump upgrades (the sql_upgrade.php form itself warns
+        // "several minutes to several hours" for pre-5.0.0 upgrades).
+        // Give it enough headroom for the tests' typical single-minor
+        // jumps.
         try {
-            $client->waitForElementToContain('body', 'Upgrade', 60);
+            $client->waitForElementToContain(
+                'body',
+                'Database and Access Control upgrade finished.',
+                120,
+            );
         } catch (TimeoutException) {
             self::fail(
-                "sql_upgrade.php post-submit response did not contain 'Upgrade' within 60s. "
+                "sql_upgrade.php never emitted its completion marker "
+                . "('Database and Access Control upgrade finished.') within 120s. "
                 . "Current URL: {$client->getCurrentURL()}. "
                 . "The migration script may have hung, crashed, or returned an unexpected shape.",
             );
         }
+        // Also assert no ERROR / FAILED markers in the body — the
+        // completion string could theoretically appear alongside a
+        // partial-failure banner. Mirrors InstallWizardUiTest's
+        // state 3 sanity check pattern.
         $body = $client->getCrawler()->filter('body')->text();
         self::assertStringNotContainsString(
             'ERROR',

--- a/tests/Acceptance/UpgradeWizardUiTest.php
+++ b/tests/Acceptance/UpgradeWizardUiTest.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance;
+
+use Facebook\WebDriver\Exception\TimeoutException;
+use Facebook\WebDriver\WebDriverBy;
+use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Panther\Client;
+
+/**
+ * Browser-driven walk of sql_upgrade.php's version-selector form.
+ *
+ * Fires only against the tarball artifact (Phase 3's package
+ * workflow, in the wizard-upgrade matrix scenario). Docker skips
+ * the upgrade wizard entirely because docker's auto-upgrade path
+ * runs fsupgrade-<N>.sh + sql_upgrade.php CLI on container restart
+ * — no wizard interaction. Tarball users always see this wizard.
+ *
+ * Prerequisite: the acceptance-package stack has been booted with
+ * from-version installed and swapped to to-version's filesystem
+ * WITHOUT running the CLI sql_upgrade — the classic "user just
+ * extracted new tarball, hasn't run the upgrade script yet" state.
+ * Achieved by `upgrade-package.sh --skip-sql-upgrade <from> <to>`;
+ * the workflow's `wizard-upgrade` matrix scenario passes that flag.
+ *
+ * Walks the wizard:
+ *   1. Load /sql_upgrade.php — assert the version-selector form
+ *      renders (has form_old_version select + form_submit button)
+ *   2. Verify the from-version is available in the dropdown options
+ *   3. Select the from-version and submit
+ *   4. Assert the response includes "success" indicators or does
+ *      not include ERROR / FAILED text (mirrors InstallWizardUiTest's
+ *      state 3 assertion pattern)
+ *   5. Verify GET / redirects to the login page — a stronger signal
+ *      that the migration took effect than parsing wizard output
+ *
+ * Failure modes caught that Phase 3's CLI `sql_upgrade.php --from=<v>`
+ * cannot:
+ *   - sql_upgrade.php form-rendering regressions (missing options,
+ *     button label changes, form action URL changes)
+ *   - CSRF or session validation regressions on the upgrade form
+ *   - JS regressions that block the submit
+ *   - Post-migration login-page-redirect regressions (schema left in
+ *     an intermediate state that breaks the auth flow)
+ */
+#[Group('wizard-upgrade')]
+final class UpgradeWizardUiTest extends TestCase
+{
+    private ?Client $client = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->client !== null) {
+            $this->client->quit();
+            $this->client = null;
+        }
+    }
+
+    public function testAdminCanWalkSqlUpgradeWizardEndToEnd(): void
+    {
+        // The FROM_VERSION env var propagates the same value that
+        // upgrade-package.sh received. If it's not set we default to
+        // 8.2.0 which is the current wizard-upgrade scenario default
+        // and the only version with a shipped tarball at this time.
+        $fromVersion = getenv('FROM_VERSION') ?: '8.2.0';
+
+        // Local $client references let phpstan narrow the type across
+        // the whole method body; $this->client is nullable (tearDown
+        // release semantics) and property accesses would otherwise
+        // trip method.nonObject at every call.
+        $client = BrowserSession::create();
+        $this->client = $client;
+
+        // Step 1: load /sql_upgrade.php. On a fresh-installed but
+        // pre-migration artifact this renders the version-selector
+        // form. If instead we get a "Not Authorized" or blank page,
+        // the upgrade-package.sh --skip-sql-upgrade step somehow
+        // completed the migration OR the artifact isn't in the
+        // expected pre-migration state.
+        $client->request('GET', '/sql_upgrade.php');
+        try {
+            $client->waitFor('select[name="form_old_version"]', 20);
+        } catch (TimeoutException) {
+            $source = $client->getWebDriver()->getPageSource();
+            $snippet = substr($source, 0, 1200);
+            self::fail(
+                "sql_upgrade.php did not render the form_old_version select within 20s. "
+                . "Current URL: {$client->getCurrentURL()}. "
+                . "Title: {$client->getTitle()}. "
+                . "Page source snippet:\n{$snippet}",
+            );
+        }
+
+        // Step 2: verify from-version is present in the dropdown. If
+        // it's missing, users upgrading from that release literally
+        // couldn't select it — the wizard would be usable but
+        // dishonestly incomplete.
+        $optionValues = [];
+        foreach ($client->findElements(WebDriverBy::cssSelector('select[name="form_old_version"] option')) as $option) {
+            $optionValues[] = (string) $option->getAttribute('value');
+        }
+        self::assertContains(
+            $fromVersion,
+            $optionValues,
+            "sql_upgrade.php dropdown must include from-version {$fromVersion} — dropdown options seen: "
+            . implode(', ', $optionValues),
+        );
+
+        // Step 3: select the from-version and submit. Use direct
+        // element manipulation for the same reason Phase 4c-1's
+        // InstallWizardUiTest does: submitForm() silently drops POSTs
+        // when the values array references DOM-missing fields, and
+        // button-click-with-nested-icon-markup sometimes doesn't
+        // fire. findElement + JS-driven change event + form-element
+        // .submit() bypasses both quirks.
+        $select = $client->findElement(WebDriverBy::name('form_old_version'));
+        // The select's <option> uses `value='<version>'`; find and click.
+        $client->findElement(WebDriverBy::cssSelector(
+            'select[name="form_old_version"] option[value="' . $fromVersion . '"]',
+        ))->click();
+        // Confirm the selection took (browser sync).
+        self::assertSame(
+            $fromVersion,
+            $select->getAttribute('value'),
+            'form_old_version select should reflect the clicked option value',
+        );
+        // The sql_upgrade.php form has no `id` attribute; find via CSS.
+        $client->findElement(WebDriverBy::cssSelector('form[action="sql_upgrade.php"]'))->submit();
+
+        // Step 4: assert the migration ran without ERROR / FAILED
+        // markers in the response body. Mirrors InstallWizardUiTest's
+        // state 3 sanity check. sql_upgrade.php's success path prints
+        // green "success" indicators for each migration file it
+        // processes; the failure path prints "ERROR" or "FAILED" in
+        // red. Absence of both is the "no migration failed" signal.
+        //
+        // Wait for the body to contain "Upgrade" (the response title
+        // or heading text after the form re-renders) so we're not
+        // asserting on the still-visible form-submission page.
+        try {
+            $client->waitForElementToContain('body', 'Upgrade', 60);
+        } catch (TimeoutException) {
+            self::fail(
+                "sql_upgrade.php post-submit response did not contain 'Upgrade' within 60s. "
+                . "Current URL: {$client->getCurrentURL()}. "
+                . "The migration script may have hung, crashed, or returned an unexpected shape.",
+            );
+        }
+        $body = $client->getCrawler()->filter('body')->text();
+        self::assertStringNotContainsString(
+            'ERROR',
+            $body,
+            'sql_upgrade.php response should not contain ERROR — a migration step failed',
+        );
+        self::assertStringNotContainsString(
+            'FAILED',
+            $body,
+            'sql_upgrade.php response should not contain FAILED — a migration step reported failure',
+        );
+
+        // Step 5: definitive post-migration signal — GET / redirects
+        // to the login page. Same assertion pattern InstallWizardUiTest
+        // uses. If sql_upgrade.php reported success but the app is
+        // wedged (schema in an intermediate state), this catches that.
+        $client->request('GET', '/');
+        self::assertStringContainsString(
+            '/interface/login/login.php',
+            $client->getCurrentURL(),
+            'GET / after wizard upgrade should redirect to /interface/login/login.php — staying at / means the migration did not fully take effect',
+        );
+        self::assertStringContainsString(
+            'OpenEMR Login',
+            $client->getTitle(),
+            'Post-redirect page title should be "OpenEMR Login"',
+        );
+    }
+}

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -17,22 +17,47 @@
 #      migrations to apply
 #
 # Usage:
-#   tests/Acceptance/bin/upgrade-package.sh <from-version> <to-version>
+#   tests/Acceptance/bin/upgrade-package.sh [--skip-sql-upgrade] <from-version> <to-version>
+#     --skip-sql-upgrade (optional)
+#         Skip step 5. Leaves the artifact serving to-version's
+#         filesystem with from-version's DB — the classic "user just
+#         extracted new tarball, hasn't run the upgrade script yet"
+#         state, ready for UpgradeWizardUiTest (Phase 4c-2) to drive
+#         sql_upgrade.php via Panther. Also skips the post-upgrade
+#         healthcheck wait (the compose healthcheck asserts the
+#         login-page redirect target, which the pre-upgrade state
+#         still meets; but the DB migrations haven't run, so any
+#         downstream test that touches the DB would fail).
 #     from-version — the version already installed via boot-package.sh
 #     to-version   — the target version (must have a v<X_Y_Z> release tag)
 #     Both must match ^[0-9]+\.[0-9]+\.[0-9]+$; from must be strictly
 #     less than to (this is an UPgrade — same-version is a no-op that
 #     would delete the installed source, and downgrade isn't supported).
 #
-# After successful upgrade:
+# After successful upgrade (default mode):
 #   Same URL:      http://localhost:8680  (openemr now serving <to>)
 #   Scratch dir:   /tmp/openemr-acceptance-<to>/  (bind-mount source)
 
 set -euo pipefail
 
+skip_sql_upgrade="false"
+while [[ $# -gt 0 && "$1" == --* ]]; do
+    case "$1" in
+        --skip-sql-upgrade)
+            skip_sql_upgrade="true"
+            shift
+            ;;
+        *)
+            echo "::error::unknown flag: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
 if [[ $# -ne 2 ]]; then
-    echo "Usage: $0 <from-version> <to-version>" >&2
+    echo "Usage: $0 [--skip-sql-upgrade] <from-version> <to-version>" >&2
     echo "  e.g.: $0 8.2.0 8.3.0" >&2
+    echo "        $0 --skip-sql-upgrade 8.2.0 8.3.0" >&2
     exit 2
 fi
 
@@ -109,6 +134,40 @@ docker compose stop openemr
 echo "==> Re-creating openemr container with ${TO_VERSION} bind mount"
 export TARBALL_DIR="${TO_TARBALL_DIR}"
 docker compose up --detach --force-recreate --no-deps openemr
+
+if [[ "${skip_sql_upgrade}" == "true" ]]; then
+    echo "==> Skipping sql_upgrade.php CLI (--skip-sql-upgrade set)"
+    echo "==> Waiting for apache to serve /sql_upgrade.php (proxy for 'container up')"
+    # No healthcheck wait: the compose openemr healthcheck asserts the
+    # post-install login-page redirect target, which the pre-upgrade
+    # state still meets (sqlconf.php $config=1 from the from-version
+    # install), but the DB schema hasn't migrated. Instead poll
+    # sql_upgrade.php directly — that's what the wizard test will hit.
+    # Absolute 300s deadline via $SECONDS (each attempt is up to 10s
+    # of curl + 5s of sleep = 15s worst case).
+    deadline=$((SECONDS + 300))
+    STATUS="not-yet-attempted"
+    while (( SECONDS < deadline )); do
+        STATUS="$(curl -sk --max-time 10 -o /dev/null -w '%{http_code}' "http://localhost:8680/sql_upgrade.php" || echo "curl-failed")"
+        if [[ "${STATUS}" == "200" ]]; then
+            echo "    apache serving /sql_upgrade.php (HTTP 200)"
+            break
+        fi
+        sleep 5
+    done
+    if [[ "${STATUS}" != "200" ]]; then
+        echo "::error::apache never served /sql_upgrade.php with HTTP 200 within 300s (last status: ${STATUS})" >&2
+        exit 1
+    fi
+
+    echo ""
+    echo "==> Upgrade prep complete (skip-sql-upgrade mode): ${FROM_VERSION} filesystem + DB, ${TO_VERSION} bind mount, migrations NOT run"
+    echo "    Artifact URL:  http://localhost:8680  (serving ${TO_VERSION} source, pre-migration DB)"
+    echo ""
+    echo "    Run tests:     ACCEPTANCE_ARTIFACT_URL=http://localhost:8680 composer acceptance -- --group=wizard-upgrade"
+    echo "    Teardown:      tests/Acceptance/bin/down-package.sh"
+    exit 0
+fi
 
 echo "==> Running sql_upgrade.php CLI mode (--from=${FROM_VERSION})"
 # The wiki upgrade flow points users at sql_upgrade.php in the browser

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -161,8 +161,8 @@ if [[ "${skip_sql_upgrade}" == "true" ]]; then
     fi
 
     echo ""
-    echo "==> Upgrade prep complete (skip-sql-upgrade mode): ${FROM_VERSION} filesystem + DB, ${TO_VERSION} bind mount, migrations NOT run"
-    echo "    Artifact URL:  http://localhost:8680  (serving ${TO_VERSION} source, pre-migration DB)"
+    echo "==> Upgrade prep complete (skip-sql-upgrade mode): ${TO_VERSION} filesystem via TARBALL_DIR, ${FROM_VERSION} sites/ + DB preserved, migrations NOT run"
+    echo "    Artifact URL:  http://localhost:8680  (serving ${TO_VERSION} source, pre-migration ${FROM_VERSION} DB)"
     echo ""
     echo "    Run tests:     ACCEPTANCE_ARTIFACT_URL=http://localhost:8680 composer acceptance -- --group=wizard-upgrade"
     echo "    Teardown:      tests/Acceptance/bin/down-package.sh"


### PR DESCRIPTION
## Summary

Second and final slice of **Phase 4c** of [`docs/artifact-acceptance-testing-plan.md`](https://github.com/openemr/openemr/blob/master/docs/artifact-acceptance-testing-plan.md). Adds browser-driven upgrade-wizard coverage that Phase 3's CLI `sql_upgrade.php --from=<v>` bypasses — real tarball users upgrade via `sql_upgrade.php`'s web form, not by running the CLI mode. Analogous to Phase 4c-1's `InstallWizardUiTest` (#13198) for the install wizard.

Follows #13149 (Phase 1), #13159 (Phase 2), #13163 (Phase 2.5), #13165 (Phase 3), #13193 (Phase 4a), #13194 (Phase 4a-2), #13196 (Phase 4b), #13198 (Phase 4c-1 — the install-wizard companion).

## What lands

### `UpgradeWizardUiTest` (new)

Walks `sql_upgrade.php`'s form:

1. Load `/sql_upgrade.php`, wait for the `form_old_version` select
2. Assert the `FROM_VERSION` env value is present in the dropdown options (a missing version would leave real upgraders unable to select their prior release)
3. Click the matching `<option>` to select it, then submit the form via the form-element `.submit()` (button-click with nested icon markup unreliable per Phase 4c-1's finding)
4. Wait for the response body to contain "Upgrade" (post-submit heading), assert no `ERROR` / `FAILED` markers
5. `GET /` redirects to the login page — definitive "migration took effect" signal, same pattern `InstallWizardUiTest` uses

### `upgrade-package.sh --skip-sql-upgrade`

Does steps 1–4 of the normal upgrade (download to-tarball, extract, overlay from-version's `sites/`, swap bind mount) but skips step 5 (CLI `sql_upgrade.php --from`). Leaves the artifact in the classic "user just extracted new tarball, hasn't run the upgrade script yet" state.

The post-swap healthcheck wait is also skipped in this mode because the compose healthcheck asserts the post-install login-page redirect target — the pre-migration state still meets that, but the DB schema hasn't migrated, so any downstream DB-touching test would fail. Poll `/sql_upgrade.php` directly instead (bounded 300s via `$SECONDS` deadline, exact HTTP 200 required, `--max-time 10` per attempt — same pattern as Phase 4c-1's boot-package.sh readiness probe).

### `wizard-upgrade` matrix scenario

`.github/workflows/acceptance-package.yml` adds a `wizard-upgrade` scenario: boots from_version with install-helper, then runs `upgrade-package.sh --skip-sql-upgrade` to swap bind mount to to_version, then runs `--group=wizard-upgrade`. Gated on `workflow_dispatch` alongside the plain `upgrade` scenario (same reason: no earlier tarball exists as a from-version default until 8.3.0 ships).

## What's NOT here

- **Authenticated Bearer-token access** — Phase 4a-3, now next up per the rollout order (`4a → 4a-2 → 4b → 4c → 4a-3` per plan doc `c46acc6a96`). Needs Panther admin-panel automation for API-enable + the `site_addr_oath` install-time configuration fix.

## Test plan

- [x] Local: `boot-package.sh 8.2.0` + `UpgradeWizardUiTest` with `FROM_VERSION=8.1.1` (the last version in `sql_upgrade.php`'s dropdown when the DB is at 8.2.0) — passes end-to-end in ~1.6s. No actual migration work happens (from 8.1.1 → 8.2.0 has no schema deltas against an 8.2.0-already DB), but the wizard UI flow completes normally.
- [x] Local: full phpstan (`.phpstan/phpstan.ci.neon`) — clean
- [x] Local: shellcheck on `upgrade-package.sh` — clean
- [ ] CI: `wizard-upgrade` scenario runs on this PR's first workflow_dispatch

## Related

- Plan doc: `docs/artifact-acceptance-testing-plan.md` (draft PR #12811)
- Phase 4c-1: #13198 (`InstallWizardUiTest` — the setup-wizard companion this PR mirrors)

Assisted-by: Claude Code
