### PR TITLE
ci(acceptance): Phase 7d-2 — PR-time build_locally arm64 coverage

### DIFF
--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -212,19 +212,49 @@ jobs:
   # Build the target image from the PR's docker/release/Dockerfile.
   # Runs only when detect-mode resolved build_locally=true.
   #
-  # Output: openemr/openemr:pr-built loaded from a workflow-artifact
-  # tarball. Each acceptance matrix job downloads + loads the image
-  # locally, so nothing is pushed to Docker Hub (or GHCR) — the
-  # build is self-contained to this workflow run.
+  # Output: openemr/openemr:pr-built loaded from a per-arch
+  # workflow-artifact tarball. Each acceptance matrix job downloads
+  # + loads the image locally, so nothing is pushed to Docker Hub
+  # (or GHCR) — the build is self-contained to this workflow run.
+  #
+  # Phase 7d-2: matrix on `runs_on` so arm64 gets its own native
+  # build when test_arm64=true. Chose two parallel single-arch native
+  # builds (amd64 on ubuntu-24.04, arm64 on ubuntu-24.04-arm) over a
+  # single multi-arch build on amd64 because native builds skip QEMU
+  # emulation (arm64 under emulation is ~10x slower than native) and
+  # each produces its own arch-specific artifact for the arch-matched
+  # acceptance job downstream. Both runner types are free for public
+  # repos.
   build-image:
     needs: [detect-mode]
     if: needs.detect-mode.outputs.build_locally == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mirrors the acceptance job's runs_on dimension: test_arm64
+        # true → build for both archs; default → amd64 only.
+        runs_on: ${{ inputs.test_arm64 && fromJson('["ubuntu-24.04", "ubuntu-24.04-arm"]') || fromJson('["ubuntu-24.04"]') }}
+    name: build-image (${{ matrix.runs_on }})
     steps:
     - uses: actions/checkout@v7
       with:
         # No git ops after checkout (docker build only).
         persist-credentials: false
+
+    - name: Compute arch label
+      # Convert the runs_on runner ref to a stable "amd64" / "arm64"
+      # label. Used both in the artifact name (so per-arch uploads
+      # don't collide) and in the tag (harmless local suffix that
+      # makes docker save output identifiable in per-arch logs).
+      id: arch
+      shell: bash
+      run: |
+        case "$(uname -m)" in
+          x86_64)  echo "label=amd64" >> "$GITHUB_OUTPUT" ;;
+          aarch64) echo "label=arm64" >> "$GITHUB_OUTPUT" ;;
+          *) echo "::error::unsupported runner arch $(uname -m)"; exit 1 ;;
+        esac
 
     - name: Build target image from PR Dockerfile
       # Uses the Dockerfile's default OPENEMR_VERSION=master, so the
@@ -251,7 +281,10 @@ jobs:
 
     - uses: actions/upload-artifact@v7
       with:
-        name: openemr-pr-built-image
+        # Per-arch artifact name so amd64 + arm64 uploads coexist
+        # without stomping each other. Acceptance job's download step
+        # picks the one matching its runner arch.
+        name: openemr-pr-built-image-${{ steps.arch.outputs.label }}
         path: /tmp/openemr-pr-built.tar.zst
         retention-days: 1
         compression-level: 0  # Already zstd-compressed; skip re-compress
@@ -324,12 +357,25 @@ jobs:
         # credential exposure surface.
         persist-credentials: false
 
-    # ==== Phase 2.5: load PR-built image + resolve effective tags ====
-    - name: Download PR-built image (if build-image ran)
+    # ==== Phase 2.5 (+ Phase 7d-2 arm64 dimension): load PR-built image ====
+    - name: Compute arch label
+      # Per-arch artifact naming (Phase 7d-2): amd64 runners pick the
+      # amd64 tarball, arm64 runners pick the arm64 tarball, so each
+      # acceptance cell loads the image slice matching its own runner.
+      id: arch
+      shell: bash
+      run: |
+        case "$(uname -m)" in
+          x86_64)  echo "label=amd64" >> "$GITHUB_OUTPUT" ;;
+          aarch64) echo "label=arm64" >> "$GITHUB_OUTPUT" ;;
+          *) echo "::error::unsupported runner arch $(uname -m)"; exit 1 ;;
+        esac
+
+    - name: Download PR-built image (if build-image ran, arch-matched)
       if: needs.build-image.result == 'success'
       uses: actions/download-artifact@v8
       with:
-        name: openemr-pr-built-image
+        name: openemr-pr-built-image-${{ steps.arch.outputs.label }}
         path: /tmp
 
     - name: Load PR-built image into docker (if downloaded)

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -388,12 +388,21 @@ jobs:
         set -euo pipefail
         target_ref="release-prep/${REL_BRANCH}"
         echo "==> Dispatching acceptance-docker.yml against ${target_ref}"
+        # Phase 7d-2: test_arm64=true expands build-image into a two-arch
+        # matrix (amd64 + arm64 native runners, per-arch artifacts) and
+        # the acceptance matrix into 6 cells (3 scenarios × 2 archs).
+        # Catches rel-branch Dockerfile regressions that only surface on
+        # arm64 at release-prep review time, rather than post-merge on
+        # the daily latest-gate. Dispatch swallows arg-unknown failures
+        # so pre-Phase-7d-2 rel-branches (still using the amd64-only
+        # build-image shape) keep working.
         if ! gh workflow run acceptance-docker.yml \
           --repo "${{ github.repository }}" \
           --ref "${target_ref}" \
-          -f build_locally=true
+          -f build_locally=true \
+          -f test_arm64=true
         then
-          echo "::warning::acceptance-docker.yml dispatch failed for ${target_ref} (workflow file may predate build_locally input on this rel-branch); continuing release-prep without docker-side pre-merge acceptance gate"
+          echo "::warning::acceptance-docker.yml dispatch failed for ${target_ref} (workflow file may predate build_locally or test_arm64 input on this rel-branch); continuing release-prep without docker-side pre-merge acceptance gate"
         fi
 
     # --- Master-side partner PR (release-finalize) ---------------------


### PR DESCRIPTION
Extends Phase 7d-1 (#13254) into acceptance-docker.yml's build-image job (Phase 2.5 PR-time path), closing the release-prep-PR arm64 gap that Phase 7d-1's daily latest-gate leaves open.

## The gap

Phase 7d-1 shipped native-arm64 acceptance coverage on the DAILY latest-gate (rel-820 orchestrator dispatch → gated docker-build-release → workflow_call acceptance-docker with test_arm64=true). But the `build-image` job in acceptance-docker.yml's PR-time build_locally path was still amd64-only:

- `docker build docker/release` on ubuntu-24.04 → amd64 image
- One artifact `openemr-pr-built-image`
- Downstream acceptance runs both amd64 + arm64, but arm64 cells download an amd64 tarball → `docker load` fails or wrong-arch image runs under emulation

Result: arm64 regressions in a rel-branch's Dockerfile (base-image bump, apk pkg drift, etc.) only surface post-merge on the daily orchestrator, not at release-prep review time when they're cheap to catch.

## The fix

`build-image` job matrixed on `runs_on: [ubuntu-24.04, ubuntu-24.04-arm]` gated on the existing `test_arm64` input:

- Each arch builds natively (no QEMU) on its own runner. amd64+arm64 GHA runners both free for public repos.
- Per-arch artifact naming: `openemr-pr-built-image-amd64` / `openemr-pr-built-image-arm64`.
- Acceptance job's download step picks the artifact matching its own runner arch (`uname -m` → label). No cross-arch tarball loads.

`release-prep.yml`'s dispatch of acceptance-docker.yml grows `-f test_arm64=true` alongside the existing `-f build_locally=true`. Swallow-on-failure guard preserved so pre-Phase-7d-2 rel-branches (still on the amd64-only build-image shape) degrade to amd64-only rather than failing hard.

Every other trigger (PR touching docker/release/**, schedule, workflow_dispatch without test_arm64) stays amd64-only. Default behavior unchanged.

## Test plan

- [ ] CI actionlint passes
- [ ] Merge → sync-byte-identical propagates to rel-820
- [ ] Post-merge, manual workflow_dispatch of acceptance-docker.yml on rel-820 with `build_locally=true test_arm64=true` — verifies both build-image cells produce arch-matched artifacts and all 6 acceptance cells load + boot correctly
- [ ] Next release-prep cycle (7d-2 auto-fires via release-prep.yml's dispatch) — release-prep PR CI shows 6 acceptance cells, arm64 regressions in the Dockerfile caught pre-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)