### PR TITLE
ci(docker): Phase 7c-docker-latest-gate — acceptance-gate `latest` builds

### DIFF
--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -68,6 +68,27 @@ on:
         description: 'Build target image from the PR docker/release/Dockerfile instead of pulling to_tag from Docker Hub (Phase 2.5 PR-image validation)'
         type: boolean
         default: false
+  # Phase 7c-docker-latest-gate: called by docker-build-release.yml as
+  # a pre-publish gate. The caller has already built the release image,
+  # saved it via `docker save` as a workflow-run artifact, and dispatches
+  # this workflow with the artifact name. When these inputs are set, the
+  # build-image job self-skips (the caller-supplied artifact takes its
+  # place) and the acceptance matrix downloads the caller's artifact
+  # instead of Phase 2.5's `openemr-pr-built-image` default.
+  # Mirrors acceptance-package.yml's Phase 7c-tarball workflow_call
+  # (caller_tarball_artifact / to_version).
+  workflow_call:
+    inputs:
+      from_tag:
+        description: 'Prior openemr Docker Hub tag. Defaults to latest.'
+        required: false
+        type: string
+        default: 'latest'
+      caller_image_artifact:
+        description: 'Name of the workflow-run artifact holding the caller-supplied docker save zstd tarball (openemr-<name>.tar.zst). When set, skips this workflow build-image job and treats the caller-supplied image as if it were PR-built.'
+        required: false
+        type: string
+        default: ''
   push:
     paths:
     - '.github/workflows/acceptance-docker.yml'
@@ -136,12 +157,35 @@ jobs:
       env:
         EVENT_NAME: ${{ github.event_name }}
         DISPATCH_BUILD_LOCALLY: ${{ inputs.build_locally }}
+        CALLER_IMAGE_ARTIFACT: ${{ inputs.caller_image_artifact }}
         PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         PUSH_BEFORE_SHA: ${{ github.event.before }}
         PUSH_HEAD_SHA: ${{ github.sha }}
       run: |
         set -euo pipefail
+
+        # Phase 7c-docker workflow_call gate — caller (docker-build-release.yml)
+        # already has the image built and uploaded as an artifact. Skip the
+        # diff-detection dance entirely; force build_locally=true. The
+        # build-image job self-skips (see its `if:` condition below) and
+        # the acceptance jobs download the caller's artifact name instead
+        # of Phase 2.5's `openemr-pr-built-image` default.
+        #
+        # Detect on CALLER_IMAGE_ARTIFACT being non-empty, NOT on
+        # $EVENT_NAME == 'workflow_call' — GitHub Actions reports the
+        # original event that started the CALLING workflow in a called
+        # workflow's github.event_name (so workflow_dispatch of docker-
+        # build-release.yml surfaces as workflow_dispatch here, not
+        # workflow_call). The caller_image_artifact input is only populated
+        # in workflow_call invocations, so it's the reliable signal.
+        # (Same signal choice as acceptance-package.yml's detect-mode.)
+        if [[ -n "$CALLER_IMAGE_ARTIFACT" ]]; then
+          echo "==> workflow_call gate mode (caller=${CALLER_IMAGE_ARTIFACT}): forcing build_locally=true"
+          echo "build_locally=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
         # Manual dispatch always wins — honor the input.
         if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
           echo "build_locally=${DISPATCH_BUILD_LOCALLY}" >> "$GITHUB_OUTPUT"
@@ -181,7 +225,14 @@ jobs:
   # build is self-contained to this workflow run.
   build-image:
     needs: [detect-mode]
-    if: needs.detect-mode.outputs.build_locally == 'true'
+    # Skip when the caller (Phase 7c-docker workflow_call gate) already
+    # supplied the image as an artifact — no point re-running docker
+    # build when the caller just did that against the exact source
+    # being validated. The acceptance job downloads the caller's
+    # artifact by name in that case.
+    if: >-
+      needs.detect-mode.outputs.build_locally == 'true'
+      && inputs.caller_image_artifact == ''
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7
@@ -225,6 +276,12 @@ jobs:
     # only if build-image itself failed (no point running the fresh-install-to
     # / upgrade scenarios if their target image failed to build) or if
     # detect-mode failed (shouldn't happen — trivial job).
+    #
+    # build-image is `skipped` in two cases: (1) detect-mode said
+    # build_locally=false (Phase 2 default path — acceptance runs against
+    # Docker Hub tags), or (2) the caller (Phase 7c-docker workflow_call
+    # gate) supplied its own image artifact — the download step below
+    # picks that up.
     if: >-
       always()
       && github.repository_owner == 'openemr' && github.repository == 'openemr/openemr'
@@ -271,18 +328,59 @@ jobs:
         # credential exposure surface.
         persist-credentials: false
 
-    # ==== Phase 2.5: load PR-built image + resolve effective tags ====
-    - name: Download PR-built image (if build-image ran)
-      if: needs.build-image.result == 'success'
+    # ==== Load PR-built or caller-supplied image + resolve effective tags ====
+    # Two source paths converge here:
+    #   Phase 2.5 (PR validation): build-image job just uploaded
+    #     openemr-pr-built-image. Download that.
+    #   Phase 7c-docker (workflow_call gate): caller (docker-build-release.yml)
+    #     already uploaded the release-candidate image under
+    #     inputs.caller_image_artifact — build-image self-skipped.
+    #     Download that artifact name instead.
+    #
+    # Both land the image tarball at /tmp/openemr-pr-built.tar.zst so the
+    # docker-load step below doesn't need to care which path fired.
+    - name: Download PR-built image (Phase 2.5)
+      if: needs.build-image.result == 'success' && inputs.caller_image_artifact == ''
       uses: actions/download-artifact@v8
       with:
         name: openemr-pr-built-image
         path: /tmp
 
-    - name: Load PR-built image into docker (if downloaded)
-      if: needs.build-image.result == 'success'
+    - name: Download caller-supplied image (Phase 7c-docker gate)
+      if: inputs.caller_image_artifact != ''
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.caller_image_artifact }}
+        path: /tmp
+
+    - name: Load PR-built or caller-supplied image into docker
+      if: needs.build-image.result == 'success' || inputs.caller_image_artifact != ''
       run: |
-        zstd -d -c /tmp/openemr-pr-built.tar.zst | docker load
+        # Find whichever .tar.zst the download step landed in /tmp — Phase 2.5's
+        # build-image uploads openemr-pr-built.tar.zst; a Phase 7c-docker caller
+        # may name its artifact file differently. Glob rather than assume.
+        TARBALL=$(find /tmp -maxdepth 1 -name '*.tar.zst' -type f | head -1)
+        if [[ -z "$TARBALL" ]]; then
+          echo "::error::no .tar.zst image artifact found in /tmp after download"
+          find /tmp -maxdepth 1 -type f
+          exit 1
+        fi
+        # Parse the loaded image ref out of `docker load` output rather
+        # than assume the tag name. Phase 2.5's build-image tags as
+        # openemr/openemr:pr-built directly; a Phase 7c-docker caller may
+        # save under any openemr/openemr:<name> tag (e.g., matching what
+        # it intends to push). Retag to :pr-built so downstream steps
+        # have a single well-known handle.
+        LOAD_OUT=$(zstd -d -c "$TARBALL" | docker load)
+        echo "$LOAD_OUT"
+        LOADED=$(echo "$LOAD_OUT" | awk -F': ' '/^Loaded image:/{print $2; exit}')
+        if [[ -z "$LOADED" ]]; then
+          echo "::error::could not determine loaded image ref from docker load output"
+          exit 1
+        fi
+        if [[ "$LOADED" != "openemr/openemr:pr-built" ]]; then
+          docker tag "$LOADED" openemr/openemr:pr-built
+        fi
         docker image inspect openemr/openemr:pr-built --format 'loaded: {{.Id}}'
 
     - name: Resolve effective image tags
@@ -302,11 +400,20 @@ jobs:
         MATRIX_SCENARIO: ${{ matrix.scenario }}
         MATRIX_IMAGE_TAG: ${{ matrix.image_tag }}
         BUILD_IMAGE_RESULT: ${{ needs.build-image.result }}
