### PR TITLE
refactor(ci): extract release app-token generation into composite action

### DIFF
--- a/.github/actions/generate-app-token/action.yml
+++ b/.github/actions/generate-app-token/action.yml
@@ -1,10 +1,12 @@
-name: Generate release app token
+name: Generate app token
 description: >
   Mint a GitHub App installation token via
   actions/create-github-app-token@v3. Centralizes the boilerplate so
-  every release-mechanism workflow that needs a bot-scoped token wires
-  it the same way (single point to bump the underlying action version,
-  add new inputs, or adjust minted-token defaults).
+  every workflow that needs a bot-scoped token wires it the same way
+  (single point to bump the underlying action version, add new inputs,
+  or adjust minted-token defaults). Used by the release-mechanism
+  workflows (RELEASE_APP), dependabot auto-merge (AUTO_MERGE_APP),
+  and the reserved-word refresh (RESERVED_WORD_BOT).
 
 inputs:
   client-id:

--- a/.github/actions/generate-release-app-token/action.yml
+++ b/.github/actions/generate-release-app-token/action.yml
@@ -26,8 +26,10 @@ inputs:
   repositories:
     description: >
       Newline- or comma-separated repository names to scope the
-      installation token to (least-privilege). Defaults to unset,
-      which mints a token spanning every repo the app is installed on.
+      installation token to (least-privilege). When `owner` is set,
+      leaving this unset grants access to every repository in that
+      owner's installation; when both are unset, access is limited to
+      the current repository.
     required: false
     default: ''
   permission-contents:

--- a/.github/actions/generate-release-app-token/action.yml
+++ b/.github/actions/generate-release-app-token/action.yml
@@ -1,0 +1,80 @@
+name: Generate release app token
+description: >
+  Mint a GitHub App installation token via
+  actions/create-github-app-token@v3. Centralizes the boilerplate so
+  every release-mechanism workflow that needs a bot-scoped token wires
+  it the same way (single point to bump the underlying action version,
+  add new inputs, or adjust minted-token defaults).
+
+inputs:
+  client-id:
+    description: GitHub App client ID (typically vars.RELEASE_APP_CLIENT_ID).
+    required: true
+  private-key:
+    description: >
+      GitHub App private key PEM (typically
+      secrets.RELEASE_APP_PRIVATE_KEY).
+    required: true
+  owner:
+    description: >
+      Owner to scope the installation token to. Defaults to unset,
+      which lets create-github-app-token@v3 pick the current repo's
+      owner. Set explicitly when scoping to sibling repositories
+      (e.g. dispatch targets like website-openemr, demo_farm_openemr).
+    required: false
+    default: ''
+  repositories:
+    description: >
+      Newline- or comma-separated repository names to scope the
+      installation token to (least-privilege). Defaults to unset,
+      which mints a token spanning every repo the app is installed on.
+    required: false
+    default: ''
+  permission-contents:
+    description: >
+      Optional least-privilege grant for the `contents` permission
+      (read | write). Leave unset to inherit the App installation's
+      default.
+    required: false
+    default: ''
+  permission-metadata:
+    description: >
+      Optional least-privilege grant for the `metadata` permission
+      (read). Leave unset to inherit the App installation's default.
+    required: false
+    default: ''
+  permission-pull-requests:
+    description: >
+      Optional least-privilege grant for the `pull-requests`
+      permission (read | write). Leave unset to inherit the App
+      installation's default.
+    required: false
+    default: ''
+  permission-statuses:
+    description: >
+      Optional least-privilege grant for the `statuses` permission
+      (read | write). Leave unset to inherit the App installation's
+      default.
+    required: false
+    default: ''
+
+outputs:
+  token:
+    description: The minted GitHub App installation token.
+    value: ${{ steps.create-token.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+  - name: Create GitHub App token
+    id: create-token
+    uses: actions/create-github-app-token@v3
+    with:
+      client-id: ${{ inputs.client-id }}
+      private-key: ${{ inputs.private-key }}
+      owner: ${{ inputs.owner }}
+      repositories: ${{ inputs.repositories }}
+      permission-contents: ${{ inputs.permission-contents }}
+      permission-metadata: ${{ inputs.permission-metadata }}
+      permission-pull-requests: ${{ inputs.permission-pull-requests }}
+      permission-statuses: ${{ inputs.permission-statuses }}

--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -218,8 +218,8 @@ files:
   exclude-branches: [rel-800, rel-704]
 - path: .github/actions/setup-php-composer/action.yml
   exclude-branches: [rel-800, rel-704]
-# Phase 10b (openemr/openemr#TBD, 2026-07-30): generate-release-app-token
-# is called via `uses: ./.github/actions/generate-release-app-token`
+# Phase 10b (openemr/openemr#TBD, 2026-07-30): generate-app-token
+# is called via `uses: ./.github/actions/generate-app-token`
 # from build-release.yml, release-prep.yml, build-patch.yml, patch-prep-
 # automation.yml, branch-cut-automation.yml, release-permissions-check.yml,
 # and reusable-publish-release.yml -- all of which are in this block
@@ -228,7 +228,7 @@ files:
 # action.yml must exist on every branch the caller workflows can fire
 # from. rel-800/rel-704 excluded for the same reason the callers are
 # (those branches predate the release mechanism entirely).
-- path: .github/actions/generate-release-app-token/**
+- path: .github/actions/generate-app-token/**
   exclude-branches: [rel-800, rel-704]
 - path: .github/PULL_REQUEST_TEMPLATE/release-prep.md
   exclude-branches: [rel-800, rel-704]

--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -218,6 +218,18 @@ files:
   exclude-branches: [rel-800, rel-704]
 - path: .github/actions/setup-php-composer/action.yml
   exclude-branches: [rel-800, rel-704]
+# Phase 10b (openemr/openemr#TBD, 2026-07-30): generate-release-app-token
+# is called via `uses: ./.github/actions/generate-release-app-token`
+# from build-release.yml, release-prep.yml, build-patch.yml, patch-prep-
+# automation.yml, branch-cut-automation.yml, release-permissions-check.yml,
+# and reusable-publish-release.yml -- all of which are in this block
+# with the same rel-800/rel-704 exclusion. Composite paths resolve
+# against the workflow's local checkout at step-load time, so the
+# action.yml must exist on every branch the caller workflows can fire
+# from. rel-800/rel-704 excluded for the same reason the callers are
+# (those branches predate the release mechanism entirely).
+- path: .github/actions/generate-release-app-token/**
+  exclude-branches: [rel-800, rel-704]
 - path: .github/PULL_REQUEST_TEMPLATE/release-prep.md
   exclude-branches: [rel-800, rel-704]
 - path: .github/PULL_REQUEST_TEMPLATE/release-finalize.md

--- a/.github/workflows/branch-cut-automation.yml
+++ b/.github/workflows/branch-cut-automation.yml
@@ -58,13 +58,13 @@ jobs:
     - name: Checkout composite action
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout: .github/actions/generate-app-token
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
     - name: Mint App token
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/branch-cut-automation.yml
+++ b/.github/workflows/branch-cut-automation.yml
@@ -52,9 +52,19 @@ jobs:
         php-version:
         - '8.5'
     steps:
+    # Sparse checkout of just the composite action so the token-mint
+    # step below can resolve `uses: ./.github/actions/...`. Full
+    # checkouts happen later against the master/new-rel-branch refs.
+    - name: Checkout composite action
+      uses: actions/checkout@v7
+      with:
+        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout-cone-mode: false
+        persist-credentials: false
+
     - name: Mint App token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -120,10 +120,21 @@ jobs:
         printf '::error::release_tag is required when dry_run is false\n'
         exit 1
 
+    # Sparse checkout of just the composite action so the token-mint
+    # step below can resolve `uses: ./.github/actions/...`. Full
+    # checkout happens after the token is minted (uses the token).
+    - name: Checkout composite action
+      if: '!inputs.dry_run'
+      uses: actions/checkout@v7
+      with:
+        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout-cone-mode: false
+        persist-credentials: false
+
     - name: Generate app token
       if: '!inputs.dry_run'
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -127,14 +127,14 @@ jobs:
       if: '!inputs.dry_run'
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout: .github/actions/generate-app-token
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
     - name: Generate app token
       if: '!inputs.dry_run'
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -134,10 +134,21 @@ jobs:
         printf '::error::release_tag is required when dry_run is false\n'
         exit 1
 
+    # Sparse checkout of just the composite action so the token-mint
+    # step below can resolve `uses: ./.github/actions/...`. Full
+    # checkout happens after the token is minted (uses the token).
+    - name: Checkout composite action
+      if: '!inputs.dry_run'
+      uses: actions/checkout@v7
+      with:
+        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout-cone-mode: false
+        persist-credentials: false
+
     - name: Generate app token
       if: '!inputs.dry_run'
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -141,14 +141,14 @@ jobs:
       if: '!inputs.dry_run'
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout: .github/actions/generate-app-token
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
     - name: Generate app token
       if: '!inputs.dry_run'
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,13 +18,13 @@ jobs:
     - name: Checkout composite action
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout: .github/actions/generate-app-token
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
     - name: Generate GitHub App token
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.AUTO_MERGE_APP_CLIENT_ID }}
         private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,9 +12,19 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-24.04
     steps:
+    # Sparse checkout of just the composite action so the token-mint
+    # step below can resolve `uses: ./.github/actions/...`. This
+    # workflow doesn't otherwise need a checkout.
+    - name: Checkout composite action
+      uses: actions/checkout@v7
+      with:
+        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout-cone-mode: false
+        persist-credentials: false
+
     - name: Generate GitHub App token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.AUTO_MERGE_APP_CLIENT_ID }}
         private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}

--- a/.github/workflows/notify-release-targets-changed.yml
+++ b/.github/workflows/notify-release-targets-changed.yml
@@ -34,9 +34,20 @@ jobs:
         php-version:
         - '8.5'
     steps:
+    # Sparse checkout of just the composite action so the token-mint
+    # step below can resolve `uses: ./.github/actions/...`. Full
+    # checkout happens later (in this workflow that's just for
+    # setup-php-composer's autoload).
+    - name: Checkout composite action
+      uses: actions/checkout@v7
+      with:
+        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout-cone-mode: false
+        persist-credentials: false
+
     - name: Mint App token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/notify-release-targets-changed.yml
+++ b/.github/workflows/notify-release-targets-changed.yml
@@ -41,13 +41,13 @@ jobs:
     - name: Checkout composite action
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout: .github/actions/generate-app-token
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
     - name: Mint App token
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/patch-prep-automation.yml
+++ b/.github/workflows/patch-prep-automation.yml
@@ -66,13 +66,13 @@ jobs:
     - name: Checkout composite action
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout: .github/actions/generate-app-token
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
     - name: Mint App token
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/patch-prep-automation.yml
+++ b/.github/workflows/patch-prep-automation.yml
@@ -59,9 +59,20 @@ jobs:
         php-version:
         - '8.5'
     steps:
+    # Sparse checkout of just the composite action so the token-mint
+    # step below can resolve `uses: ./.github/actions/...`. Full
+    # checkout happens later (the two later checkouts here use the
+    # rel branch, not master, so we can't collapse them into this).
+    - name: Checkout composite action
+      uses: actions/checkout@v7
+      with:
+        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout-cone-mode: false
+        persist-credentials: false
+
     - name: Mint App token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/refresh-reserved-word-supplement.yml
+++ b/.github/workflows/refresh-reserved-word-supplement.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Generate GitHub App token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RESERVED_WORD_BOT_CLIENT_ID }}
         private-key: ${{ secrets.RESERVED_WORD_BOT_PRIVATE_KEY }}

--- a/.github/workflows/refresh-reserved-word-supplement.yml
+++ b/.github/workflows/refresh-reserved-word-supplement.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Generate GitHub App token
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RESERVED_WORD_BOT_CLIENT_ID }}
         private-key: ${{ secrets.RESERVED_WORD_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release-amendment.yml
+++ b/.github/workflows/release-amendment.yml
@@ -75,7 +75,7 @@ jobs:
 
     - name: Mint App token
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-amendment.yml
+++ b/.github/workflows/release-amendment.yml
@@ -75,7 +75,7 @@ jobs:
 
     - name: Mint App token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Mint App token
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Mint App token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Mint App token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -548,7 +548,7 @@ jobs:
 
     - name: Mint App token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Mint App token
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -548,7 +548,7 @@ jobs:
 
     - name: Mint App token
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/reusable-publish-release.yml
+++ b/.github/workflows/reusable-publish-release.yml
@@ -77,9 +77,19 @@ jobs:
     # boundaries anyway (writing a token to `$GITHUB_OUTPUT` masks it
     # in logs but the value that reaches the downstream job is often
     # empty). Regenerating is the documented path.
+    # Sparse checkout of just the composite action so the token-mint
+    # step below can resolve `uses: ./.github/actions/...`. Full
+    # checkout happens after the token is minted (uses the token).
+    - name: Checkout composite action
+      uses: actions/checkout@v7
+      with:
+        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout-cone-mode: false
+        persist-credentials: false
+
     - name: Generate app token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/reusable-publish-release.yml
+++ b/.github/workflows/reusable-publish-release.yml
@@ -83,13 +83,13 @@ jobs:
     - name: Checkout composite action
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout: .github/actions/generate-app-token
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
     - name: Generate app token
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -110,9 +110,19 @@ jobs:
     env:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
+    # Sparse checkout of just the composite action so the token-mint
+    # step below can resolve `uses: ./.github/actions/...`. Full
+    # checkout happens after the token is minted (uses the token).
+    - name: Checkout composite action
+      uses: actions/checkout@v7
+      with:
+        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout-cone-mode: false
+        persist-credentials: false
+
     - name: Mint release App token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -116,13 +116,13 @@ jobs:
     - name: Checkout composite action
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout: .github/actions/generate-app-token
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
     - name: Mint release App token
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/sync-byte-identical.yml
+++ b/.github/workflows/sync-byte-identical.yml
@@ -100,13 +100,13 @@ jobs:
     - name: Checkout composite action
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout: .github/actions/generate-app-token
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
     - name: Mint App token
       id: app-token
-      uses: ./.github/actions/generate-release-app-token
+      uses: ./.github/actions/generate-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/sync-byte-identical.yml
+++ b/.github/workflows/sync-byte-identical.yml
@@ -92,9 +92,21 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.enumerate-rel-branches.outputs.branches) }}
     steps:
+    # Sparse checkout of master's composite action so the token-mint
+    # step below can resolve `uses: ./.github/actions/...`. The rel-
+    # branch checkout below overwrites this with the branch's own
+    # tree (which may or may not have the composite -- rel-800 +
+    # rel-704 don't; see .github/byte-identical.yml).
+    - name: Checkout composite action
+      uses: actions/checkout@v7
+      with:
+        sparse-checkout: .github/actions/generate-release-app-token
+        sparse-checkout-cone-mode: false
+        persist-credentials: false
+
     - name: Mint App token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: ./.github/actions/generate-release-app-token
       with:
         client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Extracts the repeated `actions/create-github-app-token@v3` boilerplate from 14 callsites into a single composite at `.github/actions/generate-release-app-token/action.yml`. Every release-mechanism workflow (and the two non-release ones that also mint an app token) now delegates through the composite, so the underlying action version + minted-token input surface is managed in one place.

Zero behavior change. All existing inputs surface through the composite; empty-string defaults are passed through unchanged (the underlying action's `lib/get-permissions-from-inputs.js` explicitly skips empty values, and `owner` / `repositories` are handled the same way).

## What changed

**New composite:** `.github/actions/generate-release-app-token/action.yml`
- Inputs: `client-id`, `private-key` (required); `owner`, `repositories`, `permission-contents`, `permission-metadata`, `permission-pull-requests`, `permission-statuses` (optional, empty-string default).
- Output: `token` (the minted installation token).

**Callsites converted (14 total across 13 workflows):**
- Release pipeline: `build-release.yml`, `build-patch.yml`, `ship-release.yml`, `reusable-publish-release.yml`
- Release-prep: `release-prep.yml` (build-package + finalize), `release-amendment.yml`, `release-permissions-check.yml`
- Automation: `branch-cut-automation.yml`, `patch-prep-automation.yml`, `notify-release-targets-changed.yml`, `sync-byte-identical.yml`
- Non-release consumers: `refresh-reserved-word-supplement.yml`, `dependabot-auto-merge.yml`

**Bootstrap checkout:** Workflows that previously minted a token *before* any `actions/checkout` step now include a sparse-checkout of just `.github/actions/generate-release-app-token/` ahead of the token step, since local composite paths resolve against the runner's checked-out tree at step-load time. Subsequent full checkouts in the same job overwrite the sparse checkout transparently.

**Byte-identical wiring:** Added `.github/actions/generate-release-app-token/**` to `.github/byte-identical.yml` with `exclude-branches: [rel-800, rel-704]` — the same rel-branch exclusion the caller workflows in that file already carry. rel-810 + rel-820 pull the composite via the byte-identical sync so their copies of the caller workflows can resolve `./.github/actions/generate-release-app-token` locally.

## Plan doc reference

Phase 10b of the release-mechanism unification work tracked in `docs/release-mechanism-migration-from-devops.md`.

## Test plan

- [x] `actionlint` (pinned `rhysd/actionlint:1.7.10` docker image) runs clean on the changed workflow tree
- [x] Pre-commit suite passes (actionlint + yaml + codespell + conventional-commits + trim/EOF hooks)
- [ ] Real-world verification lands with the next release-mechanism firing that exercises one of the converted workflows (release-prep on the next rel-830 push, sync-byte-identical on the next master push, or a manual dispatch of release-permissions-check). No functional test in this PR because the composite is a pass-through — the underlying `actions/create-github-app-token@v3` behavior is unchanged.