### PR TITLE
refactor: incidental cleanups

### DIFF
--- a/interface/modules/zend_modules/public/xsl/_narrative-block-attrs.xsl
+++ b/interface/modules/zend_modules/public/xsl/_narrative-block-attrs.xsl
@@ -41,8 +41,6 @@
   -->
   <xsl:variable name="narrative-block-url-attrs"
     select="' href '"/>
-  <xsl:variable name="narrative-block-url-safe-prefixes"
-    select="' http:// https:// mailto: tel: # '"/>
 
   <!--
     Iterate every attribute on the context element and emit a copy of

--- a/interface/modules/zend_modules/public/xsl/_narrative-block-attrs.xsl
+++ b/interface/modules/zend_modules/public/xsl/_narrative-block-attrs.xsl
@@ -31,18 +31,57 @@
     select="' ID abbr align axis border cellpadding cellspacing char charoff colspan frame headers href language listType mediaType name referencedObject rel rev revised rowspan rules scope span styleCode summary title valign width '"/>
 
   <!--
+    URL-bearing attributes additionally require a recognized scheme
+    prefix. The plain allowlist above accepts `href` on narrative
+    elements, but XSL doesn't distinguish `href="https://example.org"`
+    from `href="data:text/html,..."` without this extra check —
+    narrow to the schemes real CDA narrative content actually uses.
+
+    `#` is included so fragment-only links (in-page anchors) still work.
+  -->
+  <xsl:variable name="narrative-block-url-attrs"
+    select="' href '"/>
+  <xsl:variable name="narrative-block-url-safe-prefixes"
+    select="' http:// https:// mailto: tel: # '"/>
+
+  <!--
     Iterate every attribute on the context element and emit a copy of
     each one whose local-name is on the allowlist. Non-allowlisted
-    attributes are silently dropped.
+    attributes are silently dropped. For URL-bearing attributes, the
+    value must additionally start with a safe scheme prefix.
 
     Use from ccd.xsl / qrda.xsl in place of `<xsl:copy-of select="@*"/>`.
   -->
   <xsl:template name="safe-copy-narrative-attrs">
     <xsl:for-each select="@*">
+      <xsl:variable name="attr-name" select="local-name(.)"/>
       <xsl:if test="contains($narrative-block-attr-allowlist,
-                             concat(' ', local-name(.), ' '))">
-        <xsl:copy-of select="."/>
+                             concat(' ', $attr-name, ' '))">
+        <xsl:choose>
+          <xsl:when test="contains($narrative-block-url-attrs,
+                                   concat(' ', $attr-name, ' '))">
+            <xsl:call-template name="copy-if-safe-url"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:copy-of select="."/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:if>
     </xsl:for-each>
+  </xsl:template>
+
+  <!--
+    Emit the current attribute only if its value starts with one of the
+    safe URL prefixes. Called with an attribute node as context.
+  -->
+  <xsl:template name="copy-if-safe-url">
+    <xsl:variable name="value" select="."/>
+    <xsl:if test="starts-with($value, 'http://')
+               or starts-with($value, 'https://')
+               or starts-with($value, 'mailto:')
+               or starts-with($value, 'tel:')
+               or starts-with($value, '#')">
+      <xsl:copy-of select="."/>
+    </xsl:if>
   </xsl:template>
 </xsl:stylesheet>

--- a/interface/modules/zend_modules/public/xsl/cda.xsl
+++ b/interface/modules/zend_modules/public/xsl/cda.xsl
@@ -1736,6 +1736,24 @@ limitations under the License.
             that would have been safely dropped anyway.
           -->
         </xsl:when>
+        <xsl:when test="contains($narrative-block-url-attrs,
+                                 concat(' ', $attr-name, ' '))">
+          <!--
+            URL-bearing attribute (href/...). Copy only if the value
+            starts with a recognized scheme prefix; otherwise silently
+            drop. Ordered before the scrubbedSource check because
+            legitimate URL characters (`:`, `/`) live on the
+            simple-sanitizer-match list and would otherwise trigger the
+            warning path.
+          -->
+          <xsl:if test="starts-with($source, 'http://')
+                     or starts-with($source, 'https://')
+                     or starts-with($source, 'mailto:')
+                     or starts-with($source, 'tel:')
+                     or starts-with($source, '#')">
+            <xsl:copy-of select="."/>
+          </xsl:if>
+        </xsl:when>
         <xsl:when test="contains($lcSource, 'javascript')">
           <p>
             <xsl:value-of select="$javascript-injection-warning"/>

