### PR TITLE
refactor(ci): Phase 10e-2 -- extract acceptance-only source-run guardrails

### DIFF
--- a/.github/scripts/validate-source-run.sh
+++ b/.github/scripts/validate-source-run.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Validate a source workflow run for the acceptance-only recovery path.
+#
+# Both acceptance-only.yml (tarball recovery) and docker-acceptance-only.yml
+# (docker recovery) previously carried near-identical inline blocks that
+# validated a source_run_id operator input against three (docker: four)
+# guardrails:
+#
+#   1. wrong-workflow    -- .path must match EXPECTED_WORKFLOW_PATH
+#   2. wrong-coordinates -- optional: candidate_tag input must equal
+#                           "release-candidate-<run_id>-<run_attempt>"
+#                           (docker-side only; skipped when
+#                           EXPECTED_CANDIDATE_TAG is unset)
+#   3. too-old           -- .created_at must be within 48h of now
+#
+# Guard ordering: cheapest-first (wrong-workflow -> wrong-coordinates ->
+# too-old). All three are pure text/arithmetic on the run JSON; a network
+# existence check (docker-side "candidate still on Docker Hub") lives in a
+# separate helper, verify-dockerhub-tag-exists.sh, so this script stays
+# offline-testable.
+#
+# Extracted so a fix to any guard (a different age ceiling, an additional
+# metadata check, a richer error hint) lands once instead of twice.
+#
+# Inputs (env)
+#   SOURCE_RUN_ID              required. Operator-supplied workflow run
+#                              ID; used only for error-message context
+#                              (the RUN_JSON is the authoritative shape).
+#   EXPECTED_WORKFLOW_PATH     required. e.g.
+#                              ".github/workflows/build-release.yml"
+#                              (tarball) or
+#                              ".github/workflows/docker-build-release.yml"
+#                              (docker).
+#   RUN_JSON                   required. JSON blob from
+#                              `gh api repos/{owner}/{repo}/actions/runs/{id}`.
+#                              Read from stdin when the env var is unset
+#                              or empty; env is the primary form so
+#                              callers can pipe-avoid.
+#   EXPECTED_CANDIDATE_TAG     optional. When set, enforces
+#                              CANDIDATE_TAG (also required if set) equals
+#                              "release-candidate-${SOURCE_RUN_ID}-${.run_attempt}".
+#                              Docker-side only.
+#   CANDIDATE_TAG              required only when EXPECTED_CANDIDATE_TAG is
+#                              enforced. Value the operator typed at
+#                              dispatch time.
+#   AGE_CEILING_HOURS          optional, default 48. Age ceiling; primarily
+#                              a test hook (production callers rely on
+#                              the default).
+#
+# Stdout / stderr
+#   Progress lines to stdout, `::error::` annotations on any failure.
+#
+# Exit codes
+#   0   all validations passed
+#   1   any validation failed OR required env var missing OR RUN_JSON
+#       missing a required field
+
+set -euo pipefail
+
+: "${SOURCE_RUN_ID:?SOURCE_RUN_ID must be set (source workflow run ID)}"
+: "${EXPECTED_WORKFLOW_PATH:?EXPECTED_WORKFLOW_PATH must be set (e.g. .github/workflows/build-release.yml)}"
+
+AGE_CEILING_HOURS="${AGE_CEILING_HOURS:-48}"
+
+# Load RUN_JSON from env or stdin. Env is primary so callers running
+# `gh api ... | validate-source-run.sh` and callers that already captured
+# the JSON into a variable both work without extra glue.
+if [[ -z "${RUN_JSON:-}" ]]; then
+    RUN_JSON=$(cat)
+fi
+
+if [[ -z "${RUN_JSON}" ]]; then
+    echo "::error::RUN_JSON is empty (neither the env var nor stdin supplied a run JSON blob)."
+    exit 1
+fi
+
+# jq -e turns absent/null values into a non-zero exit so a malformed
+# blob fails here rather than at the comparison step with a confusing
+# empty-string message.
+source_path=$(printf '%s' "${RUN_JSON}" | jq -er .path) || {
+    echo "::error::RUN_JSON missing required field '.path' (source run metadata is malformed or a different shape than expected)."
+    exit 1
+}
+source_created_at=$(printf '%s' "${RUN_JSON}" | jq -er .created_at) || {
+    echo "::error::RUN_JSON missing required field '.created_at' (source run metadata is malformed or a different shape than expected)."
+    exit 1
+}
+
+# Guard 1 (cheapest): workflow_path.
+#
+# Uses .path rather than .name to avoid brittleness if the workflow name
+# is edited (path is the file location, which is more stable). GitHub's
+# workflow listing endpoint returns .path as ".github/workflows/<file>".
+echo "==> Confirming source run is a ${EXPECTED_WORKFLOW_PATH##*/} run"
+if [[ "${source_path}" != "${EXPECTED_WORKFLOW_PATH}" ]]; then
+    echo "::error::source run ${SOURCE_RUN_ID} was produced by '${source_path}', not '${EXPECTED_WORKFLOW_PATH}'."
+    echo "::error::this recovery workflow only accepts source runs from ${EXPECTED_WORKFLOW_PATH##*/} -- the artifact/tag shape is specific to that workflow."
+    exit 1
+fi
+
+# Guard 2 (medium): candidate_tag coordinates binding (docker-side only).
+#
+# Bind operator-supplied candidate_tag to the source run's own
+# coordinates. Without this check, an operator could dispatch a docker
+# recovery workflow with a valid source_run_id but a candidate_tag
+# pointing at an unrelated image on Docker Hub -- aliasing that foreign
+# image under the requested final tags. Match the exact format
+# docker-build-release.yml stamps via GATE_CANDIDATE_TAG env:
+# release-candidate-<run_id>-<run_attempt>.
+if [[ -n "${EXPECTED_CANDIDATE_TAG:-}" ]]; then
+    : "${CANDIDATE_TAG:?CANDIDATE_TAG must be set when EXPECTED_CANDIDATE_TAG enforcement is enabled}"
+
+    source_run_attempt=$(printf '%s' "${RUN_JSON}" | jq -er .run_attempt) || {
+        echo "::error::RUN_JSON missing required field '.run_attempt' (needed for candidate_tag coordinates binding)."
+        exit 1
+    }
+
+    echo "==> Confirming candidate_tag matches source run coordinates"
+    expected_candidate_tag="release-candidate-${SOURCE_RUN_ID}-${source_run_attempt}"
+    if [[ "${CANDIDATE_TAG}" != "${expected_candidate_tag}" ]]; then
+        echo "::error::candidate_tag mismatch: operator supplied '${CANDIDATE_TAG}' but source run ${SOURCE_RUN_ID} (attempt ${source_run_attempt}) would have produced '${expected_candidate_tag}'."
+        echo "::error::docker-acceptance-only aliases the candidate image under the final tags -- a mismatched candidate_tag risks publishing an unrelated image (accidentally or maliciously). Re-dispatch with candidate_tag='${expected_candidate_tag}', or pick a different source_run_id whose coordinates match the intended candidate."
+        exit 1
+    fi
+
+    # Enforcement check upstream expected the same value; assert equality
+    # so callers can trust EXPECTED_CANDIDATE_TAG === CANDIDATE_TAG after
+    # this passes.
+    if [[ "${EXPECTED_CANDIDATE_TAG}" != "${expected_candidate_tag}" ]]; then
+        echo "::error::EXPECTED_CANDIDATE_TAG ('${EXPECTED_CANDIDATE_TAG}') doesn't match the derived candidate_tag ('${expected_candidate_tag}'). Caller likely computed EXPECTED_CANDIDATE_TAG from stale inputs."
+        exit 1
+    fi
+fi
+
+# Guard 3 (still cheap but last): age ceiling.
+#
+# Use date -d for portable ISO-8601 parsing; both dates are UTC by
+# convention so no TZ juggling needed.
+echo "==> Checking source run age (<= ${AGE_CEILING_HOURS}h)"
+source_epoch=$(date -d "${source_created_at}" +%s) || {
+    echo "::error::source run created_at '${source_created_at}' is not a parseable timestamp."
+    exit 1
+}
+now_epoch=$(date -u +%s)
+age_seconds=$(( now_epoch - source_epoch ))
+age_hours=$(( age_seconds / 3600 ))
+ceiling_seconds=$(( AGE_CEILING_HOURS * 3600 ))
+
+echo "    source_epoch=${source_epoch} now_epoch=${now_epoch} age_hours=${age_hours}"
+
+if [[ "${age_seconds}" -gt "${ceiling_seconds}" ]]; then
+    echo "::error::source run ${SOURCE_RUN_ID} is ${age_hours}h old (> ${AGE_CEILING_HOURS}h ceiling)."
+    echo "::error::An artifact this old risks being stale -- the rel-branch may have advanced since build, and re-running acceptance against the old bundle would validate a version the branch has already moved past."
+    echo "::error::Recovery paths for stale runs: (1) dispatch the source workflow fresh with the same inputs to rebuild + re-gate from current rel-branch tip; (2) re-run the failed source run in-place via the Actions UI (rebuilds from the same commit the annotated tag points at, which is still the ship point)."
+    exit 1
+fi
+
+echo "==> source run eligible: age=${age_hours}h, workflow=${EXPECTED_WORKFLOW_PATH##*/}"

