### PR TITLE
chore(codecov): carry forward coverage for flags

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -27,3 +27,12 @@ coverage:
       default:
         target: 50%       # New code must have at least 50% coverage (was 0%)
         threshold: 5%     # Flexibility for config/migration/generated files
+
+# Carry forward coverage for flags not uploaded on a given commit.
+# PRs only collect coverage from one config (apache_82_118) while the
+# nightly scheduled run uploads all configs to master HEAD — without
+# carryforward, codecov/project compares a single-config head total
+# against a full-matrix base total and reports a phantom drop.
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
Carry forward coverage for flags not uploaded on a given commit. PRs only collect coverage from one config (apache_82_118) while the nightly scheduled run uploads all configs to master HEAD — without carryforward, codecov/project compares a single-config head total against a full-matrix base total and reports a phantom drop.

#### Changes proposed in this pull request:


#### Was AI used? Yes, consulted with claude.ai

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
