### PR TITLE
refactor(release): Phase 10a — extract OCI-label verify to shared script

### DIFF
--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -120,6 +120,12 @@ files:
 # Same trade-off already accepted for acceptance-docker.yml itself.
 - path: .github/workflows/docker-build-release.yml
   exclude-branches: [rel-800, rel-704]
+# verify-oci-labels.sh is called from docker-build-release.yml in three
+# places; same rel-800/rel-704 exclusion applies (those branches don't
+# carry the caller workflow — see the docker-build-release.yml entry
+# above for the load-time reusable-workflow-reference constraint).
+- path: .github/scripts/verify-oci-labels.sh
+  exclude-branches: [rel-800, rel-704]
 - .github/workflows/docker-test-core.yml
 - .github/workflows/docker-test-release.yml
 - .github/actions/test-actions-core/action.yml

--- a/.github/scripts/verify-oci-labels.sh
+++ b/.github/scripts/verify-oci-labels.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Verify OCI labels on a pushed OpenEMR docker image.
+#
+# Pulls REF_TAG from Docker Hub, then asserts that the image's
+# org.opencontainers.image.{revision,version,created} labels match the
+# expected values, and that the four static labels
+# org.opencontainers.image.{title,source,url,licenses} are present and
+# non-empty. Prints a success summary on green, ::error:: annotations on
+# any mismatch, and exits non-zero on any failure.
+#
+# Called from .github/workflows/docker-build-release.yml in three places:
+#   1. the build job's "gated path" step (Phase 7c-docker candidate tag)
+#   2. the build job's "non-gated path" step (first tag of expanded list)
+#   3. the publish job's post-imagetools-create step (first tag of final
+#      expanded list, as defense-in-depth against imagetools pointing at
+#      the wrong manifest)
+#
+# All three previously carried near-identical inline blocks. Extracted
+# here so a fix to the verify logic (new label, tweaked comparison,
+# richer error hints) lands once instead of three times.
+#
+# Inputs (env, all required)
+#   REF_TAG               full image ref to pull + inspect
+#                         (e.g. "openemr/openemr:8.1.0" or
+#                          "openemr/openemr:release-candidate-12345-1")
+#   EXPECTED_REVISION     value the org.opencontainers.image.revision
+#                         label must equal (the OPENEMR_VERSION build
+#                         arg -- git ref baked into the image)
+#   EXPECTED_VERSION      value the org.opencontainers.image.version
+#                         label must equal (the IMAGE_VERSION build arg
+#                         -- human-facing version parsed from
+#                         version.php at the resolved ref)
+#   EXPECTED_BUILD_DATE   value the org.opencontainers.image.created
+#                         label must equal (the BUILD_DATE build arg --
+#                         YYYY-MM-DD of the build)
+#
+# Exit codes
+#   0   all label checks passed
+#   1   one or more label checks failed, OR REF_TAG couldn't be pulled
+
+set -euo pipefail
+
+: "${REF_TAG:?REF_TAG env var is required}"
+: "${EXPECTED_REVISION:?EXPECTED_REVISION env var is required}"
+: "${EXPECTED_VERSION:?EXPECTED_VERSION env var is required}"
+: "${EXPECTED_BUILD_DATE:?EXPECTED_BUILD_DATE env var is required}"
+
+docker pull "${REF_TAG}"
+
+inspect_label() {
+    # docker's Go-template `index` returns the literal string "<no value>"
+    # when a label key is missing on newer Docker versions, instead of an
+    # empty string. Normalize it back to empty so callers (both the
+    # value-comparison and the presence-checks below) can rely on -z to
+    # mean "label absent."
+    local key="$1"
+    local value
+    value=$(docker inspect --format "{{ index .Config.Labels \"org.opencontainers.image.${key}\" }}" "${REF_TAG}")
+    if [[ "${value}" == "<no value>" ]]; then
+        echo ""
+    else
+        echo "${value}"
+    fi
+}
+
+FAIL=0
+
+# Value checks: the three labels that vary per build and have a
+# computable expected value.
+ACTUAL_REVISION=$(inspect_label revision)
+if [[ "${ACTUAL_REVISION}" != "${EXPECTED_REVISION}" ]]; then
+    echo "::error::revision label '${ACTUAL_REVISION}' doesn't match expected '${EXPECTED_REVISION}'"
+    echo "  This means docker/release/Dockerfile either dropped the OPENEMR_VERSION ARG or hardcoded the LABEL value."
+    FAIL=1
+fi
+
+ACTUAL_VERSION=$(inspect_label version)
+if [[ "${ACTUAL_VERSION}" != "${EXPECTED_VERSION}" ]]; then
+    echo "::error::version label '${ACTUAL_VERSION}' doesn't match expected '${EXPECTED_VERSION}' (parsed from openemr@${EXPECTED_REVISION}/version.php)"
+    echo "  This means docker/release/Dockerfile either dropped the IMAGE_VERSION ARG or hardcoded the LABEL value."
+    FAIL=1
+fi
+
+ACTUAL_CREATED=$(inspect_label created)
+if [[ "${ACTUAL_CREATED}" != "${EXPECTED_BUILD_DATE}" ]]; then
+    echo "::error::created label '${ACTUAL_CREATED}' doesn't match expected '${EXPECTED_BUILD_DATE}'"
+    echo "  This means docker/release/Dockerfile either dropped the BUILD_DATE ARG or hardcoded the LABEL value."
+    FAIL=1
+fi
+
+# Presence checks: the four static labels that don't vary per build.
+# Catches the "someone truncated the Dockerfile and the whole LABEL
+# block disappeared" failure mode that the value checks above wouldn't
+# see if those three ARGs were also gone.
+for STATIC_LABEL in title source url licenses; do
+    VALUE=$(inspect_label "${STATIC_LABEL}")
+    if [[ -z "${VALUE}" ]]; then
+        echo "::error::Image is missing org.opencontainers.image.${STATIC_LABEL} label entirely"
+        echo "  Check that docker/release/Dockerfile's LABEL block at the final stage is intact."
+        FAIL=1
+    else
+        echo "✓ ${STATIC_LABEL}=${VALUE}"
+    fi
+done
+
+[[ "${FAIL}" -eq 0 ]] || exit 1
+echo "✓ revision=${ACTUAL_REVISION} version=${ACTUAL_VERSION} created=${ACTUAL_CREATED}"

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -299,46 +299,10 @@ jobs:
         EXPECTED_VERSION: ${{ steps.image_version.outputs.value }}
         EXPECTED_BUILD_DATE: ${{ steps.build_date.outputs.date }}
         REF_TAG: openemr/openemr:${{ env.GATE_CANDIDATE_TAG }}