--- a/.github/scripts/verify-dockerhub-tag-exists.sh
+++ b/.github/scripts/verify-dockerhub-tag-exists.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Verify that a Docker Hub tag exists (remote existence probe).
+#
+# Called from docker-acceptance-only.yml as a fail-fast guardrail: if
+# cleanup-candidate somehow ran despite acceptance failure, or an operator
+# manually deleted the candidate before recovering, the HEAD-like GET here
+# fails fast with a clear error -- much better than acceptance-docker.yml
+# failing later with a confusing "image pull failed" message deep in the
+# matrix.
+#
+# Uses the anonymous Docker Hub v2 API tag endpoint: no login needed for
+# an existence check.
+#
+# Extracted from the "Verify candidate tag exists on Docker Hub" step in
+# docker-acceptance-only.yml so the curl bounds + response-code branching
+# live in one place. Kept separate from validate-source-run.sh because
+# this is a remote-state check (needs network + curl mock in tests) --
+# validate-source-run.sh is a pure JSON parse.
+#
+# Inputs (env)
+#   TAG    required. The tag to probe (e.g. "release-candidate-30443247578-1").
+#   REPO   optional, default "openemr/openemr". Docker Hub repo path.
+#
+# Stdout / stderr
+#   Progress lines to stdout, `::error::` annotations on any failure.
+#   On unexpected non-200/404 responses, the response body is dumped to
+#   stdout for post-mortem context.
+#
+# Exit codes
+#   0   tag exists (HTTP 200)
+#   1   tag missing (HTTP 404), unexpected HTTP status, or curl-level
+#       failure (DNS, TLS, timeout, connection reset -- anything that
+#       prevents an HTTP response)
+
+set -euo pipefail
+
+: "${TAG:?TAG must be set (Docker Hub tag to probe, e.g. release-candidate-12345-1)}"
+REPO="${REPO:-openemr/openemr}"
+
+url="https://hub.docker.com/v2/repositories/${REPO}/tags/${TAG}/"
+echo "==> GET ${url}"
+
+# Bound the request explicitly: --connect-timeout guards TCP/TLS setup,
+# --max-time guards total wall time. Without these, curl's defaults are
+# effectively unbounded and a hung Docker Hub could stall the job until
+# the runner's own timeout fires.
+#
+# Capture curl's exit code explicitly (via `|| curl_exit=$?`) so a
+# curl-level failure (DNS, TLS, timeout, connection reset -- anything
+# that prevents an HTTP response) produces a clear error instead of
+# tripping `set -e` and leaving the case-statement handler unreached.
+# `|| ...` disarms `set -e` for this one call; we re-arm by explicitly
+# checking $curl_exit.
+response_body_file=$(mktemp)
+trap 'rm -f "${response_body_file}"' EXIT
+
+curl_exit=0
+http_code=$(curl --connect-timeout 10 --max-time 30 -sS \
+    -o "${response_body_file}" -w '%{http_code}' "${url}") || curl_exit=$?
+if [[ "${curl_exit}" -ne 0 ]]; then
+    echo "::error::Docker Hub request failed before receiving an HTTP response (DNS, TLS, timeout, or connection error). curl exit: ${curl_exit}"
+    exit 1
+fi
+
+case "${http_code}" in
+    200)
+        echo "==> Tag ${REPO}:${TAG} exists on Docker Hub."
+        ;;
+    404)
+        echo "::error::Tag ${REPO}:${TAG} not found on Docker Hub (HTTP 404)."
+        echo "::error::The candidate may have been already cleaned up (successful publish path deletes it) or manually deleted."
+        echo "::error::Recovery paths: (1) if the source run's publish succeeded, no recovery needed; (2) if the source run failed BEFORE publish and the candidate is gone anyway, dispatch docker-build-release.yml fresh."
+        exit 1
+        ;;
+    *)
+        echo "::error::Unexpected HTTP ${http_code} from Docker Hub v2 API. Response:"
+        cat "${response_body_file}" || true
+        exit 1
+        ;;
+esac

--- a/.github/workflows/acceptance-only.yml
+++ b/.github/workflows/acceptance-only.yml
@@ -127,80 +127,35 @@ jobs:
       artifact_name: openemr-release-candidate-${{ inputs.version }}
     steps:
     # Guardrail A: validate the source run is under 48h old + was
-    # produced by build-release.yml. Both checks live in the same
-    # step so we fail fast before spending download-artifact time
-    # on an ineligible run.
+    # produced by build-release.yml. Delegates to the shared
+    # validate-source-run.sh (see that script's header for the
+    # per-guard rationale). Extracted from the previous inline block
+    # so acceptance-only.yml and docker-acceptance-only.yml share the
+    # same validation surface — a fix to the age check or the
+    # workflow_path check lands once instead of twice.
     #
-    # Why 48h: a stale artifact risks not matching the current
-    # rel-branch tip (some other PR might have landed in the
-    # meantime), and the whole point of acceptance-only is fast
-    # recovery from a known-good build — if it's been >48h since
-    # the build, "re-run failed jobs" or a fresh build-release
-    # dispatch is the safer path.
-    #
-    # Why check workflow_id: the input is a raw run ID, and
-    # actions/download-artifact will happily fetch an artifact by
-    # name from any run the token can see. Confirming the source
-    # run is a build-release.yml run means we're validating a
-    # release-shape bundle, not (say) an unrelated workflow that
-    # happens to have uploaded an artifact of the same name shape
-    # (e.g., a hand-crafted repro of an acceptance failure).
+    # Only EXPECTED_WORKFLOW_PATH is passed (no EXPECTED_CANDIDATE_TAG):
+    # tarball recovery has no operator-supplied candidate binding to
+    # cross-check.
     - name: Validate source run eligibility
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
         SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        EXPECTED_WORKFLOW_PATH: .github/workflows/build-release.yml
       run: |
         set -euo pipefail
 
-        # Fetch the source run's metadata. jq -e turns absent/false
-        # values into a non-zero exit so a garbage run ID (bad number,
-        # deleted run) fails here rather than at download time with a
-        # confusing "artifact not found."
         echo "==> Fetching source run metadata"
-        run_json=$(gh api "repos/${REPO}/actions/runs/${SOURCE_RUN_ID}")
+        RUN_JSON=$(gh api "repos/${REPO}/actions/runs/${SOURCE_RUN_ID}")
+        export RUN_JSON
 
