### PR TITLE
fix(ci): preserve executable bit when sync-byte-identical.sh copies files from master

### DIFF
--- a/.github/scripts/sync-byte-identical.sh
+++ b/.github/scripts/sync-byte-identical.sh
@@ -187,7 +187,15 @@ for FILE in "${FILES_TO_CHECK[@]}"; do
     echo "  + ${FILE}  (add)"
     dir=$(dirname "${FILE}")
     mkdir -p "${dir}"
-    git show "master:${FILE}" > "${FILE}"
+    # Use `git checkout master -- FILE` rather than
+    # `git show master:FILE > FILE` — the redirect writes only the
+    # blob content and leaves the file at the writer's umask, which
+    # silently strips the executable bit off .sh files that were
+    # 100755 on master. `git checkout` restores content AND mode
+    # from master's tree entry, and stages the file in the process
+    # (peter-evans's downstream `git add -A` picks it up either way,
+    # so the earlier staging is harmless).
+    git checkout master -- "${FILE}"
     CHANGES+=("add: ${FILE}")
     continue
   fi
@@ -207,7 +215,8 @@ for FILE in "${FILES_TO_CHECK[@]}"; do
   fi
 
   echo "  ~ ${FILE}  (update from master)"
-  git show "master:${FILE}" > "${FILE}"
+  # Same mode-preserving pattern as the add case above.
+  git checkout master -- "${FILE}"
   CHANGES+=("update: ${FILE}")
 done
 

--- a/tests/bats/ci-scripts/sync-byte-identical/helpers.bash
+++ b/tests/bats/ci-scripts/sync-byte-identical/helpers.bash
@@ -55,6 +55,35 @@ write_on_branch() {
     git commit -q -m "write $path on $branch"
 }
 
+# Add or update an EXECUTABLE (100755) file on a specific branch. Same
+# as write_on_branch but chmod +x before staging so git records the
+# tree entry with mode 100755. Used by the mode-preservation tests to
+# verify sync-byte-identical.sh keeps the executable bit intact when
+# copying from master to a rel branch.
+write_executable_on_branch() {
+    local branch="$1" path="$2" content="$3"
+    git checkout -q "$branch"
+    mkdir -p "$(dirname "$path")"
+    echo "$content" > "$path"
+    chmod +x "$path"
+    git add "$path"
+    git commit -q -m "write executable $path on $branch"
+}
+
+# Read the mode git will record for a file in the next commit — i.e.
+# what's staged in the CURRENT INDEX. Returns strings like "100644"
+# or "100755" (empty if the file isn't staged).
+#
+# sync-byte-identical.sh stages its file changes via git-checkout
+# without committing; peter-evans (the workflow that calls the
+# script) creates the commit later. So mode-preservation tests need
+# to inspect the index, not the committed tree — the committed tree
+# still holds whatever mode was there before the sync ran.
+git_staged_mode() {
+    local path="$1"
+    git ls-files -s -- "$path" | awk '{print $1}'
+}
+
 # Delete a file on a specific branch.
 delete_on_branch() {
     local branch="$1" path="$2"

--- a/tests/bats/ci-scripts/sync-byte-identical/sync.bats
+++ b/tests/bats/ci-scripts/sync-byte-identical/sync.bats
@@ -516,3 +516,61 @@ teardown() {
     # And no rename-sweep re-delete attempt printed.
     ! grep -qF "delete: master removed this path entirely" <(echo "${output}")
 }
+
+# ---------- Mode preservation ----------
+#
+# Regression cover for the bug where `git show master:FILE > FILE`
+# wrote only the blob content and left the file at the writer's umask,
+# stripping the executable bit off .sh files that were 100755 on
+# master. Surfaced by a real sync PR to rel-820 where the freshly-
+# copied tests/Acceptance/bin/boot-package.sh landed as 100644 and
+# CI failed with "Permission denied" (exit 126). Fix switched both
+# the add and update paths from `git show > FILE` to
+# `git checkout master -- FILE` which preserves mode.
+
+@test "add case preserves executable bit (100755) from master" {
+    write_executable_on_branch master src/tool.sh "#!/bin/sh\necho hi"
+    write_files_all_config src/tool.sh
+
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ -f src/tool.sh ]]
+    # The synced file must be executable both in the working tree and
+    # in git's tree entry (peter-evans would commit the working-tree
+    # + index state, so both need to be 755).
+    [[ -x src/tool.sh ]]
+    [[ "$(git_staged_mode src/tool.sh)" == "100755" ]]
+    grep -qxF "add: src/tool.sh" "$OUTPUT_DIR/changes.txt"
+}
+
+@test "update case preserves executable bit (100755) from master" {
+    write_executable_on_branch master  src/tool.sh "master-content"
+    write_executable_on_branch rel-810 src/tool.sh "older-content"
+    write_files_all_config src/tool.sh
+
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ "$(cat src/tool.sh)" == "master-content" ]]
+    [[ -x src/tool.sh ]]
+    [[ "$(git_staged_mode src/tool.sh)" == "100755" ]]
+    grep -qxF "update: src/tool.sh" "$OUTPUT_DIR/changes.txt"
+}
+
+@test "update case demotes 100755 to 100644 when master's mode changed" {
+    write_on_branch            master  src/tool.sh "master-content"     # 100644
+    write_executable_on_branch rel-810 src/tool.sh "older-content"      # 100755
+    write_files_all_config src/tool.sh
+
+    git checkout -q rel-810
+    OUTPUT_DIR="$OUTPUT_DIR" run bash "$SYNC_BYTE_IDENTICAL_SCRIPT" rel-810
+
+    [[ $status -eq 0 ]]
+    [[ "$(cat src/tool.sh)" == "master-content" ]]
+    [[ ! -x src/tool.sh ]]
+    [[ "$(git_staged_mode src/tool.sh)" == "100644" ]]
+    grep -qxF "update: src/tool.sh" "$OUTPUT_DIR/changes.txt"
+}


