### PR TITLE
refactor(forms): centralize encounter-form patient-ownership helper

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -61763,7 +61763,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#2 \\$isAndCondition of method OpenEMR\\\\Services\\\\EncounterService\\:\\:search\\(\\) expects bool, array\\<string, string\\> given\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/Services/EncounterService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -5572,7 +5572,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/painmap/report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$form_id of method C_AbstractClickmap\\:\\:view_action\\(\\) expects string, int\\<0, max\\> given\\.$#',
+    'message' => '#^Parameter \\#1 \\$form_id of method C_FormPainMap\\:\\:view_action\\(\\) expects string, int\\|false\\|null given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/painmap/view.php',
 ];

--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -5532,11 +5532,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/note/view.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$text of function attr_url expects string, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/note/view.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/note/view.php',

--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -3877,7 +3877,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/clinic_note/view.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$text of function attr_url expects string, mixed given\\.$#',
+    'message' => '#^Parameter \\#1 \\$text of function attr_url expects string, int\\<0, max\\> given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/clinic_note/view.php',
 ];
@@ -5572,7 +5572,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/painmap/report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$form_id of method C_AbstractClickmap\\:\\:view_action\\(\\) expects string, mixed given\\.$#',
+    'message' => '#^Parameter \\#1 \\$form_id of method C_AbstractClickmap\\:\\:view_action\\(\\) expects string, int\\<0, max\\> given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/painmap/view.php',
 ];
@@ -5958,11 +5958,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$formid of static method OpenEMR\\\\Common\\\\Forms\\\\CoreFormToPortalUtility\\:\\:formPatientPortalPostSave\\(\\) expects int, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/sdoh/save.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#2 \\$formid of static method OpenEMR\\\\Common\\\\Forms\\\\CoreFormToPortalUtility\\:\\:confirmFormBootstrapPatient\\(\\) expects int, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/sdoh/save.php',
 ];

--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -5572,11 +5572,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/painmap/report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$form_id of method C_FormPainMap\\:\\:view_action\\(\\) expects string, int\\|false\\|null given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/painmap/view.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/phq9/common.php',

--- a/.phpstan/baseline/cast.int.php
+++ b/.phpstan/baseline/cast.int.php
@@ -174,11 +174,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to int\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/requisition/new.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to int\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/transfer_summary/new.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -413,11 +413,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/note/view.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 11,
     'path' => __DIR__ . '/../../interface/forms/procedure_order/common.php',
 ];

--- a/.phpstan/baseline/echo.nonString.php
+++ b/.phpstan/baseline/echo.nonString.php
@@ -164,11 +164,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/prior_auth/view.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/procedure_order/common.php',
 ];
 $ignoreErrors[] = [
@@ -184,17 +179,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/ros/view.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/soap/save.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/soap/view.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -503,11 +503,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/prior_auth/C_FormPriorAuth.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/forms/prior_auth/FormPriorAuth.class.php',
 ];
@@ -558,11 +553,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/ros/C_FormROS.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 141,
     'path' => __DIR__ . '/../../interface/forms/ros/FormROS.class.php',
 ];
@@ -580,11 +570,6 @@ $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/forms/sdoh/report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/soap/C_FormSOAP.class.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',

--- a/.phpstan/baseline/function.alreadyNarrowedType.php
+++ b/.phpstan/baseline/function.alreadyNarrowedType.php
@@ -98,6 +98,11 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/patient_file/encounter/load_form.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/super/edit_globals.php',
 ];

--- a/.phpstan/baseline/function.alreadyNarrowedType.php
+++ b/.phpstan/baseline/function.alreadyNarrowedType.php
@@ -98,11 +98,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/encounter/load_form.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/super/edit_globals.php',
 ];

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -35447,16 +35447,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/EncounterService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\EncounterService\\:\\:getSensitivity\\(\\) has parameter \\$encounter_id with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/EncounterService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\EncounterService\\:\\:getSensitivity\\(\\) has parameter \\$pid with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/EncounterService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\EncounterService\\:\\:getSoapNote\\(\\) has parameter \\$eid with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/EncounterService.php',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -3387,11 +3387,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/prior_auth/C_FormPriorAuth.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method C_FormPriorAuth\\:\\:view_action\\(\\) has parameter \\$form_id with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/prior_auth/C_FormPriorAuth.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method FormPriorAuth\\:\\:__construct\\(\\) has parameter \\$id with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/prior_auth/FormPriorAuth.class.php',
@@ -3603,11 +3598,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method C_FormROS\\:\\:__construct\\(\\) has parameter \\$template_mod with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/ros/C_FormROS.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_FormROS\\:\\:view_action\\(\\) has parameter \\$form_id with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/ros/C_FormROS.class.php',
 ];
@@ -4365,11 +4355,6 @@ $ignoreErrors[] = [
     'message' => '#^Function sdoh_report\\(\\) has parameter \\$pid with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/sdoh/report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_FormSOAP\\:\\:view_action\\(\\) has parameter \\$form_id with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/soap/C_FormSOAP.class.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method FormSOAP\\:\\:__construct\\(\\) has parameter \\$id with no type specified\\.$#',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -1377,11 +1377,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/prior_auth/C_FormPriorAuth.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method C_FormPriorAuth\\:\\:view_action\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/prior_auth/C_FormPriorAuth.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method FormPriorAuth\\:\\:get_activity\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/prior_auth/FormPriorAuth.class.php',
@@ -1473,11 +1468,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method C_FormROS\\:\\:default_action_process\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/ros/C_FormROS.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_FormROS\\:\\:view_action\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/ros/C_FormROS.class.php',
 ];
@@ -2908,11 +2898,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method C_FormSOAP\\:\\:default_action_process\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/soap/C_FormSOAP.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method C_FormSOAP\\:\\:view_action\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/soap/C_FormSOAP.class.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -4078,7 +4078,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'pid\' on array\\|false\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/LBF/new.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.notFound.php
+++ b/.phpstan/baseline/offsetAccess.notFound.php
@@ -172,57 +172,57 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-weno/templates/indexrx.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'care_plan\' might not exist on array\\{\\}\\|array\\{care_plan\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, text\\: mixed, code\\: mixed, description\\: mixed, plan_type\\: mixed\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'care_plan\' might not exist on array\\{\\}\\|array\\{care_plan\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, text\\: mixed, code\\: mixed, description\\: mixed, plan_type\\: mixed\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'encounter\' might not exist on array\\{\\}\\|array\\{encounter\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, date\\: mixed, provider_npi\\: mixed, provider_name\\: mixed, provider_address\\: mixed, provider_city\\: mixed, provider_state\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'encounter\' might not exist on array\\{\\}\\|array\\{encounter\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, date\\: mixed, provider_npi\\: mixed, provider_name\\: mixed, provider_address\\: mixed, provider_city\\: mixed, provider_state\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'functional_cognitive_status\' might not exist on array\\{\\}\\|array\\{functional_cognitive_status\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, text\\: mixed, code\\: mixed, date\\: mixed, description\\: mixed\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'functional_cognitive_status\' might not exist on array\\{\\}\\|array\\{functional_cognitive_status\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, text\\: mixed, code\\: mixed, date\\: mixed, description\\: mixed\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'immunization\' might not exist on array\\{\\}\\|array\\{immunization\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, administered_date\\: mixed, route_code\\: mixed, route_code_text\\: mixed, cvx_code\\: mixed, cvx_code_text\\: mixed, amount_administered\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'immunization\' might not exist on array\\{\\}\\|array\\{immunization\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, administered_date\\: mixed, route_code\\: mixed, route_code_text\\: mixed, cvx_code\\: mixed, cvx_code_text\\: mixed, amount_administered\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'lists1\' might not exist on array\\{\\}\\|array\\{lists1\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, begdate\\: mixed, enddate\\: mixed, list_code\\: mixed, list_code_text\\: mixed, status\\: mixed, observation_text\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'lists1\' might not exist on array\\{\\}\\|array\\{lists1\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, begdate\\: mixed, enddate\\: mixed, list_code\\: mixed, list_code_text\\: mixed, status\\: mixed, observation_text\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'lists2\' might not exist on array\\{\\}\\|array\\{lists2\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, begdate\\: mixed, enddate\\: mixed, list_code\\: mixed, list_code_text\\: mixed, severity_al\\: mixed, status\\: mixed, reaction\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'lists2\' might not exist on array\\{\\}\\|array\\{lists2\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, begdate\\: mixed, enddate\\: mixed, list_code\\: mixed, list_code_text\\: mixed, severity_al\\: mixed, status\\: mixed, reaction\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'lists3\' might not exist on array\\{\\}\\|array\\{lists3\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, begdate\\: mixed, enddate\\: mixed, route\\: mixed, note\\: mixed, indication\\: mixed, route_display\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'lists3\' might not exist on array\\{\\}\\|array\\{lists3\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, begdate\\: mixed, enddate\\: mixed, route\\: mixed, note\\: mixed, indication\\: mixed, route_display\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'procedure\' might not exist on array\\{\\}\\|array\\{procedure\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, codeSystemName\\: mixed, code\\: mixed, code_text\\: mixed, date\\: mixed, represented_organization1\\: mixed, represented_organization_address1\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'procedure\' might not exist on array\\{\\}\\|array\\{procedure\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, codeSystemName\\: mixed, code\\: mixed, code_text\\: mixed, date\\: mixed, represented_organization1\\: mixed, represented_organization_address1\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'procedure_result\' might not exist on array\\{\\}\\|array\\{procedure_result\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{proc_text\\: mixed, proc_code\\: mixed, extension\\: mixed, date\\: mixed, status\\: mixed, results_text\\: mixed, results_code\\: mixed, results_range\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'procedure_result\' might not exist on array\\{\\}\\|array\\{procedure_result\\?\\: array\\<int\\<1, max\\>, array\\{proc_text\\: mixed, proc_code\\: mixed, extension\\: mixed, date\\: mixed, status\\: mixed, results_text\\: mixed, results_code\\: mixed, results_range\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'referral\' might not exist on array\\{\\}\\|array\\{referral\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{body\\: mixed, root\\: mixed\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'referral\' might not exist on array\\{\\}\\|array\\{referral\\?\\: array\\<int\\<1, max\\>, array\\{body\\: mixed, root\\: mixed\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'vitals\' might not exist on array\\{\\}\\|array\\{vitals\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, date\\: mixed, temperature\\: mixed, bpd\\: mixed, bps\\: mixed, head_circ\\: mixed, pulse\\: mixed, height\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'vitals\' might not exist on array\\{\\}\\|array\\{vitals\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, date\\: mixed, temperature\\: mixed, bpd\\: mixed, bps\\: mixed, head_circ\\: mixed, pulse\\: mixed, height\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
@@ -292,12 +292,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_file/encounter/load_form.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'code\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, code\\: mixed, code_type\\: mixed, charges\\: 0\\|float, payments\\: 0\\}\\.$#',
+    'message' => '#^Offset \'code\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, code\\: mixed, code_type\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/front_payment.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'code_type\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, code\\: mixed, code_type\\: mixed, charges\\: 0\\|float, payments\\: 0\\}\\.$#',
+    'message' => '#^Offset \'code_type\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, code\\: mixed, code_type\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/front_payment.php',
 ];
@@ -337,6 +337,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Offset \'employer_data\' might not exist on array\\{patient_data\\: non\\-empty\\-array, employer_data\\?\\: non\\-empty\\-array\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics_save.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Offset float does not exist on list\\<non\\-empty\\-array\\>\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/procedure_tools/ereqs/ereq_universal_form.php',
@@ -352,8 +357,33 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/procedure_tools/labcorp/gen_hl7_order.inc.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Offset \'adjustments\' might not exist on array\\{insname\\: string, ptname\\?\\: string, pid\\: mixed, count\\?\\: \\(float\\|int\\), id\\?\\: mixed, encounter\\?\\: mixed, invnumber\\?\\: mixed, custid\\?\\: mixed, \\.\\.\\.\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/reports/collections_report.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'amount\' might not exist on array\\{insname\\: string, ptname\\?\\: string, pid\\: mixed, count\\?\\: \\(float\\|int\\), id\\?\\: mixed, encounter\\?\\: mixed, invnumber\\?\\: mixed, custid\\?\\: mixed, \\.\\.\\.\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/reports/collections_report.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'charges\' might not exist on array\\{insname\\: string, ptname\\?\\: string, pid\\: mixed, count\\?\\: \\(float\\|int\\), id\\?\\: mixed, encounter\\?\\: mixed, invnumber\\?\\: mixed, custid\\?\\: mixed, \\.\\.\\.\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/reports/collections_report.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'count\' might not exist on array\\{insname\\: string, ptname\\?\\: string, pid\\: mixed, count\\?\\: \\(float\\|int\\), id\\?\\: mixed, encounter\\?\\: mixed, invnumber\\?\\: mixed, custid\\?\\: mixed, \\.\\.\\.\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/reports/collections_report.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Offset \'groupnumber\' might not exist on array\\{id\\: mixed, pid\\: mixed, encounter\\: mixed, invnumber\\: non\\-falsy\\-string, custid\\: mixed, name\\: non\\-falsy\\-string, address1\\: mixed, city\\: mixed, \\.\\.\\.\\}\\.$#',
     'count' => 2,
+    'path' => __DIR__ . '/../../interface/reports/collections_report.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'paid\' might not exist on array\\{insname\\: string, ptname\\?\\: string, pid\\: mixed, count\\?\\: \\(float\\|int\\), id\\?\\: mixed, encounter\\?\\: mixed, invnumber\\?\\: mixed, custid\\?\\: mixed, \\.\\.\\.\\}\\.$#',
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/collections_report.php',
 ];
 $ignoreErrors[] = [
@@ -367,67 +397,42 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/reports/insurance_allocation_report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 0 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1\\|2, 9\\?\\: 1\\|2, 10\\?\\: 1\\|2, 11\\?\\: 1\\|2, \\.\\.\\.\\}\\.$#',
+    'message' => '#^Offset 10 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 1 might not exist on array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\|array\\{mixed, 0, 0, 1, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\.$#',
+    'message' => '#^Offset 11 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 10 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1\\|2, 9\\?\\: 1\\|2, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
+    'message' => '#^Offset 12 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 11 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1\\|2, 9\\?\\: 1\\|2, 10\\?\\: 1\\|2, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
+    'message' => '#^Offset 5 might not exist on array\\{4\\: 1\\}\\|array\\{mixed, 0, 0, 0, 0\\|1, 0, 0, 0, \\.\\.\\.\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 12 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1\\|2, 9\\?\\: 1\\|2, 10\\?\\: 1\\|2, 11\\?\\: 1\\|2, \\.\\.\\.\\}\\.$#',
+    'message' => '#^Offset 6 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0, 0, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 2 might not exist on array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\|array\\{mixed, 0, 0, 1, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\.$#',
+    'message' => '#^Offset 7 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 3 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
+    'message' => '#^Offset 8 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 4 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset 5 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset 6 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset 7 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset 8 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset 9 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1\\|2, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
+    'message' => '#^Offset 9 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
@@ -437,9 +442,29 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset int\\<1, 12\\> might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1\\|2, 9\\?\\: 1\\|2, 10\\?\\: 1\\|2, 11\\?\\: 1\\|2, \\.\\.\\.\\}\\.$#',
+    'message' => '#^Offset \'date\' does not exist on array\\{\\}\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
+    'path' => __DIR__ . '/../../interface/reports/pat_ledger.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'provider_id\' does not exist on array\\{\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/reports/pat_ledger.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'reason\' does not exist on array\\{\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/reports/pat_ledger.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'name\' might not exist on array\\{name\\?\\: string, phone\\?\\: string, fax\\?\\: string, street\\?\\: string, city\\?\\: string, state\\?\\: string, postal_code\\?\\: string, country_code\\?\\: string, \\.\\.\\.\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/usergroup/facilities.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'username\' might not exist on array\\{password\\: \'NoLongerUsed\', username\\?\\: string, fname\\?\\: string, mname\\?\\: string, lname\\?\\: string, suffix\\?\\: string, email\\?\\: string, valedictory\\?\\: string, \\.\\.\\.\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/usergroup/usergroup_admin.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Offset \'ALL\' might not exist on array\\{\\}\\|array\\{ALL\\: string\\}\\.$#',
@@ -482,32 +507,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/clinical_rules.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'desc\' might not exist on array\\{name\\?\\: string, mime\\: non\\-empty\\-list\\<string\\>, desc\\?\\: string\\|false, file\\: string, doc_id\\: non\\-empty\\-array\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'desc\' might not exist on array\\{name\\?\\: string, mime\\: non\\-empty\\-list\\<string\\>, desc\\?\\: string\\|false, file\\: string, doc_id\\?\\: non\\-empty\\-array\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Offset \'host\' might not exist on array\\{scheme\\: \'http\'\\|\'tcp\', host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Offset \'host\' might not exist on array\\{scheme\\: \'https\', host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'mime\' might not exist on array\\{name\\?\\: string, mime\\?\\: non\\-empty\\-list\\<string\\>\\|string, desc\\?\\: string\\|false, file\\: string, doc_id\\?\\: non\\-empty\\-array\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'name\' might not exist on array\\{name\\?\\: string, mime\\?\\: non\\-empty\\-list\\<string\\>\\|string, desc\\?\\: string\\|false, file\\: string, doc_id\\?\\: non\\-empty\\-array\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
 ];
