### PR TITLE
chore(rector): add library/edihistory to scanDirectories 

### DIFF
--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -49,7 +49,7 @@ jobs:
       uses: actions/cache@v6
       with:
         path: /tmp/rector
-        key: ${{ runner.os }}-rector-${{ steps.rector-version.outputs.version }}-${{ hashFiles('rector.php') }}-${{ github.run_id }}
+        key: ${{ runner.os }}-rector-${{ steps.rector-version.outputs.version }}-${{ hashFiles('rector.php', 'rector-bootstrap.php', '.phpstan/rector-scan.neon', 'tests/Rector/Rules/**') }}-${{ github.run_id }}
         restore-keys: ${{ runner.os }}-rector-${{ steps.rector-version.outputs.version }}-${{ hashFiles('rector.php') }}-
 
     - name: Create Rector cache directory

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         path: /tmp/rector
         key: ${{ runner.os }}-rector-${{ steps.rector-version.outputs.version }}-${{ hashFiles('rector.php', 'rector-bootstrap.php', '.phpstan/rector-scan.neon', 'tests/Rector/Rules/**') }}-${{ github.run_id }}
-        restore-keys: ${{ runner.os }}-rector-${{ steps.rector-version.outputs.version }}-${{ hashFiles('rector.php') }}-
+        restore-keys: ${{ runner.os }}-rector-${{ steps.rector-version.outputs.version }}-${{ hashFiles('rector.php', 'rector-bootstrap.php', '.phpstan/rector-scan.neon', 'tests/Rector/Rules/**') }}-
 
     - name: Create Rector cache directory
       run: mkdir -p /tmp/rector

--- a/.phpstan/rector-scan.neon
+++ b/.phpstan/rector-scan.neon
@@ -18,6 +18,7 @@ parameters:
         - ../interface/modules/zend_modules
         - ../library/classes/ClinicalTypes
         - ../library/classes/rulesets
+        - ../library/edihistory
         # Only verysimple: fwk/libs/util declares a lowercase `class thumbnail`
         # that collides (case-insensitively) with library/classes/thumbnail's
         # Thumbnail and corrupts type resolution when scanned.

--- a/library/edihistory/edih_csv_data.php
+++ b/library/edihistory/edih_csv_data.php
@@ -220,7 +220,7 @@ function edih_list_denied_claims($filetype, $filename, $trace = '')
     if ($ft == 'f997') {
         $str_html = edih_997_error($filename);
         return $str_html;
-    } elseif (strpos('|f271|f277|f835', (string) $ft)) {
+    } elseif (strpos('|f271|f277|f835', $ft)) {
         $row_ar = csv_denied_by_file($ft, $filename, $trace);
     } else {
         $str_html .= "Invalid file type " . text($filetype) . " for denied claim search<br />";
@@ -609,7 +609,7 @@ function edih_csv_to_html($file_type, $csv_type, $period = '', $datestart = '', 
     //
     // now create the body of the table
     //
-    $cls = (strpos('|f837|f270|f276|f278', (string) $tp)) ? 'sub' : 'rsp';
+    $cls = (strpos('|f837|f270|f276|f278', $tp)) ? 'sub' : 'rsp';
     //
     $idx = 0;
     if ($csv_type == 'file') {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
current master rector is red

#### Changes proposed in this pull request:
adds `library/edihistory` to `scanDirectories` and creates a better cache key for CI

#### Was an AI assistant used? Yes, consulted with claude.ai

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
