### PR TITLE
feat(acceptance): Phase 3.6 slice 2 — upgrade-side ZIP coverage

### DIFF
--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -497,10 +497,11 @@ jobs:
         #   default (acceptance-surface push/PR/schedule):
         #     fresh-install × [tar, zip] + wizard-install × [tar, zip] = 4
         #   expanded (dispatch, build_locally, or workflow_call gate):
-        #     above 4 + upgrade[tar] + wizard-upgrade[tar]             = 6
-        # upgrade + wizard-upgrade stay tar-only until upgrade-package.sh
-        # grows --to-local-zip (Phase 3.6 slice 2).
-        include: ${{ (github.event_name == 'workflow_dispatch' || inputs.caller_tarball_artifact != '' || inputs.caller_zip_artifact != '' || needs.detect-mode.outputs.build_locally == 'true') && fromJson('[{"scenario":"fresh-install","format":"tar"},{"scenario":"fresh-install","format":"zip"},{"scenario":"wizard-install","format":"tar"},{"scenario":"wizard-install","format":"zip"},{"scenario":"upgrade","format":"tar"},{"scenario":"wizard-upgrade","format":"tar"}]') || fromJson('[{"scenario":"fresh-install","format":"tar"},{"scenario":"fresh-install","format":"zip"},{"scenario":"wizard-install","format":"tar"},{"scenario":"wizard-install","format":"zip"}]') }}
+        #     above 4 + upgrade × [tar, zip] + wizard-upgrade × [tar, zip] = 8
+        # All 4 scenarios now cover both formats (Phase 3.6 slice 2 added
+        # upgrade-package.sh --to-local-zip alongside boot-package.sh's
+        # --local-zip).
+        include: ${{ (github.event_name == 'workflow_dispatch' || inputs.caller_tarball_artifact != '' || inputs.caller_zip_artifact != '' || needs.detect-mode.outputs.build_locally == 'true') && fromJson('[{"scenario":"fresh-install","format":"tar"},{"scenario":"fresh-install","format":"zip"},{"scenario":"wizard-install","format":"tar"},{"scenario":"wizard-install","format":"zip"},{"scenario":"upgrade","format":"tar"},{"scenario":"upgrade","format":"zip"},{"scenario":"wizard-upgrade","format":"tar"},{"scenario":"wizard-upgrade","format":"zip"}]') || fromJson('[{"scenario":"fresh-install","format":"tar"},{"scenario":"fresh-install","format":"zip"},{"scenario":"wizard-install","format":"tar"},{"scenario":"wizard-install","format":"zip"}]') }}
     env:
       FROM_VERSION: ${{ inputs.from_version || '8.2.0' }}
       # Single source of truth for to_version — see the
@@ -651,15 +652,19 @@ jobs:
             echo "==> Using PR-built ${MATRIX_FORMAT} (Phase 3.5): $LOCAL_PATH"
           fi
           echo "to_local_flag=${LOCAL_FLAG}" >> "$GITHUB_OUTPUT"
-          # upgrade-package.sh only accepts --to-local-tarball today;
-          # matrix pins format=tar for upgrade scenarios, so this only
-          # ever fires on the tar path. Leave empty in the zip case as
-          # a defensive no-op — no upgrade step will consume it.
-          if [[ "$MATRIX_FORMAT" == "tar" ]]; then
-            echo "to_upgrade_local_flag=--to-local-tarball=${LOCAL_PATH}" >> "$GITHUB_OUTPUT"
-          else
-            echo "to_upgrade_local_flag=" >> "$GITHUB_OUTPUT"
-          fi
+          # upgrade-package.sh --to-local-tarball / --to-local-zip
+          # symmetric with boot-package.sh's --local-{tarball,zip}
+          # (Phase 3.6 slice 2). Emit whichever flag matches the
+          # matrix format so upgrade + wizard-upgrade[zip] cells
+          # exercise the zip extraction path in upgrade-package.sh.
+          case "$MATRIX_FORMAT" in
+            tar)
+              echo "to_upgrade_local_flag=--to-local-tarball=${LOCAL_PATH}" >> "$GITHUB_OUTPUT"
+              ;;
+            zip)
+              echo "to_upgrade_local_flag=--to-local-zip=${LOCAL_PATH}" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
         else
           echo "==> No local artifact; to_version will be fetched from the GitHub release page"
           echo "to_local_flag=" >> "$GITHUB_OUTPUT"

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -180,6 +180,16 @@ case "${ARTIFACT_FORMAT}" in
         tar -pxzf "${ARTIFACT_PATH}" -C "${TARBALL_DIR}" --strip-components=1
         ;;
     zip)