+        CALLER_IMAGE_ARTIFACT: ${{ inputs.caller_image_artifact }}
         # TO_TAG is already a job-level env, but hoisted here for the
         # zero-splice-in-run: convention.
       run: |
         LOCAL_TAG="openemr/openemr:pr-built"
-        if [[ "$BUILD_IMAGE_RESULT" == "success" ]]; then
+        # BUILT signals "the to-side image is a locally-loaded artifact"
+        # rather than a Docker Hub tag. Two sources:
+        #   Phase 2.5 — the build-image job produced openemr-pr-built-image
+        #   Phase 7c-docker gate — the caller (docker-build-release.yml)
+        #     supplied the release-candidate image as caller_image_artifact
+        # Either way, the load step above loaded it as
+        # openemr/openemr:pr-built, so downstream scenarios can treat both
+        # paths identically.
+        if [[ "$BUILD_IMAGE_RESULT" == "success" || -n "$CALLER_IMAGE_ARTIFACT" ]]; then
           BUILT="true"
         else
           BUILT="false"

--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -69,14 +69,18 @@ on:
         type: boolean
         default: false
   # Phase 7c-docker-latest-gate: called by docker-build-release.yml as
-  # a pre-publish gate. The caller has already built the release image,
-  # saved it via `docker save` as a workflow-run artifact, and dispatches
-  # this workflow with the artifact name. When these inputs are set, the
-  # build-image job self-skips (the caller-supplied artifact takes its
-  # place) and the acceptance matrix downloads the caller's artifact
-  # instead of Phase 2.5's `openemr-pr-built-image` default.
+  # a pre-publish gate. Caller has already pushed the release image to
+  # Docker Hub under a candidate tag (e.g., openemr/openemr:release-
+  # candidate-<run-id>-<attempt>) and dispatches this workflow with
+  # to_tag set to that candidate suffix. The candidate is a real Docker
+  # Hub tag on the same repo, so the acceptance matrix pulls it via the
+  # existing to_tag path — no artifact plumbing, no local image load,
+  # and the bytes tested here are the exact bytes that publish's
+  # imagetools-create step will alias onto the final tag list.
   # Mirrors acceptance-package.yml's Phase 7c-tarball workflow_call
-  # (caller_tarball_artifact / to_version).
+  # shape (different underlying transport — Docker Hub tag vs workflow
+  # artifact — but same "caller-supplied artifact, pre-publish gate"
+  # semantics).
   workflow_call:
     inputs:
       from_tag:
@@ -84,11 +88,11 @@ on:
         required: false
         type: string
         default: 'latest'
-      caller_image_artifact:
-        description: 'Name of the workflow-run artifact holding the caller-supplied docker save zstd tarball (openemr-<name>.tar.zst). When set, skips this workflow build-image job and treats the caller-supplied image as if it were PR-built.'
+      to_tag:
+        description: 'Target openemr Docker Hub tag (typically a Phase 7c-docker gate candidate tag suffix; may also be next / a version-pinned tag / etc.).'
         required: false
         type: string
-        default: ''
+        default: 'next'
   push:
     paths:
     - '.github/workflows/acceptance-docker.yml'
@@ -157,34 +161,18 @@ jobs:
       env:
         EVENT_NAME: ${{ github.event_name }}
         DISPATCH_BUILD_LOCALLY: ${{ inputs.build_locally }}
-        CALLER_IMAGE_ARTIFACT: ${{ inputs.caller_image_artifact }}
         PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         PUSH_BEFORE_SHA: ${{ github.event.before }}
         PUSH_HEAD_SHA: ${{ github.sha }}
       run: |
         set -euo pipefail
-
-        # Phase 7c-docker workflow_call gate — caller (docker-build-release.yml)
-        # already has the image built and uploaded as an artifact. Skip the
-        # diff-detection dance entirely; force build_locally=true. The
-        # build-image job self-skips (see its `if:` condition below) and
-        # the acceptance jobs download the caller's artifact name instead
-        # of Phase 2.5's `openemr-pr-built-image` default.
-        #
-        # Detect on CALLER_IMAGE_ARTIFACT being non-empty, NOT on
-        # $EVENT_NAME == 'workflow_call' — GitHub Actions reports the
-        # original event that started the CALLING workflow in a called
-        # workflow's github.event_name (so workflow_dispatch of docker-
-        # build-release.yml surfaces as workflow_dispatch here, not
-        # workflow_call). The caller_image_artifact input is only populated
-        # in workflow_call invocations, so it's the reliable signal.
-        # (Same signal choice as acceptance-package.yml's detect-mode.)
-        if [[ -n "$CALLER_IMAGE_ARTIFACT" ]]; then
-          echo "==> workflow_call gate mode (caller=${CALLER_IMAGE_ARTIFACT}): forcing build_locally=true"
-          echo "build_locally=true" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
+        # Phase 7c-docker workflow_call gate: caller pushed the candidate
+        # image to Docker Hub before calling this workflow, so build_locally
+        # stays FALSE (the existing to_tag path pulls the candidate from
+        # Docker Hub, no local build needed). Nothing to add here for
+        # workflow_call — inputs.to_tag flows through the normal fallback
+        # chain to the acceptance matrix's TO_TAG env.
 
         # Manual dispatch always wins — honor the input.
         if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
@@ -225,14 +213,7 @@ jobs:
   # build is self-contained to this workflow run.
   build-image:
     needs: [detect-mode]
-    # Skip when the caller (Phase 7c-docker workflow_call gate) already
-    # supplied the image as an artifact — no point re-running docker
-    # build when the caller just did that against the exact source
-    # being validated. The acceptance job downloads the caller's
-    # artifact by name in that case.
-    if: >-
-      needs.detect-mode.outputs.build_locally == 'true'
-      && inputs.caller_image_artifact == ''
+    if: needs.detect-mode.outputs.build_locally == 'true'
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7
@@ -276,12 +257,6 @@ jobs:
     # only if build-image itself failed (no point running the fresh-install-to
     # / upgrade scenarios if their target image failed to build) or if
     # detect-mode failed (shouldn't happen — trivial job).
-    #
-    # build-image is `skipped` in two cases: (1) detect-mode said
-    # build_locally=false (Phase 2 default path — acceptance runs against
-    # Docker Hub tags), or (2) the caller (Phase 7c-docker workflow_call
-    # gate) supplied its own image artifact — the download step below
-    # picks that up.
     if: >-
       always()
       && github.repository_owner == 'openemr' && github.repository == 'openemr/openemr'
@@ -328,74 +303,18 @@ jobs:
         # credential exposure surface.
         persist-credentials: false
 
-    # ==== Load PR-built or caller-supplied image + resolve effective tags ====
-    # Two source paths converge here:
-    #   Phase 2.5 (PR validation): build-image job just uploaded
-    #     openemr-pr-built-image. Download that.
-    #   Phase 7c-docker (workflow_call gate): caller (docker-build-release.yml)
-    #     already uploaded the release-candidate image under
-    #     inputs.caller_image_artifact — build-image self-skipped.
-    #     Download that artifact name instead.
-    #
-    # Both land the image tarball at /tmp/openemr-pr-built.tar.zst so the
-    # docker-load step below doesn't need to care which path fired.
-    - name: Download PR-built image (Phase 2.5)
-      if: needs.build-image.result == 'success' && inputs.caller_image_artifact == ''
+    # ==== Phase 2.5: load PR-built image + resolve effective tags ====
+    - name: Download PR-built image (if build-image ran)
+      if: needs.build-image.result == 'success'
       uses: actions/download-artifact@v8
       with:
         name: openemr-pr-built-image
         path: /tmp
 
-    - name: Download caller-supplied image (Phase 7c-docker gate)
-      if: inputs.caller_image_artifact != ''
-      uses: actions/download-artifact@v8
-      with:
-        name: ${{ inputs.caller_image_artifact }}
-        path: /tmp
-
-    - name: Load PR-built or caller-supplied image into docker
-      if: needs.build-image.result == 'success' || inputs.caller_image_artifact != ''
+    - name: Load PR-built image into docker (if downloaded)
+      if: needs.build-image.result == 'success'
       run: |
