### PR TITLE
ci(docker-build-release): Phase 11 -- native arm64 release builds

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -368,6 +368,32 @@ jobs:
           IMAGE_VERSION=${{ needs.prep.outputs.image_version }}
           BUILD_DATE=${{ needs.prep.outputs.build_date }}
 
+    # Verify OCI labels on the just-pushed per-arch intermediate BEFORE
+    # merge-manifest fans them out. Runs on the matrix runner so each
+    # arch verifies its OWN image natively (docker pull on the single-
+    # arch intermediate tag trivially fetches the runner's arch). Moved
+    # here from merge-manifest (post-Phase-11 review): merge-manifest's
+    # verify only ever inspected the runner's arch (amd64 on ubuntu-
+    # 24.04) via docker pull's platform-selection, leaving arm64 label
+    # drift unverified. Per-arch verify catches both.
+    - name: Verify per-arch OCI labels — gated path
+      if: inputs.gate_with_acceptance
+      env:
+        EXPECTED_REVISION: ${{ needs.prep.outputs.openemr_version_ref }}
+        EXPECTED_VERSION: ${{ needs.prep.outputs.image_version }}
+        EXPECTED_BUILD_DATE: ${{ needs.prep.outputs.build_date }}
+        REF_TAG: openemr/openemr:${{ needs.prep.outputs.candidate_tag }}-${{ steps.arch.outputs.label }}
+      run: .github/scripts/verify-oci-labels.sh
+
+    - name: Verify per-arch OCI labels — non-gated path
+      if: ${{ !inputs.gate_with_acceptance }}
+      env:
+        EXPECTED_REVISION: ${{ needs.prep.outputs.openemr_version_ref }}
+        EXPECTED_VERSION: ${{ needs.prep.outputs.image_version }}
+        EXPECTED_BUILD_DATE: ${{ needs.prep.outputs.build_date }}
+        REF_TAG: openemr/openemr:${{ env.ARCH_INTERMEDIATE_PREFIX }}-${{ steps.arch.outputs.label }}
+      run: .github/scripts/verify-oci-labels.sh
+
   # Phase 11 merge-manifest: unify the per-arch intermediate pushes
   # into the final multi-arch manifest(s) via `docker buildx imagetools
   # create`. This is a metadata-only op on Docker Hub -- no image blobs
@@ -437,50 +463,24 @@ jobs:
           docker buildx imagetools create -t "$tag" "$SRC_AMD64" "$SRC_ARM64"
         done
 
-    # Verify labels once against the merged manifest. Pre-Phase-11 this
-    # ran twice (gated vs non-gated) on the per-flavor push; post-Phase-11
-    # the per-arch intermediates share the merged digest, so one verify
-    # covers both platform slices and both flavors. REF_TAG picks the
-    # merged candidate for the gated path, the first expanded final tag
-    # for the non-gated path. Same verify script the publish site uses.
-    - name: Verify pushed image OCI labels — gated path
-      if: inputs.gate_with_acceptance
-      env:
-        EXPECTED_REVISION: ${{ needs.prep.outputs.openemr_version_ref }}
-        EXPECTED_VERSION: ${{ needs.prep.outputs.image_version }}
-        EXPECTED_BUILD_DATE: ${{ needs.prep.outputs.build_date }}
-        REF_TAG: openemr/openemr:${{ needs.prep.outputs.candidate_tag }}
-      # Runs against the merged candidate tag before spending
-      # acceptance-gate CI budget on an image whose Dockerfile ARGs
-      # didn't flow through correctly. Same verify script the non-gated
-      # + publish sites use.
-      run: .github/scripts/verify-oci-labels.sh
+    # Note: OCI-label verify moved into build-arch (per-arch, native).
+    # The old merge-manifest-side verify only inspected the runner's arch
+    # (amd64 on ubuntu-24.04) via docker pull's platform-selection,
+    # leaving arm64 label drift unverified. Per-arch verify catches
+    # both by running on the matrix runner where docker pull trivially
+    # matches the runner's own arch.
 