-      run: |
-        # Same verify logic as the non-gated path below, but runs against
-        # the candidate tag before spending acceptance-gate CI budget on
-        # an image whose Dockerfile ARGs didn't flow through correctly.
-        docker pull "$REF_TAG"
-        inspect_label() {
-          V=$(docker inspect --format "{{ index .Config.Labels \"org.opencontainers.image.$1\" }}" "$REF_TAG")
-          if [ "$V" = "<no value>" ]; then
-            echo ""
-          else
-            echo "$V"
-          fi
-        }
-        FAIL=0
-        ACTUAL_REVISION=$(inspect_label revision)
-        if [ "$ACTUAL_REVISION" != "$EXPECTED_REVISION" ]; then
-          echo "::error::revision label '$ACTUAL_REVISION' doesn't match expected '$EXPECTED_REVISION'"
-          FAIL=1
-        fi
-        ACTUAL_VERSION=$(inspect_label version)
-        if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
-          echo "::error::version label '$ACTUAL_VERSION' doesn't match expected '$EXPECTED_VERSION'"
-          FAIL=1
-        fi
-        ACTUAL_CREATED=$(inspect_label created)
-        if [ "$ACTUAL_CREATED" != "$EXPECTED_BUILD_DATE" ]; then
-          echo "::error::created label '$ACTUAL_CREATED' doesn't match expected '$EXPECTED_BUILD_DATE'"
-          FAIL=1
-        fi
-        for STATIC_LABEL in title source url licenses; do
-          VALUE=$(inspect_label "$STATIC_LABEL")
-          if [ -z "$VALUE" ]; then
-            echo "::error::Image is missing org.opencontainers.image.${STATIC_LABEL} label entirely"
-            FAIL=1
-          else
-            echo "✓ ${STATIC_LABEL}=${VALUE}"
-          fi
-        done
-        [ "$FAIL" -eq 0 ] || exit 1
-        echo "✓ revision=$ACTUAL_REVISION version=$ACTUAL_VERSION created=$ACTUAL_CREATED"
+      # Runs against the candidate tag before spending acceptance-gate CI
+      # budget on an image whose Dockerfile ARGs didn't flow through
+      # correctly. Same verify script the non-gated + publish sites use.
+      run: .github/scripts/verify-oci-labels.sh
 
     - name: Verify pushed image OCI labels — non-gated path
       if: ${{ !inputs.gate_with_acceptance }}
@@ -347,67 +311,13 @@ jobs:
         EXPECTED_VERSION: ${{ steps.image_version.outputs.value }}
         EXPECTED_BUILD_DATE: ${{ steps.build_date.outputs.date }}
         TAGS_LIST: ${{ steps.expand_docker_tags.outputs.list }}
+      # First pushed tag is the representative one to verify -- all tags
+      # in TAGS_LIST point at the same manifest so inspecting one covers
+      # all of them.
       run: |
