### PR TITLE
feat(acceptance): Phase 3.6 — ZIP acceptance coverage for fresh-install + wizard-install

### DIFF
--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -233,16 +233,26 @@ jobs:
         # Actions reports the original event that started the CALLING
         # workflow in a called workflow's github.event_name (so
         # workflow_dispatch of build-release.yml surfaces as
-        # workflow_dispatch here, not workflow_call). Either caller_*
-        # input being populated is the reliable signal; build-release.yml
-        # sets both to the same artifact name (single bundle contains
-        # both formats), but the gate honours either alone as well.
+        # workflow_dispatch here, not workflow_call).
+        #
+        # Enforce both-or-neither on the caller_*_artifact pair. If the
+        # caller passes only one (say tarball), the other-format matrix
+        # cells (zip) would either fail their download step or silently
+        # skip — masking a real integration mistake at the caller side.
+        # build-release.yml correctly passes both today (single bundle
+        # contains both formats), so requiring symmetric inputs costs
+        # nothing at the intended caller and catches misconfiguration
+        # in any future caller cleanly.
         if [[ -n "$CALLER_TARBALL_ARTIFACT" || -n "$CALLER_ZIP_ARTIFACT" ]]; then
+          if [[ -z "$CALLER_TARBALL_ARTIFACT" || -z "$CALLER_ZIP_ARTIFACT" ]]; then
+            echo "::error::workflow_call requires BOTH caller_tarball_artifact AND caller_zip_artifact to be set (or neither). Got tarball='${CALLER_TARBALL_ARTIFACT:-<empty>}', zip='${CALLER_ZIP_ARTIFACT:-<empty>}'."
+            exit 1
+          fi
           if [[ -z "$DISPATCH_TO_VERSION" ]]; then
             echo "::error::workflow_call with caller_tarball_artifact/caller_zip_artifact requires to_version to be set explicitly"
             exit 1
           fi
-          echo "==> workflow_call gate mode (tarball=${CALLER_TARBALL_ARTIFACT:-<none>}, zip=${CALLER_ZIP_ARTIFACT:-<none>}): forcing build_locally=true"
+          echo "==> workflow_call gate mode (tarball=${CALLER_TARBALL_ARTIFACT}, zip=${CALLER_ZIP_ARTIFACT}): forcing build_locally=true"
           echo "build_locally=true" >> "$GITHUB_OUTPUT"
           emit_to_version "true"
           exit 0

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -89,6 +89,11 @@ on:
         required: false
         type: string
         default: ''
+      caller_zip_artifact:
+        description: 'Name of the workflow-run artifact holding the caller-supplied ZIP (openemr-<to_version>.zip). When set, skips this workflow build-tarball job and treats the caller-supplied ZIP as if it were PR-built. Phase 3.6 companion to caller_tarball_artifact — build-release.yml passes both since its release-output bundle contains both formats under the same artifact name.'
+        required: false
+        type: string
+        default: ''
   push:
     paths:
     - '.github/workflows/acceptance-package.yml'
@@ -175,6 +180,7 @@ jobs:
         DISPATCH_BUILD_LOCALLY: ${{ inputs.build_locally }}
         DISPATCH_TO_VERSION: ${{ inputs.to_version }}
         CALLER_TARBALL_ARTIFACT: ${{ inputs.caller_tarball_artifact }}
+        CALLER_ZIP_ARTIFACT: ${{ inputs.caller_zip_artifact }}
         PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -214,27 +220,29 @@ jobs:
         }
 
         # Phase 7c workflow_call gate — caller (build-release.yml)
-        # already has the tarball built and uploaded as an artifact.
-        # Skip the diff-detection dance entirely; treat as build_locally=true
-        # with the caller-supplied version. The build-tarball job self-
-        # skips (see its `if:` condition below) and the bootflags step
-        # downloads the caller's artifact name instead of Phase 3.5's
-        # `openemr-pr-built-tarball` default.
+        # already has the tarball (+ Phase 3.6 ZIP) built and uploaded
+        # as an artifact. Skip the diff-detection dance entirely; treat
+        # as build_locally=true with the caller-supplied version. The
+        # build-tarball job self-skips (see its `if:` condition below)
+        # and the bootflags step downloads the caller's artifact name
+        # instead of Phase 3.5's `openemr-pr-built-tarball` /
+        # `openemr-pr-built-zip` defaults.
         #
-        # Detect on CALLER_TARBALL_ARTIFACT being non-empty, NOT on
-        # $EVENT_NAME == 'workflow_call' — GitHub Actions reports the
-        # original event that started the CALLING workflow in a called
-        # workflow's github.event_name (so workflow_dispatch of build-
-        # release.yml surfaces as workflow_dispatch here, not
-        # workflow_call). The caller_tarball_artifact input is only
-        # populated in workflow_call invocations, so it's the reliable
-        # signal.
-        if [[ -n "$CALLER_TARBALL_ARTIFACT" ]]; then
+        # Detect on CALLER_TARBALL_ARTIFACT / CALLER_ZIP_ARTIFACT being
+        # non-empty, NOT on $EVENT_NAME == 'workflow_call' — GitHub
+        # Actions reports the original event that started the CALLING
+        # workflow in a called workflow's github.event_name (so
+        # workflow_dispatch of build-release.yml surfaces as
+        # workflow_dispatch here, not workflow_call). Either caller_*
+        # input being populated is the reliable signal; build-release.yml
+        # sets both to the same artifact name (single bundle contains
+        # both formats), but the gate honours either alone as well.
+        if [[ -n "$CALLER_TARBALL_ARTIFACT" || -n "$CALLER_ZIP_ARTIFACT" ]]; then
           if [[ -z "$DISPATCH_TO_VERSION" ]]; then
-            echo "::error::workflow_call with caller_tarball_artifact requires to_version to be set explicitly"
+            echo "::error::workflow_call with caller_tarball_artifact/caller_zip_artifact requires to_version to be set explicitly"
             exit 1
           fi
