### PR TITLE
ci(orchestrator): only pass gate_with_acceptance when true

### DIFF
--- a/.github/workflows/docker-release-orchestrator.yml
+++ b/.github/workflows/docker-release-orchestrator.yml
@@ -158,10 +158,26 @@ jobs:
           fi
         done
 
+        # Only pass `-f gate_with_acceptance=...` when we actually want
+        # the gate on (GATE=true). rel-800 and rel-704 carry the pre-
+        # Phase-7c docker-build-release.yml (see the exclude-branches
+        # for that path in .github/byte-identical.yml) which doesn't
+        # declare a `gate_with_acceptance` input — GitHub Actions
+        # rejects `gh workflow run -f <unknown>` with HTTP 422
+        # "Unexpected inputs provided", failing dispatch entirely
+        # before the target workflow even loads. Omitting the flag
+        # lets the receiving workflow's input default (false) do the
+        # right thing whether the input exists (master + rel-820) or
+        # not (rel-800 + rel-704).
+        GATE_ARGS=()
+        if [[ "$GATE" == "true" ]]; then
+          GATE_ARGS=(-f gate_with_acceptance=true)
+        fi
+
         gh workflow run docker-build-release.yml \
           --repo "$REPO" \
           --ref "$BRANCH" \
           -f docker_tags="$DOCKER_TAGS" \
           -f openemr_version_ref="$OPENEMR_VERSION_REF" \
-          -f gate_with_acceptance="$GATE"
+          "${GATE_ARGS[@]}"
         echo "Dispatched $BRANCH with docker_tags=$DOCKER_TAGS openemr_version_ref=$OPENEMR_VERSION_REF gate_with_acceptance=$GATE"


### PR DESCRIPTION
Follow-up to #13239 (Phase 7c-docker-latest-gate) + #13245/#13246 (the rel-800/rel-704 reverts).

## The break

Today's manual orchestrator dispatch failed rel-800 and rel-704 at fan-out:

\`\`\`
could not create workflow dispatch event: HTTP 422:
Unexpected inputs provided: ["gate_with_acceptance"]
\`\`\`

Those branches carry the reverted (pre-Phase-7c) \`docker-build-release.yml\` — no \`gate_with_acceptance\` input. But this orchestrator unconditionally sends \`-f gate_with_acceptance=false\` for those rows. GitHub Actions rejects unknown \`workflow_dispatch\` inputs at the API layer before the workflow file loads.

## The fix

Build a conditional args array; only include the flag when GATE=true (i.e., only for rows with \`latest\` in \`docker_tags\` — currently just rel-820).

- master + rel-820 have the Phase 7c-era workflow with the input declared (default: false). Omission keeps the same behavior via the default.
- rel-800 + rel-704 have the reverted workflow without the input. Omission avoids the 422.

No changes needed to the downstream \`docker-build-release.yml\`.

## Test plan

- [ ] CI actionlint passes
- [ ] Merge → next orchestrator run (manual dispatch or 06:00 UTC schedule): all 4 rows dispatch cleanly; rel-820 goes through the gated path with test_arm64=true; master + rel-800 + rel-704 go through the non-gated single-step build+push

🤖 Generated with [Claude Code](https://claude.com/claude-code)