### PR TITLE
chore(crypto): Deprecate the non-setting-checked cryptography APIs

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -10692,11 +10692,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$string of function trim expects string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php',

--- a/interface/modules/custom_modules/oe-module-faxsms/library/faxMedia.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/faxMedia.php
@@ -41,6 +41,7 @@ if (!is_string($token) || $token === '') {
 
 try {
     $crypto = new \OpenEMR\Common\Crypto\CryptoGen();
+    // @phpstan-ignore method.deprecated (needs OTP conversion)
     $plain = $crypto->decryptStandard($token);
     if (!is_string($plain) || $plain === '') {
         http_response_code(403);

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
@@ -360,6 +360,7 @@ class SignalWireClient extends AppDispatch implements FaxChannelInterface
             // gives both confidentiality and tamper-detection, so faxMedia.php
             // can trust it without a session.
             $payload = json_encode(['f' => $name, 'site' => $siteId, 'exp' => time() + $ttl]);
+            // @phpstan-ignore method.deprecated (needs OTP conversion)
             $token = $this->crypto->encryptStandard((string)$payload);
             if (!is_string($token) || $token === '') {
                 @unlink($path);

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
@@ -3,6 +3,7 @@
 namespace OpenEMR\Modules\FaxSMS\Controller;
 
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Crypto\CryptoGenException;
 use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\RCVoice\VoiceFunctionsTrait;
@@ -91,23 +92,34 @@ class VoiceClient extends AppDispatch
         }
         $credentials = sqlQuery("SELECT * FROM `module_faxsms_credentials` WHERE `auth_user` = ? AND `vendor` = ?", [$this->authUser, $vendor]);
 
+        $empty = [
+            'extension' => '',
+            'phone' => '',
+            'smsNumber' => '',
+            'appKey' => '',
+            'appSecret' => '',
+            'server' => '',
+            'portal' => '',
+            'production' => '',
+            'jwt' => ''
+        ];
+
         if (empty($credentials)) {
-            return [
-                'extension' => '',
-                'phone' => '',
-                'smsNumber' => '',
-                'appKey' => '',
-                'appSecret' => '',
-                'server' => '',
-                'portal' => '',
-                'production' => '',
-                'jwt' => ''
-            ];
+            return $empty;
         } else {
             $credentials = $credentials['credentials'];
         }
 
-        $decrypt = $this->crypto->decryptStandard(is_string($credentials) ? $credentials : null);
+        // decryptFromDatabase (not decryptStandard) so rows written while
+        // `database_encryption` was off are passed through as plaintext. These
+        // rows are written by CredentialsRepository::storeSetup(), which
+        // encrypts conditionally on that same setting.
+        try {
+            $decrypt = $this->crypto->decryptFromDatabase(is_string($credentials) ? $credentials : null);
+        } catch (CryptoGenException) {
+            return $empty;
+        }
+
         return json_decode($decrypt, true);
     }
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
@@ -4,7 +4,6 @@ namespace OpenEMR\Modules\FaxSMS\Controller;
 
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Crypto\CryptoGenException;
-use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\RCVoice\VoiceFunctionsTrait;
 
@@ -52,7 +51,6 @@ class VoiceClient extends AppDispatch
     public $apiBase;
     protected $platform;
     protected $rcsdk;
-    protected CryptoInterface $crypto;
 
     public function __construct()
     {

--- a/interface/modules/custom_modules/oe-module-faxsms/src/RCVoice/VoiceFunctionsTrait.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/RCVoice/VoiceFunctionsTrait.php
@@ -108,7 +108,7 @@ trait VoiceFunctionsTrait
             } catch (CryptoGenException) {
                 return '';
             }
-            $data = json_decode($plain, true);
+            $data = json_decode((string) $plain, true);
             if (is_array($data) && !empty($data['secret']) && is_string($data['secret'])) {
                 return $data['secret'];
             }

--- a/interface/modules/custom_modules/oe-module-faxsms/src/RCVoice/VoiceFunctionsTrait.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/RCVoice/VoiceFunctionsTrait.php
@@ -13,10 +13,13 @@
 namespace OpenEMR\Modules\FaxSMS\RCVoice;
 
 use OpenEMR\Common\Crypto\CryptoGenException;
+use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Core\OEGlobalsBag;
 
 trait VoiceFunctionsTrait
 {
+    protected CryptoInterface $crypto;
+
     public function install(): string
     {
         // Call-event tracking is a RingCentral-only, strictly opt-in feature.

--- a/interface/modules/custom_modules/oe-module-faxsms/src/RCVoice/VoiceFunctionsTrait.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/RCVoice/VoiceFunctionsTrait.php
@@ -12,6 +12,7 @@
 
 namespace OpenEMR\Modules\FaxSMS\RCVoice;
 
+use OpenEMR\Common\Crypto\CryptoGenException;
 use OpenEMR\Core\OEGlobalsBag;
 
 trait VoiceFunctionsTrait
@@ -58,7 +59,7 @@ trait VoiceFunctionsTrait
 
     /**
      * Fetch the persisted RingCentral webhook secret, creating and storing one
-     * (encrypted at rest) on first use.
+     * on first use (encrypted at rest when `database_encryption` is on).
      *
      * Stored under a fixed (auth_user=0, vendor='_voice_webhook') row in
      * module_faxsms_credentials so the session-less voice_webhook.php can read
@@ -73,7 +74,7 @@ trait VoiceFunctionsTrait
         }
 
         $secret = bin2hex(random_bytes(32));
-        $content = $this->crypto->encryptStandard((string)json_encode(['secret' => $secret]));
+        $content = $this->crypto->encryptForDatabase((string)json_encode(['secret' => $secret]));
         // Insert without overwriting a row a concurrent install() may have just
         // written; the no-op UPDATE keeps the existing (already-registered) secret.
         sqlQuery(
@@ -99,8 +100,12 @@ trait VoiceFunctionsTrait
             ['_voice_webhook']
         );
         if (!empty($row['credentials'])) {
-            $plain = $this->crypto->decryptStandard((string)$row['credentials']);
-            $data = json_decode((string)$plain, true);
+            try {
+                $plain = $this->crypto->decryptFromDatabase((string)$row['credentials']);
+            } catch (CryptoGenException) {
+                return '';
+            }
+            $data = json_decode($plain, true);
             if (is_array($data) && !empty($data['secret']) && is_string($data['secret'])) {
                 return $data['secret'];
             }

--- a/src/BC/Crypto/ContextualEncryptionTrait.php
+++ b/src/BC/Crypto/ContextualEncryptionTrait.php
@@ -25,6 +25,7 @@ trait ContextualEncryptionTrait
         if (!$this->shouldEncryptForDatabase) {
             return $value;
         }
+        // @phpstan-ignore method.deprecated (permitted for internal use)
         return $this->encryptStandard($value, keySource: KeySource::Drive);
     }
 
@@ -36,6 +37,7 @@ trait ContextualEncryptionTrait
         if (!$this->shouldEncryptForFilesystem) {
             return $value;
         }
+        // @phpstan-ignore method.deprecated (permitted for internal use)
         return $this->encryptStandard($value, keySource: KeySource::Database);
     }
 
@@ -47,6 +49,7 @@ trait ContextualEncryptionTrait
         if (!$this->cryptCheckStandard($value)) {
             return $value;
         }
+        // @phpstan-ignore method.deprecated (permitted for internal use)
         $result = $this->decryptStandard($value, keySource: KeySource::Drive, minimumVersion: $minimumVersion);
         if ($result === false) {
             throw new CryptoGenException('Decryption failed');
@@ -62,6 +65,7 @@ trait ContextualEncryptionTrait
         if (!$this->cryptCheckStandard($value)) {
             return $value;
         }
+        // @phpstan-ignore method.deprecated (permitted for internal use)
         $result = $this->decryptStandard($value, keySource: KeySource::Database);
         if ($result === false) {
             throw new CryptoGenException('Decryption failed');

--- a/src/Common/Crypto/CryptoGen.php
+++ b/src/Common/Crypto/CryptoGen.php
@@ -454,7 +454,7 @@ class CryptoGen implements CryptoInterface
         $fileContents = $this->fileGetContents($keyPath);
         $key = $keyVersion->usesLegacyStorage()
             ? base64_decode(rtrim($fileContents))
-            : $this->decryptStandard($fileContents, keySource: KeySource::Database);
+            : $this->decryptStandard($fileContents, keySource: KeySource::Database); // @phpstan-ignore method.deprecated (permitted for internal use)
         if (!empty($key)) {
             return $key;
         }
@@ -479,7 +479,7 @@ class CryptoGen implements CryptoInterface
         }
         $fileContents = $keyVersion->usesLegacyStorage()
             ? base64_encode($key)
-            : $this->encryptStandard($key, keySource: KeySource::Database);
+            : $this->encryptStandard($key, keySource: KeySource::Database); // @phpstan-ignore method.deprecated (permitted for internal use)
         $this->filePutContents($keyPath, $fileContents);
 
         // round trip to be sure the newly created key is correctly stored, encoded and encrypted
@@ -488,7 +488,7 @@ class CryptoGen implements CryptoInterface
             $storedFileContents = $this->fileGetContents($keyPath);
             $storedKey = $keyVersion->usesLegacyStorage()
                 ? base64_decode(rtrim($storedFileContents))
-                : $this->decryptStandard($storedFileContents, keySource: KeySource::Database);
+                : $this->decryptStandard($storedFileContents, keySource: KeySource::Database); // @phpstan-ignore method.deprecated (permitted for internal use)
             if ($key === $storedKey) {
                 return $key;
             }

--- a/src/Common/Crypto/CryptoInterface.php
+++ b/src/Common/Crypto/CryptoInterface.php
@@ -17,7 +17,7 @@ interface CryptoInterface
     /**
      * Encrypts data using the standard encryption method
      *
-     * @deprecated use encryptForDatabase, encryptForDrive, or PasswordBasedCrypto
+     * @deprecated use encryptForDatabase, encryptForFilesystem, or PasswordBasedCrypto
      *
      * @param ?string $value     The data to encrypt
      * @param KeySource $keySource The source of the standard keys.
@@ -28,7 +28,7 @@ interface CryptoInterface
     /**
      * Decrypts data using the standard decryption method
      *
-     * @deprecated use decryptFromDatabase, decryptFromDrive, or PasswordBasedCrypto
+     * @deprecated use decryptFromDatabase, decryptFromFilesystem, or PasswordBasedCrypto
      *
      * @param ?string $value          The data to decrypt
      * @param KeySource $keySource      The source of the standard keys.

--- a/src/Common/Crypto/CryptoInterface.php
+++ b/src/Common/Crypto/CryptoInterface.php
@@ -17,6 +17,8 @@ interface CryptoInterface
     /**
      * Encrypts data using the standard encryption method
      *
+     * @deprecated use encryptForDatabase, encryptForDrive, or PasswordBasedCrypto
+     *
      * @param ?string $value     The data to encrypt
      * @param KeySource $keySource The source of the standard keys.
      * @return string The encrypted data
@@ -25,6 +27,8 @@ interface CryptoInterface
 
     /**
      * Decrypts data using the standard decryption method
+     *
+     * @deprecated use decryptFromDatabase, decryptFromDrive, or PasswordBasedCrypto
      *
      * @param ?string $value          The data to decrypt
      * @param KeySource $keySource      The source of the standard keys.

--- a/src/FHIR/SMART/SMARTLaunchToken.php
+++ b/src/FHIR/SMART/SMARTLaunchToken.php
@@ -129,6 +129,7 @@ class SMARTLaunchToken
         $cryptoGen = ServiceContainer::getCrypto();
         $jsonEncoded = json_encode($context);
         ServiceContainer::getLogger()->debug(self::class . "->serialize() Context before encryption", ['context' => $context, 'json' => $jsonEncoded]);
+        // @phpstan-ignore method.deprecated (needs OTP conversion)
         $launchParams = $cryptoGen->encryptStandard($jsonEncoded !== false ? $jsonEncoded : null);
         return base64_encode($launchParams); // make it URL safe
     }
@@ -159,6 +160,7 @@ class SMARTLaunchToken
         if ($jsonEncrypted === false) {
             throw new \InvalidArgumentException("serialized token is not valid base64");
         }
+        // @phpstan-ignore method.deprecated (needs OTP conversion)
         $jsonEncoded = $cryptoGen->decryptStandard($jsonEncrypted);
         if ($jsonEncoded === false) {
             throw new \InvalidArgumentException("serialized token could not be decrypted.  Token was either invalid or something is wrong with the encryption keys");

--- a/tests/Tests/Common/Crypto/CryptoGenDecryptionTest.php
+++ b/tests/Tests/Common/Crypto/CryptoGenDecryptionTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @deprecated (This is to bulk-supress testing of deprecated methods)
+ * @deprecated (This is to bulk-suppress testing of deprecated methods)
  */
 final class CryptoGenDecryptionTest extends TestCase
 {

--- a/tests/Tests/Common/Crypto/CryptoGenDecryptionTest.php
+++ b/tests/Tests/Common/Crypto/CryptoGenDecryptionTest.php
@@ -28,6 +28,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @deprecated (This is to bulk-supress testing of deprecated methods)
+ */
 final class CryptoGenDecryptionTest extends TestCase
 {
     private static CryptoFixtureManager $fixtureManager;

--- a/tests/Tests/Unit/Common/Crypto/CryptoGenTest.php
+++ b/tests/Tests/Unit/Common/Crypto/CryptoGenTest.php
@@ -25,7 +25,7 @@ use ReflectionMethod;
 use ReflectionProperty;
 
 /**
- * @deprecated (This is to bulk-supress testing of deprecated methods)
+ * @deprecated (This is to bulk-suppress testing of deprecated methods)
  */
 final class CryptoGenTest extends TestCase
 {

--- a/tests/Tests/Unit/Common/Crypto/CryptoGenTest.php
+++ b/tests/Tests/Unit/Common/Crypto/CryptoGenTest.php
@@ -24,6 +24,9 @@ use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 
+/**
+ * @deprecated (This is to bulk-supress testing of deprecated methods)
+ */
 final class CryptoGenTest extends TestCase
 {
     /**


### PR DESCRIPTION
#### Short description of what this changes or resolves:
The encryptStandard/decryptStandard CryptoInterface APIs were _de-facto_ deprecated when their replacements were added, but that was never formalized (more accurately, they were quasi-intended to be removed from the interface and perhaps left as private methods). They force callers to check the system encryption settings in order to behave correctly; their replacements handle that automatically.

There are two places where _none_ of the replacements work: inside faxsms, and SMARTLaunchToken. What these really need is more of an OTP with slightly different guarantees. I'll file follow-up issues (if they don't already exist) to address them; for now, they get an phpstan-ignore with reasoning.

#### Changes proposed in this pull request:
- Marks the methods deprecated at the interface
- Fixes a couple places that either slipped through or were re-added since the migration to the newer APIs
- Left notes for the places with no suitable replacement as phpstan-ignore

#### Was an AI assistant used? Yes / No
Yes