-        # Find whichever .tar.zst the download step landed in /tmp — Phase 2.5's
-        # build-image uploads openemr-pr-built.tar.zst; a Phase 7c-docker caller
-        # may name its artifact file differently. Enforce exactly one match:
-        # multiple tarballs would mean the two source paths (Phase 2.5 build +
-        # workflow_call caller) somehow both fired for the same run, which is
-        # a workflow shape bug worth failing loudly on rather than picking
-        # whichever `head -1` happens to return.
-        mapfile -t TARBALLS < <(find /tmp -maxdepth 1 -name '*.tar.zst' -type f)
-        case "${#TARBALLS[@]}" in
-          0)
-            echo "::error::no .tar.zst image artifact found in /tmp after download"
-            find /tmp -maxdepth 1 -type f
-            exit 1
-            ;;
-          1)
-            TARBALL="${TARBALLS[0]}"
-            ;;
-          *)
-            echo "::error::expected exactly one .tar.zst in /tmp, found ${#TARBALLS[@]}:"
-            printf '  %s\n' "${TARBALLS[@]}"
-            echo "::error::both Phase 2.5 build-image and workflow_call caller artifact appear to have downloaded — workflow shape bug."
-            exit 1
-            ;;
-        esac
-        # Parse the loaded image ref out of `docker load` output rather
-        # than assume the tag name. Phase 2.5's build-image tags as
-        # openemr/openemr:pr-built directly; a Phase 7c-docker caller may
-        # save under any openemr/openemr:<name> tag (e.g., matching what
-        # it intends to push). Retag to :pr-built so downstream steps
-        # have a single well-known handle.
-        LOAD_OUT=$(zstd -d -c "$TARBALL" | docker load)
-        echo "$LOAD_OUT"
-        LOADED=$(echo "$LOAD_OUT" | awk -F': ' '/^Loaded image:/{print $2; exit}')
-        if [[ -z "$LOADED" ]]; then
-          echo "::error::could not determine loaded image ref from docker load output"
-          exit 1
-        fi
-        if [[ "$LOADED" != "openemr/openemr:pr-built" ]]; then
-          docker tag "$LOADED" openemr/openemr:pr-built
-        fi
+        zstd -d -c /tmp/openemr-pr-built.tar.zst | docker load
         docker image inspect openemr/openemr:pr-built --format 'loaded: {{.Id}}'
 
     - name: Resolve effective image tags
@@ -415,20 +334,11 @@ jobs:
         MATRIX_SCENARIO: ${{ matrix.scenario }}
         MATRIX_IMAGE_TAG: ${{ matrix.image_tag }}
         BUILD_IMAGE_RESULT: ${{ needs.build-image.result }}
-        CALLER_IMAGE_ARTIFACT: ${{ inputs.caller_image_artifact }}
         # TO_TAG is already a job-level env, but hoisted here for the
         # zero-splice-in-run: convention.
       run: |
         LOCAL_TAG="openemr/openemr:pr-built"
-        # BUILT signals "the to-side image is a locally-loaded artifact"
-        # rather than a Docker Hub tag. Two sources:
-        #   Phase 2.5 — the build-image job produced openemr-pr-built-image
-        #   Phase 7c-docker gate — the caller (docker-build-release.yml)
-        #     supplied the release-candidate image as caller_image_artifact
-        # Either way, the load step above loaded it as
-        # openemr/openemr:pr-built, so downstream scenarios can treat both
-        # paths identically.
-        if [[ "$BUILD_IMAGE_RESULT" == "success" || -n "$CALLER_IMAGE_ARTIFACT" ]]; then
+        if [[ "$BUILD_IMAGE_RESULT" == "success" ]]; then
           BUILT="true"
         else
           BUILT="false"

--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -358,13 +358,28 @@ jobs:
       run: |
         # Find whichever .tar.zst the download step landed in /tmp — Phase 2.5's
         # build-image uploads openemr-pr-built.tar.zst; a Phase 7c-docker caller
-        # may name its artifact file differently. Glob rather than assume.
-        TARBALL=$(find /tmp -maxdepth 1 -name '*.tar.zst' -type f | head -1)
-        if [[ -z "$TARBALL" ]]; then
-          echo "::error::no .tar.zst image artifact found in /tmp after download"
-          find /tmp -maxdepth 1 -type f
-          exit 1
-        fi
+        # may name its artifact file differently. Enforce exactly one match:
+        # multiple tarballs would mean the two source paths (Phase 2.5 build +
+        # workflow_call caller) somehow both fired for the same run, which is
+        # a workflow shape bug worth failing loudly on rather than picking
+        # whichever `head -1` happens to return.
+        mapfile -t TARBALLS < <(find /tmp -maxdepth 1 -name '*.tar.zst' -type f)
+        case "${#TARBALLS[@]}" in
+          0)
+            echo "::error::no .tar.zst image artifact found in /tmp after download"
+            find /tmp -maxdepth 1 -type f
+            exit 1
+            ;;
+          1)
+            TARBALL="${TARBALLS[0]}"
+            ;;
+          *)
+            echo "::error::expected exactly one .tar.zst in /tmp, found ${#TARBALLS[@]}:"
+            printf '  %s\n' "${TARBALLS[@]}"
+            echo "::error::both Phase 2.5 build-image and workflow_call caller artifact appear to have downloaded — workflow shape bug."
+            exit 1
+            ;;
+        esac
         # Parse the loaded image ref out of `docker load` output rather
         # than assume the tag name. Phase 2.5's build-image tags as
         # openemr/openemr:pr-built directly; a Phase 7c-docker caller may

--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -93,6 +93,11 @@ on:
         required: false
         type: string
         default: 'next'
+      test_arm64:
+        description: 'Also run every matrix scenario on ubuntu-24.04-arm runners (Phase 7c-docker latest-gate uses this to cover the arm64 slice of the multi-arch candidate manifest, since the runner arch decides which slice `docker pull` fetches). Doubles matrix breadth; leave false for push/PR/schedule paths where the arm64 signal is not worth the runner-minutes.'
+        required: false
+        type: boolean
+        default: false
   push:
     paths:
     - '.github/workflows/acceptance-docker.yml'
@@ -262,13 +267,25 @@ jobs:
       && github.repository_owner == 'openemr' && github.repository == 'openemr/openemr'
       && needs.detect-mode.result == 'success'
       && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       # Don't fail-fast: if fresh-install on `next` breaks, we still
       # want the upgrade scenario's result to distinguish "target
       # installer broken" from "upgrade path broken" (different code).
       fail-fast: false
       matrix:
+        # Runner-arch dimension: workflow_call sets test_arm64=true (Phase
+        # 7c-docker latest-gate) so the matrix expands to both amd64 and
+        # arm64 slices of the candidate manifest. Every other invocation
+        # (push/PR/schedule) stays amd64-only.
+        runs_on: ${{ inputs.test_arm64 && fromJson('["ubuntu-24.04", "ubuntu-24.04-arm"]') || fromJson('["ubuntu-24.04"]') }}
+        # Scenario dimension. Cartesian-multiplied with runs_on; each
+        # cell picks up its scenario-specific description/image_tag/
+        # test_group from the include block below.
+        scenario:
+        - fresh-install-from
+        - fresh-install-to
+        - upgrade
         include:
         - scenario: fresh-install-from
           description: 'Fresh install of from_tag'
@@ -293,7 +310,11 @@ jobs:
       # upgrade scenario.
       COMPOSE_PROJECT_NAME: openemr-acceptance
       ACCEPTANCE_ARTIFACT_URL: http://localhost:8580
-    name: ${{ matrix.description }}
+    # Arch suffix in the job name so amd64 vs arm64 runs of the same
+    # scenario are distinguishable in the Actions UI + `gh pr checks`
+    # output. On amd64-only matrices the suffix is still present but
+    # redundant — worth the visual consistency vs a conditional.
+    name: ${{ matrix.description }} (${{ matrix.runs_on }})
     steps:
     - uses: actions/checkout@v7
       with:

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -39,14 +39,14 @@
 #     this true for rows whose docker_tags include `latest` — see
 #     docker-release-orchestrator.yml.
 #