-        source_workflow_id=$(printf '%s' "$run_json" | jq -er .workflow_id)
-        source_created_at=$(printf '%s' "$run_json" | jq -er .created_at)
-        source_name=$(printf '%s' "$run_json" | jq -er .name)
-        source_path=$(printf '%s' "$run_json" | jq -er .path)
+        source_name=$(printf '%s' "$RUN_JSON" | jq -er .name)
+        source_path=$(printf '%s' "$RUN_JSON" | jq -er .path)
+        source_created_at=$(printf '%s' "$RUN_JSON" | jq -er .created_at)
+        echo "    source run: id=${SOURCE_RUN_ID} name='${source_name}' path='${source_path}' created_at='${source_created_at}'"
 
-        echo "    source run: id=${SOURCE_RUN_ID} name='${source_name}' path='${source_path}'"
-        echo "    source run: workflow_id=${source_workflow_id} created_at=${source_created_at}"
-
-        # workflow_id check: look up build-release.yml's ID in this
-        # repo and compare. Uses .path rather than .name to avoid
-        # brittleness if the workflow name is edited (path is the
-        # file location, which is more stable). GitHub's workflow
-        # listing endpoint returns .path as ".github/workflows/<file>".
-        echo "==> Confirming source run is a build-release.yml run"
-        expected_path=".github/workflows/build-release.yml"
-        if [ "$source_path" != "$expected_path" ]; then
-          echo "::error::source run ${SOURCE_RUN_ID} was produced by '${source_path}', not '${expected_path}'."
-          echo "::error::acceptance-only only accepts source runs from build-release.yml — the artifact shape (openemr-release-candidate-<version>) is specific to that workflow."
-          exit 1
-        fi
-
-        # Age check: 48h ceiling on source-run age. Use date -d for
-        # portable ISO-8601 parsing; both dates are UTC by convention
-        # so no TZ juggling needed.
-        echo "==> Checking source run age (<= 48h)"
-        source_epoch=$(date -d "$source_created_at" +%s)
-        now_epoch=$(date -u +%s)
-        age_seconds=$(( now_epoch - source_epoch ))
-        age_hours=$(( age_seconds / 3600 ))
-        ceiling_seconds=$(( 48 * 3600 ))
-
-        echo "    source_epoch=${source_epoch} now_epoch=${now_epoch} age_hours=${age_hours}"
-
-        if [ "$age_seconds" -gt "$ceiling_seconds" ]; then
-          echo "::error::source run ${SOURCE_RUN_ID} is ${age_hours}h old (> 48h ceiling)."
-          echo "::error::An artifact this old risks being stale — the rel-branch may have advanced since build, and re-running acceptance against the old bundle would validate a version the branch has already moved past."
-          echo "::error::Recovery paths for stale runs: (1) dispatch build-release.yml fresh with the same version_branch + version + release_tag inputs to rebuild + re-gate from current rel-branch tip; (2) re-run the failed build-release run in-place via the Actions UI (rebuilds from the same commit the annotated tag points at, which is still the ship point)."
-          exit 1
-        fi
-
-        echo "==> source run eligible: age=${age_hours}h, workflow=build-release.yml"
+        .github/scripts/validate-source-run.sh
 
     # Cross-run artifact download: actions/download-artifact@v8 with
     # both `run-id` and `github-token` fetches from ANOTHER run in the

--- a/.github/workflows/acceptance-only.yml
+++ b/.github/workflows/acceptance-only.yml
@@ -150,9 +150,14 @@ jobs:
         RUN_JSON=$(gh api "repos/${REPO}/actions/runs/${SOURCE_RUN_ID}")
         export RUN_JSON
 
-        source_name=$(printf '%s' "$RUN_JSON" | jq -er .name)
-        source_path=$(printf '%s' "$RUN_JSON" | jq -er .path)
-        source_created_at=$(printf '%s' "$RUN_JSON" | jq -er .created_at)
+        # Non-strict extraction (`.field // "unknown"`) — these three
+        # are only used for the log line below. The friendly BATS-tested
+        # ::error:: guards in validate-source-run.sh cover the "field
+        # missing" cases; a strict `jq -er` here would trip set -e
+        # first with a raw jq error, defeating the script's guards.
+        source_name=$(printf '%s' "$RUN_JSON" | jq -r '.name // "unknown"')
+        source_path=$(printf '%s' "$RUN_JSON" | jq -r '.path // "unknown"')
+        source_created_at=$(printf '%s' "$RUN_JSON" | jq -r '.created_at // "unknown"')
         echo "    source run: id=${SOURCE_RUN_ID} name='${source_name}' path='${source_path}' created_at='${source_created_at}'"
 
         .github/scripts/validate-source-run.sh

--- a/.github/workflows/acceptance-only.yml
+++ b/.github/workflows/acceptance-only.yml
@@ -150,14 +150,16 @@ jobs:
         RUN_JSON=$(gh api "repos/${REPO}/actions/runs/${SOURCE_RUN_ID}")
         export RUN_JSON
 
-        # Non-strict extraction (`.field // "unknown"`) — these three
-        # are only used for the log line below. The friendly BATS-tested
-        # ::error:: guards in validate-source-run.sh cover the "field
-        # missing" cases; a strict `jq -er` here would trip set -e
-        # first with a raw jq error, defeating the script's guards.
-        source_name=$(printf '%s' "$RUN_JSON" | jq -r '.name // "unknown"')
-        source_path=$(printf '%s' "$RUN_JSON" | jq -r '.path // "unknown"')
-        source_created_at=$(printf '%s' "$RUN_JSON" | jq -r '.created_at // "unknown"')
+        # Non-strict extraction handles BOTH missing fields (`.field //
+        # "unknown"`) AND malformed JSON payload (`|| echo "unknown"`
+        # captures the jq-parse-failure case). Without the outer capture,
+        # a non-JSON RUN_JSON would fail these probes under set -euo
+        # pipefail before the friendly BATS-tested ::error:: guards in
+        # validate-source-run.sh can run. These three fields are only
+        # used for the log line below.
+        source_name=$(printf '%s' "$RUN_JSON" | jq -r '.name // "unknown"' 2>/dev/null || echo "unknown")
+        source_path=$(printf '%s' "$RUN_JSON" | jq -r '.path // "unknown"' 2>/dev/null || echo "unknown")
+        source_created_at=$(printf '%s' "$RUN_JSON" | jq -r '.created_at // "unknown"' 2>/dev/null || echo "unknown")
         echo "    source run: id=${SOURCE_RUN_ID} name='${source_name}' path='${source_path}' created_at='${source_created_at}'"
 
         .github/scripts/validate-source-run.sh

--- a/.github/workflows/docker-acceptance-only.yml
+++ b/.github/workflows/docker-acceptance-only.yml
@@ -124,115 +124,54 @@ jobs:
       build_date: ${{ steps.inspect_candidate.outputs.created }}
     steps:
     # Guardrail A: source run must be a docker-build-release.yml run
-    # under 48h old. Same shape acceptance-only.yml uses — see that
-    # workflow's Validate step for the full rationale on each check.
+    # under 48h old AND the operator-supplied candidate_tag must match
+    # the run's coordinates. Delegates to the shared validate-source-
+    # run.sh (see that script's header for the per-guard rationale).
+    # Extracted from the previous inline block so acceptance-only.yml
+    # and docker-acceptance-only.yml share the same validation surface
+    # — a fix to any guard lands once instead of twice.
+    #
+    # EXPECTED_CANDIDATE_TAG is set (unlike acceptance-only.yml) to
+    # enable the candidate_tag coordinates-binding check specific to
+    # the docker-side recovery path.
     - name: Validate source run eligibility
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
         SOURCE_RUN_ID: ${{ inputs.source_run_id }}
