### PR TITLE
refactor(release): Phase 10e-3 -- extract Docker Hub tag-delete to shared script

### DIFF
--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -153,6 +153,14 @@ files:
 # Same rel-800/rel-704 exclusion applies.
 - path: .github/workflows/reusable-docker-publish.yml
   exclude-branches: [rel-800, rel-704]
+# Phase 10e-3 (openemr/openemr#TBD, 2026-07-30): dockerhub-delete-tag.sh
+# is called from reusable-docker-publish.yml's cleanup-candidate job.
+# The reusable's `run: .github/scripts/dockerhub-delete-tag.sh` resolves
+# at runtime against the branch's own checkout, so every branch that
+# carries the reusable must also carry the script. Same rel-800/rel-704
+# exclusion applies (those branches don't carry the reusable).
+- path: .github/scripts/dockerhub-delete-tag.sh
+  exclude-branches: [rel-800, rel-704]
 - .github/workflows/docker-test-core.yml
 - .github/workflows/docker-test-release.yml
 - .github/actions/test-actions-core/action.yml

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -10,6 +10,7 @@ from testing or reuse.
 |---|---|---|
 | [`sync-byte-identical.sh`](sync-byte-identical.sh) | [`.github/workflows/sync-byte-identical.yml`](../workflows/sync-byte-identical.yml) | [`tests/bats/ci-scripts/sync-byte-identical/`](../../tests/bats/ci-scripts/sync-byte-identical/) (BATS, synthetic git repo) |
 | [`validate-byte-identical.sh`](validate-byte-identical.sh) | [`.github/workflows/validate-byte-identical.yml`](../workflows/validate-byte-identical.yml) | [`tests/bats/ci-scripts/validate-byte-identical/`](../../tests/bats/ci-scripts/validate-byte-identical/) (BATS, curl mocked via PATH shim) |
+| [`dockerhub-delete-tag.sh`](dockerhub-delete-tag.sh) | [`.github/workflows/reusable-docker-publish.yml`](../workflows/reusable-docker-publish.yml) | [`tests/bats/ci-scripts/dockerhub-delete-tag/`](../../tests/bats/ci-scripts/dockerhub-delete-tag/) (BATS, curl mocked via PATH shim) |
 
 ## Running the tests locally
 

--- a/.github/scripts/dockerhub-delete-tag.sh
+++ b/.github/scripts/dockerhub-delete-tag.sh
@@ -57,15 +57,23 @@ REPO="${REPO:-openemr/openemr}"
 # TLS, timeout, connection reset) produces a clear ::error:: instead of
 # silently propagating a JSON-parse failure downstream.
 login_response_file=$(mktemp)
-trap 'rm -f "${login_response_file}"' EXIT
+# Write the token to a tempfile so jq can read it via --rawfile
+# instead of receiving it as a --arg. That keeps the raw token out of
+# jq's argv (visible via `ps aux` for the jq call's lifetime). Both
+# tempfiles cleaned up in the same trap.
+token_file=$(mktemp)
+trap 'rm -f "${login_response_file}" "${token_file}"' EXIT
+printf '%s' "${DOCKERHUB_TOKEN}" > "${token_file}"
 
 echo "==> POST https://hub.docker.com/v2/users/login/"
-# Build the JSON body with jq so a `"` or `\` in the username or token
-# doesn't produce a malformed request. Piped via stdin so the raw token
-# never appears in argv (visible via `ps` for the curl call's lifetime).
+# Build the JSON body with jq so a `"` or `\` in either credential
+# doesn't produce a malformed request. Username is short + non-secret
+# so --arg is fine; token uses --rawfile (see token_file above) to
+# stay out of argv. Body piped to curl via stdin so it also stays out
+# of curl's argv.
 login_body=$(jq -n \
     --arg u "${DOCKERHUB_USERNAME}" \
-    --arg p "${DOCKERHUB_TOKEN}" \
+    --rawfile p "${token_file}" \
     '{username: $u, password: $p}')
 curl_exit=0
 curl --connect-timeout 10 --max-time 30 -sS \
@@ -86,8 +94,11 @@ fi
 JWT=$(jq -r '.token // ""' < "${login_response_file}" 2>/dev/null || echo "")
 if [[ -z "${JWT}" ]] || [[ "${JWT}" = "null" ]]; then
     echo "::error::Could not obtain Docker Hub JWT from login response (no .token field, or field was null/empty)."
-    echo "::error::Response body:"
-    cat "${login_response_file}" || true
+    echo "::error::Response body (each line prefixed to prevent workflow-command injection):"
+    # `sed 's/^/  /'` on every line + `tr -d '\r'` strips CR — prevents
+    # a response containing `::error::` or `%0A` from being interpreted
+    # as an injected GHA workflow command.
+    sed 's/^/  /' "${login_response_file}" | tr -d '\r' || true
     exit 1
 fi
 
