### PR TITLE
fix(portal): create patient document staging directory as 0700

### DIFF
--- a/portal/report/document_downloads_action.php
+++ b/portal/report/document_downloads_action.php
@@ -59,7 +59,7 @@ foreach ($documentIds as $documentId) {
     $path .= convert_safe_file_dir_name($cat['name']) . "/";
     // Create the folder structure at the temporary dir
     if (!is_dir($tmp . "/" . $pid . "/" . $path)) {
-        if (!mkdir($concurrentDirectory = $tmp . "/" . $pid . "/" . $path, 0777, true) && !is_dir($concurrentDirectory)) {
+        if (!mkdir($concurrentDirectory = $tmp . "/" . $pid . "/" . $path, 0700, true) && !is_dir($concurrentDirectory)) {
             die("Error creating directory!");
         }
     }


### PR DESCRIPTION
### What

`portal/report/document_downloads_action.php:62` creates the temporary staging directory for patient document downloads with mode `0777`.

```php
if (!mkdir($concurrentDirectory = $tmp . "/" . $pid . "/" . $path, 0777, true) && !is_dir($concurrentDirectory)) {
```

### Why it matters

The directory holds copies of a patient's documents while the zip archive is assembled. At `0777`, any local account on the host can read those documents, or modify them before the archive is built. On a shared or multi-tenant host that is a straightforward local disclosure path.

### Why 0700 is enough

The lifecycle is entirely inside one request: the same process creates the directory, copies the documents in, zips it up (`Zip(...)` further down the file), and streams the archive back. Nothing outside the web server user needs to read or traverse it, so the tightest mode works without behavior change. `0700` is also already the mode used for comparable directories elsewhere in the codebase.

### Change

One character class on one line, `0777` to `0700`. No behavioral change for the normal path.

Spotted while running [ClearMap](https://github.com/Vantage-IO/clearmap), an open-source HIPAA technical-risk scanner I work on, across a set of healthcare codebases. Happy to adjust the mode (`0750` if a group needs traversal in some deployment) or the framing if you would rather handle it differently.