### PR TITLE
feat(audit): skip transaction control statements

### DIFF
--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -126,6 +126,26 @@ class EventAuditLogger implements AuditLoggerInterface
     }
 
     /**
+     * Matches transaction control statements, which are never auditable: they
+     * name no table, touch no patient data, and carry no bound parameters.
+     *
+     * Both database layers route these through auditSQLEvent(). ADODB's
+     * BeginTrans()/CommitTrans()/RollbackTrans() run BEGIN/COMMIT/ROLLBACK
+     * through the audited ADODB_mysqli_log::Execute() wrapper, and the DBAL
+     * logging middleware synthesizes START TRANSACTION/COMMIT/ROLLBACK for the
+     * driver-level calls plus SAVEPOINT statements for nested transactions.
+     */
+    private const TRANSACTION_CONTROL_PATTERN = '/^(?:'
+        . 'BEGIN\b'
+        . '|START\s+TRANSACTION\b'
+        . '|COMMIT\b'
+        . '|ROLLBACK\b'
+        . '|SAVEPOINT\b'
+        . '|RELEASE\s+SAVEPOINT\b'
+        . '|SET\s+AUTOCOMMIT\s*='
+        . ')/i';
+
+    /**
      * @var array<string, EventCategory>
      */
     private const LOG_TABLES = [
@@ -429,6 +449,10 @@ class EventAuditLogger implements AuditLoggerInterface
     public function auditSQLEvent($statement, $outcome, $binds = null): void
     {
         $statement = trim((string) $statement);
+
+        if (preg_match(self::TRANSACTION_CONTROL_PATTERN, $statement) === 1) {
+            return;
+        }
 
         if (
             (stripos($statement, "insert into log") !== false)      // avoid infinite loop

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -223,4 +223,108 @@ class EventAuditLoggerTest extends TestCase
 
         $logger->auditSQLEvent($sql, true);
     }
+
+    /**
+     * Statements emitted by the two database layers to control transactions.
+     *
+     * ADODB emits BEGIN/COMMIT/ROLLBACK; the DBAL logging middleware emits
+     * START TRANSACTION/COMMIT/ROLLBACK plus SAVEPOINT statements for nested
+     * transactions. Legacy call sites additionally toggle autocommit directly.
+     *
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function transactionControlStatementProvider(): array
+    {
+        return [
+            'adodb begin' => ['BEGIN'],
+            'dbal start transaction' => ['START TRANSACTION'],
+            'commit' => ['COMMIT'],
+            'rollback' => ['ROLLBACK'],
+            'dbal savepoint' => ['SAVEPOINT DOCTRINE_1'],
+            'dbal release savepoint' => ['RELEASE SAVEPOINT DOCTRINE_1'],
+            'dbal rollback to savepoint' => ['ROLLBACK TO SAVEPOINT DOCTRINE_1'],
+            'autocommit off' => ['SET autocommit=0'],
+            'autocommit on' => ['SET autocommit=1'],
+            'autocommit with spaces' => ['SET AUTOCOMMIT = 1'],
+            'trailing semicolon' => ['START TRANSACTION;'],
+            'lowercase' => ['start transaction'],
+            'leading whitespace' => ["  COMMIT\n"],
+        ];
+    }
+
+    #[DataProvider('transactionControlStatementProvider')]
+    public function testAuditSQLEventSkipsTransactionControl(string $sql): void
+    {
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->never())
+            ->method('record');
+
+        $this->session->method('get')
+            ->willReturnCallback(fn (string $key) => match ($key) {
+                'authUser' => 'testuser',
+                'authProvider' => 'default',
+                default => null,
+            });
+
+        // Maximally permissive config plus breakglass, so nothing but the
+        // transaction-control check itself can be responsible for the skip.
+        $this->breakglassChecker->method('isBreakglassUser')
+            ->willReturn(true);
+
+        $config = new AuditConfig(
+            enabled: true,
+            forceBreakglass: true,
+            queryEvents: true,
+            httpRequestEvents: true,
+            enabledEventTypes: EventCategory::cases(),
+        );
+
+        $logger = new EventAuditLogger(
+            sink: $sink,
+            session: $this->session,
+            config: $config,
+            breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
+        );
+
+        $logger->auditSQLEvent($sql, true);
+    }
+
+    /**
+     * Guards the provider above against becoming vacuous: a statement that
+     * merely starts with a transaction-control keyword must still be audited.
+     */
+    public function testAuditSQLEventStillLogsStatementsWithTransactionKeywordPrefix(): void
+    {
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->once())
+            ->method('record');
+
+        $this->session->method('get')
+            ->willReturnCallback(fn (string $key) => match ($key) {
+                'authUser' => 'testuser',
+                'authProvider' => 'default',
+                default => null,
+            });
+
+        $config = new AuditConfig(
+            enabled: true,
+            forceBreakglass: false,
+            queryEvents: true,
+            httpRequestEvents: true,
+            enabledEventTypes: EventCategory::cases(),
+        );
+
+        $logger = new EventAuditLogger(
+            sink: $sink,
+            session: $this->session,
+            config: $config,
+            breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
+        );
+
+        $logger->auditSQLEvent('UPDATE patient_data SET committed = 1 WHERE pid = 1', true);
+    }
 }


### PR DESCRIPTION
#### Short description of what this changes or resolves:
The SQL audit logger sort of accidentally skipped SQL transaction control related statements in the audit log. While this is the desired behavior, it wasn't explicit nor tested and might not survive a refactor, plus it misses some other syntaxes (e.g. doctrine's nested transaction handling). This corrects both.

#### Changes proposed in this pull request:
- Add a stoplist into the auditor to skip transaction control commands
- Add tests

#### Was an AI assistant used? Yes / No
Yes