### PR TITLE
ci(phpstan): exclude tests/Acceptance/bin/*.php on rel-820

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,6 +18,15 @@ parameters:
   # not maintained in this repo, so exclude it from analysis the same way vendor/
   # is excluded.
   - interface/modules/custom_modules/oe-module-claimrev-connect/*
+  # Acceptance-harness bootstrap scripts — runtime-only. install-helper.php
+  # is copied into a running container's mount point at execution time
+  # and depends on container-absolute paths (autoload.php under
+  # /var/www/localhost/htdocs/openemr) that don't exist on the runner
+  # where phpstan runs. Nothing else references these files at build
+  # time, so excluding from analysis is appropriate. (Backported from
+  # master alongside the tests/Acceptance surface to unblock rel-820
+  # acceptance gating for Phase 7c-docker-latest-gate.)
+  - tests/Acceptance/bin/*.php
   paths:
   - Documentation
   - _rest_routes.inc.php


### PR DESCRIPTION
Backport the master-side `tests/Acceptance/bin/*.php` phpstan exclude to rel-820.

## Why

The rel-820 auto-sync PR #13236 propagates master's `tests/Acceptance/` surface (including the new `bin/` bootstrap scripts) onto rel-820 as part of the Phase 7c-docker-latest-gate prep sequence. Its phpstan (8.5) job then fails against `tests/Acceptance/bin/api-enable.php` with the same class of errors master already suppresses — mixed-type accesses, `empty()`-in-strict-mode complaints, and `Path in require_once() ... is not a file` for the container-absolute `require '/var/www/localhost/htdocs/openemr/vendor/autoload.php'` paths.

Master handles this via a whole-file exclude in `phpstan.neon.dist`. Because `phpstan.neon.dist` is not itself in the byte-identical manifest (it diverges structurally between master and rel-820), the exclude has to be backported explicitly.

## What

Adds one entry (with wording mirrored from master's comment) to the existing `excludePaths:` list in rel-820's `phpstan.neon.dist`. rel-820's config uses the flat form (no `analyseAndScan:` sub-key), which excludes from both analyse and scan — sufficient here.

## Sequence

1. This PR merges → phpstan exclude in place on rel-820
2. Sync-byte-identical re-fires on the next master push or manual dispatch
3. #13236 CI goes green → merges → acceptance surface is live on rel-820
4. Phase 7c-docker-latest-gate can then wire the orchestrator to gate `latest` pushes on rel-820 acceptance

## Test plan

- [ ] CI phpstan job passes on this PR (no new errors introduced by the exclude itself)
- [ ] After merge, re-run of #13236 sync passes phpstan

🤖 Generated with [Claude Code](https://claude.com/claude-code)