### PR TITLE
ci(acceptance): Phase 7d-1 — multi-arch ChromeDriver setup composite action

### DIFF
--- a/.github/actions/setup-chromedriver-multiarch/action.yml
+++ b/.github/actions/setup-chromedriver-multiarch/action.yml
@@ -1,0 +1,92 @@
+# Install a matched Chrome + ChromeDriver pair on both amd64 and arm64
+# GitHub-hosted runners so Symfony Panther can drive a headless browser.
+#
+# Delegates by runner arch:
+#
+#   amd64 (ubuntu-24.04, x86_64) — hand off to `nanasess/setup-chromedriver@v2`.
+#   The runner ships with google-chrome pre-installed; nanasess reads that
+#   version and installs the matching ChromeDriver from Chrome for Testing.
+#   Matches the existing pattern documented in the "Panther-in-CI gotchas"
+#   memory reference: nanasess over browser-actions/setup-chrome because
+#   the latter drifts Chrome + ChromeDriver from independent release
+#   channels.
+#
+#   arm64 (ubuntu-24.04-arm, aarch64) — install chromium + chromium-driver
+#   from the xtradeb PPA. Rationale for that specific source:
+#     * Google Chrome ships amd64-only debs from Google's apt repo. No arm64.
+#     * Chrome for Testing does NOT publish a `linux-arm64` platform variant
+#       as of 2026-07 (only linux64 / mac-arm64 / mac-x64 / win32 / win64).
+#       Tracking: GoogleChromeLabs/chrome-for-testing#1 (open, promised
+#       Q2 2026 → slipped to July, crbug/374811603 still unshipped).
+#     * Ubuntu noble's own `chromium` / `chromium-browser` are snap-
+#       transitional stubs that don't work headlessly in CI.
+#     * browser-actions/setup-chrome@v2 (as of v2.1.2, 2026-05-06) still
+#       marks all Linux ARM64 columns as unsupported in its own README.
+#     * xtradeb/apps PPA publishes native arm64 debs for both chromium
+#       + chromium-driver as a byte-matched-version pair — eliminates
+#       the drift risk that killed the browser-actions path.
+#
+# When Chrome for Testing eventually ships linux-arm64, the arm64 branch
+# below becomes a drop-in swap to a manual CFT install (or, ideally,
+# nanasess grows arm64 support and both arches use it).
+#
+# Symlinks the chromium binary to /usr/local/bin/google-chrome + /chrome
+# so downstream code that autodetects a browser binary (Panther defaults,
+# Selenium capabilities without an explicit `binary` path, tests written
+# for amd64 that assume `google-chrome` exists) works unchanged on arm64.
+name: Set up ChromeDriver (multi-arch)
+description: >-
+  Install a matched Chrome + ChromeDriver pair on amd64 or arm64 GitHub-
+  hosted runners. Delegates to nanasess/setup-chromedriver@v2 on amd64
+  and to the xtradeb PPA chromium install on arm64.
+
+runs:
+  using: composite
+  steps:
+  - name: Detect runner arch
+    id: arch
+    shell: bash
+    run: |
+      case "$(uname -m)" in
+        x86_64)  echo "arch=amd64" >> "$GITHUB_OUTPUT" ;;
+        aarch64) echo "arch=arm64" >> "$GITHUB_OUTPUT" ;;
+        *)
+          echo "::error::unsupported runner arch $(uname -m); expected x86_64 or aarch64."
+          exit 1
+          ;;
+      esac
+
+  - name: Install ChromeDriver via nanasess (amd64)
+    if: steps.arch.outputs.arch == 'amd64'
+    uses: nanasess/setup-chromedriver@v2
+
+  - name: Install Chromium + chromium-driver via xtradeb PPA (arm64)
+    if: steps.arch.outputs.arch == 'arm64'
+    shell: bash
+    run: |
+      set -euxo pipefail
+      # Add PPA + install matched-pair native arm64 debs.
+      sudo add-apt-repository -y ppa:xtradeb/apps
+      sudo apt-get update
+      sudo apt-get install -y chromium chromium-driver
+
+      # xtradeb packages chromedriver as /usr/bin/chromedriver on current
+      # noble releases; symlink from /usr/local/bin (higher priority on
+      # $PATH) as a defensive no-op if the future package name shifts.
+      if [ ! -x /usr/local/bin/chromedriver ] && [ -x /usr/bin/chromedriver ]; then
+        sudo ln -sf /usr/bin/chromedriver /usr/local/bin/chromedriver
+      fi
+
+      # Panther + most Chrome-driving code autodetects a browser binary
+      # by looking for `google-chrome` first. On arm64 we have chromium
+      # at /usr/bin/chromium; symlink so autodetect finds it without
+      # each test having to know the arch.
+      sudo ln -sf /usr/bin/chromium /usr/local/bin/google-chrome
+      sudo ln -sf /usr/bin/chromium /usr/local/bin/chrome
+
+      # Surface installed versions in the log — quick diagnostic when
+      # a future upstream Chromium release breaks Panther selector
+      # behavior or driver protocol expectations.
+      chromium --version
+      chromedriver --version
+      google-chrome --version