-          echo "==> workflow_call gate mode (caller=${CALLER_TARBALL_ARTIFACT}): forcing build_locally=true"
+          echo "==> workflow_call gate mode (tarball=${CALLER_TARBALL_ARTIFACT:-<none>}, zip=${CALLER_ZIP_ARTIFACT:-<none>}): forcing build_locally=true"
           echo "build_locally=true" >> "$GITHUB_OUTPUT"
           emit_to_version "true"
           exit 0
@@ -347,13 +355,15 @@ jobs:
   build-tarball:
     needs: [detect-mode]
     # Skip when the caller (Phase 7c workflow_call gate) already
-    # supplied the tarball as an artifact — no point re-running
+    # supplied the tarball (or ZIP) as an artifact — no point re-running
     # PackageAssembler when the caller just did that against the exact
     # tree being validated. The bootflags step downloads the caller's
-    # artifact by name in that case.
+    # artifact by name in that case. Either caller_* input being set
+    # is enough to skip since build-release.yml passes both.
     if: >-
       needs.detect-mode.outputs.build_locally == 'true'
       && inputs.caller_tarball_artifact == ''
+      && inputs.caller_zip_artifact == ''
     runs-on: ubuntu-24.04
     env:
       # Single source of truth for the to_version label — see the
@@ -397,7 +407,7 @@ jobs:
       # symfony/console + symfony/process deps.
       run: composer install --prefer-dist --no-progress --no-scripts --no-interaction
 
-    - name: Build tarball from PR checkout via PackageAssembler
+    - name: Build package from PR checkout via PackageAssembler
       # --release-version uses the workflow's to_version so the output
       # filename matches what boot-package.sh's VERSION arg + downstream
       # scratch-dir naming expects. Version string doesn't get baked
@@ -405,21 +415,37 @@ jobs:
       #
       # --openemr-dir is the PR checkout itself; --output-dir writes
       # under /tmp so the artifact upload step can grab it by known path.
+      # PackageAssembler produces BOTH openemr-<version>.tar.gz AND
+      # openemr-<version>.zip in one pass — both are uploaded below for
+      # the Phase 3.6 matrix's `format` dimension.
       run: |
         mkdir -p /tmp/release-output
         php tools/release/bin/package-assemble.php \
           --release-version="${TO_VERSION}" \
           --openemr-dir=. \
           --output-dir=/tmp/release-output
-        ls -lh "/tmp/release-output/openemr-${TO_VERSION}.tar.gz"
+        ls -lh \
+          "/tmp/release-output/openemr-${TO_VERSION}.tar.gz" \
+          "/tmp/release-output/openemr-${TO_VERSION}.zip"
 
-    - uses: actions/upload-artifact@v7
+    - name: Upload PR-built tarball artifact
+      uses: actions/upload-artifact@v7
       with:
         name: openemr-pr-built-tarball
-        # Upload just the .tar.gz; the .zip is a duplicate for
-        # Windows-user convenience on the real release and isn't
-        # what the linux-based acceptance stack extracts.
         path: /tmp/release-output/openemr-${{ needs.detect-mode.outputs.to_version }}.tar.gz
+        retention-days: 1
+
+    # Phase 3.6: upload the ZIP under a distinct artifact name so the
+    # acceptance matrix's `format: zip` cells can download it in parallel
+    # with the tarball cells. Distinct artifact-per-format keeps each
+    # matrix leg's download step size-minimal (a single file) and lets
+    # the workflow_call gate reference each format independently
+    # (caller_tarball_artifact / caller_zip_artifact).
+    - name: Upload PR-built zip artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: openemr-pr-built-zip
+        path: /tmp/release-output/openemr-${{ needs.detect-mode.outputs.to_version }}.zip
         retention-days: 1
 
   acceptance:
@@ -440,6 +466,9 @@ jobs:
       # from "upgrade path broken" (different code paths).
       fail-fast: false
       matrix:
+        # Scenarios × formats. Two dimensions folded into an `include`
+        # list because the cartesian isn't uniform — see below.
+        #
         # Scenarios:
         #   fresh-install   — CLI install-helper.php then acceptance suite
         #   wizard-install  — no install-helper; InstallWizardUiTest
@@ -450,26 +479,47 @@ jobs:
         #                     pre-migration; UpgradeWizardUiTest walks
         #                     sql_upgrade.php via Panther
         #