-    - name: Verify pushed image OCI labels — non-gated path
-      if: ${{ !inputs.gate_with_acceptance }}
-      env:
-        EXPECTED_REVISION: ${{ needs.prep.outputs.openemr_version_ref }}
-        EXPECTED_VERSION: ${{ needs.prep.outputs.image_version }}
-        EXPECTED_BUILD_DATE: ${{ needs.prep.outputs.build_date }}
-        TAGS_LIST: ${{ needs.prep.outputs.expanded_tags }}
-      # First pushed tag is the representative one to verify -- all tags
-      # in TAGS_LIST point at the same manifest so inspecting one covers
-      # all of them.
-      run: |
-        REF_TAG=$(echo "${TAGS_LIST}" | head -1)
-        export REF_TAG
-        .github/scripts/verify-oci-labels.sh
-
-    # Cleanup the per-arch intermediate tags after verify succeeds. The
+    # Cleanup the per-arch intermediate tags after merge succeeds. The
     # merged manifests still reference the arch-specific image digests
     # directly (imagetools create copies the digests into the manifest
     # list), so deleting the intermediate tag pointers is safe -- the
     # multi-arch tag(s) keep working. Default step `if: success()`
-    # preserves the per-arch intermediates on verify failure so an
-    # operator can inspect them (they're the only surviving reference
-    # to the individual arch digests once the merged manifest is in
-    # place). continue-on-error so a Docker Hub delete failure doesn't
-    # tank the whole workflow run -- a stray build-arch-* or
+    # preserves the per-arch intermediates on merge failure (or on any
+    # earlier build-arch failure that skips merge) so an operator can
+    # inspect them (they're the only surviving reference to the
+    # individual arch digests once the merged manifest is in place).
+    # continue-on-error so a Docker Hub delete failure doesn't tank the
+    # whole workflow run -- a stray build-arch-* or
     # release-candidate-*-<arch> tag is cosmetically annoying but not
     # a correctness issue, same rationale as reusable-docker-
     # publish.yml's cleanup-candidate.

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -48,6 +48,21 @@
 #     manifest onto each final tag — the digests users pull for both
 #     amd64 and arm64 match what acceptance ran against.
 #
+# Phase 11 (native arm64 release builds): the build stage was
+# restructured from a single QEMU-emulated multi-arch push on an amd64
+# runner into a three-job flow — `prep` (shared metadata), `build-arch`
+# (matrix over runs_on: [ubuntu-24.04, ubuntu-24.04-arm], each pushing
+# a per-arch intermediate tag natively), and `merge-manifest` (unifies
+# the per-arch pushes into the final multi-arch manifest via `docker
+# buildx imagetools create`, then deletes the per-arch intermediates).
+# Motivation: arm64 under QEMU emulation is ~10x slower than native,
+# and QEMU has historically been a reliability drag on this workflow.
+# Both native runner types are free for public repos. Downstream
+# `acceptance-gate` + `publish-and-cleanup` are unchanged in behavior;
+# they just chain off `merge-manifest.outputs.*` instead of the old
+# monolithic `build.outputs.*`. Same output shape, same digests
+# threaded through publish, byte-identical guarantee preserved.
+#
 # Triggered by:
 #   * workflow_dispatch -- driven by the master orchestrator on its
 #     scheduled tick (dispatching against this branch's --ref with both
@@ -86,15 +101,24 @@ permissions:
   contents: read
 
 # Candidate tag suffix used to hand the gated build's image from the