@@ -98,7 +109,7 @@ fi
 #   *   = anything else is unexpected; surface the response body and
 #         exit non-zero so the operator can see what happened.
 delete_response_file=$(mktemp)
-trap 'rm -f "${login_response_file}" "${delete_response_file}"' EXIT
+trap 'rm -f "${login_response_file}" "${token_file}" "${delete_response_file}"' EXIT
 
 url="https://hub.docker.com/v2/repositories/${REPO}/tags/${TAG}/"
 echo "==> DELETE ${url}"
@@ -123,8 +134,9 @@ case "${http_code}" in
         echo "==> cleanup OK: ${REPO}:${TAG} already gone (HTTP 404)"
         ;;
     *)
-        echo "::error::Docker Hub tag delete returned HTTP ${http_code}. Response body:"
-        cat "${delete_response_file}" || true
+        echo "::error::Docker Hub tag delete returned HTTP ${http_code}. Response body (each line prefixed to prevent workflow-command injection):"
+        # Same sanitization as the login-response echo above.
+        sed 's/^/  /' "${delete_response_file}" | tr -d '\r' || true
         exit 1
         ;;
 esac

--- a/.github/scripts/dockerhub-delete-tag.sh
+++ b/.github/scripts/dockerhub-delete-tag.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Delete a tag from Docker Hub via the v2 API.
+#
+# Docker Hub's tag-delete endpoint requires a JWT obtained from the user-
+# login endpoint (a raw personal-access-token isn't sufficient for this
+# specific endpoint). Cheap two-call flow: POST /v2/users/login/ ->
+# extract .token -> DELETE the tag.
+#
+# Extracted from .github/workflows/reusable-docker-publish.yml's
+# cleanup-candidate job. That job carries `continue-on-error: true` on
+# the workflow side (a stale release-candidate-* tag is cosmetically
+# annoying but not a correctness issue), so a silent regression in the
+# inline JWT flow would go unnoticed forever. Pulling the logic into a
+# script lets BATS assert the exit-code / status-code interpretation
+# stays correct.
+#
+# Inputs (env, all required unless noted)
+#   DOCKERHUB_USERNAME    Docker Hub username used for the login POST.
+#   DOCKERHUB_TOKEN       Docker Hub password or PAT used for login. Must
+#                         be a token/password with permission to delete
+#                         repository tags (the reusable workflow passes
+#                         the same DOCKERHUB_TOKEN it uses for
+#                         docker/login-action).
+#   TAG                   The tag to delete (e.g.
+#                         `release-candidate-30443247578-1`). Just the
+#                         tag portion — the repository is separate.
+#   REPO                  Optional. Repository the tag lives under.
+#                         Defaults to `openemr/openemr`.
+#
+# Exit codes
+#   0   Tag deleted (HTTP 204), OR tag already gone (HTTP 404 —
+#       idempotent re-run).
+#   1   JWT login failed (network error, non-JSON body, missing .token),
+#       OR the DELETE returned an unexpected status (401, 403, 5xx, etc.)
+#
+# The caller in reusable-docker-publish.yml keeps
+# `continue-on-error: true` on the workflow step, so a non-zero exit
+# here surfaces as an annotation without failing the run. That's a
+# separate decision from what THIS script returns — the script's job is
+# to interpret the API responses honestly; the workflow decides whether
+# a cleanup failure should block the release.
+
+set -euo pipefail
+
+: "${DOCKERHUB_USERNAME:?DOCKERHUB_USERNAME env var is required}"
+: "${DOCKERHUB_TOKEN:?DOCKERHUB_TOKEN env var is required}"
+: "${TAG:?TAG env var is required}"
+REPO="${REPO:-openemr/openemr}"
+
+# Mint a JWT. Bounded curl: --connect-timeout 10 (TCP/TLS setup) +
+# --max-time 30 (total wall time). Without those, a hung Docker Hub
+# stalls the job until the runner's outer timeout fires. -sS keeps
+# routine output quiet but still surfaces curl errors on stderr.
+#
+# Capture curl's exit code explicitly so a network-level failure (DNS,
+# TLS, timeout, connection reset) produces a clear ::error:: instead of
+# silently propagating a JSON-parse failure downstream.
+login_response_file=$(mktemp)
+trap 'rm -f "${login_response_file}"' EXIT
+
+echo "==> POST https://hub.docker.com/v2/users/login/"
+curl_exit=0
+curl --connect-timeout 10 --max-time 30 -sS \
+    -H 'Content-Type: application/json' \
+    -X POST \
+    -d "{\"username\": \"${DOCKERHUB_USERNAME}\", \"password\": \"${DOCKERHUB_TOKEN}\"}" \
+    -o "${login_response_file}" \
+    https://hub.docker.com/v2/users/login/ || curl_exit=$?
+
+if [[ "${curl_exit}" -ne 0 ]]; then
+    echo "::error::Docker Hub login request failed before receiving an HTTP response (DNS, TLS, timeout, or connection error). curl exit: ${curl_exit}"
+    exit 1
+fi
+
+# Parse .token. jq -r on missing/null keys emits the literal string
+# "null" (not empty), so both "" and "null" mean "no usable token." A
+# response body without a .token key also lands in the "null" bucket.
+JWT=$(jq -r '.token // ""' < "${login_response_file}" 2>/dev/null || echo "")
+if [[ -z "${JWT}" ]] || [[ "${JWT}" = "null" ]]; then
+    echo "::error::Could not obtain Docker Hub JWT from login response (no .token field, or field was null/empty)."
+    echo "::error::Response body:"
+    cat "${login_response_file}" || true
+    exit 1
+fi
+
+# DELETE the tag. Same bounded-curl pattern as the login POST. HTTP-code
+# semantics preserved from the inline block being extracted:
+#   204 = deleted (success)
+#   404 = already gone (also success — idempotent re-run)
+#   *   = anything else is unexpected; surface the response body and
+#         exit non-zero so the operator can see what happened.
+delete_response_file=$(mktemp)
+trap 'rm -f "${login_response_file}" "${delete_response_file}"' EXIT
+
+url="https://hub.docker.com/v2/repositories/${REPO}/tags/${TAG}/"
+echo "==> DELETE ${url}"
+curl_exit=0
+http_code=$(curl --connect-timeout 10 --max-time 30 -sS \
+    -X DELETE \
+    -H "Authorization: JWT ${JWT}" \
+    -o "${delete_response_file}" \
+    -w '%{http_code}' \
+    "${url}") || curl_exit=$?
+
+if [[ "${curl_exit}" -ne 0 ]]; then
+    echo "::error::Docker Hub DELETE request failed before receiving an HTTP response (DNS, TLS, timeout, or connection error). curl exit: ${curl_exit}"
+    exit 1
+fi
+
+case "${http_code}" in
+    204)
+        echo "==> cleanup OK: ${REPO}:${TAG} deleted (HTTP 204)"
+        ;;
+    404)
+        echo "==> cleanup OK: ${REPO}:${TAG} already gone (HTTP 404)"
+        ;;
+    *)
+        echo "::error::Docker Hub tag delete returned HTTP ${http_code}. Response body:"
+        cat "${delete_response_file}" || true
+        exit 1
+        ;;
+esac

