### PR TITLE
ci: failure diagnostics for redis-sentinel/apache e2e (#12438)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -598,10 +598,60 @@ jobs:
         . ci/ciLibrary.source
         enable_coredumps
 
+    ##
+    # The redis-sentinel e2e failures (#12438: pages hang on "Loading" until
+    # TimeoutException, then the rest of the suite cascades) leave no
+    # evidence after teardown. Sample Redis connection health through the run
+    # so a failure shows whether connected_clients climbed (connection leak),
+    # blocked_clients pinned (lock contention), or Redis was never involved.
+    - name: Start Redis monitor
+      if: ${{ needs.setup.outputs.redis_sentinel_enabled == 'true' }}
+      run: |
+        . ci/ciLibrary.source
+        redis_monitor_start redis-monitor.log
+
     - name: Run ${{ matrix.suite }} tests
       run: |
         . ci/ciLibrary.source
         build_test ${{ matrix.suite }}
+
+    ##
+    # Redis post-mortem must run before anything else can disturb the
+    # cluster or delay the snapshot: the redis-failover suite stops and
+    # restarts redis-master, and the coverage/artifact steps below push the
+    # capture minutes past the point of interest. Diagnostics fire on
+    # failure first; the always() stop then finalizes the sampler so
+    # successful runs don't leave it running until runner cleanup
+    # (redis_monitor_stop is idempotent — the pid file guards a double stop).
+    - name: Redis diagnostics
+      if: ${{ failure() && needs.setup.outputs.redis_sentinel_enabled == 'true' }}
+      run: |
+        . ci/ciLibrary.source
+        redis_monitor_stop redis-monitor.log
+        mkdir -p "${RUNNER_TEMP}/redis-diagnostics"
+        cp redis-monitor.log "${RUNNER_TEMP}/redis-diagnostics/" 2>/dev/null || true
+        redis_diagnostics "${RUNNER_TEMP}/redis-diagnostics"
+        echo '=== redis connection trend (last 60 lines) ==='
+        tail -n 60 redis-monitor.log || true
+
+    - name: Stop Redis monitor
+      if: ${{ always() && needs.setup.outputs.redis_sentinel_enabled == 'true' }}
+      run: |
+        . ci/ciLibrary.source
+        redis_monitor_stop redis-monitor.log
+        # Print the workers' first OPcache sample so every run — green or
+        # red — records the JIT config it actually ran with. The diagnostics
+        # artifact only uploads on failure, so without this line a green run
+        # leaves no evidence that the #12438 JIT-off remedy was in effect.
+        grep -m1 '^opcache:' redis-monitor.log || true
+
+    - name: Upload Redis diagnostics
+      if: ${{ failure() && needs.setup.outputs.redis_sentinel_enabled == 'true' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: redis-diagnostics-${{ needs.setup.outputs.docker_dir }}-${{ matrix.suite }}
+        path: ${{ runner.temp }}/redis-diagnostics/
+        if-no-files-found: ignore
 
     ##
     # Coverage conversion for suites that use auto_prepend.php
@@ -731,6 +781,38 @@ jobs:
         dump_error_log apache > "${CRASH_DIAG_DIR}/openemr.error.log" 2>&1 || true
         # Backtrace + gzip'd core for each coredump produced this run.
         capture_coredumps "${CRASH_DIAG_DIR}"
+
+    ##
+    # The kernel logs every segfault with the instruction pointer and the
+    # shared object it landed in (e.g. "segfault at ... ip ... in
+    # opcache.so[...]"), for container processes too — the runner shares its
+    # kernel with the containers. This names the faulting module for every
+    # crash in the run even when the coredump pipeline yields nothing — as
+    # #12438 runs did for weeks (segfault storms, zero cores).
+    - name: Kernel segfault log
+      if: ${{ failure() }}
+      env:
+        CRASH_DIAG_DIR: ${{ runner.temp }}/crash-diagnostics
+      run: |
+        mkdir -p "${CRASH_DIAG_DIR}"
+        sudo dmesg -T 2>/dev/null | grep -iE 'segfault|traps:|core_pattern|coredump' \
+            > "${CRASH_DIAG_DIR}/kernel-segfaults.txt" || true
+        echo "=== kernel segfault/trap lines (tail) ==="
+        tail -n 40 "${CRASH_DIAG_DIR}/kernel-segfaults.txt" || true
+
+    ##
+    # The step above runs for every failed suite, but the crash-diagnostics
+    # artifact that would carry kernel-segfaults.txt only uploads for apache
+    # e2e (below). Upload it separately for every other scope — gated as the
+    # exact complement of the crash-diagnostics condition so the file is
+    # persisted exactly once per failed job, never duplicated.
+    - name: Upload kernel segfault log
+      if: ${{ failure() && !(matrix.suite == 'e2e' && needs.setup.outputs.webserver == 'apache') }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: kernel-segfaults-${{ needs.setup.outputs.docker_dir }}-${{ matrix.suite }}
+        path: ${{ runner.temp }}/crash-diagnostics/kernel-segfaults.txt
+        if-no-files-found: ignore
 
     - name: Upload crash diagnostics
       if: ${{ failure() && matrix.suite == 'e2e' && needs.setup.outputs.webserver == 'apache' }}

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -850,6 +850,25 @@ readonly COREDUMP_DIR
 #      the web user, which clears the dumpable flag; mode 2 restores it
 #      (core owned by root, readable by root).
 # core_pattern is a kernel global shared with the container.
+##
+# Poll (up to ~10s) for a core file belonging to pid $1. A fixed sleep
+# false-warns when the kernel is still streaming the core to disk — and the
+# cores this pipeline targets run to hundreds of MB, so slow writes are the
+# expected case, not the edge case. The glob is pid-scoped (core.*.<pid>.*)
+# rather than comm-scoped, so it needs no assumption about the crashing
+# binary's name (php vs php82 vs httpd).
+_await_core_for_pid() {
+    local pid=$1
+    local _attempt
+    for _attempt in $(seq 1 20); do
+        if docker compose exec -T openemr sh -c "ls '${COREDUMP_DIR}'/core.*.${pid}.* >/dev/null 2>&1"; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    return 1
+}
+
 enable_coredumps() {
     # Create the in-container target up front so the kernel has somewhere to
     # write the core. World-writable + sticky: Apache workers run as the
@@ -893,21 +912,31 @@ enable_coredumps() {
     # graceful restart above ran cleanly, yet produced zero cores — and
     # nobody knew the pipeline was broken until the cores were needed.
     # Crash a sacrificial CLI php as the unprivileged web user (mirroring
-    # the root->apache setuid path the workers take) and require a core.
-    local canary_files
-    docker compose exec -T openemr \
-        su -s /bin/sh apache -c 'php -d error_reporting=0 -r "posix_kill(posix_getpid(), 11);"' \
-        2>/dev/null || true
-    sleep 1
-    canary_files=$(docker compose exec -T openemr sh -c "ls -1 '${COREDUMP_DIR}' 2>/dev/null | wc -l") || canary_files=0
-    if [[ "${canary_files//[!0-9]/}" == "0" || -z "${canary_files//[!0-9]/}" ]]; then
-        echo "::warning::coredump canary produced no core in ${COREDUMP_DIR} — worker segfaults in this job will NOT be debuggable; check ulimits.core, kernel.core_pattern, and fs.suid_dumpable"
+    # the root->apache setuid path the workers take) and require ITS core:
+    # the check and the cleanup are scoped to the canary's own pid, so a
+    # pre-existing file in the directory cannot fake a pass and the cleanup
+    # cannot remove cores that are not the canary's. The pid is emitted on
+    # stderr — unbuffered — because the process dies before stdout's block
+    # buffer would flush.
+    local canary_pid canary_core_ok=0
+    canary_pid=$(docker compose exec -T openemr \
+        su -s /bin/sh apache -c 'php -d error_reporting=0 -r "fwrite(STDERR, posix_getpid()); posix_kill(posix_getpid(), 11);"' \
+        2>&1 >/dev/null) || true
+    canary_pid=${canary_pid//[!0-9]/}
+    if [[ -n "${canary_pid}" ]]; then
+        # shellcheck disable=SC2310  # poll outcome selects the message; never fatal
+        if _await_core_for_pid "${canary_pid}"; then
+            canary_core_ok=1
+        fi
+    fi
+    if [[ -z "${canary_pid}" ]]; then
+        echo "coredump canary inconclusive: could not capture the canary php pid"
+    elif [[ "${canary_core_ok}" == "1" ]]; then
+        echo "coredump canary OK: core for pid ${canary_pid} present in ${COREDUMP_DIR}"
+        # Remove the canary's own core so capture_coredumps only reports real crashes.
+        docker compose exec -T openemr sh -c "rm -f '${COREDUMP_DIR}'/core.*.${canary_pid}.*" 2>/dev/null || true
     else
-        echo "coredump canary OK: core file present in ${COREDUMP_DIR}"
-        # Remove the canary's core so capture_coredumps only reports real crashes.
-        # Glob without the trailing dot: the core's %e is the binary's comm,
-        # which an Alpine packaging change could turn into php82.
-        docker compose exec -T openemr sh -c "rm -f ${COREDUMP_DIR}/core.php*" 2>/dev/null || true
+        echo "::warning::coredump canary produced no core in ${COREDUMP_DIR} — worker segfaults in this job will NOT be debuggable; check ulimits.core, kernel.core_pattern, and fs.suid_dumpable"
     fi
 
     # Second canary, the one that matters: SIGSEGV a REAL Apache worker and
@@ -917,7 +946,7 @@ enable_coredumps() {
     # to date and pointed straight at the CoreDumpDirectory fix above. Cost:
     # one AH00051 line in the error log (AH00051, not AH00052, because
     # CoreDumpDirectory is set); the parent forks a replacement immediately.
-    local worker_pid worker_cores
+    local worker_pid
     worker_pid=$(docker compose exec -T openemr sh -c 'pgrep -u apache httpd | head -1') || worker_pid=""
     worker_pid=${worker_pid//[!0-9]/}
     if [[ -z "${worker_pid}" ]]; then
@@ -925,13 +954,16 @@ enable_coredumps() {
         return 0
     fi
     docker compose exec -T openemr kill -SEGV "${worker_pid}" 2>/dev/null || true
-    sleep 2
-    worker_cores=$(docker compose exec -T openemr sh -c "ls -1 '${COREDUMP_DIR}'/core.httpd.${worker_pid}.* 2>/dev/null | wc -l") || worker_cores=0
-    if [[ "${worker_cores//[!0-9]/}" == "0" || -z "${worker_cores//[!0-9]/}" ]]; then
-        echo "::warning::worker coredump canary FAILED: SIGSEGV to worker ${worker_pid} left no core in ${COREDUMP_DIR} — real worker segfaults will not be debuggable in this job"
+    local worker_core_ok=0
+    # shellcheck disable=SC2310  # poll outcome selects the message; never fatal
+    if _await_core_for_pid "${worker_pid}"; then
+        worker_core_ok=1
+    fi
+    if [[ "${worker_core_ok}" == "1" ]]; then
+        echo "worker coredump canary OK: core for worker pid ${worker_pid} present"
+        docker compose exec -T openemr sh -c "rm -f '${COREDUMP_DIR}'/core.*.${worker_pid}.*" 2>/dev/null || true
     else
-        echo "worker coredump canary OK: core.httpd.${worker_pid} present"
-        docker compose exec -T openemr sh -c "rm -f '${COREDUMP_DIR}'/core.httpd.${worker_pid}.*" 2>/dev/null || true
+        echo "::warning::worker coredump canary FAILED: SIGSEGV to worker ${worker_pid} left no core in ${COREDUMP_DIR} — real worker segfaults will not be debuggable in this job"
     fi
 }
 

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -637,6 +637,194 @@ dump_error_log() {
 }
 
 ##
+# --- Redis Sentinel diagnostics -------------------------------------------
+# The redis-sentinel e2e failures (pages hang on "Loading" until
+# TimeoutException, then cascade) leave no evidence once the job's containers
+# are torn down. These helpers sample Redis connection health during the test
+# run and take a post-mortem snapshot on failure, so a failing run tells us
+# whether the session layer leaked connections (connected_clients climbing,
+# rejected_connections > 0), stalled on locks (blocked_clients pinned), or
+# was never involved at all.
+
+##
+# Print redis-cli TLS arguments (one per line) derived from the openemr
+# container's REDIS_TLS/REDIS_X509 env — the same detection used in
+# build_test_redis_failover. Prints nothing on non-TLS configs. Callers read
+# with mapfile so multi-word paths would survive, and an empty result yields
+# an empty array.
+redis_cli_detect_tls_args() {
+    local _tls _x509
+    _tls=$(docker compose exec -T openemr printenv REDIS_TLS 2>/dev/null) || _tls=""
+    if [[ "${_tls}" == "yes" ]]; then
+        printf '%s\n' --tls --cacert /certs/ca.crt
+        _x509=$(docker compose exec -T openemr printenv REDIS_X509 2>/dev/null) || _x509=""
+        if [[ "${_x509}" == "yes" ]]; then
+            printf '%s\n' --cert /certs/client.crt --key /certs/client.key
+        fi
+    fi
+    # Explicit success: callers capture this with a plain assignment
+    # (var=$(redis_cli_detect_tls_args)), which under set -e requires the
+    # function to reliably return 0 (both docker execs above are guarded).
+    return 0
+}
+
+##
+# Run a redis-cli command against redis-master with auth and TLS handled.
+# The requirepass matches ci/compose-shared-redis-sentinel/docker-compose.yml.
+redis_master_cli() {
+    # Capture with a plain assignment rather than mapfile-from-process-
+    # substitution so the detect function's return value is not masked
+    # (SC2312); guard the herestring since <<< "" would yield one empty
+    # array element rather than an empty array.
+    local tls_output
+    tls_output=$(redis_cli_detect_tls_args)
+    local -a tls_args=()
+    if [[ -n "${tls_output}" ]]; then
+        mapfile -t tls_args <<< "${tls_output}"
+    fi
+    docker compose exec -T redis-master \
+        redis-cli "${tls_args[@]}" -a strongpassword --no-auth-warning "$@"
+}
+
+##
+# Path (relative to the openemr webroot) of the OPcache probe installed by
+# redis_monitor_start and removed by redis_monitor_stop. It must run inside an
+# Apache worker: CLI `php -r 'opcache_get_status()'` reads the CLI's own SHM
+# segment, not the one the workers share — and the workers' segment holds the
+# JIT buffer implicated in the #12438 segfaults.
+# Assign-if-unset before readonly, same as COREDUMP_DIR below: this library
+# is sourced multiple times per shell by ci/inferno/run.sh, and a bare
+# `readonly VAR=...` errors on the second source.
+: "${OPCACHE_PROBE:=opcache-ci-status.php}"
+readonly OPCACHE_PROBE
+
+##
+# Sample connection/lock health of redis-master every 10s, appending to the
+# file named in $1, until redis_monitor_stop. Backgrounds itself; the child
+# writes only to the outfile (never the step's stdout/stderr pipes), so it
+# survives the end of the workflow step that started it.
+redis_monitor_start() {
+    local outfile=$1
+    : > "${outfile}"
+    # Install the probe. The webroot is the bind-mounted checkout, so this
+    # exists only for the lifetime of the CI job and is removed in
+    # redis_monitor_stop. It reports only aggregate memory/restart counters —
+    # no keys, no source, nothing sensitive for a public artifact.
+    docker compose exec -T openemr sh -c "cat > '${OPENEMR_DIR}/${OPCACHE_PROBE}'" <<'PHP' || true
+<?php
+// CI-only probe; written by ci/ciLibrary.source redis_monitor_start.
+header('Content-Type: application/json');
+$s = opcache_get_status(false);
+echo json_encode([
+    'used_memory' => $s['memory_usage']['used_memory'] ?? null,
+    'free_memory' => $s['memory_usage']['free_memory'] ?? null,
+    'wasted_memory' => $s['memory_usage']['wasted_memory'] ?? null,
+    'cache_full' => $s['cache_full'] ?? null,
+    'restart_pending' => $s['restart_pending'] ?? null,
+    'restart_in_progress' => $s['restart_in_progress'] ?? null,
+    'oom_restarts' => $s['opcache_statistics']['oom_restarts'] ?? null,
+    'hash_restarts' => $s['opcache_statistics']['hash_restarts'] ?? null,
+    'manual_restarts' => $s['opcache_statistics']['manual_restarts'] ?? null,
+    'num_cached_scripts' => $s['opcache_statistics']['num_cached_scripts'] ?? null,
+    // Worker-truth for the JIT config: the image entrypoint (openemr.sh)
+    // enables JIT at first boot, so CLI probes and the static image lie.
+    'jit' => ini_get('opcache.jit'),
+    'jit_buffer_size' => ini_get('opcache.jit_buffer_size'),
+]), "\n";
+PHP
+    (
+        # This sampler must outlive failovers and container restarts: drop
+        # the library's errexit/xtrace inside the child so a failed sample
+        # neither kills the loop nor writes to the (soon closed) step pipe.
+        set +e +x
+        while true; do
+            {
+                # Let date print the separator itself: no command
+                # substitution, so no return value for SC2312 to worry about.
+                date -u '+=== %Y-%m-%dT%H:%M:%SZ'
+                redis_master_cli INFO clients 2>&1 | grep -E '^(connected|blocked)_clients'
+                redis_master_cli INFO stats 2>&1 | grep -E '^(rejected_connections|total_connections_received)'
+                redis_master_cli INFO memory 2>&1 | grep -E '^used_memory_human'
+                # OPcache health of the Apache workers, via the probe above.
+                # cache_full/restart_pending flipping true or oom_restarts
+                # incrementing right before a segfault avalanche is the
+                # smoking gun for the SHM-corruption theory (#12438).
+                printf 'opcache: '
+                docker compose exec -T openemr \
+                    curl -sf "http://localhost/${OPCACHE_PROBE}" 2>&1
+                echo
+            } >> "${outfile}" 2>&1
+            sleep 10
+        done
+    ) &
+    local monitor_pid=$!
+    echo "${monitor_pid}" > "${outfile}.pid"
+    echo "redis monitor started (pid ${monitor_pid}), sampling to ${outfile}"
+}
+
+redis_monitor_stop() {
+    local outfile=$1
+    local monitor_pid
+    # Remove the OPcache probe from the bind-mounted webroot. Best-effort:
+    # the container may already be gone at cleanup time.
+    docker compose exec -T openemr rm -f "${OPENEMR_DIR}/${OPCACHE_PROBE}" 2>/dev/null || true
+    if [[ -f "${outfile}.pid" ]]; then
+        monitor_pid=$(cat "${outfile}.pid") || monitor_pid=""
+        if [[ -n "${monitor_pid}" ]]; then
+            kill "${monitor_pid}" 2>/dev/null || true
+        fi
+        rm -f "${outfile}.pid"
+    fi
+}
+
+##
+# Post-mortem snapshot of the Redis cluster into directory $1 (host path).
+# Everything is best-effort: any of these can fail if the cluster is the
+# thing that died, and a partial snapshot is still a snapshot.
+#
+# Artifact safety: this lands in a downloadable artifact on a public PR, so
+# only aggregate/metadata commands are used. In particular SLOWLOG GET is
+# deliberately NOT captured — slowlog entries include the arguments of each
+# slow command, which for session writes means serialized session payloads.
+# INFO commandstats/latencystats carry the same "which command was slow"
+# signal (per-command call counts, cumulative usec, and latency percentiles)
+# without any payload data, and CLIENT LIST exposes only connection metadata
+# (addr, age, idle, last cmd name), never values.
+# Best-effort by design: every capture below is `|| true` because a dead
+# cluster — the very thing being diagnosed — may refuse any of these
+# commands, and a partial snapshot must still be written. set -e being
+# neutralized inside the function calls (SC2310) is therefore intended.
+# shellcheck disable=SC2310
+redis_diagnostics() {
+    local dest=$1
+    local tls_output
+    local -a tls_args=()
+    mkdir -p "${dest}"
+    tls_output=$(redis_cli_detect_tls_args)
+    if [[ -n "${tls_output}" ]]; then
+        mapfile -t tls_args <<< "${tls_output}"
+    fi
+    redis_master_cli INFO > "${dest}/redis-info.txt" 2>&1 || true
+    redis_master_cli CLIENT LIST > "${dest}/redis-client-list.txt" 2>&1 || true
+    {
+        echo '# SLOWLOG LEN (entry count only; entries themselves contain'
+        echo '# command payloads and are not exported):'
+        redis_master_cli SLOWLOG LEN
+        echo
+        echo '# Per-command aggregate stats:'
+        redis_master_cli INFO commandstats
+        echo
+        echo '# Per-command latency percentiles:'
+        redis_master_cli INFO latencystats
+    } > "${dest}/redis-command-stats.txt" 2>&1 || true
+    docker compose exec -T sentinel-1 \
+        redis-cli "${tls_args[@]}" -p 26379 SENTINEL master redis-master \
+        > "${dest}/sentinel-master-state.txt" 2>&1 || true
+    dc logs --timestamps redis-master redis-replica-1 redis-replica-2 sentinel-1 sentinel-2 \
+        > "${dest}/redis-container-logs.txt" 2>&1 || true
+}
+
+##
 # Directory inside the openemr container where coredumps are collected. The
 # kernel core_pattern (set by enable_coredumps) is interpreted within the
 # crashing process's mount namespace, so this is a container path. It is not
@@ -669,6 +857,21 @@ enable_coredumps() {
     dc exec -T openemr sh -c "mkdir -p '${COREDUMP_DIR}' && chmod 1777 '${COREDUMP_DIR}'"
     sudo sysctl -w "kernel.core_pattern=${COREDUMP_DIR}/core.%e.%p.%t"
     sudo sysctl -w 'fs.suid_dumpable=2'
+    # Make the kernel actually LOG segfaults ("segfault at ... ip ... in
+    # xyz.so") so the workflow's dmesg capture has something to capture: the
+    # stock runner kernel logs nothing for them by default (#12438).
+    sudo sysctl -w 'debug.exception-trace=1'
+    sudo sysctl -w 'kernel.print-fatal-signals=1'
+
+    # CoreDumpDirectory makes each Apache child call prctl(PR_SET_DUMPABLE, 1)
+    # after its root->apache setuid. Without it, children sit in the kernel's
+    # restrictive "suid-safe" dumpable state — setuid WITHOUT exec keeps
+    # dumpable at the fs.suid_dumpable value — which is how #12438 runs kept
+    # producing worker segfaults with zero cores while exec-based probes
+    # dumped fine (execve of a non-setuid binary RESETS dumpable to 1). The
+    # graceful restart below both loads this directive and re-forks the
+    # workers under it.
+    dc exec -T openemr sh -c "printf 'CoreDumpDirectory %s\n' '${COREDUMP_DIR}' > /etc/apache2/conf.d/zz-ci-coredump.conf"
     # The two sysctls above are checked at the moment a process changes UID.
     # Apache started earlier in the compose `up` and its prefork workers
     # already dropped root -> apache before we ran these sysctls, so those
@@ -684,6 +887,52 @@ enable_coredumps() {
     # shellcheck disable=SC2310  # graceful restart failure is diagnostic, not fatal
     dc exec -T openemr sh -c 'httpd -k graceful' \
         || echo 'enable_coredumps: graceful restart failed; existing workers keep dumpable=0'
+
+    # Canary: prove the whole coredump pipeline works in THIS job before
+    # trusting it. #12438 runs had a hundred-plus worker segfaults after the
+    # graceful restart above ran cleanly, yet produced zero cores — and
+    # nobody knew the pipeline was broken until the cores were needed.
+    # Crash a sacrificial CLI php as the unprivileged web user (mirroring
+    # the root->apache setuid path the workers take) and require a core.
+    local canary_files
+    docker compose exec -T openemr \
+        su -s /bin/sh apache -c 'php -d error_reporting=0 -r "posix_kill(posix_getpid(), 11);"' \
+        2>/dev/null || true
+    sleep 1
+    canary_files=$(docker compose exec -T openemr sh -c "ls -1 '${COREDUMP_DIR}' 2>/dev/null | wc -l") || canary_files=0
+    if [[ "${canary_files//[!0-9]/}" == "0" || -z "${canary_files//[!0-9]/}" ]]; then
+        echo "::warning::coredump canary produced no core in ${COREDUMP_DIR} — worker segfaults in this job will NOT be debuggable; check ulimits.core, kernel.core_pattern, and fs.suid_dumpable"
+    else
+        echo "coredump canary OK: core file present in ${COREDUMP_DIR}"
+        # Remove the canary's core so capture_coredumps only reports real crashes.
+        # Glob without the trailing dot: the core's %e is the binary's comm,
+        # which an Alpine packaging change could turn into php82.
+        docker compose exec -T openemr sh -c "rm -f ${COREDUMP_DIR}/core.php*" 2>/dev/null || true
+    fi
+
+    # Second canary, the one that matters: SIGSEGV a REAL Apache worker and
+    # require its core. The CLI canary above cannot stand in for this — its
+    # execve resets dumpable to 1, so it passes even when the workers (setuid,
+    # no exec) cannot dump. This canary would have failed loudly on every run
+    # to date and pointed straight at the CoreDumpDirectory fix above. Cost:
+    # one AH00051 line in the error log (AH00051, not AH00052, because
+    # CoreDumpDirectory is set); the parent forks a replacement immediately.
+    local worker_pid worker_cores
+    worker_pid=$(docker compose exec -T openemr sh -c 'pgrep -u apache httpd | head -1') || worker_pid=""
+    worker_pid=${worker_pid//[!0-9]/}
+    if [[ -z "${worker_pid}" ]]; then
+        echo "worker coredump canary skipped: no apache worker process found"
+        return 0
+    fi
+    docker compose exec -T openemr kill -SEGV "${worker_pid}" 2>/dev/null || true
+    sleep 2
+    worker_cores=$(docker compose exec -T openemr sh -c "ls -1 '${COREDUMP_DIR}'/core.httpd.${worker_pid}.* 2>/dev/null | wc -l") || worker_cores=0
+    if [[ "${worker_cores//[!0-9]/}" == "0" || -z "${worker_cores//[!0-9]/}" ]]; then
+        echo "::warning::worker coredump canary FAILED: SIGSEGV to worker ${worker_pid} left no core in ${COREDUMP_DIR} — real worker segfaults will not be debuggable in this job"
+    else
+        echo "worker coredump canary OK: core.httpd.${worker_pid} present"
+        docker compose exec -T openemr sh -c "rm -f '${COREDUMP_DIR}'/core.httpd.${worker_pid}.*" 2>/dev/null || true
+    fi
 }
 
 ##
@@ -699,6 +948,15 @@ capture_coredumps() {
     local dest_dir=$1
     local max_core_mb=${COREDUMP_MAX_MB:-0}
     mkdir -p "${dest_dir}"
+
+    # Inventory first: which cores exist, how big, and how full the disk is.
+    # #12438 runs have logged dozens of worker segfaults (AH00051) with far
+    # fewer cores on disk — this file is how any such discrepancy explains
+    # itself (truncated cores, ENOSPC, RLIMIT_CORE, or crashes that never
+    # dumped).
+    # shellcheck disable=SC2310  # best-effort inventory; a dead container must not abort diagnostics
+    dc exec -T openemr sh -c "ls -la '${COREDUMP_DIR}' 2>&1; echo; df -h / '${COREDUMP_DIR}' 2>&1" \
+        > "${dest_dir}/coredumps.inventory.txt" 2>&1 || true
 
     local cores
     # shellcheck disable=SC2310  # missing-core is expected; || true drives the no-op branch
@@ -716,14 +974,35 @@ capture_coredumps() {
         || echo 'WARNING: gdb install failed; no backtrace will be produced. The raw core is retained in the container; set COREDUMP_MAX_MB > 0 to upload it for offline analysis.' >&2
 
     # The faulting process is an Apache worker (AH00051 in the job log).
+    # NB: busybox ash's `command -v` only honors its FIRST operand, so the
+    # previous single call `command -v apache2 httpd` printed nothing on
+    # Alpine (apache2 does not exist there) — gdb then received only the
+    # core, no executable, and bailed with "not in executable format" — a
+    # latent bug for as long as this code existed, unexercisable until a core
+    # first survived to reach it (#12438). Probe each candidate separately,
+    # httpd first (Alpine), with a path fallback.
     local exe
-    # shellcheck disable=SC2310  # missing binary is tolerated; gdb auto-detects from the core
-    exe=$(dc exec -T openemr sh -c 'command -v apache2 httpd 2>/dev/null | head -n1') || true
+    # shellcheck disable=SC2310  # missing binary is tolerated; gdb runs core-only as last resort
+    exe=$(dc exec -T openemr sh -c \
+        'command -v httpd 2>/dev/null || command -v apache2 2>/dev/null || ls /usr/sbin/httpd /usr/sbin/apache2 2>/dev/null | head -n1') || true
     exe=${exe%$'\r'}
+    exe=${exe%%$'\n'*}
 
+    # Cap the number of cores backtraced: a single #12438 e2e run produced
+    # 184 cores of ~290MB each (49GB, runner disk at 78%), all sharing ONE
+    # instruction pointer — after a handful of backtraces the rest are
+    # duplicates, and 184 gdb passes over 290MB cores would eat the job.
+    local max_backtraces=${COREDUMP_MAX_BACKTRACES:-5}
+    local processed=0
     local core base
     while IFS= read -r core; do
         [[ -n "${core}" ]] || continue
+        if (( processed >= max_backtraces )); then
+            echo "Reached COREDUMP_MAX_BACKTRACES=${max_backtraces}; remaining cores are listed in coredumps.inventory.txt but were not backtraced." \
+                > "${dest_dir}/coredumps.truncated.txt"
+            break
+        fi
+        processed=$(( processed + 1 ))
         base=$(basename "${core}")
         echo "Backtracing ${base} (exe=${exe:-auto})..."
         # `bt` (not `bt full`): a stack-only trace names the faulting frames
@@ -738,8 +1017,12 @@ capture_coredumps() {
         )
         [[ -n "${exe}" ]] && gdb_args+=("${exe}")
         gdb_args+=("${core}")
+        # </dev/null on every exec inside this loop: `docker compose exec -T`
+        # forwards (and thereby consumes) the loop's stdin — the herestring
+        # feeding `read` — so without it the loop exits after ONE core
+        # (observed: 184 cores in the inventory, one backtrace produced).
         # shellcheck disable=SC2310  # a gdb failure is logged, not fatal — keep processing cores
-        dc "${gdb_args[@]}" \
+        dc "${gdb_args[@]}" < /dev/null \
             > "${dest_dir}/${base}.backtrace.txt" 2>&1 \
             || echo "gdb failed for ${base}; see ${base}.backtrace.txt" >&2
         # Raw core upload is opt-in (COREDUMP_MAX_MB > 0) and size-gated, since
@@ -754,7 +1037,7 @@ capture_coredumps() {
         # risk streaming an oversized core past the cap; backtrace is retained.
         local size_mb=''
         # shellcheck disable=SC2310  # du failure handled explicitly below
-        size_mb=$(dc exec -T openemr sh -c "du -m '${core}' | cut -f1") || size_mb=''
+        size_mb=$(dc exec -T openemr sh -c "du -m '${core}' | cut -f1" < /dev/null) || size_mb=''
         size_mb=${size_mb%$'\r'}
         if [[ -z "${size_mb}" ]]; then
             echo "Could not determine size of ${base}; raw core omitted (cap cannot be enforced), backtrace retained." \
@@ -770,7 +1053,7 @@ capture_coredumps() {
         # gzip, permissions, disk) must not abort the loop and skip the
         # remaining cores' backtraces.
         # shellcheck disable=SC2310  # gzip failure is logged, not fatal — keep processing cores
-        if ! dc exec -T openemr gzip -c "${core}" > "${dest_dir}/${base}.gz"; then
+        if ! dc exec -T openemr gzip -c "${core}" < /dev/null > "${dest_dir}/${base}.gz"; then
             rm -f "${dest_dir}/${base}.gz"
             echo "gzip stream failed for ${base}; raw core omitted, backtrace retained." \
                 > "${dest_dir}/${base}.gz.skipped.txt"


### PR DESCRIPTION
Redis health monitoring with worker OPcache/JIT self-reporting, kernel segfault capture, coredump pipeline fixes (CoreDumpDirectory for setuid-without-exec workers, dual canaries, gdb invocation, exec-stdin loop bug), backtrace cap and core inventory.

<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
root cause of mTLS CI fail identified as PHP 8.2 OPcache JIT codegen (fixed IP 0x68ef9, executable page, with/without demonstration); resolved organizationally by dropping 8.2; diagnostics retained as the tripwire; residual note that openemr.sh still unconditionally enables JIT on all versions 

#### Changes proposed in this pull request:


#### Was AI used? Yes, claude.ai

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
