### PR TITLE
test(acceptance): Phase 4e-1 -- port AaLoginTest scenarios to acceptance

### DIFF
--- a/tests/Acceptance/AaLoginAcceptanceTest.php
+++ b/tests/Acceptance/AaLoginAcceptanceTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance;
+
+use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Panther\Client;
+
+/**
+ * Panther-driven acceptance port of the non-overlapping scenarios in
+ * tests/Tests/E2e/AaLoginTest.php.
+ *
+ * Phase 4e-1 (first Small warmup of Phase 4e — reuse tests/Tests/E2e/*
+ * flows against the SHIPPED docker release image booted by
+ * tests/Acceptance/bin/boot-docker.sh). Extends the E2eCriticalPathTest
+ * pattern shipped in PR #13196: Panther client via BrowserSession
+ * factory, base URI resolved from ACCEPTANCE_ARTIFACT_URL.
+ *
+ * Deliberately partial port — the source-side AaLoginTest has five
+ * scenarios; only two of them add signal over what already ships in
+ * the acceptance suite:
+ *
+ *   - testGoToOpenemrLoginPage        (SKIPPED — duplicate of
+ *     E2eCriticalPathTest's login-page-load assertion)
+ *   - testLoginUnauthorized           (PORTED — negative-auth signal;
+ *     nothing else in the acceptance suite asserts that a wrong
+ *     password stays on the login page instead of authenticating)
+ *   - testurlWithoutTokenShouldRedirectToLoginPage (PORTED — asserts
+ *     unauthenticated deep-links redirect to the login page; distinct
+ *     from the happy-path login-redirect chain E2eCriticalPathTest
+ *     covers)
+ *   - testAdminPageDisabledByDefault  (SKIPPED — docker/release/
+ *     openemr.sh removes admin.php from the release image after
+ *     configuration, so this scenario is meaningless against a booted
+ *     release artifact; the disabled-by-default guard is exercised
+ *     source-side against the dev checkout instead)
+ *   - testAdminPageEnabledWithEnvVar  (SKIPPED — spawns a php CLI
+ *     against a dev-checkout admin.php path; no analog in the black-
+ *     box artifact context and admin.php is removed from the image
+ *     anyway)
+ *
+ * The source-side AaLoginTest continues to run against the dev stack
+ * unchanged — this class is purely additive against the release
+ * artifact.
+ */
+#[Group('fresh-install')]
+final class AaLoginAcceptanceTest extends TestCase
+{
+    private ?Client $client = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->client !== null) {
+            // Panther leaves a Chrome subprocess + ChromeDriver session
+            // dangling if not explicitly quit. Same discipline as
+            // E2eCriticalPathTest.
+            $this->client->quit();
+            $this->client = null;
+        }
+    }
+
+    /**
+     * Wrong password should NOT authenticate; the login page stays put.
+     *
+     * Source: AaLoginTest::testLoginUnauthorized (LoginTrait::login
+     * with $goalPass=false).
+     */
+    public function testLoginWithWrongPasswordStaysOnLoginPage(): void
+    {
+        $this->client = BrowserSession::create();
+        $this->client->request('GET', '/interface/login/login.php?site=default');
+
+        self::assertSame(
+            'OpenEMR Login',
+            $this->client->getTitle(),
+            'Login page must render before submitting bad credentials — a different title means the login route itself is broken',
+        );
+
+        // Submit the login form with a deliberately wrong password.
+        // Same admin username, password with a "1" suffix — matches
+        // the source-side LoginTestData::password . "1" pattern.
+        $this->client->submitForm('login-button', [
+            'authUser' => 'admin',
+            'clearPass' => 'pass1',
+        ]);
+
+        // Post-submit the browser is still on the login page. The
+        // release image's login handler re-renders login.php on
+        // failure rather than redirecting to an error page, so the
+        // title stays "OpenEMR Login" (a successful auth would
+        // transition it to "OpenEMR").
+        self::assertSame(
+            'OpenEMR Login',
+            $this->client->getTitle(),
+            'Login with a wrong password must NOT authenticate — a title change to "OpenEMR" means the artifact accepted invalid credentials',
+        );
+    }
+
+    /**
+     * An unauthenticated request to a post-login deep-link should
+     * redirect back to the login page (not 500, not silently serve
+     * privileged content).
+     *
+     * Source: AaLoginTest::testurlWithoutTokenShouldRedirectToLoginPage.
+     */
+    public function testUnauthenticatedDeepLinkRedirectsToLoginPage(): void
+    {
+        $this->client = BrowserSession::create();
+        // Hit the post-login main shell without ever having authenticated.
+        // testing_mode=1 mirrors the source-side flow — it suppresses
+        // some prod-only redirects that would otherwise complicate the
+        // assertion (matches the source-side E2e's flag choice).
+        $this->client->request(
+            'GET',
+            '/interface/main/tabs/main.php?site=default&testing_mode=1',
+        );
+
+        self::assertSame(
+            'OpenEMR Login',
+            $this->client->getTitle(),
+            'Unauthenticated GET on /interface/main/tabs/main.php should land on the login page — a different title means the artifact either exposed post-login content or served an error page instead of the expected auth redirect',
+        );
+    }
+}