-        INPUT_CANDIDATE_TAG: ${{ inputs.candidate_tag }}
-      run: |
-        set -euo pipefail
-
-        echo "==> Fetching source run metadata"
-        run_json=$(gh api "repos/${REPO}/actions/runs/${SOURCE_RUN_ID}")
-
-        source_path=$(printf '%s' "$run_json" | jq -er .path)
-        source_created_at=$(printf '%s' "$run_json" | jq -er .created_at)
-        source_run_attempt=$(printf '%s' "$run_json" | jq -er .run_attempt)
-
-        echo "==> Confirming source run is a docker-build-release.yml run"
-        expected_path=".github/workflows/docker-build-release.yml"
-        if [ "$source_path" != "$expected_path" ]; then
-          echo "::error::source run ${SOURCE_RUN_ID} was produced by '${source_path}', not '${expected_path}'."
-          echo "::error::docker-acceptance-only only accepts source runs from docker-build-release.yml — the candidate_tag shape (release-candidate-<run-id>-<attempt>) is specific to that workflow."
-          exit 1
-        fi
-
-        # Bind operator-supplied candidate_tag to the source run's own
-        # coordinates. Without this check, an operator could dispatch
-        # this workflow with a valid source_run_id but a candidate_tag
-        # pointing at an unrelated image on Docker Hub — aliasing that
-        # foreign image under the requested final tags. Match the exact
-        # format docker-build-release.yml stamps via its
-        # GATE_CANDIDATE_TAG env: release-candidate-<run_id>-<run_attempt>.
-        echo "==> Confirming candidate_tag matches source run coordinates"
-        expected_candidate_tag="release-candidate-${SOURCE_RUN_ID}-${source_run_attempt}"
-        if [ "$INPUT_CANDIDATE_TAG" != "$expected_candidate_tag" ]; then
-          echo "::error::candidate_tag mismatch: operator supplied '${INPUT_CANDIDATE_TAG}' but source run ${SOURCE_RUN_ID} (attempt ${source_run_attempt}) would have produced '${expected_candidate_tag}'."
-          echo "::error::docker-acceptance-only aliases the candidate image under the final tags — a mismatched candidate_tag risks publishing an unrelated image (accidentally or maliciously). Re-dispatch with candidate_tag='${expected_candidate_tag}', or pick a different source_run_id whose coordinates match the intended candidate."
-          exit 1
-        fi
-
-        echo "==> Checking source run age (<= 48h)"
-        source_epoch=$(date -d "$source_created_at" +%s)
-        now_epoch=$(date -u +%s)
-        age_seconds=$(( now_epoch - source_epoch ))
-        age_hours=$(( age_seconds / 3600 ))
-        ceiling_seconds=$(( 48 * 3600 ))
-
-        if [ "$age_seconds" -gt "$ceiling_seconds" ]; then
-          echo "::error::source run ${SOURCE_RUN_ID} is ${age_hours}h old (> 48h ceiling)."
-          echo "::error::A preserved candidate this old risks not matching the rel-branch tip (some other PR may have landed). Recovery paths for stale runs: (1) dispatch docker-build-release.yml fresh (rebuilds the multi-arch image against current rel-branch tip); (2) re-run the failed docker-build-release run in-place via the Actions UI."
-          exit 1
-        fi
-
-        echo "==> source run eligible: age=${age_hours}h, workflow=docker-build-release.yml"
-
-    # Guardrail B: candidate tag must still exist on Docker Hub. If
-    # cleanup-candidate somehow ran despite acceptance failure, or an
-    # operator manually deleted the candidate before recovering, the
-    # HEAD request here fails fast with a clear error — much better
-    # than acceptance-docker.yml failing later with a confusing "image
-    # pull failed" message deep in the matrix.
-    #
-    # Uses the anonymous Docker Hub v2 API tag endpoint: no login
-    # needed for a HEAD-like existence check, and the response body
-    # (small JSON with tag metadata) is fine to parse for a defense-
-    # in-depth "tag actually is what we think" check.
-    - name: Verify candidate tag exists on Docker Hub
-      env:
+        EXPECTED_WORKFLOW_PATH: .github/workflows/docker-build-release.yml
         CANDIDATE_TAG: ${{ inputs.candidate_tag }}
       run: |
         set -euo pipefail
 
-        url="https://hub.docker.com/v2/repositories/openemr/openemr/tags/${CANDIDATE_TAG}/"
-        echo "==> HEAD ${url}"
-        # Bound the request explicitly: --connect-timeout guards TCP/TLS
-        # setup, --max-time guards total wall time. Without these, curl's
-        # defaults are effectively unbounded and a hung Docker Hub could
-        # stall the job until the runner's own timeout fires.
-        # Capture curl's exit code explicitly (via `|| curl_exit=$?`)
-        # so a curl-level failure (DNS, TLS, timeout, connection reset —
-        # anything that prevents an HTTP response) produces a clear
-        # error instead of tripping `set -e` and leaving the case-
-        # statement handler unreached. `|| ...` disarms `set -e` for
-        # this one call; we re-arm by explicitly checking $curl_exit.
-        curl_exit=0
-        http_code=$(curl --connect-timeout 10 --max-time 30 -sS \
-          -o /tmp/dh-tag-response -w '%{http_code}' "$url") || curl_exit=$?
-        if [ "$curl_exit" -ne 0 ]; then
-          echo "::error::Docker Hub request failed before receiving an HTTP response (DNS, TLS, timeout, or connection error). curl exit: ${curl_exit}"
-          exit 1
-        fi
+        echo "==> Fetching source run metadata"
+        RUN_JSON=$(gh api "repos/${REPO}/actions/runs/${SOURCE_RUN_ID}")
+        export RUN_JSON
 
-        case "$http_code" in
-          200)
-            echo "==> Candidate tag openemr/openemr:${CANDIDATE_TAG} exists on Docker Hub."
-            ;;
-          404)
-            echo "::error::Candidate tag openemr/openemr:${CANDIDATE_TAG} not found on Docker Hub (HTTP 404)."
-            echo "::error::The candidate may have been already cleaned up (successful publish path deletes it) or manually deleted."
-            echo "::error::Recovery paths: (1) if the source run's publish succeeded, no recovery needed; (2) if the source run failed BEFORE publish and the candidate is gone anyway, dispatch docker-build-release.yml fresh."
-            exit 1
-            ;;
-          *)
-            echo "::error::Unexpected HTTP ${http_code} from Docker Hub v2 API. Response:"
-            cat /tmp/dh-tag-response || true
-            exit 1
-            ;;
-        esac
+        # EXPECTED_CANDIDATE_TAG is derived from the source run
+        # coordinates and passed alongside CANDIDATE_TAG so the script
+        # can enforce operator-input == derived-coordinates. The script
+        # re-derives the same value internally as a defence-in-depth
+        # against caller drift; passing it here surfaces intent.
+        source_run_attempt=$(printf '%s' "$RUN_JSON" | jq -er .run_attempt)
+        EXPECTED_CANDIDATE_TAG="release-candidate-${SOURCE_RUN_ID}-${source_run_attempt}"
+        export EXPECTED_CANDIDATE_TAG
+
+        .github/scripts/validate-source-run.sh
+
+    # Guardrail B: candidate tag must still exist on Docker Hub.
+    # Delegates to verify-dockerhub-tag-exists.sh — see that script's
+    # header for the fail-fast rationale (avoiding a confusing "image
+    # pull failed" mid-matrix in acceptance-docker.yml). Kept separate
+    # from validate-source-run.sh because it's a network I/O check;
+    # the two scripts have distinct testability profiles (one needs a
+    # curl mock, the other doesn't touch the network).
+    - name: Verify candidate tag exists on Docker Hub
+      env:
+        TAG: ${{ inputs.candidate_tag }}
+      run: |
+        set -euo pipefail
+        .github/scripts/verify-dockerhub-tag-exists.sh
 
     # Expand the operator-provided docker_tags list into the same
     # final-tag list docker-build-release.yml's build job would have

--- a/.github/workflows/docker-acceptance-only.yml
+++ b/.github/workflows/docker-acceptance-only.yml
@@ -154,11 +154,12 @@ jobs:
         # re-derives the same value internally as a defence-in-depth
         # against caller drift; passing it here surfaces intent.
         #