-        # `upgrade` and `wizard-upgrade` are gated on either explicit
-        # workflow_dispatch (where the caller supplies from_version +
-        # to_version explicitly) OR the Phase 3.5 build_locally path
-        # (where PR-built tarball is to_version, any shipped tarball
-        # is from_version, and the pair is meaningful for pre-merge
-        # validation). On acceptance-surface-only push/PR/schedule the
-        # from_version default would need to point at a shipped tarball
-        # and right now the most recent tarball is 8.2.0 itself — no
-        # earlier tarball asset exists on the release page (patch
-        # releases only shipped .zip patches). Once 8.3.0 releases and
-        # the from_version default becomes 8.2.0 → 8.3.0, both upgrade
-        # scenarios can move back into the default matrix
-        # unconditionally.
-        # `inputs.caller_tarball_artifact` (workflow_call from
-        # build-release.yml's Phase 7c gate) also expands the matrix —
-        # can't gate on github.event_name for workflow_call because that
-        # reports the CALLING workflow's original event (typically
-        # workflow_dispatch), not "workflow_call". See detect-mode's
-        # gate check for the same signal choice.
-        scenario: ${{ (github.event_name == 'workflow_dispatch' || inputs.caller_tarball_artifact != '' || needs.detect-mode.outputs.build_locally == 'true') && fromJson('["fresh-install","wizard-install","upgrade","wizard-upgrade"]') || fromJson('["fresh-install","wizard-install"]') }}
+        # Formats (Phase 3.6):
+        #   tar   — extracts openemr-<version>.tar.gz via tar -xzf
+        #   zip   — extracts openemr-<version>.zip via unzip
+        # Both artifacts come out of the same PackageAssembler pass;
+        # the ZIP dimension catches ZIP-only regressions (line-ending
+        # translation, exec-bit preservation, empty-dir handling,
+        # path-separator handling — see the Phase 3.6 plan doc for
+        # the failure classes this closes).
+        #
+        # Constraint: `upgrade` and `wizard-upgrade` stay tar-only.
+        # upgrade-package.sh does not yet accept `--to-local-zip`
+        # (deferred to a Phase 3.6 follow-up); until then only the
+        # install-side scenarios exercise the ZIP format.
+        #
+        # `upgrade` and `wizard-upgrade` are also gated on either
+        # explicit workflow_dispatch (where the caller supplies
+        # from_version + to_version explicitly) OR the Phase 3.5
+        # build_locally path (where PR-built tarball is to_version,
+        # any shipped tarball is from_version, and the pair is
+        # meaningful for pre-merge validation). On acceptance-surface-
+        # only push/PR/schedule the from_version default would need to
+        # point at a shipped tarball and right now the most recent
+        # tarball is 8.2.0 itself — no earlier tarball asset exists on
+        # the release page (patch releases only shipped .zip patches).
+        # Once 8.3.0 releases and the from_version default becomes
+        # 8.2.0 → 8.3.0, both upgrade scenarios can move back into
+        # the default matrix unconditionally.
+        # `inputs.caller_tarball_artifact` / `inputs.caller_zip_artifact`
+        # (workflow_call from build-release.yml's Phase 7c gate) also
+        # expand the matrix — can't gate on github.event_name for
+        # workflow_call because that reports the CALLING workflow's
+        # original event (typically workflow_dispatch), not
+        # "workflow_call". See detect-mode's gate check for the same
+        # signal choice.
+        #
+        # Matrix cell counts:
+        #   default (acceptance-surface push/PR/schedule):
+        #     fresh-install × [tar,zip] + wizard-install × [tar,zip] = 4
+        #   expanded (dispatch / build_locally / caller_*_artifact):
+        #     above 4 + upgrade[tar] + wizard-upgrade[tar]           = 6
+        include: ${{ (github.event_name == 'workflow_dispatch' || inputs.caller_tarball_artifact != '' || inputs.caller_zip_artifact != '' || needs.detect-mode.outputs.build_locally == 'true') && fromJson('[{"scenario":"fresh-install","format":"tar"},{"scenario":"fresh-install","format":"zip"},{"scenario":"wizard-install","format":"tar"},{"scenario":"wizard-install","format":"zip"},{"scenario":"upgrade","format":"tar"},{"scenario":"wizard-upgrade","format":"tar"}]') || fromJson('[{"scenario":"fresh-install","format":"tar"},{"scenario":"fresh-install","format":"zip"},{"scenario":"wizard-install","format":"tar"},{"scenario":"wizard-install","format":"zip"}]') }}
     env:
       FROM_VERSION: ${{ inputs.from_version || '8.2.0' }}
       # Single source of truth for to_version — see the
@@ -477,7 +527,7 @@ jobs:
       # path resolves this to 99.99.99.
       TO_VERSION: ${{ needs.detect-mode.outputs.to_version }}
       ACCEPTANCE_ARTIFACT_URL: http://localhost:8680
-    name: ${{ matrix.scenario }}
+    name: ${{ matrix.scenario }} (${{ matrix.format }})
     steps:
     - uses: actions/checkout@v7
       with:
@@ -500,40 +550,68 @@ jobs:
     - name: Install acceptance-suite composer dependencies
       run: composer install --prefer-dist --no-progress --no-scripts --no-interaction
 
-    # ==== Load PR-built or caller-supplied tarball + resolve boot flags ====
-    # Two source paths converge here:
-    #   Phase 3.5 (PR validation): build-tarball job just uploaded
-    #     openemr-pr-built-tarball. Download that.
+    # ==== Load PR-built or caller-supplied artifact + resolve boot flags ====
+    # Two source paths × two formats converge here:
+    #   Phase 3.5 (PR validation): build-tarball job uploaded either
+    #     openemr-pr-built-tarball OR openemr-pr-built-zip depending
+    #     on matrix.format. Download the format-matching one.
     #   Phase 7c (workflow_call gate): caller (build-release.yml)
-    #     already uploaded the release-candidate tarball under
-    #     inputs.caller_tarball_artifact — build-tarball self-skipped.
-    #     Download that artifact name instead.
+    #     already uploaded a release-candidate bundle containing BOTH
+    #     formats under inputs.caller_{tarball,zip}_artifact — build-
+    #     tarball self-skipped. Download the caller's format-matching
+    #     artifact name instead.
     #
-    # Both land the tarball under /tmp/pr-built-tarball/openemr-<TO_VERSION>.tar.gz,
-    # so the bootflags step below doesn't need to care which path fired.
-    - name: Download PR-built tarball (Phase 3.5)
-      if: needs.build-tarball.result == 'success' && inputs.caller_tarball_artifact == ''
+    # All four permutations land the artifact under
+    # /tmp/pr-built-tarball/openemr-<TO_VERSION>.{tar.gz,zip}, so the
+    # bootflags step below only needs to switch on matrix.format.
+    #
+    # upgrade + wizard-upgrade cells never fire the zip-download steps —
+    # their matrix entries pin format=tar (upgrade-package.sh does not
+    # yet accept --to-local-zip; Phase 3.6 follow-up).
+    - name: Download PR-built tarball (Phase 3.5, tar)
+      if: needs.build-tarball.result == 'success' && inputs.caller_tarball_artifact == '' && matrix.format == 'tar'
       uses: actions/download-artifact@v8
       with:
         name: openemr-pr-built-tarball
         path: /tmp/pr-built-tarball
 
-    - name: Download caller-supplied tarball (Phase 7c gate)
-      if: inputs.caller_tarball_artifact != ''
+    - name: Download PR-built zip (Phase 3.5, zip)
+      if: needs.build-tarball.result == 'success' && inputs.caller_zip_artifact == '' && matrix.format == 'zip'
+      uses: actions/download-artifact@v8
+      with:
+        name: openemr-pr-built-zip
+        path: /tmp/pr-built-tarball
+
+    - name: Download caller-supplied tarball (Phase 7c gate, tar)
+      if: inputs.caller_tarball_artifact != '' && matrix.format == 'tar'
       uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.caller_tarball_artifact }}
         path: /tmp/pr-built-tarball
 
+    - name: Download caller-supplied zip (Phase 7c gate, zip)
+      if: inputs.caller_zip_artifact != '' && matrix.format == 'zip'
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.caller_zip_artifact }}
+        path: /tmp/pr-built-tarball
+
     - name: Resolve boot flags for to_version
       # `to_local_flag` is spliced into every boot-package.sh
