### PR TITLE
fix(fhir): use record provider_uuid for patient and social-history Observation performer

### DIFF
--- a/src/Services/FHIR/Observation/FhirObservationPatientService.php
+++ b/src/Services/FHIR/Observation/FhirObservationPatientService.php
@@ -268,7 +268,7 @@ class FhirObservationPatientService extends FhirServiceBase implements IPatientC
                 ,"ob_status" => 'final' // we always set this to final as there's no in-between state
                 ,"puuid" => $record['uuid']
                 ,"uuid" => UuidRegistry::uuidToString($uuidMappings[$code])
-                ,"user_uuid" => 'provider_uuid'
+                ,"user_uuid" => $record['provider_uuid'] ?? null
                 ,"date" => $record['date']
                 ,"last_updated" => $record['date']
                 ,"profiles" => $profiles

--- a/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
+++ b/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
@@ -195,7 +195,7 @@ class FhirObservationSocialHistoryService extends FhirServiceBase implements IPa
         return $processingResult;
     }
 
-    private function parseSocialHistoryIntoObservationRecords(ProcessingResult $processingResult, array $record, array $observationCodesToReturn): void
+    private function parseSocialHistoryIntoObservationRecords(ProcessingResult $processingResult, $record, $observationCodesToReturn): void
     {
         $uuidMappings = $this->getUuidMappings(UuidRegistry::uuidToBytes($record['uuid']));
         // convert each record into it's own openEMR record array
@@ -236,6 +236,7 @@ class FhirObservationSocialHistoryService extends FhirServiceBase implements IPa
                 continue;
             }
 
+            $providerUuid = is_array($record) ? ($record['provider_uuid'] ?? null) : null;
             $observation = [
                 "code" => $mapping['fullcode']
                 ,"description" => $this->getDescriptionForCode($code)
@@ -243,7 +244,7 @@ class FhirObservationSocialHistoryService extends FhirServiceBase implements IPa
                 ,"ob_status" => 'final' // we always set this to final as there's no in-between state
                 ,"puuid" => $record['puuid']
                 ,"uuid" => UuidRegistry::uuidToString($uuidMappings[$code])
-                ,"user_uuid" => $record['provider_uuid'] ?? null
+                ,"user_uuid" => $providerUuid
                 ,"date" => $record['date']
                 ,"last_updated" => $record['date']
                 ,"profiles" => $this->getProfileForVersions(self::USCGI_PROFILE_SMOKING_STATUS, $this->getSupportedVersions())

--- a/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
+++ b/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
@@ -195,7 +195,7 @@ class FhirObservationSocialHistoryService extends FhirServiceBase implements IPa
         return $processingResult;
     }
 
-    private function parseSocialHistoryIntoObservationRecords(ProcessingResult $processingResult, $record, $observationCodesToReturn): void
+    private function parseSocialHistoryIntoObservationRecords(ProcessingResult $processingResult, array $record, array $observationCodesToReturn): void
     {
         $uuidMappings = $this->getUuidMappings(UuidRegistry::uuidToBytes($record['uuid']));
         // convert each record into it's own openEMR record array

--- a/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
+++ b/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
@@ -243,7 +243,7 @@ class FhirObservationSocialHistoryService extends FhirServiceBase implements IPa
                 ,"ob_status" => 'final' // we always set this to final as there's no in-between state
                 ,"puuid" => $record['puuid']
                 ,"uuid" => UuidRegistry::uuidToString($uuidMappings[$code])
-                ,"user_uuid" => 'provider_uuid'
+                ,"user_uuid" => $record['provider_uuid'] ?? null
                 ,"date" => $record['date']
                 ,"last_updated" => $record['date']
                 ,"profiles" => $this->getProfileForVersions(self::USCGI_PROFILE_SMOKING_STATUS, $this->getSupportedVersions())


### PR DESCRIPTION


Fixes:  #13057.

Both services synthesized observation records with the performer set to the literal string 'provider_uuid' rather than $record['provider_uuid']. 
The literal flowed through FhirObservationTrait::setObservationPerformer() into a Practitioner/provider_uuid reference — invalid in US Core-profiled output — and Provenance generation for these Observations fataled bulk $export with Invalid UUID string: provider_uuid, aborting the entire export job. 
Fix reads the value the underlying services already select, with ?? null engaging the existing data-missing-extension and business-entity-Provenance fallbacks for records without an assigned provider. 
Companion to #13060: that fix hardened the null-Provenance path; this repairs the invalid-performer path that bypassed it."

<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Was an AI assistant used? Yes

Assisted-by: Claude Code
