### PR TITLE
feat(acceptance): Phase 4a-3 (1/2) — API-enable bootstrap + OAuth2 successful-flow assertions

### DIFF
--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -385,19 +385,24 @@ jobs:
       run: composer acceptance -- --group=${{ matrix.test_group }}
 
     # api-enable bootstrap fires AFTER the fresh-install group only
-    # (not upgrade — the target of upgrade is api-enabled downstream
-    # by its own path). Order matters: OAuth2SmokeTest's fresh-install
-    # tag asserts the API-disabled 404 gate that ships by default;
-    # the bootstrap flips those globals so the api-enabled group
-    # asserts the opposite behavior (endpoints return 200).
+    # (not the plain upgrade scenario — the target of upgrade is api-
+    # enabled downstream by its own path). The docker workflow uses
+    # `fresh-install-from` and `fresh-install-to` as its two fresh-
+    # install matrix values (the `-from` / `-to` distinction lets the
+    # single fresh-install scenario stand in for both sides of a
+    # future upgrade-target artifact test). Order matters:
+    # OAuth2SmokeTest's fresh-install-tagged assertions verify the
+    # API-disabled 404 gate that ships by default; the bootstrap
+    # flips those globals so the api-enabled group asserts the
+    # opposite behavior (endpoints return 200).
     - name: Bootstrap API via admin panel
-      if: matrix.scenario == 'fresh-install'
+      if: startsWith(matrix.scenario, 'fresh-install')
       env:
         OPENEMR_ENABLE_API_BOOTSTRAP: '1'
       run: php tests/Acceptance/bin/api-enable.php
 
     - name: Run acceptance suite (--group=api-enabled) against ${{ steps.tags.outputs.boot_tag }}
-      if: matrix.scenario == 'fresh-install'
+      if: startsWith(matrix.scenario, 'fresh-install')
       run: composer acceptance -- --group=api-enabled
 
     # ==== Upgrade-scenario-only steps (image swap + post-upgrade suite) ====

--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -384,6 +384,22 @@ jobs:
     - name: Run acceptance suite (--group=${{ matrix.test_group }}) against ${{ steps.tags.outputs.boot_tag }}
       run: composer acceptance -- --group=${{ matrix.test_group }}
 
+    # api-enable bootstrap fires AFTER the fresh-install group only
+    # (not upgrade — the target of upgrade is api-enabled downstream
+    # by its own path). Order matters: OAuth2SmokeTest's fresh-install
+    # tag asserts the API-disabled 404 gate that ships by default;
+    # the bootstrap flips those globals so the api-enabled group
+    # asserts the opposite behavior (endpoints return 200).
+    - name: Bootstrap API via admin panel
+      if: matrix.scenario == 'fresh-install'
+      env:
+        OPENEMR_ENABLE_API_BOOTSTRAP: '1'
+      run: php tests/Acceptance/bin/api-enable.php
+
+    - name: Run acceptance suite (--group=api-enabled) against ${{ steps.tags.outputs.boot_tag }}
+      if: matrix.scenario == 'fresh-install'
+      run: composer acceptance -- --group=api-enabled
+
     # ==== Upgrade-scenario-only steps (image swap + post-upgrade suite) ====
     - name: Stop containers (preserve named volumes)
       if: matrix.scenario == 'upgrade'

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -149,6 +149,21 @@ jobs:
       if: matrix.scenario == 'fresh-install'
       run: composer acceptance -- --group=fresh-install
 
+    # api-enable bootstrap fires AFTER the fresh-install group. Order
+    # matters: OAuth2SmokeTest's fresh-install-tagged assertions verify
+    # the API-disabled 404 gate that ships by default; the bootstrap
+    # then flips those globals so the api-enabled group can assert the
+    # opposite behavior (endpoints return 200 with real content).
+    - name: Bootstrap API via admin panel
+      if: matrix.scenario == 'fresh-install'
+      env:
+        OPENEMR_ENABLE_API_BOOTSTRAP: '1'
+      run: php tests/Acceptance/bin/api-enable.php
+
+    - name: Run acceptance suite (api-enabled of to_version)
+      if: matrix.scenario == 'fresh-install'
+      run: composer acceptance -- --group=api-enabled
+
     # ==== wizard-install scenario ====
     # Boots the artifact WITHOUT running install-helper.php so the
     # artifact serves setup.php on /. InstallWizardUiTest then drives