-      # invocation that boots the to_version tarball;
+      # invocation that boots the to_version artifact;
       # `to_upgrade_local_flag` is spliced into upgrade-package.sh
       # (different flag name, same file). When either the build-tarball
-      # job ran OR the caller supplied a tarball via workflow_call, both
-      # point at the local .tar.gz (downloaded above) and the underlying
-      # script skips its GitHub-release download entirely. Otherwise
-      # both are empty and the scripts do their normal curl.
+      # job ran OR the caller supplied an artifact via workflow_call,
+      # both point at the local .tar.gz / .zip (downloaded above) and
+      # the underlying script skips its GitHub-release download entirely.
+      # Otherwise both are empty and the scripts do their normal curl.
+      #
+      # Format switching (Phase 3.6): `to_local_flag` becomes
+      # --local-tarball=<path> for tar cells and --local-zip=<path> for
+      # zip cells. `to_upgrade_local_flag` stays --to-local-tarball only
+      # — upgrade-package.sh doesn't yet accept --to-local-zip, and the
+      # upgrade + wizard-upgrade matrix entries pin format=tar so the
+      # zip branch is unreachable for those scenarios.
       #
       # There is intentionally no `from_local_flag` — the upgrade
       # scenarios always boot the shipped from_version from GitHub
@@ -543,6 +621,8 @@ jobs:
       env:
         BUILD_TARBALL_RESULT: ${{ needs.build-tarball.result }}
         CALLER_TARBALL_ARTIFACT: ${{ inputs.caller_tarball_artifact }}
+        CALLER_ZIP_ARTIFACT: ${{ inputs.caller_zip_artifact }}
+        MATRIX_FORMAT: ${{ matrix.format }}
         TO_VERSION: ${{ needs.detect-mode.outputs.to_version }}
       run: |
         set -euo pipefail
@@ -555,24 +635,52 @@ jobs:
           echo "::error::TO_VERSION '${TO_VERSION}' does not match required X.Y.Z"
           exit 1
         fi
-        # Local-tarball sources: either build-tarball job (Phase 3.5)
+        # Which caller_* input is relevant for this matrix cell — used
+        # only to decide "did the caller supply an artifact for this
+        # format" for the log-message + presence-check below.
+        case "$MATRIX_FORMAT" in
+          tar) CALLER_ARTIFACT_FOR_FORMAT="$CALLER_TARBALL_ARTIFACT" ;;
+          zip) CALLER_ARTIFACT_FOR_FORMAT="$CALLER_ZIP_ARTIFACT" ;;
+          *)
+            echo "::error::unknown matrix.format value: '${MATRIX_FORMAT}' (expected tar or zip)"
+            exit 1
+            ;;
+        esac
+        # Local-artifact sources: either build-tarball job (Phase 3.5)
         # or workflow_call caller-supplied artifact (Phase 7c). Both
-        # download to /tmp/pr-built-tarball/openemr-<TO_VERSION>.tar.gz.
-        if [[ "$BUILD_TARBALL_RESULT" == "success" || -n "$CALLER_TARBALL_ARTIFACT" ]]; then
-          LOCAL_PATH="/tmp/pr-built-tarball/openemr-${TO_VERSION}.tar.gz"
+        # download to /tmp/pr-built-tarball/openemr-<TO_VERSION>.{tar.gz,zip}.
+        if [[ "$BUILD_TARBALL_RESULT" == "success" || -n "$CALLER_ARTIFACT_FOR_FORMAT" ]]; then
+          case "$MATRIX_FORMAT" in
+            tar)
+              LOCAL_PATH="/tmp/pr-built-tarball/openemr-${TO_VERSION}.tar.gz"
+              LOCAL_FLAG="--local-tarball=${LOCAL_PATH}"
+              ;;
+            zip)
+              LOCAL_PATH="/tmp/pr-built-tarball/openemr-${TO_VERSION}.zip"
+              LOCAL_FLAG="--local-zip=${LOCAL_PATH}"
+              ;;
+          esac
           if [[ ! -f "$LOCAL_PATH" ]]; then
-            echo "::error::local-tarball path expected but $LOCAL_PATH is not present"
+            echo "::error::local-artifact path expected but $LOCAL_PATH is not present"
             exit 1
           fi
-          if [[ -n "$CALLER_TARBALL_ARTIFACT" ]]; then
-            echo "==> Using caller-supplied tarball (Phase 7c): $LOCAL_PATH"
+          if [[ -n "$CALLER_ARTIFACT_FOR_FORMAT" ]]; then
+            echo "==> Using caller-supplied ${MATRIX_FORMAT} (Phase 7c): $LOCAL_PATH"
           else
-            echo "==> Using PR-built tarball (Phase 3.5): $LOCAL_PATH"
+            echo "==> Using PR-built ${MATRIX_FORMAT} (Phase 3.5): $LOCAL_PATH"
           fi
-          echo "to_local_flag=--local-tarball=${LOCAL_PATH}" >> "$GITHUB_OUTPUT"
-          echo "to_upgrade_local_flag=--to-local-tarball=${LOCAL_PATH}" >> "$GITHUB_OUTPUT"
+          echo "to_local_flag=${LOCAL_FLAG}" >> "$GITHUB_OUTPUT"
+          # upgrade-package.sh only accepts --to-local-tarball today;
+          # matrix pins format=tar for upgrade scenarios, so this only
+          # ever fires on the tar path. Leave empty in the zip case as
+          # a defensive no-op — no upgrade step will consume it.
+          if [[ "$MATRIX_FORMAT" == "tar" ]]; then
+            echo "to_upgrade_local_flag=--to-local-tarball=${LOCAL_PATH}" >> "$GITHUB_OUTPUT"
+          else
+            echo "to_upgrade_local_flag=" >> "$GITHUB_OUTPUT"
+          fi
         else
