### PR TITLE
build: probe autoload.files impact on sentinel e2e

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -178,14 +178,25 @@
             "library/classes"
         ],
         "files": [
-            "library/global_functions.inc.php",
-            "library/htmlspecialchars.inc.php",
-            "library/formdata.inc.php",
-            "library/sanitize.inc.php",
-            "library/formatting.inc.php",
+            "library/amc.php",
+            "library/calendar.inc.php",
+            "library/csv_like_join.php",
             "library/date_functions.php",
-            "library/validation/validate_core.php",
-            "library/translation.inc.php"
+            "library/formatting.inc.php",
+            "library/formdata.inc.php",
+            "library/global_functions.inc.php",
+            "library/gprelations.inc.php",
+            "library/htmlspecialchars.inc.php",
+            "library/payment.inc.php",
+            "library/pid.inc.php",
+            "library/pnotes.inc.php",
+            "library/registry.inc.php",
+            "library/report_database.inc.php",
+            "library/sanitize.inc.php",
+            "library/transactions.inc.php",
+            "library/translation.inc.php",
+            "library/user.inc.php",
+            "library/validation/validate_core.php"
         ],
         "exclude-from-classmap": [
             "src/Common/Compatibility/Checker.php",


### PR DESCRIPTION
> **TEMPORARY / DEBUGGING ONLY — do not merge.**
> This branch exists solely to isolate a CI failure. It will be closed and the
> branch deleted once the question below is answered.

#### Short description of what this changes or resolves:

Isolating the cause of the `PHP 8.2 - apache - mariadb 11.8.8 - Redis Sentinel mTLS / e2e`
failures seen on #13251.

On #13251 that job fails with 10–13 instances of:

```
RuntimeException: Failed to acquire Redis session lock within 60 second(s).
  at src/Common/Session/Predis/LockingRedisSessionHandler.php:208
```

Every blocked request stalls at `interface/globals.php:278` → `session_start()`,
and every PHPUnit error maps 1:1 to one of these 60s stalls (login itself fails,
so the rest of the suite skips out).

That job is unreliable generally, but this *particular* signature does not appear
on master. Sampled runs:

| Ref | Lock timeouts | Failure signature |
|---|---|---|
| #13251 (run 30422229107) | 13 | lock timeout |
| #13251 (run 30411866802) | 10 | lock timeout |
| master (30403055608) | 0 | Twig `setSourceContext() on null` |
| master (30397941516) | 0 | Twig `setSourceContext() on null` |
| master (30343650338) | 0 | — |
| #13252 (30411718618) | 0 | — |
| #12811 (30403407948) | 1 | — |

All of these runs show Apache children dying with
`AH00052: ... exit signal Segmentation fault (11)` (the issue #13240 is adding
diagnostics for). Because `LockingRedisSessionHandler` releases the lock only in
`write()`/`updateTimestamp()`/`destroy()`/`close()`, a segfaulted lock holder
orphans the key; and since `DEFAULT_LOCK_TTL_SECONDS` and
`DEFAULT_LOCK_MAX_WAIT_SECONDS` are both 60, the waiter's deadline expires at the
same moment the TTL would have freed it, so it reliably throws instead of
recovering. That explains the *shape* of the stall, but not why #13251 hits it
and master does not.

#### Changes proposed in this pull request:

Nothing intended for merge. This branch is master plus **only** the `composer.json`
`autoload.files` change from #13251 — the 11 added `library/*` entries — with none
of that PR's `require_once` removals. The additions are inert on their own (the
existing `require_once` calls dedupe), so this cleanly separates the two halves of
#13251:

- **CI reproduces the lock timeouts** → eager-loading those files is implicated.
- **CI is clean / fails the way master does** → the `require_once` removals are, and
  I'll bisect those next.

For the record, all 11 newly-autoloaded files (`amc.php`, `calendar.inc.php`,
`csv_like_join.php`, `gprelations.inc.php`, `payment.inc.php`, `pid.inc.php`,
`pnotes.inc.php`, `registry.inc.php`, `report_database.inc.php`,
`transactions.inc.php`, `user.inc.php`) contain function declarations only — no
load-time statements — and Composer's `files` autoloader runs before
`session_start()` in `globals.php`. So there is no known mechanism by which this
change alone should matter. This PR tests that expectation rather than assuming it.

Refs #13251, #13240.

#### Was an AI assistant used? Yes