--- a/tests/Acceptance/OAuth2ApiEnabledTest.php
+++ b/tests/Acceptance/OAuth2ApiEnabledTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance;
+
+use OpenEMR\Tests\Acceptance\Support\ArtifactBrowser;
+use OpenEMR\Tests\Acceptance\Support\ResponseHeaders;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * OAuth2/OIDC successful-flow smoke test — the counterpart to
+ * OAuth2SmokeTest's API-disabled 404 gate assertions.
+ *
+ * Prerequisite: the acceptance harness must have run
+ * `tests/Acceptance/bin/api-enable.php` first to enable the API
+ * globals + set site_addr_oath. Without that, /oauth2/default/*
+ * endpoints return 404 with "API is disabled" (which is what
+ * OAuth2SmokeTest asserts). This test asserts the ENABLED behavior:
+ * discovery returns provider metadata, DCR mints client credentials.
+ *
+ * Together with OAuth2SmokeTest, both sides of the API-enable gate
+ * policy are pinned down:
+ *   - default install → gate rejects (OAuth2SmokeTest)
+ *   - admin-panel-enabled install → endpoints respond normally
+ *     (this test)
+ *
+ * Full authenticated Bearer-token access (POST /oauth2/default/token
+ * exchange + GET /apis/default/api/version) is the follow-up
+ * Phase 4a-3 slice — needs the auth-code flow via login-form scrape
+ * + consent-form scrape, which is a chunky additional surface. This
+ * PR intentionally covers only the "endpoints reachable + minting
+ * credentials" half of the successful flow.
+ */
+#[Group('api-enabled')]
+final class OAuth2ApiEnabledTest extends TestCase
+{
+    public function testOidcDiscoveryReturnsProviderMetadata(): void
+    {
+        // Per OIDC Discovery spec, .well-known/openid-configuration
+        // is a JSON document listing provider endpoints. Once the
+        // API is enabled, this endpoint returns 200 with the
+        // discovery payload (rather than the 404 API-disabled gate
+        // OAuth2SmokeTest asserts on a default install).
+        $browser = ArtifactBrowser::create();
+        $browser->request(
+            'GET',
+            ArtifactBrowser::baseUrl() . '/oauth2/default/.well-known/openid-configuration',
+        );
+        $response = $browser->getResponse();
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            'OIDC discovery must return 200 when API is enabled — a 404 with "API is disabled" means the api-enable.php bootstrap did not run or did not persist',
+        );
+        self::assertStringStartsWith(
+            'application/json',
+            ResponseHeaders::first($response, 'Content-Type'),
+            'OIDC discovery response must be application/json',
+        );
+
+        $body = json_decode($response->getContent(), true);
+        self::assertIsArray($body, 'OIDC discovery response must be a JSON object');
+
+        // The four mandatory OIDC provider-metadata fields per
+        // https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata,
+        // plus registration_endpoint (optional per spec, but openemr
+        // ships DCR and downstream tests rely on it being advertised).
+        foreach (
+            ['issuer', 'authorization_endpoint', 'token_endpoint', 'jwks_uri', 'registration_endpoint'] as $key
+        ) {
+            self::assertArrayHasKey($key, $body, "OIDC discovery missing required key: {$key}");
+            self::assertIsString($body[$key]);
+            self::assertNotFalse(
+                filter_var($body[$key], FILTER_VALIDATE_URL),
+                "OIDC discovery {$key} must be a valid absolute URL",
+            );
+        }
+
+        // The issuer claim on minted tokens is derived from the
+        // provider's advertised issuer, which itself comes from
+        // globals.site_addr_oath. The api-enable.php bootstrap sets
+        // that to ACCEPTANCE_ARTIFACT_URL so tokens' iss matches
+        // what tests hit. Assert the discovery issuer reflects that.
+        // (Absolute-URL check above already validates shape.)
+        self::assertStringStartsWith(
+            ArtifactBrowser::baseUrl(),
+            $body['issuer'],
+            'OIDC issuer should start with the acceptance base URL — mismatch means api-enable.php did not set site_addr_oath correctly, and downstream authenticated tests will fail on iss-claim validation',
+        );
+    }
+
+    public function testDynamicClientRegistrationMintsClientCredentials(): void
+    {
+        // Per RFC 7591, POST /oauth2/default/registration with a
+        // well-formed client metadata document returns a response
+        // containing client_id + client_secret (for confidential
+        // clients using client_secret_* auth methods). Client name
+        // is randomized so parallel test runs don't clash.
+        $clientName = 'AcceptanceApiEnabled-' . bin2hex(random_bytes(4));
+        // application_type: 'private' is openemr's non-spec extension
+        // that signals a confidential-client registration (returns
+        // client_secret). OIDC Dynamic Registration spec only defines
+        // 'web' / 'native' — those get public clients (PKCE-only, no
+        // secret). See AuthorizationController::clientRegistration
+        // (grep "application_type"): only 'private' takes the
+        // client_secret branch. This test asserts the confidential-
+        // client shape, so 'private' is the right value.
+        $registration = [
+            'application_type' => 'private',
+            'redirect_uris' => ['https://acceptance-harness.example/callback'],
+            'client_name' => $clientName,
+            'token_endpoint_auth_method' => 'client_secret_post',
+            'contacts' => ['acceptance-harness@openemr.example'],
+            'scope' => 'openid fhirUser',
+        ];
+
+        $browser = ArtifactBrowser::create();
+        $browser->request(
+            'POST',
+            ArtifactBrowser::baseUrl() . '/oauth2/default/registration',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode($registration, JSON_THROW_ON_ERROR),
+        );
+        $response = $browser->getResponse();
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            'DCR must return 200 when API is enabled per RFC 7591 — a 404 with "API is disabled" means the api-enable.php bootstrap did not run',
+        );
+        self::assertStringStartsWith(
+            'application/json',
+            ResponseHeaders::first($response, 'Content-Type'),
+            'DCR response must be application/json',
+        );
+
+        $body = json_decode($response->getContent(), true);
+        self::assertIsArray($body, 'DCR response must be a JSON object');
+        self::assertArrayHasKey('client_id', $body, 'DCR response must include client_id per RFC 7591');
+        self::assertArrayHasKey('client_secret', $body, 'DCR response must include client_secret when token_endpoint_auth_method is client_secret_post');
+        self::assertIsString($body['client_id']);
+        self::assertIsString($body['client_secret']);
+        self::assertNotSame('', $body['client_id'], 'client_id must not be empty');
+        self::assertNotSame('', $body['client_secret'], 'client_secret must not be empty');
+        self::assertSame(
+            $clientName,
+            $body['client_name'] ?? null,
+            'DCR response should echo the submitted client_name unchanged',
+        );
+    }
+}