--- a/tests/Acceptance/AaLoginAcceptanceTest.php
+++ b/tests/Acceptance/AaLoginAcceptanceTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Acceptance;
 
+use Facebook\WebDriver\WebDriverExpectedCondition;
 use OpenEMR\Tests\Acceptance\Support\BrowserSession;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -95,7 +96,17 @@ final class AaLoginAcceptanceTest extends TestCase
             'clearPass' => 'pass1',
         ]);
 
-        // Post-submit the browser is still on the login page. The
+        // OpenEMR's authLoginScreen() redirects via `w.top.location
+        // .href = ...` (client-side JS), so reading the title
+        // immediately after submitForm can race the redirect. Wait
+        // for the URL to settle on /interface/login/login.php before
+        // asserting the title. Anti-flake sync — Panther-standard
+        // pattern for JS-driven redirects.
+        $this->client->wait(10)->until(
+            WebDriverExpectedCondition::urlContains('/interface/login/login.php'),
+        );
+
+        // Post-redirect the browser is still on the login page. The
         // release image's login handler re-renders login.php on
         // failure rather than redirecting to an error page, so the
         // title stays "OpenEMR Login" (a successful auth would
@@ -124,6 +135,15 @@ final class AaLoginAcceptanceTest extends TestCase
         $this->client->request(
             'GET',
             '/interface/main/tabs/main.php?site=default&testing_mode=1',
+        );
+
+        // Same JS-redirect race as testLoginRejectsWrongPassword:
+        // the unauthenticated main.php entry-point kicks the user
+        // back to login.php via a client-side redirect, so a title
+        // read immediately after request() can race the redirect.
+        // Wait for the URL to reach /interface/login/login.php first.
+        $this->client->wait(10)->until(
+            WebDriverExpectedCondition::urlContains('/interface/login/login.php'),
         );
 
         self::assertSame(


### PR DESCRIPTION
## Summary

Phase 4e-1 — first Small warmup slice of Phase 4e (reuse
`tests/Tests/E2e/*` flows against the SHIPPED docker release image
booted via `tests/Acceptance/bin/boot-docker.sh`). Purely additive.

New file: `tests/Acceptance/AaLoginAcceptanceTest.php` — a Panther-
driven acceptance test that ports the non-overlapping scenarios of
the source-side `tests/Tests/E2e/AaLoginTest.php` against the release
artifact. Extends the pattern shipped in #13196 (E2eCriticalPathTest):
Panther client via `Support/BrowserSession` factory, base URI resolved
from `ACCEPTANCE_ARTIFACT_URL`, tagged `#[Group('fresh-install')]` so
it runs in every scenario of the existing `acceptance-docker.yml`
matrix (`fresh-install-from`, `fresh-install-to`, `upgrade` x amd64 +
arm64) — no workflow or PHPUnit-config changes needed.

## Duplicate analysis — partial port (2 of 5 scenarios)

Of `AaLoginTest`'s five scenarios:

| Source scenario                                    | Disposition | Rationale                                                                                                                                       |
|----------------------------------------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
| `testGoToOpenemrLoginPage`                         | **skipped** | Duplicate of `E2eCriticalPathTest`'s login-page-load assertion                                                                                  |
| `testLoginUnauthorized`                            | **ported**  | Negative-auth signal — nothing else in the acceptance suite asserts a wrong password stays on the login page                                    |
| `testurlWithoutTokenShouldRedirectToLoginPage`     | **ported**  | Unauthenticated deep-link redirects to the login page — distinct from the happy-path login-redirect chain                                       |
| `testAdminPageDisabledByDefault`                   | **skipped** | `docker/release/openemr.sh` removes `admin.php` from the release image after configuration, so the disabled-by-default guard doesn't apply here |
| `testAdminPageEnabledWithEnvVar`                   | **skipped** | Spawns `php admin.php` against a dev-checkout path — no analog in the black-box artifact context, and `admin.php` is removed from the image     |

The two skipped `admin.php` scenarios remain valid source-side
against the dev checkout (which does keep `admin.php` around); the
release-image path just isn't the right layer to test them.

## Wiring

Zero workflow or config changes. The new class lives at
`tests/Acceptance/AaLoginAcceptanceTest.php` alongside
`E2eCriticalPathTest.php` and picks up automatically because:

- `tests/Acceptance/phpunit.acceptance.xml` uses
  `<directory>.</directory>` — recursive discovery
- The class is tagged `#[Group('fresh-install')]` — matches the
  `--group=fresh-install` filter every acceptance-docker matrix cell
  already runs

## Confirmation: source-side test unchanged

`tests/Tests/E2e/AaLoginTest.php` is not modified, not deleted, not
touched. Its dev-stack coverage stays exactly as it was.

## Test plan

- [x] Local run against a `boot-docker.sh`-booted
      `openemr/openemr:latest` artifact — both new tests pass
- [x] Full `--group=fresh-install` suite locally — 9/9 tests, 35
      assertions green (was 7/7 before this change)
- [x] `phpstan` clean on new file
- [x] `phpcs` clean on new file
- [x] `rector --dry-run` clean on new file
- [ ] CI acceptance-docker matrix green (fresh-install-from,
      fresh-install-to, upgrade x amd64 + arm64)