--- a/interface/modules/zend_modules/public/xsl/cda.xsl
+++ b/interface/modules/zend_modules/public/xsl/cda.xsl
@@ -1739,20 +1739,14 @@ limitations under the License.
         <xsl:when test="contains($narrative-block-url-attrs,
                                  concat(' ', $attr-name, ' '))">
           <!--
-            URL-bearing attribute (href/...). Copy only if the value
-            starts with a recognized scheme prefix; otherwise silently
-            drop. Ordered before the scrubbedSource check because
-            legitimate URL characters (`:`, `/`) live on the
-            simple-sanitizer-match list and would otherwise trigger the
-            warning path.
+            URL-bearing attribute (href/...). Delegates to the shared
+            copy-if-safe-url template so the recognized-scheme list
+            lives in one place (_narrative-block-attrs.xsl). Ordered
+            before the scrubbedSource check because legitimate URL
+            characters (`:`, `/`) live on the simple-sanitizer-match
+            list and would otherwise trigger the warning path.
           -->
-          <xsl:if test="starts-with($source, 'http://')
-                     or starts-with($source, 'https://')
-                     or starts-with($source, 'mailto:')
-                     or starts-with($source, 'tel:')
-                     or starts-with($source, '#')">
-            <xsl:copy-of select="."/>
-          </xsl:if>
+          <xsl:call-template name="copy-if-safe-url"/>
         </xsl:when>
         <xsl:when test="contains($lcSource, 'javascript')">
           <p>

--- a/library/edihistory/edih_archive.php
+++ b/library/edihistory/edih_archive.php
@@ -8,7 +8,9 @@
  * @subpackage ediHistory
  * @link       https://www.open-emr.org
  * @author     Kevin McCormick
+ * @author     Michael A. Smith <michael@opencoreemr.com>
  * @copyright  Copyright (c) 2016 Kevin McCormick    Longview, Texas
+ * @copyright  Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license    https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -730,6 +732,13 @@ function edih_archive_csv_combine($filetype, $csvtype)
  */
 function edih_archive_restore($archive_name)
 {
+    // Archive names must be plain filenames matching the format used at
+    // archive creation time (e.g. "<date>_archive.zip"). Reject anything
+    // else to keep restore constrained to well-formed archive entries.
+    if (!preg_match('/\A[\w.-]+\.zip\z/', $archive_name)) {
+        csv_edihist_log("edih_archive_restore: rejected archive name");
+        return "Archive: invalid archive file name<br />";
+    }
     //
     $str_out = '';
     $bdir = csv_edih_basedir();

--- a/tests/Tests/Isolated/CCDA/CcdaXslAttributeFilterTest.php
+++ b/tests/Tests/Isolated/CCDA/CcdaXslAttributeFilterTest.php
@@ -452,6 +452,11 @@ XSL;
                 [],
                 ['href'],
             ],
+            'href javascript: dropped' => [
+                'href="javascript:alert(1)"',
+                [],
+                ['href'],
+            ],
             'legitimate href preserved alongside title' => [
                 'href="https://good.example" title="tip"',
                 ['href', 'title'],

--- a/tests/Tests/Isolated/CCDA/CcdaXslAttributeFilterTest.php
+++ b/tests/Tests/Isolated/CCDA/CcdaXslAttributeFilterTest.php
@@ -265,6 +265,198 @@ XSL;
                 [],
                 ['widthy'],
             ],
