### PR TITLE
ci(sync): exclude docker-build-release.yml from rel-800/rel-704 sync

### DIFF
--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -103,8 +103,23 @@
 #                                                  bin/console tweak
 
 files:
-# Docker orchestration surface -- the historical byte-identical scope
-- .github/workflows/docker-build-release.yml
+# Docker orchestration surface -- the historical byte-identical scope.
+#
+# docker-build-release.yml carries an `if:`-gated
+# `uses: ./.github/workflows/acceptance-docker.yml` reference (Phase 7c-
+# docker-latest-gate, openemr/openemr#13239). GitHub Actions parses the
+# reusable-workflow reference at workflow-dispatch time, BEFORE
+# evaluating the `if:` guard. So on rel-800 + rel-704 (which don't
+# carry acceptance-docker.yml — see the exclude-branches on that entry
+# below) the whole workflow file fails to load with HTTP 422
+# "workflow was not found". Excluding docker-build-release.yml from
+# those two branches keeps them on the pre-Phase-7c single-step
+# build+push shape (still working for months); future changes to
+# docker-build-release.yml propagate to master + rel-820+ automatically
+# and need a manual cherry-pick if they matter for rel-800/rel-704.
+# Same trade-off already accepted for acceptance-docker.yml itself.
+- path: .github/workflows/docker-build-release.yml
+  exclude-branches: [rel-800, rel-704]
 - .github/workflows/docker-test-core.yml
 - .github/workflows/docker-test-release.yml
 - .github/actions/test-actions-core/action.yml


### PR DESCRIPTION
Fix a bootstrap issue introduced by #13239 (Phase 7c-docker-latest-gate).

## The break

#13239 added an \`if:\`-gated \`uses: ./.github/workflows/acceptance-docker.yml\` reference to \`docker-build-release.yml\`. Auto-sync #13243 propagated the new file onto rel-800 and rel-704. Those branches don't carry \`acceptance-docker.yml\` (per its own \`exclude-branches: [rel-800, rel-704]\` in byte-identical config). GitHub Actions parses reusable-workflow \`uses:\` references at workflow-dispatch time — BEFORE evaluating the \`if:\` guard — so the whole workflow file fails to load with:

\`\`\`
HTTP 422: failed to parse workflow: error parsing called workflow
"" -> "./.github/workflows/acceptance-docker.yml"
: failed to fetch workflow: workflow was not found.
\`\`\`

Yesterday's manual orchestrator dispatch failed both rel-800 and rel-704 at fan-out time with the above error.

## The fix (3 PRs, this + 2 branch reverts)

* **This PR (master):** convert docker-build-release.yml's byte-identical entry from simple-string form to object form with \`exclude-branches: [rel-800, rel-704]\`. Matches the pattern already used for acceptance-docker.yml itself.
* **rel-800 revert (openemr/openemr#TBD):** restore docker-build-release.yml on rel-800 to the pre-Phase-7c single-step build+push shape (identical to master's copy at openemr/openemr@fddcfba354).
* **rel-704 revert (openemr/openemr#TBD):** same as above for rel-704.

## Trade-off

Future master-side changes to docker-build-release.yml no longer propagate to rel-800/rel-704 automatically; those branches keep the pre-Phase-7c version. Manual cherry-pick required if a future change matters for those branches.

Same trade-off already accepted for acceptance-docker.yml — no ops burden noted in months. rel-800 and rel-704 are old, maintenance-mode branches.

## Alternative considered

Backport the full acceptance surface (composer + tests/Acceptance/ + workflow) to rel-800 and rel-704 the same way #13227/#13233/#13236 did for rel-820. Rejected for now: rel-704 uses PHP 8.1 and can't take \`symfony/mime: ^7.3\` (needs ^6.4); the acceptance suite was written against the current codebase and may make assumptions that don't hold against 8.0.0 or 7.0.4 artifacts. Real work + real correctness risk. Kept as a future project if the "gate all daily builds" idea graduates from nice-to-have to worth-the-maintenance-cost.

## Test plan

- [ ] CI actionlint passes on the changed byte-identical.yml
- [ ] Merge this + both revert PRs
- [ ] Manual orchestrator dispatch (\`gh workflow run docker-release-orchestrator.yml --repo openemr/openemr --ref master\`) — all 4 rows fan out cleanly; rel-820 goes through the gated path, master + rel-800 + rel-704 through the non-gated path
- [ ] byte-identical validator (\`validate-byte-identical.yml\`) still passes on rel-800 and rel-704 (drift is now expected + tolerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)