-          echo "==> No local tarball; to_version will be fetched from the GitHub release page"
+          echo "==> No local artifact; to_version will be fetched from the GitHub release page"
           echo "to_local_flag=" >> "$GITHUB_OUTPUT"
           echo "to_upgrade_local_flag=" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -492,43 +492,14 @@ jobs:
         # Formats (Phase 3.6):
         #   tar   — extracts openemr-<version>.tar.gz via tar -xzf
         #   zip   — extracts openemr-<version>.zip via unzip
-        # Both artifacts come out of the same PackageAssembler pass;
-        # the ZIP dimension catches ZIP-only regressions (line-ending
-        # translation, exec-bit preservation, empty-dir handling,
-        # path-separator handling — see the Phase 3.6 plan doc for
-        # the failure classes this closes).
-        #
-        # Constraint: `upgrade` and `wizard-upgrade` stay tar-only.
-        # upgrade-package.sh does not yet accept `--to-local-zip`
-        # (deferred to a Phase 3.6 follow-up); until then only the
-        # install-side scenarios exercise the ZIP format.
-        #
-        # `upgrade` and `wizard-upgrade` are also gated on either
-        # explicit workflow_dispatch (where the caller supplies
-        # from_version + to_version explicitly) OR the Phase 3.5
-        # build_locally path (where PR-built tarball is to_version,
-        # any shipped tarball is from_version, and the pair is
-        # meaningful for pre-merge validation). On acceptance-surface-
-        # only push/PR/schedule the from_version default would need to
-        # point at a shipped tarball and right now the most recent
-        # tarball is 8.2.0 itself — no earlier tarball asset exists on
-        # the release page (patch releases only shipped .zip patches).
-        # Once 8.3.0 releases and the from_version default becomes
-        # 8.2.0 → 8.3.0, both upgrade scenarios can move back into
-        # the default matrix unconditionally.
-        # `inputs.caller_tarball_artifact` / `inputs.caller_zip_artifact`
-        # (workflow_call from build-release.yml's Phase 7c gate) also
-        # expand the matrix — can't gate on github.event_name for
-        # workflow_call because that reports the CALLING workflow's
-        # original event (typically workflow_dispatch), not
-        # "workflow_call". See detect-mode's gate check for the same
-        # signal choice.
-        #
-        # Matrix cell counts:
+        # Matrix cells (per Phase 3.6 + Phase 3.5 gating rules — see
+        # the plan doc's Phase 3.6 section for the full rationale):
         #   default (acceptance-surface push/PR/schedule):
