### PR TITLE
build(deps): raise guzzlehttp/psr7 floor to ^2.13 for Utils::asciiToUpper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "giggsey/libphonenumber-for-php": "^9.0",
         "google/apiclient": "^2.18.4",
         "guzzlehttp/guzzle": "^7.10.0",
-        "guzzlehttp/psr7": "^2.8",
+        "guzzlehttp/psr7": "^2.13",
         "html2text/html2text": "^4.3.2",
         "kamermans/guzzle-oauth2-subscriber": "^1.1.1",
         "knplabs/knp-snappy": "^1.5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab48b819bb13183f70a93c067355960b",
+    "content-hash": "21948e6e57747cd4f81b955d60e2ee64",
     "packages": [
         {
             "name": "academe/authorizenet-objects",


### PR DESCRIPTION
Preventive, not a fix for a current break.

Today the lockfile resolves `guzzlehttp/psr7` to 2.13.0 because `guzzlehttp/guzzle` 7.15.1 requires `^2.13`. Nothing is broken on master.

The problem is forward-looking: guzzle **7.15.2** loosened its own psr7 requirement to `^2.11` while still calling `GuzzleHttp\Psr7\Utils::asciiToUpper()`, which only exists from psr7 2.13. Once a guzzle bump to 7.15.2 lands, the root `^2.8` constraint would let Composer resolve psr7 down to 2.11 or 2.12, producing a fatal "call to undefined method" at runtime. Raising the root floor to `^2.13` closes that gap ahead of the bump.

No dependency versions change here — psr7 stays locked at 2.13.0. Only the root constraint and the lockfile content-hash move.