### PR TITLE
fix: add explicit return type to session callback closures in EventAuditLoggerTest

### DIFF
--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -262,7 +262,7 @@ class EventAuditLoggerTest extends TestCase
             ->method('record');
 
         $this->session->method('get')
-            ->willReturnCallback(fn (string $key) => match ($key) {
+            ->willReturnCallback(fn (string $key): ?string => match ($key) {
                 'authUser' => 'testuser',
                 'authProvider' => 'default',
                 default => null,
@@ -303,7 +303,7 @@ class EventAuditLoggerTest extends TestCase
             ->method('record');
 
         $this->session->method('get')
-            ->willReturnCallback(fn (string $key) => match ($key) {
+            ->willReturnCallback(fn (string $key): ?string => match ($key) {
                 'authUser' => 'testuser',
                 'authProvider' => 'default',
                 default => null,


### PR DESCRIPTION
## Summary
- Rector's return-type rule flags two closures in `EventAuditLoggerTest` for a missing return type, which fails CI's `rector-check`
- Adds the explicit `?string` return type to match what Rector expects

## Test plan
- [x] `composer rector-check` passes locally
- [x] `php -l` on the changed file
- [x] Pre-commit hooks (PHPStan, PHPCS, Rector) all passed