### PR TITLE
ci(byte-identical): drop rel-820 exclusion from acceptance surface + build-release.yml (unblocked by #13227)

### DIFF
--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -149,16 +149,14 @@ files:
 - path: .github/workflows/release-permissions-check.yml
   exclude-branches: [rel-800, rel-704]
 - path: .github/workflows/build-release.yml
-  # rel-820 exclusion added 2026-07-27: Phase 7c
-  # (openemr/openemr#13207) refactored build-release.yml to
-  # `uses: ./.github/workflows/acceptance-package.yml` for the
-  # release-time acceptance gate. acceptance-package.yml is
-  # already excluded from rel-820 (see the acceptance-surface
-  # block below), so syncing master's build-release.yml to
-  # rel-820 would produce an actionlint failure ("reusable workflow
-  # file not found"). Effective from rel-830+ where both files
-  # exist together.
-  exclude-branches: [rel-820, rel-800, rel-704]
+  # rel-820 exclusion dropped 2026-07-28: rel-820 now has
+  # acceptance-package.yml too (see the acceptance-surface block
+  # below) — openemr/openemr#13227 backported symfony/mime +
+  # autoload + acceptance script to rel-820, and the acceptance-
+  # surface block below no longer excludes rel-820, so Phase 7c's
+  # `uses: ./.github/workflows/acceptance-package.yml` reference
+  # from build-release.yml resolves cleanly on rel-820.
+  exclude-branches: [rel-800, rel-704]
 - path: .github/workflows/build-patch.yml
   exclude-branches: [rel-800, rel-704]
 - path: .github/actions/setup-php-composer/action.yml
@@ -185,25 +183,28 @@ files:
 # rel-branch-executing code (the compose override + tests/Acceptance/**
 # are consumed by the workflow).
 #
-# All entries in this block exclude rel-820 in addition to rel-800 +
-# rel-704: rel-820 was cut BEFORE Phase 1 (openemr/openemr#13149,
-# landed 2026-07-24) added `symfony/mime` to require-dev for
-# BrowserKit's POST-body path. Syncing tests/Acceptance/** onto
-# rel-820 would produce a branch where the acceptance suite can't
-# actually run (the login-form POST throws LogicException about
-# symfony/mime missing). Enforcement starts effectively at rel-830+
-# (not yet cut; will be cut from a master that already has the
-# dep in composer.json).
-#
-# Not permanent: once rel-820 is EOL (post-next-next release),
-# remove rel-820 from these exclude-branches lists.
+# rel-820 exclusion dropped 2026-07-28: rel-820 originally had to
+# be excluded because it was cut BEFORE Phase 1
+# (openemr/openemr#13149, landed 2026-07-24) added `symfony/mime`
+# to require-dev — syncing tests/Acceptance/** onto rel-820 would
+# have produced a branch where the acceptance suite couldn't run
+# (login-form POST throws LogicException). openemr/openemr#13227
+# backported symfony/mime + the OpenEMR\Tests\Acceptance autoload-
+# dev entry + the `acceptance` composer script to rel-820, so the
+# suite runs there now. Backporting was worth it because rel-820
+# owns the `latest` docker tag and the nightly orchestrator
+# rebuilds `latest` daily — without the acceptance harness on
+# rel-820, we couldn't wire Phase 7c-docker-latest-gate to gate
+# those nightly builds until 8.3.0 shipped. rel-800 + rel-704
+# stay excluded (further behind the composer surface + no
+# active-release-line concern).
 - path: .github/workflows/acceptance-docker.yml
-  exclude-branches: [rel-820, rel-800, rel-704]
+  exclude-branches: [rel-800, rel-704]
 - path: .github/workflows/acceptance-package.yml
-  exclude-branches: [rel-820, rel-800, rel-704]
+  exclude-branches: [rel-800, rel-704]
 - path: .github/docker/acceptance-docker-compose.yml
-  exclude-branches: [rel-820, rel-800, rel-704]
+  exclude-branches: [rel-800, rel-704]
 - path: .github/docker/acceptance-package-compose.yml
-  exclude-branches: [rel-820, rel-800, rel-704]
+  exclude-branches: [rel-800, rel-704]
 - path: tests/Acceptance/**
-  exclude-branches: [rel-820, rel-800, rel-704]
+  exclude-branches: [rel-800, rel-704]


### PR DESCRIPTION
## Summary

Step 2 of the [rel-820 acceptance-surface unlock sequence](https://github.com/openemr/openemr/pull/13227). Now that rel-820 has `symfony/mime` + the acceptance autoload/script surface (via #13227, just merged), the byte-identical exclusions that specifically cited "rel-820 was cut before that composer surface landed" are stale. Drops rel-820 from all six affected `exclude-branches` lists:

- `.github/workflows/acceptance-docker.yml`
- `.github/workflows/acceptance-package.yml`
- `.github/docker/acceptance-docker-compose.yml`
- `.github/docker/acceptance-package-compose.yml`
- `tests/Acceptance/**`
- `.github/workflows/build-release.yml` (Phase 7c added this exclusion specifically because the reusable-workflow reference to acceptance-package.yml couldn't resolve; now it can)

rel-800 + rel-704 stay excluded — further behind the composer surface, no active-release-line concern.

## Why not just wait for rel-830

rel-820 owns the `latest` docker tag today. The nightly orchestrator rebuilds `latest` from rel-820 every day at 06:00 UTC. The in-flight Phase 7c-docker-latest-gate implementation acceptance-gates those nightly builds — but only if `acceptance-docker.yml` is present on rel-820. Deferring to 8.3.0-ship (rotates `latest` to rel-830) leaves a bounded but real window where daily `latest` docker pushes aren't acceptance-gated. #13227 + this PR close the window immediately.

## What happens after merge

Next `sync-byte-identical.yml` run will propagate the acceptance workflow files + `tests/Acceptance/**` + master's Phase-7c-shape `build-release.yml` to rel-820. All resolve cleanly against #13227's composer surface. That opens a sync PR to rel-820 with ~5000 lines of test file additions + the workflow file updates.

## Follow-up

Once the sync PR lands on rel-820, step 4 opens: Phase 7c-docker-latest-gate implementation on master (adds `workflow_call` trigger to acceptance-docker.yml, `gate_with_acceptance` input to docker-build-release.yml, orchestrator conditional dispatch for `latest`-tagged rows). That syncs to rel-820 automatically once merged, and the nightly orchestrator starts acceptance-gating rel-820's `latest` builds.

## Test plan

- [x] YAML parses.
- [x] Only exclusion-list edits + comment updates — no other functional changes.
- [ ] Sync PR to rel-820 auto-opens post-merge, its diff-against-rel-branches CI resolves cleanly (no reusable-workflow-file-not-found errors).
- [ ] rel-820 acceptance-docker.yml daily-schedule fires cleanly once synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)