--- a/tests/Acceptance/Support/ArtifactBrowser.php
+++ b/tests/Acceptance/Support/ArtifactBrowser.php
@@ -67,9 +67,18 @@ final class ArtifactBrowser
         return in_array($host, ['localhost', '127.0.0.1', '::1', 'host.docker.internal'], true);
     }
 
+    /**
+     * @return non-empty-string
+     */
     public static function baseUrl(): string
     {
         $url = getenv('ACCEPTANCE_ARTIFACT_URL');
-        return $url !== false && $url !== '' ? rtrim($url, '/') : 'http://localhost:8580';
+        if ($url !== false && $url !== '') {
+            $trimmed = rtrim($url, '/');
+            if ($trimmed !== '') {
+                return $trimmed;
+            }
+        }
+        return 'http://localhost:8580';
     }
 }

--- a/tests/Acceptance/bin/api-enable.php
+++ b/tests/Acceptance/bin/api-enable.php
@@ -1,0 +1,208 @@
+<?php
+
+/**
+ * Panther-driven bootstrap: enable OpenEMR's REST API globals + set
+ * site_addr_oath to the acceptance-runner-visible URL, both via the
+ * admin panel's Administration → Globals → Connectors tab.
+ *
+ * Fires between artifact boot and any acceptance test that needs the
+ * API enabled with correct OAuth issuer configuration. Currently that
+ * means Phase 4a-3's OAuth2 successful-flow tests (extended
+ * OAuth2SmokeTest assertions) and the eventual authenticated
+ * `/api/version` tests (Phase 4a-3 follow-up).
+ *
+ * Why the admin panel rather than direct SQL writes or install-time
+ * env-var overrides:
+ *   - The admin panel IS the user-facing API-enable path. Real
+ *     admins flip these toggles from Administration → Globals. If
+ *     the panel breaks (tab-render regression, form field renaming,
+ *     save handler bug), no shipped artifact can enable its API —
+ *     acceptance should catch that by using the same path.
+ *   - install-helper.php + docker's auto_configure.php could set
+ *     the globals directly (via SQL after Installer::quick_install),
+ *     but that decouples the acceptance harness from the real
+ *     admin-panel flow and would leave a regression there
+ *     undetected.
+ *
+ * Env inputs:
+ *   ACCEPTANCE_ARTIFACT_URL — the URL Panther points Chrome at. Also
+ *                             used as site_addr_oath so the OAuth
+ *                             issuer claim matches what tests hit.
+ *   SELENIUM_USE_GRID       — see Support/BrowserSession.
+ *   OPENEMR_ENABLE_API_BOOTSTRAP — opt-in guard. Set to 1 to run;
+ *                             refuse without it. Same
+ *                             defence-in-depth pattern
+ *                             install-helper.php uses.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    exit("api-enable.php is a CLI-only bootstrap; refusing non-CLI invocation\n");
+}
+
+if (!getenv('OPENEMR_ENABLE_API_BOOTSTRAP')) {
+    fwrite(STDERR, "api-enable.php: refusing to run without OPENEMR_ENABLE_API_BOOTSTRAP=1\n");
+    exit(1);
+}
+
+require_once dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+use Facebook\WebDriver\WebDriverBy;
+use OpenEMR\Tests\Acceptance\Support\ArtifactBrowser;
+use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+
+$baseUrl = ArtifactBrowser::baseUrl();
+
+echo "==> api-enable.php: bootstrapping API via admin panel\n";
+echo "    Artifact URL: {$baseUrl}\n";
+echo "    site_addr_oath target: {$baseUrl}\n";
+
+$client = BrowserSession::create();
+try {
+    // Step 1: log in as admin.
+    echo "==> Logging in as admin\n";
+    $client->request('GET', $baseUrl . '/interface/login/login.php?site=default');
+    $client->submitForm('login-button', ['authUser' => 'admin', 'clearPass' => 'pass']);
+    $client->waitFor('#mainMenu', 30);
+
+    // Step 2: load the globals editor.
+    echo "==> Loading /interface/super/edit_globals.php\n";
+    $client->request('GET', $baseUrl . '/interface/super/edit_globals.php');
+    $client->waitFor('#theform', 30);
+
+    // Step 3: look up each target field's form_N name by walking
+    // the label text. Field names are indexed (form_0..form_N) based
+    // on iteration order over the globals.inc.php metadata array, so
+    // absolute indices shift when globals get added/removed. Label
+    // text is the stable identifier.
+    echo "==> Resolving field names by label\n";
+    /** @var string $mappingJson */
+    $mappingJson = $client->executeScript(<<<'JS_WRAP'
+        function findInputByLabel(labelText) {
+            const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+            let node;
+            while (node = walker.nextNode()) {
+                if (node.textContent.includes(labelText)) {
+                    let el = node.parentElement;
+                    for (let i = 0; i < 8; i++) {
+                        const inputs = el.querySelectorAll('input, select, textarea');
+                        if (inputs.length > 0) {
+                            return { name: inputs[0].name, type: inputs[0].type };
+                        }
+                        el = el.parentElement;
+                        if (!el) break;
+                    }
+                }
+            }
+            return null;
+        }
+        return JSON.stringify({
+            site_addr_oath:   findInputByLabel('Site Address Override'),
+            rest_api:         findInputByLabel('Enable OpenEMR Standard REST API'),
+            rest_fhir_api:    findInputByLabel('Enable OpenEMR Standard FHIR REST API'),
+            rest_portal_api:  findInputByLabel('Enable OpenEMR Patient Portal REST API'),
+        });
+    JS_WRAP);
+    $mapping = json_decode($mappingJson, true, 512, JSON_THROW_ON_ERROR);
+    foreach (['site_addr_oath', 'rest_api', 'rest_fhir_api', 'rest_portal_api'] as $key) {
+        if (empty($mapping[$key])) {
+            fwrite(STDERR, "api-enable.php: could not find '{$key}' input by label — admin panel structure may have regressed\n");
+            exit(1);
+        }
+        echo "    {$key} → form field '{$mapping[$key]['name']}' (type={$mapping[$key]['type']})\n";
+    }
+
+    // Step 4: set the 3 checkbox toggles + the text field. Uses JS
+    // rather than WebDriver's click()/sendKeys() because openemr's
+    // edit_globals form has a very high field count (400+) with lots
+    // of scrolling; JS assignment is faster and doesn't depend on
+    // scrolling elements into view.
+    echo "==> Setting field values\n";
+    $client->executeScript(<<<JS
+        const map = {$mappingJson};
+        const url = arguments[0];
+        for (const [key, target] of Object.entries({
+            site_addr_oath: url,
+            rest_api: true,
+            rest_fhir_api: true,
+            rest_portal_api: true,
+        })) {
+            const el = document.querySelector('[name="' + map[key].name + '"]');
+            if (map[key].type === 'checkbox') {
+                el.checked = target;
+            } else {
+                el.value = target;
+            }
+            el.dispatchEvent(new Event('change', {bubbles: true}));
+        }
+    JS, [$baseUrl]);
+
+    // Step 5: submit form_save. The form posts to itself and reloads
+    // with success indicators + updated field values.
+    echo "==> Submitting form_save\n";
+    $client->findElement(WebDriverBy::name('form_save'))->click();
+
+    // Step 6: verify by re-reading the field values after reload.
+    // edit_globals.php pre-populates from DB, so if our save took,
+    // the reloaded page will show the new values.
+    echo "==> Waiting for post-save reload\n";
+    $client->waitFor('#theform', 30);
+    /** @var string $verifyJson */
+    $verifyJson = $client->executeScript(<<<JS_WRAP
+        function findInputByLabel(labelText) {
+            const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+            let node;
+            while (node = walker.nextNode()) {
+                if (node.textContent.includes(labelText)) {
+                    let el = node.parentElement;
+                    for (let i = 0; i < 8; i++) {
+                        const inputs = el.querySelectorAll('input, select, textarea');
+                        if (inputs.length > 0) {
+                            const inp = inputs[0];
+                            return { value: inp.value, checked: inp.checked ?? null };
+                        }
+                        el = el.parentElement;
+                        if (!el) break;
+                    }
+                }
+            }
+            return null;
+        }
+        return JSON.stringify({
+            site_addr_oath:   findInputByLabel('Site Address Override'),
+            rest_api:         findInputByLabel('Enable OpenEMR Standard REST API'),
+            rest_fhir_api:    findInputByLabel('Enable OpenEMR Standard FHIR REST API'),
+            rest_portal_api:  findInputByLabel('Enable OpenEMR Patient Portal REST API'),
+        });
+    JS_WRAP);
+    $verify = json_decode($verifyJson, true, 512, JSON_THROW_ON_ERROR);
+    echo "==> Post-save state:\n";
+    foreach ($verify as $key => $state) {
+        echo "    {$key}: " . json_encode($state) . "\n";
+    }
+    $failed = [];
+    if (($verify['site_addr_oath']['value'] ?? '') !== $baseUrl) {
+        $failed[] = "site_addr_oath (expected '{$baseUrl}', got '" . ($verify['site_addr_oath']['value'] ?? '') . "')";
+    }
+    foreach (['rest_api', 'rest_fhir_api', 'rest_portal_api'] as $key) {
+        if (($verify[$key]['checked'] ?? false) !== true) {
+            $failed[] = $key . ' (expected checked=true)';
+        }
+    }
+    if (!empty($failed)) {
+        fwrite(STDERR, "api-enable.php: post-save verification failed for: " . implode(', ', $failed) . "\n");
+        exit(1);
+    }
+
+    echo "==> Bootstrap complete: API enabled + site_addr_oath set\n";
+} finally {
+    $client->quit();
+}

