### PR TITLE
feat(acceptance): Phase 3.5 — build-from-codebase tarball validation for PR CI

### DIFF
--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -325,7 +325,11 @@ jobs:
     - name: Set up Node for `npm ci` + `npm run build`
       uses: actions/setup-node@v6
       with:
-        node-version: '22'
+        # Match build-release.yml (the canonical release-time tarball
+        # builder) — this job is validating what that same shape would
+        # produce, so drifting node-version between them defeats the
+        # point. Also matches styling.yml + js-test.yml + inferno-test.
+        node-version: '24'
 
     - name: Install harness composer deps (autoloader for PackageAssembler)
       # tools/release/bin/package-assemble.php requires vendor/autoload.php

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -78,14 +78,6 @@ on:
     - 'tools/release/**'
     - 'build.xml'
     - '.gitattributes'
-    # version.php is bumped on every release-prep PR (release-prep.yml
-    # writes it via peter-evans). Listing it here is what lets the
-    # detect-mode job even see release-prep pushes — without it, a
-    # `chore(release): prep X.Y.Z` PR would touch only version.php +
-    # docker-compose.yml and this workflow would skip. On release-prep
-    # head branches, detect-mode force-enables build_locally=true so
-    # the release-in-flight's tarball gets exercised end-to-end.
-    - 'version.php'
   pull_request:
     paths:
     - '.github/workflows/acceptance-package.yml'
@@ -96,7 +88,6 @@ on:
     - 'tools/release/**'
     - 'build.xml'
     - '.gitattributes'
-    - 'version.php'
   schedule:
   - cron: '0 10 * * *'
 
@@ -199,13 +190,32 @@ jobs:
         # release-prep detection — the release-prep.yml conductor opens
         # a long-lived PR from release-prep/<rel-branch> INTO its
         # rel-branch (base=rel-820, head=release-prep/rel-820, title
-        # like `chore(release): prep 8.2.1`). Force build_locally=true
-        # on these regardless of what files the PR happens to touch —
-        # the whole point of the release-prep PR is validating the
-        # tarball this release would ship. Detected on both pull_request
-        # (head_ref matches) AND push (branch matches) so the check
-        # fires however the release-prep branch is currently being
-        # exercised.
+        # like `chore(release): prep 8.2.1`). When this workflow fires
+        # on such a branch, force build_locally=true regardless of
+        # what files the PR happens to touch — the whole point of the
+        # release-prep PR is validating the tarball this release would
+        # ship.
+        #
+        # NOTE on how the workflow actually gets triggered on
+        # release-prep PRs: the existing paths filter above doesn't
+        # match a typical release-prep PR (which only touches
+        # `version.php` + `docker/production/docker-compose.yml`), and
+        # adding either of those to the paths filter would over-fire
+        # on unrelated version bumps and docker-compose edits. The
+        # intended trigger is release-prep.yml explicitly dispatching
+        # this workflow (via `gh workflow run acceptance-package.yml
+        # --ref release-prep/<branch> -f build_locally=true`) after
+        # it opens or updates the release-prep PR — that couples the
+        # trigger to the release-prep concern itself rather than to
+        # incidental file paths. That wiring is a follow-up PR; until
+        # it lands, this block still catches manual workflow_dispatch
+        # against a release-prep branch and any PR that happens to
+        # touch a paths-list file (e.g. a tools/release change piggy-
+        # backing on the release-prep PR).
+        #
+        # Detected on both pull_request (head_ref matches) AND push
+        # (branch matches) so the check fires however the release-prep
+        # branch is currently being exercised.
         HEAD_REF=""
         case "$EVENT_NAME" in
           pull_request) HEAD_REF="$PR_HEAD_REF" ;;

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -127,6 +127,18 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       build_locally: ${{ steps.decide.outputs.build_locally }}
+      # to_version resolved once here so build-tarball's artifact
+      # filename, the acceptance job's env, and the bootflags step's
+      # LOCAL_PATH all agree on the same value. On the build_locally
+      # path with no explicit dispatch input, this becomes 99.99.99 so
+      # the upgrade + wizard-upgrade scenarios (unblocked when
+      # build_locally=true) receive distinct FROM (8.2.0) / TO values
+      # rather than upgrade-package.sh's identical-version reject. The
+      # version string is a naming label only (drives filenames + the
+      # scratch-dir name; sql_upgrade.php reads --from=FROM_VERSION,
+      # not the to side), so any semver-shaped > 8.2.0 works and
+      # 99.99.99 is unmistakably synthetic in logs.
+      to_version: ${{ steps.decide.outputs.to_version }}
     steps:
     - uses: actions/checkout@v7
       with:
@@ -136,16 +148,42 @@ jobs:
       env:
         EVENT_NAME: ${{ github.event_name }}
         DISPATCH_BUILD_LOCALLY: ${{ inputs.build_locally }}
+        DISPATCH_TO_VERSION: ${{ inputs.to_version }}
         PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         PUSH_BEFORE_SHA: ${{ github.event.before }}
         PUSH_HEAD_SHA: ${{ github.sha }}
       run: |
         set -euo pipefail
