### PR TITLE
feat(phpstan): forbid direct access to the $_SESSION superglobal

### DIFF
--- a/.phpstan/extension.neon
+++ b/.phpstan/extension.neon
@@ -68,6 +68,9 @@ services:
 - class: OpenEMR\PHPStan\Rules\ForbiddenRequestGlobalsRule
   tags:
   - phpstan.rules.rule
+- class: OpenEMR\PHPStan\Rules\ForbiddenSessionSuperglobalRule
+  tags:
+  - phpstan.rules.rule
 - class: OpenEMR\PHPStan\Rules\ForbiddenShellExecutionRule
   tags:
   - phpstan.rules.rule

--- a/.phpstan/phpstan.github.neon
+++ b/.phpstan/phpstan.github.neon
@@ -16,3 +16,6 @@ parameters:
     # patterns the rule should flag; excluding them keeps full-codebase
     # PHPStan runs from reporting those intentional bugs.
     - ../tests/Tests/Isolated/PHPStan/Sql/data
+    # Fixture for ForbiddenSessionSuperglobalRuleTest — deliberately reads and
+    # writes $_SESSION so the rule has something to flag.
+    - ../tests/Tests/Isolated/PHPStan/data

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -395,7 +395,7 @@ if (!empty($_REQUEST['go'])) { ?>
                             $delete_id = $_POST['delete_id'];
                             for ($i = 0; $i < count($delete_id); $i++) {
                                 // IDOR protection: verify note is assigned to current user
-                                if (!checkPnotesNoteId($delete_id[$i], $_SESSION['authUser'])) {
+                                if (!checkPnotesNoteId($delete_id[$i], $session->get('authUser'))) {
                                     continue; // skip notes not assigned to user
                                 }
                                 deletePnote($delete_id[$i]);

--- a/tests/PHPStan/Rules/ForbiddenSessionSuperglobalRule.php
+++ b/tests/PHPStan/Rules/ForbiddenSessionSuperglobalRule.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Custom PHPStan Rule to Forbid Direct $_SESSION Access
+ *
+ * Forbid direct access to the $_SESSION superglobal in favor of the session
+ * wrapper: read through the Symfony SessionInterface returned by
+ * SessionWrapperFactory, write through SessionUtil.
+ *
+ * Raw $_SESSION access is a hidden dependency that bypasses the read_and_close
+ * lock cycle, the session bags, and any testing seam. Code that reads it cannot
+ * run outside a web SAPI without the superglobal being faked.
+ *
+ * This mirrors ForbiddenRequestGlobalsRule ($_GET, $_POST, ...) and
+ * ForbiddenGlobalsAccessRule ($GLOBALS); $_SESSION gets its own rule because
+ * its replacement API — and therefore its guidance — is different.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Variable>
+ */
+class ForbiddenSessionSuperglobalRule implements Rule
+{
+    /**
+     * Paths allowed to touch $_SESSION directly: the test suite, and the
+     * session infrastructure that owns the superglobal so nothing else has
+     * to. Matched as substrings of the normalized (forward-slash) path, so
+     * they work regardless of the absolute prefix.
+     *
+     * @var list<string>
+     */
+    public const DEFAULT_EXEMPT_PATH_FRAGMENTS = [
+        '/tests/',
+        '/src/Common/Session/',
+    ];
+
+    /**
+     * @param list<string> $exemptPathFragments
+     */
+    public function __construct(
+        private readonly array $exemptPathFragments = self::DEFAULT_EXEMPT_PATH_FRAGMENTS,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Variable::class;
+    }
+
+    /**
+     * @param Variable $node
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!is_string($node->name) || $node->name !== '_SESSION') {
+            return [];
+        }
+
+        $file = str_replace('\\', '/', $scope->getFile());
+        foreach ($this->exemptPathFragments as $fragment) {
+            if (str_contains($file, $fragment)) {
+                return [];
+            }
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                'Direct access to $_SESSION is forbidden. Use the session wrapper instead.',
+            )
+                ->identifier('openemr.forbiddenSessionSuperglobal')
+                ->tip('Read: SessionWrapperFactory::getInstance()->getActiveSession()->get($key). Write: SessionUtil::setSession() / SessionUtil::unsetSession(). See src/Common/Session/.')
+                ->build(),
+        ];
+    }
+}

--- a/tests/Tests/Isolated/PHPStan/ForbiddenSessionSuperglobalRuleTest.php
+++ b/tests/Tests/Isolated/PHPStan/ForbiddenSessionSuperglobalRuleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Tests for ForbiddenSessionSuperglobalRule.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\PHPStan;
+
+use OpenEMR\PHPStan\Rules\ForbiddenSessionSuperglobalRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbiddenSessionSuperglobalRule>
+ */
+final class ForbiddenSessionSuperglobalRuleTest extends RuleTestCase
+{
+    private const EXPECTED_MESSAGE = 'Direct access to $_SESSION is forbidden. Use the session wrapper instead.';
+
+    private const EXPECTED_TIP = 'Read: SessionWrapperFactory::getInstance()->getActiveSession()->get($key). Write: SessionUtil::setSession() / SessionUtil::unsetSession(). See src/Common/Session/.';
+
+    /** @var list<string> */
+    private array $exemptPathFragments = [];
+
+    /**
+     * The fixture lives under tests/, which the shipped exemption list skips,
+     * so the default instance under test carries no exemptions. Individual
+     * tests opt one in via $exemptPathFragments.
+     */
+    protected function getRule(): Rule
+    {
+        return new ForbiddenSessionSuperglobalRule($this->exemptPathFragments);
+    }
+
+    public function testFlagsSessionSuperglobalReadsAndWrites(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/session_superglobal_usage.php'],
+            [
+                [self::EXPECTED_MESSAGE, 19, self::EXPECTED_TIP],
+                [self::EXPECTED_MESSAGE, 24, self::EXPECTED_TIP],
+            ],
+        );
+    }
+
+    public function testExemptPathIsIgnored(): void
+    {
+        $this->exemptPathFragments = ['/PHPStan/data/'];
+
+        $this->analyse([__DIR__ . '/data/session_superglobal_usage.php'], []);
+    }
+
+    public function testShippedExemptionsCoverTheFixturePath(): void
+    {
+        $this->exemptPathFragments = ForbiddenSessionSuperglobalRule::DEFAULT_EXEMPT_PATH_FRAGMENTS;
+
+        // The fixture lives under tests/, so the shipped '/tests/' exemption
+        // must silence it — the same way it silences the real test suite.
+        $this->analyse([__DIR__ . '/data/session_superglobal_usage.php'], []);
+    }
+}

--- a/tests/Tests/Isolated/PHPStan/data/session_superglobal_usage.php
+++ b/tests/Tests/Isolated/PHPStan/data/session_superglobal_usage.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Fixture for ForbiddenSessionSuperglobalRuleTest.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\PHPStan\data;
+
+function readAuthUser(): mixed
+{
+    return $_SESSION['authUser'] ?? null;
+}
+
+function writeAuthUser(string $user): void
+{
+    $_SESSION['authUser'] = $user;
+}
+
+function readRequestGlobal(): mixed
+{
+    // Not $_SESSION — this rule must leave other superglobals alone.
+    return $_GET['authUser'] ?? null;
+}


### PR DESCRIPTION
`$_SESSION` was the last superglobal without a rule of its own. `$GLOBALS` is covered by `ForbiddenGlobalsAccessRule`, and `$_GET` / `$_POST` / `$_REQUEST` / `$_FILES` / `$_COOKIE` / `$_SERVER` by `ForbiddenRequestGlobalsRule` — direct session access stayed legal by omission.

Reading `$_SESSION` is a hidden dependency: it bypasses the `read_and_close` lock cycle, the Symfony session bags, and any testing seam, and the calling code cannot run outside a web SAPI without the superglobal being faked. Session state belongs behind the wrapper — read through the `SessionInterface` from `SessionWrapperFactory`, write through `SessionUtil`.

## What's here

- `tests/PHPStan/Rules/ForbiddenSessionSuperglobalRule.php` — flags any `$_SESSION` access, identifier `openemr.forbiddenSessionSuperglobal`.
- Registered in `.phpstan/extension.neon`.
- Isolated test + fixture covering the flagged case and the exemption mechanism.
- One call-site fix in `interface/main/messages/messages.php`.

`$_SESSION` gets its own rule rather than another entry in `ForbiddenRequestGlobalsRule` because its replacement API — and therefore the tip PHPStan prints — is different, and a distinct identifier keeps the two independently suppressible.

## Exemptions

`tests/` and `src/Common/Session/`. The former sets up session state directly; the latter is the infrastructure that owns the superglobal so nothing else has to.

## No baseline growth

The codebase had exactly one violation outside the exempt paths: `messages.php` passed `$_SESSION['authUser']` to `checkPnotesNoteId()` while calling `$session->get('authUser')` four lines below. Fixed here rather than baselined, so the rule ships with zero baseline entries — `composer phpstan` is clean and `composer phpstan-baseline` regenerates byte-identically.
