### PR TITLE
refactor(fee-sheet): type the load_fee_sheet_options() signature

### DIFF
--- a/.phpstan/baseline/class.notFound.php
+++ b/.phpstan/baseline/class.notFound.php
@@ -2,11 +2,6 @@
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
-    'message' => '#^Function load_fee_sheet_options\\(\\) has invalid return type an\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_options_queries.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function pnConfigGetVar\\(\\) has invalid return type value\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnAPI.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -332,11 +332,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function load_fee_sheet_options\\(\\) should return an but returns list\\<fee_sheet_option\\>\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/fee_sheet/review/fee_sheet_options_queries.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function get_appt_data\\(\\) should return array but returns array\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/group_attendance/functions.php',

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 return [
     'all' => [
-        'class.notFound.php' => 156,
+        'class.notFound.php' => 155,
         'classConstant.notFound.php' => 0,
         'constant.notFound.php' => 0,
         'function.notFound.php' => 0,

--- a/interface/forms/fee_sheet/review/fee_sheet_options_queries.php
+++ b/interface/forms/fee_sheet/review/fee_sheet_options_queries.php
@@ -30,9 +30,9 @@ class fee_sheet_option
  * get a list of fee sheet options
  *
  * @param string $pricelevel which pricing level to retrieve
- * @return an array containing the options
+ * @return fee_sheet_option[] containing the options
  */
-function load_fee_sheet_options($pricelevel)
+function load_fee_sheet_options(string $pricelevel): array
 {
     $clFSO_code_type = 'substring_index(fso.fs_codes,"|",1)';
     $clFSO_code = 'replace(substring_index(fso.fs_codes,"|",-2),"|","")';


### PR DESCRIPTION
The docblock on `load_fee_sheet_options()` declared `@return an array containing the options`. PHPStan parses `an` as a class name, which does not exist, so the function had both an invalid return type and no native one.

Replace the annotation with `fee_sheet_option[]` and add a native `: array`. The function has a single return path that always yields an array of `fee_sheet_option` (the class declared just above it), and the only caller (`fee_sheet_options_ajax.php`) json-encodes it, so nothing depends on a non-array return.

Also drops the two PHPStan baseline entries (`class.notFound`, `return.type`) that the fix makes stale.