-        # Pull the first pushed tag back and inspect its labels.
-        REF_TAG=$(echo "$TAGS_LIST" | head -1)
-        docker pull "$REF_TAG"
-
-        inspect_label() {
-          # docker's Go-template `index` returns the literal string "<no value>"
-          # when a label key is missing on newer Docker versions, instead of an
-          # empty string. Normalize it back to empty so callers (both the
-          # value-comparison and the presence-checks below) can rely on -z to
-          # mean "label absent."
-          V=$(docker inspect --format "{{ index .Config.Labels \"org.opencontainers.image.$1\" }}" "$REF_TAG")
-          if [ "$V" = "<no value>" ]; then
-            echo ""
-          else
-            echo "$V"
-          fi
-        }
-
-        FAIL=0
-
-        # Value checks: the two labels that vary per build and have a
-        # computable expected value.
-        ACTUAL_REVISION=$(inspect_label revision)
-        if [ "$ACTUAL_REVISION" != "$EXPECTED_REVISION" ]; then
-          echo "::error::revision label '$ACTUAL_REVISION' doesn't match expected '$EXPECTED_REVISION'"
-          echo "  This means docker/release/Dockerfile either dropped the OPENEMR_VERSION ARG or hardcoded the LABEL value."
-          FAIL=1
-        fi
-
-        ACTUAL_VERSION=$(inspect_label version)
-        if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
-          echo "::error::version label '$ACTUAL_VERSION' doesn't match expected '$EXPECTED_VERSION' (parsed from openemr@${EXPECTED_REVISION}/version.php)"
-          echo "  This means docker/release/Dockerfile either dropped the IMAGE_VERSION ARG or hardcoded the LABEL value."
-          FAIL=1
-        fi
-
-        ACTUAL_CREATED=$(inspect_label created)
-        if [ "$ACTUAL_CREATED" != "$EXPECTED_BUILD_DATE" ]; then
-          echo "::error::created label '$ACTUAL_CREATED' doesn't match expected '$EXPECTED_BUILD_DATE'"
-          echo "  This means docker/release/Dockerfile either dropped the BUILD_DATE ARG or hardcoded the LABEL value."
-          FAIL=1
-        fi
-
-        # Presence checks: the four static labels that don't vary per build.
-        # Catches the "someone truncated the Dockerfile and the whole LABEL
-        # block disappeared" failure mode that the value checks above wouldn't
-        # see if those three ARGs were also gone.
-        for STATIC_LABEL in title source url licenses; do
-          VALUE=$(inspect_label "$STATIC_LABEL")
-          if [ -z "$VALUE" ]; then
-            echo "::error::Image is missing org.opencontainers.image.${STATIC_LABEL} label entirely"
-            echo "  Check that docker/release/Dockerfile's LABEL block at the final stage is intact."
-            FAIL=1
-          else
-            echo "✓ ${STATIC_LABEL}=${VALUE}"
-          fi
-        done
-
-        [ "$FAIL" -eq 0 ] || exit 1
-        echo "✓ revision=$ACTUAL_REVISION version=$ACTUAL_VERSION created=$ACTUAL_CREATED"
+        REF_TAG=$(echo "${TAGS_LIST}" | head -1)
+        export REF_TAG
+        .github/scripts/verify-oci-labels.sh
 
   # Phase 7c-docker gate: run the full acceptance-docker matrix against
   # the image build produced + saved as an artifact. Publish only fires
@@ -456,6 +366,12 @@ jobs:
     if: inputs.gate_with_acceptance
     runs-on: ubuntu-24.04
     steps:
+    # Needed so the "Verify pushed image OCI labels" step below can call
+    # .github/scripts/verify-oci-labels.sh. Publish is a separate job
+    # from build so the workspace doesn't carry over — must re-checkout.
+    - name: Checkout
+      uses: actions/checkout@v7
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
@@ -488,51 +404,15 @@ jobs:
         EXPECTED_VERSION: ${{ needs.build.outputs.image_version }}
         EXPECTED_BUILD_DATE: ${{ needs.build.outputs.build_date }}
         TAGS_LIST: ${{ needs.build.outputs.expanded_tags }}
+      # Runs against the first published final tag as a defense-in-depth
+      # check that imagetools-create actually pointed the tag at a
+      # manifest with the expected labels (it should, by construction,
+      # but the check is essentially free). Same verify script the
+      # build job's gated + non-gated sites use.
       run: |