-# build job (single multi-arch push) to acceptance-gate (which pulls
-# the candidate from Docker Hub) and publish (which aliases the
-# candidate's manifest onto each final tag). Unique per run+attempt so
-# concurrent orchestrator dispatches never collide on the same tag.
-# The `release-candidate-` prefix + GitHub run coordinates make the
-# tag unmistakably temporary; the cleanup-candidate job deletes it
-# once publish finishes (or acceptance fails).
+# merge-manifest job (multi-arch imagetools create of the per-arch
+# pushes) to acceptance-gate (which pulls the candidate from Docker
+# Hub) and publish (which aliases the candidate's manifest onto each
+# final tag). Unique per run+attempt so concurrent orchestrator
+# dispatches never collide on the same tag. The `release-candidate-`
+# prefix + GitHub run coordinates make the tag unmistakably temporary;
+# the cleanup-candidate job deletes it once publish finishes (or
+# acceptance fails).
+#
+# ARCH_INTERMEDIATE_PREFIX names the per-arch intermediate tags the
+# build-arch matrix pushes (Phase 11). Each arch push lands at
+# `<prefix>-<amd64|arm64>`; merge-manifest imagetools-creates the
+# final tag(s) from that pair and then deletes the intermediates.
+# Same run-id + attempt scoping as GATE_CANDIDATE_TAG so parallel
+# workflow runs don't collide on the intermediate namespace either.
 env:
   GATE_CANDIDATE_TAG: release-candidate-${{ github.run_id }}-${{ github.run_attempt }}
+  ARCH_INTERMEDIATE_PREFIX: build-arch-${{ github.run_id }}-${{ github.run_attempt }}
 
 # Serialize per-(branch, docker_tags) builds. Two dispatches with
 # the same ref AND the same docker_tags input (e.g., release-
@@ -115,14 +139,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  # Phase 11 job split (prep -> build-arch matrix -> merge-manifest):
+  #
+  # `prep` computes the shared metadata both arch builds must consume
+  # identically -- BUILD_DATE, resolved openemr_version_ref, extracted
+  # IMAGE_VERSION, expanded final-tag list -- so the amd64 and arm64
+  # builds bake the exact same OCI labels and the merged multi-arch
+  # manifest's per-platform slices are label-consistent. Compute once
+  # here, thread through needs.prep.outputs.* into build-arch and
+  # merge-manifest.
+  #
+  # Cheap ubuntu-24.04 runner: no build work happens here, just
+  # metadata resolution + one gh api call for version.php.
+  prep:
     # Only run from the upstream openemr/openemr repository (not downstream forks).
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr'
     runs-on: ubuntu-24.04
-    # Downstream jobs (acceptance-gate, publish, cleanup-candidate — gated
-    # path only) look up the candidate tag + expanded final tag list from
-    # these outputs. `env` doesn't cross job boundaries so re-surface the
-    # tag suffix here even though it originated from a workflow-level env.
+    # Downstream jobs (build-arch, merge-manifest -- and via merge-
+    # manifest, acceptance-gate and publish-and-cleanup) look up shared
+    # build metadata from these outputs. `env` doesn't cross job
+    # boundaries so re-surface the tag suffix here even though it
+    # originated from a workflow-level env.
     outputs:
       candidate_tag: ${{ env.GATE_CANDIDATE_TAG }}
       expanded_tags: ${{ steps.expand_docker_tags.outputs.list }}
@@ -132,18 +169,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v7
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v4
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Compute build date
       id: build_date
@@ -243,63 +268,201 @@ jobs:
         echo "value=$VERSION" >> "$GITHUB_OUTPUT"
         echo "✓ Extracted IMAGE_VERSION=$VERSION from openemr@${REF}/version.php"
 