### PR DESCRIPTION
## Summary

`sync-byte-identical.sh`'s add + update cases used `git show master:FILE > FILE`, which writes only the blob content and leaves the file at the writer's umask. .sh files that were `100755` on master arrived on the target rel-branch as `100644`. Switch both to `git checkout master -- FILE`, which preserves mode from master's tree entry AND stages the change.

## How this surfaced

openemr/openemr#13236 (the sync PR opened after openemr/openemr#13233 landed) tried to sync `tests/Acceptance/bin/*.sh` from master to rel-820. Master had `boot-package.sh` + `upgrade-package.sh` + `boot-docker.sh` + `down-*.sh` at `100755`; they landed on the sync PR's `sync-byte-identical/rel-820` branch at `100644`. rel-820 CI failed with `Permission denied` (exit 126) when acceptance-package's boot step tried to invoke the freshly-synced boot-package.sh.

Direct verification:
```
$ gh api "repos/openemr/openemr/git/trees/master:tests/Acceptance/bin" --jq '.tree[] | "\(.mode) \(.path)"'
100755 boot-package.sh
100755 upgrade-package.sh
...

$ gh api "repos/openemr/openemr/git/trees/sync-byte-identical/rel-820:tests/Acceptance/bin" --jq '.tree[] | "\(.mode) \(.path)"'
100644 boot-package.sh
100644 upgrade-package.sh
...
```

## Test coverage

Three new BATS tests in `tests/bats/ci-scripts/sync-byte-identical/`:

- **add case preserves 100755 from master** — file exists on master at 100755, doesn't exist on rel-branch; after sync, staged mode should be 100755.
- **update case preserves 100755 from master** — same 100755 on both sides, master has different content; after sync, staged mode still 100755.
- **update case demotes 100755 → 100644 when master's mode changed** — rel-branch has 100755, master has 100644; after sync, staged mode should be 100644.

Tests read the STAGED mode via new `git_staged_mode` helper (`git ls-files -s`). Necessary because sync-byte-identical.sh stages via git-checkout without committing (peter-evans commits later), so mode verification has to look at the index, not the branch's committed tree.

All 31 bats tests pass locally (28 pre-existing + 3 new).

## Side effect

`git checkout` stages the file into the index (unlike `git show > FILE` which left it unstaged for peter-evans's later `git add -A` to pick up). Peter-evans still runs `git add -A`, so the earlier staging is redundant but harmless.

## Follow-up

Once this merges, the next `sync-byte-identical.yml` run will re-force-push #13236's `sync-byte-identical/rel-820` branch with correct file modes. rel-820 CI on that PR should then pass.

## Test plan

- [x] All 31 BATS tests pass locally (`bats tests/bats/ci-scripts/sync-byte-identical/`).
- [x] `test-byte-identical-scripts.yml` will run these on this PR.
- [ ] After merge: next sync-byte-identical run re-computes #13236 with 100755 files, its rel-820 CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)