--- a/.github/actions/setup-chromedriver-multiarch/action.yml
+++ b/.github/actions/setup-chromedriver-multiarch/action.yml
@@ -70,12 +70,19 @@ runs:
       sudo apt-get update
       sudo apt-get install -y chromium chromium-driver
 
-      # xtradeb packages chromedriver as /usr/bin/chromedriver on current
-      # noble releases; symlink from /usr/local/bin (higher priority on
-      # $PATH) as a defensive no-op if the future package name shifts.
-      if [ ! -x /usr/local/bin/chromedriver ] && [ -x /usr/bin/chromedriver ]; then
-        sudo ln -sf /usr/bin/chromedriver /usr/local/bin/chromedriver
+      # xtradeb ships chromedriver as /usr/bin/chromedriver — fail loudly
+      # if that assumption drifts (packaging rename, install-path change)
+      # rather than silently falling back to whatever chromedriver an
+      # earlier setup step happened to leave in $PATH. Force-symlink into
+      # /usr/local/bin (higher $PATH priority than /usr/bin) so callers
+      # that resolve `chromedriver` always land on the freshly-installed
+      # xtradeb copy, even if some other step pre-created the target.
+      if [ ! -x /usr/bin/chromedriver ]; then
+        echo "::error::chromium-driver package did not install /usr/bin/chromedriver — xtradeb PPA may have restructured its packaging."
+        dpkg -L chromium-driver 2>&1 | head -20 || true
+        exit 1
       fi
+      sudo ln -sf /usr/bin/chromedriver /usr/local/bin/chromedriver
 
       # Panther + most Chrome-driving code autodetects a browser binary
       # by looking for `google-chrome` first. On arm64 we have chromium

--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -221,5 +221,15 @@ files:
   exclude-branches: [rel-800, rel-704]
 - path: .github/docker/acceptance-package-compose.yml
   exclude-branches: [rel-800, rel-704]
