### PR TITLE
ci: report checks on merge_group so merge queues can be enabled

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -9,12 +9,19 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 jobs:
   all-checks:
     name: All Checks Passed
     runs-on: ubuntu-24.04
     steps:
+    # "All Checks Passed" is the single required status context for master and
+    # rel-*, so it has to report on merge groups too — a required check that
+    # never reports stalls the queue forever. On a merge_group event github.sha
+    # is the merge group's head commit, and every workflow that opts into
+    # merge_group attaches its check runs to that same SHA, so the wait below
+    # aggregates them exactly as it does for a pull request head.
     - uses: lewagon/wait-on-check-action@v1.8.1
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -9,6 +9,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -9,6 +9,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -9,6 +9,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 jobs:
   mysql:

--- a/.github/workflows/docker-compose-lint.yml
+++ b/.github/workflows/docker-compose-lint.yml
@@ -9,6 +9,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 permissions:
   contents: read
@@ -41,6 +42,10 @@ jobs:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Get changed docker compose files
+      # Skipped in the merge queue, where there is no pull request to diff
+      # against. The step below then falls through to recursive mode and lints
+      # every compose file, which is the right scope for a merged-state check.
+      if: github.event_name != 'merge_group'
       id: changed-files
       continue-on-error: true
       uses: tj-actions/changed-files@v47

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -16,6 +16,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.number || github.run_id }}

--- a/.github/workflows/js-test.yml
+++ b/.github/workflows/js-test.yml
@@ -9,6 +9,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,6 +9,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -9,6 +9,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.number || github.run_id }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,6 +13,7 @@ on:
     # Run weekly on Monday at 9am UTC
   - cron: 0 9 * * 1
   workflow_dispatch:
+  merge_group:
 
 permissions:
   contents: read
@@ -37,7 +38,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run Semgrep (full scan)
-      if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
       # Exclude the default echoed-request and printed-request rules from p/php
       # and use our custom versions in semgrep.yaml instead. Our custom rules add
       # OpenEMR's sanitization functions (attr, text, xlt, etc.) to prevent false
@@ -64,10 +65,13 @@ jobs:
           --output=semgrep-results.sarif \
           .
 
-    - name: Run Semgrep (PR diff only)
-      if: github.event_name == 'pull_request'
+    - name: Run Semgrep (diff only)
+      if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
       env:
-        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        # A merge group has no pull request; its payload carries the base SHA
+        # directly. Diffing against it scans the combined changes of every
+        # entry in the group against the target branch.
+        BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
       # Exclude the default echoed-request and printed-request rules from p/php
       # and use our custom versions in semgrep.yaml instead. Our custom rules add
       # OpenEMR's sanitization functions (attr, text, xlt, etc.) to prevent false
@@ -77,6 +81,10 @@ jobs:
       # JS/Node rulesets scan frontend scripts and ccdaservice.
       run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        if [ -z "$BASE_SHA" ]; then
+          printf '::error::BASE_SHA is empty for event %s; refusing to scan nothing\n' "$GITHUB_EVENT_NAME"
+          exit 1
+        fi
         semgrep \
           --config p/php \
           --config p/security-audit \

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -9,6 +9,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 jobs:
   spellcheck:

--- a/.github/workflows/styling.yml
+++ b/.github/workflows/styling.yml
@@ -9,6 +9,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -9,6 +9,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -6,6 +6,7 @@
 #
 # Matrix strategy:
 # - Pull requests: Only PHP 8.2 configurations (oldest supported) for faster feedback
+# - Merge queue: Only PHP 8.2 configurations, to bound queue latency
 # - Pull requests with "Test-Mode: full" trailer: All configurations (like nightly)
 # - Push to master/rel-*: All configurations
 #
@@ -28,6 +29,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 permissions:
   contents: read
@@ -72,12 +74,14 @@ jobs:
     - name: Collect Docker Dirs
       id: docker-dirs
       env:
-        IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
+        REDUCED_MATRIX: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         FULL_TEST_MODE: ${{ steps.test-mode.outputs.full }}
       ##
       # Collect the docker directory names from ci subdirectories
       # and compute display names for each configuration.