--- a/.github/scripts/dockerhub-delete-tag.sh
+++ b/.github/scripts/dockerhub-delete-tag.sh
@@ -60,13 +60,20 @@ login_response_file=$(mktemp)
 trap 'rm -f "${login_response_file}"' EXIT
 
 echo "==> POST https://hub.docker.com/v2/users/login/"
+# Build the JSON body with jq so a `"` or `\` in the username or token
+# doesn't produce a malformed request. Piped via stdin so the raw token
+# never appears in argv (visible via `ps` for the curl call's lifetime).
+login_body=$(jq -n \
+    --arg u "${DOCKERHUB_USERNAME}" \
+    --arg p "${DOCKERHUB_TOKEN}" \
+    '{username: $u, password: $p}')
 curl_exit=0
 curl --connect-timeout 10 --max-time 30 -sS \
     -H 'Content-Type: application/json' \
     -X POST \
-    -d "{\"username\": \"${DOCKERHUB_USERNAME}\", \"password\": \"${DOCKERHUB_TOKEN}\"}" \
+    --data-binary @- \
     -o "${login_response_file}" \
-    https://hub.docker.com/v2/users/login/ || curl_exit=$?
+    https://hub.docker.com/v2/users/login/ <<< "${login_body}" || curl_exit=$?
 
 if [[ "${curl_exit}" -ne 0 ]]; then
     echo "::error::Docker Hub login request failed before receiving an HTTP response (DNS, TLS, timeout, or connection error). curl exit: ${curl_exit}"

--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -145,41 +145,28 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
+    # Needed so the "Delete candidate tag from Docker Hub" step below can
+    # call .github/scripts/dockerhub-delete-tag.sh. persist-credentials:
+    # false because the delete step authenticates to Docker Hub with its
+    # own DOCKERHUB_USERNAME/TOKEN; leaving GITHUB_TOKEN in .git/config
+    # would be zero-value credential surface.
+    - name: Checkout
+      uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+
     - name: Delete candidate tag from Docker Hub
+      # continue-on-error preserves the pre-extraction behavior: a stale
+      # candidate tag is cosmetically annoying but not a correctness
+      # issue (the release-candidate-<run-id>-<attempt> naming makes it
+      # obvious it's an internal artifact), so cleanup failures shouldn't
+      # fail the whole release. Orthogonal to the script's exit code —
+      # the script exits non-zero on JWT failure / unexpected HTTP so the
+      # regression is visible in logs and BATS coverage, but the workflow
+      # tolerates it.
       continue-on-error: true
       env:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        CANDIDATE_TAG: ${{ inputs.candidate_tag }}