-        # Same verify shape as the non-gated build job's step. Runs
-        # against the first published final tag as a defense-in-depth
-        # check that imagetools-create actually pointed the tag at a
-        # manifest with the expected labels (it should, by construction,
-        # but the check is essentially free).
-        REF_TAG=$(echo "$TAGS_LIST" | head -1)
-        docker pull "$REF_TAG"
-
-        inspect_label() {
-          V=$(docker inspect --format "{{ index .Config.Labels \"org.opencontainers.image.$1\" }}" "$REF_TAG")
-          if [ "$V" = "<no value>" ]; then
-            echo ""
-          else
-            echo "$V"
-          fi
-        }
-
-        FAIL=0
-        ACTUAL_REVISION=$(inspect_label revision)
-        if [ "$ACTUAL_REVISION" != "$EXPECTED_REVISION" ]; then
-          echo "::error::revision label '$ACTUAL_REVISION' doesn't match expected '$EXPECTED_REVISION'"
-          FAIL=1
-        fi
-        ACTUAL_VERSION=$(inspect_label version)
-        if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
-          echo "::error::version label '$ACTUAL_VERSION' doesn't match expected '$EXPECTED_VERSION'"
-          FAIL=1
-        fi
-        ACTUAL_CREATED=$(inspect_label created)
-        if [ "$ACTUAL_CREATED" != "$EXPECTED_BUILD_DATE" ]; then
-          echo "::error::created label '$ACTUAL_CREATED' doesn't match expected '$EXPECTED_BUILD_DATE'"
-          FAIL=1
-        fi
-        for STATIC_LABEL in title source url licenses; do
-          VALUE=$(inspect_label "$STATIC_LABEL")
-          if [ -z "$VALUE" ]; then
-            echo "::error::Image is missing org.opencontainers.image.${STATIC_LABEL} label entirely"
-            FAIL=1
-          else
-            echo "✓ ${STATIC_LABEL}=${VALUE}"
-          fi
-        done
-        [ "$FAIL" -eq 0 ] || exit 1
-        echo "✓ revision=$ACTUAL_REVISION version=$ACTUAL_VERSION created=$ACTUAL_CREATED"
+        REF_TAG=$(echo "${TAGS_LIST}" | head -1)
+        export REF_TAG
+        .github/scripts/verify-oci-labels.sh
 
   # Phase 7c-docker cleanup: delete the candidate tag from Docker Hub
   # after publish (success or fail). Runs on the gated path when the

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -369,8 +369,13 @@ jobs:
     # Needed so the "Verify pushed image OCI labels" step below can call
     # .github/scripts/verify-oci-labels.sh. Publish is a separate job
     # from build so the workspace doesn't carry over — must re-checkout.
+    # persist-credentials: false because publish uses its own app-token
+    # (steps.<>.outputs.token) for gh commands; leaving GITHUB_TOKEN in
+    # .git/config would be zero-value credential surface.
     - name: Checkout
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4

--- a/.github/workflows/test-byte-identical-scripts.yml
+++ b/.github/workflows/test-byte-identical-scripts.yml
@@ -8,9 +8,12 @@
 # version (v1.13.0) and put it on PATH. No bats-support / bats-assert
 # dependencies -- the tests use plain [[ ]] asserts.
 #
-# Not in any byte-identical set: the scripts these tests cover are
-# master-only (auto-sync + the canary's logic), so the tests live on
-# master only too.
+# Not in any byte-identical set: even where a script under test IS
+# byte-identical-synced to rel branches (e.g. verify-oci-labels.sh syncs
+# to rel-820+), the byte-identical canary guarantees each rel branch
+# runs an exact byte copy of master's script -- so master-side test
+# coverage is enough. Master's script gets exercised on every PR; rel
+# branches inherit the identical bytes, no extra CI needed there.
 
 name: Test byte-identical scripts
 
@@ -47,3 +50,4 @@ jobs:
         bats tests/bats/ci-scripts/sync-byte-identical/
         bats tests/bats/ci-scripts/validate-byte-identical/
         bats tests/bats/ci-scripts/list-manifest-paths/
+        bats tests/bats/ci-scripts/verify-oci-labels/