-        # Non-strict extraction with an empty-string fallback so a
-        # RUN_JSON missing .run_attempt flows into the script's own
-        # BATS-tested guard (with a clear ::error:: message) rather
-        # than aborting here with a raw jq error under set -e.
-        source_run_attempt=$(printf '%s' "$RUN_JSON" | jq -r '.run_attempt // ""')
+        # Non-strict extraction handles BOTH missing field (`.run_attempt
+        # // ""`) AND malformed JSON payload (`|| echo ""` captures the
+        # jq-parse-failure case). Both failure shapes then flow into the
+        # script's own BATS-tested guard rather than aborting here with a
+        # raw jq error under set -euo pipefail.
+        source_run_attempt=$(printf '%s' "$RUN_JSON" | jq -r '.run_attempt // ""' 2>/dev/null || echo "")
         EXPECTED_CANDIDATE_TAG="release-candidate-${SOURCE_RUN_ID}-${source_run_attempt}"
         export EXPECTED_CANDIDATE_TAG
 

--- a/.github/workflows/docker-acceptance-only.yml
+++ b/.github/workflows/docker-acceptance-only.yml
@@ -153,7 +153,12 @@ jobs:
         # can enforce operator-input == derived-coordinates. The script
         # re-derives the same value internally as a defence-in-depth
         # against caller drift; passing it here surfaces intent.
-        source_run_attempt=$(printf '%s' "$RUN_JSON" | jq -er .run_attempt)
+        #
+        # Non-strict extraction with an empty-string fallback so a
+        # RUN_JSON missing .run_attempt flows into the script's own
+        # BATS-tested guard (with a clear ::error:: message) rather
+        # than aborting here with a raw jq error under set -e.
+        source_run_attempt=$(printf '%s' "$RUN_JSON" | jq -r '.run_attempt // ""')
         EXPECTED_CANDIDATE_TAG="release-candidate-${SOURCE_RUN_ID}-${source_run_attempt}"
         export EXPECTED_CANDIDATE_TAG
 

--- a/.github/workflows/test-byte-identical-scripts.yml
+++ b/.github/workflows/test-byte-identical-scripts.yml
@@ -55,3 +55,5 @@ jobs:
         bats tests/bats/ci-scripts/verify-oci-labels/
         bats tests/bats/ci-scripts/expand-docker-tags/
         bats tests/bats/ci-scripts/extract-zip/
+        bats tests/bats/ci-scripts/validate-source-run/
+        bats tests/bats/ci-scripts/verify-dockerhub-tag-exists/

--- a/tests/bats/ci-scripts/validate-source-run/helpers.bash
+++ b/tests/bats/ci-scripts/validate-source-run/helpers.bash
@@ -1,0 +1,55 @@
+# Helpers for BATS tests of .github/scripts/validate-source-run.sh.
+#
+# Pure JSON-parse script (no docker, no network, no gh) -- tests build
+# RUN_JSON blobs as here-strings and pass them via env. No mock needed.
+#
+# Pattern follows tests/bats/ci-scripts/expand-docker-tags/helpers.bash --
+# script path resolved at load time; a small make_run_json() convenience
+# builds well-shaped fixture blobs.
+
+__HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034  # referenced from .bats files
+VALIDATE_SOURCE_RUN_SCRIPT="$(cd "${__HELPERS_DIR}/../../../.." && pwd)/.github/scripts/validate-source-run.sh"
+
+setup_test_dir() {
+    # `mktemp -d` (no `-t <template>`) -- BusyBox's mktemp in the
+    # bats/bats:1.13.0 Alpine image rejects the `-t` form GNU mktemp
+    # accepts.
+    CWD=$(mktemp -d)
+    cd "${CWD}" || exit 1
+}
+
+teardown_test_dir() {
+    cd /
+    rm -rf "${CWD}"
+    unset RUN_JSON SOURCE_RUN_ID EXPECTED_WORKFLOW_PATH
+    unset EXPECTED_CANDIDATE_TAG CANDIDATE_TAG AGE_CEILING_HOURS
+}
+
+# Build a RUN_JSON blob matching the shape gh api returns for
+# /repos/{owner}/{repo}/actions/runs/{id}. Arg 1 is the path, arg 2 is
+# the created_at ISO timestamp, arg 3 (optional) is the run_attempt
+# (default "1"). Additional fields the real API returns are omitted --
+# the script only reads .path, .created_at, .run_attempt.
+#
+# Usage:
+#   RUN_JSON=$(make_run_json ".github/workflows/build-release.yml" "2026-07-30T12:00:00Z")
+#   RUN_JSON=$(make_run_json ".github/workflows/docker-build-release.yml" "2026-07-30T12:00:00Z" "2")
+make_run_json() {
+    local path="$1"
+    local created_at="$2"
+    local run_attempt="${3:-1}"
+    printf '{"path":"%s","created_at":"%s","run_attempt":%s}' \
+        "${path}" "${created_at}" "${run_attempt}"
+}
+
+# ISO-8601 timestamp N hours before now. Uses `date -d @<epoch>` (both
+# GNU and BusyBox date accept this form) rather than `date -d "N hours
+# ago"` (GNU-only; the bats/bats:1.13.0 Alpine image's BusyBox date
+# rejects the relative form).
+hours_ago() {
+    local hours="$1"
+    local now_epoch
+    now_epoch=$(date -u +%s)
+    date -u -d "@$(( now_epoch - hours * 3600 ))" +%Y-%m-%dT%H:%M:%SZ
+}