@@ -662,19 +667,34 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'code\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: 0\\|float, payments\\: 0, reason\\: mixed, code_type\\: mixed, code\\: mixed\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
+    'message' => '#^Offset \'code\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0, reason\\: mixed, code_type\\: mixed, code\\: mixed\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/portal_payment.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'code_type\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: 0\\|float, payments\\: 0, reason\\: mixed, code_type\\: mixed, code\\: mixed\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
+    'message' => '#^Offset \'code_type\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0, reason\\: mixed, code_type\\: mixed, code\\: mixed\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/portal_payment.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'reason\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: 0\\|float, payments\\: 0, reason\\: mixed, code_type\\: mixed, code\\: mixed\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
+    'message' => '#^Offset \'reason\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0, reason\\: mixed, code_type\\: mixed, code\\: mixed\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/portal_payment.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'date\' does not exist on array\\{\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../portal/report/pat_ledger.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'provider_id\' does not exist on array\\{\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../portal/report/pat_ledger.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'reason\' does not exist on array\\{\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../portal/report/pat_ledger.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Offset 1 might not exist on array\\{\\}\\|array\\{non\\-falsy\\-string, string, numeric\\-string\\}\\.$#',
@@ -687,7 +707,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/report/portal_custom_report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'data\' might not exist on array\\{\\}\\|array\\{data\\: non\\-empty\\-array, company\\: array\\|false, object\\: InsuranceCompany\\}\\.$#',
+    'message' => '#^Offset \'data\' might not exist on array\\{\\}\\|array\\{data\\: non\\-empty\\-array, company\\?\\: array\\|false, object\\?\\: InsuranceCompany\\}\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Billing/Claim.php',
 ];
@@ -707,7 +727,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Billing/EDI270.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'message\' might not exist on array\\{start_date\\: mixed, end_date\\: mixed\\}\\|array\\{type\\: string, benefit_type\\: mixed, start_date\\: string, end_date\\: string, coverage_level\\: mixed, coverage_type\\: mixed, plan_type\\: mixed, plan_description\\: string, \\.\\.\\.\\}\\.$#',
+    'message' => '#^Offset \'message\' might not exist on array\\{type\\?\\: string, benefit_type\\?\\: mixed, start_date\\: mixed, end_date\\: mixed, coverage_level\\?\\: mixed, coverage_type\\?\\: mixed, plan_type\\?\\: mixed, plan_description\\?\\: string, \\.\\.\\.\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Billing/EDI270.php',
 ];
@@ -717,17 +737,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Billing/EDI270.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'count\' might not exist on array\\{start\\: mixed, count\\?\\: \\(float\\|int\\)\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/EdiHistory/X12File.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'bal\' might not exist on array\\{chg\\: float\\|int, bal\\: float\\|int, code_type\\: mixed, code_value\\: mixed, modifier\\: mixed, code_text\\: mixed, dtl\\?\\: non\\-empty\\-array\\<\'          1000\'\\|\'          1001\', array\\{chg\\: numeric\\-string\\}\\>\\}\\|array\\{chg\\: float\\|int, bal\\?\\: float\\|int\\}\\.$#',
+    'message' => '#^Offset \'bal\' might not exist on array\\{chg\\: float\\|int, bal\\: float\\|int, code_type\\: mixed, code_value\\: mixed, modifier\\: mixed, code_text\\: mixed, dtl\\?\\: array\\<literal\\-string&non\\-falsy\\-string&numeric\\-string, array\\{chg\\: numeric\\-string\\}\\>\\}\\|array\\{chg\\: float\\|int, bal\\?\\: float\\|int\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Billing/InvoiceSummary.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'dtl\' might not exist on array\\{chg\\: float\\|int, bal\\: float\\|int, code_type\\: mixed, code_value\\: mixed, modifier\\: mixed, code_text\\: mixed, dtl\\?\\: non\\-empty\\-array\\<\'          1000\'\\|\'          1001\', array\\{chg\\: numeric\\-string\\}\\>\\}\\|array\\{chg\\: float\\|int, bal\\: float\\|int\\}\\.$#',
+    'message' => '#^Offset \'dtl\' might not exist on array\\{chg\\: float\\|int, bal\\: float\\|int, code_type\\: mixed, code_value\\: mixed, modifier\\: mixed, code_text\\: mixed, dtl\\?\\: array\\<literal\\-string&non\\-falsy\\-string&numeric\\-string, array\\{chg\\: numeric\\-string\\}\\>\\}\\|array\\{chg\\: float\\|int, bal\\: float\\|int\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Billing/InvoiceSummary.php',
 ];
@@ -785,31 +800,6 @@ $ignoreErrors[] = [
     'message' => '#^Offset \'streetAddress\' might not exist on array\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Isolated/USPS/USPSAddressVerifyV3Test.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'PATH_INFO\' does not exist on array\\{REQUEST_METHOD\\: \'GET\', HTTP_HOST\\: \'localhost\', DOCUMENT_ROOT\\: \'/var/www/html\', REQUEST_URI\\: \'/apis/dispatch\\.php\\?…\', QUERY_STRING\\: \'_REWRITE_COMMAND\\=…\', SCRIPT_NAME\\: \'/apis/dispatch\\.php\', SCRIPT_FILENAME\\: \'/var/www/html…\'\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Http/HttpRestRequestTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'PATH_INFO\' does not exist on array\\{REQUEST_METHOD\\: \'GET\', HTTP_HOST\\: \'localhost\', DOCUMENT_ROOT\\: \'/var/www/html\', REQUEST_URI\\: \'/dispatch\\.php\\?…\', QUERY_STRING\\: \'_REWRITE_COMMAND\\=…\', SCRIPT_NAME\\: \'/dispatch\\.php\'\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Http/HttpRestRequestTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'PATH_INFO\' does not exist on array\\{REQUEST_METHOD\\: \'GET\', HTTP_HOST\\: \'localhost\', DOCUMENT_ROOT\\: \'/var/www/html…\', REQUEST_URI\\: \'/apis/dispatch\\.php\\?…\', QUERY_STRING\\: \'_REWRITE_COMMAND…\', SCRIPT_NAME\\: \'/apis/dispatch\\.php\', SCRIPT_FILENAME\\: \'/var/www/html…\'\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Http/HttpRestRequestTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'PATH_INFO\' does not exist on array\\{REQUEST_METHOD\\: \'POST\', HTTP_HOST\\: \'localhost\', DOCUMENT_ROOT\\: \'/var/www/html…\', REQUEST_URI\\: \'/apis/dispatch\\.php\\?…\', QUERY_STRING\\: \'_REWRITE_COMMAND…\', SCRIPT_NAME\\: \'/apis/dispatch\\.php\', SCRIPT_FILENAME\\: \'/var/www/html…\'\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Http/HttpRestRequestTest.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'PHP_SELF\' does not exist on array\\{REQUEST_METHOD\\: \'GET\', HTTP_HOST\\: \'localhost\', DOCUMENT_ROOT\\: \'/var/www/html…\', REQUEST_URI\\: \'/apis/dispatch\\.php\\?…\', QUERY_STRING\\: \'_REWRITE_COMMAND…\', SCRIPT_NAME\\: \'/apis/dispatch\\.php\', SCRIPT_FILENAME\\: \'/var/www/html…\'\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Http/HttpRestRequestTest.php',
 ];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/offsetAccess.notFound.php
+++ b/.phpstan/baseline/offsetAccess.notFound.php
@@ -172,57 +172,57 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-weno/templates/indexrx.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'care_plan\' might not exist on array\\{\\}\\|array\\{care_plan\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, text\\: mixed, code\\: mixed, description\\: mixed, plan_type\\: mixed\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'care_plan\' might not exist on array\\{\\}\\|array\\{care_plan\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, text\\: mixed, code\\: mixed, description\\: mixed, plan_type\\: mixed\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'encounter\' might not exist on array\\{\\}\\|array\\{encounter\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, date\\: mixed, provider_npi\\: mixed, provider_name\\: mixed, provider_address\\: mixed, provider_city\\: mixed, provider_state\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'encounter\' might not exist on array\\{\\}\\|array\\{encounter\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, date\\: mixed, provider_npi\\: mixed, provider_name\\: mixed, provider_address\\: mixed, provider_city\\: mixed, provider_state\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'functional_cognitive_status\' might not exist on array\\{\\}\\|array\\{functional_cognitive_status\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, text\\: mixed, code\\: mixed, date\\: mixed, description\\: mixed\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'functional_cognitive_status\' might not exist on array\\{\\}\\|array\\{functional_cognitive_status\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, text\\: mixed, code\\: mixed, date\\: mixed, description\\: mixed\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'immunization\' might not exist on array\\{\\}\\|array\\{immunization\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, administered_date\\: mixed, route_code\\: mixed, route_code_text\\: mixed, cvx_code\\: mixed, cvx_code_text\\: mixed, amount_administered\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'immunization\' might not exist on array\\{\\}\\|array\\{immunization\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, administered_date\\: mixed, route_code\\: mixed, route_code_text\\: mixed, cvx_code\\: mixed, cvx_code_text\\: mixed, amount_administered\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'lists1\' might not exist on array\\{\\}\\|array\\{lists1\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, begdate\\: mixed, enddate\\: mixed, list_code\\: mixed, list_code_text\\: mixed, status\\: mixed, observation_text\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'lists1\' might not exist on array\\{\\}\\|array\\{lists1\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, begdate\\: mixed, enddate\\: mixed, list_code\\: mixed, list_code_text\\: mixed, status\\: mixed, observation_text\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'lists2\' might not exist on array\\{\\}\\|array\\{lists2\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, begdate\\: mixed, enddate\\: mixed, list_code\\: mixed, list_code_text\\: mixed, severity_al\\: mixed, status\\: mixed, reaction\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'lists2\' might not exist on array\\{\\}\\|array\\{lists2\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, begdate\\: mixed, enddate\\: mixed, list_code\\: mixed, list_code_text\\: mixed, severity_al\\: mixed, status\\: mixed, reaction\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'lists3\' might not exist on array\\{\\}\\|array\\{lists3\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, begdate\\: mixed, enddate\\: mixed, route\\: mixed, note\\: mixed, indication\\: mixed, route_display\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'lists3\' might not exist on array\\{\\}\\|array\\{lists3\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, begdate\\: mixed, enddate\\: mixed, route\\: mixed, note\\: mixed, indication\\: mixed, route_display\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'procedure\' might not exist on array\\{\\}\\|array\\{procedure\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, codeSystemName\\: mixed, code\\: mixed, code_text\\: mixed, date\\: mixed, represented_organization1\\: mixed, represented_organization_address1\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'procedure\' might not exist on array\\{\\}\\|array\\{procedure\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, root\\: mixed, codeSystemName\\: mixed, code\\: mixed, code_text\\: mixed, date\\: mixed, represented_organization1\\: mixed, represented_organization_address1\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'procedure_result\' might not exist on array\\{\\}\\|array\\{procedure_result\\?\\: array\\<int\\<1, max\\>, array\\{proc_text\\: mixed, proc_code\\: mixed, extension\\: mixed, date\\: mixed, status\\: mixed, results_text\\: mixed, results_code\\: mixed, results_range\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'procedure_result\' might not exist on array\\{\\}\\|array\\{procedure_result\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{proc_text\\: mixed, proc_code\\: mixed, extension\\: mixed, date\\: mixed, status\\: mixed, results_text\\: mixed, results_code\\: mixed, results_range\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'referral\' might not exist on array\\{\\}\\|array\\{referral\\?\\: array\\<int\\<1, max\\>, array\\{body\\: mixed, root\\: mixed\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'referral\' might not exist on array\\{\\}\\|array\\{referral\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{body\\: mixed, root\\: mixed\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'vitals\' might not exist on array\\{\\}\\|array\\{vitals\\?\\: array\\<int\\<1, max\\>, array\\{extension\\: mixed, date\\: mixed, temperature\\: mixed, bpd\\: mixed, bps\\: mixed, head_circ\\: mixed, pulse\\: mixed, height\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
+    'message' => '#^Offset \'vitals\' might not exist on array\\{\\}\\|array\\{vitals\\?\\: non\\-empty\\-array\\<int\\<1, max\\>, array\\{extension\\: mixed, date\\: mixed, temperature\\: mixed, bpd\\: mixed, bps\\: mixed, head_circ\\: mixed, pulse\\: mixed, height\\: mixed, \\.\\.\\.\\}\\>\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php',
 ];
@@ -287,12 +287,17 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_file/encounter/find_code_dynamic_ajax.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'code\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, code\\: mixed, code_type\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
+    'message' => '#^Offset \'encounter\' might not exist on array\\{pid\\: int, encounter\\: int\\}\\|null\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/patient_file/encounter/load_form.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'code\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, code\\: mixed, code_type\\: mixed, charges\\: 0\\|float, payments\\: 0\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/front_payment.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'code_type\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, code\\: mixed, code_type\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
+    'message' => '#^Offset \'code_type\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, code\\: mixed, code_type\\: mixed, charges\\: 0\\|float, payments\\: 0\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/front_payment.php',
 ];