-#     arm64 note: acceptance-gate exercises linux/amd64 only (the GHA
-#     runner arch). But the candidate manifest is multi-arch, and
-#     publish aliases the SAME manifest onto each final tag — so the
-#     amd64 slice tested and the amd64 slice on `latest` share a
-#     digest, and arm64 is preserved without a fresh rebuild. Accepted
-#     trade-off per the plan doc: arm64 bytes ship without direct
-#     acceptance coverage, but not through a separate build path
-#     that could drift from the tested amd64.
+#     arm64 coverage: acceptance-gate runs its full 3-scenario matrix on
+#     BOTH ubuntu-24.04 (amd64) and ubuntu-24.04-arm (arm64) runners
+#     via the workflow_call's test_arm64=true input. `docker pull` on
+#     each runner fetches the matching slice from the candidate's
+#     multi-arch manifest, so both platform slices are validated end-
+#     to-end. Publish then aliases the SAME multi-arch manifest onto
+#     each final tag — the digests users pull for both amd64 and arm64
+#     match what acceptance ran against.
 #
 # Triggered by:
 #   * workflow_dispatch -- driven by the master orchestrator on its
@@ -434,6 +434,14 @@ jobs:
       # whether Docker Hub `latest` is currently installable, complementing
       # the gated candidate assertion.
       to_tag: ${{ needs.build.outputs.candidate_tag }}
+      # Expand the matrix onto ubuntu-24.04-arm runners in addition to
+      # amd64. `docker pull` on arm64 runners fetches the arm64 slice
+      # of the candidate manifest, so with test_arm64=true we're
+      # covering both platform slices — closes the arm64-unvalidated
+      # gap the original 7c-docker plan doc accepted. Runner-minutes
+      # roughly double for the gated path only (every other acceptance-
+      # docker invocation stays amd64-only via test_arm64's false default).
+      test_arm64: true
     # acceptance-docker doesn't currently use org secrets, but forward
     # for future-proofing (matches build-release.yml -> acceptance-package
     # workflow_call shape).

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -24,6 +24,26 @@
 #     override bakes rel-810 source, which is what a maintainer
 #     testing a branch in isolation typically wants.
 #
+#   gate_with_acceptance
+#     Phase 7c-docker-latest-gate: when true, refactor build+push into
+#     build (amd64-only local load + save to artifact) -> workflow_call
+#     acceptance-docker.yml against the saved image -> publish (multi-arch
+#     build+push, gated on acceptance passing). Default false preserves
+#     the pre-Phase-7c single-step build+push shape for every row that
+#     doesn't ship a widely-consumed floating tag. Orchestrator sets this
+#     true for rows whose docker_tags include `latest` — see
+#     docker-release-orchestrator.yml.
+#
+#     arm64 note: the acceptance run only exercises linux/amd64 (the
+#     GHA runner arch). The publish step still builds + pushes both
+#     platforms; the gated amd64 build's layers cache-restore into the
+#     publish build so amd64 typically reuses the tested bits. arm64
+#     is built fresh in publish and ships unvalidated — accepted
+#     trade-off, per the plan doc's arm64-gap note (arm64-specific
+#     bugs are rare vs the base-image-drift class of failures the
+#     daily gate catches, and arm64 emulation would substantially
+#     inflate daily orchestrator runtime).
+#
 # Triggered by:
 #   * workflow_dispatch -- driven by the master orchestrator on its
 #     scheduled tick (dispatching against this branch's --ref with both
@@ -53,6 +73,10 @@ on:
         required: false
         type: string
         default: ''
+      gate_with_acceptance:
+        description: 'Phase 7c-docker: gate publish on acceptance-docker.yml passing. Orchestrator sets true for rows whose docker_tags include `latest`.'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -80,6 +104,16 @@ jobs:
     # Only run from the upstream openemr/openemr repository (not downstream forks).
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr'
     runs-on: ubuntu-24.04
+    # Downstream jobs (acceptance-gate + publish, gated path only) look
+    # up the artifact by name and re-derive the tag list + build args
+    # from these outputs, matching GitHub Actions cross-job wiring
+    # conventions (env doesn't cross job boundaries).
+    outputs:
+      image_artifact_name: openemr-release-candidate-image
+      expanded_tags: ${{ steps.expand_docker_tags.outputs.list }}
+      openemr_version_ref: ${{ steps.resolve_openemr_version_ref.outputs.ref }}
+      image_version: ${{ steps.image_version.outputs.value }}
+      build_date: ${{ steps.build_date.outputs.date }}
     steps:
     - name: Checkout
       uses: actions/checkout@v7
@@ -205,7 +239,51 @@ jobs:
         echo "value=$VERSION" >> "$GITHUB_OUTPUT"
         echo "✓ Extracted IMAGE_VERSION=$VERSION from openemr@${REF}/version.php"
 
-    - name: Build and push
+    # Phase 7c-docker gated path splits build+push into three jobs:
+    # here we build amd64 only (loaded locally, not pushed), save +
+    # upload as an artifact, and let the acceptance-gate + publish jobs
+    # downstream consume it. Cache-to writes the amd64 layers to GHA
+    # cache so publish's multi-arch rebuild cache-restores amd64 rather
+    # than re-doing that work — the tested amd64 bits and the pushed
+    # amd64 bits should be byte-identical in the common case.
+    #
+    # Non-gated path (the pre-Phase-7c shape, still every non-latest row)
+    # keeps the single-step multi-arch build+push below.
+    - name: Build (amd64, load only) — gated path
+      if: inputs.gate_with_acceptance
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/release
+        platforms: linux/amd64
+        load: true
+        tags: openemr/openemr:release-candidate
+        build-args: |
+          OPENEMR_VERSION=${{ steps.resolve_openemr_version_ref.outputs.ref }}
+          IMAGE_VERSION=${{ steps.image_version.outputs.value }}
+          BUILD_DATE=${{ steps.build_date.outputs.date }}
+        cache-to: type=gha,mode=max,scope=docker-build-release-${{ github.ref }}-${{ inputs.docker_tags }}
+        cache-from: type=gha,scope=docker-build-release-${{ github.ref }}-${{ inputs.docker_tags }}
+
+    - name: Save gated image to tarball
+      if: inputs.gate_with_acceptance
+      run: |
+        docker save openemr/openemr:release-candidate \
+          | zstd -T0 -3 -o /tmp/openemr-release-candidate.tar.zst
+        ls -lh /tmp/openemr-release-candidate.tar.zst
+
+    - uses: actions/upload-artifact@v7
+      if: inputs.gate_with_acceptance
+      with:
+        name: openemr-release-candidate-image
+        path: /tmp/openemr-release-candidate.tar.zst
+        # Only needs to survive from build -> acceptance-gate -> publish
+        # within one workflow run — no downstream consumer, no reason
+        # to accumulate.
+        retention-days: 1
+        compression-level: 0  # Already zstd-compressed; skip re-compress
+
+    - name: Build and push — non-gated path
+      if: ${{ !inputs.gate_with_acceptance }}
       uses: docker/build-push-action@v7
       with:
         context: ./docker/release
@@ -217,7 +295,56 @@ jobs:
           IMAGE_VERSION=${{ steps.image_version.outputs.value }}
           BUILD_DATE=${{ steps.build_date.outputs.date }}
 