-    # Phase 7c-docker gated path: multi-arch build+push to a candidate
-    # tag on Docker Hub (single push, both platforms). acceptance-gate
-    # pulls the candidate; publish aliases the candidate's manifest onto
-    # each final tag via `docker buildx imagetools create` (no rebuild,
-    # digest-identical across build/test/publish); cleanup-candidate
-    # deletes the tag after publish. arm64 IS validated in the sense
-    # that publish points its final-tag manifests at the same digest
-    # acceptance ran against — but acceptance itself only exercises
-    # amd64 (GHA runner arch). Accepted trade-off per plan doc.
-    #
-    # Non-gated path (the pre-Phase-7c shape, still every non-latest row)
-    # keeps the single-step multi-arch build+push below.
-    - name: Build and push to candidate tag — gated path
+  # Phase 11 native-arch build matrix: one native build per arch, each
+  # pushed to a per-arch intermediate tag on Docker Hub. Replaces the
+  # pre-Phase-11 single monolithic QEMU-emulated multi-arch build on
+  # amd64. No setup-qemu-action anywhere -- both runner types build
+  # their own arch natively.
+  #
+  # Same set of build-args in both cells (sourced from needs.prep.outputs)
+  # so amd64 and arm64 bake identical OCI labels; merge-manifest verifies
+  # once against the merged manifest downstream (labels are digest-shared
+  # across arches at that point).
+  #
+  # fail-fast: false so a transient amd64 flake doesn't cancel a
+  # good arm64 run mid-push (or vice versa) -- half a manifest is worse
+  # than seeing both fail independently, since merge-manifest gates on
+  # both succeeding anyway.
+  #
+  # Gated path pushes to `<candidate>-<arch>`; non-gated path pushes to
+  # `<intermediate-prefix>-<arch>`. Both flavors are per-arch single-tag
+  # pushes -- merge-manifest handles the fan-out to the full expanded_tags
+  # list on the non-gated path via imagetools create (one merge per
+  # final tag, all pointing at the same underlying multi-arch digest).
+  build-arch:
+    needs: [prep]
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs_on: [ubuntu-24.04, ubuntu-24.04-arm]
+    name: build-arch (${{ matrix.runs_on }})
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Compute arch label
+      # Convert the runs_on runner ref to a stable "amd64" / "arm64"
+      # label -- same pattern as acceptance-docker.yml's build-image
+      # job. Used to name the per-arch intermediate tag so amd64 and
+      # arm64 pushes land at distinct pointers that merge-manifest
+      # can imagetools-create into a single multi-arch manifest.
+      id: arch
+      shell: bash
+      run: |
+        case "$(uname -m)" in
+          x86_64)  echo "label=amd64" >> "$GITHUB_OUTPUT" ;;
+          aarch64) echo "label=arm64" >> "$GITHUB_OUTPUT" ;;
+          *) echo "::error::unsupported runner arch $(uname -m)"; exit 1 ;;
+        esac
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    # Phase 7c-docker gated path (Phase 11-restructured): native per-arch
+    # build+push to `<candidate>-<arch>` intermediate. merge-manifest
+    # imagetools-creates the final `<candidate>` multi-arch manifest
+    # from the amd64/arm64 pair; acceptance-gate then pulls that
+    # multi-arch tag; publish aliases it onto each final tag via
+    # `docker buildx imagetools create` (no rebuild, digest-identical
+    # across build/test/publish); cleanup-candidate deletes the
+    # candidate tag after publish. Per-arch intermediates get cleaned
+    # up by merge-manifest post-merge.
+    - name: Build and push per-arch intermediate — gated path
       if: inputs.gate_with_acceptance
       uses: docker/build-push-action@v7
       with:
         context: ./docker/release
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/${{ steps.arch.outputs.label }}
         push: true
-        tags: openemr/openemr:${{ env.GATE_CANDIDATE_TAG }}
+        tags: openemr/openemr:${{ needs.prep.outputs.candidate_tag }}-${{ steps.arch.outputs.label }}
         build-args: |
-          OPENEMR_VERSION=${{ steps.resolve_openemr_version_ref.outputs.ref }}
-          IMAGE_VERSION=${{ steps.image_version.outputs.value }}
-          BUILD_DATE=${{ steps.build_date.outputs.date }}
+          OPENEMR_VERSION=${{ needs.prep.outputs.openemr_version_ref }}
+          IMAGE_VERSION=${{ needs.prep.outputs.image_version }}
+          BUILD_DATE=${{ needs.prep.outputs.build_date }}
 