@@ -332,11 +337,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'employer_data\' might not exist on array\\{patient_data\\: non\\-empty\\-array, employer_data\\?\\: non\\-empty\\-array\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics_save.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Offset float does not exist on list\\<non\\-empty\\-array\\>\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/procedure_tools/ereqs/ereq_universal_form.php',
@@ -352,33 +352,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/procedure_tools/labcorp/gen_hl7_order.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'adjustments\' might not exist on array\\{insname\\: string, ptname\\?\\: string, pid\\: mixed, count\\?\\: \\(float\\|int\\), id\\?\\: mixed, encounter\\?\\: mixed, invnumber\\?\\: mixed, custid\\?\\: mixed, \\.\\.\\.\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/collections_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'amount\' might not exist on array\\{insname\\: string, ptname\\?\\: string, pid\\: mixed, count\\?\\: \\(float\\|int\\), id\\?\\: mixed, encounter\\?\\: mixed, invnumber\\?\\: mixed, custid\\?\\: mixed, \\.\\.\\.\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/collections_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'charges\' might not exist on array\\{insname\\: string, ptname\\?\\: string, pid\\: mixed, count\\?\\: \\(float\\|int\\), id\\?\\: mixed, encounter\\?\\: mixed, invnumber\\?\\: mixed, custid\\?\\: mixed, \\.\\.\\.\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/collections_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'count\' might not exist on array\\{insname\\: string, ptname\\?\\: string, pid\\: mixed, count\\?\\: \\(float\\|int\\), id\\?\\: mixed, encounter\\?\\: mixed, invnumber\\?\\: mixed, custid\\?\\: mixed, \\.\\.\\.\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/collections_report.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Offset \'groupnumber\' might not exist on array\\{id\\: mixed, pid\\: mixed, encounter\\: mixed, invnumber\\: non\\-falsy\\-string, custid\\: mixed, name\\: non\\-falsy\\-string, address1\\: mixed, city\\: mixed, \\.\\.\\.\\}\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../interface/reports/collections_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'paid\' might not exist on array\\{insname\\: string, ptname\\?\\: string, pid\\: mixed, count\\?\\: \\(float\\|int\\), id\\?\\: mixed, encounter\\?\\: mixed, invnumber\\?\\: mixed, custid\\?\\: mixed, \\.\\.\\.\\}\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/collections_report.php',
 ];
 $ignoreErrors[] = [
@@ -392,42 +367,67 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/reports/insurance_allocation_report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 10 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1\\}\\.$#',
+    'message' => '#^Offset 0 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1\\|2, 9\\?\\: 1\\|2, 10\\?\\: 1\\|2, 11\\?\\: 1\\|2, \\.\\.\\.\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 11 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1\\}\\.$#',
+    'message' => '#^Offset 1 might not exist on array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\|array\\{mixed, 0, 0, 1, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 12 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1\\}\\.$#',
+    'message' => '#^Offset 10 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1\\|2, 9\\?\\: 1\\|2, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 5 might not exist on array\\{4\\: 1\\}\\|array\\{mixed, 0, 0, 0, 0\\|1, 0, 0, 0, \\.\\.\\.\\}\\.$#',
+    'message' => '#^Offset 11 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1\\|2, 9\\?\\: 1\\|2, 10\\?\\: 1\\|2, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 6 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0, 0, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1\\}\\.$#',
+    'message' => '#^Offset 12 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1\\|2, 9\\?\\: 1\\|2, 10\\?\\: 1\\|2, 11\\?\\: 1\\|2, \\.\\.\\.\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 7 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1\\}\\.$#',
+    'message' => '#^Offset 2 might not exist on array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\|array\\{mixed, 0, 0, 1, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 8 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1\\}\\.$#',
+    'message' => '#^Offset 3 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 9 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1\\}\\.$#',
+    'message' => '#^Offset 4 might not exist on array\\{mixed, 0, 0, 0, 0\\|1, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset 5 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset 6 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset 7 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset 8 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset 9 might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1\\|2, 9\\?\\: 1, 10\\?\\: 1, 11\\?\\: 1, \\.\\.\\.\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
@@ -437,29 +437,9 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'date\' does not exist on array\\{\\}\\.$#',
+    'message' => '#^Offset int\\<1, 12\\> might not exist on array\\{mixed, 0, 0, 0, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, 0\\|1\\|2, \\.\\.\\.\\}\\|non\\-empty\\-array\\{4\\?\\: 1\\|2, 5\\?\\: 1\\|2, 6\\?\\: 1\\|2, 7\\?\\: 1\\|2, 8\\?\\: 1\\|2, 9\\?\\: 1\\|2, 10\\?\\: 1\\|2, 11\\?\\: 1\\|2, \\.\\.\\.\\}\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/pat_ledger.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'provider_id\' does not exist on array\\{\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/pat_ledger.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'reason\' does not exist on array\\{\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/pat_ledger.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'name\' might not exist on array\\{name\\?\\: string, phone\\?\\: string, fax\\?\\: string, street\\?\\: string, city\\?\\: string, state\\?\\: string, postal_code\\?\\: string, country_code\\?\\: string, \\.\\.\\.\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/usergroup/facilities.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'username\' might not exist on array\\{password\\: \'NoLongerUsed\', username\\?\\: string, fname\\?\\: string, mname\\?\\: string, lname\\?\\: string, suffix\\?\\: string, email\\?\\: string, valedictory\\?\\: string, \\.\\.\\.\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/usergroup/usergroup_admin.php',
+    'path' => __DIR__ . '/../../interface/reports/ippf_daily.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Offset \'ALL\' might not exist on array\\{\\}\\|array\\{ALL\\: string\\}\\.$#',
@@ -502,12 +482,32 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/clinical_rules.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Offset \'desc\' might not exist on array\\{name\\?\\: string, mime\\: non\\-empty\\-list\\<string\\>, desc\\?\\: string\\|false, file\\: string, doc_id\\: non\\-empty\\-array\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'desc\' might not exist on array\\{name\\?\\: string, mime\\: non\\-empty\\-list\\<string\\>, desc\\?\\: string\\|false, file\\: string, doc_id\\?\\: non\\-empty\\-array\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Offset \'host\' might not exist on array\\{scheme\\: \'http\'\\|\'tcp\', host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Offset \'host\' might not exist on array\\{scheme\\: \'https\', host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'mime\' might not exist on array\\{name\\?\\: string, mime\\?\\: non\\-empty\\-list\\<string\\>\\|string, desc\\?\\: string\\|false, file\\: string, doc_id\\?\\: non\\-empty\\-array\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'name\' might not exist on array\\{name\\?\\: string, mime\\?\\: non\\-empty\\-list\\<string\\>\\|string, desc\\?\\: string\\|false, file\\: string, doc_id\\?\\: non\\-empty\\-array\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/direct_message_check.inc.php',
 ];
@@ -662,34 +662,19 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'code\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0, reason\\: mixed, code_type\\: mixed, code\\: mixed\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
+    'message' => '#^Offset \'code\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: 0\\|float, payments\\: 0, reason\\: mixed, code_type\\: mixed, code\\: mixed\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/portal_payment.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'code_type\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0, reason\\: mixed, code_type\\: mixed, code\\: mixed\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
+    'message' => '#^Offset \'code_type\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: 0\\|float, payments\\: 0, reason\\: mixed, code_type\\: mixed, code\\: mixed\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/portal_payment.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'reason\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0, reason\\: mixed, code_type\\: mixed, code\\: mixed\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
+    'message' => '#^Offset \'reason\' might not exist on array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: 0\\|float, payments\\: 0, reason\\: mixed, code_type\\: mixed, code\\: mixed\\}\\|array\\{encounter\\: mixed, date\\: mixed, last_level_closed\\: mixed, charges\\: float, payments\\: 0\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/portal_payment.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'date\' does not exist on array\\{\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/report/pat_ledger.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'provider_id\' does not exist on array\\{\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/report/pat_ledger.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Offset \'reason\' does not exist on array\\{\\}\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/report/pat_ledger.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Offset 1 might not exist on array\\{\\}\\|array\\{non\\-falsy\\-string, string, numeric\\-string\\}\\.$#',
@@ -702,7 +687,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/report/portal_custom_report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'data\' might not exist on array\\{\\}\\|array\\{data\\: non\\-empty\\-array, company\\?\\: array\\|false, object\\?\\: InsuranceCompany\\}\\.$#',
+    'message' => '#^Offset \'data\' might not exist on array\\{\\}\\|array\\{data\\: non\\-empty\\-array, company\\: array\\|false, object\\: InsuranceCompany\\}\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Billing/Claim.php',
 ];
@@ -722,7 +707,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Billing/EDI270.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'message\' might not exist on array\\{type\\?\\: string, benefit_type\\?\\: mixed, start_date\\: mixed, end_date\\: mixed, coverage_level\\?\\: mixed, coverage_type\\?\\: mixed, plan_type\\?\\: mixed, plan_description\\?\\: string, \\.\\.\\.\\}\\.$#',
+    'message' => '#^Offset \'message\' might not exist on array\\{start_date\\: mixed, end_date\\: mixed\\}\\|array\\{type\\: string, benefit_type\\: mixed, start_date\\: string, end_date\\: string, coverage_level\\: mixed, coverage_type\\: mixed, plan_type\\: mixed, plan_description\\: string, \\.\\.\\.\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Billing/EDI270.php',
 ];
@@ -732,12 +717,17 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Billing/EDI270.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'bal\' might not exist on array\\{chg\\: float\\|int, bal\\: float\\|int, code_type\\: mixed, code_value\\: mixed, modifier\\: mixed, code_text\\: mixed, dtl\\?\\: array\\<literal\\-string&non\\-falsy\\-string&numeric\\-string, array\\{chg\\: numeric\\-string\\}\\>\\}\\|array\\{chg\\: float\\|int, bal\\?\\: float\\|int\\}\\.$#',
+    'message' => '#^Offset \'count\' might not exist on array\\{start\\: mixed, count\\?\\: \\(float\\|int\\)\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../src/Billing/EdiHistory/X12File.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'bal\' might not exist on array\\{chg\\: float\\|int, bal\\: float\\|int, code_type\\: mixed, code_value\\: mixed, modifier\\: mixed, code_text\\: mixed, dtl\\?\\: non\\-empty\\-array\\<\'          1000\'\\|\'          1001\', array\\{chg\\: numeric\\-string\\}\\>\\}\\|array\\{chg\\: float\\|int, bal\\?\\: float\\|int\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Billing/InvoiceSummary.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset \'dtl\' might not exist on array\\{chg\\: float\\|int, bal\\: float\\|int, code_type\\: mixed, code_value\\: mixed, modifier\\: mixed, code_text\\: mixed, dtl\\?\\: array\\<literal\\-string&non\\-falsy\\-string&numeric\\-string, array\\{chg\\: numeric\\-string\\}\\>\\}\\|array\\{chg\\: float\\|int, bal\\: float\\|int\\}\\.$#',
+    'message' => '#^Offset \'dtl\' might not exist on array\\{chg\\: float\\|int, bal\\: float\\|int, code_type\\: mixed, code_value\\: mixed, modifier\\: mixed, code_text\\: mixed, dtl\\?\\: non\\-empty\\-array\\<\'          1000\'\\|\'          1001\', array\\{chg\\: numeric\\-string\\}\\>\\}\\|array\\{chg\\: float\\|int, bal\\: float\\|int\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Billing/InvoiceSummary.php',
 ];
@@ -795,6 +785,31 @@ $ignoreErrors[] = [
     'message' => '#^Offset \'streetAddress\' might not exist on array\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Isolated/USPS/USPSAddressVerifyV3Test.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'PATH_INFO\' does not exist on array\\{REQUEST_METHOD\\: \'GET\', HTTP_HOST\\: \'localhost\', DOCUMENT_ROOT\\: \'/var/www/html\', REQUEST_URI\\: \'/apis/dispatch\\.php\\?…\', QUERY_STRING\\: \'_REWRITE_COMMAND\\=…\', SCRIPT_NAME\\: \'/apis/dispatch\\.php\', SCRIPT_FILENAME\\: \'/var/www/html…\'\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Http/HttpRestRequestTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'PATH_INFO\' does not exist on array\\{REQUEST_METHOD\\: \'GET\', HTTP_HOST\\: \'localhost\', DOCUMENT_ROOT\\: \'/var/www/html\', REQUEST_URI\\: \'/dispatch\\.php\\?…\', QUERY_STRING\\: \'_REWRITE_COMMAND\\=…\', SCRIPT_NAME\\: \'/dispatch\\.php\'\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Http/HttpRestRequestTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'PATH_INFO\' does not exist on array\\{REQUEST_METHOD\\: \'GET\', HTTP_HOST\\: \'localhost\', DOCUMENT_ROOT\\: \'/var/www/html…\', REQUEST_URI\\: \'/apis/dispatch\\.php\\?…\', QUERY_STRING\\: \'_REWRITE_COMMAND…\', SCRIPT_NAME\\: \'/apis/dispatch\\.php\', SCRIPT_FILENAME\\: \'/var/www/html…\'\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Http/HttpRestRequestTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'PATH_INFO\' does not exist on array\\{REQUEST_METHOD\\: \'POST\', HTTP_HOST\\: \'localhost\', DOCUMENT_ROOT\\: \'/var/www/html…\', REQUEST_URI\\: \'/apis/dispatch\\.php\\?…\', QUERY_STRING\\: \'_REWRITE_COMMAND…\', SCRIPT_NAME\\: \'/apis/dispatch\\.php\', SCRIPT_FILENAME\\: \'/var/www/html…\'\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Http/HttpRestRequestTest.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Offset \'PHP_SELF\' does not exist on array\\{REQUEST_METHOD\\: \'GET\', HTTP_HOST\\: \'localhost\', DOCUMENT_ROOT\\: \'/var/www/html…\', REQUEST_URI\\: \'/apis/dispatch\\.php\\?…\', QUERY_STRING\\: \'_REWRITE_COMMAND…\', SCRIPT_NAME\\: \'/apis/dispatch\\.php\', SCRIPT_FILENAME\\: \'/var/www/html…\'\\}\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Http/HttpRestRequestTest.php',
 ];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -1014,22 +1014,12 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/note/print.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
     'path' => __DIR__ . '/../../interface/forms/note/save.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../interface/forms/note/save.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/forms/note/view.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
@@ -1130,11 +1120,6 @@ $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../interface/forms/requisition/barcode.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/requisition/new.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -1058,7 +1058,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/prior_auth/C_FormPriorAuth.class.php',
 ];
 $ignoreErrors[] = [
@@ -1153,7 +1153,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/ros/C_FormROS.class.php',
 ];
 $ignoreErrors[] = [
@@ -1183,7 +1183,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/soap/C_FormSOAP.class.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -1158,11 +1158,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/ros/view.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 8,
     'path' => __DIR__ . '/../../interface/forms/sdoh/new.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -767,11 +767,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/clinic_note/new.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/clinic_note/view.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 8,
     'path' => __DIR__ . '/../../interface/forms/clinic_note/view.php',
@@ -808,7 +803,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/dictation/save.php',
 ];
 $ignoreErrors[] = [
@@ -938,7 +933,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/gad7/save.php',
 ];
 $ignoreErrors[] = [
@@ -1038,17 +1033,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/painmap/view.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/phq9/common.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/phq9/save.php',
 ];
 $ignoreErrors[] = [
@@ -1075,11 +1065,6 @@ $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 6,
     'path' => __DIR__ . '/../../interface/forms/prior_auth/save.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/prior_auth/view.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
@@ -1153,7 +1138,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/reviewofs/save.php',
 ];
 $ignoreErrors[] = [
@@ -1188,7 +1173,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 7,
+    'count' => 4,
     'path' => __DIR__ . '/../../interface/forms/sdoh/save.php',
 ];
 $ignoreErrors[] = [
@@ -1200,11 +1185,6 @@ $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../interface/forms/soap/C_FormSOAP.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/soap/view.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -1757,11 +1757,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/htmlspecialchars.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function getLabProviders\\(\\) should return array\\|null but returns array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/lab.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function getFacilities\\(\\) should return array\\|int but returns mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../library/patient.inc.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -8537,16 +8537,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/EncounterService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\EncounterService\\:\\:getSensitivity\\(\\) should return string but returns array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/EncounterService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\EncounterService\\:\\:getSensitivity\\(\\) should return string but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/EncounterService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\EncounterService\\:\\:updateEncounter\\(\\) should return OpenEMR\\\\Validators\\\\ProcessingResult but returns string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/EncounterService.php',

--- a/.phpstan/baseline/return.unusedType.php
+++ b/.phpstan/baseline/return.unusedType.php
@@ -82,11 +82,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/lab.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function getLabProviders\\(\\) never returns null so it can be removed from the return type\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/lab.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function getLabconfig\\(\\) never returns null so it can be removed from the return type\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/lab.inc.php',

--- a/interface/forms/LBF/new.php
+++ b/interface/forms/LBF/new.php
@@ -18,6 +18,7 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Forms\CoreFormToPortalUtility;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -140,6 +141,10 @@ if ($patientPortalSession && !empty($formid)) {
 
 $visitid = (int)(empty($_GET['visitid']) ? $encounter : $_GET['visitid']);
 
+if ($is_core) {
+    EncounterFormAccess::assertFormBelongsToSessionPatient($formid, is_string($formname) ? $formname : '');
+}
+
 // If necessary get the encounter from the forms table entry for this form.
 if ($formid && !$visitid && $is_core) {
     $frow = sqlQuery(
@@ -148,9 +153,6 @@ if ($formid && !$visitid && $is_core) {
         [$formid, $formname]
     );
     $visitid = (int)$frow['encounter'];
-    if ($frow['pid'] != $pid) {
-        die("Internal error: patient ID mismatch!");
-    }
 }
 
 if (!$from_trend_form && !$visitid && !$from_lbf_edit && $is_core) {

--- a/interface/forms/aftercare_plan/save.php
+++ b/interface/forms/aftercare_plan/save.php
@@ -15,6 +15,7 @@
 require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -38,6 +39,7 @@ if (! $encounter) { // comes from globals.php
 }
 
 $id = (int) ($_GET['id'] ?? '');
+EncounterFormAccess::assertFormBelongsToSessionPatient($id, 'aftercare_plan');
 
 $sets = "pid = ?,
     groupname = ?,

--- a/interface/forms/clinic_note/view.php
+++ b/interface/forms/clinic_note/view.php
@@ -17,6 +17,7 @@
 require_once("../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -40,6 +41,7 @@ if (! $encounter) { // comes from globals.php
 }
 
 $formid = $_GET['id'];
+EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'clinic_note');
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 // If Save was clicked, save the info.

--- a/interface/forms/clinic_note/view.php
+++ b/interface/forms/clinic_note/view.php
@@ -40,8 +40,11 @@ if (! $encounter) { // comes from globals.php
     die("Internal error: we do not seem to be in an encounter!");
 }
 
-$formid = $_GET['id'];
-EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'clinic_note');
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+
+$formid = $formId;
+EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'clinic_note');
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 // If Save was clicked, save the info.

--- a/interface/forms/clinical_instructions/save.php
+++ b/interface/forms/clinical_instructions/save.php
@@ -15,6 +15,7 @@
 require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -38,6 +39,7 @@ if (!$encounter) { // comes from globals.php
 }
 
 $id = (int) ($_GET['id'] ?? '');
+EncounterFormAccess::assertFormBelongsToSessionPatient($id, 'clinical_instructions');
 $instruction = $_POST["instruction"];
 
 if ($id && $id != 0) {

--- a/interface/forms/dictation/save.php
+++ b/interface/forms/dictation/save.php
@@ -41,6 +41,7 @@ if ($_GET["mode"] == "new") {
     $newid = formSubmit("form_dictation", $_POST, $formId, $userauthorized);
     addForm($encounter, "Speech Dictation", $newid, "dictation", $pid, $userauthorized);
 } elseif ($_GET["mode"] == "update") {
+    EncounterFormAccess::requirePositiveFormId($formId, 'dictation');
     sqlStatement("update form_dictation set pid = ?,groupname=?,user=?,authorized=?,activity=1, date = NOW(), dictation=?, additional_notes=? where id=?", [$session->get('pid'),$session->get('authProvider'),$session->get('authUser'),$userauthorized,$_POST["dictation"],$_POST["additional_notes"],$formId]);
 }
 

--- a/interface/forms/dictation/save.php
+++ b/interface/forms/dictation/save.php
@@ -32,13 +32,16 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 
-EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'dictation');
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+
+EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'dictation');
 
 if ($_GET["mode"] == "new") {
-    $newid = formSubmit("form_dictation", $_POST, ($_GET["id"] ?? null), $userauthorized);
+    $newid = formSubmit("form_dictation", $_POST, $formId, $userauthorized);
     addForm($encounter, "Speech Dictation", $newid, "dictation", $pid, $userauthorized);
 } elseif ($_GET["mode"] == "update") {
-    sqlStatement("update form_dictation set pid = ?,groupname=?,user=?,authorized=?,activity=1, date = NOW(), dictation=?, additional_notes=? where id=?", [$session->get('pid'),$session->get('authProvider'),$session->get('authUser'),$userauthorized,$_POST["dictation"],$_POST["additional_notes"],$_GET["id"]]);
+    sqlStatement("update form_dictation set pid = ?,groupname=?,user=?,authorized=?,activity=1, date = NOW(), dictation=?, additional_notes=? where id=?", [$session->get('pid'),$session->get('authProvider'),$session->get('authUser'),$userauthorized,$_POST["dictation"],$_POST["additional_notes"],$formId]);
 }
 
 formHeader("Redirecting....");