-      run: |
-        set -euo pipefail
-        # Docker Hub v2 API tag deletion requires a JWT obtained from the
-        # user-login endpoint (the raw personal-access-token isn't
-        # sufficient for this specific endpoint). Cheap two-call flow:
-        # POST /v2/users/login/ -> extract .token -> DELETE the tag.
-        # If the JWT flow fails (e.g., PAT lacks write:delete perms), the
-        # `continue-on-error: true` on the step swallows it — the tag
-        # lingers until manually cleaned, non-blocking.
-        JWT=$(curl -sf --max-time 30 -H 'Content-Type: application/json' \
-          -X POST -d "{\"username\": \"${DOCKERHUB_USERNAME}\", \"password\": \"${DOCKERHUB_TOKEN}\"}" \
-          https://hub.docker.com/v2/users/login/ | jq -r .token)
-        if [ -z "$JWT" ] || [ "$JWT" = "null" ]; then
-          echo "::warning::could not obtain Docker Hub JWT — cleanup skipped, candidate tag left in place"
-          exit 0
-        fi
-        echo "==> DELETE openemr/openemr:${CANDIDATE_TAG}"
-        HTTP_CODE=$(curl -s --max-time 30 -o /tmp/dh-delete-response -w '%{http_code}' \
-          -X DELETE \
-          -H "Authorization: JWT ${JWT}" \
-          "https://hub.docker.com/v2/repositories/openemr/openemr/tags/${CANDIDATE_TAG}/")
-        case "$HTTP_CODE" in
-          204|404)
-            # 204 = deleted; 404 = already gone (idempotent re-run).
-            echo "==> cleanup OK (HTTP ${HTTP_CODE})"
-            ;;
-          *)
-            echo "::warning::Docker Hub tag delete returned HTTP ${HTTP_CODE}:"
-            cat /tmp/dh-delete-response || true
-            exit 1
-            ;;
-        esac
+        TAG: ${{ inputs.candidate_tag }}
+      run: .github/scripts/dockerhub-delete-tag.sh

--- a/.github/workflows/test-byte-identical-scripts.yml
+++ b/.github/workflows/test-byte-identical-scripts.yml
@@ -57,3 +57,4 @@ jobs:
         bats tests/bats/ci-scripts/extract-zip/
         bats tests/bats/ci-scripts/validate-source-run/
         bats tests/bats/ci-scripts/verify-dockerhub-tag-exists/
+        bats tests/bats/ci-scripts/dockerhub-delete-tag/

--- a/tests/bats/ci-scripts/dockerhub-delete-tag/curl-mock.sh
+++ b/tests/bats/ci-scripts/dockerhub-delete-tag/curl-mock.sh
@@ -52,7 +52,7 @@ while [[ $# -gt 0 ]]; do
         -o) output_file="$2"; shift 2 ;;
         -w) write_format="$2"; shift 2 ;;
         -H) shift 2 ;;
-        -d|--data|--data-raw) shift 2 ;;
+        -d|--data|--data-raw|--data-binary) shift 2 ;;
         --connect-timeout|--max-time|--retry|--retry-delay) shift 2 ;;
         --retry-connrefused|-sS|-s|-S|-f) shift ;;
         http://*|https://*) url="$1"; shift ;;
@@ -68,7 +68,15 @@ fi
 # Route based on URL + method.
 case "${url}" in
     https://hub.docker.com/v2/users/login/)
-        # Login POST. Simulate a network failure if requested.
+        # Login POST. Guard: a regression that flips the login call to a
+        # different HTTP method would still match on URL alone; assert
+        # method here so the mock fails loudly instead of pretending to
+        # log in with a GET (or whatever).
+        if [[ "${method}" != "POST" ]]; then
+            echo "curl-mock: expected POST for login, got ${method}" >&2
+            exit 2
+        fi
+        # Simulate a network failure if requested.
         login_exit="${MOCK_LOGIN_EXIT:-0}"
         if [[ "${login_exit}" -ne 0 ]]; then
             exit "${login_exit}"
@@ -89,7 +97,12 @@ case "${url}" in
         exit 0
         ;;
     https://hub.docker.com/v2/repositories/*/tags/*/)
-        # DELETE tag. Same network-failure simulation hook.
+        # DELETE tag. Guard method the same way as login above.
+        if [[ "${method}" != "DELETE" ]]; then
+            echo "curl-mock: expected DELETE for tag route, got ${method}" >&2
+            exit 2
+        fi
+        # Same network-failure simulation hook.
         delete_exit="${MOCK_DELETE_EXIT:-0}"
         if [[ "${delete_exit}" -ne 0 ]]; then
             exit "${delete_exit}"

