### PR TITLE
refactor(acceptance): Phase 10d — extract shared ZIP-extract helper for boot-package + upgrade-package

### DIFF
--- a/.github/workflows/test-byte-identical-scripts.yml
+++ b/.github/workflows/test-byte-identical-scripts.yml
@@ -10,10 +10,11 @@
 #
 # Not in any byte-identical set: even where a script under test IS
 # byte-identical-synced to rel branches (e.g. verify-oci-labels.sh syncs
-# to rel-820+), the byte-identical canary guarantees each rel branch
-# runs an exact byte copy of master's script -- so master-side test
-# coverage is enough. Master's script gets exercised on every PR; rel
-# branches inherit the identical bytes, no extra CI needed there.
+# to rel-820+, extract-zip.sh syncs to rel-810+ via the
+# tests/Acceptance/** glob), the byte-identical canary guarantees each
+# rel branch runs an exact byte copy of master's script -- so master-
+# side test coverage is enough. Master's script gets exercised on every
+# PR; rel branches inherit the identical bytes, no extra CI needed there.
 
 name: Test byte-identical scripts
 
@@ -23,6 +24,7 @@ on:
     - master
     paths:
     - '.github/scripts/**'
+    - 'tests/Acceptance/bin/lib/**'
     - 'tests/bats/ci-scripts/**'
     - '.github/workflows/test-byte-identical-scripts.yml'
   workflow_dispatch:
@@ -52,3 +54,4 @@ jobs:
         bats tests/bats/ci-scripts/list-manifest-paths/
         bats tests/bats/ci-scripts/verify-oci-labels/
         bats tests/bats/ci-scripts/expand-docker-tags/
+        bats tests/bats/ci-scripts/extract-zip/

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -111,6 +111,9 @@ TARBALL_URL="https://github.com/openemr/openemr/releases/download/${TAG_NAME}/op
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." &>/dev/null && pwd)"
 
+# shellcheck source=tests/Acceptance/bin/lib/extract-zip.sh
+source "${SCRIPT_DIR}/lib/extract-zip.sh"
+
 # Persist TARBALL_DIR + HELPER_PATH for every compose invocation in this
 # script (compose reparses the file each time and would otherwise warn
 # about the unset variable + create broken bind mounts).
@@ -180,47 +183,16 @@ case "${ARTIFACT_FORMAT}" in
         tar -pxzf "${ARTIFACT_PATH}" -C "${TARBALL_DIR}" --strip-components=1
         ;;
     zip)