-    - name: Verify pushed image OCI labels
+    - name: Verify local gated image OCI labels — gated path
+      if: inputs.gate_with_acceptance
+      env:
+        EXPECTED_REVISION: ${{ steps.resolve_openemr_version_ref.outputs.ref }}
+        EXPECTED_VERSION: ${{ steps.image_version.outputs.value }}
+        EXPECTED_BUILD_DATE: ${{ steps.build_date.outputs.date }}
+        REF_TAG: openemr/openemr:release-candidate
+      run: |
+        # Same verify logic as non-gated path below, just skips the
+        # `docker pull` (image is already local from the --load build).
+        # Runs against the release-candidate tag so any Dockerfile drift
+        # is caught before we spend acceptance-gate + publish CI budget.
+        inspect_label() {
+          V=$(docker inspect --format "{{ index .Config.Labels \"org.opencontainers.image.$1\" }}" "$REF_TAG")
+          if [ "$V" = "<no value>" ]; then
+            echo ""
+          else
+            echo "$V"
+          fi
+        }
+        FAIL=0
+        ACTUAL_REVISION=$(inspect_label revision)
+        if [ "$ACTUAL_REVISION" != "$EXPECTED_REVISION" ]; then
+          echo "::error::revision label '$ACTUAL_REVISION' doesn't match expected '$EXPECTED_REVISION'"
+          FAIL=1
+        fi
+        ACTUAL_VERSION=$(inspect_label version)
+        if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+          echo "::error::version label '$ACTUAL_VERSION' doesn't match expected '$EXPECTED_VERSION'"
+          FAIL=1
+        fi
+        ACTUAL_CREATED=$(inspect_label created)
+        if [ "$ACTUAL_CREATED" != "$EXPECTED_BUILD_DATE" ]; then
+          echo "::error::created label '$ACTUAL_CREATED' doesn't match expected '$EXPECTED_BUILD_DATE'"
+          FAIL=1
+        fi
+        for STATIC_LABEL in title source url licenses; do
+          VALUE=$(inspect_label "$STATIC_LABEL")
+          if [ -z "$VALUE" ]; then
+            echo "::error::Image is missing org.opencontainers.image.${STATIC_LABEL} label entirely"
+            FAIL=1
+          else
+            echo "✓ ${STATIC_LABEL}=${VALUE}"
+          fi
+        done
+        [ "$FAIL" -eq 0 ] || exit 1
+        echo "✓ revision=$ACTUAL_REVISION version=$ACTUAL_VERSION created=$ACTUAL_CREATED"
+
+    - name: Verify pushed image OCI labels — non-gated path
+      if: ${{ !inputs.gate_with_acceptance }}
       env:
         EXPECTED_REVISION: ${{ steps.resolve_openemr_version_ref.outputs.ref }}
         EXPECTED_VERSION: ${{ steps.image_version.outputs.value }}
@@ -282,5 +409,119 @@ jobs:
           fi
         done
 
+        [ "$FAIL" -eq 0 ] || exit 1
+        echo "✓ revision=$ACTUAL_REVISION version=$ACTUAL_VERSION created=$ACTUAL_CREATED"
+
+  # Phase 7c-docker gate: run the full acceptance-docker matrix against
+  # the image build produced + saved as an artifact. Publish only fires
+  # if this passes. Skipped when gate_with_acceptance=false (the pre-
+  # Phase-7c shape, and the current default for every non-latest row).
+  #
+  # Runs against THIS branch's copy of acceptance-docker.yml — matches
+  # the acceptance surface the release branch says is canon. Downside:
+  # acceptance-docker.yml must exist on the target rel-branch (byte-
+  # identical propagation handles this for rel-820+ post-#13236; rel-800
+  # and rel-704 are excluded from the acceptance surface so they'd need
+  # this input kept false anyway).
+  acceptance-gate:
+    name: Acceptance gate
+    needs: [build]
+    if: inputs.gate_with_acceptance
+    uses: ./.github/workflows/acceptance-docker.yml
+    with:
+      caller_image_artifact: ${{ needs.build.outputs.image_artifact_name }}
+    # acceptance-docker doesn't currently use org secrets, but forward
+    # for future-proofing (matches build-release.yml -> acceptance-package
+    # workflow_call shape).
+    secrets: inherit
+
+  # Phase 7c-docker publish: rebuild multi-arch and push to Docker Hub.
+  # amd64 cache-restores from the gated build (same GHA cache scope), so
+  # the tested amd64 bytes and the pushed amd64 bytes should be
+  # byte-identical in the common case. arm64 is built fresh here — see
+  # the header note on the accepted arm64 gap. Skipped when
+  # gate_with_acceptance=false.
+  publish:
+    name: Publish
+    needs: [build, acceptance-gate]
+    if: inputs.gate_with_acceptance
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build multi-arch and push
+      uses: docker/build-push-action@v7
+      with:
+        context: ./docker/release
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ needs.build.outputs.expanded_tags }}
+        build-args: |
+          OPENEMR_VERSION=${{ needs.build.outputs.openemr_version_ref }}
+          IMAGE_VERSION=${{ needs.build.outputs.image_version }}
+          BUILD_DATE=${{ needs.build.outputs.build_date }}
+        cache-from: type=gha,scope=docker-build-release-${{ github.ref }}-${{ inputs.docker_tags }}
+
+    - name: Verify pushed image OCI labels
+      env:
+        EXPECTED_REVISION: ${{ needs.build.outputs.openemr_version_ref }}
+        EXPECTED_VERSION: ${{ needs.build.outputs.image_version }}
+        EXPECTED_BUILD_DATE: ${{ needs.build.outputs.build_date }}
+        TAGS_LIST: ${{ needs.build.outputs.expanded_tags }}
+      run: |
+        # Same verify shape as the non-gated build job's step. Runs
+        # against the first published tag so this catches any drift
+        # between the gated build's local verify (against
+        # release-candidate) and the pushed multi-arch image.
+        REF_TAG=$(echo "$TAGS_LIST" | head -1)
+        docker pull "$REF_TAG"
+
+        inspect_label() {
+          V=$(docker inspect --format "{{ index .Config.Labels \"org.opencontainers.image.$1\" }}" "$REF_TAG")
+          if [ "$V" = "<no value>" ]; then
+            echo ""
+          else
+            echo "$V"
+          fi
+        }
+
+        FAIL=0
+        ACTUAL_REVISION=$(inspect_label revision)
+        if [ "$ACTUAL_REVISION" != "$EXPECTED_REVISION" ]; then
+          echo "::error::revision label '$ACTUAL_REVISION' doesn't match expected '$EXPECTED_REVISION'"
+          FAIL=1
+        fi
+        ACTUAL_VERSION=$(inspect_label version)
+        if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+          echo "::error::version label '$ACTUAL_VERSION' doesn't match expected '$EXPECTED_VERSION'"
+          FAIL=1
+        fi
+        ACTUAL_CREATED=$(inspect_label created)
+        if [ "$ACTUAL_CREATED" != "$EXPECTED_BUILD_DATE" ]; then
+          echo "::error::created label '$ACTUAL_CREATED' doesn't match expected '$EXPECTED_BUILD_DATE'"
+          FAIL=1
+        fi
+        for STATIC_LABEL in title source url licenses; do
+          VALUE=$(inspect_label "$STATIC_LABEL")
+          if [ -z "$VALUE" ]; then
+            echo "::error::Image is missing org.opencontainers.image.${STATIC_LABEL} label entirely"
+            FAIL=1
+          else
+            echo "✓ ${STATIC_LABEL}=${VALUE}"
+          fi
+        done
         [ "$FAIL" -eq 0 ] || exit 1
         echo "✓ revision=$ACTUAL_REVISION version=$ACTUAL_VERSION created=$ACTUAL_CREATED"

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -81,6 +81,14 @@ on:
 permissions:
   contents: read
 
+# Artifact name used to hand the gated build's saved image tarball
+# from the build job to the acceptance-gate + publish jobs. Defined
+# once here so a rename touches one line — the upload step reads
+# it via env, and the build job's `image_artifact_name` output also
+# resolves from it via env, keeping the two references in sync.
+env:
+  GATE_IMAGE_ARTIFACT_NAME: openemr-release-candidate-image
+
 # Serialize per-(branch, docker_tags) builds. Two dispatches with
 # the same ref AND the same docker_tags input (e.g., release-
 # targets.yml push + daily orchestrator cron landing close
@@ -109,7 +117,7 @@ jobs:
     # from these outputs, matching GitHub Actions cross-job wiring
     # conventions (env doesn't cross job boundaries).
     outputs:
-      image_artifact_name: openemr-release-candidate-image
+      image_artifact_name: ${{ env.GATE_IMAGE_ARTIFACT_NAME }}
       expanded_tags: ${{ steps.expand_docker_tags.outputs.list }}
       openemr_version_ref: ${{ steps.resolve_openemr_version_ref.outputs.ref }}
       image_version: ${{ steps.image_version.outputs.value }}
@@ -274,7 +282,7 @@ jobs:
     - uses: actions/upload-artifact@v7
       if: inputs.gate_with_acceptance
       with:
-        name: openemr-release-candidate-image
+        name: ${{ env.GATE_IMAGE_ARTIFACT_NAME }}
         path: /tmp/openemr-release-candidate.tar.zst
         # Only needs to survive from build -> acceptance-gate -> publish
         # within one workflow run — no downstream consumer, no reason

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -25,24 +25,28 @@
 #     testing a branch in isolation typically wants.
 #
 #   gate_with_acceptance