--- a/tests/bats/ci-scripts/verify-oci-labels/docker-mock.sh
+++ b/tests/bats/ci-scripts/verify-oci-labels/docker-mock.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Mock `docker` CLI for BATS tests of verify-oci-labels.sh.
+#
+# The mock replaces the real `docker` binary on PATH so the script under
+# test never touches Docker Hub. Two subcommands are supported:
+#
+#   docker pull <ref>
+#     If the fixture file $MOCK_DOCKER_LABELS_FILE exists, exits 0.
+#     Otherwise exits 1 (simulates a pull failure -- no manifest available).
+#     Prints nothing (the real docker CLI is chatty but the script doesn't
+#     grep its output, so silence keeps test output clean).
+#
+#   docker inspect --format <template> <ref>
+#     Reads label values from $MOCK_DOCKER_LABELS_FILE, one label per
+#     line in "<key>=<value>" format. Only Go-template `index` on
+#     .Config.Labels is supported (the shape the script uses):
+#
+#         {{ index .Config.Labels "org.opencontainers.image.<KEY>" }}
+#
+#     If the key is present in the fixture, echoes its value.
+#     If the key is absent, echoes "<no value>" (matches the real
+#     docker CLI's behavior for missing labels).
+#
+# Fixture file format ($MOCK_DOCKER_LABELS_FILE):
+#   One label per line, "<KEY>=<VALUE>". KEY is the bit after
+#   "org.opencontainers.image." (e.g. "revision", "version", "title").
+#   Blank lines and #-prefixed lines are ignored. Setting a value to
+#   the literal string ABSENT is equivalent to omitting the line
+#   (the mock returns "<no value>").
+#
+#   Example:
+#     revision=master
+#     version=8.2.0
+#     created=2026-01-15
+#     title=OpenEMR
+#     source=https://github.com/openemr/openemr
+#     url=https://www.open-emr.org
+#     licenses=GPL-3.0-or-later
+#
+# Controlled via env in the calling shell:
+#   MOCK_DOCKER_LABELS_FILE   path to the fixture (required for inspect
+#                             + required-for-success for pull)
+
+set -euo pipefail
+
+subcommand="${1:-}"
+shift || true
+
+case "${subcommand}" in
+    pull)
+        # docker pull <ref>
+        if [[ -f "${MOCK_DOCKER_LABELS_FILE:-}" ]]; then
+            exit 0
+        fi
+        echo "Error response from daemon: manifest not found (mock)" >&2
+        exit 1
+        ;;
+    inspect)
+        # docker inspect --format <template> <ref>
+        # Real invocation:
+        #   docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.KEY" }}' <ref>
+        format=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --format)
+                    format="$2"
+                    shift 2
+                    ;;
+                --format=*)
+                    format="${1#--format=}"
+                    shift
+                    ;;
+                *)
+                    # positional (the image ref) -- ignore, we don't validate it
+                    shift
+                    ;;
+            esac
+        done
+
+        # Extract KEY from the Go template. Look for the last quoted string.
+        # The template is always shaped as:
+        #   {{ index .Config.Labels "org.opencontainers.image.<KEY>" }}
+        key=""
+        if [[ "${format}" =~ \"org\.opencontainers\.image\.([^\"]+)\" ]]; then
+            key="${BASH_REMATCH[1]}"
+        fi
+
+        if [[ -z "${key}" ]]; then
+            echo "docker-mock: unsupported format template: ${format}" >&2
+            exit 2
+        fi
+
+        # Look up the key in the fixture file.
+        if [[ ! -f "${MOCK_DOCKER_LABELS_FILE:-}" ]]; then
+            echo "docker-mock: MOCK_DOCKER_LABELS_FILE not set or missing" >&2
+            exit 2
+        fi
+
+        value=""
+        found=0
+        while IFS= read -r line || [[ -n "${line}" ]]; do
+            # Skip comments + blanks.
+            [[ -z "${line}" || "${line}" =~ ^[[:space:]]*# ]] && continue
+            if [[ "${line}" == "${key}="* ]]; then
+                value="${line#*=}"
+                found=1
+                break
+            fi
+        done < "${MOCK_DOCKER_LABELS_FILE}"
+
+        if [[ "${found}" -eq 0 || "${value}" == "ABSENT" ]]; then
+            # Real docker prints the literal string "<no value>" for
+            # missing labels on newer Docker versions. The script under
+            # test normalizes this back to empty in its inspect_label
+            # helper; the mock's job is just to emit the raw string.
+            echo "<no value>"
+        else
+            echo "${value}"
+        fi
+        ;;
+    *)
+        echo "docker-mock: unsupported subcommand: ${subcommand}" >&2
+        exit 2
+        ;;
+esac

--- a/tests/bats/ci-scripts/verify-oci-labels/helpers.bash
+++ b/tests/bats/ci-scripts/verify-oci-labels/helpers.bash
@@ -1,0 +1,104 @@
+# Helpers for BATS tests of .github/scripts/verify-oci-labels.sh.
+#
+# Loaded by verify.bats via `load 'helpers'`. Installs a `docker` mock on
+# PATH (see docker-mock.sh for the contract) so the script under test
+# never touches the real Docker CLI or Docker Hub.
+#
+# Pattern follows tests/bats/ci-scripts/validate-byte-identical/helpers.bash --
+# standalone bash, no bats-support / bats-assert; plain [[ ]] asserts.
+
+# Absolute path to the script under test, captured AT LOAD TIME (before
+# any @test does `cd` into its temp working dir).
+__HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034
+VERIFY_OCI_LABELS_SCRIPT="$(cd "${__HELPERS_DIR}/../../../.." && pwd)/.github/scripts/verify-oci-labels.sh"
+
+# Fresh working dir + docker mock. Sets the following vars in the calling
+# shell (BATS's setup() runs in the same shell as the @test):
+#
+#   CWD                        fresh temp dir; the test cd's into it
+#   MOCK_DOCKER_LABELS_FILE    exported -- fixture the docker mock reads.
+#                              Tests populate this via write_labels() to
+#                              simulate different image label shapes.
+#   PATH                       prepended with the docker mock dir.
+setup_test_dir() {
+    CWD=$(mktemp -d -t verify-oci-labels-test-XXXX)
+
+    export MOCK_DOCKER_LABELS_FILE="${CWD}/labels.txt"
+
+    # Install the docker mock at the front of PATH.
+    local mock_dir="${CWD}/.docker-mock"
+    mkdir -p "${mock_dir}"
+    cp "${__HELPERS_DIR}/docker-mock.sh" "${mock_dir}/docker"
+    chmod +x "${mock_dir}/docker"
+    export PATH="${mock_dir}:${PATH}"
+
+    cd "${CWD}" || exit 1
+
+    # Force plain output regardless of caller environment. The script's
+    # `echo "::error::..."` lines are recognized as annotations by GitHub
+    # Actions runners (which set GITHUB_ACTIONS=true globally); the tests
+    # assert on the plain-text substring form, which is what the runner
+    # collapses those lines to anyway when GITHUB_ACTIONS is unset. Not
+    # strictly needed here (the script emits ::error:: unconditionally),
+    # but mirrors the convention from the other ci-scripts BATS suites.
+    unset GITHUB_ACTIONS
+
+    # Sensible defaults for the 4 required env vars. Individual tests
+    # override any subset via `export VAR=...` before running the script.
+    export REF_TAG="openemr/openemr:test-tag"
+    export EXPECTED_REVISION="master"
+    export EXPECTED_VERSION="8.2.0"
+    export EXPECTED_BUILD_DATE="2026-01-15"
+}
+
+teardown_test_dir() {
+    cd /
+    # Restore PATH first so a subsequent shell command uses real binaries.
+    export PATH="${PATH#"${CWD}/.docker-mock":}"
+    rm -rf "${CWD}"
+    unset MOCK_DOCKER_LABELS_FILE
+    unset REF_TAG EXPECTED_REVISION EXPECTED_VERSION EXPECTED_BUILD_DATE
+}
+
+# Write the labels-fixture file the docker mock reads. Each arg is a
+# "<key>=<value>" pair (or "<key>=ABSENT" to simulate a missing label).
+#
+# Usage:
+#   write_labels \
+#       revision=master \
+#       version=8.2.0 \
+#       created=2026-01-15 \
+#       title=OpenEMR \
+#       source=https://github.com/openemr/openemr \
+#       url=https://www.open-emr.org \
+#       licenses=GPL-3.0-or-later
+write_labels() {
+    : > "${MOCK_DOCKER_LABELS_FILE}"
+    for pair in "$@"; do
+        echo "${pair}" >> "${MOCK_DOCKER_LABELS_FILE}"
+    done
+}
+
+# Convenience: write a fully-valid label set matching the setup_test_dir
+# defaults (EXPECTED_REVISION=master, EXPECTED_VERSION=8.2.0,
+# EXPECTED_BUILD_DATE=2026-01-15). Tests that want to exercise a
+# specific failure mode start from this and either override individual
+# labels before calling the script, or overwrite via a fresh write_labels.
+write_all_good_labels() {
+    write_labels \
+        revision=master \
+        version=8.2.0 \
+        created=2026-01-15 \
+        title=OpenEMR \
+        source=https://github.com/openemr/openemr \
+        url=https://www.open-emr.org \
+        licenses=GPL-3.0-or-later
+}
+
+# Delete the labels file so `docker pull` in the mock returns non-zero
+# (simulates a manifest-not-found failure). Also causes subsequent
+# `docker inspect` to fail loudly if the pull ever slips past the guard.
+simulate_pull_failure() {
+    rm -f "${MOCK_DOCKER_LABELS_FILE}"
+}

--- a/tests/bats/ci-scripts/verify-oci-labels/verify.bats
+++ b/tests/bats/ci-scripts/verify-oci-labels/verify.bats
@@ -1,0 +1,220 @@
+# BATS tests for .github/scripts/verify-oci-labels.sh
+#
+# Runs the script against a mock `docker` CLI (see helpers.bash +
+# docker-mock.sh). Covers:
+#   - all-good happy path (exit 0, success summary)
+#   - each of the three value-check failure modes (revision / version /
+#     created mismatch) -- verifies the Dockerfile-context hint is
+#     emitted alongside the primary ::error:: line
+#   - each of the four presence-check failure modes (title / source /
+#     url / licenses missing) -- verifies the intact-LABEL-block hint
+#   - the docker "<no value>" normalization (inspect returning literal
+#     "<no value>" is treated as empty and triggers the presence check)
+#   - multiple failures accumulate into a single exit 1 (no early-exit
+#     hiding follow-on failures)
+#   - required-env-var guards (script exits non-zero when any of the 4
+#     inputs is unset)
+#   - pull failure surfaces via set -e (exit non-zero, no fake-success)
+#
+# What's NOT covered
+#   - the exact docker CLI wire format ("docker pull <ref>" arg count,
+#     "docker inspect --format" arg ordering) -- the mock accepts the
+#     shape the current script uses. If the script's docker invocations
+#     ever diverge from that shape, the mock's parsing will need
+#     updating in lockstep.
+
+load 'helpers'
+
+setup() {
+    setup_test_dir
+}
+
+teardown() {
+    teardown_test_dir
+}
+
+# --- happy path ---
+
+@test "all labels correct -> exit 0 with success summary" {
+    write_all_good_labels
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    [[ "${output}" == *"✓ revision=master version=8.2.0 created=2026-01-15"* ]]
+    [[ "${output}" == *"✓ title=OpenEMR"* ]]
+    [[ "${output}" == *"✓ source=https://github.com/openemr/openemr"* ]]
+    [[ "${output}" == *"✓ url=https://www.open-emr.org"* ]]
+    [[ "${output}" == *"✓ licenses=GPL-3.0-or-later"* ]]
+    # No error output on the happy path.
+    [[ "${output}" != *"::error::"* ]]
+}
+
+# --- value-check failures (with Dockerfile-context hints) ---
+
+@test "revision mismatch -> exit 1 with OPENEMR_VERSION hint" {
+    write_labels \
+        revision=wrong-branch \
+        version=8.2.0 \
+        created=2026-01-15 \
+        title=OpenEMR source=x url=y licenses=z
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::revision label 'wrong-branch' doesn't match expected 'master'"* ]]
+    [[ "${output}" == *"dropped the OPENEMR_VERSION ARG or hardcoded the LABEL value"* ]]
+}
+
+@test "version mismatch -> exit 1 with IMAGE_VERSION hint" {
+    write_labels \
+        revision=master \
+        version=7.0.0 \
+        created=2026-01-15 \
+        title=OpenEMR source=x url=y licenses=z
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::version label '7.0.0' doesn't match expected '8.2.0' (parsed from openemr@master/version.php)"* ]]
+    [[ "${output}" == *"dropped the IMAGE_VERSION ARG or hardcoded the LABEL value"* ]]
+}
+
+@test "created mismatch -> exit 1 with BUILD_DATE hint" {
+    write_labels \
+        revision=master \
+        version=8.2.0 \
+        created=1999-12-31 \
+        title=OpenEMR source=x url=y licenses=z
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::created label '1999-12-31' doesn't match expected '2026-01-15'"* ]]
+    [[ "${output}" == *"dropped the BUILD_DATE ARG or hardcoded the LABEL value"* ]]
+}
+
+# --- presence-check failures (with intact-LABEL-block hint) ---
+
+@test "missing title label -> exit 1 with LABEL-block hint" {
+    write_labels \
+        revision=master version=8.2.0 created=2026-01-15 \
+        title=ABSENT source=x url=y licenses=z
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Image is missing org.opencontainers.image.title label entirely"* ]]
+    [[ "${output}" == *"LABEL block at the final stage is intact"* ]]
+}
+
+@test "missing source label -> exit 1" {
+    write_labels \
+        revision=master version=8.2.0 created=2026-01-15 \
+        title=OpenEMR source=ABSENT url=y licenses=z
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Image is missing org.opencontainers.image.source label entirely"* ]]
+}
+
+@test "missing url label -> exit 1" {
+    write_labels \
+        revision=master version=8.2.0 created=2026-01-15 \
+        title=OpenEMR source=x url=ABSENT licenses=z
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Image is missing org.opencontainers.image.url label entirely"* ]]
+}
+
+@test "missing licenses label -> exit 1" {
+    write_labels \
+        revision=master version=8.2.0 created=2026-01-15 \
+        title=OpenEMR source=x url=y licenses=ABSENT
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Image is missing org.opencontainers.image.licenses label entirely"* ]]
+}
+
+# --- normalization of docker's "<no value>" sentinel ---
+
+@test "docker '<no value>' sentinel treated as empty (revision comparison)" {
+    # revision is absent from the fixture => docker mock echoes "<no value>".
+    # The script's inspect_label helper must normalize that to "" so the
+    # comparison surfaces as a mismatch rather than accidentally matching
+    # some other "<no value>" string.
+    write_labels \
+        version=8.2.0 created=2026-01-15 \
+        title=OpenEMR source=x url=y licenses=z
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    # The mismatch line shows an empty string, not "<no value>".
+    [[ "${output}" == *"::error::revision label '' doesn't match expected 'master'"* ]]
+    [[ "${output}" != *"<no value>"* ]]
+}
+
+@test "docker '<no value>' sentinel treated as empty (static-label presence)" {
+    # title is absent from the fixture => docker mock echoes "<no value>".
+    # -z must fire, triggering the "missing label entirely" error rather
+    # than accepting the sentinel string as a valid non-empty value.
+    write_labels \
+        revision=master version=8.2.0 created=2026-01-15 \
+        source=x url=y licenses=z
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Image is missing org.opencontainers.image.title label entirely"* ]]
+    [[ "${output}" != *"✓ title=<no value>"* ]]
+}
+
+# --- multiple failures accumulate ---
+
+@test "multiple failures accumulate into a single exit 1" {
+    # Wrong revision + missing title + wrong created: all 3 should show
+    # up in output rather than the script bailing after the first
+    # mismatch.
+    write_labels \
+        revision=nope \
+        version=8.2.0 \
+        created=1999-12-31 \
+        title=ABSENT \
+        source=x url=y licenses=z
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"revision label 'nope'"* ]]
+    [[ "${output}" == *"created label '1999-12-31'"* ]]
+    [[ "${output}" == *"Image is missing org.opencontainers.image.title label entirely"* ]]
+}
+
+# --- required env-var guards ---
+
+@test "missing REF_TAG -> non-zero exit with clear error" {
+    write_all_good_labels
+    unset REF_TAG
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"REF_TAG"* ]]
+}
+
+@test "missing EXPECTED_REVISION -> non-zero exit" {
+    write_all_good_labels
+    unset EXPECTED_REVISION
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"EXPECTED_REVISION"* ]]
+}
+
+@test "missing EXPECTED_VERSION -> non-zero exit" {
+    write_all_good_labels
+    unset EXPECTED_VERSION
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"EXPECTED_VERSION"* ]]
+}
+
+@test "missing EXPECTED_BUILD_DATE -> non-zero exit" {
+    write_all_good_labels
+    unset EXPECTED_BUILD_DATE
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"EXPECTED_BUILD_DATE"* ]]
+}
+
+# --- pull failure ---
+
+@test "docker pull failure -> non-zero exit (no fake success)" {
+    # No labels fixture => mock's `docker pull` exits 1.
+    # set -e in the script must propagate that up.
+    simulate_pull_failure
+    run bash "${VERIFY_OCI_LABELS_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" != *"✓ revision="* ]]  # summary line must NOT fire
+}