-    - name: Build and push — non-gated path
+    # Non-gated path (the pre-Phase-7c shape, still every non-latest row):
+    # native per-arch build+push to `<intermediate-prefix>-<arch>`.
+    # merge-manifest imagetools-creates the full expanded_tags list from
+    # the amd64/arm64 intermediate pair -- one multi-arch manifest per
+    # final tag, all pointing at the same underlying digest. The
+    # intermediate tag namespace is disjoint from any user-facing tag,
+    # so a partial fanout (some intermediates pushed, merge-manifest
+    # skipped due to earlier failure) can't confuse users.
+    - name: Build and push per-arch intermediate — non-gated path
       if: ${{ !inputs.gate_with_acceptance }}
       uses: docker/build-push-action@v7
       with:
         context: ./docker/release
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/${{ steps.arch.outputs.label }}
         push: true
-        tags: ${{ steps.expand_docker_tags.outputs.list }}
+        tags: openemr/openemr:${{ env.ARCH_INTERMEDIATE_PREFIX }}-${{ steps.arch.outputs.label }}
         build-args: |
-          OPENEMR_VERSION=${{ steps.resolve_openemr_version_ref.outputs.ref }}
-          IMAGE_VERSION=${{ steps.image_version.outputs.value }}
-          BUILD_DATE=${{ steps.build_date.outputs.date }}
+          OPENEMR_VERSION=${{ needs.prep.outputs.openemr_version_ref }}
+          IMAGE_VERSION=${{ needs.prep.outputs.image_version }}
+          BUILD_DATE=${{ needs.prep.outputs.build_date }}
 
-    - name: Verify pushed candidate image OCI labels — gated path
+  # Phase 11 merge-manifest: unify the per-arch intermediate pushes
+  # into the final multi-arch manifest(s) via `docker buildx imagetools
+  # create`. This is a metadata-only op on Docker Hub -- no image blobs
+  # are pulled or pushed, just a manifest list pointing at the two
+  # per-arch digests. Same primitive Phase 10c's reusable-docker-publish
+  # uses to alias the candidate onto each final tag; merge-manifest
+  # applies it one level earlier in the pipeline to collapse the
+  # per-arch fanout back into a single multi-arch pointer.
+  #
+  # Outputs mirror the pre-Phase-11 build job's outputs so downstream
+  # `acceptance-gate` + `publish-and-cleanup` see no interface change
+  # -- they just chain off `needs.merge-manifest.outputs.*` now.
+  merge-manifest:
+    needs: [prep, build-arch]
+    runs-on: ubuntu-24.04
+    outputs:
+      candidate_tag: ${{ needs.prep.outputs.candidate_tag }}
+      expanded_tags: ${{ needs.prep.outputs.expanded_tags }}
+      openemr_version_ref: ${{ needs.prep.outputs.openemr_version_ref }}
+      image_version: ${{ needs.prep.outputs.image_version }}
+      build_date: ${{ needs.prep.outputs.build_date }}
+    steps:
+    # Needed so the "Verify pushed image OCI labels" step below can call
+    # .github/scripts/verify-oci-labels.sh, and the cleanup step can call
+    # .github/scripts/dockerhub-delete-tag.sh.
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    # Gated path: single imagetools-create to collapse the two per-arch
+    # intermediates into the multi-arch candidate tag that acceptance-
+    # gate will pull.
+    - name: Merge per-arch intermediates into candidate manifest — gated path
       if: inputs.gate_with_acceptance
       env:
-        EXPECTED_REVISION: ${{ steps.resolve_openemr_version_ref.outputs.ref }}
-        EXPECTED_VERSION: ${{ steps.image_version.outputs.value }}
-        EXPECTED_BUILD_DATE: ${{ steps.build_date.outputs.date }}
-        REF_TAG: openemr/openemr:${{ env.GATE_CANDIDATE_TAG }}
-      # Runs against the candidate tag before spending acceptance-gate CI
-      # budget on an image whose Dockerfile ARGs didn't flow through
-      # correctly. Same verify script the non-gated + publish sites use.
+        CANDIDATE_TAG: ${{ needs.prep.outputs.candidate_tag }}
+      run: |
+        SRC_AMD64="openemr/openemr:${CANDIDATE_TAG}-amd64"
+        SRC_ARM64="openemr/openemr:${CANDIDATE_TAG}-arm64"
+        DST="openemr/openemr:${CANDIDATE_TAG}"
+        echo "==> merging ${SRC_AMD64} + ${SRC_ARM64} -> ${DST}"
+        docker buildx imagetools create -t "$DST" "$SRC_AMD64" "$SRC_ARM64"
+
+    # Non-gated path: one imagetools-create per entry in expanded_tags,
+    # all pointing at the same underlying digest. Matches the
+    # reusable-docker-publish alias loop shape (same primitive, same
+    # multi-arch preservation semantics).
+    - name: Merge per-arch intermediates onto each final tag — non-gated path
+      if: ${{ !inputs.gate_with_acceptance }}
+      env:
+        INTERMEDIATE_PREFIX: ${{ env.ARCH_INTERMEDIATE_PREFIX }}
+        TAGS_LIST: ${{ needs.prep.outputs.expanded_tags }}
+      run: |
+        SRC_AMD64="openemr/openemr:${INTERMEDIATE_PREFIX}-amd64"
+        SRC_ARM64="openemr/openemr:${INTERMEDIATE_PREFIX}-arm64"
+        for tag in $TAGS_LIST; do
+          [ -z "$tag" ] && continue
+          echo "==> merging ${SRC_AMD64} + ${SRC_ARM64} -> ${tag}"
+          docker buildx imagetools create -t "$tag" "$SRC_AMD64" "$SRC_ARM64"
+        done
+
+    # Verify labels once against the merged manifest. Pre-Phase-11 this
+    # ran twice (gated vs non-gated) on the per-flavor push; post-Phase-11
+    # the per-arch intermediates share the merged digest, so one verify
+    # covers both platform slices and both flavors. REF_TAG picks the
+    # merged candidate for the gated path, the first expanded final tag
+    # for the non-gated path. Same verify script the publish site uses.
+    - name: Verify pushed image OCI labels — gated path
+      if: inputs.gate_with_acceptance
+      env:
+        EXPECTED_REVISION: ${{ needs.prep.outputs.openemr_version_ref }}
+        EXPECTED_VERSION: ${{ needs.prep.outputs.image_version }}
+        EXPECTED_BUILD_DATE: ${{ needs.prep.outputs.build_date }}
+        REF_TAG: openemr/openemr:${{ needs.prep.outputs.candidate_tag }}
+      # Runs against the merged candidate tag before spending
+      # acceptance-gate CI budget on an image whose Dockerfile ARGs
+      # didn't flow through correctly. Same verify script the non-gated
+      # + publish sites use.
       run: .github/scripts/verify-oci-labels.sh
 
     - name: Verify pushed image OCI labels — non-gated path
       if: ${{ !inputs.gate_with_acceptance }}
       env:
-        EXPECTED_REVISION: ${{ steps.resolve_openemr_version_ref.outputs.ref }}
-        EXPECTED_VERSION: ${{ steps.image_version.outputs.value }}
-        EXPECTED_BUILD_DATE: ${{ steps.build_date.outputs.date }}
-        TAGS_LIST: ${{ steps.expand_docker_tags.outputs.list }}
+        EXPECTED_REVISION: ${{ needs.prep.outputs.openemr_version_ref }}
+        EXPECTED_VERSION: ${{ needs.prep.outputs.image_version }}
+        EXPECTED_BUILD_DATE: ${{ needs.prep.outputs.build_date }}
+        TAGS_LIST: ${{ needs.prep.outputs.expanded_tags }}
       # First pushed tag is the representative one to verify -- all tags
       # in TAGS_LIST point at the same manifest so inspecting one covers
       # all of them.
@@ -307,6 +470,38 @@ jobs:
         REF_TAG=$(echo "${TAGS_LIST}" | head -1)
         export REF_TAG
         .github/scripts/verify-oci-labels.sh