+
+            // --- href scheme filtering ---
+            'href https preserved' => [
+                'href="https://example.org/x"',
+                ['href'],
+                [],
+            ],
+            'href http preserved' => [
+                'href="http://example.org/x"',
+                ['href'],
+                [],
+            ],
+            'href mailto preserved' => [
+                'href="mailto:a@b.example"',
+                ['href'],
+                [],
+            ],
+            'href tel preserved' => [
+                'href="tel:+15555550100"',
+                ['href'],
+                [],
+            ],
+            'href fragment preserved' => [
+                'href="#section"',
+                ['href'],
+                [],
+            ],
+            'href javascript: dropped' => [
+                'href="javascript:alert(1)"',
+                [],
+                ['href'],
+            ],
+            'href data:text/html dropped' => [
+                'href="data:text/html,&lt;script&gt;alert(1)&lt;/script&gt;"',
+                [],
+                ['href'],
+            ],
+            'href vbscript dropped' => [
+                'href="vbscript:alert(1)"',
+                [],
+                ['href'],
+            ],
+            'href file:// dropped' => [
+                'href="file:///etc/passwd"',
+                [],
+                ['href'],
+            ],
+            'href empty dropped' => [
+                'href=""',
+                [],
+                ['href'],
+            ],
+            'href relative path dropped' => [
+                'href="/relative/path"',
+                [],
+                ['href'],
+            ],
+            'href mixed benign + malicious side-by-side' => [
+                'href="https://good.example" title="tip"',
+                ['href', 'title'],
+                [],
+            ],
+        ];
+    }
+
+    /**
+     * Drive cda.xsl's inline `output-attrs` template with a synthetic <n1:td>
+     * element and assert that URL-scheme filtering on `href` is applied.
+     * Parallel to safe-copy-narrative-attrs coverage above; cda.xsl uses
+     * inline logic rather than calling the shared template, so it needs
+     * its own regression coverage.
+     *
+     * @param non-empty-string $inputAttrs
+     * @param list<string> $expectedNames
+     * @param list<string> $droppedNames
+     */
+    #[DataProvider('cdaOutputAttrsUrlCasesProvider')]
+    public function testCdaOutputAttrsUrlScheme(string $inputAttrs, array $expectedNames, array $droppedNames): void
+    {
+        $xslPath = realpath(self::XSL_DIR . '/cda.xsl');
+        self::assertNotFalse($xslPath, 'cda.xsl must resolve');
+
+        // Wrapper imports cda.xsl and drives output-attrs on a synthetic
+        // <n1:td>. `match="/"` overrides the imported match="/" (import
+        // lowers priority) so our root template runs instead of cda.xsl's
+        // ClinicalDocument-only dispatcher.
+        $wrapperXsl = <<<XSL
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:n1="urn:hl7-org:v3">
+  <xsl:import href="file://$xslPath"/>
+  <xsl:output method="xml" indent="no" omit-xml-declaration="yes"/>
+  <xsl:template match="/">
+    <result>
+      <xsl:for-each select="n1:td">
+        <xsl:call-template name="output-attrs"/>
+      </xsl:for-each>
+    </result>
+  </xsl:template>
+</xsl:stylesheet>
+XSL;
+
+        $xsl = new DOMDocument();
+        $xsl->loadXML($wrapperXsl);
+
+        $xml = new DOMDocument();
+        $xml->loadXML('<n1:td xmlns:n1="urn:hl7-org:v3" ' . $inputAttrs . '/>');
+
+        $proc = new XSLTProcessor();
+        $proc->importStylesheet($xsl);
+        $result = (string) $proc->transformToXml($xml);
+
+        foreach ($expectedNames as $name) {
+            $this->assertMatchesRegularExpression(
+                '/\b' . preg_quote($name, '/') . '=/',
+                $result,
+                "Expected `$name=` to be preserved in: $result"
+            );
+        }
+        foreach ($droppedNames as $name) {
+            $this->assertDoesNotMatchRegularExpression(
+                '/\b' . preg_quote($name, '/') . '=/',
+                $result,
+                "Expected `$name=` to be dropped from: $result"
+            );
+        }
+    }
+
+    /**
+     * @return array<string, array{non-empty-string, list<string>, list<string>}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function cdaOutputAttrsUrlCasesProvider(): array
+    {
+        return [
+            'href https preserved' => [
+                'href="https://example.org/x"',
+                ['href'],
+                [],
+            ],
+            'href http preserved' => [
+                'href="http://example.org/x"',
+                ['href'],
+                [],
+            ],
+            'href mailto preserved' => [
+                'href="mailto:a@b.example"',
+                ['href'],
+                [],
+            ],
+            'href tel preserved' => [
+                'href="tel:+15555550100"',
+                ['href'],
+                [],
+            ],
+            'href fragment preserved' => [
+                'href="#section"',
+                ['href'],
+                [],
+            ],
+            'href data:text/html dropped' => [
+                'href="data:text/html,&lt;script&gt;alert(1)&lt;/script&gt;"',
+                [],
+                ['href'],
+            ],
+            'href vbscript dropped' => [
+                'href="vbscript:alert(1)"',
+                [],
+                ['href'],
+            ],
+            'href file:// dropped' => [
+                'href="file:///etc/passwd"',
+                [],
+                ['href'],
+            ],
+            'href empty dropped' => [
+                'href=""',
+                [],
+                ['href'],
+            ],
+            'href relative path dropped' => [
+                'href="/relative/path"',
+                [],
+                ['href'],
+            ],
+            'legitimate href preserved alongside title' => [
+                'href="https://good.example" title="tip"',
+                ['href', 'title'],
+                [],
+            ],
         ];
     }
 }

--- a/tests/Tests/Isolated/library/EdihArchiveNamePatternTest.php
+++ b/tests/Tests/Isolated/library/EdihArchiveNamePatternTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Isolated test for the archive-name pattern applied at
+ * `edih_archive_restore()` in `library/edihistory/edih_archive.php`.
+ * Verifying the pattern in isolation catches accidental relaxation of
+ * the anchors or the `.zip` suffix requirement without needing the full
+ * edihistory dependency chain.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class EdihArchiveNamePatternTest extends TestCase
+{
+    private const PATTERN = '/\A[\w.-]+\.zip\z/';
+
+    #[DataProvider('acceptedNamesProvider')]
+    public function testAccepts(string $name): void
+    {
+        $this->assertSame(1, preg_match(self::PATTERN, $name), "Expected accepted: $name");
+    }
+
+    #[DataProvider('rejectedNamesProvider')]
+    public function testRejects(string $name): void
+    {
+        $this->assertSame(0, preg_match(self::PATTERN, $name), "Expected rejected: $name");
+    }
+
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function acceptedNamesProvider(): array
+    {
+        return [
+            'timestamped archive'  => ['20260701_archive.zip'],
+            'dashed name'          => ['test-archive.zip'],
+            'dotted name'          => ['archive.2026.zip'],
+            'alphanumeric only'    => ['archive1.zip'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function rejectedNamesProvider(): array
+    {
+        return [
+            'unix-style parent-dir path'    => ['../../etc/passwd'],
+            'windows-style parent-dir path' => ['..\\..\\Windows\\win.ini'],
+            'no extension'             => ['foo'],
+            'wrong extension'          => ['foo.php'],
+            'double extension probe'   => ['foo.zip.evil'],
+            'empty'                    => [''],
+            'leading dot'              => ['.zip'],
+            'contains slash'           => ['dir/archive.zip'],
+            'contains backslash'       => ['dir\\archive.zip'],
+            'contains space'           => ['my archive.zip'],
+            'null byte'                => ["archive.zip\0.php"],
+        ];
+    }
+}


### PR DESCRIPTION
- `library/edihistory/edih_archive.php` — reject archive-file names that don't match the expected `<name>.zip` shape.
- `interface/modules/zend_modules/public/xsl/cda.xsl`,
  `interface/modules/zend_modules/public/xsl/_narrative-block-attrs.xsl`
  — accept URL attribute values only when they begin with a well-known scheme prefix (`http://`, `https://`, `mailto:`, `tel:`, `#`).
- Isolated test coverage for the two changes above.

Byte-equal render regression check against the PR #13195 (SHA `441a8b58`) baseline — repo CCDA fixture through `cda.xsl` + all QRDA fixtures through `qrda.xsl`:

| Stylesheet | Fixture                        | Current bytes | Baseline bytes | Byte-equal |
|------------|--------------------------------|---------------|----------------|------------|
| cda.xsl    | ccda-example-response1.xml     | 610,377       | 610,377        | ✓          |
| qrda.xsl   | BH Adult_1.xml                 | 5,648         | 5,648          | ✓          |
| qrda.xsl   | BH Adult_2.xml                 | 5,649         | 5,649          | ✓          |
| qrda.xsl   | Heart Adult_Z31.xml            | 5,654         | 5,654          | ✓          |
| qrda.xsl   | catI_doc_28.xml                | 5,650         | 5,650          | ✓          |
| qrda.xsl   | catI_doc_29.xml                | 5,660         | 5,660          | ✓          |
| qrda.xsl   | catI_gen_Heart_Adult_Z31.xml   | 5,708         | 5,708          | ✓          |

All 7 fixtures byte-identical.