### PR DESCRIPTION
## Summary

`Comment from Claude:`

`.github/workflows/docker-build-release.yml` previously carried three near-identical inline blocks (~35 lines each) that verified the OCI labels on a pushed image:

- **Gated path** (build job): verifies `openemr/openemr:${GATE_CANDIDATE_TAG}` before spending acceptance-gate CI budget
- **Non-gated path** (build job): verifies the first tag from `TAGS_LIST`
- **Publish job**: post-`imagetools-create` defense-in-depth check on the first final tag

All three shared the same `inspect_label` helper, the same revision/version/created value checks, and the same title/source/url/licenses presence checks.

This slice extracts that logic into a single script at `.github/scripts/verify-oci-labels.sh` with an env-driven contract (`REF_TAG` + `EXPECTED_REVISION` + `EXPECTED_VERSION` + `EXPECTED_BUILD_DATE`) and rewrites the three sites to be thin callers. A future tweak to the verify surface (new label, richer error hint, additional presence check) now lands in one place instead of three.

## Behavior preservation

Same failure conditions, same primary `::error::` annotation lines, same exit code (1 on any mismatch, 0 on green).

The verbose Dockerfile-context hints that previously lived only in the non-gated block ("This means `docker/release/Dockerfile` either dropped the `OPENEMR_VERSION` ARG or hardcoded the LABEL value.", etc.) are now emitted from all three sites — an unambiguous upgrade for the two sites that previously stopped at the short "label doesn't match" line, matching the task-brief direction to preserve the fullest message form.