--- a/interface/forms/dictation/save.php
+++ b/interface/forms/dictation/save.php
@@ -13,6 +13,7 @@
 require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -30,6 +31,8 @@ require_once("$srcdir/forms.inc.php");
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+
+EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'dictation');
 
 if ($_GET["mode"] == "new") {
     $newid = formSubmit("form_dictation", $_POST, ($_GET["id"] ?? null), $userauthorized);

--- a/interface/forms/eye_mag/new.php
+++ b/interface/forms/eye_mag/new.php
@@ -89,9 +89,9 @@ if (!empty($erow['form_id']) && ($erow['form_id'] > '0')) {
             "user, groupname, authorized, formdir) values (NOW(),?,?,?,?,?,?,?,?)";
     $answer = sqlInsert($sql, [$encounter,$form_name,$newid,$pid,$user,$group,$providerid,$form_folder]);
     // Keep the session encounter in sync with the value just written to the
-    // forms table.  view.php reads $encounter exclusively from the session
-    // (via globals.php) and compares it against the stored encounter for IDOR
-    // protection; if they diverge the guard fires a 404 "Form not found".
+    // forms table.  view.php reads $encounter from the session (via
+    // globals.php) and compares it to the stored encounter; a mismatch
+    // returns 404 "Form not found".
     SessionUtil::setSession('encounter', $encounter);
 }
 

--- a/interface/forms/eye_mag/view.php
+++ b/interface/forms/eye_mag/view.php
@@ -37,8 +37,8 @@ $form_id     = $id;
 $action      = $_REQUEST['action'] ?? null;
 $finalize    = $_REQUEST['finalize'] ?? null;
 $display     = $_REQUEST['display'] ?? null;
-// $pid and $encounter are set by globals.php from the session.
-// Use them instead of request parameters to prevent IDOR.
+// $pid and $encounter are set by globals.php from the session; use them
+// instead of request parameters.
 $pid = (int) $pid; // @phpstan-ignore variable.undefined (set by globals.php)
 $encounter = (int) $encounter; // @phpstan-ignore variable.undefined (set by globals.php)
 $refresh     = $_REQUEST['refresh'] ?? null;

--- a/interface/forms/gad7/save.php
+++ b/interface/forms/gad7/save.php
@@ -14,6 +14,7 @@
 require_once("../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionUtil;
@@ -32,6 +33,8 @@ require_once("$srcdir/forms.inc.php");
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+
+EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'gad7');
 
 if (!$encounter) {
     $encounter = date("Ymd");

--- a/interface/forms/gad7/save.php
+++ b/interface/forms/gad7/save.php
@@ -47,6 +47,7 @@ if ($_GET["mode"] == "new") {
     $newid = formSubmit("form_gad7", $_POST, $formId, $userauthorized);
     addForm($encounter, "GAD-7 Form", $newid, "gad7", $pid, $userauthorized);
 } elseif ($_GET["mode"] == "update") {
+    EncounterFormAccess::requirePositiveFormId($formId, 'gad7');
     $pid = $session->get('pid');
     $authProvider = $session->get('authProvider');
     $authUser = $session->get('authUser');

--- a/interface/forms/gad7/save.php
+++ b/interface/forms/gad7/save.php
@@ -34,14 +34,17 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 
-EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'gad7');
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+
+EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'gad7');
 
 if (!$encounter) {
     $encounter = date("Ymd");
 }
 
 if ($_GET["mode"] == "new") {
-    $newid = formSubmit("form_gad7", $_POST, $_GET["id"], $userauthorized);
+    $newid = formSubmit("form_gad7", $_POST, $formId, $userauthorized);
     addForm($encounter, "GAD-7 Form", $newid, "gad7", $pid, $userauthorized);
 } elseif ($_GET["mode"] == "update") {
     $pid = $session->get('pid');
@@ -75,7 +78,7 @@ if ($_GET["mode"] == "new") {
             $_POST["irritable_score"],
             $_POST["fear_score"],
             $_POST["difficulty"],
-            $_GET["id"]
+            $formId
         ]
     );
 }

--- a/interface/forms/misc_billing_options/save.php
+++ b/interface/forms/misc_billing_options/save.php
@@ -20,6 +20,7 @@ require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\BC\Utilities;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionUtil;
@@ -65,6 +66,7 @@ if (Utilities::isDateEmpty($_POST["hospitalization_date_from"])) {
 }
 
 $id = (int)($_GET['id'] ?? '');
+EncounterFormAccess::assertFormBelongsToSessionPatient($id, 'misc_billing_options');
 
 $sets = "pid = ?,
     groupname = ?,

--- a/interface/forms/note/print.php
+++ b/interface/forms/note/print.php
@@ -15,6 +15,7 @@
 
 require_once(__DIR__ . "/../../globals.php");
 
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -32,10 +33,14 @@ $provider_results = sqlQuery("select fname, lname from users where username=?", 
 /* name of this form */
 $form_name = "note";
 
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+EncounterFormAccess::assertFormBelongsToSessionPatient($formId, $form_name);
+
 // get the record from the database
 $obj = [];
-if ($_GET['id'] != "") {
-    $obj = formFetch("form_" . $form_name, $_GET["id"]);
+if ($formId > 0) {
+    $obj = formFetch("form_" . $form_name, $formId);
 }
 
 ?>

--- a/interface/forms/note/save.php
+++ b/interface/forms/note/save.php
@@ -16,6 +16,7 @@
 require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -38,13 +39,17 @@ CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
  */
 $table_name = "form_note";
 
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'note');
+
 $_POST['date_of_signature'] = DateToYYYYMMDD($_POST['date_of_signature']);
 
 if ($_GET["mode"] == "new") {
-    $newid = formSubmit($table_name, $_POST, $_GET["id"] ?? '', $userauthorized);
+    $newid = formSubmit($table_name, $_POST, $formId, $userauthorized);
     addForm($encounter, "Work/School Note", $newid, "note", $pid, $userauthorized);
 } elseif ($_GET["mode"] == "update") {
-    $success = formUpdate($table_name, $_POST, $_GET["id"], $userauthorized);
+    $success = formUpdate($table_name, $_POST, $formId, $userauthorized);
 }
 
 formHeader("Redirecting....");

--- a/interface/forms/note/view.php
+++ b/interface/forms/note/view.php
@@ -17,6 +17,7 @@
 require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -36,10 +37,14 @@ $provider_results = sqlQuery("select fname, lname from users where username=?", 
 /* name of this form */
 $form_name = "note";
 
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+EncounterFormAccess::assertFormBelongsToSessionPatient($formId, $form_name);
+
 // get the record from the database
 $obj = [];
-if ($_GET['id'] != "") {
-    $obj = formFetch("form_" . $form_name, $_GET["id"]);
+if ($formId > 0) {
+    $obj = formFetch("form_" . $form_name, $formId);
 }
 
 ?>
@@ -62,7 +67,7 @@ $(function () {
         });
 
 function PrintForm() {
-    newwin = window.open(<?php echo js_escape($rootdir . "/forms/" . $form_name . "/print.php?id=" . urlencode((string) $_GET["id"])); ?>,"mywin");
+    newwin = window.open(<?php echo js_escape($rootdir . "/forms/" . $form_name . "/print.php?id=" . urlencode((string) $formId)); ?>,"mywin");
 }
 
 </script>
@@ -70,7 +75,7 @@ function PrintForm() {
 </head>
 <body class="body_top">
 
-<form method=post action="<?php echo $rootdir . "/forms/" . $form_name . "/save.php?mode=update&id=" . attr_url($_GET["id"]);?>" name="my_form" id="my_form">
+<form method=post action="<?php echo $rootdir . "/forms/" . $form_name . "/save.php?mode=update&id=" . attr_url((string) $formId);?>" name="my_form" id="my_form">
 <input type="hidden" name="csrf_token_form" value="<?php echo CsrfUtils::collectCsrfToken(session: $session); ?>" />
 
 <span class="title"><?php echo xlt('Work/School Note'); ?></span><br /><br />

--- a/interface/forms/painmap/C_FormPainMap.class.php
+++ b/interface/forms/painmap/C_FormPainMap.class.php
@@ -49,7 +49,7 @@ class C_FormPainMap extends C_AbstractClickmap
      * @brief Overrides parent to gate the form load on session-patient ownership
      *  before delegating to parent::view_action().
      */
-    function view_action($form_id)
+    public function view_action($form_id): string
     {
         $formId = is_numeric($form_id) ? (int) $form_id : 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, self::$FORM_CODE);

--- a/interface/forms/painmap/C_FormPainMap.class.php
+++ b/interface/forms/painmap/C_FormPainMap.class.php
@@ -11,6 +11,7 @@
 
 /* Include the class we're extending. */
 
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Core\OEGlobalsBag;
 
 require_once(OEGlobalsBag::getInstance()->getProjectDir() . "/interface/clickmap/C_AbstractClickmap.php");
@@ -42,6 +43,18 @@ class C_FormPainMap extends C_AbstractClickmap
     public function __construct()
     {
         parent::__construct();
+    }
+
+    /**
+     * @brief Overrides parent to gate the form load on session-patient ownership
+     *  before delegating to parent::view_action().
+     */
+    function view_action($form_id)
+    {
+        $formId = is_numeric($form_id) ? (int) $form_id : 0;
+        EncounterFormAccess::assertFormBelongsToSessionPatient($formId, self::$FORM_CODE);
+
+        return parent::view_action($form_id);
     }
 
     /**

--- a/interface/forms/painmap/C_FormPainMap.class.php
+++ b/interface/forms/painmap/C_FormPainMap.class.php
@@ -54,7 +54,7 @@ class C_FormPainMap extends C_AbstractClickmap
         $formId = is_numeric($form_id) ? (int) $form_id : 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, self::$FORM_CODE);
 
-        return parent::view_action($form_id);
+        return parent::view_action((string) $formId);
     }
 
     /**

--- a/interface/forms/painmap/view.php
+++ b/interface/forms/painmap/view.php
@@ -11,6 +11,7 @@
 
 /* include globals.php, required. */
 
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Core\OEGlobalsBag;
 
 require_once(__DIR__ . '/../../globals.php');
@@ -20,6 +21,8 @@ require_once(OEGlobalsBag::getInstance()->getSrcDir() . '/api.inc.php');
 
 /* include our smarty derived controller class. */
 require('C_FormPainMap.class.php');
+
+EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'painmap');
 
 /* Create a form object. */
 $c = new C_FormPainMap();

--- a/interface/forms/painmap/view.php
+++ b/interface/forms/painmap/view.php
@@ -22,10 +22,13 @@ require_once(OEGlobalsBag::getInstance()->getSrcDir() . '/api.inc.php');
 /* include our smarty derived controller class. */
 require('C_FormPainMap.class.php');
 
-EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'painmap');
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+
+EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'painmap');
 
 /* Create a form object. */
 $c = new C_FormPainMap();
 
 /* Render a 'view/edit form' page. */
-echo $c->view_action($_GET['id']);
+echo $c->view_action($formId);

--- a/interface/forms/painmap/view.php
+++ b/interface/forms/painmap/view.php
@@ -11,7 +11,6 @@
 
 /* include globals.php, required. */
 
-use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Core\OEGlobalsBag;
 
 require_once(__DIR__ . '/../../globals.php');
@@ -22,13 +21,8 @@ require_once(OEGlobalsBag::getInstance()->getSrcDir() . '/api.inc.php');
 /* include our smarty derived controller class. */
 require('C_FormPainMap.class.php');
 
-$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
-$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
-
-EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'painmap');
-
 /* Create a form object. */
 $c = new C_FormPainMap();
 
 /* Render a 'view/edit form' page. */
-echo $c->view_action($formId);
+echo $c->view_action(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT));

--- a/interface/forms/painmap/view.php
+++ b/interface/forms/painmap/view.php
@@ -25,4 +25,4 @@ require('C_FormPainMap.class.php');
 $c = new C_FormPainMap();
 
 /* Render a 'view/edit form' page. */
-echo $c->view_action(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT));
+echo $c->view_action((string) filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT));

--- a/interface/forms/phq9/save.php
+++ b/interface/forms/phq9/save.php
@@ -14,6 +14,7 @@
 require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -31,6 +32,8 @@ require_once("$srcdir/forms.inc.php");
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+
+EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'phq9');
 
 if (!$encounter) {
     $encounter = date("Ymd");

--- a/interface/forms/phq9/save.php
+++ b/interface/forms/phq9/save.php
@@ -46,6 +46,7 @@ if ($_GET["mode"] == "new") {
     $newid = formSubmit("form_phq9", $_POST, $formId, $userauthorized);
     addForm($encounter, "PHQ-9 Form", $newid, "phq9", $pid, $userauthorized);
 } elseif ($_GET["mode"] == "update") {
+    EncounterFormAccess::requirePositiveFormId($formId, 'phq9');
     sqlStatement(
         "update form_phq9 set pid = ?,
             groupname = ?,

--- a/interface/forms/phq9/save.php
+++ b/interface/forms/phq9/save.php
@@ -33,14 +33,17 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 
-EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'phq9');
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+
+EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'phq9');
 
 if (!$encounter) {
     $encounter = date("Ymd");
 }
 
 if ($_GET["mode"] == "new") {
-    $newid = formSubmit("form_phq9", $_POST, $_GET["id"], $userauthorized);
+    $newid = formSubmit("form_phq9", $_POST, $formId, $userauthorized);
     addForm($encounter, "PHQ-9 Form", $newid, "phq9", $pid, $userauthorized);
 } elseif ($_GET["mode"] == "update") {
     sqlStatement(
@@ -75,7 +78,7 @@ if ($_GET["mode"] == "new") {
             $_POST["psychomotor_score"],
             $_POST["suicide_score"],
             $_POST["difficulty"],
-            $_GET["id"]
+            $formId
         ]
     );
 }

--- a/interface/forms/physical_exam/new.php
+++ b/interface/forms/physical_exam/new.php
@@ -17,6 +17,7 @@ require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -112,6 +113,7 @@ $showTreatmentLine = function (string $line_id, string $description, array $line
 };
 
 $formid = $request->query->getString('id');
+EncounterFormAccess::assertFormBelongsToSessionPatient((int) $formid, 'physical_exam');
 
 // If Save was clicked, save the info.
 //

--- a/interface/forms/prior_auth/C_FormPriorAuth.class.php
+++ b/interface/forms/prior_auth/C_FormPriorAuth.class.php
@@ -43,7 +43,7 @@ class C_FormPriorAuth extends Controller
         return $this->fetch($this->template_dir . $this->template_mod . "_new.html");
     }
 