--- a/tests/Acceptance/bin/api-enable.php
+++ b/tests/Acceptance/bin/api-enable.php
@@ -114,8 +114,11 @@ try {
     $mapping = json_decode($mappingJson, true, 512, JSON_THROW_ON_ERROR);
     foreach (['site_addr_oath', 'rest_api', 'rest_fhir_api', 'rest_portal_api'] as $key) {
         if (empty($mapping[$key])) {
-            fwrite(STDERR, "api-enable.php: could not find '{$key}' input by label — admin panel structure may have regressed\n");
-            exit(1);
+            // Throw rather than exit() so the outer finally block runs
+            // (Chrome subprocess gets $client->quit() and doesn't leak).
+            throw new RuntimeException(
+                "could not find '{$key}' input by label — admin panel structure may have regressed",
+            );
         }
         echo "    {$key} → form field '{$mapping[$key]['name']}' (type={$mapping[$key]['type']})\n";
     }
@@ -198,8 +201,11 @@ try {
         }
     }
     if (!empty($failed)) {
-        fwrite(STDERR, "api-enable.php: post-save verification failed for: " . implode(', ', $failed) . "\n");
-        exit(1);
+        // Throw rather than exit() so the outer finally block runs
+        // (Chrome subprocess gets $client->quit() and doesn't leak).
+        throw new RuntimeException(
+            'post-save verification failed for: ' . implode(', ', $failed),
+        );
     }
 
     echo "==> Bootstrap complete: API enabled + site_addr_oath set\n";