--- a/tests/bats/ci-scripts/dockerhub-delete-tag/curl-mock.sh
+++ b/tests/bats/ci-scripts/dockerhub-delete-tag/curl-mock.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Mock `curl` for BATS tests of dockerhub-delete-tag.sh.
+#
+# The script under test makes two curl calls:
+#   1. POST https://hub.docker.com/v2/users/login/  (login → JWT)
+#   2. DELETE https://hub.docker.com/v2/repositories/<repo>/tags/<tag>/
+#
+# Both are exercised through this mock. The mock parses curl's flags
+# just enough to identify which call it is (method + URL), then reads
+# fixture files controlled by env vars to decide what to emit:
+#
+#   MOCK_LOGIN_RESPONSE_FILE     path to a file whose contents become
+#                                the body written to curl's -o target on
+#                                the login POST. Missing/empty file =
+#                                empty body.
+#   MOCK_LOGIN_EXIT              curl-level exit code for the login POST
+#                                (default 0). Set to non-zero to simulate
+#                                a network-level failure (DNS, TLS,
+#                                timeout, connection reset).
+#   MOCK_DELETE_HTTP_CODE        HTTP status code to emit on stdout via
+#                                the -w '%{http_code}' contract for the
+#                                DELETE (default 204).
+#   MOCK_DELETE_RESPONSE_FILE    optional path to a file whose contents
+#                                become the body written to curl's -o
+#                                target on the DELETE. Missing =
+#                                empty body.
+#   MOCK_DELETE_EXIT             curl-level exit code for the DELETE
+#                                (default 0). Non-zero simulates a
+#                                network-level failure post-login.
+#
+# The mock always honors curl's -o (output file) and -w (write-out
+# format) flags. When -w is present and includes %{http_code}, the mock
+# writes the (resolved) HTTP code to stdout — matching what the script
+# captures via `$(curl ... -w '%{http_code}')`. Other -w tokens are
+# passed through unchanged (the script only uses %{http_code}).
+
+set -euo pipefail
+
+method="GET"
+output_file=""
+write_format=""
+url=""
+
+# Parse curl flags. Only the ones the script actually uses need
+# handling; everything else is accept-and-ignore so a future tweak to
+# the script's curl flags doesn't silently break the mock.
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -X) method="$2"; shift 2 ;;
+        -X*) method="${1#-X}"; shift ;;
+        -o) output_file="$2"; shift 2 ;;
+        -w) write_format="$2"; shift 2 ;;
+        -H) shift 2 ;;
+        -d|--data|--data-raw) shift 2 ;;
+        --connect-timeout|--max-time|--retry|--retry-delay) shift 2 ;;
+        --retry-connrefused|-sS|-s|-S|-f) shift ;;
+        http://*|https://*) url="$1"; shift ;;
+        *) shift ;;
+    esac
+done
+
+if [[ -z "${url}" ]]; then
+    echo "curl-mock: no URL provided (parsed method=${method})" >&2
+    exit 2
+fi
+
+# Route based on URL + method.
+case "${url}" in
+    https://hub.docker.com/v2/users/login/)
+        # Login POST. Simulate a network failure if requested.
+        login_exit="${MOCK_LOGIN_EXIT:-0}"
+        if [[ "${login_exit}" -ne 0 ]]; then
+            exit "${login_exit}"
+        fi
+
+        # Write the fixture body to the -o file (script consumes it via
+        # `< "${login_response_file}"` for jq parsing).
+        if [[ -n "${output_file}" ]]; then
+            if [[ -n "${MOCK_LOGIN_RESPONSE_FILE:-}" && -f "${MOCK_LOGIN_RESPONSE_FILE}" ]]; then
+                cp "${MOCK_LOGIN_RESPONSE_FILE}" "${output_file}"
+            else
+                : > "${output_file}"
+            fi
+        fi
+
+        # The script's login curl doesn't use -w — nothing to write to
+        # stdout. Exit 0.
+        exit 0
+        ;;
+    https://hub.docker.com/v2/repositories/*/tags/*/)
+        # DELETE tag. Same network-failure simulation hook.
+        delete_exit="${MOCK_DELETE_EXIT:-0}"
+        if [[ "${delete_exit}" -ne 0 ]]; then
+            exit "${delete_exit}"
+        fi
+
+        if [[ -n "${output_file}" ]]; then
+            if [[ -n "${MOCK_DELETE_RESPONSE_FILE:-}" && -f "${MOCK_DELETE_RESPONSE_FILE}" ]]; then
+                cp "${MOCK_DELETE_RESPONSE_FILE}" "${output_file}"
+            else
+                : > "${output_file}"
+            fi
+        fi
+
+        # Emit the HTTP code via the -w contract. The script only uses
+        # %{http_code}, so we replace that token in the format string
+        # rather than parsing arbitrary write-out formats.
+        http_code="${MOCK_DELETE_HTTP_CODE:-204}"
+        if [[ -n "${write_format}" ]]; then
+            printf '%s' "${write_format//%\{http_code\}/${http_code}}"
+        fi
+        exit 0
+        ;;
+    *)
+        echo "curl-mock: unsupported URL: ${url} (method=${method})" >&2
+        exit 2
+        ;;
+esac

