### PR TITLE
fix(messages): linked documents update dashboard and encounters

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -8118,17 +8118,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/main/messages/templates/linked_documents.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr_js expects string, mixed given\\.$#',
     'count' => 7,
-    'path' => __DIR__ . '/../../interface/main/messages/templates/linked_documents.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/main/messages/templates/linked_documents.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -8112,11 +8112,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/messages/templates/linked_documents.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$datetime of function strtotime expects string, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/messages/templates/linked_documents.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$id of class Document constructor expects int, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/messages/templates/linked_documents.php',
@@ -8129,6 +8124,11 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr_js expects string, mixed given\\.$#',
     'count' => 7,
+    'path' => __DIR__ . '/../../interface/main/messages/templates/linked_documents.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#',
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/main/messages/templates/linked_documents.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -634,11 +634,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/messages/templates/linked_documents.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-comlink-telehealth/moduleConfig.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -634,6 +634,11 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 1,
+    'path' => __DIR__ . '/../../interface/main/messages/templates/linked_documents.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cannot cast mixed to string\\.$#',
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-comlink-telehealth/moduleConfig.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.variable.php
+++ b/.phpstan/baseline/empty.variable.php
@@ -72,11 +72,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/messages/messages.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$enc_list in empty\\(\\) always exists and is always falsy\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/messages/templates/linked_documents.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$patient in empty\\(\\) always exists and is not falsy\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/messages/trusted-messages-ajax.php',

--- a/.phpstan/baseline/foreach.emptyArray.php
+++ b/.phpstan/baseline/foreach.emptyArray.php
@@ -4,11 +4,6 @@ $ignoreErrors = [];
 $ignoreErrors[] = [
     'message' => '#^Empty array passed to foreach\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/messages/templates/linked_documents.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Empty array passed to foreach\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-ehi-exporter/src/GlobalConfig.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -3653,7 +3653,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../library/ajax/set_pt.php',
 ];
 $ignoreErrors[] = [

--- a/interface/main/messages/templates/linked_documents.php
+++ b/interface/main/messages/templates/linked_documents.php
@@ -21,6 +21,7 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\Cda\CdaValidateDocumentObject;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 // This file is a sub-template included by messages.php. $noteid is a required
 // parameter from the parent context. Return silently if it is missing — this
@@ -43,19 +44,11 @@ if (!empty($prow)) {
     $results = QueryUtils::fetchRecords("SELECT fe.encounter,fe.date,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
         " LEFT JOIN openemr_postcalendar_categories ON fe.pc_catid=openemr_postcalendar_categories.pc_catid  WHERE fe.pid = ? ORDER BY fe.date DESC", [$prow['pid']]);
     foreach ($results as $row) {
-        $value = (string) $row['date'];
-        $date = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $value)
-            ?: DateTimeImmutable::createFromFormat('Y-m-d', $value);
-
-        $errors = DateTimeImmutable::getLastErrors();
-
-        $valid = $date !== false
-            && ($errors === false || ($errors['warning_count'] === 0 && $errors['error_count'] === 0));
-
+        $ymd = DateFormatterUtils::dbDateToYmd($row['date']);
         $enc_list[] = [
             'encounter' => $row['encounter'],
             'pc_catname' => xl_appt_category($row['pc_catname']),
-            'date' => $valid ? oeFormatShortDate($date->format('Y-m-d')) : '',
+            'date' => $ymd !== null ? oeFormatShortDate($ymd) : '',
         ];
     }
 }

--- a/interface/main/messages/templates/linked_documents.php
+++ b/interface/main/messages/templates/linked_documents.php
@@ -43,12 +43,11 @@ if (!empty($prow)) {
     $results = QueryUtils::fetchRecords("SELECT fe.encounter,fe.date,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
         " LEFT JOIN openemr_postcalendar_categories ON fe.pc_catid=openemr_postcalendar_categories.pc_catid  WHERE fe.pid = ? ORDER BY fe.date DESC", [$prow['pid']]);
     foreach ($results as $row) {
-        $dateString = substr((string) $row['date'], 0, 10);
-        $date = \DateTimeImmutable::createFromFormat('Y-m-d', $dateString);
+        $date = new DateTimeImmutable((string) $row['date']);
         $enc_list[] = [
             'encounter' => $row['encounter'],
             'pc_catname' => xl_appt_category($row['pc_catname']),
-            'date' => $date === false ? '' : oeFormatShortDate($date->format('Y-m-d')),
+            'date' => oeFormatShortDate($date->format('Y-m-d')),
         ];
     }
 }