+# Composite action used from acceptance-docker.yml (Phase 7d-1 arm64
+# ChromeDriver setup fix). Referenced via `uses: ./.github/actions/
+# setup-chromedriver-multiarch` — GitHub Actions resolves that path
+# against the workflow's checkout at dispatch time, so the action.yml
+# must exist on every branch that carries acceptance-docker.yml.
+# Excluded from rel-800 + rel-704 for the same reason acceptance-
+# docker.yml is: those branches don't carry the caller workflow, so
+# they don't need the callee action either.
+- path: .github/actions/setup-chromedriver-multiarch/**
+  exclude-branches: [rel-800, rel-704]
 - path: tests/Acceptance/**
   exclude-branches: [rel-800, rel-704]

--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -398,22 +398,27 @@ jobs:
         # but naming them keeps failure modes obvious).
         extensions: curl, dom, mbstring, tokenizer, xml
 
-    # ChromeDriver for the E2eCriticalPathTest — Panther launches a
-    # headless subprocess Chrome bound to the mapped artifact port.
-    # ubuntu-24.04 runners ship with google-chrome pre-installed
-    # (/opt/google/chrome/chrome); nanasess/setup-chromedriver@v2
-    # detects that version and installs the exactly-matching
-    # ChromeDriver from Chrome-for-Testing so Panther's
-    # driver-version-detection succeeds.
+    # Chrome + ChromeDriver for Panther-driven acceptance tests.
+    # Composite action delegates by runner arch (see the action's
+    # own comment header for the full source-choice rationale):
     #
-    # Do NOT swap this for browser-actions/setup-chrome@v1 with
-    # install-chromedriver: true — that action pulls Chrome from
-    # Google's Linux repo and ChromeDriver from CfT with independent
-    # release cadences, and drifts a mismatched pair through
-    # (Chrome 150 + ChromeDriver 151 was the concrete example that
-    # first bit this test).
+    #   amd64 — nanasess/setup-chromedriver@v2 reads the runner's
+    #   pre-installed google-chrome and installs the matching
+    #   ChromeDriver from Chrome for Testing. Do NOT swap this for
+    #   browser-actions/setup-chrome@v2 — that action pulls Chrome
+    #   and ChromeDriver from independent release channels and drifts
+    #   a mismatched pair through (Chrome 150 + ChromeDriver 151 was
+    #   the concrete example that first bit this test). Also it
+    #   still marks Linux ARM64 unsupported as of v2.1.2 (2026-05).
+    #
+    #   arm64 — xtradeb PPA chromium + chromium-driver install.
+    #   Google Chrome has no arm64 deb (Google's apt repo is
+    #   amd64-only) and Chrome for Testing hasn't shipped a
+    #   linux-arm64 platform variant yet (crbug/374811603 open).
+    #   xtradeb ships browser + driver as a matched-pair version,
+    #   eliminating the drift risk.
     - name: Set up matching ChromeDriver for Panther-driven acceptance tests
-      uses: nanasess/setup-chromedriver@v2
+      uses: ./.github/actions/setup-chromedriver-multiarch
 
     - name: Install acceptance-suite composer dependencies
       # `--no-scripts` skips OpenEMR's post-install scripts (they assume


### PR DESCRIPTION
Restores arm64 acceptance coverage that #13239 (Phase 7c-docker-latest-gate) added but couldn't ship. The first end-to-end run of the gated flow on 2026-07-28 failed at arm64 ChromeDriver setup — `nanasess/setup-chromedriver@v2` relies on the runner's pre-installed google-chrome to pick a matching ChromeDriver, and `ubuntu-24.04-arm` runners don't ship with Chrome. The action's fallback \`apt install google-chrome-stable\` also fails because Google Chrome ships amd64-only debs.

## What's in the box

New composite action at \`.github/actions/setup-chromedriver-multiarch/\` delegates by runner arch:

- **amd64**: unchanged — uses `nanasess/setup-chromedriver@v2` (matches the runner's pre-installed google-chrome to Chrome for Testing's ChromeDriver).
- **arm64**: installs `chromium` + `chromium-driver` from the [xtradeb PPA](https://launchpad.net/~xtradeb/+archive/ubuntu/apps). Symlinks the chromium binary to `/usr/local/bin/google-chrome` + `/chrome` so Panther's default binary autodetect works unchanged.

acceptance-docker.yml swaps `uses: nanasess/setup-chromedriver@v2` for `uses: ./.github/actions/setup-chromedriver-multiarch`. Once landed + synced to rel-820, Phase 7c-docker-latest-gate's `test_arm64: true` becomes functional: the daily orchestrator's gated `latest` build validates both amd64 and arm64 slices of the multi-arch candidate manifest.

byte-identical.yml adds the composite action path with the same `exclude-branches: [rel-800, rel-704]` as acceptance-docker.yml — callee only needs to exist on branches that carry the caller.

## Why xtradeb over other options

Researched + verified 2026-07-29:

- **Chrome for Testing** publishes no `linux-arm64` variant (tracked in [GoogleChromeLabs/chrome-for-testing#1](https://github.com/GoogleChromeLabs/chrome-for-testing/issues/1), crbug/374811603 still open; Q2 2026 promised launch slipped to July, unshipped as of this PR).
- **Ubuntu noble's own chromium** is a snap-transitional stub that doesn't work headlessly in CI.
- **browser-actions/setup-chrome@v2.1.2** still marks Linux ARM64 unsupported in its own README as of 2026-05-06.
- **xtradeb** ships browser + driver as a byte-matched-pair version, eliminating the drift risk that killed the browser-actions path (Chrome 150 + ChromeDriver 151 was the concrete incident that led us to nanasess in the first place).

Revisit when CFT ships linux-arm64 — likely a drop-in swap.

## acceptance-package.yml scope

Still uses nanasess directly (amd64-only). It doesn't yet have a `test_arm64` input, so composite adoption there is a follow-up when we grow acceptance-package arm64 coverage. Keeps this PR's diff narrow to the immediate 7c-docker unblocker.

## Test plan

- [ ] CI actionlint passes on acceptance-docker.yml
- [ ] Merge → sync-byte-identical propagates the new composite action + updated acceptance-docker.yml to rel-820
- [ ] Post-merge: manual \`gh workflow run docker-release-orchestrator.yml --repo openemr/openemr --ref master -f include=rel-820\` — rel-820 gated flow's 6 matrix cells (3 scenarios × amd64/arm64) all pass. First green run means Phase 7c-docker-latest-gate is truly complete with arm64 coverage.
- [ ] Verify chromium version surfaced in the arm64 job log (composite action logs it via `chromium --version` + `chromedriver --version` for debuggability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)