-      # For PRs (without full mode): only PHP 8.2 configs (oldest supported).
+      # For PRs and merge queue entries (without full mode): only PHP 8.2
+      # configs (oldest supported), so a queued group is not gated on the
+      # whole nightly-scale matrix.
       # For PRs with full mode or pushes to master/rel-*: all configs.
       run: |
         shopt -s nullglob
@@ -87,10 +91,10 @@ jobs:
         dirs=( "${dirs[@]%/docker-compose.yml}" )
         dirs=( "${dirs[@]#ci/}" )
 
-        if [[ "${IS_PULL_REQUEST}" = 'true' && "${FULL_TEST_MODE}" != 'true' ]]; then
-          # For PRs without full mode: filter to only PHP 8.2 configurations
+        if [[ "${REDUCED_MATRIX}" = 'true' && "${FULL_TEST_MODE}" != 'true' ]]; then
+          # Reduced matrix: filter to only PHP 8.2 configurations
           ci/parse_docker_dir.sh "${dirs[@]}" |
-            jq -rc --arg is_pr "${IS_PULL_REQUEST}" 'map({
+            jq -rc 'map({
               docker_dir: .output.docker_dir,
               php: .output.php,
               display_name: ("PHP \(.output.php) - \(.output.webserver) - \(.output.database) \(.output.db)" + (if .output.redis_sentinel_enabled == "true" then (" - Redis Sentinel" + (if (.output.docker_dir | endswith("_mtls")) then " mTLS" elif (.output.docker_dir | endswith("_tls")) then " TLS" else "" end)) else "" end) + (if (.output.docker_dir | endswith("_upgrade")) then " - Upgrade from 5.0.0" else "" end)),
@@ -121,8 +125,10 @@ jobs:
     with:
       docker_dir: ${{ matrix.config.docker_dir }}
       display_name: ${{ matrix.config.display_name }}
-      # Enable coverage for one config: apache_82_118 on PRs (oldest PHP), apache_85_118 on push
+      # Enable coverage for one config: apache_82_118 on PRs (oldest PHP), apache_85_118 on push.
+      # Merge queue runs collect none: the PR run already reported patch coverage
+      # for the same changes, and apache_85_118 is not in the reduced matrix anyway.
       # Full coverage for all configs runs in scheduled nightly workflow
-      enable_coverage: ${{ (github.event_name == 'pull_request' && matrix.config.docker_dir == 'apache_82_118') || (github.event_name != 'pull_request' && matrix.config.docker_dir == 'apache_85_118') }}
+      enable_coverage: ${{ (github.event_name == 'pull_request' && matrix.config.docker_dir == 'apache_82_118') || (github.event_name == 'push' && matrix.config.docker_dir == 'apache_85_118') }}
       save_composer_cache: ${{ matrix.config.save_composer_cache == 'true' }}
       save_node_cache: ${{ matrix.config.save_node_cache == 'true' }}

--- a/.github/workflows/test-frontcontroller.yml
+++ b/.github/workflows/test-frontcontroller.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
     - master
+  merge_group:
 
 env:
   ENVIRONMENT: ci

--- a/.github/workflows/validate-byte-identical.yml
+++ b/.github/workflows/validate-byte-identical.yml
@@ -48,6 +48,7 @@ on:
     branches:
     - master
     - 'rel-*'
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -9,6 +9,7 @@ on:
     branches:
     - master
     - rel-*
+  merge_group:
 
 permissions:
   contents: read
@@ -41,8 +42,10 @@ jobs:
         pre-commit run trailing-whitespace --files ${{ steps.changed-files.outputs.all_changed_files }}
         pre-commit run end-of-file-fixer --files ${{ steps.changed-files.outputs.all_changed_files }}
         pre-commit run mixed-line-ending --files ${{ steps.changed-files.outputs.all_changed_files }}
-    - name: Run whitespace hooks (push - all files)
-      if: github.event_name == 'push'
+    # Merge groups take the all-files path alongside pushes: tj-actions/changed-files
+    # has no pull request to diff against there, and the whole-repo run is fast.
+    - name: Run whitespace hooks (push / merge queue - all files)
+      if: github.event_name != 'pull_request'
       run: |
         pre-commit run --all-files trailing-whitespace
         pre-commit run --all-files end-of-file-fixer

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -10,6 +10,7 @@ on:
     - master
     - rel-*
   workflow_dispatch:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
