### PR TITLE
fix(camos): iterate url search params for ajax save

### DIFF
--- a/interface/forms/CAMOS/new.php
+++ b/interface/forms/CAMOS/new.php
@@ -888,13 +888,19 @@ function processajax (serverPage, obj, getOrPost, str){
   }
 }
 
-
+// form_array is an Array used as an associative map (form_array['content'] = ...).
+// String keys do not contribute to .length and are not visited by the array
+// iterator, so `new URLSearchParams(form_array)` yields an empty string and the
+// POST body is dropped. Iterate with for...in to pick up the string-keyed
+// properties. Works for plain objects too, so callers may use either shape.
 function setformvalues(form_array){
-
-  //Run through a list of all objects and build query string
-  const params = new URLSearchParams(form_array);
-  //Then return the string values.
-  return params.toString();
+    const params = new URLSearchParams();
+    for (const key in form_array) {
+        if (Object.prototype.hasOwnProperty.call(form_array, key)) {
+            params.append(key, form_array[key]);
+        }
+    }
+    return params.toString();
 }
 
 //END OF AJAX RELATED FUNCTIONS


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
form_array is an Array used as an associative map (form_array['content'] = ...).
String keys do not contribute to .length and are not visited by the array
iterator, so `new URLSearchParams(form_array)` yields an empty string and the
POST body is dropped. 

#### Changes proposed in this pull request:
Iterate with for...in to pick up the string-keyed
properties. Works for plain objects too, so callers may use either shape.

#### Was AI used? Yes, claude.ai

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