-    function view_action($form_id)
+    public function view_action($form_id): string
     {
         $formId = is_numeric($form_id) ? (int) $form_id : 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'prior_auth');
@@ -61,7 +61,11 @@ class C_FormPriorAuth extends Controller
             return;
         }
 
-        $this->form = new FormPriorAuth($_POST['id']);
+        $postId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
+        $formId = is_int($postId) && $postId >= 0 ? $postId : 0;
+        EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'prior_auth');
+
+        $this->form = $formId > 0 ? new FormPriorAuth($formId) : new FormPriorAuth();
         parent::populate_object($this->form);
 
 
@@ -70,7 +74,7 @@ class C_FormPriorAuth extends Controller
             OEGlobalsBag::getInstance()->set('encounter', date("Ymd"));
         }
 
-        if (empty($_POST['id'])) {
+        if ($formId === 0) {
             $session = SessionWrapperFactory::getInstance()->getActiveSession();
             addForm(OEGlobalsBag::getInstance()->get('encounter'), "Prior Authorization", $this->form->id, "prior_auth", OEGlobalsBag::getInstance()->get('pid'), $session->get('userauthorized'));
             $_POST['process'] = "";

--- a/interface/forms/prior_auth/C_FormPriorAuth.class.php
+++ b/interface/forms/prior_auth/C_FormPriorAuth.class.php
@@ -72,7 +72,7 @@ class C_FormPriorAuth extends Controller
 
         $this->form = $formId > 0 ? new FormPriorAuth($formId) : new FormPriorAuth();
         parent::populate_object($this->form);
-
+        EncounterFormAccess::applySessionPidToForm($this->form);
 
         $this->form->persist();
         if (OEGlobalsBag::getInstance()->get('encounter') == "") {

--- a/interface/forms/prior_auth/C_FormPriorAuth.class.php
+++ b/interface/forms/prior_auth/C_FormPriorAuth.class.php
@@ -14,6 +14,7 @@ require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getProjectDir() . "/libr
 require_once("FormPriorAuth.class.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
@@ -44,7 +45,10 @@ class C_FormPriorAuth extends Controller
 
     function view_action($form_id)
     {
-        $prior_auth = is_numeric($form_id) ? new FormPriorAuth($form_id) : new FormPriorAuth();
+        $formId = is_numeric($form_id) ? (int) $form_id : 0;
+        EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'prior_auth');
+
+        $prior_auth = is_numeric($form_id) ? new FormPriorAuth($formId) : new FormPriorAuth();
 
         $this->assign("VIEW", true);
         $this->assign("prior_auth", $prior_auth);

--- a/interface/forms/prior_auth/C_FormPriorAuth.class.php
+++ b/interface/forms/prior_auth/C_FormPriorAuth.class.php
@@ -13,13 +13,11 @@
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getProjectDir() . "/library/forms.inc.php");
 require_once("FormPriorAuth.class.php");
 
-use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
-use Symfony\Component\HttpFoundation\Response;
 
 class C_FormPriorAuth extends Controller
 {
@@ -63,11 +61,9 @@ class C_FormPriorAuth extends Controller
             return;
         }
 
+        // Empty-string POST id is the new-form case; missing/invalid → 0.
         $postId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
-        if ($postId === false) {
-            AccessDeniedHelper::deny('Invalid prior_auth form id', 'security-access', Response::HTTP_NOT_FOUND);
-        }
-        $formId = $postId ?? 0;
+        $formId = is_int($postId) ? $postId : 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'prior_auth');
 
         $this->form = $formId > 0 ? new FormPriorAuth($formId) : new FormPriorAuth();

--- a/interface/forms/prior_auth/C_FormPriorAuth.class.php
+++ b/interface/forms/prior_auth/C_FormPriorAuth.class.php
@@ -13,11 +13,13 @@
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getProjectDir() . "/library/forms.inc.php");
 require_once("FormPriorAuth.class.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
+use Symfony\Component\HttpFoundation\Response;
 
 class C_FormPriorAuth extends Controller
 {
@@ -43,12 +45,12 @@ class C_FormPriorAuth extends Controller
         return $this->fetch($this->template_dir . $this->template_mod . "_new.html");
     }
 
-    public function view_action($form_id): string
+    public function view_action(int|false|null $form_id): string
     {
-        $formId = is_numeric($form_id) ? (int) $form_id : 0;
+        $formId = is_int($form_id) && $form_id >= 0 ? $form_id : 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'prior_auth');
 
-        $prior_auth = is_numeric($form_id) ? new FormPriorAuth($formId) : new FormPriorAuth();
+        $prior_auth = $formId > 0 ? new FormPriorAuth($formId) : new FormPriorAuth();
 
         $this->assign("VIEW", true);
         $this->assign("prior_auth", $prior_auth);
@@ -61,8 +63,11 @@ class C_FormPriorAuth extends Controller
             return;
         }
 
-        $postId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
-        $formId = is_int($postId) && $postId >= 0 ? $postId : 0;
+        $postId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        if ($postId === false) {
+            AccessDeniedHelper::deny('Invalid prior_auth form id', 'security-access', Response::HTTP_NOT_FOUND);
+        }
+        $formId = $postId ?? 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'prior_auth');
 
         $this->form = $formId > 0 ? new FormPriorAuth($formId) : new FormPriorAuth();

--- a/interface/forms/prior_auth/view.php
+++ b/interface/forms/prior_auth/view.php
@@ -22,7 +22,10 @@ require_once("$srcdir/api.inc.php");
 
 require("C_FormPriorAuth.class.php");
 
-EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'prior_auth');
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+
+EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'prior_auth');
 
 $c = new C_FormPriorAuth();
-echo $c->view_action($_GET['id']);
+echo $c->view_action($formId);

--- a/interface/forms/prior_auth/view.php
+++ b/interface/forms/prior_auth/view.php
@@ -12,7 +12,6 @@
 
 require_once(__DIR__ . "/../../globals.php");
 
-use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Core\OEGlobalsBag;
 
 // Hoist legacy `globals.php` locals so PHPStan can see them (#11792 Phase 5).
@@ -22,10 +21,5 @@ require_once("$srcdir/api.inc.php");
 
 require("C_FormPriorAuth.class.php");
 
-$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
-$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
-
-EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'prior_auth');
-
 $c = new C_FormPriorAuth();
-echo $c->view_action($formId);
+echo $c->view_action(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT));

--- a/interface/forms/prior_auth/view.php
+++ b/interface/forms/prior_auth/view.php
@@ -12,6 +12,7 @@
 
 require_once(__DIR__ . "/../../globals.php");
 
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Core\OEGlobalsBag;
 
 // Hoist legacy `globals.php` locals so PHPStan can see them (#11792 Phase 5).
@@ -20,6 +21,8 @@ $srcdir = OEGlobalsBag::getInstance()->getSrcDir();
 require_once("$srcdir/api.inc.php");
 
 require("C_FormPriorAuth.class.php");
+
+EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'prior_auth');
 
 $c = new C_FormPriorAuth();
 echo $c->view_action($_GET['id']);

--- a/interface/forms/procedure_order/common.php
+++ b/interface/forms/procedure_order/common.php
@@ -22,6 +22,7 @@
 require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Forms\ReasonStatusCodes;
 use OpenEMR\Common\Orders\Hl7OrderGenerationException;
@@ -166,6 +167,9 @@ $reqStr = "";
 // If Save or Transmit was clicked, save the info.
 if (($_POST['bn_save'] ?? null) || !empty($_POST['bn_xmit']) || !empty($_POST['bn_save_exit'])) {
     CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+    if ($formid) {
+        EncounterFormAccess::assertFormBelongsToSessionPatient($formid, 'procedure_order');
+    }
     $ppid = (int)($_POST['form_lab_id'] ?? null);
     if (get_lab_name($ppid) === 'labcorp') {
         if (!empty($_POST['form_account_facility'])) {

--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -15,6 +15,7 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Forms\CoreFormToPortalUtility;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -129,6 +130,10 @@ try {
             'questionnaire_assessments',
             $nonNegativeInt($session->get('pid', 0)) ?? 0
         );
+
+        if (!$isPortal) {
+            EncounterFormAccess::assertFormBelongsToSessionPatient($formid, 'questionnaire_assessments');
+        }
 
         $questionnaireJson = is_string($form['questionnaire'] ?? null)
             ? $form['questionnaire']

--- a/interface/forms/requisition/new.php
+++ b/interface/forms/requisition/new.php
@@ -14,6 +14,7 @@
 
 require_once(__DIR__ . "/../../globals.php");
 
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -32,7 +33,9 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 $returnurl = 'encounter_top.php';
 
-$formid = (int) ($_GET['id'] ?? 0);
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formid = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+EncounterFormAccess::assertFormBelongsToSessionPatient($formid, 'requisition');
 $obj = $formid ? formFetch("form_requisition", $formid) : [];
 
 global $pid ;

--- a/interface/forms/reviewofs/save.php
+++ b/interface/forms/reviewofs/save.php
@@ -16,6 +16,7 @@
 require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -33,6 +34,8 @@ require_once("$srcdir/forms.inc.php");
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+
+EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'reviewofs');
 
 if ($_GET["mode"] == "new") {
     $newid = formSubmit("form_reviewofs", $_POST, ($_GET["id"] ?? ''), $userauthorized);

--- a/interface/forms/reviewofs/save.php
+++ b/interface/forms/reviewofs/save.php
@@ -44,6 +44,7 @@ if ($_GET["mode"] == "new") {
     $newid = formSubmit("form_reviewofs", $_POST, $formId, $userauthorized);
     addForm($encounter, "Review of Systems Checks", $newid, "reviewofs", $pid, $userauthorized);
 } elseif ($_GET["mode"] == "update") {
+    EncounterFormAccess::requirePositiveFormId($formId, 'reviewofs');
     sqlStatement(
         "UPDATE form_reviewofs set pid = ?,
             groupname=?,

--- a/interface/forms/reviewofs/save.php
+++ b/interface/forms/reviewofs/save.php
@@ -35,10 +35,13 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 
-EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'reviewofs');
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+
+EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'reviewofs');
 
 if ($_GET["mode"] == "new") {
-    $newid = formSubmit("form_reviewofs", $_POST, ($_GET["id"] ?? ''), $userauthorized);
+    $newid = formSubmit("form_reviewofs", $_POST, $formId, $userauthorized);
     addForm($encounter, "Review of Systems Checks", $newid, "reviewofs", $pid, $userauthorized);
 } elseif ($_GET["mode"] == "update") {
     sqlStatement(
@@ -269,7 +272,7 @@ if ($_GET["mode"] == "new") {
             ($_POST["cushing_syndrom"] ?? null),
             ($_POST["addison_syndrom"] ?? null),
             ($_POST["additional_notes"] ?? null),
-            $_GET["id"]
+            $formId
         ]
     );
 }

--- a/interface/forms/ros/C_FormROS.class.php
+++ b/interface/forms/ros/C_FormROS.class.php
@@ -50,9 +50,10 @@ class C_FormROS extends Controller
 
     function view_action($form_id)
     {
-        EncounterFormAccess::assertFormBelongsToSessionPatient(is_numeric($form_id) ? (int) $form_id : 0, 'ros');
+        $formId = is_numeric($form_id) ? (int) $form_id : 0;
+        EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'ros');
 
-        $ros = is_numeric($form_id) ? new FormROS($form_id) : new FormROS();
+        $ros = is_numeric($form_id) ? new FormROS($formId) : new FormROS();
 
         $this->assign("form", $ros);
         return $this->fetch($this->template_dir . $this->template_mod . "_new.html");

--- a/interface/forms/ros/C_FormROS.class.php
+++ b/interface/forms/ros/C_FormROS.class.php
@@ -77,6 +77,7 @@ class C_FormROS extends Controller
         $this->form = $formId > 0 ? new FormROS($formId) : new FormROS();
 
         parent::populate_object($this->form);
+        EncounterFormAccess::applySessionPidToForm($this->form);
         $this->form->persist();
 
         if (OEGlobalsBag::getInstance()->get('encounter') == "") {

--- a/interface/forms/ros/C_FormROS.class.php
+++ b/interface/forms/ros/C_FormROS.class.php
@@ -48,7 +48,7 @@ class C_FormROS extends Controller
         return $this->fetch($this->template_dir . $this->template_mod . "_new.html");
     }
 
-    function view_action($form_id)
+    public function view_action($form_id): string
     {
         $formId = is_numeric($form_id) ? (int) $form_id : 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'ros');
@@ -65,7 +65,11 @@ class C_FormROS extends Controller
             return;
         }
 
-        $this->form = new FormROS($_POST['id']);
+        $postId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
+        $formId = is_int($postId) && $postId >= 0 ? $postId : 0;
+        EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'ros');
+
+        $this->form = $formId > 0 ? new FormROS($formId) : new FormROS();
 
         parent::populate_object($this->form);
         $this->form->persist();
@@ -74,7 +78,7 @@ class C_FormROS extends Controller
             OEGlobalsBag::getInstance()->set('encounter', date("Ymd"));
         }
 
-        if (empty($_POST['id'])) {
+        if ($formId === 0) {
             $session = SessionWrapperFactory::getInstance()->getActiveSession();
             addForm(OEGlobalsBag::getInstance()->get('encounter'), "Review Of Systems", $this->form->id, "ros", OEGlobalsBag::getInstance()->get('pid'), $session->get('userauthorized'));
             $_POST['process'] = "";

--- a/interface/forms/ros/C_FormROS.class.php
+++ b/interface/forms/ros/C_FormROS.class.php
@@ -18,11 +18,13 @@ if (!defined('OPENEMR_GLOBALS_LOADED')) {
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getProjectDir() . "/library/forms.inc.php");
 require_once("FormROS.class.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
+use Symfony\Component\HttpFoundation\Response;
 
 class C_FormROS extends Controller
 {
@@ -48,12 +50,12 @@ class C_FormROS extends Controller
         return $this->fetch($this->template_dir . $this->template_mod . "_new.html");
     }
 
-    public function view_action($form_id): string
+    public function view_action(int|false|null $form_id): string
     {
-        $formId = is_numeric($form_id) ? (int) $form_id : 0;
+        $formId = is_int($form_id) && $form_id >= 0 ? $form_id : 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'ros');
 
-        $ros = is_numeric($form_id) ? new FormROS($formId) : new FormROS();
+        $ros = $formId > 0 ? new FormROS($formId) : new FormROS();
 
         $this->assign("form", $ros);
         return $this->fetch($this->template_dir . $this->template_mod . "_new.html");
@@ -65,8 +67,11 @@ class C_FormROS extends Controller
             return;
         }
 
-        $postId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
-        $formId = is_int($postId) && $postId >= 0 ? $postId : 0;
+        $postId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        if ($postId === false) {
+            AccessDeniedHelper::deny('Invalid ros form id', 'security-access', Response::HTTP_NOT_FOUND);
+        }
+        $formId = $postId ?? 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'ros');
 
         $this->form = $formId > 0 ? new FormROS($formId) : new FormROS();

--- a/interface/forms/ros/C_FormROS.class.php
+++ b/interface/forms/ros/C_FormROS.class.php
@@ -18,13 +18,11 @@ if (!defined('OPENEMR_GLOBALS_LOADED')) {
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getProjectDir() . "/library/forms.inc.php");
 require_once("FormROS.class.php");
 
-use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
-use Symfony\Component\HttpFoundation\Response;
 
 class C_FormROS extends Controller
 {
@@ -67,11 +65,9 @@ class C_FormROS extends Controller
             return;
         }
 
+        // Empty-string POST id is the new-form case; missing/invalid → 0.
         $postId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
-        if ($postId === false) {
-            AccessDeniedHelper::deny('Invalid ros form id', 'security-access', Response::HTTP_NOT_FOUND);
-        }
-        $formId = $postId ?? 0;
+        $formId = is_int($postId) ? $postId : 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'ros');
 
         $this->form = $formId > 0 ? new FormROS($formId) : new FormROS();