-        # Fail early if unzip isn't on PATH. The subsequent extract
-        # would blow up mid-flight AFTER the scratch dir is prepared,
-        # producing a confusing "no such file or directory" from the
-        # `mv` below rather than a clear "install unzip" signal.
-        # GHA ubuntu-24.04 runners ship unzip pre-installed; guard is
-        # for minimal-image / self-hosted-runner future callers.
-        if ! command -v unzip >/dev/null 2>&1; then
-            echo "::error::unzip is required for --local-zip / zip extraction but was not found on PATH" >&2
-            exit 1
-        fi
-        # unzip has no --strip-components; extract to a temp dir first,
-        # then move the single top-level `openemr-<version>/` contents up
-        # into ${TARBALL_DIR} to mirror the tarball layout.
-        #
-        # Trap-composition note: this branch installs an EXIT cleanup for
-        # ZIP_TMP. The download branch above installs an EXIT cleanup
-        # for ARTIFACT_PATH. The two branches are mutually exclusive by
-        # construction (this branch is entered ONLY when --local-zip is
-        # set, in which case the download branch is skipped) so the
-        # simple `trap 'rm -rf ...' EXIT` here doesn't clobber anything.
-        # If a future refactor introduces coexisting cleanups, revisit.
-        ZIP_TMP="$(mktemp -d -t "openemr-acceptance-zip.XXXXXX")"
-        trap 'rm -rf "${ZIP_TMP}"' EXIT
-        # -q quiet; -o overwrite (no interactive prompt).
-        unzip -qo "${ARTIFACT_PATH}" -d "${ZIP_TMP}"
-        # Enforce exactly one top-level dir inside the ZIP. `mv .../*/*`
-        # would silently merge if PackageAssembler ever regressed to
-        # multiple top-level entries — surface that as a hard error
-        # instead of a subtly-broken web root. Glob-based check avoids
-        # find + process-substitution + shellcheck SC2312.
-        shopt -s nullglob
-        ZIP_ROOTS=("${ZIP_TMP}"/*)
-        shopt -u nullglob
-        if [[ ${#ZIP_ROOTS[@]} -ne 1 || ! -d "${ZIP_ROOTS[0]}" ]]; then
-            echo "::error::expected exactly one top-level directory in ${ARTIFACT_PATH}, found ${#ZIP_ROOTS[@]}:" >&2
-            printf '  %s\n' "${ZIP_ROOTS[@]}" >&2
-            exit 1
-        fi
-        shopt -s dotglob
-        mv "${ZIP_ROOTS[0]}"/* "${TARBALL_DIR}"/
-        shopt -u dotglob
+        # Delegate to the shared helper — same extract-into-scratch,
+        # enforce-single-top-level-dir, mv-into-place dance that
+        # upgrade-package.sh's zip branch also runs. See
+        # lib/extract-zip.sh for the full rationale (unzip PATH guard,
+        # single-top-level enforcement, trap-composition notes).
+        extract_zip_flattening_single_top_level_dir \
+            "${ARTIFACT_PATH}" \
+            "${TARBALL_DIR}" \
+            "openemr-acceptance-zip.XXXXXX" \
+            "--local-zip / zip extraction"
         ;;
     *)
         # ARTIFACT_FORMAT is derived from the flag-parsing block above

--- a/tests/Acceptance/bin/lib/extract-zip.sh
+++ b/tests/Acceptance/bin/lib/extract-zip.sh
@@ -102,9 +102,9 @@ extract_zip_flattening_single_top_level_dir() {
     # instead of a subtly-broken web root. Glob-based check avoids
     # find + process-substitution + shellcheck SC2312.
     local zip_roots
-    shopt -s nullglob
+    shopt -s nullglob dotglob
     zip_roots=("${zip_tmp}"/*)
-    shopt -u nullglob
+    shopt -u nullglob dotglob
     if [[ ${#zip_roots[@]} -ne 1 || ! -d "${zip_roots[0]}" ]]; then
         echo "::error::expected exactly one top-level directory in ${zip_path}, found ${#zip_roots[@]}:" >&2
         printf '  %s\n' "${zip_roots[@]}" >&2

--- a/tests/Acceptance/bin/lib/extract-zip.sh
+++ b/tests/Acceptance/bin/lib/extract-zip.sh
@@ -1,0 +1,116 @@
+# shellcheck shell=bash
+#
+# Shared ZIP-extraction helper for the acceptance package/upgrade scripts.
+#
+# Sourced by:
+#   tests/Acceptance/bin/boot-package.sh
+#   tests/Acceptance/bin/upgrade-package.sh
+#
+# Rationale: PackageAssembler ships both a .tar.gz and a .zip artifact.
+# tar natively supports --strip-components=1; unzip does not, so both
+# callers had to extract into a scratch dir, enforce exactly one
+# top-level directory inside the ZIP, and mv its contents up into
+# ${TARBALL_DIR}. That ~30-line dance was byte-identical between the
+# two scripts; this helper hosts the one copy.
+#
+# Behavior — MUST match the pre-extraction inline code exactly (release-
+# mechanism scripts are byte-identical-synced to rel branches; any
+# behavioral drift here changes what installs on production tags):
+#
+#   1. If unzip is not on PATH, fail with an ::error:: message including
+#      the caller-supplied noun (so the message stays consistent with
+#      each caller's flag naming — "--local-zip" vs "--to-local-zip").
+#   2. mktemp -d a scratch dir (caller-supplied template prefix). trap
+#      cleanup on EXIT.
+#   3. unzip -qo the artifact into the scratch dir.
+#   4. Enforce exactly one top-level directory inside the ZIP via a
+#      nullglob-guarded array — reject anything else with an ::error::
+#      listing what was found.
+#   5. mv the single top-level dir's contents (including dotfiles) up
+#      into the destination.
+#
+# Trap-composition note: this helper installs an EXIT cleanup for the
+# scratch dir it creates. Callers may also have their own EXIT trap for
+# a downloaded artifact path. Callers' ARTIFACT_PATH cleanup only exists
+# on the download branch (mutually exclusive with the local-zip branch
+# that reaches this helper), so the bare `trap ... EXIT` here doesn't
+# clobber a live caller trap. If a future refactor introduces coexisting
+# EXIT cleanups, revisit both call sites.
+#
+# Not exported as an env-invoked script — sourcing keeps the trap
+# installed in the caller's shell (an external script's trap would
+# fire when the subshell exits, before the caller's `mv` completes,
+# defeating the whole point).
+
+# Extract a ZIP archive whose contents are wrapped in a single top-level
+# directory (the shape PackageAssembler produces), flattening that
+# wrapper into the destination directory.
+#
+# Usage:
+#   extract_zip_flattening_single_top_level_dir \
+#       <zip_path> <dest_dir> <mktemp_template> <error_context>
+#
+# Args:
+#   zip_path         Path to the .zip file to extract. Must exist.
+#   dest_dir         Existing directory the flattened contents move into.
+#   mktemp_template  Prefix for the scratch mktemp -d template. Each
+#                    caller passes a distinct prefix so overlapping
+#                    invocations (e.g. debugging with two scripts
+#                    concurrently) get distinct scratch dirs.
+#   error_context    Human-readable phrase describing the flag that
+#                    produced this zip (e.g. "--local-zip / zip
+#                    extraction" or "--to-local-zip / zip extraction").
+#                    Interpolated into the "unzip is required for X but
+#                    was not found on PATH" error to keep each caller's
+#                    diagnostic message flag-accurate.
+#
+# Exit: returns via a non-zero exit (not just a `return`) because the
+# calling scripts run under `set -euo pipefail` and expect failures here
+# to abort the whole boot/upgrade rather than continue past a broken
+# extraction.
+extract_zip_flattening_single_top_level_dir() {
+    local zip_path="$1"
+    local dest_dir="$2"
+    local mktemp_template="$3"
+    local error_context="$4"
+
+    # Fail early if unzip isn't on PATH. The subsequent extract
+    # would blow up mid-flight AFTER the scratch dir is prepared,
+    # producing a confusing "no such file or directory" from the
+    # `mv` below rather than a clear "install unzip" signal.
+    # GHA ubuntu-24.04 runners ship unzip pre-installed; guard is
+    # for minimal-image / self-hosted-runner future callers.
+    if ! command -v unzip >/dev/null 2>&1; then
+        echo "::error::unzip is required for ${error_context} but was not found on PATH" >&2
+        exit 1
+    fi
+
+    # unzip has no --strip-components; extract to a temp dir first,
+    # then move the single top-level `openemr-<version>/` contents up
+    # into ${dest_dir} to mirror the tarball layout.
+    local zip_tmp
+    zip_tmp="$(mktemp -d -t "${mktemp_template}")"
+    # shellcheck disable=SC2064  # want zip_tmp captured at trap-install time, not on EXIT
+    trap "rm -rf '${zip_tmp}'" EXIT
+
+    # -q quiet; -o overwrite (no interactive prompt).
+    unzip -qo "${zip_path}" -d "${zip_tmp}"
+
+    # Enforce exactly one top-level dir inside the ZIP. `mv .../*/*`
+    # would silently merge if PackageAssembler ever regressed to
+    # multiple top-level entries — surface that as a hard error
+    # instead of a subtly-broken web root. Glob-based check avoids
+    # find + process-substitution + shellcheck SC2312.
+    local zip_roots
+    shopt -s nullglob
+    zip_roots=("${zip_tmp}"/*)
+    shopt -u nullglob
+    if [[ ${#zip_roots[@]} -ne 1 || ! -d "${zip_roots[0]}" ]]; then
+        echo "::error::expected exactly one top-level directory in ${zip_path}, found ${#zip_roots[@]}:" >&2
+        printf '  %s\n' "${zip_roots[@]}" >&2
+        exit 1
+    fi
+    shopt -s dotglob
+    mv "${zip_roots[0]}"/* "${dest_dir}"/
+    shopt -u dotglob
+}

--- a/tests/Acceptance/bin/lib/extract-zip.sh
+++ b/tests/Acceptance/bin/lib/extract-zip.sh
@@ -127,7 +127,12 @@ extract_zip_flattening_single_top_level_dir() {
     local zip_entries
     zip_entries=("${zip_roots[0]}"/*)
     if [[ ${#zip_entries[@]} -gt 0 ]]; then
-        mv "${zip_entries[@]}" "${dest_dir}"/
+        # `|| exit 1` makes the helper's failure contract portable —
+        # current callers run under set -euo pipefail so mv failure
+        # would already abort, but a future caller sourcing this
+        # without set -e would otherwise see eval return zero after a
+        # failed mv and continue past a broken extraction.
+        mv "${zip_entries[@]}" "${dest_dir}"/ || exit 1
     fi
     eval "${shopt_saved}"
 }

--- a/tests/Acceptance/bin/lib/extract-zip.sh
+++ b/tests/Acceptance/bin/lib/extract-zip.sh
@@ -101,16 +101,33 @@ extract_zip_flattening_single_top_level_dir() {
     # multiple top-level entries — surface that as a hard error
     # instead of a subtly-broken web root. Glob-based check avoids
     # find + process-substitution + shellcheck SC2312.
+    # Helper is sourced — save the caller's nullglob+dotglob state so
+    # we can restore it before returning. `shopt -p` emits shopt
+    # commands that recreate the current state; eval replays them.
+    local shopt_saved
+    shopt_saved="$(shopt -p nullglob dotglob)"
+
     local zip_roots
     shopt -s nullglob dotglob
     zip_roots=("${zip_tmp}"/*)
-    shopt -u nullglob dotglob
     if [[ ${#zip_roots[@]} -ne 1 || ! -d "${zip_roots[0]}" ]]; then
         echo "::error::expected exactly one top-level directory in ${zip_path}, found ${#zip_roots[@]}:" >&2
         printf '  %s\n' "${zip_roots[@]}" >&2
+        # No shopt restore here — `exit` terminates the whole shell
+        # (callers run under set -euo pipefail), so caller-visible
+        # shell state is moot.
         exit 1
     fi
-    shopt -s dotglob
-    mv "${zip_roots[0]}"/* "${dest_dir}"/
-    shopt -u dotglob
+
+    # Keep nullglob+dotglob on for the flatten mv. An empty top-level
+    # dir would otherwise expand `${zip_roots[0]}/*` to a literal `*`
+    # and error; with nullglob the array is simply empty and we skip
+    # the mv (dest stays empty — callers will fail their own presence
+    # checks downstream if they expected content).
+    local zip_entries
+    zip_entries=("${zip_roots[0]}"/*)
+    if [[ ${#zip_entries[@]} -gt 0 ]]; then
+        mv "${zip_entries[@]}" "${dest_dir}"/
+    fi
+    eval "${shopt_saved}"
 }

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -129,6 +129,9 @@ TO_TARBALL_URL="https://github.com/openemr/openemr/releases/download/${TO_TAG_NA
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." &>/dev/null && pwd)"
 
+# shellcheck source=tests/Acceptance/bin/lib/extract-zip.sh
+source "${SCRIPT_DIR}/lib/extract-zip.sh"
+
 export HELPER_PATH="${SCRIPT_DIR}/install-helper.php"
 export COMPOSE_FILE="${REPO_ROOT}/.github/docker/acceptance-package-compose.yml"
 export COMPOSE_PROJECT_NAME="openemr-acceptance-package"
@@ -212,28 +215,16 @@ case "${ARTIFACT_FORMAT}" in
         ;;
     zip)
         # Same unzip + single-top-level-dir enforcement as
-        # boot-package.sh's zip branch. Download and zip branches are
-        # mutually exclusive (this branch only runs when --to-local-zip
-        # is set) so the bare EXIT trap doesn't clobber the download
-        # branch's ARTIFACT_PATH cleanup.
-        if ! command -v unzip >/dev/null 2>&1; then
-            echo "::error::unzip is required for --to-local-zip / zip extraction but was not found on PATH" >&2
-            exit 1
-        fi
-        ZIP_TMP="$(mktemp -d -t "openemr-acceptance-upgrade-zip.XXXXXX")"
-        trap 'rm -rf "${ZIP_TMP}"' EXIT
-        unzip -qo "${ARTIFACT_PATH}" -d "${ZIP_TMP}"
-        shopt -s nullglob
-        ZIP_ROOTS=("${ZIP_TMP}"/*)
-        shopt -u nullglob
-        if [[ ${#ZIP_ROOTS[@]} -ne 1 || ! -d "${ZIP_ROOTS[0]}" ]]; then
-            echo "::error::expected exactly one top-level directory in ${ARTIFACT_PATH}, found ${#ZIP_ROOTS[@]}:" >&2
-            printf '  %s\n' "${ZIP_ROOTS[@]}" >&2
-            exit 1
-        fi
-        shopt -s dotglob
-        mv "${ZIP_ROOTS[0]}"/* "${TO_TARBALL_DIR}"/
-        shopt -u dotglob
+        # boot-package.sh's zip branch — both call the shared helper.
+        # Download and zip branches are mutually exclusive (this branch
+        # only runs when --to-local-zip is set) so the helper's bare
+        # EXIT trap doesn't clobber the download branch's
+        # ARTIFACT_PATH cleanup.
+        extract_zip_flattening_single_top_level_dir \
+            "${ARTIFACT_PATH}" \
+            "${TO_TARBALL_DIR}" \
+            "openemr-acceptance-upgrade-zip.XXXXXX" \
+            "--to-local-zip / zip extraction"
         ;;
     *)
         echo "::error::unexpected ARTIFACT_FORMAT '${ARTIFACT_FORMAT}' (expected 'tar' or 'zip')" >&2

--- a/tests/bats/ci-scripts/extract-zip/extract.bats
+++ b/tests/bats/ci-scripts/extract-zip/extract.bats
@@ -1,0 +1,260 @@
+# BATS tests for tests/Acceptance/bin/lib/extract-zip.sh.
+#
+# Covers extract_zip_flattening_single_top_level_dir — the shared helper
+# sourced by boot-package.sh + upgrade-package.sh. Behavior contract:
+#   - single top-level directory in the zip is flattened into dest
+#   - contents (including dotfiles) all land in dest
+#   - multi top-level entries -> hard error (not silent merge)
+#   - zero top-level entries (empty zip) -> hard error
+#   - top-level file (not dir) -> hard error
+#   - missing zip file -> unzip error propagates (set -e in caller)
+#   - unzip not on PATH -> ::error:: with caller-supplied context noun
+#   - error_context noun appears verbatim in the unzip-missing message
+#     (so boot-package's "--local-zip" and upgrade-package's
+#     "--to-local-zip" wording stays distinct)
+
+load 'helpers'
+
+# Install the `zip` binary if missing. `unzip` ships in bats/bats:1.13.0's
+# Alpine base image but `zip` does not, and this suite builds fixture
+# archives with `zip -q` in helpers.bash::make_zip. GHA ubuntu-24.04
+# runners already have both. Runs once per test file.
+setup_file() {
+    if ! command -v zip >/dev/null 2>&1; then
+        if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache zip >/dev/null 2>&1 || true
+        elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update >/dev/null 2>&1 && apt-get install -y zip >/dev/null 2>&1 || true
+        fi
+    fi
+    if ! command -v zip >/dev/null 2>&1; then
+        echo "# skip-reason: 'zip' binary not installable in this environment" >&3
+        skip "zip binary required to build fixture archives"
+    fi
+}
+
+setup() {
+    setup_test_dir
+}
+
+teardown() {
+    teardown_test_dir
+}
+
+@test "single top-level dir: contents flattened into dest" {
+    mkdir -p "${STAGING_DIR}/openemr-8.2.0/interface"
+    echo "index" >"${STAGING_DIR}/openemr-8.2.0/index.php"
+    echo "iface" >"${STAGING_DIR}/openemr-8.2.0/interface/main.php"
+    make_zip openemr-8.2.0 openemr-8.2.0
+
+    run_extract "${ZIP_DIR}/openemr-8.2.0.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" "test context"
+
+    [[ ${status} -eq 0 ]]
+    [[ -f "${DEST_DIR}/index.php" ]]
+    [[ -f "${DEST_DIR}/interface/main.php" ]]
+    [[ "$(cat "${DEST_DIR}/index.php")" == "index" ]]
+    # Wrapper dir itself must NOT appear inside dest — that would mean
+    # the flattening didn't happen and callers would end up with a
+    # doubly-nested webroot.
+    [[ ! -d "${DEST_DIR}/openemr-8.2.0" ]]
+}
+
+@test "single top-level dir: dotfiles also flattened (shopt -s dotglob)" {
+    mkdir -p "${STAGING_DIR}/openemr-8.2.0"
+    echo "htaccess" >"${STAGING_DIR}/openemr-8.2.0/.htaccess"
+    echo "index" >"${STAGING_DIR}/openemr-8.2.0/index.php"
+    make_zip openemr-8.2.0 openemr-8.2.0
+
+    run_extract "${ZIP_DIR}/openemr-8.2.0.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" "test context"
+
+    [[ ${status} -eq 0 ]]
+    [[ -f "${DEST_DIR}/.htaccess" ]]
+    [[ -f "${DEST_DIR}/index.php" ]]
+}
+
+@test "single top-level dir: nested directory structure preserved" {
+    mkdir -p "${STAGING_DIR}/openemr-8.2.0/sites/default/documents"
+    echo "config" >"${STAGING_DIR}/openemr-8.2.0/sites/default/sqlconf.php"
+    make_zip openemr-8.2.0 openemr-8.2.0
+
+    run_extract "${ZIP_DIR}/openemr-8.2.0.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" "test context"
+
+    [[ ${status} -eq 0 ]]
+    [[ -d "${DEST_DIR}/sites/default/documents" ]]
+    [[ -f "${DEST_DIR}/sites/default/sqlconf.php" ]]
+}
+
+@test "multi top-level entries: rejected with clear error" {
+    mkdir -p "${STAGING_DIR}/openemr-8.2.0"
+    mkdir -p "${STAGING_DIR}/rogue-dir"
+    echo "x" >"${STAGING_DIR}/openemr-8.2.0/index.php"
+    echo "y" >"${STAGING_DIR}/rogue-dir/oops.php"
+    make_zip mixed openemr-8.2.0 rogue-dir
+
+    run_extract "${ZIP_DIR}/mixed.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" "test context"
+
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"expected exactly one top-level directory"* ]]
+    [[ "${output}" == *"found 2"* ]]
+    # dest must stay empty on failure — no partial merge
+    [[ -z "$(ls -A "${DEST_DIR}")" ]]
+}
+
+@test "top-level file (not directory) rejected" {
+    # A zip containing a single top-level file (rather than a
+    # directory) should fail the `-d "${zip_roots[0]}"` guard.
+    echo "loose" >"${STAGING_DIR}/loose-file.txt"
+    make_zip loose loose-file.txt
+
+    run_extract "${ZIP_DIR}/loose.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" "test context"
+
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"expected exactly one top-level directory"* ]]
+    [[ "${output}" == *"found 1"* ]]
+}
+
+@test "empty zip rejected (zero top-level entries)" {
+    # `zip` refuses to create a truly empty archive, so build one with
+    # printf + zip stdin trickery: create with a dummy entry then
+    # delete it, leaving a 0-entry archive.
+    echo "x" >"${STAGING_DIR}/temp"
+    (cd "${STAGING_DIR}" && zip -q "${ZIP_DIR}/empty.zip" temp && zip -qd "${ZIP_DIR}/empty.zip" temp)
+
+    run_extract "${ZIP_DIR}/empty.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" "test context"
+
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"expected exactly one top-level directory"* ]]
+    [[ "${output}" == *"found 0"* ]]
+}
+
+@test "missing zip file: unzip surfaces failure, extraction aborts" {
+    run_extract "${ZIP_DIR}/does-not-exist.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" "test context"
+
+    [[ ${status} -ne 0 ]]
+    # dest stays empty because the mv never runs
+    [[ -z "$(ls -A "${DEST_DIR}")" ]]
+}
+
+@test "error_context noun interpolated into unzip-missing error" {
+    # PATH stripped so `command -v unzip` fails; assert the
+    # caller-supplied noun appears verbatim in the diagnostic.
+    mkdir -p "${STAGING_DIR}/openemr-8.2.0"
+    echo "x" >"${STAGING_DIR}/openemr-8.2.0/index.php"
+    make_zip openemr-8.2.0 openemr-8.2.0
+
+    # Use absolute path to bash — PATH="" would otherwise prevent the
+    # shell binary itself from being found by `run`, masking the guard
+    # we're actually trying to exercise (unzip missing).
+    local bash_bin
+    bash_bin="$(command -v bash)"
+    PATH="" run "${bash_bin}" -c \
+        "source '${EXTRACT_ZIP_LIB}'; extract_zip_flattening_single_top_level_dir \"\$@\"" \
+        _ "${ZIP_DIR}/openemr-8.2.0.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" \
+        "--local-zip / zip extraction"
+
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"unzip is required for --local-zip / zip extraction"* ]]
+    [[ "${output}" == *"was not found on PATH"* ]]
+}
+
+@test "error_context noun distinguishes boot-package vs upgrade-package callers" {
+    # Same guard, different noun — proves the parameterization actually
+    # flows through (regression guard: swap the source-of-truth from a
+    # hard-coded string to a $4 parameter without breaking either
+    # caller's error message).
+    mkdir -p "${STAGING_DIR}/openemr-8.2.0"
+    echo "x" >"${STAGING_DIR}/openemr-8.2.0/index.php"
+    make_zip openemr-8.2.0 openemr-8.2.0
+
+    # Use absolute path to bash — PATH="" would otherwise prevent the
+    # shell binary itself from being found by `run`, masking the guard
+    # we're actually trying to exercise (unzip missing).
+    local bash_bin
+    bash_bin="$(command -v bash)"
+    PATH="" run "${bash_bin}" -c \
+        "source '${EXTRACT_ZIP_LIB}'; extract_zip_flattening_single_top_level_dir \"\$@\"" \
+        _ "${ZIP_DIR}/openemr-8.2.0.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" \
+        "--to-local-zip / zip extraction"
+
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"unzip is required for --to-local-zip / zip extraction"* ]]
+}
+
+@test "error message includes zip path (for grep-in-CI-logs debuggability)" {
+    mkdir -p "${STAGING_DIR}/dirA" "${STAGING_DIR}/dirB"
+    echo "x" >"${STAGING_DIR}/dirA/f"
+    echo "y" >"${STAGING_DIR}/dirB/f"
+    make_zip badzip dirA dirB
+
+    run_extract "${ZIP_DIR}/badzip.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" "test context"
+
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"${ZIP_DIR}/badzip.zip"* ]]
+}
+
+@test "dest dir need not be empty pre-call, but wrapper contents move into it" {
+    # Callers (boot-package.sh, upgrade-package.sh) mkdir -p the dest
+    # before invoking. Nothing in this helper's contract says the dest
+    # must be empty — a leftover file in dest should coexist alongside
+    # the extracted tree.
+    mkdir -p "${STAGING_DIR}/openemr-8.2.0"
+    echo "extracted" >"${STAGING_DIR}/openemr-8.2.0/index.php"
+    make_zip openemr-8.2.0 openemr-8.2.0
+    echo "preexisting" >"${DEST_DIR}/already-here.txt"
+
+    run_extract "${ZIP_DIR}/openemr-8.2.0.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" "test context"
+
+    [[ ${status} -eq 0 ]]
+    [[ -f "${DEST_DIR}/index.php" ]]
+    [[ -f "${DEST_DIR}/already-here.txt" ]]
+}
+
+@test "scratch dir cleaned up on success (EXIT trap fires)" {
+    mkdir -p "${STAGING_DIR}/openemr-8.2.0"
+    echo "x" >"${STAGING_DIR}/openemr-8.2.0/index.php"
+    make_zip openemr-8.2.0 openemr-8.2.0
+
+    # Snapshot /tmp entries matching our scratch-template prefix before
+    # + after; the trap should leave no residue.
+    local before_count
+    before_count="$(find /tmp -maxdepth 1 -name 'extract-zip-cleanup-success.*' 2>/dev/null | wc -l)"
+
+    run_extract "${ZIP_DIR}/openemr-8.2.0.zip" "${DEST_DIR}" "extract-zip-cleanup-success.XXXXXX" "test context"
+
+    [[ ${status} -eq 0 ]]
+    local after_count
+    after_count="$(find /tmp -maxdepth 1 -name 'extract-zip-cleanup-success.*' 2>/dev/null | wc -l)"
+    [[ "${after_count}" -eq "${before_count}" ]]
+}
+
+@test "scratch dir cleaned up on failure (EXIT trap fires on multi-top-level rejection)" {
+    mkdir -p "${STAGING_DIR}/dirA" "${STAGING_DIR}/dirB"
+    echo "x" >"${STAGING_DIR}/dirA/f"
+    echo "y" >"${STAGING_DIR}/dirB/f"
+    make_zip mixed dirA dirB
+
+    local before_count
+    before_count="$(find /tmp -maxdepth 1 -name 'extract-zip-cleanup-failure.*' 2>/dev/null | wc -l)"
+
+    run_extract "${ZIP_DIR}/mixed.zip" "${DEST_DIR}" "extract-zip-cleanup-failure.XXXXXX" "test context"
+
+    [[ ${status} -ne 0 ]]
+    local after_count
+    after_count="$(find /tmp -maxdepth 1 -name 'extract-zip-cleanup-failure.*' 2>/dev/null | wc -l)"
+    [[ "${after_count}" -eq "${before_count}" ]]
+}
+
+@test "wrapper dir name doesn't have to match zip filename (any single top-level dir works)" {
+    # The single-top-level-dir enforcement doesn't care what the dir is
+    # NAMED — it just requires exactly one. Confirms we're not
+    # accidentally checking for a specific `openemr-<version>/` string.
+    mkdir -p "${STAGING_DIR}/arbitrary-name"
+    echo "x" >"${STAGING_DIR}/arbitrary-name/marker"
+    make_zip weird arbitrary-name
+
+    run_extract "${ZIP_DIR}/weird.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" "test context"
+
+    [[ ${status} -eq 0 ]]
+    [[ -f "${DEST_DIR}/marker" ]]
+    [[ ! -d "${DEST_DIR}/arbitrary-name" ]]
+}

--- a/tests/bats/ci-scripts/extract-zip/extract.bats
+++ b/tests/bats/ci-scripts/extract-zip/extract.bats
@@ -100,6 +100,23 @@ teardown() {
     [[ -z "$(ls -A "${DEST_DIR}")" ]]
 }
 
+@test "single top-level dir is empty: succeeds silently, dest stays empty" {
+    # Regression guard for the nullglob-off-during-mv bug: with nullglob
+    # disabled between the root check and the mv, an empty top-level dir
+    # would expand `${zip_roots[0]}/*` to a literal `*` and mv would fail
+    # with "cannot stat '.../\\*': No such file or directory". Keeping
+    # nullglob on through the mv turns that into a no-op (dest stays
+    # empty — callers detect empty content via their own downstream
+    # presence checks).
+    mkdir -p "${STAGING_DIR}/openemr-8.2.0"
+    make_zip empty-openemr openemr-8.2.0
+
+    run_extract "${ZIP_DIR}/empty-openemr.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" "test context"
+
+    [[ ${status} -eq 0 ]]
+    [[ -z "$(ls -A "${DEST_DIR}")" ]]
+}
+
 @test "multi top-level entries with dot-prefixed sibling: rejected (nullglob+dotglob)" {
     # Regression guard for the nullglob-alone bug: without `dotglob`,
     # the single-root check ignored dot-prefixed top-level entries so

--- a/tests/bats/ci-scripts/extract-zip/extract.bats
+++ b/tests/bats/ci-scripts/extract-zip/extract.bats
@@ -100,6 +100,24 @@ teardown() {
     [[ -z "$(ls -A "${DEST_DIR}")" ]]
 }
 
+@test "multi top-level entries with dot-prefixed sibling: rejected (nullglob+dotglob)" {
+    # Regression guard for the nullglob-alone bug: without `dotglob`,
+    # the single-root check ignored dot-prefixed top-level entries so
+    # `openemr-.../` + `.metadata` would pass with found=1 and
+    # `.metadata` would be silently dropped by the wrapper flatten.
+    mkdir -p "${STAGING_DIR}/openemr-8.2.0"
+    echo "x" >"${STAGING_DIR}/openemr-8.2.0/index.php"
+    echo "meta" >"${STAGING_DIR}/.metadata"
+    make_zip with-dotfile openemr-8.2.0 .metadata
+
+    run_extract "${ZIP_DIR}/with-dotfile.zip" "${DEST_DIR}" "extract-zip-test.XXXXXX" "test context"
+
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"expected exactly one top-level directory"* ]]
+    [[ "${output}" == *"found 2"* ]]
+    [[ -z "$(ls -A "${DEST_DIR}")" ]]
+}
+
 @test "top-level file (not directory) rejected" {
     # A zip containing a single top-level file (rather than a
     # directory) should fail the `-d "${zip_roots[0]}"` guard.

--- a/tests/bats/ci-scripts/extract-zip/helpers.bash
+++ b/tests/bats/ci-scripts/extract-zip/helpers.bash
@@ -1,0 +1,61 @@
+# Helpers for BATS tests of tests/Acceptance/bin/lib/extract-zip.sh.
+#
+# The library is a sourced bash function, not an env-invoked script, so
+# tests need a small wrapper that sources the library and calls the
+# function under `run`. See run_extract() below.
+#
+# mktemp portability: this helpers file uses `mktemp -d` WITHOUT `-t
+# <template>`. BusyBox's mktemp (Alpine's bats/bats:1.13.0 base image)
+# rejects the `-t <template>` form that GNU coreutils accepts, and this
+# suite is expected to run in that container too. The extract-zip.sh
+# library itself uses `mktemp -d -t <template>` — that's fine because
+# it runs on GHA ubuntu-24.04 runners (GNU coreutils), not in the BATS
+# container.
+
+__HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034  # referenced from .bats files
+EXTRACT_ZIP_LIB="$(cd "${__HELPERS_DIR}/../../../.." && pwd)/tests/Acceptance/bin/lib/extract-zip.sh"
+
+setup_test_dir() {
+    # -d only; NO `-t <template>` — BusyBox mktemp rejects that form.
+    TEST_DIR="$(mktemp -d)"
+    ZIP_DIR="${TEST_DIR}/zips"
+    DEST_DIR="${TEST_DIR}/dest"
+    STAGING_DIR="${TEST_DIR}/staging"
+    mkdir -p "${ZIP_DIR}" "${DEST_DIR}" "${STAGING_DIR}"
+}
+
+teardown_test_dir() {
+    cd /
+    if [[ -n "${TEST_DIR:-}" && -d "${TEST_DIR}" ]]; then
+        rm -rf "${TEST_DIR}"
+    fi
+    unset TEST_DIR ZIP_DIR DEST_DIR STAGING_DIR
+}
+
+# Build a .zip at ${ZIP_DIR}/${1}.zip whose top-level entries are the
+# staged directory tree passed as ${2}... (each entry is a path
+# relative to ${STAGING_DIR} that must already exist). The wrapper dir
+# structure is caller's responsibility — this helper just zips whatever
+# is at ${STAGING_DIR}/${entry}.
+#
+# Example:
+#   make_zip openemr-8.2.0 openemr-8.2.0
+#   → produces openemr-8.2.0.zip with a single top-level `openemr-8.2.0/`
+make_zip() {
+    local zip_name="$1"
+    shift
+    (
+        cd "${STAGING_DIR}"
+        # -q quiet; -r recurse into any dirs; explicit path list rather
+        # than `*` so callers get deterministic top-level entries.
+        zip -qr "${ZIP_DIR}/${zip_name}.zip" "$@"
+    )
+}
+
+# Wrapper: source the library, run the function under `run`. Callers
+# pass all four positional args exactly as the production callers do.
+run_extract() {
+    run bash -c "source '${EXTRACT_ZIP_LIB}'; extract_zip_flattening_single_top_level_dir \"\$@\"" \
+        _ "$@"
+}


### PR DESCRIPTION
## Summary

- Hoists the ~30-line ZIP-extract dance (mktemp scratch dir, unzip, single-top-level-dir enforcement, mv-into-place) out of `boot-package.sh` and `upgrade-package.sh` into a new shared helper at `tests/Acceptance/bin/lib/extract-zip.sh` (sourced by both).
- Adds BATS coverage at `tests/bats/ci-scripts/extract-zip/` (14 tests) and wires it into `test-byte-identical-scripts.yml`.
- Behavior-preserving: same unzip PATH guard, same single-top-level enforcement, same EXIT-trap cleanup ordering, same `::error::` message shapes. Each caller passes its own mktemp template prefix and `error_context` noun so the diagnostics stay flag-accurate (`--local-zip` vs `--to-local-zip`).

## Byte-identical scope

The helper lives under `tests/Acceptance/`, so the existing `tests/Acceptance/**` entry in `.github/byte-identical.yml` auto-syncs it to rel-810+ alongside the two callers that source it. No new byte-identical entry needed; the sync canary handles the propagation.

## BATS portability note

Helpers use `mktemp -d` without `-t <template>` — BusyBox's mktemp (Alpine's `bats/bats:1.13.0` base image) rejects the `-t` form. The extract-zip.sh library itself keeps GNU coreutils' `mktemp -d -t <template>` since it runs on GHA `ubuntu-24.04` runners. A `setup_file` hook `apk add`s `zip` when missing (`unzip` ships in the base image but `zip` does not — needed to build fixture archives).

## Test plan

- [x] `docker run --rm -v $(pwd):/code -w /code bats/bats:1.13.0 tests/bats/ci-scripts/extract-zip/` — 14/14 pass
- [x] `shellcheck --check-sourced --external-sources` clean on helper + both callers
- [ ] Acceptance CI (`acceptance-package.yml` matrix `format: zip` cells) exercises the refactored zip branch on PR + merge
- [ ] `test-byte-identical-scripts.yml` runs the new suite on this PR

## Follow-ups

- After merge, byte-identical sync canary will propagate the helper + refactored scripts to rel-810 + rel-820 on its next run. rel-800 + rel-704 are excluded from the `tests/Acceptance/**` glob (they predate the acceptance surface entirely).