### PR DESCRIPTION
## Summary

First slice of **Phase 4a-3** of [`docs/artifact-acceptance-testing-plan.md`](https://github.com/openemr/openemr/blob/master/docs/artifact-acceptance-testing-plan.md). Bundles 4a-3-1 (Panther admin-panel bootstrap for API-enable + `site_addr_oath`) with 4a-3-2 (extend OAuth2 coverage with successful-flow assertions unlocked by the bootstrap).

Full authenticated Bearer `GET /apis/default/api/version` stays as the 4a-3-3 follow-up — needs the auth-code flow login+consent form scraping, which is its own chunk of surface.

Follows #13149 (Phase 1), #13159 (Phase 2), #13163 (Phase 2.5), #13165 (Phase 3), #13193 (Phase 4a), #13194 (Phase 4a-2), #13196 (Phase 4b), #13198 (Phase 4c-1), #13199 (Phase 4c-2).

## What lands

### `tests/Acceptance/bin/api-enable.php` (new)

Panther-driven bootstrap script, CLI-invocable via `php tests/Acceptance/bin/api-enable.php`. Sequence:

1. Log in as admin via Panther
2. Load `/interface/super/edit_globals.php`
3. Resolve each target field's `form_N` name by walking the DOM for its label text — `form_N` indices shift when `globals.inc.php` gets added-to; label text is the stable identifier
4. Set the 3 REST_API/REST_FHIR_API/REST_PORTAL_API checkboxes + `site_addr_oath` text field (via `executeScript` — faster than scroll-into-view + click for a 400-field form)
5. Submit `form_save`
6. Verify all 4 values persisted post-reload

Guarded by `OPENEMR_ENABLE_API_BOOTSTRAP=1` opt-in env var — same defense-in-depth pattern `install-helper.php` uses.

**Why the admin panel rather than direct SQL writes or install-time env-var overrides** — the admin panel IS the user-facing API-enable path. If it breaks (tab regression, form-field renaming, save handler bug), no shipped artifact can enable its API. Acceptance catches that by using the same path.

### `tests/Acceptance/OAuth2ApiEnabledTest` (new)

Successful-flow counterpart to `OAuth2SmokeTest`'s API-disabled 404 gate assertions. Two tests, tagged `#[Group('api-enabled')]`:

- **`testOidcDiscoveryReturnsProviderMetadata`** — `GET /oauth2/default/.well-known/openid-configuration` returns 200 with the mandatory OIDC provider-metadata fields (issuer, authorization_endpoint, token_endpoint, jwks_uri, registration_endpoint), each a valid absolute URL. Also asserts the issuer starts with `ACCEPTANCE_ARTIFACT_URL` — proves the bootstrap set `site_addr_oath` correctly, and gives 4a-3-3's authenticated tests a working `iss` claim to validate against.

- **`testDynamicClientRegistrationMintsClientCredentials`** — POST `/oauth2/default/registration` with a well-formed RFC 7591 body (`application_type='private'` — openemr's non-spec extension for confidential-client registration, only path that returns a `client_secret`; see `AuthorizationController::clientRegistration`'s client_role logic) returns 200 with non-empty `client_id` + `client_secret`. Client name randomized per run.

Together with `OAuth2SmokeTest`, both sides of the API-enable gate policy are pinned down — default install → gate rejects; admin-panel-enabled install → endpoints respond normally.

### Workflow changes

Both `.github/workflows/acceptance-{docker,package}.yml` add two steps in the `fresh-install` scenario, ordered AFTER the `fresh-install` group and BEFORE any `api-enabled` tests:

1. **Bootstrap API via admin panel** — `php tests/Acceptance/bin/api-enable.php` with `OPENEMR_ENABLE_API_BOOTSTRAP=1`
2. **Run acceptance suite `--group=api-enabled`**

Order matters: `OAuth2SmokeTest`'s assertions on the API-disabled state must run BEFORE the bootstrap flips those globals.

### `Support/ArtifactBrowser::baseUrl()` typing

Tightened return type to `non-empty-string` via phpdoc so `assertStringStartsWith()` on the discovery issuer doesn't flag `argument.type` in phpstan. Underlying return was already non-empty (env var check + non-empty fallback); phpdoc just makes it explicit.

## What's NOT here

- **Full authenticated Bearer `/api/version`** — Phase 4a-3-3 follow-up. Needs the auth-code flow login+consent form scraping (analog to `AuthorizationLogoutFullFlowTest`).
- **Panther bootstrap for docker acceptance's `upgrade` scenario** — API-enable only wired to `fresh-install` scenario. Upgrade path's `post-upgrade` group could also benefit but that's a follow-up decision.

## Test plan

- [x] Local: `OAuth2ApiEnabledTest` passes (2 tests / 29 assertions) against dev-easy stack via `SELENIUM_USE_GRID=true`
- [x] Local: `api-enable.php` verified end-to-end against dev-easy's pre-enabled state — no-op save path still exercises the full admin-panel walk, verifies all 4 values re-persist
- [x] Local: full phpstan (`.phpstan/phpstan.ci.neon`) — clean
- [ ] CI: bootstrap will run on the ubuntu-24.04 runner via `nanasess/setup-chromedriver`'s already-installed Chrome (Phase 4b's setup)

## Related

- Plan doc: `docs/artifact-acceptance-testing-plan.md` (draft PR #12811)
- Phase 4b: #13196 (Panther plumbing this PR's bootstrap runs on)
- Phase 4a-2: #13194 (`OAuth2SmokeTest` — the API-disabled gate this PR's `OAuth2ApiEnabledTest` complements)
- Phase 4c-2: #13199 (the wizard-family precedent this PR's admin-panel automation follows)

Assisted-by: Claude Code