--- a/interface/forms/ros/C_FormROS.class.php
+++ b/interface/forms/ros/C_FormROS.class.php
@@ -19,6 +19,7 @@ require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getProjectDir() . "/libr
 require_once("FormROS.class.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
@@ -49,6 +50,7 @@ class C_FormROS extends Controller
 
     function view_action($form_id)
     {
+        EncounterFormAccess::assertFormBelongsToSessionPatient(is_numeric($form_id) ? (int) $form_id : 0, 'ros');
 
         $ros = is_numeric($form_id) ? new FormROS($form_id) : new FormROS();
 

--- a/interface/forms/ros/view.php
+++ b/interface/forms/ros/view.php
@@ -22,4 +22,4 @@ require_once("$srcdir/api.inc.php");
 require("C_FormROS.class.php");
 
 $c = new C_FormROS();
-echo $c->view_action($_GET['id']);
+echo $c->view_action(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT));

--- a/interface/forms/sdoh/save.php
+++ b/interface/forms/sdoh/save.php
@@ -56,6 +56,7 @@ if ($_GET["mode"] == "new") {
     addForm($encounter, "Social Screening Tool", $newid, "sdoh", $pid, $userauthorized);
     $formid = $newid;
 } elseif ($_GET["mode"] == "update") {
+    EncounterFormAccess::requirePositiveFormId($formId, 'sdoh');
     // if running from patient portal, then below will ensure patient can only see their forms
     CoreFormToPortalUtility::confirmFormBootstrapPatient($patientPortalSession, $formId, 'sdoh', $session->get('pid'));
     if (!$patientPortalSession) {

--- a/interface/forms/sdoh/save.php
+++ b/interface/forms/sdoh/save.php
@@ -12,6 +12,7 @@
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Forms\CoreFormToPortalUtility;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -54,6 +55,9 @@ if ($_GET["mode"] == "new") {
 } elseif ($_GET["mode"] == "update") {
     // if running from patient portal, then below will ensure patient can only see their forms
     CoreFormToPortalUtility::confirmFormBootstrapPatient($patientPortalSession, $_GET['id'], 'sdoh', $session->get('pid'));
+    if (!$patientPortalSession) {
+        EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'sdoh');
+    }
     $formid = $_GET["id"];
     sqlStatement(
         "UPDATE form_sdoh set pid = ?,

--- a/interface/forms/sdoh/save.php
+++ b/interface/forms/sdoh/save.php
@@ -43,6 +43,9 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+
 if (!$encounter) {
     $encounter = date("Ymd");
 }
@@ -54,11 +57,11 @@ if ($_GET["mode"] == "new") {
     $formid = $newid;
 } elseif ($_GET["mode"] == "update") {
     // if running from patient portal, then below will ensure patient can only see their forms
-    CoreFormToPortalUtility::confirmFormBootstrapPatient($patientPortalSession, $_GET['id'], 'sdoh', $session->get('pid'));
+    CoreFormToPortalUtility::confirmFormBootstrapPatient($patientPortalSession, $formId, 'sdoh', $session->get('pid'));
     if (!$patientPortalSession) {
-        EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'sdoh');
+        EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'sdoh');
     }
-    $formid = $_GET["id"];
+    $formid = $formId;
     sqlStatement(
         "UPDATE form_sdoh set pid = ?,
             groupname=?,
@@ -328,7 +331,7 @@ WHERE id=?",
         ($_POST["contactotherinput"] ?? ''),
         ($_POST["totalscore"] ?? null),
         ($_POST["additional_notes"] ?? null),
-            $_GET["id"]
+            $formId
         ]
     );
 }

--- a/interface/forms/soap/C_FormSOAP.class.php
+++ b/interface/forms/soap/C_FormSOAP.class.php
@@ -47,7 +47,7 @@ class C_FormSOAP extends Controller
         );
     }
 
-    function view_action($form_id)
+    public function view_action($form_id): string
     {
         $formId = is_numeric($form_id) ? (int) $form_id : 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'soap');
@@ -70,7 +70,11 @@ class C_FormSOAP extends Controller
             return;
         }
 
-        $this->form = new FormSOAP($_POST['id']);
+        $postId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
+        $formId = is_int($postId) && $postId >= 0 ? $postId : 0;
+        EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'soap');
+
+        $this->form = $formId > 0 ? new FormSOAP($formId) : new FormSOAP();
         parent::populate_object($this->form);
 
         $this->form->persist();
@@ -78,7 +82,7 @@ class C_FormSOAP extends Controller
             OEGlobalsBag::getInstance()->set('encounter', date("Ymd"));
         }
 
-        if (empty($_POST['id'])) {
+        if ($formId === 0) {
             $session = SessionWrapperFactory::getInstance()->getActiveSession();
             addForm(
                 OEGlobalsBag::getInstance()->get('encounter'),

--- a/interface/forms/soap/C_FormSOAP.class.php
+++ b/interface/forms/soap/C_FormSOAP.class.php
@@ -81,6 +81,7 @@ class C_FormSOAP extends Controller
 
         $this->form = $formId > 0 ? new FormSOAP($formId) : new FormSOAP();
         parent::populate_object($this->form);
+        EncounterFormAccess::applySessionPidToForm($this->form);
 
         $this->form->persist();
         if (OEGlobalsBag::getInstance()->get('encounter') == "") {

--- a/interface/forms/soap/C_FormSOAP.class.php
+++ b/interface/forms/soap/C_FormSOAP.class.php
@@ -14,6 +14,7 @@
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getProjectDir() . "/library/forms.inc.php");
 require_once("FormSOAP.class.php");
 
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
@@ -48,7 +49,10 @@ class C_FormSOAP extends Controller
 
     function view_action($form_id)
     {
-        $form = is_numeric($form_id) ? new FormSOAP($form_id) : new FormSOAP();
+        $formId = is_numeric($form_id) ? (int) $form_id : 0;
+        EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'soap');
+
+        $form = is_numeric($form_id) ? new FormSOAP($formId) : new FormSOAP();
 
         return $this->twig->getTwig()->render(
             'soap_form.twig',

--- a/interface/forms/soap/C_FormSOAP.class.php
+++ b/interface/forms/soap/C_FormSOAP.class.php
@@ -14,11 +14,13 @@
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getProjectDir() . "/library/forms.inc.php");
 require_once("FormSOAP.class.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
+use Symfony\Component\HttpFoundation\Response;
 
 class C_FormSOAP extends Controller
 {
@@ -47,12 +49,12 @@ class C_FormSOAP extends Controller
         );
     }
 
-    public function view_action($form_id): string
+    public function view_action(int|false|null $form_id): string
     {
-        $formId = is_numeric($form_id) ? (int) $form_id : 0;
+        $formId = is_int($form_id) && $form_id >= 0 ? $form_id : 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'soap');
 
-        $form = is_numeric($form_id) ? new FormSOAP($formId) : new FormSOAP();
+        $form = $formId > 0 ? new FormSOAP($formId) : new FormSOAP();
 
         return $this->twig->getTwig()->render(
             'soap_form.twig',
@@ -70,8 +72,11 @@ class C_FormSOAP extends Controller
             return;
         }
 
-        $postId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
-        $formId = is_int($postId) && $postId >= 0 ? $postId : 0;
+        $postId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        if ($postId === false) {
+            AccessDeniedHelper::deny('Invalid soap form id', 'security-access', Response::HTTP_NOT_FOUND);
+        }
+        $formId = $postId ?? 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'soap');
 
         $this->form = $formId > 0 ? new FormSOAP($formId) : new FormSOAP();

--- a/interface/forms/soap/C_FormSOAP.class.php
+++ b/interface/forms/soap/C_FormSOAP.class.php
@@ -14,13 +14,11 @@
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getProjectDir() . "/library/forms.inc.php");
 require_once("FormSOAP.class.php");
 
-use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
-use Symfony\Component\HttpFoundation\Response;
 
 class C_FormSOAP extends Controller
 {
@@ -72,11 +70,9 @@ class C_FormSOAP extends Controller
             return;
         }
 
+        // Empty-string POST id is the new-form case; missing/invalid → 0.
         $postId = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
-        if ($postId === false) {
-            AccessDeniedHelper::deny('Invalid soap form id', 'security-access', Response::HTTP_NOT_FOUND);
-        }
-        $formId = $postId ?? 0;
+        $formId = is_int($postId) ? $postId : 0;
         EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'soap');
 
         $this->form = $formId > 0 ? new FormSOAP($formId) : new FormSOAP();

--- a/interface/forms/soap/view.php
+++ b/interface/forms/soap/view.php
@@ -12,7 +12,6 @@
 
 require_once(__DIR__ . "/../../globals.php");
 
-use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Core\OEGlobalsBag;
 
 // Hoist legacy `globals.php` locals so PHPStan can see them (#11792 Phase 5).
@@ -22,10 +21,5 @@ require_once("$srcdir/api.inc.php");
 
 require("C_FormSOAP.class.php");
 
-$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
-$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
-
-EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'soap');
-
 $c = new C_FormSOAP();
-echo $c->view_action($formId);
+echo $c->view_action(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT));

--- a/interface/forms/soap/view.php
+++ b/interface/forms/soap/view.php
@@ -22,7 +22,10 @@ require_once("$srcdir/api.inc.php");
 
 require("C_FormSOAP.class.php");
 
-EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'soap');
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput >= 0 ? $formIdInput : 0;
+
+EncounterFormAccess::assertFormBelongsToSessionPatient($formId, 'soap');
 
 $c = new C_FormSOAP();
-echo $c->view_action($_GET['id']);
+echo $c->view_action($formId);

--- a/interface/forms/soap/view.php
+++ b/interface/forms/soap/view.php
@@ -12,6 +12,7 @@
 
 require_once(__DIR__ . "/../../globals.php");
 
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Core\OEGlobalsBag;
 
 // Hoist legacy `globals.php` locals so PHPStan can see them (#11792 Phase 5).
@@ -20,6 +21,8 @@ $srcdir = OEGlobalsBag::getInstance()->getSrcDir();
 require_once("$srcdir/api.inc.php");
 
 require("C_FormSOAP.class.php");
+
+EncounterFormAccess::assertFormBelongsToSessionPatient(filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT), 'soap');
 
 $c = new C_FormSOAP();
 echo $c->view_action($_GET['id']);

--- a/interface/forms/track_anything/new.php
+++ b/interface/forms/track_anything/new.php
@@ -14,6 +14,7 @@
 
 require_once(__DIR__ . "/../../globals.php");
 
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
@@ -45,6 +46,8 @@ if (empty($formid)) {
         $formid = $_POST['formid'] ?? null;
     }
 }
+
+EncounterFormAccess::assertFormBelongsToSessionPatient(is_numeric($formid) ? (int) $formid : 0, 'track_anything');
 
 $myprocedureid =  $_POST['procedure2track'] ?? null;
 

--- a/interface/forms/transfer_summary/save.php
+++ b/interface/forms/transfer_summary/save.php
@@ -15,6 +15,7 @@
 require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -38,6 +39,7 @@ if (!$encounter) { // comes from globals.php
 }
 
 $id = (int) ($_GET['id'] ?? '');
+EncounterFormAccess::assertFormBelongsToSessionPatient($id, 'transfer_summary');
 
 $sets = "pid = ?,
   groupname = ?,

--- a/interface/forms/treatment_plan/save.php
+++ b/interface/forms/treatment_plan/save.php
@@ -15,6 +15,7 @@
 require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -38,6 +39,7 @@ if (!$encounter) { // comes from globals.php
 }
 
 $id = (int) ($_GET['id'] ?? '');
+EncounterFormAccess::assertFormBelongsToSessionPatient($id, 'treatment_plan');
 
 $sets = "pid = ?,
   groupname = ?,