-        #     fresh-install × [tar,zip] + wizard-install × [tar,zip] = 4
-        #   expanded (dispatch / build_locally / caller_*_artifact):
-        #     above 4 + upgrade[tar] + wizard-upgrade[tar]           = 6
+        #     fresh-install × [tar, zip] + wizard-install × [tar, zip] = 4
+        #   expanded (dispatch, build_locally, or workflow_call gate):
+        #     above 4 + upgrade[tar] + wizard-upgrade[tar]             = 6
+        # upgrade + wizard-upgrade stay tar-only until upgrade-package.sh
+        # grows --to-local-zip (Phase 3.6 slice 2).
         include: ${{ (github.event_name == 'workflow_dispatch' || inputs.caller_tarball_artifact != '' || inputs.caller_zip_artifact != '' || needs.detect-mode.outputs.build_locally == 'true') && fromJson('[{"scenario":"fresh-install","format":"tar"},{"scenario":"fresh-install","format":"zip"},{"scenario":"wizard-install","format":"tar"},{"scenario":"wizard-install","format":"zip"},{"scenario":"upgrade","format":"tar"},{"scenario":"wizard-upgrade","format":"tar"}]') || fromJson('[{"scenario":"fresh-install","format":"tar"},{"scenario":"fresh-install","format":"zip"},{"scenario":"wizard-install","format":"tar"},{"scenario":"wizard-install","format":"zip"}]') }}
     env:
       FROM_VERSION: ${{ inputs.from_version || '8.2.0' }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -279,7 +279,13 @@ jobs:
     if: '!inputs.dry_run'
     uses: ./.github/workflows/acceptance-package.yml
     with:
+      # Both caller_* inputs reference the SAME artifact name because
+      # the release-output bundle contains BOTH openemr-<version>.tar.gz
+      # AND openemr-<version>.zip (see build-package's upload-artifact
+      # step). acceptance-package's per-format download step picks the
+      # right file out of the bundle by matrix.format.
       caller_tarball_artifact: ${{ needs.build-package.outputs.artifact_name }}
+      caller_zip_artifact: ${{ needs.build-package.outputs.artifact_name }}
       to_version: ${{ needs.build-package.outputs.release_version }}
     # Acceptance-package doesn't currently use secrets, but forward
     # them for future-proofing (e.g. if a downstream test grows a

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -184,14 +184,40 @@ case "${ARTIFACT_FORMAT}" in
         # then move the single top-level `openemr-<version>/` contents up
         # into ${TARBALL_DIR} to mirror the tarball layout.
         ZIP_TMP="$(mktemp -d -t "openemr-acceptance-zip.XXXXXX")"
-        trap 'rm -rf "${ZIP_TMP}"' EXIT
-        # -q quiet; -o overwrite (no interactive prompt). PackageAssembler
-        # produces a single top-level `openemr-<version>/` dir; anything
-        # else is a packaging bug and the mv below will fail loudly.
+        # Compose with any existing EXIT trap (the download branch above
+        # may have installed one for ${ARTIFACT_PATH} cleanup) rather
+        # than clobbering. Currently the branches are mutually exclusive
+        # so a bare replace would be safe, but composing is future-proof
+        # against a later refactor that introduces coexisting cleanups.
+        PRIOR_TRAP="$(trap -p EXIT | sed -E "s/^trap -- '(.*)' EXIT$/\1/" || true)"
+        if [[ -n "${PRIOR_TRAP}" ]]; then
+            trap "${PRIOR_TRAP}; rm -rf \"${ZIP_TMP}\"" EXIT
+        else
+            trap 'rm -rf "${ZIP_TMP}"' EXIT
+        fi
+        # -q quiet; -o overwrite (no interactive prompt).
         unzip -qo "${ARTIFACT_PATH}" -d "${ZIP_TMP}"
+        # Enforce exactly one top-level dir inside the ZIP. `mv .../*/*`
+        # would silently merge if PackageAssembler ever regressed to
+        # multiple top-level entries — surface that as a hard error
+        # instead of a subtly-broken web root.
+        mapfile -t ZIP_ROOTS < <(find "${ZIP_TMP}" -mindepth 1 -maxdepth 1)
+        if [[ ${#ZIP_ROOTS[@]} -ne 1 || ! -d "${ZIP_ROOTS[0]}" ]]; then
+            echo "::error::expected exactly one top-level directory in ${ARTIFACT_PATH}, found ${#ZIP_ROOTS[@]}:" >&2
+            printf '  %s\n' "${ZIP_ROOTS[@]}" >&2
+            exit 1
+        fi
         shopt -s dotglob
-        mv "${ZIP_TMP}"/*/* "${TARBALL_DIR}"/
+        mv "${ZIP_ROOTS[0]}"/* "${TARBALL_DIR}"/
         shopt -u dotglob
+        ;;
+    *)
+        # ARTIFACT_FORMAT is derived from the flag-parsing block above
+        # (--local-tarball → tar, --local-zip → zip, download → tar) so
+        # any other value is a programming error rather than user input.
+        # Fail loud rather than silently continue with an empty web root.
+        echo "::error::unexpected ARTIFACT_FORMAT '${ARTIFACT_FORMAT}' (expected 'tar' or 'zip')" >&2
+        exit 1
         ;;
 esac
 

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -9,7 +9,8 @@
 # via OpenEMR's Installer class.
 #
 # Usage:
-#   tests/Acceptance/bin/boot-package.sh [--skip-install-helper] [--local-tarball=<path>] <version>
+#   tests/Acceptance/bin/boot-package.sh [--skip-install-helper] \
+#     [--local-tarball=<path> | --local-zip=<path>] <version>
 #     --skip-install-helper (optional)
 #         Skip the install-helper.php step. Leaves the artifact serving
 #         setup.php on http://localhost:8680/, ready for the
@@ -20,7 +21,7 @@
 #         instead, waits for /setup.php to return 200 (proves apache is
 #         serving on the mapped port).
 #     --local-tarball=<path> (optional)
-#         Extract the given local tarball instead of curl-ing the
+#         Extract the given local .tar.gz instead of curl-ing the
 #         GitHub release page. Enables Phase 3.5 PR-tarball validation:
 #         the acceptance-package workflow builds the tarball via
 #         PackageAssembler from the PR checkout, uploads it as a
@@ -28,11 +29,18 @@
 #         downloaded path here. Skips the network fetch entirely; the
 #         `<version>` arg is still required (used for the scratch dir
 #         name only in this mode).
+#     --local-zip=<path> (optional)
+#         Extract the given local .zip instead. Same semantics as
+#         --local-tarball but for the ZIP artifact PackageAssembler
+#         also produces alongside the tarball. Enables Phase 3.6 ZIP
+#         acceptance coverage — the matrix's `format: zip` cells use
+#         this to validate the shipped ZIP boots + installs correctly.
+#         Mutually exclusive with --local-tarball.
 #     version — release tag suffix, must match ^[0-9]+\.[0-9]+\.[0-9]+$
 #               (e.g. 8.2.0). Anything else is rejected before any path
 #               is constructed — VERSION is caller-controlled and flows
 #               into `rm -rf` / `curl -o` paths.
-#               Without --local-tarball: fetches
+#               Without --local-tarball / --local-zip: fetches
 #               https://github.com/openemr/openemr/releases/download/v<X_Y_Z>/openemr-<version>.tar.gz
 #
 # After a successful boot (default mode):
@@ -47,6 +55,7 @@ set -euo pipefail
 
 skip_install_helper="false"
 local_tarball=""
+local_zip=""
 while [[ $# -gt 0 && "$1" == --* ]]; do
     case "$1" in
         --skip-install-helper)
@@ -57,6 +66,10 @@ while [[ $# -gt 0 && "$1" == --* ]]; do
             local_tarball="${1#--local-tarball=}"
             shift
             ;;
+        --local-zip=*)
+            local_zip="${1#--local-zip=}"
+            shift
+            ;;
         *)
             echo "::error::unknown flag: $1" >&2
             exit 2
@@ -64,11 +77,17 @@ while [[ $# -gt 0 && "$1" == --* ]]; do
     esac
 done
 
+if [[ -n "${local_tarball}" && -n "${local_zip}" ]]; then
+    echo "::error::--local-tarball and --local-zip are mutually exclusive" >&2
+    exit 2
+fi
+
 if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 [--skip-install-helper] [--local-tarball=<path>] <version>" >&2
+    echo "Usage: $0 [--skip-install-helper] [--local-tarball=<path> | --local-zip=<path>] <version>" >&2
     echo "  e.g.: $0 8.2.0" >&2
     echo "        $0 --skip-install-helper 8.2.0" >&2
     echo "        $0 --local-tarball=/tmp/openemr-8.2.0.tar.gz 8.2.0" >&2
+    echo "        $0 --local-zip=/tmp/openemr-8.2.0.zip 8.2.0" >&2
     exit 2
 fi
 
@@ -115,14 +134,27 @@ if [[ -n "${local_tarball}" ]]; then
     # from their own cwd) would otherwise see `tar` look for it under
     # REPO_ROOT and either extract the wrong file or fail. realpath
     # handles both leading-`./` and no-leading-`./` shapes uniformly.
-    TARBALL_PATH="$(realpath "${local_tarball}")"
+    ARTIFACT_PATH="$(realpath "${local_tarball}")"
+    ARTIFACT_FORMAT="tar"
+    # No trap cleanup — the caller owns this file.
+elif [[ -n "${local_zip}" ]]; then
+    # Local-zip mode — same shape as local-tarball; the only difference
+    # is the extractor further below (unzip vs tar -xzf). Phase 3.6
+    # validation of the shipped ZIP artifact.
+    if [[ ! -f "${local_zip}" ]]; then
+        echo "::error::--local-zip path does not exist or is not a regular file: ${local_zip}" >&2
+        exit 2
+    fi
+    ARTIFACT_PATH="$(realpath "${local_zip}")"
+    ARTIFACT_FORMAT="zip"
     # No trap cleanup — the caller owns this file.
 else
     # Random tarball path via mktemp — a predictable path like
     # /tmp/openemr-${VERSION}.tar.gz would let a local attacker
     # pre-create a symlink to redirect the curl download.
-    TARBALL_PATH="$(mktemp -t "openemr-acceptance-tarball.XXXXXX.tar.gz")"
-    trap 'rm -f "${TARBALL_PATH}"' EXIT
+    ARTIFACT_PATH="$(mktemp -t "openemr-acceptance-tarball.XXXXXX.tar.gz")"
+    ARTIFACT_FORMAT="tar"
+    trap 'rm -f "${ARTIFACT_PATH}"' EXIT
 fi
 
 cd "${REPO_ROOT}"
@@ -132,16 +164,36 @@ rm -rf "${TARBALL_DIR}"
 mkdir -p "${TARBALL_DIR}"
 
 if [[ -n "${local_tarball}" ]]; then
-    echo "==> Using local tarball ${TARBALL_PATH} (--local-tarball set — skipping GitHub download)"
+    echo "==> Using local tarball ${ARTIFACT_PATH} (--local-tarball set — skipping GitHub download)"
+elif [[ -n "${local_zip}" ]]; then
+    echo "==> Using local zip ${ARTIFACT_PATH} (--local-zip set — skipping GitHub download)"
 else
     echo "==> Downloading ${TARBALL_URL}"
-    curl -fsSL "${TARBALL_URL}" -o "${TARBALL_PATH}"
+    curl -fsSL "${TARBALL_URL}" -o "${ARTIFACT_PATH}"
 fi
 
-echo "==> Extracting into ${TARBALL_DIR}"
-# --strip-components=1 pulls contents up so ${TARBALL_DIR} matches the
-# openemr web-root layout the flex image's bind mount expects.
-tar -pxzf "${TARBALL_PATH}" -C "${TARBALL_DIR}" --strip-components=1
+echo "==> Extracting into ${TARBALL_DIR} (format=${ARTIFACT_FORMAT})"
+case "${ARTIFACT_FORMAT}" in
+    tar)
+        # --strip-components=1 pulls contents up so ${TARBALL_DIR} matches
+        # the openemr web-root layout the flex image's bind mount expects.
+        tar -pxzf "${ARTIFACT_PATH}" -C "${TARBALL_DIR}" --strip-components=1
+        ;;
+    zip)
+        # unzip has no --strip-components; extract to a temp dir first,
+        # then move the single top-level `openemr-<version>/` contents up
+        # into ${TARBALL_DIR} to mirror the tarball layout.
+        ZIP_TMP="$(mktemp -d -t "openemr-acceptance-zip.XXXXXX")"
+        trap 'rm -rf "${ZIP_TMP}"' EXIT
+        # -q quiet; -o overwrite (no interactive prompt). PackageAssembler
+        # produces a single top-level `openemr-<version>/` dir; anything
+        # else is a packaging bug and the mv below will fail loudly.
+        unzip -qo "${ARTIFACT_PATH}" -d "${ZIP_TMP}"
+        shopt -s dotglob
+        mv "${ZIP_TMP}"/*/* "${TARBALL_DIR}"/
+        shopt -u dotglob
+        ;;
+esac
 
 echo "==> Booting compose stack (mysql + openemr, EMPTY=yes)"
 docker compose up --detach --no-recreate

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -183,35 +183,26 @@ case "${ARTIFACT_FORMAT}" in
         # unzip has no --strip-components; extract to a temp dir first,
         # then move the single top-level `openemr-<version>/` contents up
         # into ${TARBALL_DIR} to mirror the tarball layout.
+        #
+        # Trap-composition note: this branch installs an EXIT cleanup for
+        # ZIP_TMP. The download branch above installs an EXIT cleanup
+        # for ARTIFACT_PATH. The two branches are mutually exclusive by
+        # construction (this branch is entered ONLY when --local-zip is
+        # set, in which case the download branch is skipped) so the
+        # simple `trap 'rm -rf ...' EXIT` here doesn't clobber anything.
+        # If a future refactor introduces coexisting cleanups, revisit.
         ZIP_TMP="$(mktemp -d -t "openemr-acceptance-zip.XXXXXX")"
-        # Compose with any existing EXIT trap (the download branch above
-        # may have installed one for ${ARTIFACT_PATH} cleanup) rather
-        # than clobbering. Currently the branches are mutually exclusive
-        # so a bare replace would be safe, but composing is future-proof
-        # against a later refactor that introduces coexisting cleanups.
-        PRIOR_TRAP="$(trap -p EXIT | sed -E "s/^trap -- '(.*)' EXIT$/\1/" || true)"
-        if [[ -n "${PRIOR_TRAP}" ]]; then
-            # shellcheck disable=SC2064
-            # Intentional expansion-at-decl-time: PRIOR_TRAP + ZIP_TMP
-            # must be baked into the trap string NOW so the composed
-            # cleanup captures the current values, not whatever the
-            # shell happens to have when EXIT fires.
-            trap "${PRIOR_TRAP}; rm -rf \"${ZIP_TMP}\"" EXIT
-        else
-            trap 'rm -rf "${ZIP_TMP}"' EXIT
-        fi
+        trap 'rm -rf "${ZIP_TMP}"' EXIT
         # -q quiet; -o overwrite (no interactive prompt).
         unzip -qo "${ARTIFACT_PATH}" -d "${ZIP_TMP}"
         # Enforce exactly one top-level dir inside the ZIP. `mv .../*/*`
         # would silently merge if PackageAssembler ever regressed to
         # multiple top-level entries — surface that as a hard error
-        # instead of a subtly-broken web root.
-        # find here can only fail on an unwritable /tmp, which is a
-        # shell precondition; the "invoke separately to avoid masking
-        # return value" ceremony (SC2312) would add noise without
-        # changing behavior.
-        # shellcheck disable=SC2312
-        mapfile -t ZIP_ROOTS < <(find "${ZIP_TMP}" -mindepth 1 -maxdepth 1)
+        # instead of a subtly-broken web root. Glob-based check avoids
+        # find + process-substitution + shellcheck SC2312.
+        shopt -s nullglob
+        ZIP_ROOTS=("${ZIP_TMP}"/*)
+        shopt -u nullglob
         if [[ ${#ZIP_ROOTS[@]} -ne 1 || ! -d "${ZIP_ROOTS[0]}" ]]; then
             echo "::error::expected exactly one top-level directory in ${ARTIFACT_PATH}, found ${#ZIP_ROOTS[@]}:" >&2
             printf '  %s\n' "${ZIP_ROOTS[@]}" >&2

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -191,6 +191,11 @@ case "${ARTIFACT_FORMAT}" in
         # against a later refactor that introduces coexisting cleanups.
         PRIOR_TRAP="$(trap -p EXIT | sed -E "s/^trap -- '(.*)' EXIT$/\1/" || true)"
         if [[ -n "${PRIOR_TRAP}" ]]; then
+            # shellcheck disable=SC2064
+            # Intentional expansion-at-decl-time: PRIOR_TRAP + ZIP_TMP
+            # must be baked into the trap string NOW so the composed
+            # cleanup captures the current values, not whatever the
+            # shell happens to have when EXIT fires.
             trap "${PRIOR_TRAP}; rm -rf \"${ZIP_TMP}\"" EXIT
         else
             trap 'rm -rf "${ZIP_TMP}"' EXIT
@@ -201,6 +206,11 @@ case "${ARTIFACT_FORMAT}" in
         # would silently merge if PackageAssembler ever regressed to
         # multiple top-level entries — surface that as a hard error
         # instead of a subtly-broken web root.
+        # find here can only fail on an unwritable /tmp, which is a
+        # shell precondition; the "invoke separately to avoid masking
+        # return value" ceremony (SC2312) would add noise without
+        # changing behavior.
+        # shellcheck disable=SC2312
         mapfile -t ZIP_ROOTS < <(find "${ZIP_TMP}" -mindepth 1 -maxdepth 1)
         if [[ ${#ZIP_ROOTS[@]} -ne 1 || ! -d "${ZIP_ROOTS[0]}" ]]; then
             echo "::error::expected exactly one top-level directory in ${ARTIFACT_PATH}, found ${#ZIP_ROOTS[@]}:" >&2


### PR DESCRIPTION
## Summary

Ships Phase 3.6 of the artifact acceptance testing plan: black-box
validation of the shipped `openemr-<version>.zip` artifact via a
`format` matrix dimension on `acceptance-package.yml`. Both artifacts
come out of the same `PackageAssembler` pass, but the ZIP dimension
catches ZIP-only regression classes tar can't (line-ending translation,
exec-bit preservation, empty-dir handling, path-separator handling —
see the Phase 3.6 plan section for the failure classes this closes).

### Matrix shape

| Trigger surface | Cells |
|---|---|
| Default (acceptance-surface push/PR/schedule) | `fresh-install × [tar, zip]` + `wizard-install × [tar, zip]` = **4** |
| Expanded (dispatch / build_locally / caller_*_artifact) | above 4 + `upgrade[tar]` + `wizard-upgrade[tar]` = **6** |

`upgrade` + `wizard-upgrade` stay tar-only in this PR — see
_Deferred_ below.

### Changes

- **`tests/Acceptance/bin/boot-package.sh`** grows
  `--local-zip=<path>` alongside the existing `--local-tarball=<path>`.
  Extractor switches to `unzip -qo` + a stage-and-mv dance (unzip
  has no `--strip-components` equivalent).
- **`.github/workflows/acceptance-package.yml`**:
    - `workflow_call` trigger gains `caller_zip_artifact: string`
      alongside `caller_tarball_artifact`. `detect-mode`'s Phase 7c
      gate check ORs the two so either alone forces
      `build_locally=true`.
    - `build-tarball` job's PackageAssembler step already produces
      both files; adds a second `upload-artifact` step for the ZIP
      under `openemr-pr-built-zip` (distinct artifact name keeps
      each matrix leg's download size-minimal).
    - `acceptance` matrix converts from a bare `scenario` list to
      `matrix.include` because format-per-scenario isn't uniform.
      Conditional expansion still fires on the same signal set.
    - Download step split by format (tar / zip); `matrix.format`
      picks which of the four (Phase 3.5 tar, Phase 3.5 zip,
      Phase 7c tar, Phase 7c zip) fires per cell.
    - Boot-flags step switches on `matrix.format` to emit
      `--local-tarball=<path>` vs `--local-zip=<path>` for
      `to_local_flag`; `to_upgrade_local_flag` stays tar-only.
- **`.github/workflows/build-release.yml`**: `acceptance-gate` now
  passes both `caller_tarball_artifact` + `caller_zip_artifact`
  (both reference the same bundle `artifact_name` — `build-package`'s
  `upload-artifact` step ships tar+zip+changelog+checksums under one
  name and acceptance-package's per-format download pattern picks the
  right file out).

### Deferred (follow-up PRs)

- `upgrade-package.sh --to-local-zip` — unblocks `upgrade[zip]` +
  `wizard-upgrade[zip]` matrix cells.
- `RELEASE_PROCESS.md` Phase 7 automation-reflection updates + ZIP
  note in the release-gate acceptance section.

## Test plan

- [ ] CI green on this PR — `acceptance-package.yml`'s own
      acceptance-surface path fires and validates both `tar` + `zip`
      cells for fresh-install + wizard-install.
- [ ] Since `tools/release/**` + `build.xml` + `.gitattributes` are
      unchanged in this PR, the `build_locally` auto-detect won't
      expand to upgrade[tar] + wizard-upgrade[tar] here. Sanity check
      by dispatch (or fold into a follow-up that touches the release
      surface) that the expanded matrix still fires the 6 cells.
- [ ] Post-merge: dispatch a `build-release.yml` dry-run against
      `rel-830` (once cut) to confirm the workflow_call plumbing
      accepts both `caller_*_artifact` inputs cleanly.
- [ ] Post-merge: intentionally break ZIP-only behavior in a scratch
      branch (e.g. mutate PackageAssembler to strip exec bits on ZIP
      output) and verify fresh-install[zip] catches it while
      fresh-install[tar] stays green — plan-doc-defined exit criterion
      for this phase.

Assisted-by: Claude Code