+
+    # Cleanup the per-arch intermediate tags after verify succeeds. The
+    # merged manifests still reference the arch-specific image digests
+    # directly (imagetools create copies the digests into the manifest
+    # list), so deleting the intermediate tag pointers is safe -- the
+    # multi-arch tag(s) keep working. Default step `if: success()`
+    # preserves the per-arch intermediates on verify failure so an
+    # operator can inspect them (they're the only surviving reference
+    # to the individual arch digests once the merged manifest is in
+    # place). continue-on-error so a Docker Hub delete failure doesn't
+    # tank the whole workflow run -- a stray build-arch-* or
+    # release-candidate-*-<arch> tag is cosmetically annoying but not
+    # a correctness issue, same rationale as reusable-docker-
+    # publish.yml's cleanup-candidate.
+    - name: Cleanup per-arch intermediate tags from Docker Hub
+      continue-on-error: true
+      env:
+        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        GATED: ${{ inputs.gate_with_acceptance }}
+        CANDIDATE_TAG: ${{ needs.prep.outputs.candidate_tag }}
+        INTERMEDIATE_PREFIX: ${{ env.ARCH_INTERMEDIATE_PREFIX }}
+      run: |
+        if [ "$GATED" = "true" ]; then
+          PREFIX="$CANDIDATE_TAG"
+        else
+          PREFIX="$INTERMEDIATE_PREFIX"
+        fi
+        for arch in amd64 arm64; do
+          TAG="${PREFIX}-${arch}" .github/scripts/dockerhub-delete-tag.sh || \
+            echo "::warning::failed to delete intermediate tag openemr/openemr:${PREFIX}-${arch} (non-fatal; manual cleanup may be needed)"
+        done
 
   # Phase 7c-docker gate: run the full acceptance-docker matrix against
   # the image build produced + saved as an artifact. Publish only fires
@@ -321,7 +516,7 @@ jobs:
   # this input kept false anyway).
   acceptance-gate:
     name: Acceptance gate
-    needs: [build]
+    needs: [merge-manifest]
     if: inputs.gate_with_acceptance
     uses: ./.github/workflows/acceptance-docker.yml
     with:
@@ -332,7 +527,7 @@ jobs:
       # `latest` (real currently-shipped image) — a secondary smoke of
       # whether Docker Hub `latest` is currently installable, complementing
       # the gated candidate assertion.
-      to_tag: ${{ needs.build.outputs.candidate_tag }}
+      to_tag: ${{ needs.merge-manifest.outputs.candidate_tag }}
       # (arm64 coverage is now unconditional in acceptance-docker.yml
       # — matrix runs both ubuntu-24.04 and ubuntu-24.04-arm on every
       # trigger. The former test_arm64 opt-in input was retired in
@@ -351,7 +546,7 @@ jobs:
   # expands back into publish + cleanup-candidate jobs at run time.
   #
   # Same gate as before (inputs.gate_with_acceptance) — non-gated path
-  # publishes directly from the build job, no reusable involved.
+  # publishes directly from the merge-manifest job, no reusable involved.
   #
   # Phase 9 (skip-build re-run for release recovery, 2026-07-28) is
   # still honored by the reusable's `cleanup-candidate` job: it fires
@@ -361,13 +556,13 @@ jobs:
   # preservation was designed for — see docker-acceptance-only.yml.
   publish-and-cleanup:
     name: Publish + cleanup
-    needs: [build, acceptance-gate]
+    needs: [merge-manifest, acceptance-gate]
     if: inputs.gate_with_acceptance
     uses: ./.github/workflows/reusable-docker-publish.yml
     with:
