### PR TITLE
test(bats): use portable mktemp -d across 5 helper suites (Phase 10e slice 1)

### DIFF
--- a/tests/bats/ci-scripts/expand-docker-tags/helpers.bash
+++ b/tests/bats/ci-scripts/expand-docker-tags/helpers.bash
@@ -9,7 +9,10 @@ __HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXPAND_DOCKER_TAGS_SCRIPT="$(cd "${__HELPERS_DIR}/../../../.." && pwd)/.github/scripts/expand-docker-tags.sh"
 
 setup_test_dir() {
-    CWD=$(mktemp -d -t expand-docker-tags-test-XXXX)
+    # `mktemp -d` (no `-t <template>`) — BusyBox's mktemp in the
+    # bats/bats:1.13.0 Alpine image rejects the `-t` form that GNU
+    # mktemp accepts.
+    CWD=$(mktemp -d)
     cd "${CWD}" || exit 1
 }
 

--- a/tests/bats/ci-scripts/list-manifest-paths/helpers.bash
+++ b/tests/bats/ci-scripts/list-manifest-paths/helpers.bash
@@ -9,7 +9,10 @@ __HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIST_MANIFEST_PATHS_SCRIPT="$(cd "${__HELPERS_DIR}/../../../.." && pwd)/.github/scripts/list-manifest-paths.sh"
 
 setup_test_dir() {
-    CWD=$(mktemp -d -t list-manifest-paths-test-XXXX)
+    # `mktemp -d` (no `-t <template>`) — BusyBox's mktemp in the
+    # bats/bats:1.13.0 Alpine image rejects the `-t` form that GNU
+    # mktemp accepts.
+    CWD=$(mktemp -d)
     # shellcheck disable=SC2034  # referenced from .bats files
     MANIFEST="${CWD}/manifest.yml"
     cd "${CWD}" || exit 1

--- a/tests/bats/ci-scripts/sync-byte-identical/helpers.bash
+++ b/tests/bats/ci-scripts/sync-byte-identical/helpers.bash
@@ -20,7 +20,10 @@ SYNC_BYTE_IDENTICAL_SCRIPT="$(cd "${__HELPERS_DIR}/../../../.." && pwd)/.github/
 # the same shell as the @test that follows).
 setup_test_repo() {
     local rel_branch="${1:-rel-810}"
-    REPO=$(mktemp -d -t sync-byte-identical-test-XXXX)
+    # `mktemp -d` (no `-t <template>`) — BusyBox's mktemp in the
+    # bats/bats:1.13.0 Alpine image rejects the `-t` form that GNU
+    # mktemp accepts.
+    REPO=$(mktemp -d)
     OUTPUT_DIR="${REPO}/output"
     mkdir -p "$OUTPUT_DIR"
 

--- a/tests/bats/ci-scripts/validate-byte-identical/helpers.bash
+++ b/tests/bats/ci-scripts/validate-byte-identical/helpers.bash
@@ -26,7 +26,10 @@ VALIDATE_BYTE_IDENTICAL_SCRIPT="$(cd "${__HELPERS_DIR}/../../../.." && pwd)/.git
 #   RAW_FETCH_BASE_URL   exported -- the script + curl mock both consume.
 #   PATH                 prepended with the curl mock dir.
 setup_test_dir() {
-    CWD=$(mktemp -d -t validate-byte-identical-test-XXXX)
+    # `mktemp -d` (no `-t <template>`) — BusyBox's mktemp in the
+    # bats/bats:1.13.0 Alpine image rejects the `-t` form that GNU
+    # mktemp accepts.
+    CWD=$(mktemp -d)
     FAKE_REMOTE_DIR="${CWD}/.fake-remote"
     mkdir -p "${FAKE_REMOTE_DIR}"
 

--- a/tests/bats/ci-scripts/verify-oci-labels/helpers.bash
+++ b/tests/bats/ci-scripts/verify-oci-labels/helpers.bash
@@ -22,7 +22,10 @@ VERIFY_OCI_LABELS_SCRIPT="$(cd "${__HELPERS_DIR}/../../../.." && pwd)/.github/sc
 #                              simulate different image label shapes.
 #   PATH                       prepended with the docker mock dir.
 setup_test_dir() {
-    CWD=$(mktemp -d -t verify-oci-labels-test-XXXX)
+    # `mktemp -d` (no `-t <template>`) — BusyBox's mktemp in the
+    # bats/bats:1.13.0 Alpine image rejects the `-t` form that GNU
+    # mktemp accepts.
+    CWD=$(mktemp -d)
 
     export MOCK_DOCKER_LABELS_FILE="${CWD}/labels.txt"
 


### PR DESCRIPTION
## Summary

Phase 10e slice 1 — portable-mktemp helpers cleanup.

BusyBox's mktemp rejects the `-t <template>` form GNU mktemp
accepts. Running any of the 5 affected BATS suites in the
`bats/bats:1.13.0` Alpine image — the natural way to exercise
BATS locally without installing bats + all its deps on the host
— fails at `setup_test_dir` with `mktemp: : Invalid argument`
before any test can run. GHA runners on ubuntu-24.04 have GNU
coreutils so CI was unaffected, but the failure blocks local
iteration.

Switches the 5 helper files still on the templated form to the
portable form already used by the extract-zip suite (from #13286):

- `tests/bats/ci-scripts/expand-docker-tags/helpers.bash`
- `tests/bats/ci-scripts/validate-byte-identical/helpers.bash`
- `tests/bats/ci-scripts/verify-oci-labels/helpers.bash`
- `tests/bats/ci-scripts/sync-byte-identical/helpers.bash`
- `tests/bats/ci-scripts/list-manifest-paths/helpers.bash`

Each site gets a short inline comment documenting the why so
the next person reaching for `-t <template>` sees the trap.

## Not in scope

Local Alpine runnability turns out to be a bigger project than
just mktemp. With the mktemp gate lifted, some suites still need
Alpine deps they don't have:

- `sync-byte-identical`: needs `git` (setup fails immediately)
- `validate-byte-identical` test 16: needs `yq`
- `list-manifest-paths` test 10: needs `yq`

The other 3 suites (`expand-docker-tags`, `verify-oci-labels`,
`extract-zip`) run cleanly in Alpine after this fix. Full Alpine
runnability needs a Dockerfile or Alpine `apk add` prelude and
is worth a separate slice if local iteration becomes routine.

## Test plan

- [x] Master baseline reproduces the setup failure (`mktemp: : Invalid argument`)
- [x] After fix: extract-zip 16/16, expand-docker-tags 16/16, verify-oci-labels 16/16 in `bats/bats:1.13.0`
- [x] Actionlint / shellcheck / pre-commit all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)