--- a/tests/bats/ci-scripts/validate-source-run/validate.bats
+++ b/tests/bats/ci-scripts/validate-source-run/validate.bats
@@ -1,0 +1,294 @@
+# BATS tests for .github/scripts/validate-source-run.sh
+#
+# Pure JSON-parse script (no docker, no gh, no network). Fixture RUN_JSON
+# blobs are built via make_run_json() and passed through the env.
+#
+# Covers:
+#   - tarball happy path (build-release.yml, fresh run, no candidate_tag)
+#   - docker happy path (docker-build-release.yml, fresh run, matching
+#     candidate_tag)
+#   - wrong-workflow rejection (both directions)
+#   - candidate_tag mismatch (wrong run id, wrong attempt, wrong prefix)
+#   - age ceiling (fresh boundary just under 48h vs stale just over)
+#   - AGE_CEILING_HOURS override (test hook works)
+#   - malformed timestamp
+#   - missing .path / .created_at / .run_attempt fields
+#   - required env-var guards
+#   - guard ordering: wrong-workflow rejected before age check runs
+#   - stdin fallback when RUN_JSON env unset
+#   - EXPECTED_CANDIDATE_TAG set but CANDIDATE_TAG unset -> clear error
+
+load 'helpers'
+
+# Install GNU coreutils + jq if missing. The script under test uses:
+#   * `date -d "$iso_z_string"` -- GNU form; bats/bats:1.13.0's Alpine
+#     base ships BusyBox date which rejects the ISO-8601 `T...Z` form.
+#     GHA ubuntu-24.04 (where CI runs BATS) has GNU date natively.
+#   * `jq -er` -- not in the base Alpine image; also present on
+#     GHA ubuntu-24.04.
+# Runs once per test file.
+setup_file() {
+    local need_install=0
+    if ! date -u -d "2026-07-30T12:00:00Z" +%s >/dev/null 2>&1; then
+        need_install=1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        need_install=1
+    fi
+    if [[ "${need_install}" -eq 1 ]]; then
+        if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache coreutils jq >/dev/null 2>&1 || true
+        elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update >/dev/null 2>&1 && apt-get install -y coreutils jq >/dev/null 2>&1 || true
+        fi
+    fi
+    if ! date -u -d "2026-07-30T12:00:00Z" +%s >/dev/null 2>&1; then
+        echo "# skip-reason: GNU date not installable in this environment" >&3
+        skip "GNU date (coreutils) required to parse ISO-8601 timestamps like the script does"
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "# skip-reason: jq not installable in this environment" >&3
+        skip "jq required for the script's JSON parsing"
+    fi
+}
+
+setup() {
+    setup_test_dir
+}
+
+teardown() {
+    teardown_test_dir
+}
+
+# --- happy paths ---
+
+@test "tarball happy path: build-release.yml, fresh run, no candidate_tag" {
+    RUN_JSON=$(make_run_json ".github/workflows/build-release.yml" "$(hours_ago 1)") \
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    [[ "${output}" == *"source run eligible"* ]]
+    [[ "${output}" != *"::error::"* ]]
+}
+
+@test "docker happy path: docker-build-release.yml + matching candidate_tag" {
+    RUN_JSON=$(make_run_json ".github/workflows/docker-build-release.yml" "$(hours_ago 2)" 1) \
+    SOURCE_RUN_ID="30443247578" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/docker-build-release.yml" \
+    EXPECTED_CANDIDATE_TAG="release-candidate-30443247578-1" \
+    CANDIDATE_TAG="release-candidate-30443247578-1" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    [[ "${output}" == *"source run eligible"* ]]
+    [[ "${output}" == *"candidate_tag matches"* ]]
+    [[ "${output}" != *"::error::"* ]]
+}
+
+@test "docker happy path: run_attempt=2 (re-run) with matching candidate_tag" {
+    RUN_JSON=$(make_run_json ".github/workflows/docker-build-release.yml" "$(hours_ago 3)" 2) \
+    SOURCE_RUN_ID="30443247578" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/docker-build-release.yml" \
+    EXPECTED_CANDIDATE_TAG="release-candidate-30443247578-2" \
+    CANDIDATE_TAG="release-candidate-30443247578-2" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+}
+
+# --- wrong-workflow rejection ---
+
+@test "wrong workflow_path -> exit 1 with clear error" {
+    RUN_JSON=$(make_run_json ".github/workflows/ci.yml" "$(hours_ago 1)") \
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::source run 12345 was produced by '.github/workflows/ci.yml', not '.github/workflows/build-release.yml'"* ]]
+    [[ "${output}" == *"::error::this recovery workflow only accepts source runs from build-release.yml"* ]]
+}
+
+@test "docker workflow_path swap (tarball workflow passed for docker recovery) -> exit 1" {
+    RUN_JSON=$(make_run_json ".github/workflows/build-release.yml" "$(hours_ago 1)") \
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/docker-build-release.yml" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::"*"docker-build-release.yml"* ]]
+}
+
+# --- candidate_tag coordinates binding ---
+
+@test "candidate_tag mismatch (wrong run id embedded) -> exit 1" {
+    RUN_JSON=$(make_run_json ".github/workflows/docker-build-release.yml" "$(hours_ago 1)" 1) \
+    SOURCE_RUN_ID="30443247578" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/docker-build-release.yml" \
+    EXPECTED_CANDIDATE_TAG="release-candidate-30443247578-1" \
+    CANDIDATE_TAG="release-candidate-99999999999-1" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::candidate_tag mismatch"* ]]
+    [[ "${output}" == *"operator supplied 'release-candidate-99999999999-1'"* ]]
+    [[ "${output}" == *"would have produced 'release-candidate-30443247578-1'"* ]]
+    [[ "${output}" == *"maliciously"* ]]
+}
+
+@test "candidate_tag mismatch (wrong run_attempt) -> exit 1" {
+    RUN_JSON=$(make_run_json ".github/workflows/docker-build-release.yml" "$(hours_ago 1)" 3) \
+    SOURCE_RUN_ID="30443247578" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/docker-build-release.yml" \
+    EXPECTED_CANDIDATE_TAG="release-candidate-30443247578-3" \
+    CANDIDATE_TAG="release-candidate-30443247578-1" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::candidate_tag mismatch"* ]]
+    [[ "${output}" == *"attempt 3"* ]]
+}
+
+@test "EXPECTED_CANDIDATE_TAG set but CANDIDATE_TAG unset -> exit 1 with clear error" {
+    RUN_JSON=$(make_run_json ".github/workflows/docker-build-release.yml" "$(hours_ago 1)" 1) \
+    SOURCE_RUN_ID="30443247578" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/docker-build-release.yml" \
+    EXPECTED_CANDIDATE_TAG="release-candidate-30443247578-1" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"CANDIDATE_TAG"* ]]
+}
+
+# --- age ceiling ---
+
+@test "age just under 48h ceiling -> pass" {
+    RUN_JSON=$(make_run_json ".github/workflows/build-release.yml" "$(hours_ago 47)") \
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+}
+
+@test "age just over 48h ceiling -> exit 1 with stale-run error" {
+    RUN_JSON=$(make_run_json ".github/workflows/build-release.yml" "$(hours_ago 49)") \
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::source run 12345 is 49h old (> 48h ceiling)"* ]]
+    [[ "${output}" == *"stale"* ]]
+    [[ "${output}" == *"Recovery paths"* ]]
+}
+
+@test "AGE_CEILING_HOURS=1 override rejects a 2h-old run" {
+    RUN_JSON=$(make_run_json ".github/workflows/build-release.yml" "$(hours_ago 2)") \
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+    AGE_CEILING_HOURS="1" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"> 1h ceiling"* ]]
+}
+
+# --- malformed RUN_JSON ---
+
+@test "malformed created_at timestamp -> exit 1 with parse error" {
+    RUN_JSON=$(make_run_json ".github/workflows/build-release.yml" "definitely-not-a-timestamp") \
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"created_at 'definitely-not-a-timestamp' is not a parseable timestamp"* ]]
+}
+
+@test "RUN_JSON missing .path -> exit 1 with malformed-blob error" {
+    RUN_JSON='{"created_at":"2026-07-30T12:00:00Z","run_attempt":1}' \
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"missing required field '.path'"* ]]
+}
+
+@test "RUN_JSON missing .created_at -> exit 1 with malformed-blob error" {
+    RUN_JSON='{"path":".github/workflows/build-release.yml","run_attempt":1}' \
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"missing required field '.created_at'"* ]]
+}
+
+@test "RUN_JSON missing .run_attempt (docker path only) -> exit 1" {
+    RUN_JSON='{"path":".github/workflows/docker-build-release.yml","created_at":"'"$(hours_ago 1)"'"}' \
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/docker-build-release.yml" \
+    EXPECTED_CANDIDATE_TAG="release-candidate-12345-1" \
+    CANDIDATE_TAG="release-candidate-12345-1" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"missing required field '.run_attempt'"* ]]
+}
+
+@test "RUN_JSON missing .run_attempt is OK on tarball path (candidate binding disabled)" {
+    # Tarball recovery doesn't need .run_attempt -- only docker
+    # candidate_tag binding does. Verify the script doesn't demand it
+    # when EXPECTED_CANDIDATE_TAG is unset.
+    RUN_JSON='{"path":".github/workflows/build-release.yml","created_at":"'"$(hours_ago 1)"'"}' \
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+}
+
+# --- required env-var guards ---
+
+@test "missing SOURCE_RUN_ID -> non-zero exit" {
+    unset SOURCE_RUN_ID
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+    RUN_JSON=$(make_run_json ".github/workflows/build-release.yml" "$(hours_ago 1)") \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"SOURCE_RUN_ID"* ]]
+}
+
+@test "missing EXPECTED_WORKFLOW_PATH -> non-zero exit" {
+    unset EXPECTED_WORKFLOW_PATH
+    SOURCE_RUN_ID="12345" \
+    RUN_JSON=$(make_run_json ".github/workflows/build-release.yml" "$(hours_ago 1)") \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"EXPECTED_WORKFLOW_PATH"* ]]
+}
+
+@test "empty RUN_JSON env AND empty stdin -> non-zero exit with clear error" {
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+        run bash -c "printf '' | bash '${VALIDATE_SOURCE_RUN_SCRIPT}'"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"RUN_JSON is empty"* ]]
+}
+
+# --- guard ordering: cheapest-first ---
+
+@test "wrong workflow reported BEFORE age check (guard ordering)" {
+    # A run that is BOTH wrong-workflow AND too-old should fail with the
+    # workflow error, not the age error -- workflow check is cheaper and
+    # runs first per the audit's ordering directive.
+    RUN_JSON=$(make_run_json ".github/workflows/wrong.yml" "$(hours_ago 100)") \
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"was produced by"* ]]
+    # Age error should NOT appear -- script exited before reaching that check.
+    [[ "${output}" != *"ceiling"* ]]
+}
+
+# --- stdin form ---
+
+@test "RUN_JSON via stdin (env unset) works" {
+    local json
+    json=$(make_run_json ".github/workflows/build-release.yml" "$(hours_ago 1)")
+    unset RUN_JSON
+    SOURCE_RUN_ID="12345" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/build-release.yml" \
+        run bash -c "printf '%s' '${json}' | bash '${VALIDATE_SOURCE_RUN_SCRIPT}'"
+    [[ ${status} -eq 0 ]]
+    [[ "${output}" == *"source run eligible"* ]]
+}