-#     Phase 7c-docker-latest-gate: when true, refactor build+push into
-#     build (amd64-only local load + save to artifact) -> workflow_call
-#     acceptance-docker.yml against the saved image -> publish (multi-arch
-#     build+push, gated on acceptance passing). Default false preserves
-#     the pre-Phase-7c single-step build+push shape for every row that
-#     doesn't ship a widely-consumed floating tag. Orchestrator sets this
-#     true for rows whose docker_tags include `latest` — see
+#     Phase 7c-docker-latest-gate: when true, split build+push into a
+#     three-job flow: (1) build multi-arch and push to a temporary
+#     candidate tag on Docker Hub (openemr/openemr:release-candidate-
+#     <run-id>-<attempt>); (2) workflow_call acceptance-docker.yml with
+#     to_tag pointed at the candidate; (3) on acceptance pass, alias
+#     the candidate's manifest onto each final tag via `docker buildx
+#     imagetools create` (no rebuild — digest-identical across
+#     build/test/publish). A cleanup-candidate job then deletes the
+#     candidate tag from Docker Hub. Default false preserves the
+#     pre-Phase-7c single-step build+push shape for every row that
+#     doesn't ship a widely-consumed floating tag. Orchestrator sets
+#     this true for rows whose docker_tags include `latest` — see
 #     docker-release-orchestrator.yml.
 #
-#     arm64 note: the acceptance run only exercises linux/amd64 (the
-#     GHA runner arch). The publish step still builds + pushes both
-#     platforms; the gated amd64 build's layers cache-restore into the
-#     publish build so amd64 typically reuses the tested bits. arm64
-#     is built fresh in publish and ships unvalidated — accepted
-#     trade-off, per the plan doc's arm64-gap note (arm64-specific
-#     bugs are rare vs the base-image-drift class of failures the
-#     daily gate catches, and arm64 emulation would substantially
-#     inflate daily orchestrator runtime).
+#     arm64 note: acceptance-gate exercises linux/amd64 only (the GHA
+#     runner arch). But the candidate manifest is multi-arch, and
+#     publish aliases the SAME manifest onto each final tag — so the
+#     amd64 slice tested and the amd64 slice on `latest` share a
+#     digest, and arm64 is preserved without a fresh rebuild. Accepted
+#     trade-off per the plan doc: arm64 bytes ship without direct
+#     acceptance coverage, but not through a separate build path
+#     that could drift from the tested amd64.
 #
 # Triggered by:
 #   * workflow_dispatch -- driven by the master orchestrator on its
@@ -81,13 +85,16 @@ on:
 permissions:
   contents: read
 
-# Artifact name used to hand the gated build's saved image tarball
-# from the build job to the acceptance-gate + publish jobs. Defined
-# once here so a rename touches one line — the upload step reads
-# it via env, and the build job's `image_artifact_name` output also
-# resolves from it via env, keeping the two references in sync.
+# Candidate tag suffix used to hand the gated build's image from the
+# build job (single multi-arch push) to acceptance-gate (which pulls
+# the candidate from Docker Hub) and publish (which aliases the
+# candidate's manifest onto each final tag). Unique per run+attempt so
+# concurrent orchestrator dispatches never collide on the same tag.
+# The `release-candidate-` prefix + GitHub run coordinates make the
+# tag unmistakably temporary; the cleanup-candidate job deletes it
+# once publish finishes (or acceptance fails).
 env:
-  GATE_IMAGE_ARTIFACT_NAME: openemr-release-candidate-image
+  GATE_CANDIDATE_TAG: release-candidate-${{ github.run_id }}-${{ github.run_attempt }}
 
 # Serialize per-(branch, docker_tags) builds. Two dispatches with
 # the same ref AND the same docker_tags input (e.g., release-
@@ -112,12 +119,12 @@ jobs:
     # Only run from the upstream openemr/openemr repository (not downstream forks).
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr'
     runs-on: ubuntu-24.04
-    # Downstream jobs (acceptance-gate + publish, gated path only) look
-    # up the artifact by name and re-derive the tag list + build args
-    # from these outputs, matching GitHub Actions cross-job wiring
-    # conventions (env doesn't cross job boundaries).
+    # Downstream jobs (acceptance-gate, publish, cleanup-candidate — gated
+    # path only) look up the candidate tag + expanded final tag list from
+    # these outputs. `env` doesn't cross job boundaries so re-surface the
+    # tag suffix here even though it originated from a workflow-level env.
     outputs:
-      image_artifact_name: ${{ env.GATE_IMAGE_ARTIFACT_NAME }}
+      candidate_tag: ${{ env.GATE_CANDIDATE_TAG }}
       expanded_tags: ${{ steps.expand_docker_tags.outputs.list }}
       openemr_version_ref: ${{ steps.resolve_openemr_version_ref.outputs.ref }}
       image_version: ${{ steps.image_version.outputs.value }}
@@ -247,48 +254,30 @@ jobs:
         echo "value=$VERSION" >> "$GITHUB_OUTPUT"
         echo "✓ Extracted IMAGE_VERSION=$VERSION from openemr@${REF}/version.php"
 
-    # Phase 7c-docker gated path splits build+push into three jobs:
-    # here we build amd64 only (loaded locally, not pushed), save +
-    # upload as an artifact, and let the acceptance-gate + publish jobs
-    # downstream consume it. Cache-to writes the amd64 layers to GHA
-    # cache so publish's multi-arch rebuild cache-restores amd64 rather
-    # than re-doing that work — the tested amd64 bits and the pushed
-    # amd64 bits should be byte-identical in the common case.
+    # Phase 7c-docker gated path: multi-arch build+push to a candidate
+    # tag on Docker Hub (single push, both platforms). acceptance-gate
+    # pulls the candidate; publish aliases the candidate's manifest onto
+    # each final tag via `docker buildx imagetools create` (no rebuild,
+    # digest-identical across build/test/publish); cleanup-candidate
+    # deletes the tag after publish. arm64 IS validated in the sense
+    # that publish points its final-tag manifests at the same digest
+    # acceptance ran against — but acceptance itself only exercises
+    # amd64 (GHA runner arch). Accepted trade-off per plan doc.
     #
     # Non-gated path (the pre-Phase-7c shape, still every non-latest row)
     # keeps the single-step multi-arch build+push below.
-    - name: Build (amd64, load only) — gated path
+    - name: Build and push to candidate tag — gated path
       if: inputs.gate_with_acceptance
       uses: docker/build-push-action@v7
       with:
         context: ./docker/release
-        platforms: linux/amd64
-        load: true
-        tags: openemr/openemr:release-candidate
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: openemr/openemr:${{ env.GATE_CANDIDATE_TAG }}
         build-args: |
           OPENEMR_VERSION=${{ steps.resolve_openemr_version_ref.outputs.ref }}
           IMAGE_VERSION=${{ steps.image_version.outputs.value }}
           BUILD_DATE=${{ steps.build_date.outputs.date }}
-        cache-to: type=gha,mode=max,scope=docker-build-release-${{ github.ref }}-${{ inputs.docker_tags }}
-        cache-from: type=gha,scope=docker-build-release-${{ github.ref }}-${{ inputs.docker_tags }}
-
-    - name: Save gated image to tarball
-      if: inputs.gate_with_acceptance
-      run: |
-        docker save openemr/openemr:release-candidate \
-          | zstd -T0 -3 -o /tmp/openemr-release-candidate.tar.zst
-        ls -lh /tmp/openemr-release-candidate.tar.zst
-
-    - uses: actions/upload-artifact@v7
-      if: inputs.gate_with_acceptance
-      with:
-        name: ${{ env.GATE_IMAGE_ARTIFACT_NAME }}
-        path: /tmp/openemr-release-candidate.tar.zst
-        # Only needs to survive from build -> acceptance-gate -> publish
-        # within one workflow run — no downstream consumer, no reason
-        # to accumulate.
-        retention-days: 1
-        compression-level: 0  # Already zstd-compressed; skip re-compress
 
     - name: Build and push — non-gated path
       if: ${{ !inputs.gate_with_acceptance }}