--- a/tests/bats/ci-scripts/dockerhub-delete-tag/delete-tag.bats
+++ b/tests/bats/ci-scripts/dockerhub-delete-tag/delete-tag.bats
@@ -20,6 +20,26 @@
 
 load 'helpers'
 
+# Install jq if missing. The script under test uses jq to build the
+# login body (safe JSON escaping) and to parse the login response for
+# .token. GHA ubuntu-24.04 runners ship jq pre-installed. The
+# bats/bats:1.13.0 Alpine base image (natural way to iterate locally)
+# does not — same setup_file pattern extract-zip uses for `zip`. Runs
+# once per test file.
+setup_file() {
+    if ! command -v jq >/dev/null 2>&1; then
+        if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache jq >/dev/null 2>&1 || true
+        elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update >/dev/null 2>&1 && apt-get install -y jq >/dev/null 2>&1 || true
+        fi
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "# skip-reason: 'jq' binary not installable in this environment" >&3
+        skip "jq binary required to build/parse login JSON"
+    fi
+}
+
 setup() {
     setup_test_dir
 }

--- a/tests/bats/ci-scripts/dockerhub-delete-tag/delete-tag.bats
+++ b/tests/bats/ci-scripts/dockerhub-delete-tag/delete-tag.bats
@@ -1,0 +1,116 @@
+# BATS tests for .github/scripts/dockerhub-delete-tag.sh
+#
+# Runs the script against a mock `curl` (see helpers.bash + curl-mock.sh).
+# Covers the failure modes called out in the Phase 10e coverage audit:
+#   - JWT ok / DELETE 204                    (happy path)
+#   - JWT null (login response .token=null)  (JWT-parse failure)
+#   - JWT missing (login response has no .token) (JWT-parse failure)
+#   - DELETE 404                              (already-gone → success)
+#   - DELETE 401                              (auth rejected → failure)
+#   - DELETE 5xx                              (Docker Hub error → failure)
+#   - curl connect-fail on login              (network error, no response)
+#   - curl connect-fail on delete             (network error, no response)
+#
+# What's NOT covered
+#   - the exact wire format of curl flags (--connect-timeout ordering,
+#     etc.) — the mock accepts the shape the current script uses.
+#   - jq's behavior on invalid JSON — jq itself is trusted; we exercise
+#     the two JSON shapes the script actually differentiates
+#     (null-token, missing-token).
+
+load 'helpers'
+
+setup() {
+    setup_test_dir
+}
+
+teardown() {
+    teardown_test_dir
+}
+
+# --- happy path ---
+
+@test "valid JWT + DELETE 204 -> exit 0 with success message" {
+    # Defaults from setup_test_dir already configure this. Just run.
+    run bash "${DOCKERHUB_DELETE_TAG_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    [[ "${output}" == *"POST https://hub.docker.com/v2/users/login/"* ]]
+    [[ "${output}" == *"DELETE https://hub.docker.com/v2/repositories/openemr/openemr/tags/release-candidate-12345-1/"* ]]
+    [[ "${output}" == *"cleanup OK: openemr/openemr:release-candidate-12345-1 deleted (HTTP 204)"* ]]
+    [[ "${output}" != *"::error::"* ]]
+}
+
+# --- JWT failure modes ---
+
+@test "login response has .token=null -> exit 1 with clear error" {
+    write_login_body_null_token
+    run bash "${DOCKERHUB_DELETE_TAG_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Could not obtain Docker Hub JWT"* ]]
+    # Response body is surfaced so the operator can diagnose (e.g.
+    # "invalid credentials" would show up here).
+    [[ "${output}" == *"invalid credentials"* ]]
+    # Script must NOT have proceeded to the DELETE call.
+    [[ "${output}" != *"DELETE https://hub.docker.com"* ]]
+}
+
+@test "login response missing .token field -> exit 1 with clear error" {
+    write_login_body_missing_token
+    run bash "${DOCKERHUB_DELETE_TAG_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Could not obtain Docker Hub JWT"* ]]
+    [[ "${output}" == *"account is disabled"* ]]
+    [[ "${output}" != *"DELETE https://hub.docker.com"* ]]
+}
+
+# --- DELETE status-code interpretation ---
+
+@test "DELETE 404 -> exit 0 (already-gone counts as success)" {
+    export MOCK_DELETE_HTTP_CODE="404"
+    run bash "${DOCKERHUB_DELETE_TAG_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    [[ "${output}" == *"cleanup OK: openemr/openemr:release-candidate-12345-1 already gone (HTTP 404)"* ]]
+    [[ "${output}" != *"::error::"* ]]
+}
+
+@test "DELETE 401 -> exit 1 with response body surfaced" {
+    export MOCK_DELETE_HTTP_CODE="401"
+    write_delete_body '{"detail":"authentication credentials were not provided"}'
+    run bash "${DOCKERHUB_DELETE_TAG_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Docker Hub tag delete returned HTTP 401"* ]]
+    [[ "${output}" == *"authentication credentials were not provided"* ]]
+}
+
+@test "DELETE 500 -> exit 1 with response body surfaced" {
+    export MOCK_DELETE_HTTP_CODE="500"
+    write_delete_body '{"detail":"internal server error"}'
+    run bash "${DOCKERHUB_DELETE_TAG_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Docker Hub tag delete returned HTTP 500"* ]]
+    [[ "${output}" == *"internal server error"* ]]
+}
+
+# --- curl network-level failures ---
+
+@test "curl connect-fail during login -> exit 1 with network error" {
+    # curl exit 6 = "Couldn't resolve host". Any non-zero exit before an
+    # HTTP response is received must be surfaced.
+    export MOCK_LOGIN_EXIT="6"
+    run bash "${DOCKERHUB_DELETE_TAG_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Docker Hub login request failed before receiving an HTTP response"* ]]
+    [[ "${output}" == *"curl exit: 6"* ]]
+    # Never reached the DELETE.
+    [[ "${output}" != *"DELETE https://hub.docker.com"* ]]
+}
+
+@test "curl connect-fail during delete -> exit 1 with network error" {
+    # Login succeeds; DELETE hits a network error (e.g. TLS handshake
+    # failure post-login, curl exit 35).
+    export MOCK_DELETE_EXIT="35"
+    run bash "${DOCKERHUB_DELETE_TAG_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Docker Hub DELETE request failed before receiving an HTTP response"* ]]
+    [[ "${output}" == *"curl exit: 35"* ]]
+}