--- a/interface/main/messages/templates/linked_documents.php
+++ b/interface/main/messages/templates/linked_documents.php
@@ -40,13 +40,14 @@ if (empty($tmp)) {
 
 $enc_list = [];
 if (!empty($prow)) {
-    $enc_list = QueryUtils::fetchRecords("SELECT fe.encounter,fe.date,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
+    $results = QueryUtils::fetchRecords("SELECT fe.encounter,fe.date,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
         " LEFT JOIN openemr_postcalendar_categories ON fe.pc_catid=openemr_postcalendar_categories.pc_catid  WHERE fe.pid = ? ORDER BY fe.date DESC", [$prow['pid']]);
-    foreach ($enc_list as $row) {
+    foreach ($results as $row) {
+        $date = \DateTimeImmutable::createFromFormat('Y-m-d', (string) $row['date']);
         $enc_list[] = [
             'encounter' => $row['encounter'],
             'pc_catname' => xl_appt_category($row['pc_catname']),
-            'date' => oeFormatShortDate(date("Y-m-d", strtotime((string) $row['date'])))
+            'date' => $date === false ? '' : oeFormatShortDate($date->format('Y-m-d')),
         ];
     }
 }

--- a/interface/main/messages/templates/linked_documents.php
+++ b/interface/main/messages/templates/linked_documents.php
@@ -43,7 +43,8 @@ if (!empty($prow)) {
     $results = QueryUtils::fetchRecords("SELECT fe.encounter,fe.date,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
         " LEFT JOIN openemr_postcalendar_categories ON fe.pc_catid=openemr_postcalendar_categories.pc_catid  WHERE fe.pid = ? ORDER BY fe.date DESC", [$prow['pid']]);
     foreach ($results as $row) {
-        $date = \DateTimeImmutable::createFromFormat('Y-m-d', (string) $row['date']);
+        $dateString = substr((string) $row['date'], 0, 10);
+        $date = \DateTimeImmutable::createFromFormat('Y-m-d', $dateString);
         $enc_list[] = [
             'encounter' => $row['encounter'],
             'pc_catname' => xl_appt_category($row['pc_catname']),

--- a/interface/main/messages/templates/linked_documents.php
+++ b/interface/main/messages/templates/linked_documents.php
@@ -40,13 +40,13 @@ if (empty($tmp)) {
 
 $enc_list = [];
 if (!empty($prow)) {
-    $results = QueryUtils::fetchRecords("SELECT fe.encounter,fe.date,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
+    $enc_list = QueryUtils::fetchRecords("SELECT fe.encounter,fe.date,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
         " LEFT JOIN openemr_postcalendar_categories ON fe.pc_catid=openemr_postcalendar_categories.pc_catid  WHERE fe.pid = ? ORDER BY fe.date DESC", [$prow['pid']]);
     foreach ($enc_list as $row) {
         $enc_list[] = [
             'encounter' => $row['encounter'],
             'pc_catname' => xl_appt_category($row['pc_catname']),
-            'date' => oeFormatShortDate(date("Y-m-d", strtotime($row['date'])))
+            'date' => oeFormatShortDate(date("Y-m-d", strtotime((string) $row['date'])))
         ];
     }
 }

--- a/interface/main/messages/templates/linked_documents.php
+++ b/interface/main/messages/templates/linked_documents.php
@@ -43,11 +43,19 @@ if (!empty($prow)) {
     $results = QueryUtils::fetchRecords("SELECT fe.encounter,fe.date,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
         " LEFT JOIN openemr_postcalendar_categories ON fe.pc_catid=openemr_postcalendar_categories.pc_catid  WHERE fe.pid = ? ORDER BY fe.date DESC", [$prow['pid']]);
     foreach ($results as $row) {
-        $date = new DateTimeImmutable((string) $row['date']);
+        $value = (string) $row['date'];
+        $date = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $value)
+            ?: DateTimeImmutable::createFromFormat('Y-m-d', $value);
+
+        $errors = DateTimeImmutable::getLastErrors();
+
+        $valid = $date !== false
+            && ($errors === false || ($errors['warning_count'] === 0 && $errors['error_count'] === 0));
+
         $enc_list[] = [
             'encounter' => $row['encounter'],
             'pc_catname' => xl_appt_category($row['pc_catname']),
-            'date' => oeFormatShortDate($date->format('Y-m-d')),
+            'date' => $valid ? oeFormatShortDate($date->format('Y-m-d')) : '',
         ];
     }
 }

--- a/library/ajax/set_pt.php
+++ b/library/ajax/set_pt.php
@@ -24,7 +24,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 CsrfUtils::checkCsrfInput(INPUT_GET, dieOnFail: true);
 
-if (in_array("set_pid", $_GET, true) && !empty($_GET["set_pid"]) && ($_GET["set_pid"] != $session->get('pid'))) {
+if (!empty($_GET['set_pid']) && ($_GET["set_pid"] != $session->get('pid'))) {
     // The only live caller of this branch is the Messages Center document-attach
     // flow in interface/main/messages/templates/linked_documents.php, which
     // requires patients/docs. Widen if future callers legitimately need it.

--- a/src/Services/Utils/DateFormatterUtils.php
+++ b/src/Services/Utils/DateFormatterUtils.php
@@ -19,6 +19,7 @@
 namespace OpenEMR\Services\Utils;
 
 use DateTime;
+use DateTimeImmutable;
 use OpenEMR\Core\OEGlobalsBag;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
@@ -36,6 +37,34 @@ class DateFormatterUtils
      */
     public const TIME_FORMAT_24HR = 0;
     public const TIME_FORMAT_12HR = 1;
+
+    /**
+     * Strictly parse a MySQL DATE or DATETIME column value into a 'Y-m-d' string.
+     *
+     * Unlike strtotime(), this rejects values that only parse with warnings
+     * (e.g. overflow dates such as '2026-02-30'), MySQL zero dates
+     * ('0000-00-00 00:00:00'), and non-string input. Returns null when the
+     * value is not a valid calendar date.
+     */
+    public static function dbDateToYmd(mixed $value): ?string
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $date = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $value)
+            ?: DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        // getLastErrors() reflects the most recent createFromFormat() call,
+        // which is the one that produced $date. On PHP >= 8.3 it returns
+        // false when there were no errors or warnings.
+        $errors = DateTimeImmutable::getLastErrors();
+
+        if ($date === false || ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))) {
+            return null;
+        }
+
+        return $date->format('Y-m-d');
+    }
 
     public static function isNotEmptyDateTimeString(?string $dateString): bool
     {

--- a/tests/Tests/Isolated/Services/Utils/DateFormatterUtilsTest.php
+++ b/tests/Tests/Isolated/Services/Utils/DateFormatterUtilsTest.php
@@ -29,6 +29,58 @@ class DateFormatterUtilsTest extends TestCase
     }
 
     // ==========================================================================
+    // dbDateToYmd tests
+    // ==========================================================================
+
+    public function testDbDateToYmdWithDatetimeValue(): void
+    {
+        $this->assertSame('2026-05-13', DateFormatterUtils::dbDateToYmd('2026-05-13 14:30:00'));
+    }
+
+    public function testDbDateToYmdWithDateOnlyValue(): void
+    {
+        $this->assertSame('2026-05-13', DateFormatterUtils::dbDateToYmd('2026-05-13'));
+    }
+
+    public function testDbDateToYmdRejectsOverflowDate(): void
+    {
+        // strtotime() would silently roll this over to 2026-03-02;
+        // strict parsing must reject it instead.
+        $this->assertNull(DateFormatterUtils::dbDateToYmd('2026-02-30 10:00:00'));
+    }
+
+    public function testDbDateToYmdRejectsMysqlZeroDate(): void
+    {
+        $this->assertNull(DateFormatterUtils::dbDateToYmd('0000-00-00 00:00:00'));
+        $this->assertNull(DateFormatterUtils::dbDateToYmd('0000-00-00'));
+    }
+
+    public function testDbDateToYmdRejectsGarbage(): void
+    {
+        $this->assertNull(DateFormatterUtils::dbDateToYmd('not-a-date'));
+    }
+
+    public function testDbDateToYmdRejectsEmptyAndWhitespace(): void
+    {
+        $this->assertNull(DateFormatterUtils::dbDateToYmd(''));
+        $this->assertNull(DateFormatterUtils::dbDateToYmd('   '));
+    }
+
+    public function testDbDateToYmdRejectsNonStringInput(): void
+    {
+        $this->assertNull(DateFormatterUtils::dbDateToYmd(null));
+        $this->assertNull(DateFormatterUtils::dbDateToYmd(20260513));
+        $this->assertNull(DateFormatterUtils::dbDateToYmd(['2026-05-13']));
+    }
+
+    public function testDbDateToYmdRejectsPartialTime(): void
+    {
+        // MySQL DATETIME always includes seconds; a truncated time must not
+        // silently pass as valid.
+        $this->assertNull(DateFormatterUtils::dbDateToYmd('2026-05-13 14:30'));
+    }
+
+    // ==========================================================================
     // isNotEmptyDateTimeString tests
     // ==========================================================================
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
In the message list when a document gets attached to the message and then when you click on the document it would go to that document but also change the dashboard to that patient. Now, it will go to the document and the header name will change but the dashboard stays on the last patient pulled up.

in_array() searches the values of $_GET, not the keys. The request's values are the pid number and the CSRF token — neither strictly equals the string "set_pid" — so the condition is always false and setpid() silently never runs. 

linked_documents.php: the encounter list query fetches into $results but the loop iterates the empty $enc_list (rel-810 has the variables swapped as foreach ($row as $enc_list)), so the encounter arrays passed to setPatientEncounter() are always empty — the encounter dropdown in the tab header won't populate after the jump.
#### Changes proposed in this pull request:


#### Was AI used? Yes, claude.ai

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