--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -447,8 +447,8 @@ class C_FormVitals
         $vitalsArray = [];
         if (!empty($_POST['id'])) {
             $vitalsArray = $vitalsService->getVitalsForForm($_POST['id']) ?? [];
-            // Verify the vital belongs to this patient/encounter to prevent IDOR.
-            // If not, treat as a new form (ignore the supplied id).
+            // If the vital doesn't belong to this patient/encounter, treat
+            // as a new form and ignore the supplied id.
             if (
                 !empty($vitalsArray)
                 && ($vitalsArray['pid'] != $GLOBALS['pid'] || $vitalsArray['eid'] != $GLOBALS['encounter'])

--- a/interface/patient_file/encounter/load_form.php
+++ b/interface/patient_file/encounter/load_form.php
@@ -16,8 +16,12 @@ require_once("../../globals.php");
 
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Forms\EncounterFormAccess;
 use OpenEMR\Common\Forms\FormLocator;
+use OpenEMR\Common\Session\EncounterSessionUtil;
+use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Services\EncounterService;
 use OpenEMR\Telemetry\TelemetryService;
 
 /**
@@ -42,6 +46,32 @@ if (!str_starts_with((string) $_GET["formname"], 'LBF')) {
         AccessDeniedHelper::denyWithTemplate("ACL check failed for form: " . $formLabel, $formLabel);
     }
 }
+// Confirm the target form (if identified by an existing form_id) belongs to the
+// session patient. No-ops when creating a new form (id <= 0).
+$formnameInput = filter_input(INPUT_GET, 'formname', FILTER_UNSAFE_RAW);
+EncounterFormAccess::assertFormBelongsToSessionPatient(
+    filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT),
+    is_string($formnameInput) ? $formnameInput : '',
+);
+
+// Enforce encounter sensitivity ACL so a form load cannot bypass the
+// sensitivity filter shown on the encounter dashboard.
+$encounterInput = filter_input(INPUT_GET, 'encounter', FILTER_VALIDATE_INT);
+$pidInput = filter_input(INPUT_GET, 'pid', FILTER_VALIDATE_INT);
+$sensitivityEncounterId = is_int($encounterInput) && $encounterInput > 0
+    ? $encounterInput
+    : EncounterSessionUtil::getEncounter();
+$sensitivityPid = is_int($pidInput) && $pidInput > 0
+    ? $pidInput
+    : PatientSessionUtil::getPid();
+if ($sensitivityEncounterId > 0) {
+    $sensitivity = (new EncounterService())->getSensitivity($sensitivityPid, $sensitivityEncounterId);
+    // getSensitivity returns string when a row is found, [] when not.
+    if (is_string($sensitivity) && $sensitivity !== '' && !AclMain::aclCheckCore('sensitivities', $sensitivity)) {
+        AccessDeniedHelper::denyWithTemplate('Not authorized to view encounter form.', 'Not authorized');
+    }
+}
+
 $formLocator = new FormLocator();
 $file = $formLocator->findFile($_GET['formname'], $pageName, 'load_form.php');
 require_once($file);

--- a/interface/patient_file/encounter/load_form.php
+++ b/interface/patient_file/encounter/load_form.php
@@ -23,6 +23,7 @@ use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\EncounterService;
 use OpenEMR\Telemetry\TelemetryService;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @gloal $incdir the include directory
@@ -46,28 +47,29 @@ if (!str_starts_with((string) $_GET["formname"], 'LBF')) {
         AccessDeniedHelper::denyWithTemplate("ACL check failed for form: " . $formLabel, $formLabel);
     }
 }
-// Confirm the target form (if identified by an existing form_id) belongs to the
-// session patient. No-ops when creating a new form (id <= 0).
+$formIdInput = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$formId = is_int($formIdInput) && $formIdInput > 0 ? $formIdInput : 0;
 $formnameInput = filter_input(INPUT_GET, 'formname', FILTER_UNSAFE_RAW);
-EncounterFormAccess::assertFormBelongsToSessionPatient(
-    filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT),
-    is_string($formnameInput) ? $formnameInput : '',
-);
+$formDir = is_string($formnameInput) ? $formnameInput : '';
 
-// Enforce encounter sensitivity ACL so a form load cannot bypass the
-// sensitivity filter shown on the encounter dashboard.
-$encounterInput = filter_input(INPUT_GET, 'encounter', FILTER_VALIDATE_INT);
-$pidInput = filter_input(INPUT_GET, 'pid', FILTER_VALIDATE_INT);
-$sensitivityEncounterId = is_int($encounterInput) && $encounterInput > 0
-    ? $encounterInput
-    : EncounterSessionUtil::getEncounter();
-$sensitivityPid = is_int($pidInput) && $pidInput > 0
-    ? $pidInput
-    : PatientSessionUtil::getPid();
+$sessionPid = PatientSessionUtil::getPid();
+$sensitivityEncounterId = EncounterSessionUtil::getEncounter();
+
+if ($formId > 0) {
+    $formOwner = EncounterFormAccess::fetchFormOwner($formId, $formDir);
+    if (!EncounterFormAccess::isFormOwnedBySession($formOwner['pid'] ?? null, $sessionPid)) {
+        AccessDeniedHelper::deny(
+            sprintf('Form %d/%s not accessible by session pid %d', $formId, $formDir, $sessionPid),
+            'security-access',
+            Response::HTTP_NOT_FOUND,
+        );
+    }
+    $sensitivityEncounterId = $formOwner['encounter'];
+}
+
 if ($sensitivityEncounterId > 0) {
-    $sensitivity = (new EncounterService())->getSensitivity($sensitivityPid, $sensitivityEncounterId);
-    // getSensitivity returns string when a row is found, [] when not.
-    if (is_string($sensitivity) && $sensitivity !== '' && !AclMain::aclCheckCore('sensitivities', $sensitivity)) {
+    $sensitivity = (new EncounterService())->getSensitivity($sessionPid, $sensitivityEncounterId);
+    if ($sensitivity !== null && $sensitivity !== '' && !AclMain::aclCheckCore('sensitivities', $sensitivity)) {
         AccessDeniedHelper::denyWithTemplate('Not authorized to view encounter form.', 'Not authorized');
     }
 }

--- a/library/lab.inc.php
+++ b/library/lab.inc.php
@@ -107,12 +107,12 @@ function getProcedureProvider($prov_id): array|bool
  */
 function getLabProviders($prov_id): ?array
 {
-
     $sql = "select fname, lname from users where authorized = 1 and active = 1 and username != '' and id = ?";
     $rez = sqlQuery($sql, [$prov_id]);
 
-
-    return $rez;
+    // sqlQuery returns false when no row matches; the declared return type is
+    // ?array, so coerce to null.
+    return is_array($rez) ? $rez : null;
 }
 
 /*

--- a/src/Common/Forms/EncounterFormAccess.php
+++ b/src/Common/Forms/EncounterFormAccess.php
@@ -141,17 +141,22 @@ final class EncounterFormAccess
      * persisted row's pid tracks session context rather than whatever the
      * caller submitted.
      *
-     * No-op when the form object has no `set_pid` method or when the session
-     * has no active patient (`PatientSessionUtil::getPid()` returns 0).
-     * `$sessionPid` may be supplied for tests.
+     * Fails closed (audit-logged 404) when the session has no active patient
+     * (`PatientSessionUtil::getPid()` returns a non-positive value) — form
+     * save flows require a patient context. `$sessionPid` may be supplied
+     * for tests.
      */
     public static function applySessionPidToForm(mixed $form, ?int $sessionPid = null): void
     {
-        if (!is_object($form) || !method_exists($form, 'set_pid')) {
-            return;
-        }
         $sessionPid ??= PatientSessionUtil::getPid();
-        if ($sessionPid > 0) {
+        if ($sessionPid <= 0) {
+            AccessDeniedHelper::deny(
+                'Form save attempted without an active patient session',
+                'security-access',
+                Response::HTTP_NOT_FOUND,
+            );
+        }
+        if (is_object($form) && method_exists($form, 'set_pid')) {
             $form->set_pid($sessionPid);
         }
     }

--- a/src/Common/Forms/EncounterFormAccess.php
+++ b/src/Common/Forms/EncounterFormAccess.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Encounter-form access guard.
+ *
+ * Confirms that a form identified by (form_id, formdir) belongs to the
+ * session's active patient (and optionally, the session's active encounter).
+ * Intended to be called at the top of form entry-point scripts
+ * (`interface/forms/<form>/save.php`, `view.php`, `new.php`, and equivalents)
+ * that accept an attacker-controllable `id` / `formid` request parameter.
+ *
+ * Generalization of the portal-only guard previously offered by
+ * `CoreFormToPortalUtility::confirmFormBootstrapPatient`. Where a form
+ * has additional invariants (e.g. eye_mag's per-encounter binding), the
+ * caller can opt into encounter enforcement via the fourth argument.
+ *
+ * Design: the security-relevant comparison is isolated in the pure
+ * `isFormOwnedBySession()` method (unit-testable, no DB, no session, no
+ * process termination) so the trust boundary has direct test coverage.
+ * `assertFormBelongsToSessionPatient()` composes the pure check with a DB
+ * fetch and terminates the request on mismatch via `AccessDeniedHelper::deny()`.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Forms;
+
+use OpenEMR\Common\Acl\AccessDeniedHelper;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Session\PatientSessionUtil;
+use Symfony\Component\HttpFoundation\Response;
+
+final class EncounterFormAccess
+{
+    /**
+     * Pure comparison: does the form's owner pid/encounter permit access from
+     * the given session pid/encounter?
+     *
+     * A `null` $ownerPid represents "form not found" (fetch returned no row);
+     * that case always returns false. Encounter enforcement only fires when
+     * `$sessionEncounter` is non-null (opt-in per caller); when omitted, the
+     * check is pid-only.
+     */
+    public static function isFormOwnedBySession(
+        ?int $ownerPid,
+        int $sessionPid,
+        ?int $ownerEncounter = null,
+        ?int $sessionEncounter = null,
+    ): bool {
+        if ($ownerPid === null || $ownerPid !== $sessionPid) {
+            return false;
+        }
+
+        if ($sessionEncounter !== null && $ownerEncounter !== $sessionEncounter) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Confirm the form belongs to the session patient (and optionally the
+     * session encounter). Terminates the request with an audit-logged 404
+     * on mismatch, via `AccessDeniedHelper::deny()`.
+     *
+     * Callers pass the form-scoped identifiers they already have on hand.
+     * The check is skipped when `$formId` is not a positive integer — this
+     * covers the "new form being created" case (no existing row to verify)
+     * as well as absent/malformed request input. `int|false|null` is chosen
+     * to accept `filter_input(..., FILTER_VALIDATE_INT)` directly so callers
+     * do not need to widen the value before calling.
+     *
+     * @param int|false|null $formId           The `forms.form_id` of the target row.
+     * @param string         $formDir          The `forms.formdir` of the target row.
+     * @param int|null       $sessionPid       Session's active patient id. Defaults to `$_SESSION['pid']`.
+     * @param int|null       $sessionEncounter If non-null, additionally require the form's encounter to match.
+     */
+    public static function assertFormBelongsToSessionPatient(
+        int|false|null $formId,
+        string $formDir,
+        ?int $sessionPid = null,
+        ?int $sessionEncounter = null,
+    ): void {
+        if (!is_int($formId) || $formId <= 0) {
+            return;
+        }
+
+        $sessionPid ??= PatientSessionUtil::getPid();
+
+        $formOwner = QueryUtils::querySingleRow(
+            "SELECT pid, encounter FROM forms WHERE form_id = ? AND formdir = ? AND deleted = 0",
+            [$formId, $formDir],
+        );
+
+        $ownerPid = null;
+        $ownerEncounter = null;
+        if (is_array($formOwner)) {
+            $ownerPidRaw = $formOwner['pid'] ?? null;
+            $ownerEncounterRaw = $formOwner['encounter'] ?? null;
+            $ownerPid = is_numeric($ownerPidRaw) ? (int) $ownerPidRaw : null;
+            $ownerEncounter = is_numeric($ownerEncounterRaw) ? (int) $ownerEncounterRaw : null;
+        }
+
+        if (!self::isFormOwnedBySession($ownerPid, $sessionPid, $ownerEncounter, $sessionEncounter)) {
+            AccessDeniedHelper::deny(
+                sprintf('Form %d/%s not accessible by session pid %d', $formId, $formDir, $sessionPid),
+                'security-access',
+                Response::HTTP_NOT_FOUND,
+            );
+        }
+    }
+}

--- a/src/Common/Forms/EncounterFormAccess.php
+++ b/src/Common/Forms/EncounterFormAccess.php
@@ -135,6 +135,28 @@ final class EncounterFormAccess
     }
 
     /**
+     * Set a hydrated form object's pid to the session patient. Intended to
+     * run after a generic hydration step (e.g. `Controller::populate_object`
+     * which iterates `$_POST` and calls `set_$field` for each key), so the
+     * persisted row's pid tracks session context rather than whatever the
+     * caller submitted.
+     *
+     * No-op when the form object has no `set_pid` method or when the session
+     * has no active patient (`PatientSessionUtil::getPid()` returns 0).
+     * `$sessionPid` may be supplied for tests.
+     */
+    public static function applySessionPidToForm(mixed $form, ?int $sessionPid = null): void
+    {
+        if (!is_object($form) || !method_exists($form, 'set_pid')) {
+            return;
+        }
+        $sessionPid ??= PatientSessionUtil::getPid();
+        if ($sessionPid > 0) {
+            $form->set_pid($sessionPid);
+        }
+    }
+
+    /**
      * Look up the pid+encounter of a form. Returns null when the form row is
      * absent or deleted. Callers that need the form's encounter for downstream
      * checks (e.g. sensitivity ACL) can compose this with

--- a/src/Common/Forms/EncounterFormAccess.php
+++ b/src/Common/Forms/EncounterFormAccess.php
@@ -108,6 +108,23 @@ final class EncounterFormAccess
     }
 
     /**
+     * Terminates the request with an audit-logged 404 unless `$formId` is a
+     * positive integer. Intended for update-mode branches where a missing or
+     * malformed form id should not silently proceed as a no-op UPDATE.
+     */
+    public static function requirePositiveFormId(int|false|null $formId, string $formDir): int
+    {
+        if (!is_int($formId) || $formId <= 0) {
+            AccessDeniedHelper::deny(
+                sprintf('Missing or invalid form id for %s', $formDir),
+                'security-access',
+                Response::HTTP_NOT_FOUND,
+            );
+        }
+        return $formId;
+    }
+
+    /**
      * Look up the pid+encounter of a form. Returns null when the form row is
      * absent or deleted. Callers that need the form's encounter for downstream
      * checks (e.g. sensitivity ACL) can compose this with

--- a/src/Common/Forms/EncounterFormAccess.php
+++ b/src/Common/Forms/EncounterFormAccess.php
@@ -7,18 +7,18 @@
  * session's active patient (and optionally, the session's active encounter).
  * Intended to be called at the top of form entry-point scripts
  * (`interface/forms/<form>/save.php`, `view.php`, `new.php`, and equivalents)
- * that accept an attacker-controllable `id` / `formid` request parameter.
+ * that read the form id from the request.
  *
  * Generalization of the portal-only guard previously offered by
  * `CoreFormToPortalUtility::confirmFormBootstrapPatient`. Where a form
  * has additional invariants (e.g. eye_mag's per-encounter binding), the
  * caller can opt into encounter enforcement via the fourth argument.
  *
- * Design: the security-relevant comparison is isolated in the pure
+ * Design: the ownership comparison is isolated in the pure
  * `isFormOwnedBySession()` method (unit-testable, no DB, no session, no
- * process termination) so the trust boundary has direct test coverage.
- * `assertFormBelongsToSessionPatient()` composes the pure check with a DB
- * fetch and terminates the request on mismatch via `AccessDeniedHelper::deny()`.
+ * process termination). `assertFormBelongsToSessionPatient()` composes
+ * the pure check with a DB fetch and terminates the request on mismatch
+ * via `AccessDeniedHelper::deny()`.
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org

--- a/src/Common/Forms/EncounterFormAccess.php
+++ b/src/Common/Forms/EncounterFormAccess.php
@@ -41,9 +41,10 @@ final class EncounterFormAccess
      * the given session pid/encounter?
      *
      * A `null` $ownerPid represents "form not found" (fetch returned no row);
-     * that case always returns false. Encounter enforcement only fires when
-     * `$sessionEncounter` is non-null (opt-in per caller); when omitted, the
-     * check is pid-only.
+     * that case always returns false. A `$sessionPid <= 0` means "no active
+     * patient in session" (PatientSessionUtil::getPid() sentinel); also always
+     * denies. Encounter enforcement only fires when `$sessionEncounter` is
+     * non-null (opt-in per caller); when omitted, the check is pid-only.
      */
     public static function isFormOwnedBySession(
         ?int $ownerPid,
@@ -51,7 +52,7 @@ final class EncounterFormAccess
         ?int $ownerEncounter = null,
         ?int $sessionEncounter = null,
     ): bool {
-        if ($ownerPid === null || $ownerPid !== $sessionPid) {
+        if ($sessionPid <= 0 || $ownerPid === null || $ownerPid !== $sessionPid) {
             return false;
         }
 
@@ -90,27 +91,44 @@ final class EncounterFormAccess
         }
 
         $sessionPid ??= PatientSessionUtil::getPid();
+        $owner = self::fetchFormOwner($formId, $formDir);
 
-        $formOwner = QueryUtils::querySingleRow(
-            "SELECT pid, encounter FROM forms WHERE form_id = ? AND formdir = ? AND deleted = 0",
-            [$formId, $formDir],
-        );
-
-        $ownerPid = null;
-        $ownerEncounter = null;
-        if (is_array($formOwner)) {
-            $ownerPidRaw = $formOwner['pid'] ?? null;
-            $ownerEncounterRaw = $formOwner['encounter'] ?? null;
-            $ownerPid = is_numeric($ownerPidRaw) ? (int) $ownerPidRaw : null;
-            $ownerEncounter = is_numeric($ownerEncounterRaw) ? (int) $ownerEncounterRaw : null;
-        }
-
-        if (!self::isFormOwnedBySession($ownerPid, $sessionPid, $ownerEncounter, $sessionEncounter)) {
+        if (!self::isFormOwnedBySession(
+            $owner['pid'] ?? null,
+            $sessionPid,
+            $owner['encounter'] ?? null,
+            $sessionEncounter,
+        )) {
             AccessDeniedHelper::deny(
                 sprintf('Form %d/%s not accessible by session pid %d', $formId, $formDir, $sessionPid),
                 'security-access',
                 Response::HTTP_NOT_FOUND,
             );
         }
+    }
+
+    /**
+     * Look up the pid+encounter of a form. Returns null when the form row is
+     * absent or deleted. Callers that need the form's encounter for downstream
+     * checks (e.g. sensitivity ACL) can compose this with
+     * `isFormOwnedBySession()` and reuse the returned encounter.
+     *
+     * @return array{pid: int, encounter: int}|null
+     */
+    public static function fetchFormOwner(int $formId, string $formDir): ?array
+    {
+        $row = QueryUtils::querySingleRow(
+            "SELECT pid, encounter FROM forms WHERE form_id = ? AND formdir = ? AND deleted = 0",
+            [$formId, $formDir],
+        );
+        if (!is_array($row)) {
+            return null;
+        }
+        $pidRaw = $row['pid'] ?? null;
+        $encounterRaw = $row['encounter'] ?? null;
+        if (!is_numeric($pidRaw) || !is_numeric($encounterRaw)) {
+            return null;
+        }
+        return ['pid' => (int) $pidRaw, 'encounter' => (int) $encounterRaw];
     }
 }

--- a/src/Common/Forms/EncounterFormAccess.php
+++ b/src/Common/Forms/EncounterFormAccess.php
@@ -108,13 +108,23 @@ final class EncounterFormAccess
     }
 
     /**
+     * Pure predicate: is the given value a positive integer form id?
+     *
+     * @phpstan-assert-if-true int $formId
+     */
+    public static function isPositiveFormId(int|false|null $formId): bool
+    {
+        return is_int($formId) && $formId > 0;
+    }
+
+    /**
      * Terminates the request with an audit-logged 404 unless `$formId` is a
      * positive integer. Intended for update-mode branches where a missing or
      * malformed form id should not silently proceed as a no-op UPDATE.
      */
     public static function requirePositiveFormId(int|false|null $formId, string $formDir): int
     {
-        if (!is_int($formId) || $formId <= 0) {
+        if (!self::isPositiveFormId($formId)) {
             AccessDeniedHelper::deny(
                 sprintf('Missing or invalid form id for %s', $formDir),
                 'security-access',

--- a/src/Controllers/Interface/Forms/Observation/ObservationController.php
+++ b/src/Controllers/Interface/Forms/Observation/ObservationController.php
@@ -253,7 +253,10 @@ class ObservationController
             );
         }
 
-        $formId = $request->query->getInt('id');
+        // The edit template renders `?id=` (empty) for a fresh observation, so
+        // use get()+cast rather than InputBag::getInt() which throws on
+        // present-but-non-int values.
+        $formId = (int) $request->query->get('id', 0);
         $postData = $request->request->all();
 
         try {

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -709,18 +709,16 @@ class EncounterService extends BaseService
 
     /**
      * Returns the sensitivity level for the encounter matching the patient and encounter identifier.
-     *
-     * @param  $pid          The legacy identifier of particular patient
-     * @param  $encounter_id The identifier of a particular encounter
-     * @return string         sensitivity_level of first row of encounter data
+     * Returns null when no matching encounter row exists.
      */
-    public function getSensitivity($pid, $encounter_id)
+    public function getSensitivity(mixed $pid, mixed $encounter_id): ?string
     {
         $encounterResult = $this->search(['pid' => $pid, 'eid' => $encounter_id], $options = ['limit' => '1']);
-        if ($encounterResult->hasData()) {
-            return $encounterResult->getData()[0]['sensitivity'];
+        if (!$encounterResult->hasData()) {
+            return null;
         }
-        return [];
+        $sensitivity = $encounterResult->getData()[0]['sensitivity'] ?? null;
+        return is_string($sensitivity) ? $sensitivity : null;
     }
 
     /**

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -713,7 +713,10 @@ class EncounterService extends BaseService
      */
     public function getSensitivity(mixed $pid, mixed $encounter_id): ?string
     {
-        $encounterResult = $this->search(['pid' => $pid, 'eid' => $encounter_id], $options = ['limit' => '1']);
+        $encounterResult = $this->search(
+            ['pid' => $pid, 'eid' => $encounter_id],
+            options: ['limit' => 1],
+        );
         if (!$encounterResult->hasData()) {
             return null;
         }

--- a/tests/Tests/Isolated/Common/Forms/EncounterFormAccessTest.php
+++ b/tests/Tests/Isolated/Common/Forms/EncounterFormAccessTest.php
@@ -121,34 +121,6 @@ final class EncounterFormAccessTest extends TestCase
         $this->assertSame(42, $form->pid);
     }
 
-    public function testApplySessionPidToFormNoOpWhenSessionPidZero(): void
-    {
-        $form = new class {
-            public int $pid = 0;
-            public function set_pid(int $pid): void
-            {
-                $this->pid = $pid;
-            }
-        };
-        $form->set_pid(99);
-        EncounterFormAccess::applySessionPidToForm($form, sessionPid: 0);
-        $this->assertSame(99, $form->pid);
-    }
-
-    public function testApplySessionPidToFormNoOpWhenSessionPidNegative(): void
-    {
-        $form = new class {
-            public int $pid = 0;
-            public function set_pid(int $pid): void
-            {
-                $this->pid = $pid;
-            }
-        };
-        $form->set_pid(99);
-        EncounterFormAccess::applySessionPidToForm($form, sessionPid: -1);
-        $this->assertSame(99, $form->pid);
-    }
-
     public function testApplySessionPidToFormNoOpWhenFormHasNoSetPidMethod(): void
     {
         $form = new class {

--- a/tests/Tests/Isolated/Common/Forms/EncounterFormAccessTest.php
+++ b/tests/Tests/Isolated/Common/Forms/EncounterFormAccessTest.php
@@ -79,4 +79,31 @@ final class EncounterFormAccessTest extends TestCase
             'session pid 0 with encounter opt-in' => [0,  0,  100, 100, false],
         ];
     }
+
+    /**
+     * @param bool $expected
+     */
+    #[DataProvider('positiveFormIdCasesProvider')]
+    public function testIsPositiveFormId(int|false|null $formId, bool $expected): void
+    {
+        $this->assertSame($expected, EncounterFormAccess::isPositiveFormId($formId));
+    }
+
+    /**
+     * @return array<string, array{int|false|null, bool}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function positiveFormIdCasesProvider(): array
+    {
+        return [
+            'positive int'    => [42, true],
+            'one'             => [1, true],
+            'max int'         => [PHP_INT_MAX, true],
+            'zero'            => [0, false],
+            'negative int'    => [-1, false],
+            'false'           => [false, false],
+            'null'            => [null, false],
+        ];
+    }
 }

--- a/tests/Tests/Isolated/Common/Forms/EncounterFormAccessTest.php
+++ b/tests/Tests/Isolated/Common/Forms/EncounterFormAccessTest.php
@@ -72,9 +72,11 @@ final class EncounterFormAccessTest extends TestCase
             'pid match, encounter opt-in with owner encounter 0' => [42, 42, 0,   100, false],
             'pid match, encounter opt-in with null owner enc'    => [42, 42, null, 100, false],
 
-            // --- Session pid 0 (unauthenticated / no session pid) ---
-            'session pid 0 matches owner 0 in pid-only mode' => [0, 0, null, null, true],
-            'session pid 0 with owner pid 42 denies'         => [42, 0, null, null, false],
+            // --- Non-positive session pid ---
+            'session pid 0 with owner pid 0'      => [0,  0,  null, null, false],
+            'session pid 0 with owner pid 42'     => [42, 0,  null, null, false],
+            'negative session pid'                => [42, -1, null, null, false],
+            'session pid 0 with encounter opt-in' => [0,  0,  100, 100, false],
         ];
     }
 }

--- a/tests/Tests/Isolated/Common/Forms/EncounterFormAccessTest.php
+++ b/tests/Tests/Isolated/Common/Forms/EncounterFormAccessTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Isolated tests for the pure ownership-comparison logic in
+ * `OpenEMR\Common\Forms\EncounterFormAccess::isFormOwnedBySession()`.
+ *
+ * The security-relevant decision — "does this form's owner permit access
+ * from this session?" — lives entirely in `isFormOwnedBySession()`. The
+ * `assertFormBelongsToSessionPatient()` wrapper composes it with a DB
+ * fetch and a `deny()` call; the pure function is the trust boundary.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Forms;
+
+use OpenEMR\Common\Forms\EncounterFormAccess;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class EncounterFormAccessTest extends TestCase
+{
+    #[DataProvider('ownershipCasesProvider')]
+    public function testIsFormOwnedBySession(
+        ?int $ownerPid,
+        int $sessionPid,
+        ?int $ownerEncounter,
+        ?int $sessionEncounter,
+        bool $expected,
+    ): void {
+        $this->assertSame(
+            $expected,
+            EncounterFormAccess::isFormOwnedBySession(
+                $ownerPid,
+                $sessionPid,
+                $ownerEncounter,
+                $sessionEncounter,
+            ),
+        );
+    }
+
+    /**
+     * @return array<string, array{?int, int, ?int, ?int, bool}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function ownershipCasesProvider(): array
+    {
+        return [
+            // --- Form not found (owner null) always denies ---
+            'form not found — pid-only mode'          => [null, 42, null, null, false],
+            'form not found — encounter opt-in mode'  => [null, 42, null, 100, false],
+            'form not found with owner encounter set' => [null, 42, 100, null, false],
+
+            // --- Pid mismatch always denies ---
+            'pid mismatch — pid-only mode'                => [7,  42, null, null, false],
+            'pid mismatch — different sessions'           => [42, 43, null, null, false],
+            'pid mismatch even when encounter matches'    => [7,  42, 100, 100, false],
+            'zero owner pid vs non-zero session'          => [0,  42, null, null, false],
+
+            // --- Pid match, pid-only mode (encounter check disabled) ---
+            'pid match, both encounters null'                    => [42, 42, null, null, true],
+            'pid match, owner has encounter but session opts out' => [42, 42, 100, null, true],
+
+            // --- Pid match, encounter opt-in ---
+            'pid match, encounter match'                         => [42, 42, 100, 100, true],
+            'pid match, encounter mismatch'                      => [42, 42, 99,  100, false],
+            'pid match, encounter opt-in with owner encounter 0' => [42, 42, 0,   100, false],
+            'pid match, encounter opt-in with null owner enc'    => [42, 42, null, 100, false],
+
+            // --- Session pid 0 (unauthenticated / no session pid) ---
+            'session pid 0 matches owner 0 in pid-only mode' => [0, 0, null, null, true],
+            'session pid 0 with owner pid 42 denies'         => [42, 0, null, null, false],
+        ];
+    }
+}

--- a/tests/Tests/Isolated/Common/Forms/EncounterFormAccessTest.php
+++ b/tests/Tests/Isolated/Common/Forms/EncounterFormAccessTest.php
@@ -106,4 +106,62 @@ final class EncounterFormAccessTest extends TestCase
             'null'            => [null, false],
         ];
     }
+
+    public function testApplySessionPidToFormOverridesPreviousValue(): void
+    {
+        $form = new class {
+            public int $pid = 0;
+            public function set_pid(int $pid): void
+            {
+                $this->pid = $pid;
+            }
+        };
+        $form->set_pid(99);
+        EncounterFormAccess::applySessionPidToForm($form, sessionPid: 42);
+        $this->assertSame(42, $form->pid);
+    }
+
+    public function testApplySessionPidToFormNoOpWhenSessionPidZero(): void
+    {
+        $form = new class {
+            public int $pid = 0;
+            public function set_pid(int $pid): void
+            {
+                $this->pid = $pid;
+            }
+        };
+        $form->set_pid(99);
+        EncounterFormAccess::applySessionPidToForm($form, sessionPid: 0);
+        $this->assertSame(99, $form->pid);
+    }
+
+    public function testApplySessionPidToFormNoOpWhenSessionPidNegative(): void
+    {
+        $form = new class {
+            public int $pid = 0;
+            public function set_pid(int $pid): void
+            {
+                $this->pid = $pid;
+            }
+        };
+        $form->set_pid(99);
+        EncounterFormAccess::applySessionPidToForm($form, sessionPid: -1);
+        $this->assertSame(99, $form->pid);
+    }
+
+    public function testApplySessionPidToFormNoOpWhenFormHasNoSetPidMethod(): void
+    {
+        $form = new class {
+            public int $pid = 99;
+        };
+        EncounterFormAccess::applySessionPidToForm($form, sessionPid: 42);
+        $this->assertSame(99, $form->pid);
+    }
+
+    public function testApplySessionPidToFormNoOpForNonObject(): void
+    {
+        // No exception thrown for non-object input; no observable side effects.
+        EncounterFormAccess::applySessionPidToForm('not an object', sessionPid: 42);
+        $this->expectNotToPerformAssertions();
+    }
 }

--- a/tests/Tests/Services/Common/Forms/EncounterFormAccessTest.php
+++ b/tests/Tests/Services/Common/Forms/EncounterFormAccessTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * DB-backed tests for the fetchFormOwner() lookup in
+ * `OpenEMR\Common\Forms\EncounterFormAccess`.
+ *
+ * The pure comparison in `isFormOwnedBySession()` is covered in isolation at
+ * `tests/Tests/Isolated/Common/Forms/EncounterFormAccessTest.php`. This suite
+ * exercises the DB-touching primitive so a schema drift or query regression
+ * surfaces in CI.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Services\Common\Forms;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Forms\EncounterFormAccess;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class EncounterFormAccessTest extends TestCase
+{
+    private const FORMDIR = 'encounter_form_access_test';
+
+    /** @var list<int> */
+    private array $insertedFormIds = [];
+
+    protected function setUp(): void
+    {
+        // Ensure no leftover rows from a prior failed run.
+        QueryUtils::sqlStatementThrowException('DELETE FROM forms WHERE formdir = ?', [self::FORMDIR]);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->insertedFormIds as $id) {
+            QueryUtils::sqlStatementThrowException(
+                'DELETE FROM forms WHERE form_id = ? AND formdir = ?',
+                [$id, self::FORMDIR],
+            );
+        }
+        $this->insertedFormIds = [];
+    }
+
+    #[Test]
+    public function fetchFormOwnerReturnsPidAndEncounterForExistingRow(): void
+    {
+        $formId = $this->insertFormsRow(pid: 42, encounter: 100, deleted: 0);
+
+        $owner = EncounterFormAccess::fetchFormOwner($formId, self::FORMDIR);
+
+        $this->assertNotNull($owner);
+        $this->assertSame(42, $owner['pid']);
+        $this->assertSame(100, $owner['encounter']);
+    }
+
+    #[Test]
+    public function fetchFormOwnerReturnsNullForAbsentRow(): void
+    {
+        // No row inserted for form_id 999_999.
+        $this->assertNull(EncounterFormAccess::fetchFormOwner(999999, self::FORMDIR));
+    }
+
+    #[Test]
+    public function fetchFormOwnerReturnsNullForDeletedRow(): void
+    {
+        $formId = $this->insertFormsRow(pid: 42, encounter: 100, deleted: 1);
+
+        $this->assertNull(EncounterFormAccess::fetchFormOwner($formId, self::FORMDIR));
+    }
+
+    #[Test]
+    public function fetchFormOwnerScopesByFormdir(): void
+    {
+        // Same form_id under a different formdir should not match.
+        $formId = $this->insertFormsRow(pid: 42, encounter: 100, deleted: 0);
+
+        $this->assertNull(EncounterFormAccess::fetchFormOwner($formId, 'unrelated_formdir'));
+    }
+
+    /**
+     * Insert a `forms` row for testing. Returns the generated form_id.
+     */
+    private function insertFormsRow(int $pid, int $encounter, int $deleted): int
+    {
+        $formId = QueryUtils::sqlInsert(
+            'INSERT INTO forms (date, encounter, form_name, pid, user, groupname, authorized, formdir, deleted) '
+            . 'VALUES (NOW(), ?, ?, ?, ?, ?, ?, ?, ?)',
+            [$encounter, 'EncounterFormAccessTest form', $pid, 'test', 'Default', 1, self::FORMDIR, $deleted],
+        );
+        // `forms.form_id` is a distinct column from `forms.id`; the schema stores the
+        // form-specific-table's PK in `form_id`. For test purposes we set form_id to
+        // match the just-inserted row id — mirrors what `addForm()` does in prod.
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE forms SET form_id = ? WHERE id = ?',
+            [$formId, $formId],
+        );
+        $this->insertedFormIds[] = $formId;
+        return $formId;
+    }
+}


### PR DESCRIPTION
Adds `OpenEMR\Common\Forms\EncounterFormAccess` — generalizes the portal-only
`CoreFormToPortalUtility::confirmFormBootstrapPatient` guard into a form-generic
helper that confirms a given (form_id, formdir) row belongs to the session's
active patient (and optionally, the active encounter). On mismatch, terminates
the request with an audit-logged 404 via `AccessDeniedHelper::deny()`.

Design: the security-relevant comparison is isolated in a pure
`isFormOwnedBySession()` method — unit-testable without DB, session, or process
termination — so the trust boundary has direct test coverage. Isolated test
coverage in `tests/Tests/Isolated/Common/Forms/EncounterFormAccessTest.php`
(15 cases).

Applied at these form entry points:

- `interface/forms/gad7/save.php`
- `interface/forms/dictation/save.php`
- `interface/forms/phq9/save.php`
- `interface/forms/reviewofs/save.php`
- `interface/forms/sdoh/save.php`
- `interface/forms/clinical_instructions/save.php`
- `interface/forms/aftercare_plan/save.php`
- `interface/forms/treatment_plan/save.php`
- `interface/forms/transfer_summary/save.php`
- `interface/forms/misc_billing_options/save.php`
- `interface/forms/clinic_note/view.php`
- `interface/forms/soap/view.php`
- `interface/forms/ros/C_FormROS.class.php`
- `interface/forms/prior_auth/view.php`
- `interface/forms/painmap/view.php`
- `interface/forms/physical_exam/new.php`
- `interface/forms/track_anything/new.php`
- `interface/forms/questionnaire_assessments/questionnaire_assessments.php`
- `interface/forms/procedure_order/common.php`
- `interface/forms/LBF/new.php` (replaces existing ad-hoc pid check)

Also adds an encounter-sensitivity ACL guard at
`interface/patient_file/encounter/load_form.php` that resolves the encounter's
sensitivity via `EncounterService::getSensitivity()` and checks
`AclMain::aclCheckCore('sensitivities', $sensitivity)` before invoking the
form loader.