### PR TITLE
fix(messages): add ACL and typed input to recall handlers

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -8208,7 +8208,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'recall_\' and mixed results in an error\\.$#',
-    'count' => 5,
+    'count' => 4,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -1137,21 +1137,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/messages/save.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method delete_recall\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/messages/save.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method getAge\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/messages/save.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method save_recall\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/messages/save.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method get_data\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/messages/trusted-messages-ajax.php',
@@ -2874,11 +2859,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot call method checkModality\\(\\) on mixed\\.$#',
     'count' => 6,
-    'path' => __DIR__ . '/../../library/MedEx/API.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method generate\\(\\) on mixed\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -14512,11 +14512,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method MedExApi\\\\Events\\:\\:save_recall\\(\\) has parameter \\$saved with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/MedEx/API.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method MedExApi\\\\Logging\\:\\:log_this\\(\\) has parameter \\$data with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/MedEx/API.php',

--- a/.phpstan/baseline/missingType.property.php
+++ b/.phpstan/baseline/missingType.property.php
@@ -2862,11 +2862,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property MedExApi\\\\MedEx\\:\\:\\$events has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/MedEx/API.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property MedExApi\\\\MedEx\\:\\:\\$lastError has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/MedEx/API.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -8022,11 +8022,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method MedExApi\\\\Events\\:\\:delete_Recall\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/MedEx/API.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method MedExApi\\\\Events\\:\\:generate\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
@@ -8038,11 +8033,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method MedExApi\\\\Events\\:\\:getDatesInRecurring\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/MedEx/API.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method MedExApi\\\\Events\\:\\:save_recall\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -4393,7 +4393,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 52,
+    'count' => 48,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -1603,7 +1603,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 27,
+    'count' => 21,
     'path' => __DIR__ . '/../../interface/main/messages/save.php',
 ];
 $ignoreErrors[] = [
@@ -3483,12 +3483,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 9,
+    'count' => 6,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 37,
+    'count' => 18,
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [

--- a/interface/main/messages/js/reminder_appts.js
+++ b/interface/main/messages/js/reminder_appts.js
@@ -137,7 +137,7 @@ function add_this_recall(e) {
     }
 
     var url = "save.php";
-    formData = JSON.stringify($("form#addRecall").serialize());
+    formData = $("form#addRecall").serialize();
     top.restoreSession();
     $.ajax({
         type: 'POST',
@@ -230,7 +230,8 @@ function process_this(material, id, eid = '') {
             'uid_pc_eid': all_Data,
             'msg_notes': notes,
             'action': 'process',
-            'item': material
+            'item': material,
+            'csrf_token_form': $("input[name='csrf_token_form']").first().val()
         }
     }).done(function (result) {
         if (material === 'labels') window.open("../../patient_file/addr_appt_label.php", "_blank");
@@ -310,7 +311,8 @@ function delete_Recall(pid, r_ID) {
             data: {
                 'action': 'delete_Recall',
                 'pid': pid,
-                'r_ID': r_ID
+                'r_ID': r_ID,
+                'csrf_token_form': $("input[name='csrf_token_form']").first().val()
             }
 
         }).done(function (result) {

--- a/interface/main/messages/save.php
+++ b/interface/main/messages/save.php
@@ -13,6 +13,8 @@
 require_once "../../globals.php";
 
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
@@ -166,13 +168,18 @@ if ($_REQUEST['MedEx'] == "start") {
     exit;
 }
 
-if (($_REQUEST['pid']) && ($_REQUEST['action'] == "new_recall")) {
-    if (!AclMain::aclCheckCore('patients', 'notes') && !AclMain::aclCheckCore('patients', 'appt')) {
+if ($_REQUEST['action'] == "new_recall") {
+    if (!AclMain::aclCheckCore('patients', 'appt')) {
         http_response_code(403);
         exit;
     }
+    $targetPidInput = filter_input(INPUT_POST, 'pid', FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+    if (!is_int($targetPidInput)) {
+        http_response_code(400);
+        exit;
+    }
     $query = "SELECT * FROM patient_data WHERE pid=?";
-    $result = sqlQuery($query, [$_REQUEST['pid']]);
+    $result = sqlQuery($query, [$targetPidInput]);
     $result['age'] = $MedEx->events->getAge($result['DOB']);
     // uuid is binary and will break json_encode in binary form (not needed, so will remove it from $result array)
     unset($result['uuid']);
@@ -188,13 +195,13 @@ if (($_REQUEST['pid']) && ($_REQUEST['action'] == "new_recall")) {
      *  The other option is to use Visit Categories here.  Maybe both?  Consensus?
      */
     $query = "SELECT ORDER_DETAILS FROM form_eye_mag_orders WHERE pid=? AND ORDER_DATE_PLACED < NOW() ORDER BY ORDER_DATE_PLACED DESC LIMIT 1";
-    $result2 = sqlQuery($query, [$_REQUEST['pid']]);
+    $result2 = sqlQuery($query, [$targetPidInput]);
     if (!empty($result2)) {
         $result['PLAN'] = $result2['ORDER_DETAILS'];
     }
 
     $query = "SELECT * FROM openemr_postcalendar_events WHERE pc_pid =? ORDER BY pc_eventDate DESC LIMIT 1";
-    $result2 = sqlQuery($query, [$_REQUEST['pid']]);
+    $result2 = sqlQuery($query, [$targetPidInput]);
     if ($result2) { //if they were never actually scheduled this would be blank
         $result['DOLV']     = oeFormatShortDate($result2['pc_eventDate']);
         $result['provider'] = $result2['pc_aid'];
@@ -205,7 +212,7 @@ if (($_REQUEST['pid']) && ($_REQUEST['action'] == "new_recall")) {
      * If so we need to use that info...
      */
     $query = "SELECT * from medex_recalls where r_pid=?";
-    $result3 = sqlQuery($query, [$_REQUEST['pid']]);
+    $result3 = sqlQuery($query, [$targetPidInput]);
     if ($result3) {
         $result['recall_date']  = $result3['r_eventDate'];
         $result['PLAN']         = $result3['r_reason'];
@@ -217,13 +224,41 @@ if (($_REQUEST['pid']) && ($_REQUEST['action'] == "new_recall")) {
 }
 
 if (($_REQUEST['action'] == 'addRecall') || ($_REQUEST['add_new'])) {
-    $result = $MedEx->events->save_recall($_REQUEST);
+    CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+    if (!AclMain::aclCheckCore('patients', 'appt', '', ['write', 'wsome'])) {
+        http_response_code(403);
+        exit;
+    }
+    $targetPidInput = filter_input(INPUT_POST, 'new_pid', FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+    if (!is_int($targetPidInput)) {
+        http_response_code(400);
+        exit;
+    }
+    $MedEx->events->save_recall($targetPidInput, $_REQUEST);
     echo json_encode('saved');
     exit;
 }
 
-if (($_REQUEST['action'] == 'delete_Recall') && ($_REQUEST['pid'])) {
-    $MedEx->events->delete_recall();
+if ($_REQUEST['action'] == 'delete_Recall') {
+    CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+    if (!AclMain::aclCheckCore('patients', 'appt', '', ['write', 'wsome'])) {
+        http_response_code(403);
+        exit;
+    }
+    $recallIdInput = filter_input(INPUT_POST, 'r_ID', FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+    if (!is_int($recallIdInput)) {
+        http_response_code(400);
+        exit;
+    }
+    $recallRow = QueryUtils::querySingleRow(
+        'SELECT r_pid FROM medex_recalls WHERE r_ID = ?',
+        [$recallIdInput],
+    );
+    if (!is_array($recallRow) || !is_numeric($recallRow['r_pid'] ?? null)) {
+        http_response_code(404);
+        exit;
+    }
+    $MedEx->events->delete_Recall((int) $recallRow['r_pid'], $recallIdInput);
     echo json_encode('deleted');
     exit;
 }
@@ -236,6 +271,11 @@ SessionUtil::unsetSession('pidList');
 $pid_list = [];
 
 if ($_REQUEST['action'] == "process") {
+    CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+    if (!AclMain::aclCheckCore('patients', 'appt', '', ['write', 'wsome'])) {
+        http_response_code(403);
+        exit;
+    }
     $new_pid = json_decode((string) $_POST['parameter'], true);
     $new_pc_eid = json_decode((string) $_POST['pc_eid'], true);
 

--- a/library/MedEx/API.php
+++ b/library/MedEx/API.php
@@ -14,6 +14,8 @@
 
 namespace MedExApi;
 
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\VersionService;
@@ -1330,35 +1332,63 @@ class Events extends Base
         }
     }
 
-    public function save_recall($saved)
+    /**
+     * @param int          $pid   Patient id the recall applies to; also used to scope
+     *                            the pre-delete of any prior recall for this patient.
+     * @param array<mixed> $saved Form fields (typically `$_REQUEST`) for recall
+     *                            reason/date/provider/facility + patient contact
+     *                            details. `new_pid` is ignored — pass `$pid` instead.
+     */
+    public function save_recall(int $pid, array $saved): void
     {
-        $this->delete_Recall();
-        $mysqldate = DateToYYYYMMDD($_REQUEST['form_recall_date']);
+        $this->delete_Recall($pid);
+        $mysqldate = DateToYYYYMMDD($saved['form_recall_date'] ?? '');
         $queryINS = "INSERT INTO medex_recalls (r_pid,r_reason,r_eventDate,r_provider,r_facility)
                         VALUES (?,?,?,?,?)
                         ON DUPLICATE KEY
                         UPDATE r_reason=?, r_eventDate=?, r_provider=?,r_facility=?";
-        sqlStatement($queryINS, [$_REQUEST['new_pid'],$_REQUEST['new_reason'],$mysqldate,$_REQUEST['new_provider'],$_REQUEST['new_facility'],$_REQUEST['new_reason'],$mysqldate,$_REQUEST['new_provider'],$_REQUEST['new_facility']]);
+        QueryUtils::sqlStatementThrowException($queryINS, [
+            $pid, $saved['new_reason'] ?? '', $mysqldate, $saved['new_provider'] ?? '', $saved['new_facility'] ?? '',
+            $saved['new_reason'] ?? '', $mysqldate, $saved['new_provider'] ?? '', $saved['new_facility'] ?? '',
+        ]);
         $query = "UPDATE patient_data
                     SET phone_home=?,phone_cell=?,email=?,
                         hipaa_allowemail=?,hipaa_voice=?,hipaa_allowsms=?,
                         street=?,postal_code=?,city=?,state=?
                     WHERE pid=?";
-        $sqlValues = [$_REQUEST['new_phone_home'],$_REQUEST['new_phone_cell'],$_REQUEST['new_email'],
-                        $_REQUEST['new_email_allow'],$_REQUEST['new_voice'],$_REQUEST['new_allowsms'],
-                        $_REQUEST['new_address'],$_REQUEST['new_postal_code'],$_REQUEST['new_city'],$_REQUEST['new_state'],
-                        $_REQUEST['new_pid']];
-        sqlStatement($query, $sqlValues);
-        return;
+        QueryUtils::sqlStatementThrowException($query, [
+            $saved['new_phone_home'] ?? '', $saved['new_phone_cell'] ?? '', $saved['new_email'] ?? '',
+            $saved['new_email_allow'] ?? '', $saved['new_voice'] ?? '', $saved['new_allowsms'] ?? '',
+            $saved['new_address'] ?? '', $saved['new_postal_code'] ?? '', $saved['new_city'] ?? '', $saved['new_state'] ?? '',
+            $pid,
+        ]);
     }
 
-    public function delete_Recall()
+    /**
+     * Delete recall rows for a patient. If `$recallId` is provided, only that
+     * specific recall row is deleted (still scoped to `$pid` — never deletes a
+     * row whose `r_pid` doesn't match). If `$recallId` is null, all recall rows
+     * for the patient are deleted (used by `save_recall()` to clear before
+     * re-insert).
+     */
+    public function delete_Recall(int $pid, ?int $recallId = null): void
     {
-        $sqlQuery = "DELETE FROM medex_recalls WHERE r_pid=? OR r_ID=?";
-        sqlStatement($sqlQuery, [$_POST['pid'],$_POST['r_ID']]);
+        if ($recallId !== null) {
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM medex_recalls WHERE r_pid = ? AND r_ID = ?",
+                [$pid, $recallId],
+            );
+        } else {
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM medex_recalls WHERE r_pid = ?",
+                [$pid],
+            );
+        }
 
-        $sqlDELETE = "DELETE FROM medex_outgoing WHERE msg_pc_eid = ?";
-        sqlStatement($sqlDELETE, ['recall_' . $_POST['pid']]);
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM medex_outgoing WHERE msg_pc_eid = ?",
+            ['recall_' . $pid],
+        );
     }
 
     public function getAge($dob, $asof = '')
@@ -1910,6 +1940,7 @@ class Display extends Base
                     }
                     ?>
                     <form name="rcb" id="rcb" method="post">
+                        <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken(session: $session)); ?>" />
                         <input type="hidden" name="go" value="Recalls" />
                         <div class="text-center mb-4">
                             <button class="btn btn-primary btn-add" style="width: 200px;" onclick="goReminderRecall('addRecall');return false;"><?php echo xlt('New Recall'); ?></button>
@@ -2592,6 +2623,7 @@ class Display extends Base
             </div>
 
             <form class="prefs p-4 row" name="addRecall" id="addRecall">
+                <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken(session: $session)); ?>" />
                 <input type="hidden" name="go" id="go" value="addRecall" />
                 <input type="hidden" name="action" id="go" value="addRecall" />
                 <div class="col-4 divTable m-2 ml-auto">
@@ -3349,7 +3381,7 @@ class MedEx
     public $curl;
     public $practice;
     public $campaign;
-    public $events;
+    public Events $events;
     public $callback;
     public $logging;
     public $display;


### PR DESCRIPTION
Adds authorization, CSRF, and typed input validation to the four recall
handlers in `interface/main/messages/save.php` (`new_recall`, `addRecall`,
`delete_Recall`, `process`), and refactors the underlying MedEx recall
API to take an explicit `$pid` argument rather than reading it from
`$_REQUEST`.

- `library/MedEx/API.php`
  - `save_recall(int $pid, array $saved): void` — uses `$pid` for both
    the `medex_recalls` insert and the `patient_data` update.
  - `delete_Recall(int $pid, ?int $recallId = null): void` — the previous
    `WHERE r_pid = ? OR r_ID = ?` becomes `WHERE r_pid = ? AND r_ID = ?`
    when `$recallId` is supplied.
  - `MedEx::$events` property typed as `Events`.
  - `display_recalls()` and `display_add_recall()` now emit a
    `csrf_token_form` hidden input on the outer form so the JS callers
    can echo it back.

- `interface/main/messages/save.php`
  - `new_recall` (read): `patients/appt` view-mode ACL. Target pid parsed
    via `filter_input(INPUT_POST, 'pid', FILTER_VALIDATE_INT, min_range: 1)`
    — a 400 is returned on invalid/missing input.
  - `addRecall` (write): `CsrfUtils::checkCsrfInput` + `patients/appt`
    `['write','wsome']` ACL. Target pid parsed via
    `filter_input(INPUT_POST, 'new_pid', ...)`.
  - `delete_Recall`: same CSRF + ACL. `r_ID` is validated the same way;
    the recall's `r_pid` is then looked up server-side via
    `QueryUtils::querySingleRow` (missing row returns 404).
  - `process`: same CSRF + ACL.

- `interface/main/messages/js/reminder_appts.js` — `delete_Recall` and
  `process_this` read the CSRF token from the outer \`#rcb\` form's
  hidden input and pass it in the AJAX payload. \`add_this_recall\`
  already serializes the \`#addRecall\` form so no JS change was needed
  once the hidden input was added.

ACL modes and gating pattern mirror
\`interface/main/calendar/add_edit_event.php\` and
\`interface/main/calendar/find_appt_popup.php\`. The Recall Board picker
workflow — where staff pick a patient via \`find_patient_popup.php\` and
manage that patient's recall from outside their chart — continues to
work: the target patient comes from the request, and categorical
\`patients/appt\` write-mode authorization is what gates the operation
(matching the Recall Board's own menu-level ACL).