-      candidate_tag: ${{ needs.build.outputs.candidate_tag }}
-      expanded_tags: ${{ needs.build.outputs.expanded_tags }}
-      openemr_version_ref: ${{ needs.build.outputs.openemr_version_ref }}
-      image_version: ${{ needs.build.outputs.image_version }}
-      build_date: ${{ needs.build.outputs.build_date }}
+      candidate_tag: ${{ needs.merge-manifest.outputs.candidate_tag }}
+      expanded_tags: ${{ needs.merge-manifest.outputs.expanded_tags }}
+      openemr_version_ref: ${{ needs.merge-manifest.outputs.openemr_version_ref }}
+      image_version: ${{ needs.merge-manifest.outputs.image_version }}
+      build_date: ${{ needs.merge-manifest.outputs.build_date }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Restructures `docker-build-release.yml`'s single QEMU-emulated multi-arch push on an amd64 runner into a three-job native-per-arch flow. Downstream `acceptance-gate` + `publish-and-cleanup` see no interface change.

- `prep` (ubuntu-24.04) computes shared metadata once: BUILD_DATE, resolved openemr_version_ref, extracted IMAGE_VERSION, expanded final-tag list. Both arches consume the same values so OCI labels on the merged manifest are digest-consistent across platform slices.
- `build-arch` runs a matrix over `runs_on: [ubuntu-24.04, ubuntu-24.04-arm]`. Each cell pushes a native single-arch build to a per-arch intermediate Docker Hub tag. `platforms: linux/${arch}` -- no `docker/setup-qemu-action`, no emulation. Gated path uses `<candidate>-<arch>`; non-gated uses `build-arch-<run-id>-<attempt>-<arch>`.
- `merge-manifest` (ubuntu-24.04) collapses the per-arch intermediates into the final multi-arch manifest(s) via `docker buildx imagetools create` (metadata-only op on Docker Hub, no blob push). Gated path: single merge to `<candidate>`. Non-gated: one merge per entry in `expanded_tags`. Runs `verify-oci-labels.sh` once against the merged digest (both platform slices share the same labels), then deletes the per-arch intermediates via `dockerhub-delete-tag.sh` (continue-on-error).

## Motivation

- **Speed**: arm64 under QEMU is ~10x slower than native. Both `ubuntu-24.04` and `ubuntu-24.04-arm` are free for public repos.
- **Reliability**: QEMU has been a recurring drag on this release-critical path. Phase 7d already applied native-per-arch to `acceptance-docker.yml`'s `build-image` job; Phase 11 extends the same pattern to the release publish pipeline.
- **Parity with PR-time**: acceptance-docker.yml's PR-time build-image already validates arm64 natively; the release publisher was the last QEMU holdout.

## Scope

- Byte-identical propagation: `docker-build-release.yml` is already in `.github/byte-identical.yml` with `exclude-branches: [rel-800, rel-704]`. The restructure propagates automatically to rel-810 + rel-820 on merge. rel-800 + rel-704 retain their old QEMU-based version (they're excluded from byte-identical sync and from the acceptance surface anyway).
- Preserved: every input, every workflow-level env, the concurrency group, the OCI-label verify (moved to merge-manifest job, one verify covers both arches after merge), all rationale comments.
- Removed: `docker/setup-qemu-action@v4`, the two monolithic multi-arch `build-push-action` steps, and `platforms: linux/amd64,linux/arm64`.

## Downstream changes

`acceptance-gate` and `publish-and-cleanup` swap `needs: [build]` -> `needs: [merge-manifest]` and `needs.build.outputs.*` -> `needs.merge-manifest.outputs.*`. Same output shape (candidate_tag, expanded_tags, openemr_version_ref, image_version, build_date), same digests threaded through publish.

## Rollback plan

If the first real orchestrator run fails after merge, `git revert` this PR's commit. Docker Hub still has the previous day's successful multi-arch images published via the QEMU path; nothing downstream references the per-arch intermediate tags outside this workflow's own scope. The `release-candidate-<run-id>-<attempt>` and `build-arch-<run-id>-<attempt>-<arch>` namespaces are disjoint from any user-facing tag.

## Test plan

- [x] actionlint clean (rhysd/actionlint:1.7.10, full repo)
- [ ] Merge and observe next orchestrator run (a docker-tag-only workflow_dispatch to `manual-test` on master is the cheapest smoke)
- [ ] Confirm merged multi-arch manifest has both amd64 + arm64 platform slices on Docker Hub post-run
- [ ] Confirm per-arch intermediates get cleaned up post-verify

Rollback via revert if the first real run fails.

Assisted-by: Claude Code