--- a/tests/bats/ci-scripts/dockerhub-delete-tag/helpers.bash
+++ b/tests/bats/ci-scripts/dockerhub-delete-tag/helpers.bash
@@ -1,0 +1,107 @@
+# Helpers for BATS tests of .github/scripts/dockerhub-delete-tag.sh.
+#
+# Loaded by delete-tag.bats via `load 'helpers'`. Installs a `curl` mock
+# on PATH (see curl-mock.sh for the contract) so the script under test
+# never touches Docker Hub.
+#
+# Pattern follows tests/bats/ci-scripts/verify-oci-labels/helpers.bash --
+# standalone bash, no bats-support / bats-assert; plain [[ ]] asserts.
+
+# Absolute path to the script under test, captured AT LOAD TIME (before
+# any @test does `cd` into its temp working dir).
+__HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034
+DOCKERHUB_DELETE_TAG_SCRIPT="$(cd "${__HELPERS_DIR}/../../../.." && pwd)/.github/scripts/dockerhub-delete-tag.sh"
+
+# Fresh working dir + curl mock. Sets the following vars in the calling
+# shell (BATS's setup() runs in the same shell as the @test):
+#
+#   CWD                          fresh temp dir; the test cd's into it
+#   MOCK_LOGIN_RESPONSE_FILE     exported -- fixture the curl mock reads
+#                                to build the login POST response body.
+#                                Tests populate this via write_login_body().
+#   MOCK_DELETE_RESPONSE_FILE    exported -- fixture the curl mock reads
+#                                to build the DELETE response body.
+#                                Tests populate via write_delete_body().
+#   PATH                         prepended with the curl mock dir.
+setup_test_dir() {
+    # `mktemp -d` (no `-t <template>`) — BusyBox's mktemp in the
+    # bats/bats:1.13.0 Alpine image rejects the `-t` form that GNU
+    # mktemp accepts.
+    CWD=$(mktemp -d)
+
+    export MOCK_LOGIN_RESPONSE_FILE="${CWD}/login-body.txt"
+    export MOCK_DELETE_RESPONSE_FILE="${CWD}/delete-body.txt"
+
+    # Install the curl mock at the front of PATH.
+    local mock_dir="${CWD}/.curl-mock"
+    mkdir -p "${mock_dir}"
+    cp "${__HELPERS_DIR}/curl-mock.sh" "${mock_dir}/curl"
+    chmod +x "${mock_dir}/curl"
+    export PATH="${mock_dir}:${PATH}"
+
+    cd "${CWD}" || exit 1
+
+    # Force plain output regardless of caller environment. The script's
+    # `echo "::error::..."` lines are recognized as annotations by GitHub
+    # Actions runners; the tests assert on the plain-text substring form.
+    unset GITHUB_ACTIONS
+
+    # Sensible defaults for the 3 required env vars. Individual tests
+    # override via `export VAR=...` before running the script.
+    export DOCKERHUB_USERNAME="test-user"
+    export DOCKERHUB_TOKEN="test-token"
+    export TAG="release-candidate-12345-1"
+    # REPO defaults to openemr/openemr in the script itself, so leave it
+    # unset here to exercise that default path.
+    unset REPO
+
+    # Default mock behaviors — happy path.
+    write_login_body_valid_jwt
+    export MOCK_DELETE_HTTP_CODE="204"
+    export MOCK_LOGIN_EXIT="0"
+    export MOCK_DELETE_EXIT="0"
+    # Fresh empty DELETE response body (204 has no body typically).
+    : > "${MOCK_DELETE_RESPONSE_FILE}"
+}
+
+teardown_test_dir() {
+    cd /
+    # Restore PATH first so a subsequent shell command uses real binaries.
+    export PATH="${PATH#"${CWD}/.curl-mock":}"
+    rm -rf "${CWD}"
+    unset MOCK_LOGIN_RESPONSE_FILE MOCK_DELETE_RESPONSE_FILE
+    unset MOCK_LOGIN_EXIT MOCK_DELETE_EXIT MOCK_DELETE_HTTP_CODE
+    unset DOCKERHUB_USERNAME DOCKERHUB_TOKEN TAG REPO
+}
+
+# Write a login response containing a valid-looking JWT. This is the
+# default; tests exercising failure modes overwrite via the more
+# targeted helpers below.
+write_login_body_valid_jwt() {
+    printf '%s' '{"token":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig"}' \
+        > "${MOCK_LOGIN_RESPONSE_FILE}"
+}
+
+# Write a login response where .token is JSON null. jq -r '.token' emits
+# the literal string "null" for this shape; the script must treat that
+# as an obtain-JWT failure.
+write_login_body_null_token() {
+    printf '%s' '{"token":null,"detail":"invalid credentials"}' \
+        > "${MOCK_LOGIN_RESPONSE_FILE}"
+}
+
+# Write a login response where the .token field is absent entirely
+# (e.g. Docker Hub returned an error envelope instead of a login
+# response). jq -r '.token // ""' emits "" for this shape; the script
+# must treat that as an obtain-JWT failure too.
+write_login_body_missing_token() {
+    printf '%s' '{"detail":"account is disabled"}' \
+        > "${MOCK_LOGIN_RESPONSE_FILE}"
+}
+
+# Write an arbitrary body into the DELETE response fixture — used by
+# tests that assert the script surfaces the body on unexpected HTTP.
+write_delete_body() {
+    printf '%s' "$1" > "${MOCK_DELETE_RESPONSE_FILE}"
+}