@@ -303,18 +292,18 @@ jobs:
           IMAGE_VERSION=${{ steps.image_version.outputs.value }}
           BUILD_DATE=${{ steps.build_date.outputs.date }}
 
-    - name: Verify local gated image OCI labels — gated path
+    - name: Verify pushed candidate image OCI labels — gated path
       if: inputs.gate_with_acceptance
       env:
         EXPECTED_REVISION: ${{ steps.resolve_openemr_version_ref.outputs.ref }}
         EXPECTED_VERSION: ${{ steps.image_version.outputs.value }}
         EXPECTED_BUILD_DATE: ${{ steps.build_date.outputs.date }}
-        REF_TAG: openemr/openemr:release-candidate
+        REF_TAG: openemr/openemr:${{ env.GATE_CANDIDATE_TAG }}
       run: |
-        # Same verify logic as non-gated path below, just skips the
-        # `docker pull` (image is already local from the --load build).
-        # Runs against the release-candidate tag so any Dockerfile drift
-        # is caught before we spend acceptance-gate + publish CI budget.
+        # Same verify logic as the non-gated path below, but runs against
+        # the candidate tag before spending acceptance-gate CI budget on
+        # an image whose Dockerfile ARGs didn't flow through correctly.
+        docker pull "$REF_TAG"
         inspect_label() {
           V=$(docker inspect --format "{{ index .Config.Labels \"org.opencontainers.image.$1\" }}" "$REF_TAG")
           if [ "$V" = "<no value>" ]; then
@@ -437,30 +426,31 @@ jobs:
     if: inputs.gate_with_acceptance
     uses: ./.github/workflows/acceptance-docker.yml
     with:
-      caller_image_artifact: ${{ needs.build.outputs.image_artifact_name }}
+      # acceptance-docker.yml's matrix pulls both fresh-install-to and
+      # the upgrade-target boot from `openemr/openemr:${TO_TAG}`, so
+      # passing the candidate suffix here routes all "to-side" scenarios
+      # at the exact bytes we're gating. fresh-install-from stays on
+      # `latest` (real currently-shipped image) — a secondary smoke of
+      # whether Docker Hub `latest` is currently installable, complementing
+      # the gated candidate assertion.
+      to_tag: ${{ needs.build.outputs.candidate_tag }}
     # acceptance-docker doesn't currently use org secrets, but forward
     # for future-proofing (matches build-release.yml -> acceptance-package
     # workflow_call shape).
     secrets: inherit
 
-  # Phase 7c-docker publish: rebuild multi-arch and push to Docker Hub.
-  # amd64 cache-restores from the gated build (same GHA cache scope), so
-  # the tested amd64 bytes and the pushed amd64 bytes should be
-  # byte-identical in the common case. arm64 is built fresh here — see
-  # the header note on the accepted arm64 gap. Skipped when
-  # gate_with_acceptance=false.
+  # Phase 7c-docker publish: alias the candidate's manifest onto each
+  # final tag via `docker buildx imagetools create`. Same digest, so the
+  # bytes acceptance-gate tested ARE the bytes each final tag now points
+  # at — no rebuild, no cache-hit assumption, byte-identical guarantee.
+  # amd64 + arm64 both preserved (they were both pushed under the
+  # candidate at build time). Skipped when gate_with_acceptance=false.
   publish:
     name: Publish
     needs: [build, acceptance-gate]
     if: inputs.gate_with_acceptance
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v7
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
@@ -470,18 +460,22 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Build multi-arch and push
-      uses: docker/build-push-action@v7
-      with:
-        context: ./docker/release
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: ${{ needs.build.outputs.expanded_tags }}
-        build-args: |
-          OPENEMR_VERSION=${{ needs.build.outputs.openemr_version_ref }}
-          IMAGE_VERSION=${{ needs.build.outputs.image_version }}
-          BUILD_DATE=${{ needs.build.outputs.build_date }}
-        cache-from: type=gha,scope=docker-build-release-${{ github.ref }}-${{ inputs.docker_tags }}
+    - name: Alias candidate manifest onto each final tag
+      env:
+        CANDIDATE_TAG: ${{ needs.build.outputs.candidate_tag }}
+        TAGS_LIST: ${{ needs.build.outputs.expanded_tags }}
+      run: |
+        # `docker buildx imagetools create -t <new> <src>` creates a new
+        # manifest pointing at <src>'s digest without pulling image blobs.
+        # Multi-arch is preserved (the source manifest is a manifest list).
+        # Idempotent: re-running against an existing tag rewrites its
+        # pointer (harmless if source digest is the same).
+        SRC="openemr/openemr:${CANDIDATE_TAG}"
+        for tag in $TAGS_LIST; do
+          [ -z "$tag" ] && continue
+          echo "==> aliasing ${SRC} -> ${tag}"
+          docker buildx imagetools create -t "$tag" "$SRC"
+        done
 
     - name: Verify pushed image OCI labels
       env:
@@ -491,9 +485,10 @@ jobs:
         TAGS_LIST: ${{ needs.build.outputs.expanded_tags }}
       run: |
         # Same verify shape as the non-gated build job's step. Runs
-        # against the first published tag so this catches any drift
-        # between the gated build's local verify (against
-        # release-candidate) and the pushed multi-arch image.
+        # against the first published final tag as a defense-in-depth
+        # check that imagetools-create actually pointed the tag at a
+        # manifest with the expected labels (it should, by construction,
+        # but the check is essentially free).
         REF_TAG=$(echo "$TAGS_LIST" | head -1)
         docker pull "$REF_TAG"
 
@@ -533,3 +528,54 @@ jobs:
         done
         [ "$FAIL" -eq 0 ] || exit 1
         echo "✓ revision=$ACTUAL_REVISION version=$ACTUAL_VERSION created=$ACTUAL_CREATED"
+
+  # Phase 7c-docker cleanup: delete the candidate tag from Docker Hub
+  # after publish (success or fail). Always runs on the gated path;
+  # continue-on-error so cleanup failures don't fail the whole workflow
+  # run (a stale candidate tag is cosmetically annoying but not a
+  # correctness issue — the tag naming makes it obvious that
+  # release-candidate-<run-id>-<attempt> is an internal artifact).
+  cleanup-candidate:
+    name: Cleanup candidate tag
+    needs: [build, acceptance-gate, publish]
+    if: always() && inputs.gate_with_acceptance && needs.build.result == 'success'
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Delete candidate tag from Docker Hub
+      continue-on-error: true
+      env:
+        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        CANDIDATE_TAG: ${{ needs.build.outputs.candidate_tag }}
+      run: |
+        set -euo pipefail
+        # Docker Hub v2 API tag deletion requires a JWT obtained from the
+        # user-login endpoint (the raw personal-access-token isn't
+        # sufficient for this specific endpoint). Cheap two-call flow:
+        # POST /v2/users/login/ -> extract .token -> DELETE the tag.
+        # If the JWT flow fails (e.g., PAT lacks write:delete perms), the
+        # `continue-on-error: true` on the step swallows it — the tag
+        # lingers until manually cleaned, non-blocking.
+        JWT=$(curl -sf -H 'Content-Type: application/json' \
+          -X POST -d "{\"username\": \"${DOCKERHUB_USERNAME}\", \"password\": \"${DOCKERHUB_TOKEN}\"}" \
+          https://hub.docker.com/v2/users/login/ | jq -r .token)
+        if [ -z "$JWT" ] || [ "$JWT" = "null" ]; then
+          echo "::warning::could not obtain Docker Hub JWT — cleanup skipped, candidate tag left in place"
+          exit 0
+        fi
+        echo "==> DELETE openemr/openemr:${CANDIDATE_TAG}"
+        HTTP_CODE=$(curl -s -o /tmp/dh-delete-response -w '%{http_code}' \
+          -X DELETE \
+          -H "Authorization: JWT ${JWT}" \
+          "https://hub.docker.com/v2/repositories/openemr/openemr/tags/${CANDIDATE_TAG}/")
+        case "$HTTP_CODE" in
+          204|404)
+            # 204 = deleted; 404 = already gone (idempotent re-run).
+            echo "==> cleanup OK (HTTP ${HTTP_CODE})"
+            ;;
+          *)
+            echo "::warning::Docker Hub tag delete returned HTTP ${HTTP_CODE}:"
+            cat /tmp/dh-delete-response || true
+            exit 1
+            ;;
+        esac

