### PR TITLE
refactor(esign): replace unknown param types in Log docblocks

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -19737,12 +19737,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/ESign/ESign.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$encounterId of class ESign\\\\Encounter_Log constructor expects ESign\\\\unknown, mixed given\\.$#',
+    'message' => '#^Parameter \\#1 \\$encounterId of class ESign\\\\Encounter_Log constructor expects int\\|string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/ESign/Encounter/Controller.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$encounterId of class ESign\\\\Encounter_Log constructor expects ESign\\\\unknown, mixed given\\.$#',
+    'message' => '#^Parameter \\#1 \\$encounterId of class ESign\\\\Encounter_Log constructor expects int\\|string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/ESign/Encounter/Factory.php',
 ];
@@ -19752,17 +19752,17 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/ESign/Form/Controller.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$formId of class ESign\\\\Form_Log constructor expects ESign\\\\unknown, mixed given\\.$#',
+    'message' => '#^Parameter \\#1 \\$formId of class ESign\\\\Form_Log constructor expects int\\|string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/ESign/Form/Factory.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#2 \\$formDir of class ESign\\\\Form_Log constructor expects ESign\\\\unknown, mixed given\\.$#',
+    'message' => '#^Parameter \\#2 \\$formDir of class ESign\\\\Form_Log constructor expects string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/ESign/Form/Factory.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#3 \\$encounterId of class ESign\\\\Form_Log constructor expects ESign\\\\unknown, mixed given\\.$#',
+    'message' => '#^Parameter \\#3 \\$encounterId of class ESign\\\\Form_Log constructor expects int\\|string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/ESign/Form/Factory.php',
 ];

--- a/.phpstan/baseline/class.notFound.php
+++ b/.phpstan/baseline/class.notFound.php
@@ -107,26 +107,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/orders/receive_hl7_results.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\$encounterId of method ESign\\\\Encounter_Log\\:\\:__construct\\(\\) has invalid type ESign\\\\unknown\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Encounter/Log.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\$encounterId of method ESign\\\\Form_Log\\:\\:__construct\\(\\) has invalid type ESign\\\\unknown\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Log.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\$formDir of method ESign\\\\Form_Log\\:\\:__construct\\(\\) has invalid type ESign\\\\unknown\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Log.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\$formId of method ESign\\\\Form_Log\\:\\:__construct\\(\\) has invalid type ESign\\\\unknown\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ESign/Form/Log.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to static method NWeekdayOfMonth\\(\\) on an unknown class MedExApi\\\\Date_Calc\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/MedEx/API.php',

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 return [
     'all' => [
-        'class.notFound.php' => 111,
+        'class.notFound.php' => 107,
         'classConstant.notFound.php' => 0,
         'constant.notFound.php' => 0,
         'function.notFound.php' => 0,

--- a/library/ESign/Encounter/Log.php
+++ b/library/ESign/Encounter/Log.php
@@ -31,7 +31,7 @@ class Encounter_Log implements LogIF
      * the constructor because they aren't necessarily available
      * through the SignableIF interface when render() function is called.
      *
-     * @param unknown $encounterId
+     * @param int|string $encounterId
      */
     public function __construct($encounterId)
     {

--- a/library/ESign/Form/Log.php
+++ b/library/ESign/Form/Log.php
@@ -31,9 +31,9 @@ class Form_Log implements LogIF
      * the constructor because they aren't necessarily available
      * through the SignableIF interface when render() function is called.
      *
-     * @param unknown $formId
-     * @param unknown $formDir
-     * @param unknown $encounterId
+     * @param int|string $formId
+     * @param string $formDir
+     * @param int|string $encounterId
      */
     public function __construct($formId, $formDir, $encounterId)
     {


### PR DESCRIPTION
The literal `unknown` in these `@param` tags is junk from an old IDE template, not a type. PHPStan resolves it as a class name relative to the enclosing namespace (`ESign\unknown`) and reports `class.notFound` for each one, plus a follow-on `argument.type` at every call site for passing `mixed` to that phantom class.

Replaced with the types the values actually carry:

- `$encounterId`, `$formId` — `int|string`. They arrive both from request params (`Encounter_Controller::esign_log_view()`, `Form_Controller::esign_log_view()`) and from DB rows / globals (`Encounter_Signable` passes `$encRow["id"]`; `forms.php` passes `$iter["id"]` and `$GLOBALS["encounter"]`).
- `$formDir` — `string`. Sourced from the `forms.formdir` varchar column and the `formDir` request param.

Docblock-only. No native parameter types are added — that would be a behavior change on these legacy classes and belongs in a separate PR.

Drains four `class.notFound` baseline entries and rewrites five `argument.type` entries in place against the honest types. Those five persist because the ESign factory properties and controller request reads are themselves untyped, which is a wider refactor than a docblock correction.