### PR DESCRIPTION
## Summary

Extracts the JWT + DELETE flow from `reusable-docker-publish.yml`'s `cleanup-candidate` job into a testable shared script.

- New: `.github/scripts/dockerhub-delete-tag.sh` — mints Docker Hub JWT via `POST /v2/users/login/`, then `DELETE`s the tag. Bounded curls (`--connect-timeout 10 --max-time 30 -sS`) match Phase 10c's `docker-acceptance-only.yml` pattern. HTTP 204/404 = success (idempotent re-run); anything else = exit 1 with body surfaced.
- New: `tests/bats/ci-scripts/dockerhub-delete-tag/` (8 tests) — mocks `curl` via PATH prepend, same pattern as `verify-oci-labels/` + `validate-byte-identical/`.
- Updated: `reusable-docker-publish.yml` cleanup-candidate step is now a one-line `run:` calling the script. Workflow-side `continue-on-error: true` preserved (stale candidate tags are cosmetic, not correctness — but the script exit-code is now honest so BATS catches JWT/HTTP regressions).
- Updated: `.github/byte-identical.yml` — new script synced to rel-810/820+ with the same `rel-800, rel-704` exclusion the caller reusable already carries (reusable's `run:` resolves the script path against the branch's own checkout at runtime).
- Updated: `test-byte-identical-scripts.yml` runs the new BATS suite on PR.
- Updated: `.github/scripts/README.md` inventory row.

### Behavior tightening (not a strict preservation)

The inline block used `curl -sf` on the login POST — a 401 credential-rejection would exit curl non-zero, empty the pipe, `jq` would read nothing, and the script would emit a warning and exit 0. The extracted script captures the body regardless of HTTP status, parses `.token` with `jq`, and exits 1 with the response body surfaced on null/missing token. Workflow-side `continue-on-error` still swallows the non-zero, but the operator now gets an actionable log line instead of silence.

## Test plan

- [x] `bats tests/bats/ci-scripts/dockerhub-delete-tag/` — 8/8 pass locally in `bats/bats:1.13.0` container (with `apk add jq`; CI's `ubuntu-24.04` runner has `jq` preinstalled, consistent with other workflows that use `jq` without install).
- [x] `shellcheck --check-sourced --external-sources .github/scripts/dockerhub-delete-tag.sh` — clean.
- [x] `actionlint` on all workflows — clean.
- [x] `shellcheck` on `curl-mock.sh` + `helpers.bash` — clean.
- [ ] `test-byte-identical-scripts.yml` CI run (fires on this PR — paths match).
- [ ] `validate-byte-identical.yml` CI run confirms the new script entry parses.