+        # Fail early if unzip isn't on PATH. The subsequent extract
+        # would blow up mid-flight AFTER the scratch dir is prepared,
+        # producing a confusing "no such file or directory" from the
+        # `mv` below rather than a clear "install unzip" signal.
+        # GHA ubuntu-24.04 runners ship unzip pre-installed; guard is
+        # for minimal-image / self-hosted-runner future callers.
+        if ! command -v unzip >/dev/null 2>&1; then
+            echo "::error::unzip is required for --local-zip / zip extraction but was not found on PATH" >&2
+            exit 1
+        fi
         # unzip has no --strip-components; extract to a temp dir first,
         # then move the single top-level `openemr-<version>/` contents up
         # into ${TARBALL_DIR} to mirror the tarball layout.

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -216,6 +216,10 @@ case "${ARTIFACT_FORMAT}" in
         # mutually exclusive (this branch only runs when --to-local-zip
         # is set) so the bare EXIT trap doesn't clobber the download
         # branch's ARTIFACT_PATH cleanup.
+        if ! command -v unzip >/dev/null 2>&1; then
+            echo "::error::unzip is required for --to-local-zip / zip extraction but was not found on PATH" >&2
+            exit 1
+        fi
         ZIP_TMP="$(mktemp -d -t "openemr-acceptance-upgrade-zip.XXXXXX")"
         trap 'rm -rf "${ZIP_TMP}"' EXIT
         unzip -qo "${ARTIFACT_PATH}" -d "${ZIP_TMP}"

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -17,7 +17,8 @@
 #      migrations to apply
 #
 # Usage:
-#   tests/Acceptance/bin/upgrade-package.sh [--skip-sql-upgrade] [--to-local-tarball=<path>] <from-version> <to-version>
+#   tests/Acceptance/bin/upgrade-package.sh [--skip-sql-upgrade] \
+#     [--to-local-tarball=<path> | --to-local-zip=<path>] <from-version> <to-version>
 #     --skip-sql-upgrade (optional)
 #         Skip step 5. Leaves the artifact serving to-version's
 #         filesystem with from-version's DB — the classic "user just
@@ -29,7 +30,7 @@
 #         still meets; but the DB migrations haven't run, so any
 #         downstream test that touches the DB would fail).
 #     --to-local-tarball=<path> (optional)
-#         Extract the given local file as the to-version tarball
+#         Extract the given local .tar.gz as the to-version artifact
 #         instead of curl-ing the GitHub release page. Phase 3.5
 #         PR-tarball validation: acceptance-package workflow builds
 #         the tarball via PackageAssembler from the PR checkout,
@@ -37,9 +38,15 @@
 #         downloaded path here. from-version is always downloaded
 #         from GitHub (whole point of the upgrade test is starting
 #         from a shipped release).
+#     --to-local-zip=<path> (optional)
+#         Extract the given local .zip as the to-version artifact.
+#         Same semantics as --to-local-tarball but for the ZIP
+#         artifact — Phase 3.6 slice 2 upgrade[zip] +
+#         wizard-upgrade[zip] matrix cells use this. Mutually
+#         exclusive with --to-local-tarball.
 #     from-version — the version already installed via boot-package.sh
 #     to-version   — the target version (must have a v<X_Y_Z> release tag,
-#                    unless --to-local-tarball is set)
+#                    unless --to-local-tarball or --to-local-zip is set)
 #     Both must match ^[0-9]+\.[0-9]+\.[0-9]+$; from must be strictly
 #     less than to (this is an UPgrade — same-version is a no-op that
 #     would delete the installed source, and downgrade isn't supported).
@@ -52,6 +59,7 @@ set -euo pipefail
 
 skip_sql_upgrade="false"
 to_local_tarball=""