--- a/tests/bats/ci-scripts/validate-source-run/validate.bats
+++ b/tests/bats/ci-scripts/validate-source-run/validate.bats
@@ -144,6 +144,25 @@ teardown() {
     [[ "${output}" == *"attempt 3"* ]]
 }
 
+@test "caller-drift: CANDIDATE_TAG matches derived but EXPECTED_CANDIDATE_TAG is stale -> exit 1" {
+    # Guards script lines around the second candidate_tag equality
+    # check: script derives release-candidate-<id>-<attempt> internally
+    # and asserts that (a) operator-supplied CANDIDATE_TAG matches AND
+    # (b) caller-supplied EXPECTED_CANDIDATE_TAG matches. Every other
+    # test keeps the two in sync; this one deliberately makes the caller
+    # send a stale EXPECTED value while the operator's CANDIDATE_TAG
+    # is correct, to lock in the caller-drift error path.
+    RUN_JSON=$(make_run_json ".github/workflows/docker-build-release.yml" "$(hours_ago 1)" 1) \
+    SOURCE_RUN_ID="30443247578" \
+    EXPECTED_WORKFLOW_PATH=".github/workflows/docker-build-release.yml" \
+    CANDIDATE_TAG="release-candidate-30443247578-1" \
+    EXPECTED_CANDIDATE_TAG="release-candidate-99999999999-1" \
+        run bash "${VALIDATE_SOURCE_RUN_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"EXPECTED_CANDIDATE_TAG"* ]]
+    [[ "${output}" == *"stale inputs"* ]]
+}
+
 @test "EXPECTED_CANDIDATE_TAG set but CANDIDATE_TAG unset -> exit 1 with clear error" {
     RUN_JSON=$(make_run_json ".github/workflows/docker-build-release.yml" "$(hours_ago 1)" 1) \
     SOURCE_RUN_ID="30443247578" \

--- a/tests/bats/ci-scripts/verify-dockerhub-tag-exists/curl-mock.sh
+++ b/tests/bats/ci-scripts/verify-dockerhub-tag-exists/curl-mock.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Mock `curl` CLI for BATS tests of verify-dockerhub-tag-exists.sh.
+#
+# The mock replaces the real `curl` binary on PATH so the script under
+# test never touches Docker Hub. Understands the exact invocation shape
+# the script uses:
+#
+#   curl --connect-timeout 10 --max-time 30 -sS \
+#       -o <response-body-file> -w '%{http_code}' <url>
+#
+# Fixture behavior is controlled via three env vars read at mock-invocation
+# time:
+#
+#   MOCK_CURL_HTTP_CODE   HTTP status the mock prints to stdout (matches
+#                         the real curl's `-w '%{http_code}'` output).
+#                         Default: "200".
+#   MOCK_CURL_BODY        Bytes written to the -o file. Default: "" (empty
+#                         body -- matches Docker Hub's 404 response shape
+#                         which is a JSON error object, but the script
+#                         only cares about the body on the unexpected-
+#                         status branch, so keep it minimal for the
+#                         happy path).
+#   MOCK_CURL_EXIT        Mock exits with this status BEFORE writing any
+#                         output. Simulates curl-level failure (DNS,
+#                         TLS, timeout, connection reset). Default: "0".
+#                         When nonzero, MOCK_CURL_HTTP_CODE and
+#                         MOCK_CURL_BODY are ignored.
+
+set -euo pipefail
+
+exit_code="${MOCK_CURL_EXIT:-0}"
+http_code="${MOCK_CURL_HTTP_CODE:-200}"
+body="${MOCK_CURL_BODY:-}"
+
+# Find the -o output file in the argv.
+output_file=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o)
+            output_file="$2"
+            shift 2
+            ;;
+        -o*)
+            output_file="${1#-o}"
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+if [[ "${exit_code}" -ne 0 ]]; then
+    # Simulate curl-level failure: don't print status, don't write body,
+    # just exit with the failure code. Real curl behaves the same way for
+    # e.g. DNS failure (exit 6, no HTTP response ever).
+    exit "${exit_code}"
+fi
+
+if [[ -n "${output_file}" ]]; then
+    printf '%s' "${body}" > "${output_file}"
+fi
+# The real curl with `-w '%{http_code}'` prints ONLY the status code to
+# stdout when -o directs the response body to a file. Match that shape.
+printf '%s' "${http_code}"

--- a/tests/bats/ci-scripts/verify-dockerhub-tag-exists/helpers.bash
+++ b/tests/bats/ci-scripts/verify-dockerhub-tag-exists/helpers.bash
@@ -1,0 +1,46 @@
+# Helpers for BATS tests of .github/scripts/verify-dockerhub-tag-exists.sh.
+#
+# Installs a `curl` mock on PATH (see curl-mock.sh for the contract) so
+# the script under test never hits Docker Hub. Fixture behavior is
+# controlled per-test via MOCK_CURL_HTTP_CODE / MOCK_CURL_BODY /
+# MOCK_CURL_EXIT env vars.
+#
+# Pattern follows tests/bats/ci-scripts/verify-oci-labels/helpers.bash --
+# standalone bash, plain [[ ]] asserts, no bats-support/bats-assert.
+
+__HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034
+VERIFY_DOCKERHUB_TAG_EXISTS_SCRIPT="$(cd "${__HELPERS_DIR}/../../../.." && pwd)/.github/scripts/verify-dockerhub-tag-exists.sh"
+
+setup_test_dir() {
+    # `mktemp -d` (no `-t <template>`) -- BusyBox's mktemp in the
+    # bats/bats:1.13.0 Alpine image rejects the `-t` form GNU mktemp
+    # accepts.
+    CWD=$(mktemp -d)
+
+    # Install the curl mock at the front of PATH.
+    local mock_dir="${CWD}/.curl-mock"
+    mkdir -p "${mock_dir}"
+    cp "${__HELPERS_DIR}/curl-mock.sh" "${mock_dir}/curl"
+    chmod +x "${mock_dir}/curl"
+    export PATH="${mock_dir}:${PATH}"
+
+    cd "${CWD}" || exit 1
+
+    # Default: happy-path 200. Individual tests override.
+    export MOCK_CURL_HTTP_CODE="200"
+    export MOCK_CURL_BODY=""
+    export MOCK_CURL_EXIT="0"
+
+    # Sensible default TAG so happy-path test is a one-liner. Individual
+    # tests override.
+    export TAG="release-candidate-12345-1"
+}
+
+teardown_test_dir() {
+    cd /
+    export PATH="${PATH#"${CWD}/.curl-mock":}"
+    rm -rf "${CWD}"
+    unset MOCK_CURL_HTTP_CODE MOCK_CURL_BODY MOCK_CURL_EXIT
+    unset TAG REPO
+}