The publish job gains an `actions/checkout` step so the script is available on disk (publish is a separate job from build, so the build job's workspace doesn't carry over).

## byte-identical.yml

Added `.github/scripts/verify-oci-labels.sh` to `.github/byte-identical.yml` with the same `[rel-800, rel-704]` exclusion as `docker-build-release.yml` (those branches don't carry the caller workflow, so they don't need the callee script either).

## BATS coverage

`tests/bats/ci-scripts/verify-oci-labels/` exercises the extracted script against a mock `docker` CLI (`docker-mock.sh` serves the two subcommands the script invokes: `pull` and `inspect --format`, reading label fixtures from an env-pointed file). 16 tests cover:

- happy path
- each value-check failure mode with its Dockerfile-context hint (revision / version / created)
- each presence-check failure with the intact-LABEL-block hint (title / source / url / licenses)
- the docker `<no value>` normalization (both in value comparisons and static-label presence checks)
- multi-failure accumulation (script keeps going after first failure, exits 1 once)
- each of the four required-env-var guards
- pull failure propagation via `set -e`

Wired into `test-byte-identical-scripts.yml` alongside the existing `sync-byte-identical` + `validate-byte-identical` + `list-manifest-paths` suites.

Not covered (documented in the `.bats` file's header comment): the exact `docker` CLI wire format — the mock accepts the argv shape the current script uses; if the script's `docker` invocations ever diverge from that shape, the mock's parsing will need updating in lockstep.

## Test plan

- [ ] `test-byte-identical-scripts.yml` fires on this PR (paths filter matches `.github/scripts/**` + `tests/bats/ci-scripts/**` + itself); all four BATS suites (sync + validate + list-manifest + new verify) run green
- [ ] `validate-byte-identical.yml` canary confirms `.github/scripts/verify-oci-labels.sh` is not yet present on rel-820 (fresh add — the sync workflow will backfill on the next run)
- [ ] Actionlint clean on both modified workflow files (checked locally via `rhysd/actionlint:1.7.10`)
- [ ] Shellcheck clean on `verify-oci-labels.sh` under `enable=all` (checked locally via `koalaman/shellcheck:stable`)
- [ ] Next `docker-build-release.yml` dispatch on the gated path (Phase 7c) still produces green verify output on Docker Hub with the expected labels; a synthetic dispatch with a bogus `openemr_version_ref` still fails with the new verbose Dockerfile-context hints

---

Assisted-by: Claude Code