+to_local_zip=""
 while [[ $# -gt 0 && "$1" == --* ]]; do
     case "$1" in
         --skip-sql-upgrade)
@@ -62,6 +70,10 @@ while [[ $# -gt 0 && "$1" == --* ]]; do
             to_local_tarball="${1#--to-local-tarball=}"
             shift
             ;;
+        --to-local-zip=*)
+            to_local_zip="${1#--to-local-zip=}"
+            shift
+            ;;
         *)
             echo "::error::unknown flag: $1" >&2
             exit 2
@@ -69,11 +81,17 @@ while [[ $# -gt 0 && "$1" == --* ]]; do
     esac
 done
 
+if [[ -n "${to_local_tarball}" && -n "${to_local_zip}" ]]; then
+    echo "::error::--to-local-tarball and --to-local-zip are mutually exclusive" >&2
+    exit 2
+fi
+
 if [[ $# -ne 2 ]]; then
-    echo "Usage: $0 [--skip-sql-upgrade] [--to-local-tarball=<path>] <from-version> <to-version>" >&2
+    echo "Usage: $0 [--skip-sql-upgrade] [--to-local-tarball=<path> | --to-local-zip=<path>] <from-version> <to-version>" >&2
     echo "  e.g.: $0 8.2.0 8.3.0" >&2
     echo "        $0 --skip-sql-upgrade 8.2.0 8.3.0" >&2
     echo "        $0 --to-local-tarball=/tmp/openemr-8.3.0.tar.gz 8.2.0 8.3.0" >&2
+    echo "        $0 --to-local-zip=/tmp/openemr-8.3.0.zip 8.2.0 8.3.0" >&2
     exit 2
 fi
 
@@ -123,12 +141,24 @@ if [[ -n "${to_local_tarball}" ]]; then
     fi
     # Absolute-ize before the `cd "${REPO_ROOT}"` below — same
     # rationale as boot-package.sh's --local-tarball normalization.
-    TARBALL_PATH="$(realpath "${to_local_tarball}")"
+    ARTIFACT_PATH="$(realpath "${to_local_tarball}")"
+    ARTIFACT_FORMAT="tar"
+    # No trap cleanup — the caller owns this file.
+elif [[ -n "${to_local_zip}" ]]; then
+    # Local-zip mode — same shape as local-tarball; the extractor
+    # further below switches on ARTIFACT_FORMAT.
+    if [[ ! -f "${to_local_zip}" ]]; then
+        echo "::error::--to-local-zip path does not exist or is not a regular file: ${to_local_zip}" >&2
+        exit 2
+    fi
+    ARTIFACT_PATH="$(realpath "${to_local_zip}")"
+    ARTIFACT_FORMAT="zip"
     # No trap cleanup — the caller owns this file.
 else
     # mktemp for the download path (same rationale as boot-package.sh).
-    TARBALL_PATH="$(mktemp -t "openemr-acceptance-upgrade-tarball.XXXXXX.tar.gz")"
-    trap 'rm -f "${TARBALL_PATH}"' EXIT
+    ARTIFACT_PATH="$(mktemp -t "openemr-acceptance-upgrade-tarball.XXXXXX.tar.gz")"
+    ARTIFACT_FORMAT="tar"
+    trap 'rm -f "${ARTIFACT_PATH}"' EXIT
 fi
 
 cd "${REPO_ROOT}"
@@ -167,14 +197,45 @@ rm -rf "${TO_TARBALL_DIR}"
 mkdir -p "${TO_TARBALL_DIR}"
 
 if [[ -n "${to_local_tarball}" ]]; then
-    echo "==> Using local to-version tarball ${TARBALL_PATH} (--to-local-tarball set — skipping GitHub download)"
+    echo "==> Using local to-version tarball ${ARTIFACT_PATH} (--to-local-tarball set — skipping GitHub download)"
+elif [[ -n "${to_local_zip}" ]]; then
+    echo "==> Using local to-version zip ${ARTIFACT_PATH} (--to-local-zip set — skipping GitHub download)"
 else
     echo "==> Downloading ${TO_TARBALL_URL}"
-    curl -fsSL "${TO_TARBALL_URL}" -o "${TARBALL_PATH}"
+    curl -fsSL "${TO_TARBALL_URL}" -o "${ARTIFACT_PATH}"
 fi
 
-echo "==> Extracting into ${TO_TARBALL_DIR}"
-tar -pxzf "${TARBALL_PATH}" -C "${TO_TARBALL_DIR}" --strip-components=1
+echo "==> Extracting into ${TO_TARBALL_DIR} (format=${ARTIFACT_FORMAT})"
+case "${ARTIFACT_FORMAT}" in
+    tar)
+        tar -pxzf "${ARTIFACT_PATH}" -C "${TO_TARBALL_DIR}" --strip-components=1
+        ;;
+    zip)
+        # Same unzip + single-top-level-dir enforcement as
+        # boot-package.sh's zip branch. Download and zip branches are
+        # mutually exclusive (this branch only runs when --to-local-zip
+        # is set) so the bare EXIT trap doesn't clobber the download
+        # branch's ARTIFACT_PATH cleanup.
+        ZIP_TMP="$(mktemp -d -t "openemr-acceptance-upgrade-zip.XXXXXX")"
+        trap 'rm -rf "${ZIP_TMP}"' EXIT
+        unzip -qo "${ARTIFACT_PATH}" -d "${ZIP_TMP}"
+        shopt -s nullglob
+        ZIP_ROOTS=("${ZIP_TMP}"/*)
+        shopt -u nullglob
+        if [[ ${#ZIP_ROOTS[@]} -ne 1 || ! -d "${ZIP_ROOTS[0]}" ]]; then
+            echo "::error::expected exactly one top-level directory in ${ARTIFACT_PATH}, found ${#ZIP_ROOTS[@]}:" >&2
+            printf '  %s\n' "${ZIP_ROOTS[@]}" >&2
+            exit 1
+        fi
+        shopt -s dotglob
+        mv "${ZIP_ROOTS[0]}"/* "${TO_TARBALL_DIR}"/
+        shopt -u dotglob
+        ;;
+    *)
+        echo "::error::unexpected ARTIFACT_FORMAT '${ARTIFACT_FORMAT}' (expected 'tar' or 'zip')" >&2
+        exit 1
+        ;;
+esac
 
 echo "==> Overlaying ${FROM_VERSION}'s sites/ dir onto ${TO_VERSION} extraction"
 # Matches the wiki "Copy the old OpenEMR sites/ to the new OpenEMR at


### PR DESCRIPTION
Closes Phase 3.6 by extending #13261's install-side ZIP coverage into the upgrade + wizard-upgrade scenarios. Matrix now covers **all 4 scenarios × both formats = 8 cells** on the expanded path (dispatch / build_locally / workflow_call gate); default matrix still 4 (install-side only).

## Stacked on #13261

This branch is based off `bradymiller:phase-3-6-zip-acceptance` (the slice-1 branch). Will show a merge conflict against master until #13261 lands; once #13261 merges to master, GitHub will resolve the base automatically and this diff will show only the slice-2 changes (upgrade-package.sh + the matrix.include extension).

## What's in the box

**`tests/Acceptance/bin/upgrade-package.sh`**: gains `--to-local-zip=<path>` mirroring boot-package.sh's slice-1 `--local-zip`. Parse flag → track `ARTIFACT_FORMAT` (tar|zip) → switch extractor in a `case` block (tar path unchanged; zip path uses mktemp -d + unzip + nullglob array + single-top-level-dir enforcement + mv). Mutually exclusive with `--to-local-tarball`. Default `*)` branch hard-errors on unexpected values.

**`.github/workflows/acceptance-package.yml`**:
- `matrix.include` grows `upgrade[zip]` + `wizard-upgrade[zip]` cells. Expanded matrix = 8 cells; default (acceptance-surface-only) = 4 cells unchanged.
- Boot-flags step's `to_upgrade_local_flag` output switches on `matrix.format` to emit `--to-local-tarball` or `--to-local-zip`.

**FROM-version side unchanged** — always downloaded from GitHub release page as .tar.gz. The whole point of an upgrade test is starting from real shipped release bytes; only the TO side varies between local-built artifact and shipped tag.

## Phase 3.6 completion

After #13261 + #13262 both land, every combination the release process produces is validated:

- Every PR touching `tools/release/**` (auto-fire via build_locally): 8-cell matrix
- Every release-prep PR (via `release-prep.yml` dispatch): 8-cell matrix
- Every release-time publish (via `build-release.yml` workflow_call gate): 8-cell matrix

ZIP-only regressions (line endings, exec-bit preservation, empty-dir handling, path-separator handling) now surface at all three checkpoints.

## Test plan

- [ ] CI actionlint + shellcheck + prek pass
- [ ] Merge #13261 first; rebase this on master if needed
- [ ] Post-merge, manual `workflow_dispatch` of acceptance-package.yml with any valid `from_version/to_version` — verify 8-cell matrix, all 4 upgrade+wizard-upgrade cells (tar and zip variants) pass
- [ ] Next release-time run: publish job's acceptance-gate validates the actual shipped ZIP through upgrade path

🤖 Generated with [Claude Code](https://claude.com/claude-code)