--- a/.github/workflows/docker-release-orchestrator.yml
+++ b/.github/workflows/docker-release-orchestrator.yml
@@ -139,9 +139,29 @@ jobs:
         DOCKER_TAGS: ${{ matrix.docker_tags }}
         OPENEMR_VERSION_REF: ${{ matrix.openemr_version_ref }}
       run: |
+        # Phase 7c-docker-latest-gate: rows that ship `latest` get the
+        # acceptance pre-publish gate. Every daily build of `latest`
+        # reaches the widest end-user surface (Docker Hub's default
+        # pull) so a regression there propagates fastest — worth the
+        # extra ~30 min acceptance runtime per gated build. Other
+        # rows (version-pinned tags, dev/next floating tags) stay on
+        # the single-step build+push shape: smaller blast radius,
+        # cheaper daily runtime. See docker-build-release.yml's
+        # gate_with_acceptance input description for the mechanic.
+        GATE="false"
+        IFS=',' read -ra TAG_ARR <<< "$DOCKER_TAGS"
+        for tag in "${TAG_ARR[@]}"; do
+          tag="${tag// /}"   # strip whitespace
+          if [[ "$tag" == "latest" ]]; then
+            GATE="true"
+            break
+          fi
+        done
+
         gh workflow run docker-build-release.yml \
           --repo "$REPO" \
           --ref "$BRANCH" \
           -f docker_tags="$DOCKER_TAGS" \
-          -f openemr_version_ref="$OPENEMR_VERSION_REF"
-        echo "Dispatched $BRANCH with docker_tags=$DOCKER_TAGS openemr_version_ref=$OPENEMR_VERSION_REF"
+          -f openemr_version_ref="$OPENEMR_VERSION_REF" \
+          -f gate_with_acceptance="$GATE"
+        echo "Dispatched $BRANCH with docker_tags=$DOCKER_TAGS openemr_version_ref=$OPENEMR_VERSION_REF gate_with_acceptance=$GATE"


### PR DESCRIPTION
Adds a pre-publish acceptance gate on the daily rebuild of `latest`. Rows whose `docker_tags` include `latest` (currently rel-820) fan out through a new four-job flow instead of the pre-Phase-7c single-step build+push. Rounds out Phase 7 — see the update log in [`docs/artifact-acceptance-testing-plan.md`](https://github.com/openemr/openemr/blob/master/docs/artifact-acceptance-testing-plan.md) (#12811) for the deferral-reversal decision on 2026-07-27–28 that drove this now rather than after 8.3.0 ships.

## Why now (not after 8.3.0)

The daily orchestrator rebuilds `latest` every 06:00 UTC against rel-820. Waiting until 8.3.0 ships (rotates `latest` ownership from rel-820 to rel-830) leaves ~2 weeks of ungated daily latest pushes to Docker Hub — during a window where Alpine base-image drift or apk security updates could silently ship a broken `latest` to end users. Cheaper to backport the acceptance surface to rel-820 first (already done: #13227 composer, #13233 byte-identical config, #13237 mode-preservation fix, #13238 phpstan exclude, #13236 sync) and land the gate on master now.

## The four-job flow (gated path)

Uses **Docker Hub itself as the artifact substrate** — the build pushes multi-arch to a temporary candidate tag, acceptance pulls that tag, publish aliases the candidate's manifest onto each final tag (no rebuild, byte-identical guarantee), cleanup deletes the candidate.

1. **build** — single multi-arch build+push to `openemr/openemr:release-candidate-<run-id>-<attempt>`. Both amd64 and arm64 land under that candidate tag. OCI-label verify against the candidate before spending acceptance-gate budget.
2. **acceptance-gate** — `workflow_call ./.github/workflows/acceptance-docker.yml` with `to_tag: <candidate-suffix>` + `test_arm64: true`. Existing to_tag path pulls the candidate from Docker Hub. Matrix expands from 3 → 6 cells (3 scenarios × amd64/arm64 runners); each runner arch fetches its own slice from the multi-arch candidate manifest.
3. **publish** — `docker buildx imagetools create -t <final> <candidate>` for each expanded tag (latest, 8.2.0, 8.2.0-YYYY-MM-DD). Copies the manifest without touching image blobs. Every final tag points at the **same digest** acceptance tested — genuinely byte-identical, no cache-hit gamble.
4. **cleanup-candidate** — always runs on the gated path (`if: always() && ...`), deletes candidate tag from Docker Hub via v2 API JWT flow. `continue-on-error: true` so cleanup failures leave a stale-but-obviously-temporary tag rather than failing the run.

Non-gated path (every non-`latest` row): unchanged single-step build+push. Same job name (`build`), same steps, just with conditional `if:` guards.

## arm64 coverage — closed

The prior sketch of this PR accepted an arm64-unvalidated gap. That's now closed: acceptance-gate runs the full 3-scenario matrix on both `ubuntu-24.04` and `ubuntu-24.04-arm` runners (free for public repos since GH's Jan 2025 GA). `docker pull` on each runner fetches the matching platform slice from the candidate's multi-arch manifest, so both slices are validated end-to-end. Publish's imagetools alias preserves the same multi-arch manifest, so the arm64 users pull matches the arm64 acceptance ran against.

Runner-minutes roughly double on the gated path only — every other acceptance-docker invocation (push, PR, schedule, non-gated dispatch) keeps `test_arm64` false and runs amd64-only.

## Files touched

- `.github/workflows/acceptance-docker.yml` — workflow_call trigger with `from_tag` / `to_tag` / `test_arm64` inputs; matrix restructured into `runs_on × scenario` cartesian with per-scenario extensions via `include`; job names suffixed with runner arch for distinguishability.
- `.github/workflows/docker-build-release.yml` — `gate_with_acceptance: bool` input; workflow-level env for the candidate tag suffix (`release-candidate-<run-id>-<attempt>`); build job outputs (`candidate_tag`, `expanded_tags`, `openemr_version_ref`, `image_version`, `build_date`); gated + non-gated conditional build/verify steps; three new jobs (`acceptance-gate`, `publish`, `cleanup-candidate`).
- `.github/workflows/docker-release-orchestrator.yml` — fan-out step inspects each row's `docker_tags` and passes `gate_with_acceptance=true` when `latest` is in the tag list.

## Bootstrap sequence

Order matters for a clean rollout:

1. Merge this PR to master
2. Manually trigger sync-byte-identical.yml (`gh workflow run sync-byte-identical.yml --repo openemr/openemr --ref master`)
3. Merge the resulting rel-820 sync PR
4. Next orchestrator run (06:00 UTC daily, or manual dispatch) picks up the gated flow

If the orchestrator fires against rel-820 BEFORE step 3, `-f gate_with_acceptance=true` would fail dispatch (rel-820's docker-build-release.yml wouldn't yet recognize the input). rel-800 and rel-704 rows don't have `latest` in their tags so they stay ungated regardless.

## Test plan

- [ ] CI actionlint passes on all 3 changed workflows
- [ ] Merge → sync-byte-identical propagates all 3 to rel-820 (`docker-release-orchestrator.yml` stays master-only per its `github.ref` guard)
- [ ] Post-merge: manual `workflow_dispatch` of docker-build-release.yml on rel-820 with `docker_tags=manual-test` + `gate_with_acceptance=false` — verifies non-gated path still works
- [ ] Post-merge: manual `workflow_dispatch` of docker-release-orchestrator.yml (`include=rel-820`) — verifies gated path end-to-end: build → gate (6 matrix cells) → publish (imagetools alias) → cleanup
- [ ] Verify candidate tag briefly appears on Docker Hub during the run and is deleted after publish; final tags (`latest`, `8.2.0`, `8.2.0-YYYY-MM-DD`) all reflect the tested digest via `docker manifest inspect openemr/openemr:latest`
- [ ] After ~24h of daily runs: `latest` on Docker Hub reflects a gated build; arm64 slice's digest matches amd64 slice's tested revision label

🤖 Generated with [Claude Code](https://claude.com/claude-code)