+
+        # emit_to_version <build_locally> — resolves the to_version
+        # from dispatch input, falling back based on build_locally
+        # state. Validates the shape either way so a crafted
+        # workflow_dispatch input can't inject shell metacharacters
+        # into downstream `run:` steps that splice this value.
+        emit_to_version() {
+          local build_locally="$1"
+          local candidate
+          if [[ -n "$DISPATCH_TO_VERSION" ]]; then
+            candidate="$DISPATCH_TO_VERSION"
+          elif [[ "$build_locally" == "true" ]]; then
+            candidate="99.99.99"
+          else
+            candidate="8.2.0"
+          fi
+          if [[ ! "$candidate" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::resolved to_version '${candidate}' does not match required X.Y.Z"
+            exit 1
+          fi
+          echo "to_version=${candidate}" >> "$GITHUB_OUTPUT"
+          echo "==> resolved to_version=${candidate}"
+        }
+
         # Manual dispatch always wins — honor the input.
         if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
           echo "build_locally=${DISPATCH_BUILD_LOCALLY}" >> "$GITHUB_OUTPUT"
           echo "==> dispatch mode: build_locally=${DISPATCH_BUILD_LOCALLY}"
+          emit_to_version "${DISPATCH_BUILD_LOCALLY}"
           exit 0
         fi
         # Resolve the diff range for push/pull_request.
@@ -155,6 +193,7 @@ jobs:
           *)
             echo "==> ${EVENT_NAME} event: defaulting build_locally=false"
             echo "build_locally=false" >> "$GITHUB_OUTPUT"
+            emit_to_version "false"
             exit 0
             ;;
         esac
@@ -162,6 +201,7 @@ jobs:
         if [[ -z "$BASE" || "$BASE" == "0000000000000000000000000000000000000000" ]]; then
           echo "==> branch-creation event (no base ref): defaulting build_locally=false"
           echo "build_locally=false" >> "$GITHUB_OUTPUT"
+          emit_to_version "false"
           exit 0
         fi
         # Trigger the local-build path when the PR touches anything
@@ -172,9 +212,11 @@ jobs:
         if git diff --name-only "$BASE".."$HEAD" | grep -qE '^(tools/release/|build\.xml$|\.gitattributes$)'; then
           echo "==> tarball-build surface changed between $BASE and $HEAD: build_locally=true"
           echo "build_locally=true" >> "$GITHUB_OUTPUT"
+          emit_to_version "true"
         else
           echo "==> tarball-build surface unchanged between $BASE and $HEAD: build_locally=false"
           echo "build_locally=false" >> "$GITHUB_OUTPUT"
+          emit_to_version "false"
         fi
 
   # Build the target tarball from the PR's PackageAssembler + checkout.
@@ -190,7 +232,10 @@ jobs:
     if: needs.detect-mode.outputs.build_locally == 'true'
     runs-on: ubuntu-24.04
     env:
-      TO_VERSION: ${{ inputs.to_version || '8.2.0' }}
+      # Single source of truth for the to_version label — see the
+      # detect-mode.outputs.to_version comment for why the auto-fire
+      # path resolves this to 99.99.99.
+      TO_VERSION: ${{ needs.detect-mode.outputs.to_version }}
     steps:
     - uses: actions/checkout@v7
       with:
@@ -246,7 +291,7 @@ jobs:
         # Upload just the .tar.gz; the .zip is a duplicate for
         # Windows-user convenience on the real release and isn't
         # what the linux-based acceptance stack extracts.
-        path: /tmp/release-output/openemr-${{ inputs.to_version || '8.2.0' }}.tar.gz
+        path: /tmp/release-output/openemr-${{ needs.detect-mode.outputs.to_version }}.tar.gz
         retention-days: 1
 
   acceptance:
@@ -293,7 +338,10 @@ jobs:
         scenario: ${{ (github.event_name == 'workflow_dispatch' || needs.detect-mode.outputs.build_locally == 'true') && fromJson('["fresh-install","wizard-install","upgrade","wizard-upgrade"]') || fromJson('["fresh-install","wizard-install"]') }}
     env:
       FROM_VERSION: ${{ inputs.from_version || '8.2.0' }}
-      TO_VERSION: ${{ inputs.to_version || '8.2.0' }}
+      # Single source of truth for to_version — see the
+      # detect-mode.outputs.to_version comment for why the auto-fire
+      # path resolves this to 99.99.99.
+      TO_VERSION: ${{ needs.detect-mode.outputs.to_version }}
       ACCEPTANCE_ARTIFACT_URL: http://localhost:8680
     name: ${{ matrix.scenario }}
     steps:
@@ -343,9 +391,18 @@ jobs:
       id: bootflags
       env:
         BUILD_TARBALL_RESULT: ${{ needs.build-tarball.result }}
-        TO_VERSION: ${{ inputs.to_version || '8.2.0' }}
+        TO_VERSION: ${{ needs.detect-mode.outputs.to_version }}
       run: |
         set -euo pipefail
+        # detect-mode already validated the version shape, but re-check
+        # here so a future workflow_dispatch input change can't sneak
+        # unvalidated caller input into the LOCAL_PATH construction
+        # below (defense-in-depth against ${TO_VERSION} splicing into
+        # $GITHUB_OUTPUT with crafted newline payloads).
+        if [[ ! "$TO_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::error::TO_VERSION '${TO_VERSION}' does not match required X.Y.Z"
+          exit 1
+        fi
         if [[ "$BUILD_TARBALL_RESULT" == "success" ]]; then
           LOCAL_PATH="/tmp/pr-built-tarball/openemr-${TO_VERSION}.tar.gz"
           if [[ ! -f "$LOCAL_PATH" ]]; then

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -39,6 +39,9 @@
 #   3. push / pull_request on the acceptance-package surface itself
 #      (workflow, compose override, install-helper, boot/upgrade/down
 #      scripts, tests/Acceptance/**, composer.json / composer.lock).
+#      Also fires on tools/release/** — Phase 3.5 auto-enables the
+#      build_locally path so any PR touching PackageAssembler gets
+#      its actual tarball validated pre-merge.
 #
 # No branches: filter on push/PR — same rationale as acceptance-docker.yml.
 
@@ -57,6 +60,10 @@ on:
         required: true
         type: string
         default: '8.2.0'
+      build_locally:
+        description: 'Build target tarball from the PR checkout via PackageAssembler instead of downloading to_version from the GitHub release page (Phase 3.5 PR-tarball validation)'
+        type: boolean
+        default: false
   push:
     paths:
     - '.github/workflows/acceptance-package.yml'
@@ -64,6 +71,13 @@ on:
     - 'tests/Acceptance/**'
     - 'composer.json'
     - 'composer.lock'
+    # tools/release/** triggers the workflow AND auto-enables the
+    # build_locally path (see detect-mode job) — pre-merge answer
+    # to "will this PR ship a broken tarball?" Also captures the
+    # supporting files PackageAssembler consumes at build time.
+    - 'tools/release/**'
+    - 'build.xml'
+    - '.gitattributes'
   pull_request:
     paths:
     - '.github/workflows/acceptance-package.yml'
@@ -71,6 +85,9 @@ on:
     - 'tests/Acceptance/**'
     - 'composer.json'
     - 'composer.lock'
+    - 'tools/release/**'
+    - 'build.xml'
+    - '.gitattributes'
   schedule:
   - cron: '0 10 * * *'
 
@@ -85,8 +102,165 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
-  acceptance:
+  # Phase 3.5: decide whether to build the target tarball from the PR's
+  # tools/release/PackageAssembler + current checkout instead of pulling
+  # to_version from the GitHub release page. Two triggers:
+  #
+  #   1. workflow_dispatch with `build_locally: true` -- explicit
+  #      opt-in for maintainer-driven validation runs.
+  #
+  #   2. push/pull_request that touched tools/release/**, build.xml, or
+  #      .gitattributes -- auto-enable so any PR modifying the tarball-
+  #      build path gets its actual output validated pre-merge. Detected
+  #      via `git diff` against the event's base ref (branch's before-SHA
+  #      for push; PR's base sha for pull_request). Skips gracefully on
+  #      branch-creation events where `before` is all-zeros.
+  #
+  # Otherwise defaults to false, and the acceptance matrix uses the
+  # GitHub-released tarball (Phase 3 behavior — unchanged for scheduled
+  # runs and acceptance-surface-only PRs).
+  #
+  # Mirrors the detect-mode job in acceptance-docker.yml (Phase 2.5) —
+  # keep them in sync if the logic evolves.
+  detect-mode:
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr'
+    runs-on: ubuntu-24.04
+    outputs:
+      build_locally: ${{ steps.decide.outputs.build_locally }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - id: decide
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        DISPATCH_BUILD_LOCALLY: ${{ inputs.build_locally }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PUSH_BEFORE_SHA: ${{ github.event.before }}
+        PUSH_HEAD_SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+        # Manual dispatch always wins — honor the input.
+        if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+          echo "build_locally=${DISPATCH_BUILD_LOCALLY}" >> "$GITHUB_OUTPUT"
+          echo "==> dispatch mode: build_locally=${DISPATCH_BUILD_LOCALLY}"
+          exit 0
+        fi
+        # Resolve the diff range for push/pull_request.
+        case "$EVENT_NAME" in
+          pull_request) BASE="$PR_BASE_SHA"; HEAD="$PR_HEAD_SHA" ;;
+          push)         BASE="$PUSH_BEFORE_SHA"; HEAD="$PUSH_HEAD_SHA" ;;
+          *)
+            echo "==> ${EVENT_NAME} event: defaulting build_locally=false"
+            echo "build_locally=false" >> "$GITHUB_OUTPUT"
+            exit 0
+            ;;
+        esac
+        # Branch creation on push emits before=000...; can't diff.
+        if [[ -z "$BASE" || "$BASE" == "0000000000000000000000000000000000000000" ]]; then
+          echo "==> branch-creation event (no base ref): defaulting build_locally=false"
+          echo "build_locally=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        # Trigger the local-build path when the PR touches anything
+        # PackageAssembler consumes at build time: the assembler code
+        # itself, the phing buildfile that owns the prune target list,
+        # or the .gitattributes export-ignore rules that gate what
+        # ships. tools/release/** is the primary surface.
+        if git diff --name-only "$BASE".."$HEAD" | grep -qE '^(tools/release/|build\.xml$|\.gitattributes$)'; then
+          echo "==> tarball-build surface changed between $BASE and $HEAD: build_locally=true"
+          echo "build_locally=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "==> tarball-build surface unchanged between $BASE and $HEAD: build_locally=false"
+          echo "build_locally=false" >> "$GITHUB_OUTPUT"
+        fi
+
+  # Build the target tarball from the PR's PackageAssembler + checkout.
+  # Runs only when detect-mode resolved build_locally=true.
+  #
+  # Output: openemr-<version>.tar.gz uploaded as a workflow artifact.
+  # Each downstream acceptance matrix job downloads the artifact and
+  # passes its path to boot-package.sh --local-tarball, bypassing the
+  # GitHub release-page download entirely — nothing goes to a public
+  # registry or release page. Self-contained to this workflow run.
+  build-tarball:
+    needs: [detect-mode]
+    if: needs.detect-mode.outputs.build_locally == 'true'
+    runs-on: ubuntu-24.04
+    env:
+      TO_VERSION: ${{ inputs.to_version || '8.2.0' }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        # No git ops after checkout except PackageAssembler's `git
+        # archive HEAD` (which reads the ref, not the credentials).
+        persist-credentials: false
+
+    # PackageAssembler needs PHP + composer + Node + npm on the runner.
+    # More toolchain than the acceptance job needs (which only needs
+    # vendor/ for the harness), so break the build into its own job
+    # rather than bloat every matrix leg.
+    - name: Set up PHP + composer for PackageAssembler
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.5'
+        tools: composer:v2
+        # Extensions PackageAssembler + Symfony Process + composer's
+        # own runtime need. Explicit rather than transitive so a future
+        # composer.json change doesn't silently rely on an extension
+        # the runner happens to ship today.
+        extensions: curl, dom, mbstring, tokenizer, xml, zip
+
+    - name: Set up Node for `npm ci` + `npm run build`
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+
+    - name: Install harness composer deps (autoloader for PackageAssembler)
+      # tools/release/bin/package-assemble.php requires vendor/autoload.php
+      # to bring in the OpenEMR\Release\PackageAssembler class + its
+      # symfony/console + symfony/process deps.
+      run: composer install --prefer-dist --no-progress --no-scripts --no-interaction
+
+    - name: Build tarball from PR checkout via PackageAssembler
+      # --release-version uses the workflow's to_version so the output
+      # filename matches what boot-package.sh's VERSION arg + downstream
+      # scratch-dir naming expects. Version string doesn't get baked
+      # into the packaged codebase — it's a naming label only.
+      #
+      # --openemr-dir is the PR checkout itself; --output-dir writes
+      # under /tmp so the artifact upload step can grab it by known path.
+      run: |
+        mkdir -p /tmp/release-output
+        php tools/release/bin/package-assemble.php \
+          --release-version="${TO_VERSION}" \
+          --openemr-dir=. \
+          --output-dir=/tmp/release-output
+        ls -lh "/tmp/release-output/openemr-${TO_VERSION}.tar.gz"
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: openemr-pr-built-tarball
+        # Upload just the .tar.gz; the .zip is a duplicate for
+        # Windows-user convenience on the real release and isn't
+        # what the linux-based acceptance stack extracts.
+        path: /tmp/release-output/openemr-${{ inputs.to_version || '8.2.0' }}.tar.gz
+        retention-days: 1
+
+  acceptance:
+    needs: [detect-mode, build-tarball]
+    # Run whether build-tarball succeeded OR was skipped. Skip
+    # acceptance only if build-tarball itself failed (no point running
+    # the fresh-install / upgrade scenarios if their target tarball
+    # failed to build) or if detect-mode failed (shouldn't happen —
+    # trivial job).
+    if: >-
+      always()
+      && github.repository_owner == 'openemr' && github.repository == 'openemr/openemr'
+      && needs.detect-mode.result == 'success'
+      && (needs.build-tarball.result == 'success' || needs.build-tarball.result == 'skipped')
     runs-on: ubuntu-24.04
     strategy:
       # Don't fail-fast: distinguish "target-version installer broken"
@@ -103,16 +277,20 @@ jobs:
         #                     pre-migration; UpgradeWizardUiTest walks
         #                     sql_upgrade.php via Panther
         #
-        # `upgrade` and `wizard-upgrade` are only included on
+        # `upgrade` and `wizard-upgrade` are gated on either explicit
         # workflow_dispatch (where the caller supplies from_version +
-        # to_version explicitly). On push/PR/schedule the from_version
-        # default would need to point at a shipped tarball, and right
-        # now the most recent tarball is 8.2.0 itself — no earlier
-        # tarball asset exists on the release page (patch releases only
-        # shipped .zip patches). Once 8.3.0 releases and the
-        # from_version default becomes 8.2.0 → 8.3.0, both upgrade
-        # scenarios can move back into the default matrix.
-        scenario: ${{ github.event_name == 'workflow_dispatch' && fromJson('["fresh-install","wizard-install","upgrade","wizard-upgrade"]') || fromJson('["fresh-install","wizard-install"]') }}
+        # to_version explicitly) OR the Phase 3.5 build_locally path
+        # (where PR-built tarball is to_version, any shipped tarball
+        # is from_version, and the pair is meaningful for pre-merge
+        # validation). On acceptance-surface-only push/PR/schedule the
+        # from_version default would need to point at a shipped tarball
+        # and right now the most recent tarball is 8.2.0 itself — no
+        # earlier tarball asset exists on the release page (patch
+        # releases only shipped .zip patches). Once 8.3.0 releases and
+        # the from_version default becomes 8.2.0 → 8.3.0, both upgrade
+        # scenarios can move back into the default matrix
+        # unconditionally.
+        scenario: ${{ (github.event_name == 'workflow_dispatch' || needs.detect-mode.outputs.build_locally == 'true') && fromJson('["fresh-install","wizard-install","upgrade","wizard-upgrade"]') || fromJson('["fresh-install","wizard-install"]') }}
     env:
       FROM_VERSION: ${{ inputs.from_version || '8.2.0' }}
       TO_VERSION: ${{ inputs.to_version || '8.2.0' }}
@@ -140,10 +318,53 @@ jobs:
     - name: Install acceptance-suite composer dependencies
       run: composer install --prefer-dist --no-progress --no-scripts --no-interaction
 
+    # ==== Phase 3.5: load PR-built tarball + resolve boot flags ====
+    - name: Download PR-built tarball (if build-tarball ran)
+      if: needs.build-tarball.result == 'success'
+      uses: actions/download-artifact@v4
+      with:
+        name: openemr-pr-built-tarball
+        path: /tmp/pr-built-tarball
+
+    - name: Resolve boot flags for to_version
+      # `to_local_flag` is spliced into every boot-package.sh
+      # invocation that boots the to_version tarball;
+      # `to_upgrade_local_flag` is spliced into upgrade-package.sh
+      # (different flag name, same file). When build-tarball ran,
+      # both point at the PR-built .tar.gz (downloaded above) and
+      # the underlying script skips its GitHub-release download
+      # entirely. Otherwise both are empty and the scripts do their
+      # normal curl.
+      #
+      # There is intentionally no `from_local_flag` — the upgrade
+      # scenarios always boot the shipped from_version from GitHub
+      # (that's the whole point of testing "install the
+      # currently-shipped tarball, then upgrade to the PR-built one").
+      id: bootflags
+      env:
+        BUILD_TARBALL_RESULT: ${{ needs.build-tarball.result }}
+        TO_VERSION: ${{ inputs.to_version || '8.2.0' }}
+      run: |
+        set -euo pipefail
+        if [[ "$BUILD_TARBALL_RESULT" == "success" ]]; then
+          LOCAL_PATH="/tmp/pr-built-tarball/openemr-${TO_VERSION}.tar.gz"
+          if [[ ! -f "$LOCAL_PATH" ]]; then
+            echo "::error::build-tarball artifact was reported successful but $LOCAL_PATH is not present"
+            exit 1
+          fi
+          echo "==> Using PR-built tarball for to_version: $LOCAL_PATH"
+          echo "to_local_flag=--local-tarball=${LOCAL_PATH}" >> "$GITHUB_OUTPUT"
+          echo "to_upgrade_local_flag=--to-local-tarball=${LOCAL_PATH}" >> "$GITHUB_OUTPUT"
+        else
+          echo "==> No PR-built tarball; to_version will be fetched from the GitHub release page"
+          echo "to_local_flag=" >> "$GITHUB_OUTPUT"
+          echo "to_upgrade_local_flag=" >> "$GITHUB_OUTPUT"
+        fi
+
     # ==== fresh-install scenario ====
     - name: Boot tarball artifact (to_version)
       if: matrix.scenario == 'fresh-install'
-      run: tests/Acceptance/bin/boot-package.sh "${TO_VERSION}"
+      run: tests/Acceptance/bin/boot-package.sh ${{ steps.bootflags.outputs.to_local_flag }} "${TO_VERSION}"
 
     - name: Run acceptance suite (fresh-install of to_version)
       if: matrix.scenario == 'fresh-install'
@@ -173,13 +394,19 @@ jobs:
     # rendering, CSRF, cookie-based state.
     - name: Boot tarball artifact (to_version, no install-helper)
       if: matrix.scenario == 'wizard-install'
-      run: tests/Acceptance/bin/boot-package.sh --skip-install-helper "${TO_VERSION}"
+      run: tests/Acceptance/bin/boot-package.sh --skip-install-helper ${{ steps.bootflags.outputs.to_local_flag }} "${TO_VERSION}"
 
     - name: Run acceptance suite (wizard-install of to_version)
       if: matrix.scenario == 'wizard-install'
       run: composer acceptance -- --group=wizard-install
 
     # ==== upgrade scenario ====
+    # from_version is always the shipped GitHub-release tarball (no
+    # --local-tarball flag — testing "install the currently-shipped
+    # tarball" is the whole point of the from side). to_version can
+    # be either the shipped GitHub-release tarball OR the PR-built
+    # one (controlled by --to-local-tarball via steps.bootflags —
+    # empty string when build-tarball didn't run).
     - name: Boot tarball artifact (from_version)
       if: matrix.scenario == 'upgrade'
       run: tests/Acceptance/bin/boot-package.sh "${FROM_VERSION}"
@@ -190,7 +417,7 @@ jobs:
 
     - name: Upgrade from_version -> to_version
       if: matrix.scenario == 'upgrade'
-      run: tests/Acceptance/bin/upgrade-package.sh "${FROM_VERSION}" "${TO_VERSION}"
+      run: tests/Acceptance/bin/upgrade-package.sh ${{ steps.bootflags.outputs.to_upgrade_local_flag }} "${FROM_VERSION}" "${TO_VERSION}"
 
     - name: Run post-upgrade suite against to_version
       if: matrix.scenario == 'upgrade'
@@ -210,7 +437,7 @@ jobs:
 
     - name: Swap bind mount to to_version without running CLI upgrade
       if: matrix.scenario == 'wizard-upgrade'
-      run: tests/Acceptance/bin/upgrade-package.sh --skip-sql-upgrade "${FROM_VERSION}" "${TO_VERSION}"
+      run: tests/Acceptance/bin/upgrade-package.sh --skip-sql-upgrade ${{ steps.bootflags.outputs.to_upgrade_local_flag }} "${FROM_VERSION}" "${TO_VERSION}"
 
     - name: Run acceptance suite (wizard-upgrade)
       if: matrix.scenario == 'wizard-upgrade'

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -78,6 +78,14 @@ on:
     - 'tools/release/**'
     - 'build.xml'
     - '.gitattributes'
+    # version.php is bumped on every release-prep PR (release-prep.yml
+    # writes it via peter-evans). Listing it here is what lets the
+    # detect-mode job even see release-prep pushes — without it, a
+    # `chore(release): prep X.Y.Z` PR would touch only version.php +
+    # docker-compose.yml and this workflow would skip. On release-prep
+    # head branches, detect-mode force-enables build_locally=true so
+    # the release-in-flight's tarball gets exercised end-to-end.
+    - 'version.php'
   pull_request:
     paths:
     - '.github/workflows/acceptance-package.yml'
@@ -88,6 +96,7 @@ on:
     - 'tools/release/**'
     - 'build.xml'
     - '.gitattributes'
+    - 'version.php'
   schedule:
   - cron: '0 10 * * *'
 
@@ -151,21 +160,29 @@ jobs:
         DISPATCH_TO_VERSION: ${{ inputs.to_version }}
         PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
         PUSH_BEFORE_SHA: ${{ github.event.before }}
         PUSH_HEAD_SHA: ${{ github.sha }}
+        PUSH_REF: ${{ github.ref }}
       run: |
         set -euo pipefail
 
-        # emit_to_version <build_locally> — resolves the to_version
-        # from dispatch input, falling back based on build_locally
+        # emit_to_version <build_locally> [<preferred_version>] —
+        # resolves the to_version from dispatch input first, then the
+        # optional preferred value (e.g. the version parsed from a
+        # release-prep PR title), then falls back based on build_locally
         # state. Validates the shape either way so a crafted
         # workflow_dispatch input can't inject shell metacharacters
         # into downstream `run:` steps that splice this value.
         emit_to_version() {
           local build_locally="$1"
+          local preferred="${2:-}"
           local candidate
           if [[ -n "$DISPATCH_TO_VERSION" ]]; then
             candidate="$DISPATCH_TO_VERSION"
+          elif [[ -n "$preferred" ]]; then
+            candidate="$preferred"
           elif [[ "$build_locally" == "true" ]]; then
             candidate="99.99.99"
           else
@@ -178,6 +195,43 @@ jobs:
           echo "to_version=${candidate}" >> "$GITHUB_OUTPUT"
           echo "==> resolved to_version=${candidate}"
         }
+
+        # release-prep detection — the release-prep.yml conductor opens
+        # a long-lived PR from release-prep/<rel-branch> INTO its
+        # rel-branch (base=rel-820, head=release-prep/rel-820, title
+        # like `chore(release): prep 8.2.1`). Force build_locally=true
+        # on these regardless of what files the PR happens to touch —
+        # the whole point of the release-prep PR is validating the
+        # tarball this release would ship. Detected on both pull_request
+        # (head_ref matches) AND push (branch matches) so the check
+        # fires however the release-prep branch is currently being
+        # exercised.
+        HEAD_REF=""
+        case "$EVENT_NAME" in
+          pull_request) HEAD_REF="$PR_HEAD_REF" ;;
+          push)         HEAD_REF="${PUSH_REF#refs/heads/}" ;;
+        esac
+        if [[ "$HEAD_REF" == release-prep/* ]]; then
+          echo "==> release-prep branch detected ($HEAD_REF): forcing build_locally=true"
+          echo "build_locally=true" >> "$GITHUB_OUTPUT"
+          # Parse the release version out of the PR title
+          # (`chore(release): prep 8.2.1${suffix}`) so downstream logs
+          # and artifact filenames reflect the actual release being
+          # validated rather than the 99.99.99 synthetic default.
+          # to_version only affects log messages + artifact filename +
+          # upgrade-package.sh's from/to comparison guards; sql_upgrade.php
+          # reads --from=FROM_VERSION and derives the target from the
+          # DB `version` table populated by the from-install, NOT from
+          # the to side. So the real version is a cosmetic upgrade
+          # over 99.99.99, not a correctness requirement.
+          preferred=""
+          if [[ -n "$PR_TITLE" && "$PR_TITLE" =~ prep[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            preferred="${BASH_REMATCH[1]}"
+            echo "==> parsed release version from PR title: ${preferred}"
+          fi
+          emit_to_version "true" "${preferred}"
+          exit 0
+        fi
 
         # Manual dispatch always wins — honor the input.
         if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -110,7 +110,12 @@ if [[ -n "${local_tarball}" ]]; then
         echo "::error::--local-tarball path does not exist or is not a regular file: ${local_tarball}" >&2
         exit 2
     fi
-    TARBALL_PATH="${local_tarball}"
+    # Absolute-ize before the `cd "${REPO_ROOT}"` below — a caller who
+    # passes a relative path (e.g. `--local-tarball=openemr-8.2.0.tar.gz`
+    # from their own cwd) would otherwise see `tar` look for it under
+    # REPO_ROOT and either extract the wrong file or fail. realpath
+    # handles both leading-`./` and no-leading-`./` shapes uniformly.
+    TARBALL_PATH="$(realpath "${local_tarball}")"
     # No trap cleanup — the caller owns this file.
 else
     # Random tarball path via mktemp — a predictable path like

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -9,7 +9,7 @@
 # via OpenEMR's Installer class.
 #
 # Usage:
-#   tests/Acceptance/bin/boot-package.sh [--skip-install-helper] <version>
+#   tests/Acceptance/bin/boot-package.sh [--skip-install-helper] [--local-tarball=<path>] <version>
 #     --skip-install-helper (optional)
 #         Skip the install-helper.php step. Leaves the artifact serving
 #         setup.php on http://localhost:8680/, ready for the
@@ -19,11 +19,21 @@
 #         redirect target, which only appears AFTER a completed install;
 #         instead, waits for /setup.php to return 200 (proves apache is
 #         serving on the mapped port).
+#     --local-tarball=<path> (optional)
+#         Extract the given local tarball instead of curl-ing the
+#         GitHub release page. Enables Phase 3.5 PR-tarball validation:
+#         the acceptance-package workflow builds the tarball via
+#         PackageAssembler from the PR checkout, uploads it as a
+#         workflow artifact, and downstream matrix jobs pass the
+#         downloaded path here. Skips the network fetch entirely; the
+#         `<version>` arg is still required (used for the scratch dir
+#         name only in this mode).
 #     version — release tag suffix, must match ^[0-9]+\.[0-9]+\.[0-9]+$
 #               (e.g. 8.2.0). Anything else is rejected before any path
 #               is constructed — VERSION is caller-controlled and flows
 #               into `rm -rf` / `curl -o` paths.
-#               Fetches https://github.com/openemr/openemr/releases/download/v<X_Y_Z>/openemr-<version>.tar.gz
+#               Without --local-tarball: fetches
+#               https://github.com/openemr/openemr/releases/download/v<X_Y_Z>/openemr-<version>.tar.gz
 #
 # After a successful boot (default mode):
 #   Artifact URL:  http://localhost:8680
@@ -36,10 +46,15 @@
 set -euo pipefail
 
 skip_install_helper="false"
+local_tarball=""
 while [[ $# -gt 0 && "$1" == --* ]]; do
     case "$1" in
         --skip-install-helper)
             skip_install_helper="true"
+            shift
+            ;;
+        --local-tarball=*)
+            local_tarball="${1#--local-tarball=}"
             shift
             ;;
         *)
@@ -50,9 +65,10 @@ while [[ $# -gt 0 && "$1" == --* ]]; do
 done
 
 if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 [--skip-install-helper] <version>" >&2
+    echo "Usage: $0 [--skip-install-helper] [--local-tarball=<path>] <version>" >&2
     echo "  e.g.: $0 8.2.0" >&2
     echo "        $0 --skip-install-helper 8.2.0" >&2
+    echo "        $0 --local-tarball=/tmp/openemr-8.2.0.tar.gz 8.2.0" >&2
     exit 2
 fi
 
@@ -84,11 +100,25 @@ export HELPER_PATH="${SCRIPT_DIR}/install-helper.php"
 export COMPOSE_FILE="${REPO_ROOT}/.github/docker/acceptance-package-compose.yml"
 export COMPOSE_PROJECT_NAME="openemr-acceptance-package"
 
-# Random tarball path via mktemp — a predictable path like
-# /tmp/openemr-${VERSION}.tar.gz would let a local attacker
-# pre-create a symlink to redirect the curl download.
-TARBALL_PATH="$(mktemp -t "openemr-acceptance-tarball.XXXXXX.tar.gz")"
-trap 'rm -f "${TARBALL_PATH}"' EXIT
+if [[ -n "${local_tarball}" ]]; then
+    # Local-tarball mode: use the file the caller pointed us at, no
+    # network fetch. Path is expected to be a caller-controlled
+    # workflow-runner path (e.g. actions/download-artifact target); no
+    # mktemp / symlink defenses apply because there's no attacker-
+    # writable predictable path in play.
+    if [[ ! -f "${local_tarball}" ]]; then
+        echo "::error::--local-tarball path does not exist or is not a regular file: ${local_tarball}" >&2
+        exit 2
+    fi
+    TARBALL_PATH="${local_tarball}"
+    # No trap cleanup — the caller owns this file.
+else
+    # Random tarball path via mktemp — a predictable path like
+    # /tmp/openemr-${VERSION}.tar.gz would let a local attacker
+    # pre-create a symlink to redirect the curl download.
+    TARBALL_PATH="$(mktemp -t "openemr-acceptance-tarball.XXXXXX.tar.gz")"
+    trap 'rm -f "${TARBALL_PATH}"' EXIT
+fi
 
 cd "${REPO_ROOT}"
 
@@ -96,8 +126,12 @@ echo "==> Preparing scratch dir at ${TARBALL_DIR}"
 rm -rf "${TARBALL_DIR}"
 mkdir -p "${TARBALL_DIR}"
 
-echo "==> Downloading ${TARBALL_URL}"
-curl -fsSL "${TARBALL_URL}" -o "${TARBALL_PATH}"
+if [[ -n "${local_tarball}" ]]; then
+    echo "==> Using local tarball ${TARBALL_PATH} (--local-tarball set — skipping GitHub download)"
+else
+    echo "==> Downloading ${TARBALL_URL}"
+    curl -fsSL "${TARBALL_URL}" -o "${TARBALL_PATH}"
+fi
 
 echo "==> Extracting into ${TARBALL_DIR}"
 # --strip-components=1 pulls contents up so ${TARBALL_DIR} matches the

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -17,7 +17,7 @@
 #      migrations to apply
 #
 # Usage:
-#   tests/Acceptance/bin/upgrade-package.sh [--skip-sql-upgrade] <from-version> <to-version>
+#   tests/Acceptance/bin/upgrade-package.sh [--skip-sql-upgrade] [--to-local-tarball=<path>] <from-version> <to-version>
 #     --skip-sql-upgrade (optional)
 #         Skip step 5. Leaves the artifact serving to-version's
 #         filesystem with from-version's DB — the classic "user just
@@ -28,8 +28,18 @@
 #         login-page redirect target, which the pre-upgrade state
 #         still meets; but the DB migrations haven't run, so any
 #         downstream test that touches the DB would fail).
+#     --to-local-tarball=<path> (optional)
+#         Extract the given local file as the to-version tarball
+#         instead of curl-ing the GitHub release page. Phase 3.5
+#         PR-tarball validation: acceptance-package workflow builds
+#         the tarball via PackageAssembler from the PR checkout,
+#         uploads it as a workflow artifact, and passes the
+#         downloaded path here. from-version is always downloaded
+#         from GitHub (whole point of the upgrade test is starting
+#         from a shipped release).
 #     from-version — the version already installed via boot-package.sh
-#     to-version   — the target version (must have a v<X_Y_Z> release tag)
+#     to-version   — the target version (must have a v<X_Y_Z> release tag,
+#                    unless --to-local-tarball is set)
 #     Both must match ^[0-9]+\.[0-9]+\.[0-9]+$; from must be strictly
 #     less than to (this is an UPgrade — same-version is a no-op that
 #     would delete the installed source, and downgrade isn't supported).
@@ -41,10 +51,15 @@
 set -euo pipefail
 
 skip_sql_upgrade="false"
+to_local_tarball=""
 while [[ $# -gt 0 && "$1" == --* ]]; do
     case "$1" in
         --skip-sql-upgrade)
             skip_sql_upgrade="true"
+            shift
+            ;;
+        --to-local-tarball=*)
+            to_local_tarball="${1#--to-local-tarball=}"
             shift
             ;;
         *)
@@ -55,9 +70,10 @@ while [[ $# -gt 0 && "$1" == --* ]]; do
 done
 
 if [[ $# -ne 2 ]]; then
-    echo "Usage: $0 [--skip-sql-upgrade] <from-version> <to-version>" >&2
+    echo "Usage: $0 [--skip-sql-upgrade] [--to-local-tarball=<path>] <from-version> <to-version>" >&2
     echo "  e.g.: $0 8.2.0 8.3.0" >&2
     echo "        $0 --skip-sql-upgrade 8.2.0 8.3.0" >&2
+    echo "        $0 --to-local-tarball=/tmp/openemr-8.3.0.tar.gz 8.2.0 8.3.0" >&2
     exit 2
 fi
 
@@ -99,9 +115,19 @@ export HELPER_PATH="${SCRIPT_DIR}/install-helper.php"
 export COMPOSE_FILE="${REPO_ROOT}/.github/docker/acceptance-package-compose.yml"
 export COMPOSE_PROJECT_NAME="openemr-acceptance-package"
 
-# mktemp for the download path (same rationale as boot-package.sh).
-TARBALL_PATH="$(mktemp -t "openemr-acceptance-upgrade-tarball.XXXXXX.tar.gz")"
-trap 'rm -f "${TARBALL_PATH}"' EXIT
+if [[ -n "${to_local_tarball}" ]]; then
+    # Local-tarball mode: caller-supplied file, no network fetch.
+    if [[ ! -f "${to_local_tarball}" ]]; then
+        echo "::error::--to-local-tarball path does not exist or is not a regular file: ${to_local_tarball}" >&2
+        exit 2
+    fi
+    TARBALL_PATH="${to_local_tarball}"
+    # No trap cleanup — the caller owns this file.
+else
+    # mktemp for the download path (same rationale as boot-package.sh).
+    TARBALL_PATH="$(mktemp -t "openemr-acceptance-upgrade-tarball.XXXXXX.tar.gz")"
+    trap 'rm -f "${TARBALL_PATH}"' EXIT
+fi
 
 cd "${REPO_ROOT}"
 
@@ -114,8 +140,12 @@ echo "==> Preparing scratch dir at ${TO_TARBALL_DIR}"
 rm -rf "${TO_TARBALL_DIR}"
 mkdir -p "${TO_TARBALL_DIR}"
 
-echo "==> Downloading ${TO_TARBALL_URL}"
-curl -fsSL "${TO_TARBALL_URL}" -o "${TARBALL_PATH}"
+if [[ -n "${to_local_tarball}" ]]; then
+    echo "==> Using local to-version tarball ${TARBALL_PATH} (--to-local-tarball set — skipping GitHub download)"
+else
+    echo "==> Downloading ${TO_TARBALL_URL}"
+    curl -fsSL "${TO_TARBALL_URL}" -o "${TARBALL_PATH}"
+fi
 
 echo "==> Extracting into ${TO_TARBALL_DIR}"
 tar -pxzf "${TARBALL_PATH}" -C "${TO_TARBALL_DIR}" --strip-components=1

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -155,7 +155,12 @@ fi
 # bind mount (compose stop + up --force-recreate), so there's no
 # lingering side effect on the downstream to_version boot.
 export TARBALL_DIR="${FROM_TARBALL_DIR}"
-docker compose exec -T openemr chown -R "$(id -u):$(id -g)" /var/www/localhost/htdocs/openemr/sites
+# Split `id -u` / `id -g` into their own vars — shellcheck SC2312
+# flags inline `$(...)` in a compound command because a failing
+# substitution's non-zero exit is masked by the outer chown.
+RUNNER_UID="$(id -u)"
+RUNNER_GID="$(id -g)"
+docker compose exec -T openemr chown -R "${RUNNER_UID}:${RUNNER_GID}" /var/www/localhost/htdocs/openemr/sites
 
 echo "==> Preparing scratch dir at ${TO_TARBALL_DIR}"
 rm -rf "${TO_TARBALL_DIR}"

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -121,7 +121,9 @@ if [[ -n "${to_local_tarball}" ]]; then
         echo "::error::--to-local-tarball path does not exist or is not a regular file: ${to_local_tarball}" >&2
         exit 2
     fi
-    TARBALL_PATH="${to_local_tarball}"
+    # Absolute-ize before the `cd "${REPO_ROOT}"` below — same
+    # rationale as boot-package.sh's --local-tarball normalization.
+    TARBALL_PATH="$(realpath "${to_local_tarball}")"
     # No trap cleanup — the caller owns this file.
 else
     # mktemp for the download path (same rationale as boot-package.sh).

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -138,6 +138,25 @@ if [[ ! -d "${FROM_TARBALL_DIR}/sites" ]]; then
     exit 1
 fi
 
+# Make from-version files readable to the host user before the sites/
+# overlay below. The flex-image apache runs at its own UID (typically
+# 100 in Alpine), and any files that apache created during install-
+# helper + downstream test activity — most notably the OAuth key pair
+# under sites/default/documents/certificates/, generated during OAuth
+# setup with 0400 perms — land on the host bind mount owned by that
+# UID and unreadable to the host runner user. Without this chown, the
+# `cp -a` below fails with `Permission denied` on those keys.
+#
+# `chown -R $(id -u):$(id -g)` inside the still-running from-container
+# rewrites ownership to the host runner user via the shared bind
+# mount, giving cp read access. Runs before the TO scratch-dir setup
+# so the from-container is still up when this executes. Ownership is
+# discarded seconds later when the to-version container recreates the
+# bind mount (compose stop + up --force-recreate), so there's no
+# lingering side effect on the downstream to_version boot.
+export TARBALL_DIR="${FROM_TARBALL_DIR}"
+docker compose exec -T openemr chown -R "$(id -u):$(id -g)" /var/www/localhost/htdocs/openemr/sites
+
 echo "==> Preparing scratch dir at ${TO_TARBALL_DIR}"
 rm -rf "${TO_TARBALL_DIR}"
 mkdir -p "${TO_TARBALL_DIR}"

--- a/tools/release/bin/package-assemble.php
+++ b/tools/release/bin/package-assemble.php
@@ -7,6 +7,15 @@
  * Thin CLI wrapper around OpenEMR\Release\PackageAssembler; see that class for
  * the build steps and rationale.
  *
+ * Note that `--release-version` is a naming label only: it flows into the
+ * output filename (`openemr-<version>.tar.gz`) and the intermediate staging
+ * dir, but does NOT get baked into the packaged codebase. The shipped
+ * self-reported version comes from files in the source tree (sql/version.php
+ * and friends), which the assembler ships as-is from the checked-out ref.
+ * That's why Phase 3.5's build_locally acceptance path can label the
+ * PR-built tarball `99.99.99` without any file rewriting — the assembler's
+ * git-archive step preserves whatever version the codebase self-reports.
+ *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>

--- a/tools/release/src/PackageAssembler.php
+++ b/tools/release/src/PackageAssembler.php
@@ -16,6 +16,11 @@
  * Unlike PatchAssembler (a changed-files overlay), this produces a complete,
  * standalone install that end users extract and run without composer or npm.
  *
+ * Changes here auto-fire the acceptance-package.yml build_locally path
+ * (Phase 3.5) — the workflow builds the tarball from the PR checkout and
+ * runs the fresh-install + upgrade acceptance groups against it, catching
+ * assembler regressions pre-merge instead of at release-conductor time.
+ *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>

--- a/tools/release/src/PackageAssembler.php
+++ b/tools/release/src/PackageAssembler.php
@@ -20,6 +20,7 @@
  * (Phase 3.5) — the workflow builds the tarball from the PR checkout and
  * runs the fresh-install + upgrade acceptance groups against it, catching
  * assembler regressions pre-merge instead of at release-conductor time.
+ * See docs/artifact-acceptance-testing-plan.md for the phase design.
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org


### PR DESCRIPTION
## Summary

Phase 3.5 of [docs/artifact-acceptance-testing-plan.md](https://github.com/openemr/openemr/blob/master/docs/artifact-acceptance-testing-plan.md). Analogue of Phase 2.5 (docker `build_locally`, PR #13163) for the tarball side.

- New `build_locally` workflow_dispatch input on `acceptance-package.yml` + auto-fire on push/PR touching `tools/release/**`, `build.xml`, or `.gitattributes` (the surface `PackageAssembler` consumes at build time).
- New `detect-mode` job (mirrors docker's) + new `build-tarball` job that runs `PackageAssembler` against the PR checkout and uploads `openemr-<to_version>.tar.gz` as a workflow artifact.
- Downstream acceptance matrix jobs download that artifact and boot from it instead of curl-ing the shipped tarball from the GitHub releases page.
- `boot-package.sh --local-tarball=<path>` and `upgrade-package.sh --to-local-tarball=<path>` carry the local file path through the existing scripts without breaking the from-GitHub path. `from_version` in the upgrade scenarios is always the shipped GitHub release — the whole point of the upgrade test is starting from a shipped release.
- `upgrade` + `wizard-upgrade` matrix scenarios were previously `workflow_dispatch`-only because the `from_version` default needed a shipped earlier tarball (only 8.2.0 has one today). They now fire whenever `build_locally=true` — PR-built tarball as `to_version`, `8.2.0` as `from_version`. When there's no explicit dispatch input, `detect-mode` resolves `to_version` to the synthetic `99.99.99` so `upgrade-package.sh`'s equality/downgrade guards pass; the label is naming-only — `sql_upgrade.php` reads `--from=FROM_VERSION` and derives the target from the DB `version` table populated by the from-install, not from the to side.

## release-prep PR support

`detect-mode` also detects `release-prep/*` head branches (pull_request head_ref or push branch after stripping `refs/heads/`) and force-enables `build_locally=true` regardless of what files the PR touches — the whole point of the `release-prep.yml` conductor's PR is validating the tarball the release would ship. The block parses `X.Y.Z` out of the `chore(release): prep X.Y.Z` PR title so downstream logs and the artifact filename reflect the actual release version rather than the 99.99.99 synthetic default. Falls back to 99.99.99 on push events (no PR title context) or when the title regex misses.

**Note on how this workflow fires on a release-prep PR:** the `paths:` filter doesn't currently match a typical release-prep PR (which only touches `version.php` + `docker/production/docker-compose.yml`), and adding either to the filter would over-fire on unrelated dev-cycle version bumps. The intended wire-up is `release-prep.yml` explicitly dispatching this workflow (`gh workflow run acceptance-package.yml --ref release-prep/<branch> -f build_locally=true`) after opening or updating the release-prep PR — that couples the trigger to the release-prep concern itself. That's a follow-up PR, and it depends on Phase 3.5 being present on the target rel-branch (i.e. rel-830+, since Brady said not to backport to rel-820). Until then, the detect-mode block still catches manual `workflow_dispatch` against a release-prep branch and any release-prep PR that happens to piggyback a `tools/release/**` change onto the same push.

## Purpose

Pre-merge answer to "will this PR ship a broken tarball?" Catches `PackageAssembler` / `build.xml` / `.gitattributes` breakage against the exact tree that would ship, without waiting for the release-prep conductor to invoke `PackageAssembler` at ship time.

## Also fixed here

`upgrade-package.sh` had a pre-existing bug that Phase 3.5's newly-unblocked `upgrade` auto-fire path surfaced: `cp -a ${FROM}/sites ${TO}/sites` failed with "Permission denied" on OAuth key files (`sites/default/documents/certificates/oaprivate.key`, `.../oapublic.key`) — they're created inside the from-container by the flex-image apache uid and are unreadable to the host runner user. Fix runs `docker compose exec openemr chown -R "${RUNNER_UID}:${RUNNER_GID}" .../openemr/sites` inside the still-live from-container to rewrite ownership via the shared bind mount before the cp. Bounded to `sites/`; ownership is discarded seconds later when compose recreates the container with the to-version bind mount, so no lingering side effect. Was previously hidden by rabbit's "identical from/to versions" bug (now also fixed) — the equality guard fired before the flow ever reached the cp step.

## Rabbit review — all findings addressed

- **Critical (fixed):** upgrade + wizard-upgrade would have run `8.2.0 → 8.2.0` on the auto-fire path — `upgrade-package.sh` rejects identical from/to. `detect-mode` now resolves a distinct `to_version` once (99.99.99 default on auto-fire, real release version parsed from title on release-prep PRs, honoring explicit dispatch input everywhere).
- **Major (fixed):** `TO_VERSION` was interpolated raw into shell `run:` steps, giving `workflow_dispatch` input a template-injection surface (crafted newlines could forge extra `GITHUB_OUTPUT` lines). Now validated in `detect-mode` (single source of truth) and re-validated in `bootflags` as defense in depth.
- **Minor (fixed):** `--local-tarball` / `--to-local-tarball` paths were `-f`-checked before `cd "${REPO_ROOT}"` and consumed after — a relative caller path would silently resolve differently at extraction time. Now `realpath`-normalized right after the existence check.

## Test plan

- [x] Local end-to-end plumbing walk: `boot-package.sh --local-tarball=<local 8.2.0 tarball> 8.2.0` boots the acceptance stack; `fresh-install` acceptance group passes 6/6 (the 1 skip is `E2eCriticalPathTest` needing host chromedriver — CI has `nanasess/setup-chromedriver@v2`).
- [x] Also validated with a *relative* `--local-tarball` path from an unrelated cwd to confirm the `realpath` normalization fix.
- [x] `detect-mode` logic trace-tested locally across 5 event scenarios (release-prep PR with title, release-prep push with no title, normal PR, workflow_dispatch, release-prep PR with title suffix). All produced expected outputs.
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] Shell scripts pass `bash -n` and `shellcheck --check-sourced --external-sources`.
- [x] Pre-commit hooks pass on each commit.
- [x] **End-to-end `build_locally=true` on a real runner** ([run 30220869837](https://github.com/openemr/openemr/actions/runs/30220869837)): **6/6 scenarios green** — `detect-mode`, `build-tarball` (PackageAssembler produced the tarball from PR HEAD), `fresh-install`, `wizard-install`, `upgrade` (8.2.0 → PR-built 99.99.99 with sql_upgrade + post-upgrade), `wizard-upgrade` (8.2.0 → PR-built 99.99.99 via sql_upgrade.php wizard walk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)