Makes it possible to turn on a GitHub merge queue for `master` and `rel-*`. This PR is the code half only — it changes no merge behavior on its own. See **Repository settings change required** below for the other half.

## Why this is needed first

Once a merge queue is enabled for a branch, GitHub evaluates required status checks against the *merge group* commit rather than the pull request head. `All Checks Passed` is the single required context on `master` and `rel-*`, and it does not trigger on `merge_group` today — so the very first queued group would wait forever on a check that can never report.

This adds a `merge_group` trigger to that gate and to the workflows whose checks it aggregates, so a merge group gets validated the same way a PR head does. The difference is what is being validated: the prospective merged state, which is what catches the semantic conflicts between concurrently-approved PRs that a queue exists to prevent.

## What changed

`merge_group:` added to `all-checks-passed`, `api-docs`, `composer`, `database`, `docker-compose-lint`, `integration-tests`, `isolated-tests`, `js-test`, `phpstan`, `rector`, `semgrep`, `spellcheck`, `styling`, `syntax`, `test-all`, `test-frontcontroller`, `validate-byte-identical`, `whitespace`, `windows-tests`.

Four of those cannot do the same work in a merge group and are adjusted rather than left to fail:

- **semgrep** diffs against `github.event.merge_group.base_sha`, which covers the combined changes of every entry in the group against the target branch. It now also fails loudly if the base SHA resolves empty, instead of silently scanning nothing.
- **whitespace** and **docker-compose-lint** fall back to their existing whole-repo modes, since `tj-actions/changed-files` has no pull request to diff against.
- **test-all** keeps the reduced PHP 8.2 matrix in the queue rather than expanding to the nightly-scale matrix, so queue latency stays bounded, and collects no coverage there — the PR run already reported patch coverage for the same changes.

Workflows that are pull-request-scoped by nature (`conventional-commits` validates the PR title) or that use `paths:` filters are left alone. `merge_group` supports no `paths:` filter, so opting them in would run them unconditionally on every group. They simply do not run in a merge group; because `All Checks Passed` aggregates whatever checks exist on the ref rather than pinning a fixed list, nothing waits on them and nothing stalls.

`inferno-test` is deliberately excluded: its certification job has a 180-minute timeout and would dominate queue latency.

No workflow is removed from the `pull_request` path in this PR.

## Repository settings change required

**Do this after this PR merges, not before** — enabling the queue while `All Checks Passed` still cannot report on a merge group would block the first group indefinitely.

In the `master only - enforce ci pass to allow dependabot auto merge` ruleset (conditions already cover `~DEFAULT_BRANCH` and `refs/heads/rel-*`), add a **Merge queue** rule. The `required_status_checks` rule already present there needs no edit — `All Checks Passed` stays the pinned context and now reports on merge groups.

Two constraints worth checking when configuring it:

- The merge method must be **squash** or **rebase**. The `repo-defaults` ruleset enforces `required_linear_history`, and the queue's own merge method has to be consistent with that.
- The remaining knobs — maximum/minimum group size, wait time before merging, build concurrency, and whether a failing group is only partially rejected — are policy choices, not constraints this PR imposes.

Knock-on effect worth being aware of: `dependabot-auto-merge.yml` uses `gh pr merge --auto`, which enqueues into the merge queue instead of merging directly once the queue is on. That is the intended behavior, but it does change when those PRs actually land.

## Cost note

With the queue on, an enqueued PR's checks run once on the PR and once more in the merge group. Groups batch multiple PRs, so it is sublinear rather than a flat 2×, but it is not free. The natural follow-up — and the reason a queue tends to pay for itself — is moving the slowest checks off `pull_request` entirely so they only run in the queue. That is a separate policy decision and is not part of this PR.

## Draft status

Kept as a draft until maintainers confirm they want a merge queue at all, since the settings half is theirs to make and the code half is inert without it.