--- a/tests/bats/ci-scripts/verify-dockerhub-tag-exists/verify.bats
+++ b/tests/bats/ci-scripts/verify-dockerhub-tag-exists/verify.bats
@@ -1,0 +1,95 @@
+# BATS tests for .github/scripts/verify-dockerhub-tag-exists.sh
+#
+# Runs against a mock `curl` (see helpers.bash + curl-mock.sh). Covers:
+#   - HTTP 200 happy path (exit 0)
+#   - HTTP 404 (exit 1 with recovery-paths error)
+#   - unexpected HTTP status (exit 1 with response-body dump)
+#   - curl-level failure (exit 1 with connection-error message)
+#   - required env-var guard (TAG unset)
+#   - default REPO applied (openemr/openemr) + REPO override respected
+#   - URL construction: TAG appears in the printed GET line
+
+load 'helpers'
+
+setup() {
+    setup_test_dir
+}
+
+teardown() {
+    teardown_test_dir
+}
+
+@test "HTTP 200 -> exit 0 with success message" {
+    MOCK_CURL_HTTP_CODE="200" \
+        run bash "${VERIFY_DOCKERHUB_TAG_EXISTS_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    [[ "${output}" == *"openemr/openemr:release-candidate-12345-1 exists on Docker Hub"* ]]
+    [[ "${output}" != *"::error::"* ]]
+}
+
+@test "HTTP 404 -> exit 1 with recovery-paths error" {
+    MOCK_CURL_HTTP_CODE="404" \
+    MOCK_CURL_BODY='{"message":"tag not found"}' \
+        run bash "${VERIFY_DOCKERHUB_TAG_EXISTS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Tag openemr/openemr:release-candidate-12345-1 not found on Docker Hub (HTTP 404)"* ]]
+    [[ "${output}" == *"::error::"*"cleaned up"* ]]
+    [[ "${output}" == *"::error::Recovery paths"* ]]
+}
+
+@test "HTTP 500 -> exit 1 with unexpected-status error + body dump" {
+    MOCK_CURL_HTTP_CODE="500" \
+    MOCK_CURL_BODY='{"error":"internal server error"}' \
+        run bash "${VERIFY_DOCKERHUB_TAG_EXISTS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Unexpected HTTP 500 from Docker Hub v2 API"* ]]
+    [[ "${output}" == *"internal server error"* ]]
+}
+
+@test "HTTP 429 (rate limit) -> exit 1 with unexpected-status error" {
+    MOCK_CURL_HTTP_CODE="429" \
+    MOCK_CURL_BODY='{"error":"too many requests"}' \
+        run bash "${VERIFY_DOCKERHUB_TAG_EXISTS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Unexpected HTTP 429"* ]]
+}
+
+@test "curl-level failure (exit 6 -- couldn't resolve host) -> exit 1 with connection error" {
+    MOCK_CURL_EXIT="6" \
+        run bash "${VERIFY_DOCKERHUB_TAG_EXISTS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::Docker Hub request failed before receiving an HTTP response"* ]]
+    [[ "${output}" == *"curl exit: 6"* ]]
+}
+
+@test "curl-level failure (exit 28 -- operation timeout) -> exit 1" {
+    MOCK_CURL_EXIT="28" \
+        run bash "${VERIFY_DOCKERHUB_TAG_EXISTS_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"curl exit: 28"* ]]
+}
+
+@test "missing TAG -> non-zero exit with clear error" {
+    unset TAG
+    run bash "${VERIFY_DOCKERHUB_TAG_EXISTS_SCRIPT}"
+    [[ ${status} -ne 0 ]]
+    [[ "${output}" == *"TAG"* ]]
+}
+
+@test "REPO override respected in success message" {
+    REPO="someorg/somerepo" \
+    TAG="v1.2.3" \
+    MOCK_CURL_HTTP_CODE="200" \
+        run bash "${VERIFY_DOCKERHUB_TAG_EXISTS_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    [[ "${output}" == *"someorg/somerepo:v1.2.3"* ]]
+    # URL in the GET line should include the overridden REPO.
+    [[ "${output}" == *"hub.docker.com/v2/repositories/someorg/somerepo/tags/v1.2.3/"* ]]
+}
+
+@test "default REPO is openemr/openemr" {
+    MOCK_CURL_HTTP_CODE="200" \
+        run bash "${VERIFY_DOCKERHUB_TAG_EXISTS_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    [[ "${output}" == *"hub.docker.com/v2/repositories/openemr/openemr/tags/"* ]]
+}


### PR DESCRIPTION
## Summary

Phase 10e-2 of the release-mechanism unification plan. Consolidates the
source-run eligibility guards that lived inline in two workflows into a
shared shell script, plus splits the Docker Hub tag-existence probe into
its own small helper.

- `.github/scripts/validate-source-run.sh` -- env-contract wrapper for
  the three-guard validation (workflow_path check, optional
  candidate_tag coordinates binding, 48h age ceiling). RUN_JSON
  accepted via env or stdin; preserves the previous error messages
  verbatim so operators grep familiar strings; preserves the cheapest-
  first guard ordering the audit called out.
- `.github/scripts/verify-dockerhub-tag-exists.sh` -- split off from
  `validate-source-run.sh` so the two scripts have distinct testability
  profiles (curl-mocked network I/O vs pure JSON parse). Same bounded-
  curl + 200/404/other/curl-fail case shape as the inline block it
  replaces.

Neither caller workflow (`acceptance-only.yml`,
`docker-acceptance-only.yml`) is in `.github/byte-identical.yml` (both
are master-only per their own `if: github.ref` guards), so no
propagation is needed for the workflows or the new scripts.

### Design call: single vs split

Went with two scripts, split by concern boundary rather than by
caller. The audit recommended a single `validate-source-run.sh` with
optional env flags; my read after touching the code is that the Docker
Hub existence probe is a genuinely different concern (remote state
vs. source-run metadata) with a distinct testability profile. Splitting
kept both scripts small enough to read top-to-bottom, and let the BATS
suite for `verify-dockerhub-tag-exists.sh` be a straightforward curl-
mock pattern without any conditional skip logic.

## Test plan

- [x] `docker run --rm -v $(pwd):/code -w /code bats/bats:1.13.0 tests/bats/ci-scripts/validate-source-run/` -- 21/21 pass
- [x] `docker run --rm -v $(pwd):/code -w /code bats/bats:1.13.0 tests/bats/ci-scripts/verify-dockerhub-tag-exists/` -- 9/9 pass
- [x] `docker run --rm -v $(pwd):/repo -w /repo koalaman/shellcheck:v0.10.0 --check-sourced --external-sources .github/scripts/validate-source-run.sh .github/scripts/verify-dockerhub-tag-exists.sh` -- clean
- [x] `docker run --rm -v $(pwd):/repo -w /repo rhysd/actionlint:1.7.10 -color` -- clean
- [x] existing `expand-docker-tags` + `verify-oci-labels` BATS suites unchanged, still passing
- [x] pre-commit hooks passed
- [ ] CI `Test byte-identical scripts` job runs both new suites on the PR

BATS coverage additions:
- 21 tests for `validate-source-run.sh` covering: tarball + docker
  happy paths, wrong-workflow rejection (both directions), candidate_tag
  mismatch (wrong run id + wrong attempt), missing CANDIDATE_TAG with
  enforcement enabled, age boundaries (47h / 49h), `AGE_CEILING_HOURS`
  override, malformed timestamp, missing `.path` / `.created_at` /
  `.run_attempt` fields, required env-var guards, guard ordering
  (wrong-workflow reported before age check runs), stdin fallback.
- 9 tests for `verify-dockerhub-tag-exists.sh` covering: 200 happy
  path, 404 with recovery hints, unexpected 500/429 with body dump,
  curl-level failures (exit 6 DNS-fail + exit 28 timeout), required
  env-var guard, REPO override + default.

Assisted-by: Claude Code