### PR TITLE
refactor(acceptance): extract PantherAcceptanceTestCase + UiSeedingTrait from Small-tier ports

### DIFF
--- a/tests/Acceptance/AaLoginAcceptanceTest.php
+++ b/tests/Acceptance/AaLoginAcceptanceTest.php
@@ -14,9 +14,8 @@ namespace OpenEMR\Tests\Acceptance;
 
 use Facebook\WebDriver\WebDriverExpectedCondition;
 use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+use OpenEMR\Tests\Acceptance\Support\PantherAcceptanceTestCase;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Panther\Client;
 
 /**
  * Panther-driven acceptance port of the non-overlapping scenarios in
@@ -24,9 +23,10 @@ use Symfony\Component\Panther\Client;
  *
  * Phase 4e-1 (first Small warmup of Phase 4e — reuse tests/Tests/E2e/*
  * flows against the SHIPPED docker release image booted by
- * tests/Acceptance/bin/boot-docker.sh). Extends the E2eCriticalPathTest
- * pattern shipped in PR #13196: Panther client via BrowserSession
- * factory, base URI resolved from ACCEPTANCE_ARTIFACT_URL.
+ * tests/Acceptance/bin/boot-docker.sh). Extends PantherAcceptanceTestCase
+ * for BrowserSession lifecycle discipline, though the negative-auth
+ * flows here don't invoke performLoginAsAdmin() — they intentionally
+ * stay pre-login.
  *
  * Deliberately partial port — the source-side AaLoginTest has five
  * scenarios; only two of them add signal over what already ships in
@@ -57,21 +57,8 @@ use Symfony\Component\Panther\Client;
  */
 #[Group('fresh-install')]
 #[Group('post-upgrade')]
-final class AaLoginAcceptanceTest extends TestCase
+final class AaLoginAcceptanceTest extends PantherAcceptanceTestCase
 {
-    private ?Client $client = null;
-
-    protected function tearDown(): void
-    {
-        if ($this->client !== null) {
-            // Panther leaves a Chrome subprocess + ChromeDriver session
-            // dangling if not explicitly quit. Same discipline as
-            // E2eCriticalPathTest.
-            $this->client->quit();
-            $this->client = null;
-        }
-    }
-
     /**
      * Wrong password should NOT authenticate; the login page stays put.
      *
@@ -81,18 +68,19 @@ final class AaLoginAcceptanceTest extends TestCase
     public function testLoginWithWrongPasswordStaysOnLoginPage(): void
     {
         $this->client = BrowserSession::create();
-        $this->client->request('GET', '/interface/login/login.php?site=default');
+        $client = $this->requireClient();
+        $client->request('GET', self::LOGIN_URL);
 
         self::assertSame(
-            'OpenEMR Login',
-            $this->client->getTitle(),
+            self::LOGIN_TITLE,
+            $client->getTitle(),
             'Login page must render before submitting bad credentials — a different title means the login route itself is broken',
         );
 
         // Submit the login form with a deliberately wrong password.
         // Same admin username, password with a "1" suffix — matches
         // the source-side LoginTestData::password . "1" pattern.
-        $this->client->submitForm('login-button', [
+        $client->submitForm('login-button', [
             'authUser' => 'admin',
             'clearPass' => 'pass1',
         ]);
@@ -103,7 +91,7 @@ final class AaLoginAcceptanceTest extends TestCase
         // for the URL to settle on /interface/login/login.php before
         // asserting the title. Anti-flake sync — Panther-standard
         // pattern for JS-driven redirects.
-        $this->client->wait(10)->until(
+        $client->wait(10)->until(
             WebDriverExpectedCondition::urlContains('/interface/login/login.php'),
         );
 
@@ -113,8 +101,8 @@ final class AaLoginAcceptanceTest extends TestCase
         // title stays "OpenEMR Login" (a successful auth would
         // transition it to "OpenEMR").
         self::assertSame(
-            'OpenEMR Login',
-            $this->client->getTitle(),
+            self::LOGIN_TITLE,
+            $client->getTitle(),
             'Login with a wrong password must NOT authenticate — a title change to "OpenEMR" means the artifact accepted invalid credentials',
         );
     }
@@ -129,13 +117,14 @@ final class AaLoginAcceptanceTest extends TestCase
     public function testUnauthenticatedDeepLinkRedirectsToLoginPage(): void
     {
         $this->client = BrowserSession::create();
+        $client = $this->requireClient();
         // Hit the post-login main shell without ever having authenticated.
         // testing_mode=1 mirrors the source-side flow — it suppresses
         // some prod-only redirects that would otherwise complicate the
         // assertion (matches the source-side E2e's flag choice).
-        $this->client->request(
+        $client->request(
             'GET',
-            '/interface/main/tabs/main.php?site=default&testing_mode=1',
+            self::MAIN_SHELL_URL . '?site=default&testing_mode=1',
         );
 
         // Same JS-redirect race as testLoginRejectsWrongPassword:
@@ -143,13 +132,13 @@ final class AaLoginAcceptanceTest extends TestCase
         // back to login.php via a client-side redirect, so a title
         // read immediately after request() can race the redirect.
         // Wait for the URL to reach /interface/login/login.php first.
-        $this->client->wait(10)->until(
+        $client->wait(10)->until(
             WebDriverExpectedCondition::urlContains('/interface/login/login.php'),
         );
 
         self::assertSame(
-            'OpenEMR Login',
-            $this->client->getTitle(),
+            self::LOGIN_TITLE,
+            $client->getTitle(),
             'Unauthenticated GET on /interface/main/tabs/main.php should land on the login page — a different title means the artifact either exposed post-login content or served an error page instead of the expected auth redirect',
         );
     }

--- a/tests/Acceptance/E2eCriticalPathTest.php
+++ b/tests/Acceptance/E2eCriticalPathTest.php
@@ -12,13 +12,10 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Acceptance;
 
-use Facebook\WebDriver\Exception\TimeoutException;
-use Facebook\WebDriver\JavaScriptExecutor;
 use Facebook\WebDriver\WebDriverBy;
 use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+use OpenEMR\Tests\Acceptance\Support\PantherAcceptanceTestCase;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Panther\Client;
 
 /**
  * Browser-driven end-to-end acceptance test.
@@ -44,97 +41,19 @@ use Symfony\Component\Panther\Client;
  */
 #[Group('fresh-install')]
 #[Group('post-upgrade')]
-final class E2eCriticalPathTest extends TestCase
+final class E2eCriticalPathTest extends PantherAcceptanceTestCase
 {
-    private ?Client $client = null;
-
-    protected function tearDown(): void
-    {
-        if ($this->client !== null) {
-            // Panther leaves a Chrome subprocess + ChromeDriver session
-            // dangling if not explicitly quit. Local runs accumulate
-            // zombies; CI runners recycle so it doesn't matter there,
-            // but tearDown discipline keeps local dev clean.
-            $this->client->quit();
-            $this->client = null;
-        }
-    }
-
     public function testAdminCanLogInAndKnockoutMainMenuRenders(): void
     {
         $this->client = BrowserSession::create();
-        // Panther's request() takes either an absolute URL or a path
-        // relative to `external_base_uri` (set to ACCEPTANCE_ARTIFACT_URL
-        // in the BrowserSession factory).
-        $this->client->request('GET', '/interface/login/login.php?site=default');
-
-        self::assertSame(
-            'OpenEMR Login',
-            $this->client->getTitle(),
-            'Login page title should be "OpenEMR Login" — a different title means the login route rendered something unexpected (setup wizard, error page, blank shell)',
-        );
-
-        // Fill and submit the login form. openemr's login form
-        // requires two hidden fields (languageChoice + new_login_session_management)
-        // in addition to the visible authUser/clearPass — those are
-        // pre-populated by the form template, so submitting the
-        // form element (rather than reconstructing a POST) picks
-        // them up automatically.
-        $this->client->submitForm('login-button', [
-            'authUser' => 'admin',
-            'clearPass' => 'pass',
-        ]);
-
-        // Post-login lands on /interface/main/tabs/main.php, which
-        // loads the Knockout-templated main menu asynchronously.
-        // waitForVisibility on #mainMenu confirms the DOM node
-        // exists; the executeScript check below confirms Knockout
-        // actually populated it with children (i.e. bindings
-        // applied, not just an empty shell).
-        try {
-            $this->client->waitFor('#mainMenu', 30);
-        } catch (TimeoutException) {
-            self::fail(
-                'Post-login #mainMenu element never appeared (30s timeout). '
-                . 'Landing URL: ' . $this->client->getCurrentURL() . '. '
-                . 'Title: ' . $this->client->getTitle() . '. '
-                . 'This likely means the login POST did not authenticate, or '
-                . 'the post-login shell (interface/main/tabs/main.php) never rendered.'
-            );
-        }
-
-        // Knockout-ready gate: bindings have applied, the menu template
-        // ran, so #mainMenu has child nodes. Matches the source-side
-        // BaseTrait's waitForAppReady contract. Without this check we
-        // could pass on a broken JS build that renders the SPA shell
-        // but leaves the menu empty.
-        //
-        // Type-hint the closure's $driver as JavaScriptExecutor so
-        // phpstan can resolve executeScript() (the base WebDriver
-        // interface types the callable arg as `mixed`; source-side
-        // E2E tests baseline this on principle, but we prefer to
-        // type-narrow at the source instead).
-        try {
-            $this->client->wait(30)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
-                'return document.getElementById("mainMenu")?.children.length > 0'
-            ));
-        } catch (TimeoutException) {
-            $rawDiagnostics = $this->client->executeScript(<<<'JS_WRAP'
-                return JSON.stringify({
-                    url: location.href,
-                    title: document.title,
-                    knockoutLoaded: typeof ko !== "undefined",
-                    mainMenuChildCount: document.getElementById("mainMenu")?.children.length ?? 0,
-                });
-            JS_WRAP);
-            $diagnostics = is_string($rawDiagnostics) ? $rawDiagnostics : 'unavailable';
-            self::fail(
-                'Knockout main menu never populated (30s timeout after #mainMenu appeared). '
-                . "Page state: {$diagnostics}. This means the SPA shell loaded but the "
-                . 'JS framework (Knockout) either did not load or did not apply bindings — '
-                . 'symptom of a broken webpack build, missing JS asset, or template regression.'
-            );
-        }
+        // performLoginAsAdmin encapsulates the full login + Knockout-
+        // ready gate discipline (title change → #mainMenu appears →
+        // Knockout populates children) with diagnostic self::fail
+        // messages on each timeout. That's the exact scope this test
+        // asserts on — the post-login-shell-boots-cleanly signal —
+        // so the assertion here just checks the visible menu content
+        // after the base-class gate lands.
+        $this->performLoginAsAdmin();
 
         // At this point the app is fully booted — assert one visible
         // menu label to prove the menu isn't just full of empty nodes.
@@ -143,7 +62,8 @@ final class E2eCriticalPathTest extends TestCase
         // every skin). If this ever fails, the failure message points
         // at the specific expectation being wrong rather than a vague
         // "menu is broken."
-        $calendarMenu = $this->client->findElements(
+        $client = $this->requireClient();
+        $calendarMenu = $client->findElements(
             WebDriverBy::xpath('//div[@id="mainMenu"]//div[text()="Calendar"]'),
         );
         self::assertNotEmpty(

--- a/tests/Acceptance/FrontPaymentCssContrastAcceptanceTest.php
+++ b/tests/Acceptance/FrontPaymentCssContrastAcceptanceTest.php
@@ -16,9 +16,8 @@ use Facebook\WebDriver\Exception\TimeoutException;
 use Facebook\WebDriver\JavaScriptExecutor;
 use Facebook\WebDriver\WebDriver;
 use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+use OpenEMR\Tests\Acceptance\Support\PantherAcceptanceTestCase;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Panther\Client;
 
 /**
  * Panther-driven acceptance port of
@@ -26,13 +25,13 @@ use Symfony\Component\Panther\Client;
  *
  * Phase 4e-3 (third Small warmup of Phase 4e — reuse tests/Tests/E2e/*
  * flows against the SHIPPED docker release image booted by
- * tests/Acceptance/bin/boot-docker.sh). Extends the pattern established
- * by AaLoginAcceptanceTest (#13336) and GgUserMenuLinksAcceptanceTest
- * (#13338): Panther client via BrowserSession factory, base URI
- * resolved from ACCEPTANCE_ARTIFACT_URL, JS-redirect anti-flake
- * pattern via `wait()->until(...)` with a TYPED `$driver` parameter
- * so phpstan level 10 accepts the executeScript / getTitle /
- * getCurrentURL calls without inline @var casts.
+ * tests/Acceptance/bin/boot-docker.sh). Extends PantherAcceptanceTestCase
+ * for the BrowserSession lifecycle + shared constants; does NOT invoke
+ * performLoginAsAdmin() because the next step is a direct GET to
+ * front_payment.php (no clicks in the SPA shell), so the full
+ * Knockout-ready + modal-dismiss gate would just add wall-clock without
+ * changing the assertion outcome. See loginAsAdminAndWaitForShell()
+ * below for the scoped-down login that's actually needed here.
  *
  * Full port — the source has one scenario (testReceiptCssHasExplicitTextColor)
  * and it carries meaningful signal against a booted release artifact:
@@ -63,22 +62,8 @@ use Symfony\Component\Panther\Client;
  */
 #[Group('fresh-install')]
 #[Group('post-upgrade')]
-final class FrontPaymentCssContrastAcceptanceTest extends TestCase
+final class FrontPaymentCssContrastAcceptanceTest extends PantherAcceptanceTestCase
 {
-    private ?Client $client = null;
-
-    protected function tearDown(): void
-    {
-        if ($this->client !== null) {
-            // Panther leaves a Chrome subprocess + ChromeDriver session
-            // dangling if not explicitly quit. Same discipline as
-            // E2eCriticalPathTest / AaLoginAcceptanceTest /
-            // GgUserMenuLinksAcceptanceTest.
-            $this->client->quit();
-            $this->client = null;
-        }
-    }
-
     /**
      * The shipped front-payment receipt page must include explicit
      * `color` declarations on every element that sets a
@@ -245,21 +230,20 @@ final class FrontPaymentCssContrastAcceptanceTest extends TestCase
 
     /**
      * Log in as admin/pass and wait for the post-login shell title to
-     * settle. Same login-then-wait discipline as
-     * GgUserMenuLinksAcceptanceTest::loginAsAdminAndWaitForMenu, but
-     * scoped down: we don't need the full Knockout-ready gate here
-     * because the next step is a direct GET to front_payment.php, not
-     * a click sequence in the SPA shell. The title-change gate is the
-     * minimum sync needed to prove the session was established before
-     * we start using it.
+     * settle. Scoped-down variant of the base-class performLoginAsAdmin
+     * — we don't need the full Knockout-ready gate or the modal dismiss
+     * here because the next step is a direct GET to front_payment.php,
+     * not a click sequence in the SPA shell. The title-change gate is
+     * the minimum sync needed to prove the session was established
+     * before we start using it.
      */
     private function loginAsAdminAndWaitForShell(): void
     {
         $client = $this->requireClient();
-        $client->request('GET', '/interface/login/login.php?site=default');
+        $client->request('GET', self::LOGIN_URL);
 
         self::assertSame(
-            'OpenEMR Login',
+            self::LOGIN_TITLE,
             $client->getTitle(),
             'Login page must render before submitting credentials — a different title means '
             . 'the login route itself is broken',
@@ -271,36 +255,23 @@ final class FrontPaymentCssContrastAcceptanceTest extends TestCase
         ]);
 
         // Post-login redirect is client-side / async. Same wait-for-
-        // title pattern GgUserMenuLinksAcceptanceTest uses, with the
-        // TimeoutException wrapped in a diagnostic fail() so a broken
-        // login POST surfaces a clear signal (landing URL + observed
-        // title) rather than a bare TimeoutException on a helper line.
+        // title pattern the base class's performLoginAsAdmin uses,
+        // with the TimeoutException wrapped in a diagnostic fail() so
+        // a broken login POST surfaces a clear signal (landing URL +
+        // observed title) rather than a bare TimeoutException on a
+        // helper line.
         try {
             $client->wait(10)->until(
-                static fn(WebDriver $driver): bool => $driver->getTitle() === 'OpenEMR',
+                static fn(WebDriver $driver): bool => $driver->getTitle() === self::SHELL_TITLE,
             );
         } catch (TimeoutException) {
             self::fail(
-                'Post-login shell title never became "OpenEMR" (10s timeout). '
+                'Post-login shell title never became "' . self::SHELL_TITLE . '" (10s timeout). '
                 . 'Landing URL: ' . $client->getCurrentURL() . '. '
                 . 'Title: ' . $client->getTitle() . '. '
                 . 'This usually means the login POST did not authenticate '
                 . '(credentials wrong, POST rejected, or login handler broke).',
             );
         }
-    }
-
-    /**
-     * Narrow the nullable $this->client for phpstan and for a clearer
-     * failure mode if a helper is somehow called before setUp has run.
-     * Mirrors the requireClient() helper in
-     * GgUserMenuLinksAcceptanceTest.
-     */
-    private function requireClient(): Client
-    {
-        if ($this->client === null) {
-            self::fail('BrowserSession client not initialized — helper called before create()');
-        }
-        return $this->client;
     }
 }

--- a/tests/Acceptance/GgUserMenuLinksAcceptanceTest.php
+++ b/tests/Acceptance/GgUserMenuLinksAcceptanceTest.php
@@ -12,33 +12,26 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Acceptance;
 
-use Facebook\WebDriver\Exception\TimeoutException;
-use Facebook\WebDriver\JavaScriptExecutor;
-use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverBy;
-use Facebook\WebDriver\WebDriverElement;
 use Facebook\WebDriver\WebDriverExpectedCondition;
 use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+use OpenEMR\Tests\Acceptance\Support\PantherAcceptanceTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Panther\Client;
 
 /**
  * Panther-driven acceptance port of tests/Tests/E2e/GgUserMenuLinksTest.
  *
  * Phase 4e-2 (second Small warmup of Phase 4e — reuse tests/Tests/E2e/*
  * flows against the SHIPPED docker release image booted by
- * tests/Acceptance/bin/boot-docker.sh). Extends the pattern established
- * by AaLoginAcceptanceTest (#13336): Panther client via BrowserSession
- * factory, base URI resolved from ACCEPTANCE_ARTIFACT_URL, JS-redirect
- * anti-flake pattern via `wait()->until(...)`. Closures inside `until()`
- * MUST explicitly type their `$driver` parameter as `WebDriver` (or
+ * tests/Acceptance/bin/boot-docker.sh). Extends PantherAcceptanceTestCase
+ * for the shared login + Knockout-ready gate + Product Registration
+ * modal dismissal. Closures inside `wait()->until(...)` MUST explicitly
+ * type their `$driver` parameter as `WebDriver` (or
  * `JavaScriptExecutor` when calling executeScript) — otherwise phpstan
- * level 10 infers `mixed` for the parameter and rejects `getCurrentURL()
- * / getTitle() / executeScript()` calls on it. `WebDriverExpectedCondition`
- * carries its own types so plain-`until(WebDriverExpectedCondition::...)`
- * needs no annotation.
+ * level 10 infers `mixed` and rejects downstream method calls.
+ * `WebDriverExpectedCondition` carries its own types so plain-
+ * `until(WebDriverExpectedCondition::...)` needs no annotation.
  *
  * Full port of the source-side menuLinkProvider — all five user-menu
  * links exercise post-login UI surface (not admin.php / not any surface
@@ -60,21 +53,8 @@ use Symfony\Component\Panther\Client;
  */
 #[Group('fresh-install')]
 #[Group('post-upgrade')]
-final class GgUserMenuLinksAcceptanceTest extends TestCase
+final class GgUserMenuLinksAcceptanceTest extends PantherAcceptanceTestCase
 {
-    private ?Client $client = null;
-
-    protected function tearDown(): void
-    {
-        if ($this->client !== null) {
-            // Panther leaves a Chrome subprocess + ChromeDriver session
-            // dangling if not explicitly quit. Same discipline as
-            // E2eCriticalPathTest and AaLoginAcceptanceTest.
-            $this->client->quit();
-            $this->client = null;
-        }
-    }
-
     /**
      * Each user-menu link should navigate to (or land on) the expected
      * post-click surface — the four in-app entries open a named tab
@@ -88,7 +68,7 @@ final class GgUserMenuLinksAcceptanceTest extends TestCase
     public function testUserMenuLink(string $menuTreeIcon, string $expectedTabTitle): void
     {
         $this->client = BrowserSession::create();
-        $this->loginAsAdminAndWaitForMenu();
+        $this->performLoginAsAdmin();
 
         if ($menuTreeIcon === 'fa-sign-out-alt') {
             // Logout is a distinct assertion shape — clicking the icon
@@ -102,7 +82,7 @@ final class GgUserMenuLinksAcceptanceTest extends TestCase
             $client->wait(10)->until(
                 WebDriverExpectedCondition::urlContains('/interface/login/login.php'),
             );
-            $client->waitFor('//input[@id="authUser"]');
+            $client->waitFor(self::XPATH_LOGIN_USERNAME_INPUT);
             self::assertSame(
                 $expectedTabTitle,
                 $client->getTitle(),
@@ -132,178 +112,6 @@ final class GgUserMenuLinksAcceptanceTest extends TestCase
     }
 
     /**
-     * Log in as admin/pass and wait for the Knockout-rendered #mainMenu
-     * to actually populate — same two-gate discipline as
-     * E2eCriticalPathTest, so the click sequence below can address
-     * menu elements without racing the SPA boot.
-     */
-    private function loginAsAdminAndWaitForMenu(): void
-    {
-        $client = $this->requireClient();
-        $client->request('GET', '/interface/login/login.php?site=default');
-
-        self::assertSame(
-            'OpenEMR Login',
-            $client->getTitle(),
-            'Login page must render before submitting credentials — a different title means the login route itself is broken',
-        );
-
-        $client->submitForm('login-button', [
-            'authUser' => 'admin',
-            'clearPass' => 'pass',
-        ]);
-
-        // Post-login redirect is client-side / async — same race the
-        // source-side LoginTrait::performLogin handles by waiting for
-        // getTitle() === 'OpenEMR'. Use the same wait-for-title
-        // pattern here so downstream user-menu clicks don't race the
-        // shell load. Wrapped in try/catch so a timeout surfaces a
-        // useful diagnostic (landing URL + current title) instead of a
-        // bare TimeoutException — a failed login is by far the most
-        // likely cause of a timeout at this gate, and knowing WHICH
-        // page the browser actually landed on cuts triage time to zero.
-        try {
-            $client->wait(10)->until(
-                static fn(WebDriver $driver): bool => $driver->getTitle() === 'OpenEMR',
-            );
-        } catch (TimeoutException) {
-            self::fail(
-                'Post-login shell title never became "OpenEMR" (10s timeout). '
-                . 'Landing URL: ' . $client->getCurrentURL() . '. '
-                . 'Title: ' . $client->getTitle() . '. '
-                . 'This usually means the login POST did not authenticate '
-                . '(credentials wrong, POST rejected, or login handler broke).'
-            );
-        }
-
-        try {
-            $client->waitFor('#mainMenu', 30);
-        } catch (TimeoutException) {
-            self::fail(
-                'Post-login #mainMenu element never appeared (30s timeout). '
-                . 'Landing URL: ' . $client->getCurrentURL() . '. '
-                . 'Title: ' . $client->getTitle() . '. '
-                . 'This likely means the login POST did not authenticate, or '
-                . 'the post-login shell (interface/main/tabs/main.php) never rendered.'
-            );
-        }
-
-        // Knockout-ready gate — mirrors E2eCriticalPathTest so a broken
-        // JS build (menu shell but empty children) fails here rather
-        // than later on an obscure "user icon not clickable" message.
-        try {
-            $client->wait(30)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
-                'return document.getElementById("mainMenu")?.children.length > 0'
-            ));
-        } catch (TimeoutException) {
-            self::fail(
-                'Knockout main menu never populated (30s timeout after #mainMenu appeared). '
-                . 'This means the SPA shell loaded but the JS framework (Knockout) either did '
-                . 'not load or did not apply bindings — symptom of a broken webpack build, '
-                . 'missing JS asset, or template regression.'
-            );
-        }
-
-        $this->dismissProductRegistrationModalIfPresent();
-    }
-
-    /**
-     * The shipped release image renders a "Product Registration" modal
-     * on first login that intercepts clicks on the top-right user icon
-     * (position 1841,31 in a 1920x1080 viewport is inside the modal's
-     * hit area). The source-side dev checkout doesn't trigger this
-     * modal in the same way, so it's an acceptance-side-only gotcha.
-     *
-     * Dismiss it via the modal's own "Ask again later" button when
-     * visible; do nothing (don't fail) when it isn't there, so this
-     * stays robust if a future release image tweaks the trigger
-     * heuristic or drops the modal entirely. Short poll — the modal
-     * either appears within the SPA-ready window above or it isn't
-     * going to at all.
-     */
-    private function dismissProductRegistrationModalIfPresent(): void
-    {
-        $client = $this->requireClient();
-        // The modal is triggered by an async XHR fired from
-        // product_reg.js's document.ready — that XHR resolves and
-        // calls `.modal('toggle')` some time after main.php
-        // finishes rendering. Wait for the modal to be fully
-        // shown (both the `show` class AND display:block) so
-        // Bootstrap has committed the show-transition; calling
-        // `.modal('hide')` mid-transition is a no-op that gets
-        // clobbered when the show-side of the animation completes.
-        //
-        // 5s poll (not 15s): product_reg.js's XHR fires during
-        // document.ready which has already completed by the time
-        // the Knockout-ready gate above passes, so the modal
-        // either shows within the first few hundred ms of this
-        // poll or it isn't going to. Longer window costs the full
-        // wait × 5 scenarios × 6 matrix cells for zero signal
-        // gain when the modal doesn't appear.
-        //
-        // Try/catch scoped ONLY to this presence wait: TimeoutException
-        // here is benign ("no modal appeared, nothing to dismiss") and
-        // should not be conflated with a dismissal failure below. If
-        // the modal DID appear but the dismissal below fails, the
-        // fade-out wait's TimeoutException propagates — real failure
-        // (would otherwise leave a backdrop intercepting user-menu
-        // clicks and cause a downstream test failure with no useful
-        // signal).
-        try {
-            $client->wait(5)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
-                <<<'JS_WRAP'
-                    var modal = document.querySelector('.product-registration-modal.show');
-                    return modal !== null && modal.style.display === 'block';
-                JS_WRAP,
-            ));
-        } catch (TimeoutException) {
-            // No modal appeared within the poll window — that's fine
-            // (a re-run against the same artifact won't re-show the
-            // modal, and future release-image changes may drop it
-            // entirely); proceed with the user-menu interactions.
-            return;
-        }
-        // Modal detected — from here down, failures propagate so a
-        // failed dismissal surfaces loudly rather than getting hidden
-        // by a broad catch upstream.
-
-        // Small settle after the show transition — Bootstrap's
-        // internal state machine ignores hide() until the fade-in
-        // completes. Empirically ~150ms is the fade-in duration;
-        // 500ms gives comfortable margin without lengthening the
-        // test noticeably.
-        usleep(500_000);
-        // Guard the jQuery call — if jQuery is under noConflict or
-        // absent from window entirely, calling `window.jQuery(...)`
-        // throws a WebDriver JS error. If the guard hits (jQuery
-        // missing on a shipped OpenEMR release image would itself be
-        // a real problem to surface), the modal stays visible and
-        // the fade-out wait below times out — that TimeoutException
-        // propagates and fails the test with a clear signal that
-        // dismissal didn't complete, rather than silently letting
-        // the backdrop intercept the next user-icon click.
-        $client->executeScript(
-            <<<'JS_WRAP'
-                if (window.jQuery) {
-                    window.jQuery(".product-registration-modal").modal("hide");
-                }
-            JS_WRAP,
-        );
-        // Wait for the fade-out to complete so the subsequent
-        // user-icon click isn't intercepted by the modal
-        // backdrop mid-transition. No try/catch — a timeout here
-        // means we detected a modal but couldn't hide it, which
-        // is a real failure the test must surface.
-        $client->wait(10)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
-            <<<'JS_WRAP'
-                var modal = document.querySelector('.product-registration-modal.show');
-                var backdrop = document.querySelector('.modal-backdrop');
-                return modal === null && backdrop === null;
-            JS_WRAP,
-        ));
-    }
-
-    /**
      * Click the top-right user icon, then click the child user-menu
      * entry identified by its Font Awesome icon class. Mirrors the
      * source-side BaseTrait::goToUserMenuLink XPath sequence
@@ -318,92 +126,16 @@ final class GgUserMenuLinksAcceptanceTest extends TestCase
         $client->switchTo()->defaultContent();
 
         $this->waitAndClick(
-            WebDriverBy::xpath('//i[@id="user_icon"]'),
+            WebDriverBy::xpath(self::XPATH_USER_ICON),
             'top-right user icon',
+            10,
         );
         $this->waitAndClick(
             WebDriverBy::xpath(
                 '//ul[@id="userdropdown"]//i[contains(@class, "' . $menuTreeIcon . '")]',
             ),
             "user-menu entry with icon class {$menuTreeIcon}",
+            10,
         );
-    }
-
-    /**
-     * Wait for an element matched by $by to be clickable, then click
-     * it. Narrows WebDriverWait::until()'s `mixed` return through an
-     * instanceof check so phpstan level 10 accepts the ->click() call
-     * without inline @var casts.
-     */
-    private function waitAndClick(WebDriverBy $by, string $description): void
-    {
-        $client = $this->requireClient();
-        $element = $client->wait(10)->until(
-            WebDriverExpectedCondition::elementToBeClickable($by),
-        );
-        if (!$element instanceof WebDriverElement) {
-            self::fail(
-                "elementToBeClickable returned a non-element for {$description}; got "
-                . get_debug_type($element),
-            );
-        }
-        $element->click();
-    }
-
-    /**
-     * Wait for the currently-active tab in #tabs_div to display the
-     * expected title, with the "Loading" placeholder resolved. Mirrors
-     * the source-side BaseTrait::assertActiveTab shape but simplified
-     * for the single-string case used by every user-menu entry
-     * (no '||'-separated loading indicators, no loose match).
-     */
-    private function assertActiveTab(string $expectedTitle): void
-    {
-        $client = $this->requireClient();
-        $activeTabXpath = "//div[@id='tabs_div']/div/div[not(contains(concat(' ',normalize-space(@class),' '),' tabsNoHover '))]";
-
-        // Wait for the active tab element to exist, then wait for the
-        // "Loading" placeholder to be replaced with the real title. Two
-        // waits because the tab node is created before the tab content
-        // resolves — reading the text between those events races the
-        // async tab render.
-        $client->waitFor($activeTabXpath, 30);
-        $client->wait(30)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
-            <<<'JS_WRAP'
-                var el = document.evaluate(
-                    arguments[0],
-                    document,
-                    null,
-                    XPathResult.FIRST_ORDERED_NODE_TYPE,
-                    null,
-                ).singleNodeValue;
-                if (!el) { return false; }
-                var text = (el.textContent || '').trim();
-                return text.length > 0 && text.indexOf('Loading') === -1;
-            JS_WRAP,
-            [$activeTabXpath],
-        ));
-
-        $activeTab = $client->findElement(WebDriverBy::xpath($activeTabXpath));
-        self::assertSame(
-            $expectedTitle,
-            trim($activeTab->getText()),
-            "[{$expectedTitle}] user-menu link did not open the expected tab — "
-            . 'the click reached the app but the resulting tab title differs, which '
-            . 'means either the menu entry routes somewhere unexpected or the tab '
-            . 'label regressed',
-        );
-    }
-
-    /**
-     * Narrow the nullable $this->client for phpstan and for a clearer
-     * failure mode if a helper is somehow called before setUp has run.
-     */
-    private function requireClient(): Client
-    {
-        if ($this->client === null) {
-            self::fail('BrowserSession client not initialized — helper called before create()');
-        }
-        return $this->client;
     }
 }

--- a/tests/Acceptance/KkEncounterFormNavbarUrlAcceptanceTest.php
+++ b/tests/Acceptance/KkEncounterFormNavbarUrlAcceptanceTest.php
@@ -12,32 +12,23 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Acceptance;
 
-use Facebook\WebDriver\Exception\TimeoutException;
-use Facebook\WebDriver\JavaScriptExecutor;
-use Facebook\WebDriver\WebDriver;
-use Facebook\WebDriver\WebDriverBy;
-use Facebook\WebDriver\WebDriverElement;
-use Facebook\WebDriver\WebDriverExpectedCondition;
 use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+use OpenEMR\Tests\Acceptance\Support\PantherAcceptanceTestCase;
+use OpenEMR\Tests\Acceptance\Support\UiSeedingTrait;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Panther\Client;
 
 /**
  * Panther-driven acceptance port of tests/Tests/E2e/KkEncounterFormNavbarUrlTest.
  *
  * Phase 4e-4 (fourth + last Small warmup of Phase 4e — reuse
  * tests/Tests/E2e/* flows against the SHIPPED docker release image
- * booted by tests/Acceptance/bin/boot-docker.sh). Extends the pattern
- * established by GgUserMenuLinksAcceptanceTest (#13338) and
- * AaLoginAcceptanceTest (#13336): Panther client via BrowserSession
- * factory, base URI resolved from ACCEPTANCE_ARTIFACT_URL. Closures
- * inside `wait()->until(...)` MUST explicitly type their `$driver`
- * parameter as `WebDriver` (or `JavaScriptExecutor` when calling
- * executeScript) — otherwise phpstan level 10 infers `mixed` and
- * rejects downstream method calls. `WebDriverExpectedCondition`
- * carries its own types so plain-`until(WebDriverExpectedCondition::...)`
- * needs no annotation.
+ * booted by tests/Acceptance/bin/boot-docker.sh). Extends
+ * PantherAcceptanceTestCase for the shared login + Knockout-ready gate
+ * + Product Registration modal dismissal, and consumes UiSeedingTrait
+ * for the patient + encounter seeding helpers that the source-side
+ * ordered suite gets from CcCreatePatientTest / EeCreateEncounterTest
+ * predecessors — the acceptance suite has no such ordering, so this
+ * test seeds up front via UI navigation.
  *
  * Regression test for #10844: without pid + encounter URL params on
  * the encounter-form navbar dropdown links, form loading fell back to
@@ -61,41 +52,20 @@ use Symfony\Component\Panther\Client;
  * navigation up front. Black-box discipline — no SQL, no direct DB
  * writes, no fixture files.
  *
- * Product-registration-modal dismissal: the shipped release image
- * shows a "Product Registration" modal on first login whose backdrop
- * intercepts clicks on top-right shell elements. The seeding flow
- * clicks the user icon adjacent area (new-patient tab launch via
- * mainMenu, not user menu), but the modal's full-page backdrop can
- * intercept clicks on ANY element outside the modal's own boundary
- * until dismissed — so the same helper as GgUserMenuLinksAcceptanceTest
- * is included here defensively. Cheaper to always dismiss than to
- * debug a downstream "element not interactable" 30s post-login.
+ * Product-registration-modal dismissal: handled by the base class's
+ * performLoginAsAdmin(), which dismisses the modal as its final gate
+ * step. The seeding flow below clicks main-menu / shell shortcuts
+ * that would otherwise be blocked by the modal's backdrop, so the
+ * dismissal is defensive but load-bearing.
  *
  * The source-side KkEncounterFormNavbarUrlTest continues to run
  * against the dev stack unchanged — this class is purely additive
  * against the release artifact.
  */
 #[Group('fresh-install')]
-final class KkEncounterFormNavbarUrlAcceptanceTest extends TestCase
+final class KkEncounterFormNavbarUrlAcceptanceTest extends PantherAcceptanceTestCase
 {
-    private const PATIENT_FNAME = 'Ftest';
-    private const PATIENT_LNAME = 'Ltest';
-    private const PATIENT_DOB = '1958-05-02';
-    private const PATIENT_SEX = 'Male';
-
-    private ?Client $client = null;
-
-    protected function tearDown(): void
-    {
-        if ($this->client !== null) {
-            // Panther leaves a Chrome subprocess + ChromeDriver session
-            // dangling if not explicitly quit. Same discipline as
-            // E2eCriticalPathTest, AaLoginAcceptanceTest, and
-            // GgUserMenuLinksAcceptanceTest.
-            $this->client->quit();
-            $this->client = null;
-        }
-    }
+    use UiSeedingTrait;
 
     /**
      * Verify that every load_form.php link rendered in the encounter-
@@ -108,7 +78,7 @@ final class KkEncounterFormNavbarUrlAcceptanceTest extends TestCase
     public function testFormNavbarUrlsContainEncounterAndPid(): void
     {
         $this->client = BrowserSession::create();
-        $this->loginAsAdminAndWaitForMenu();
+        $this->performLoginAsAdmin();
 
         // Seed a patient + encounter via UI navigation — release image
         // ships with no fixtures, so these calls create the state the
@@ -197,426 +167,5 @@ final class KkEncounterFormNavbarUrlAcceptanceTest extends TestCase
                 "Form link has encounter=0 (stale session bug from #10844): {$onclick}",
             );
         }
-    }
-
-    /**
-     * Log in as admin/pass and wait for the Knockout-rendered
-     * #mainMenu to actually populate. Same two-gate discipline as
-     * E2eCriticalPathTest and GgUserMenuLinksAcceptanceTest so the
-     * subsequent seeding + navigation don't race the SPA boot.
-     */
-    private function loginAsAdminAndWaitForMenu(): void
-    {
-        $client = $this->requireClient();
-        $client->request('GET', '/interface/login/login.php?site=default');
-
-        self::assertSame(
-            'OpenEMR Login',
-            $client->getTitle(),
-            'Login page must render before submitting credentials — a different title means the login route itself is broken',
-        );
-
-        $client->submitForm('login-button', [
-            'authUser' => 'admin',
-            'clearPass' => 'pass',
-        ]);
-
-        try {
-            $client->wait(10)->until(
-                static fn(WebDriver $driver): bool => $driver->getTitle() === 'OpenEMR',
-            );
-        } catch (TimeoutException) {
-            self::fail(
-                'Post-login shell title never became "OpenEMR" (10s timeout). '
-                . 'Landing URL: ' . $client->getCurrentURL() . '. '
-                . 'Title: ' . $client->getTitle() . '. '
-                . 'This usually means the login POST did not authenticate '
-                . '(credentials wrong, POST rejected, or login handler broke).'
-            );
-        }
-
-        try {
-            $client->waitFor('#mainMenu', 30);
-        } catch (TimeoutException) {
-            self::fail(
-                'Post-login #mainMenu element never appeared (30s timeout). '
-                . 'Landing URL: ' . $client->getCurrentURL() . '. '
-                . 'Title: ' . $client->getTitle() . '. '
-                . 'This likely means the login POST did not authenticate, or '
-                . 'the post-login shell (interface/main/tabs/main.php) never rendered.'
-            );
-        }
-
-        try {
-            $client->wait(30)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
-                'return document.getElementById("mainMenu")?.children.length > 0'
-            ));
-        } catch (TimeoutException) {
-            self::fail(
-                'Knockout main menu never populated (30s timeout after #mainMenu appeared). '
-                . 'This means the SPA shell loaded but the JS framework (Knockout) either did '
-                . 'not load or did not apply bindings — symptom of a broken webpack build, '
-                . 'missing JS asset, or template regression.'
-            );
-        }
-
-        $this->dismissProductRegistrationModalIfPresent();
-    }
-
-    /**
-     * The shipped release image renders a "Product Registration" modal
-     * on first login whose backdrop can intercept clicks on elements
-     * outside its own hit area. Dismiss it via the modal's own hide()
-     * when visible; do nothing (don't fail) when absent, so this stays
-     * robust if a future release image tweaks the trigger heuristic
-     * or drops the modal entirely.
-     *
-     * Copied verbatim from GgUserMenuLinksAcceptanceTest — same
-     * modal, same dismissal shape. Extracting to a shared helper is
-     * deferred to the post-Small-tier audit called out in Brady's
-     * plan doc.
-     */
-    private function dismissProductRegistrationModalIfPresent(): void
-    {
-        $client = $this->requireClient();
-        // 5s poll (not 15s): product_reg.js's XHR fires during
-        // document.ready which has already completed by the time the
-        // Knockout-ready gate above passes, so the modal either shows
-        // within the first few hundred ms of this poll or it isn't
-        // going to.
-        //
-        // Try/catch scoped ONLY to this presence wait: TimeoutException
-        // here is benign ("no modal appeared, nothing to dismiss") and
-        // should not be conflated with a dismissal failure below.
-        try {
-            $client->wait(5)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
-                <<<'JS_WRAP'
-                    var modal = document.querySelector('.product-registration-modal.show');
-                    return modal !== null && modal.style.display === 'block';
-                JS_WRAP,
-            ));
-        } catch (TimeoutException) {
-            // No modal appeared within the poll window — proceed.
-            return;
-        }
-        // Modal detected — failures from here propagate.
-
-        // Small settle after the show transition — Bootstrap's
-        // internal state machine ignores hide() until the fade-in
-        // completes. Empirically ~150ms is the fade-in duration;
-        // 500ms gives comfortable margin.
-        usleep(500_000);
-        $client->executeScript(
-            <<<'JS_WRAP'
-                if (window.jQuery) {
-                    window.jQuery(".product-registration-modal").modal("hide");
-                }
-            JS_WRAP,
-        );
-        // Wait for the fade-out to complete so the subsequent
-        // click isn't intercepted by the modal backdrop mid-transition.
-        $client->wait(10)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
-            <<<'JS_WRAP'
-                var modal = document.querySelector('.product-registration-modal.show');
-                var backdrop = document.querySelector('.modal-backdrop');
-                return modal === null && backdrop === null;
-            JS_WRAP,
-        ));
-    }
-
-    /**
-     * Add a fresh patient (Ftest Ltest) via the "Patient/Client → New/
-     * Search" main-menu path. Mirrors the source-side PatientAddTrait
-     * flow shape: open New/Search tab → fill the DEM form in the
-     * patient iframe → click Create → confirm in the modal iframe →
-     * accept the resulting duplicate-check alert → wait for the
-     * Medical Record Dashboard header to appear.
-     */
-    private function addPatientViaUi(): void
-    {
-        $client = $this->requireClient();
-        $client->switchTo()->defaultContent();
-
-        // Open the Patient → New/Search tab. The main menu is a
-        // Knockout-rendered tree — the top-level "Patient" dropdown
-        // toggle opens the child dropdown, then the "New/Search"
-        // child label fires the tab. Both labels are rendered as
-        // <div class="menuLabel"> (not <a> or <span>), so match on
-        // that discriminator plus the exact label text.
-        $this->waitAndClick(
-            WebDriverBy::xpath(
-                '//div[@id="mainMenu"]//div[normalize-space(text())="Patient"'
-                . ' and contains(concat(" ",normalize-space(@class)," ")," dropdown-toggle ")]',
-            ),
-            'Patient top-level menu',
-        );
-        $this->waitAndClick(
-            WebDriverBy::xpath(
-                '//div[@id="mainMenu"]//div[normalize-space(text())="New/Search"'
-                . ' and contains(concat(" ",normalize-space(@class)," ")," menuLabel ")]',
-            ),
-            'New/Search menu item',
-        );
-
-        // Wait for the Search-or-Add-Patient tab title to render, then
-        // switch into the patient iframe where the create form lives.
-        $this->assertActiveTab('Search or Add Patient');
-        $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="pat"]', 30);
-        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
-
-        // Wait for the DEM form to be interactive, then fill and submit.
-        // The wait-for-clickable gate on the fname input is the anti-
-        // flake sync — the form node exists in the DOM before its JS
-        // bindings apply.
-        $client->wait(15)->until(
-            WebDriverExpectedCondition::elementToBeClickable(
-                WebDriverBy::xpath("//input[@type='text' and @name='form_fname']"),
-            ),
-        );
-
-        // Fill the visible required fields directly through the DOM.
-        // Panther's HttpBrowser-style ->submitForm doesn't work cleanly
-        // inside iframes, and this form has enough JS-bound side effects
-        // (sex/sex_identified twinning) that submitting the form element
-        // is more robust than reconstructing a POST.
-        $this->setInputValue("//input[@type='text' and @name='form_fname']", self::PATIENT_FNAME);
-        $this->setInputValue("//input[@type='text' and @name='form_lname']", self::PATIENT_LNAME);
-        $this->setInputValue("//input[@name='form_DOB']", self::PATIENT_DOB);
-        $this->setSelectValue("//select[@name='form_sex']", self::PATIENT_SEX);
-        $this->setSelectValue("//select[@name='form_sex_identified']", self::PATIENT_SEX);
-
-        $this->waitAndClick(
-            WebDriverBy::xpath("//*[@id='create']"),
-            'Create patient button',
-        );
-
-        // Confirm dialog renders inside a modal iframe. Switch out of
-        // the patient iframe first, then into the modal frame.
-        $client->switchTo()->defaultContent();
-        $client->waitFor("//iframe[@id='modalframe']", 30);
-        $this->switchToIFrame("//iframe[@id='modalframe']");
-        $client->wait(15)->until(
-            WebDriverExpectedCondition::elementToBeClickable(
-                WebDriverBy::xpath("//*[@id='confirmCreate']"),
-            ),
-        );
-        // Empirical stabilization — the modal form is clickable before
-        // its JS finishes wiring the confirm handler; a bare click can
-        // race and no-op. Same 5s wait the source-side PatientAddTrait
-        // uses.
-        sleep(5);
-        $client->findElement(WebDriverBy::xpath("//*[@id='confirmCreate']"))->click();
-
-        // A duplicate-check JS alert fires after confirm — accept it
-        // and continue.
-        $client->wait(15)->until(WebDriverExpectedCondition::alertIsPresent());
-        $client->switchTo()->alert()->accept();
-
-        // Switch back to defaults, into the patient iframe, wait for
-        // the Medical Record Dashboard header — proof the create
-        // succeeded and the browser landed on the summary.
-        $client->switchTo()->defaultContent();
-        $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="pat"]', 30);
-        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
-        $client->waitFor(
-            '//*[text()="Medical Record Dashboard - ' . self::PATIENT_FNAME . ' ' . self::PATIENT_LNAME . '"]',
-            30,
-        );
-    }
-
-    /**
-     * Add a fresh encounter for the just-created patient via the
-     * per-patient New-Encounter shortcut in the shell. Mirrors the
-     * source-side EncounterAddTrait: click the shell's New-Encounter
-     * link, fill the encounter form's category + reason, save, wait
-     * for the encounter forms iframe to render the encounter title.
-     *
-     * Post-condition on return: browser is inside the forms iframe
-     * with the navbar rendered — same DOM location the assertion
-     * needs. Caller does NOT need to re-navigate.
-     */
-    private function addEncounterViaUi(): void
-    {
-        $client = $this->requireClient();
-        $client->switchTo()->defaultContent();
-
-        // Click the "New Encounter" shortcut in the outer shell (not
-        // inside an iframe — it lives in the patient-context bar).
-        $this->waitAndClick(
-            WebDriverBy::xpath('//a[@title="New Encounter"]'),
-            'New Encounter shell shortcut',
-        );
-
-        // Switch into the encounter iframe where the create form
-        // renders.
-        $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="enc"]', 30);
-        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="enc"]');
-        $client->wait(15)->until(
-            WebDriverExpectedCondition::elementToBeClickable(
-                WebDriverBy::xpath("//button[@id='saveEncounter']"),
-            ),
-        );
-
-        // Set the required-by-form fields via JS. CATID=5 matches the
-        // source-side EncounterTestData; REASON is arbitrary.
-        $this->setSelectValue("//select[@name='pc_catid']", '5');
-        $this->setInputValue("//*[@name='reason']", 'Testing encounter');
-
-        $client->findElement(WebDriverBy::xpath("//button[@id='saveEncounter']"))->click();
-
-        // Post-save the browser lands inside the encounter forms
-        // iframe with the navbar rendered. Wait for the navbar title
-        // to confirm the encounter is open (and, incidentally, that
-        // the assertion caller doesn't need to re-navigate).
-        $client->switchTo()->defaultContent();
-        $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="enc"]', 30);
-        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="enc"]');
-        $client->waitFor('//iframe[@src="forms.php"]', 30);
-        $this->switchToIFrame('//iframe[@src="forms.php"]');
-        $client->waitFor(
-            '//span[@id="navbarEncounterTitle" and contains(text(), "Encounter for '
-                . self::PATIENT_FNAME . ' ' . self::PATIENT_LNAME . '")]',
-            30,
-        );
-    }
-
-    /**
-     * Switch the Panther client into an iframe located by XPath.
-     * Mirrors the source-side BaseTrait::switchToIFrame helper shape.
-     */
-    private function switchToIFrame(string $xpath): void
-    {
-        $client = $this->requireClient();
-        $iframe = $client->findElement(WebDriverBy::xpath($xpath));
-        $client->switchTo()->frame($iframe);
-    }
-
-    /**
-     * Set a text input's value via JS + fire an `input`/`change` event
-     * so any bound listeners run. More robust inside iframes than
-     * ->sendKeys() for forms that read via JS event listeners.
-     */
-    private function setInputValue(string $xpath, string $value): void
-    {
-        $client = $this->requireClient();
-        $client->executeScript(
-            <<<'JS_WRAP'
-                var xpath = arguments[0];
-                var value = arguments[1];
-                var el = document.evaluate(
-                    xpath,
-                    document,
-                    null,
-                    XPathResult.FIRST_ORDERED_NODE_TYPE,
-                    null,
-                ).singleNodeValue;
-                if (el) {
-                    el.value = value;
-                    el.dispatchEvent(new Event('input', { bubbles: true }));
-                    el.dispatchEvent(new Event('change', { bubbles: true }));
-                }
-            JS_WRAP,
-            [$xpath, $value],
-        );
-    }
-
-    /**
-     * Set a <select>'s value + fire change so any bound listeners run.
-     * The category dropdown on the encounter form conditionally reveals
-     * fields based on the chosen category, so the change event is
-     * necessary for the form to accept the selection.
-     */
-    private function setSelectValue(string $xpath, string $value): void
-    {
-        $client = $this->requireClient();
-        $client->executeScript(
-            <<<'JS_WRAP'
-                var xpath = arguments[0];
-                var value = arguments[1];
-                var el = document.evaluate(
-                    xpath,
-                    document,
-                    null,
-                    XPathResult.FIRST_ORDERED_NODE_TYPE,
-                    null,
-                ).singleNodeValue;
-                if (el) {
-                    el.value = value;
-                    el.dispatchEvent(new Event('change', { bubbles: true }));
-                }
-            JS_WRAP,
-            [$xpath, $value],
-        );
-    }
-
-    /**
-     * Wait for an element matched by $by to be clickable, then click
-     * it. Narrows WebDriverWait::until()'s `mixed` return through an
-     * instanceof check so phpstan level 10 accepts the ->click() call
-     * without inline @var casts.
-     */
-    private function waitAndClick(WebDriverBy $by, string $description): void
-    {
-        $client = $this->requireClient();
-        $element = $client->wait(15)->until(
-            WebDriverExpectedCondition::elementToBeClickable($by),
-        );
-        if (!$element instanceof WebDriverElement) {
-            self::fail(
-                "elementToBeClickable returned a non-element for {$description}; got "
-                . get_debug_type($element),
-            );
-        }
-        $element->click();
-    }
-
-    /**
-     * Wait for the currently-active tab in #tabs_div to display the
-     * expected title, with the "Loading" placeholder resolved. Same
-     * discipline as GgUserMenuLinksAcceptanceTest::assertActiveTab.
-     */
-    private function assertActiveTab(string $expectedTitle): void
-    {
-        $client = $this->requireClient();
-        $activeTabXpath = "//div[@id='tabs_div']/div/div[not(contains(concat(' ',normalize-space(@class),' '),' tabsNoHover '))]";
-
-        $client->waitFor($activeTabXpath, 30);
-        $client->wait(30)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
-            <<<'JS_WRAP'
-                var el = document.evaluate(
-                    arguments[0],
-                    document,
-                    null,
-                    XPathResult.FIRST_ORDERED_NODE_TYPE,
-                    null,
-                ).singleNodeValue;
-                if (!el) { return false; }
-                var text = (el.textContent || '').trim();
-                return text.length > 0 && text.indexOf('Loading') === -1;
-            JS_WRAP,
-            [$activeTabXpath],
-        ));
-
-        $activeTab = $client->findElement(WebDriverBy::xpath($activeTabXpath));
-        self::assertSame(
-            $expectedTitle,
-            trim($activeTab->getText()),
-            "[{$expectedTitle}] menu action did not open the expected tab — "
-            . 'the click reached the app but the resulting tab title differs, '
-            . 'which means either the menu entry routes somewhere unexpected '
-            . 'or the tab label regressed',
-        );
-    }
-
-    /**
-     * Narrow the nullable $this->client for phpstan and for a clearer
-     * failure mode if a helper is somehow called before setUp has run.
-     */
-    private function requireClient(): Client
-    {
-        if ($this->client === null) {
-            self::fail('BrowserSession client not initialized — helper called before create()');
-        }
-        return $this->client;
     }
 }

--- a/tests/Acceptance/Support/PantherAcceptanceTestCase.php
+++ b/tests/Acceptance/Support/PantherAcceptanceTestCase.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Acceptance\Support;
 
 use Facebook\WebDriver\Exception\TimeoutException;
+use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\JavaScriptExecutor;
 use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverBy;
@@ -131,8 +132,10 @@ abstract class PantherAcceptanceTestCase extends TestCase
             // mask the real test outcome as a teardown error.
             try {
                 $this->client->quit();
-            } catch (\Throwable) {
+            } catch (WebDriverException) {
                 // Driver session already gone; nothing left to clean up.
+                // Narrowed from \Throwable per openemr.forbiddenCatchType
+                // rule — genuine PHP errors should still propagate.
             } finally {
                 $this->client = null;
             }

--- a/tests/Acceptance/Support/PantherAcceptanceTestCase.php
+++ b/tests/Acceptance/Support/PantherAcceptanceTestCase.php
@@ -1,0 +1,401 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance\Support;
+
+use Facebook\WebDriver\Exception\TimeoutException;
+use Facebook\WebDriver\JavaScriptExecutor;
+use Facebook\WebDriver\WebDriver;
+use Facebook\WebDriver\WebDriverBy;
+use Facebook\WebDriver\WebDriverElement;
+use Facebook\WebDriver\WebDriverExpectedCondition;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Panther\Client;
+
+/**
+ * Base class for Panther-driven acceptance tests.
+ *
+ * Consolidates the client lifecycle + login + Knockout-ready gate +
+ * Product-Registration modal dismissal + iframe-switch helpers that
+ * every Small-tier 4e port (E2eCriticalPathTest, AaLoginAcceptanceTest,
+ * GgUserMenuLinksAcceptanceTest, FrontPaymentCssContrastAcceptanceTest,
+ * KkEncounterFormNavbarUrlAcceptanceTest) grew inline. Medium-tier
+ * ports consume from day one instead of re-duplicating.
+ *
+ * Design notes:
+ *
+ *   - Extends PHPUnit's `TestCase` directly rather than a project base
+ *     class; the source-side E2e BaseTrait/BaseCore split doesn't
+ *     translate 1:1 to acceptance (no phpunit-suite ordering, no
+ *     source-checkout preconditions, no per-run screenshot dir).
+ *
+ *   - Client lifecycle in tearDown() only. Every current test creates
+ *     the Client inside the test method (not setUp) so a pre-navigation
+ *     BrowserSession::create() failure surfaces as a test-method
+ *     failure with the intended assertions in the stack trace rather
+ *     than a generic setUp failure. Retain that pattern here.
+ *
+ *   - `performLoginAsAdmin()` is the FULL post-login gate: title →
+ *     #mainMenu presence → Knockout-ready → optional modal dismissal.
+ *     Every current caller wants all four; a subset-only variant would
+ *     just re-duplicate the wait-chain.
+ *
+ *   - Modal dismissal is public (well, protected) so tests that don't
+ *     invoke performLoginAsAdmin() can still opt in defensively if a
+ *     future path lands them post-login without going through the
+ *     standard gate.
+ *
+ *   - XPath / JS constants live on this class so tests reference them
+ *     via `self::` rather than redefining them per-file. The
+ *     release-image XPath discoveries (Patient label uses <div
+ *     class="menuLabel">, not <a>) live here too.
+ */
+abstract class PantherAcceptanceTestCase extends TestCase
+{
+    /**
+     * Post-login shell title — the SPA layer sets document.title to this
+     * once the shell is loaded. Used as the primary "am I authenticated
+     * yet" gate for the post-login redirect race.
+     */
+    protected const SHELL_TITLE = 'OpenEMR';
+
+    /**
+     * Login-page title — asserted before submitting credentials so a
+     * broken login route surfaces with a clear signal rather than a
+     * confusing downstream failure.
+     */
+    protected const LOGIN_TITLE = 'OpenEMR Login';
+
+    /**
+     * Top-right user icon in the post-login shell. Used by ports that
+     * click into the user dropdown (GgUserMenuLinks…).
+     */
+    protected const XPATH_USER_ICON = '//i[@id="user_icon"]';
+
+    /**
+     * XPath for the currently-active tab in the post-login #tabs_div.
+     * The `tabsNoHover` filter excludes hidden tabs — matches source-
+     * side BaseTrait::assertActiveTab discipline.
+     */
+    protected const XPATH_ACTIVE_TAB
+        = "//div[@id='tabs_div']/div/div[not(contains(concat(' ',normalize-space(@class),' '),' tabsNoHover '))]";
+
+    /**
+     * The username input on the login form. Its presence after a
+     * logout / post-logout redirect is the "we're back on login" gate.
+     */
+    protected const XPATH_LOGIN_USERNAME_INPUT = '//input[@id="authUser"]';
+
+    /**
+     * Login form path — used by the initial GET before submitting
+     * credentials.
+     */
+    protected const LOGIN_URL = '/interface/login/login.php?site=default';
+
+    /**
+     * Post-login landing path — the SPA main shell. Included as a
+     * constant so tests that hit it directly (e.g. unauthenticated
+     * redirect assertions) don't have to hardcode the string.
+     */
+    protected const MAIN_SHELL_URL = '/interface/main/tabs/main.php';
+
+    /**
+     * JS gate that returns true once Knockout has populated #mainMenu
+     * with children (i.e. bindings applied, not just an empty shell).
+     * Matches the source-side BaseTrait::waitForAppReady contract.
+     */
+    protected const JS_KNOCKOUT_READY
+        = 'return document.getElementById("mainMenu")?.children.length > 0';
+
+    protected ?Client $client = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->client !== null) {
+            // Panther leaves a Chrome subprocess + ChromeDriver session
+            // dangling if not explicitly quit. Local runs accumulate
+            // zombies; CI runners recycle so it doesn't matter there,
+            // but tearDown discipline keeps local dev clean.
+            //
+            // finally: if quit() throws (driver session already dead),
+            // still null out the client so a bare Throwable doesn't
+            // mask the real test outcome as a teardown error.
+            try {
+                $this->client->quit();
+            } catch (\Throwable) {
+                // Driver session already gone; nothing left to clean up.
+            } finally {
+                $this->client = null;
+            }
+        }
+    }
+
+    /**
+     * Narrow the nullable $this->client for phpstan and for a clearer
+     * failure mode if a helper is somehow called before create().
+     */
+    protected function requireClient(): Client
+    {
+        if ($this->client === null) {
+            self::fail('BrowserSession client not initialized — helper called before create()');
+        }
+        return $this->client;
+    }
+
+    /**
+     * Log in as admin/pass and wait for the Knockout-rendered
+     * #mainMenu to actually populate. Two-gate discipline:
+     *
+     *   1. Title change to "OpenEMR" — proves the login POST
+     *      authenticated and the post-login redirect fired.
+     *   2. `#mainMenu` element present in DOM — proves the shell
+     *      rendered.
+     *   3. Knockout applied bindings so #mainMenu has children —
+     *      proves the JS framework loaded and applied to the menu
+     *      template (catches webpack-broken builds that render the
+     *      shell but leave the menu empty).
+     *
+     * Then dismiss the Product Registration modal if it appeared, so
+     * downstream clicks aren't intercepted by the modal backdrop.
+     *
+     * All three waits wrap TimeoutException in a diagnostic self::fail
+     * that includes the observed landing URL + title — a failed login
+     * is by far the most likely cause of a timeout at these gates, and
+     * knowing WHICH page the browser actually landed on cuts triage
+     * time to zero.
+     */
+    protected function performLoginAsAdmin(): void
+    {
+        $client = $this->requireClient();
+        $client->request('GET', self::LOGIN_URL);
+
+        self::assertSame(
+            self::LOGIN_TITLE,
+            $client->getTitle(),
+            'Login page must render before submitting credentials — a different title means the login route itself is broken',
+        );
+
+        $client->submitForm('login-button', [
+            'authUser' => 'admin',
+            'clearPass' => 'pass',
+        ]);
+
+        // Post-login redirect is client-side / async — same race the
+        // source-side LoginTrait::performLogin handles by waiting for
+        // getTitle() === 'OpenEMR'.
+        try {
+            $client->wait(10)->until(
+                static fn(WebDriver $driver): bool => $driver->getTitle() === self::SHELL_TITLE,
+            );
+        } catch (TimeoutException) {
+            self::fail(
+                'Post-login shell title never became "' . self::SHELL_TITLE . '" (10s timeout). '
+                . 'Landing URL: ' . $client->getCurrentURL() . '. '
+                . 'Title: ' . $client->getTitle() . '. '
+                . 'This usually means the login POST did not authenticate '
+                . '(credentials wrong, POST rejected, or login handler broke).'
+            );
+        }
+
+        try {
+            $client->waitFor('#mainMenu', 30);
+        } catch (TimeoutException) {
+            self::fail(
+                'Post-login #mainMenu element never appeared (30s timeout). '
+                . 'Landing URL: ' . $client->getCurrentURL() . '. '
+                . 'Title: ' . $client->getTitle() . '. '
+                . 'This likely means the login POST did not authenticate, or '
+                . 'the post-login shell (interface/main/tabs/main.php) never rendered.'
+            );
+        }
+
+        // Knockout-ready gate: bindings have applied, the menu template
+        // ran, so #mainMenu has child nodes. Without this check we
+        // could pass on a broken JS build that renders the SPA shell
+        // but leaves the menu empty.
+        //
+        // Type-hint the closure's $driver as JavaScriptExecutor so
+        // phpstan can resolve executeScript() (the base WebDriver
+        // interface types the callable arg as `mixed`).
+        try {
+            $client->wait(30)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
+                self::JS_KNOCKOUT_READY
+            ));
+        } catch (TimeoutException) {
+            self::fail(
+                'Knockout main menu never populated (30s timeout after #mainMenu appeared). '
+                . 'This means the SPA shell loaded but the JS framework (Knockout) either did '
+                . 'not load or did not apply bindings — symptom of a broken webpack build, '
+                . 'missing JS asset, or template regression.'
+            );
+        }
+
+        $this->dismissProductRegistrationModalIfPresent();
+    }
+
+    /**
+     * The shipped release image renders a "Product Registration" modal
+     * on first login whose backdrop can intercept clicks on elements
+     * outside its own hit area. Dismiss it via the modal's own hide()
+     * when visible; do nothing (don't fail) when absent, so this stays
+     * robust if a future release image tweaks the trigger heuristic or
+     * drops the modal entirely.
+     *
+     * Try/catch scoped ONLY to the presence wait: TimeoutException here
+     * is benign ("no modal appeared, nothing to dismiss") and should
+     * not be conflated with a dismissal failure below. If the modal
+     * DID appear but the dismissal below fails, the fade-out wait's
+     * TimeoutException propagates as a real failure — otherwise a
+     * leftover backdrop would intercept the next click and cause a
+     * downstream test failure with no useful signal.
+     */
+    protected function dismissProductRegistrationModalIfPresent(): void
+    {
+        $client = $this->requireClient();
+        // 5s poll (not 15s): product_reg.js's XHR fires during
+        // document.ready which has already completed by the time
+        // the Knockout-ready gate above passes, so the modal
+        // either shows within the first few hundred ms of this
+        // poll or it isn't going to. Longer window costs the full
+        // wait × N scenarios × M matrix cells for zero signal gain
+        // when the modal doesn't appear.
+        try {
+            $client->wait(5)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
+                <<<'JS_WRAP'
+                    var modal = document.querySelector('.product-registration-modal.show');
+                    return modal !== null && modal.style.display === 'block';
+                JS_WRAP,
+            ));
+        } catch (TimeoutException) {
+            // No modal appeared within the poll window — that's fine
+            // (a re-run against the same artifact won't re-show the
+            // modal, and future release-image changes may drop it
+            // entirely); proceed.
+            return;
+        }
+        // Modal detected — from here down, failures propagate so a
+        // failed dismissal surfaces loudly rather than getting hidden
+        // by a broad catch upstream.
+
+        // Small settle after the show transition — Bootstrap's
+        // internal state machine ignores hide() until the fade-in
+        // completes. Empirically ~150ms is the fade-in duration;
+        // 500ms gives comfortable margin.
+        usleep(500_000);
+        // Guard the jQuery call — if jQuery is under noConflict or
+        // absent from window entirely, calling `window.jQuery(...)`
+        // throws a WebDriver JS error. If the guard hits (jQuery
+        // missing on a shipped OpenEMR release image would itself be
+        // a real problem to surface), the modal stays visible and
+        // the fade-out wait below times out — that TimeoutException
+        // propagates and fails the test with a clear signal that
+        // dismissal didn't complete, rather than silently letting
+        // the backdrop intercept the next user-icon click.
+        $client->executeScript(
+            <<<'JS_WRAP'
+                if (window.jQuery) {
+                    window.jQuery(".product-registration-modal").modal("hide");
+                }
+            JS_WRAP,
+        );
+        // Wait for the fade-out to complete so the subsequent
+        // click isn't intercepted by the modal backdrop
+        // mid-transition. No try/catch — a timeout here
+        // means we detected a modal but couldn't hide it, which
+        // is a real failure the test must surface.
+        $client->wait(10)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
+            <<<'JS_WRAP'
+                var modal = document.querySelector('.product-registration-modal.show');
+                var backdrop = document.querySelector('.modal-backdrop');
+                return modal === null && backdrop === null;
+            JS_WRAP,
+        ));
+    }
+
+    /**
+     * Switch the Panther client into an iframe located by XPath.
+     * Mirrors the source-side BaseTrait::switchToIFrame helper shape.
+     * Made available on the base class (not the seeding trait) because
+     * even non-seeding flows can end up inside iframes (front-payment,
+     * menu-tab surfaces).
+     */
+    protected function switchToIFrame(string $xpath): void
+    {
+        $client = $this->requireClient();
+        $iframe = $client->findElement(WebDriverBy::xpath($xpath));
+        $client->switchTo()->frame($iframe);
+    }
+
+    /**
+     * Wait for an element matched by $by to be clickable, then click
+     * it. Narrows WebDriverWait::until()'s `mixed` return through an
+     * instanceof check so phpstan level 10 accepts the ->click() call
+     * without inline @var casts. Default 15s matches the widest
+     * previously-used timeout across the 5 ports (10s in menu-link
+     * clicks, 15s in seeding); override via $timeoutSeconds if needed.
+     */
+    protected function waitAndClick(WebDriverBy $by, string $description, int $timeoutSeconds = 15): void
+    {
+        $client = $this->requireClient();
+        $element = $client->wait($timeoutSeconds)->until(
+            WebDriverExpectedCondition::elementToBeClickable($by),
+        );
+        if (!$element instanceof WebDriverElement) {
+            self::fail(
+                "elementToBeClickable returned a non-element for {$description}; got "
+                . get_debug_type($element),
+            );
+        }
+        $element->click();
+    }
+
+    /**
+     * Wait for the currently-active tab in #tabs_div to display the
+     * expected title, with the "Loading" placeholder resolved. Two
+     * waits: the tab node is created before the tab content resolves,
+     * so reading text between those events races the async render.
+     * Mirrors the source-side BaseTrait::assertActiveTab shape,
+     * simplified for the single-string case (no loose match, no
+     * '||'-separated loading indicators).
+     */
+    protected function assertActiveTab(string $expectedTitle): void
+    {
+        $client = $this->requireClient();
+
+        $client->waitFor(self::XPATH_ACTIVE_TAB, 30);
+        $client->wait(30)->until(fn(JavaScriptExecutor $driver): bool => (bool) $driver->executeScript(
+            <<<'JS_WRAP'
+                var el = document.evaluate(
+                    arguments[0],
+                    document,
+                    null,
+                    XPathResult.FIRST_ORDERED_NODE_TYPE,
+                    null,
+                ).singleNodeValue;
+                if (!el) { return false; }
+                var text = (el.textContent || '').trim();
+                return text.length > 0 && text.indexOf('Loading') === -1;
+            JS_WRAP,
+            [self::XPATH_ACTIVE_TAB],
+        ));
+
+        $activeTab = $client->findElement(WebDriverBy::xpath(self::XPATH_ACTIVE_TAB));
+        self::assertSame(
+            $expectedTitle,
+            trim($activeTab->getText()),
+            "[{$expectedTitle}] menu action did not open the expected tab — "
+            . 'the click reached the app but the resulting tab title differs, '
+            . 'which means either the menu entry routes somewhere unexpected '
+            . 'or the tab label regressed',
+        );
+    }
+}

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -238,7 +238,7 @@ trait UiSeedingTrait
     protected function setInputValue(string $xpath, string $value): void
     {
         $client = $this->requireClient();
-        $client->executeScript(
+        $applied = $client->executeScript(
             <<<'JS_WRAP'
                 var xpath = arguments[0];
                 var value = arguments[1];
@@ -249,13 +249,22 @@ trait UiSeedingTrait
                     XPathResult.FIRST_ORDERED_NODE_TYPE,
                     null,
                 ).singleNodeValue;
-                if (el) {
-                    el.value = value;
-                    el.dispatchEvent(new Event('input', { bubbles: true }));
-                    el.dispatchEvent(new Event('change', { bubbles: true }));
+                if (!el) {
+                    return false;
                 }
+                el.value = value;
+                el.dispatchEvent(new Event('input', { bubbles: true }));
+                el.dispatchEvent(new Event('change', { bubbles: true }));
+                return true;
             JS_WRAP,
             [$xpath, $value],
+        );
+        // Fail fast at the seeding call; a silent no-op would surface as
+        // a cryptic downstream wait timeout after the form was submitted
+        // with an unset field.
+        self::assertTrue(
+            $applied === true,
+            sprintf('setInputValue: no element found for XPath %s', $xpath),
         );
     }
 
@@ -268,7 +277,7 @@ trait UiSeedingTrait
     protected function setSelectValue(string $xpath, string $value): void
     {
         $client = $this->requireClient();
-        $client->executeScript(
+        $applied = $client->executeScript(
             <<<'JS_WRAP'
                 var xpath = arguments[0];
                 var value = arguments[1];
@@ -279,12 +288,18 @@ trait UiSeedingTrait
                     XPathResult.FIRST_ORDERED_NODE_TYPE,
                     null,
                 ).singleNodeValue;
-                if (el) {
-                    el.value = value;
-                    el.dispatchEvent(new Event('change', { bubbles: true }));
+                if (!el) {
+                    return false;
                 }
+                el.value = value;
+                el.dispatchEvent(new Event('change', { bubbles: true }));
+                return true;
             JS_WRAP,
             [$xpath, $value],
+        );
+        self::assertTrue(
+            $applied === true,
+            sprintf('setSelectValue: no element found for XPath %s', $xpath),
         );
     }
 }

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -1,0 +1,290 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance\Support;
+
+use Facebook\WebDriver\WebDriverBy;
+use Facebook\WebDriver\WebDriverExpectedCondition;
+
+/**
+ * UI-driven seeding helpers for acceptance tests that need patient +
+ * encounter fixtures against a fresh release image.
+ *
+ * The shipped release image ships with no patient fixtures — every
+ * acceptance run gets a fresh, empty database — so tests that assert
+ * on encounter/patient-scoped UI must seed via UI navigation. Black-box
+ * discipline: no SQL, no direct DB writes, no fixture files.
+ *
+ * Kept as a trait (not base-class methods) so Small-tier ports that
+ * DON'T need seeding (AaLogin, GgUserMenu, FrontPaymentCssContrast,
+ * E2eCriticalPath) don't load the helpers. Medium-tier ports that
+ * DO need patient/encounter state opt in via `use UiSeedingTrait`.
+ *
+ * The trait requires the consuming class to extend
+ * PantherAcceptanceTestCase — it calls requireClient(), waitAndClick(),
+ * assertActiveTab(), and switchToIFrame() from the base class. The
+ * type-hint below documents this contract without requiring PHP's
+ * awkward abstract-trait-method boilerplate.
+ *
+ * @method \Symfony\Component\Panther\Client requireClient()
+ * @method void waitAndClick(WebDriverBy $by, string $description, int $timeoutSeconds = 15)
+ * @method void assertActiveTab(string $expectedTitle)
+ * @method void switchToIFrame(string $xpath)
+ */
+trait UiSeedingTrait
+{
+    /**
+     * Default fixture identity used by the encounter-form navbar port
+     * (Ftest/Ltest matches the source-side PatientAddTrait's chosen
+     * fixture name, kept as a shared constant so Medium-tier ports
+     * that assert on patient-name-in-DOM can reuse the same string).
+     */
+    protected const SEED_PATIENT_FNAME = 'Ftest';
+    protected const SEED_PATIENT_LNAME = 'Ltest';
+    protected const SEED_PATIENT_DOB = '1958-05-02';
+    protected const SEED_PATIENT_SEX = 'Male';
+
+    /**
+     * Encounter category id — matches source-side EncounterTestData's
+     * chosen category (5 = "Office Visit" in the stock installer's
+     * pc_catid table).
+     */
+    protected const SEED_ENCOUNTER_CATEGORY_ID = '5';
+
+    /**
+     * Encounter free-text reason — content is arbitrary; kept as a
+     * constant so a search-by-reason follow-up test can reuse it.
+     */
+    protected const SEED_ENCOUNTER_REASON = 'Testing encounter';
+
+    /**
+     * Add a fresh patient (Ftest Ltest by default) via the "Patient/
+     * Client → New/Search" main-menu path. Mirrors the source-side
+     * PatientAddTrait flow shape: open New/Search tab → fill the DEM
+     * form in the patient iframe → click Create → confirm in the modal
+     * iframe → accept the resulting duplicate-check alert → wait for
+     * the Medical Record Dashboard header to appear.
+     *
+     * XPath discoveries from KkEncounterFormNavbarUrl port:
+     *
+     *   - Main-menu top-level label is "Patient" (not "Patient/Client"
+     *     as some earlier docs implied)
+     *   - Menu labels are rendered as `<div class="menuLabel">` and
+     *     top-level toggles as `<div class="dropdown-toggle">`, NOT
+     *     `<a>` or `<span>` — Knockout template renders divs.
+     */
+    protected function addPatientViaUi(): void
+    {
+        $client = $this->requireClient();
+        $client->switchTo()->defaultContent();
+
+        // Open the Patient → New/Search tab. The main menu is a
+        // Knockout-rendered tree — the top-level "Patient" dropdown
+        // toggle opens the child dropdown, then the "New/Search"
+        // child label fires the tab. Both labels are rendered as
+        // <div class="menuLabel"> (not <a> or <span>), so match on
+        // that discriminator plus the exact label text.
+        $this->waitAndClick(
+            WebDriverBy::xpath(
+                '//div[@id="mainMenu"]//div[normalize-space(text())="Patient"'
+                . ' and contains(concat(" ",normalize-space(@class)," ")," dropdown-toggle ")]',
+            ),
+            'Patient top-level menu',
+        );
+        $this->waitAndClick(
+            WebDriverBy::xpath(
+                '//div[@id="mainMenu"]//div[normalize-space(text())="New/Search"'
+                . ' and contains(concat(" ",normalize-space(@class)," ")," menuLabel ")]',
+            ),
+            'New/Search menu item',
+        );
+
+        // Wait for the Search-or-Add-Patient tab title to render, then
+        // switch into the patient iframe where the create form lives.
+        $this->assertActiveTab('Search or Add Patient');
+        $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="pat"]', 30);
+        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
+
+        // Wait for the DEM form to be interactive, then fill and submit.
+        // The wait-for-clickable gate on the fname input is the anti-
+        // flake sync — the form node exists in the DOM before its JS
+        // bindings apply.
+        $client->wait(15)->until(
+            WebDriverExpectedCondition::elementToBeClickable(
+                WebDriverBy::xpath("//input[@type='text' and @name='form_fname']"),
+            ),
+        );
+
+        // Fill the visible required fields directly through the DOM.
+        // Panther's HttpBrowser-style ->submitForm doesn't work cleanly
+        // inside iframes, and this form has enough JS-bound side effects
+        // (sex/sex_identified twinning) that submitting the form element
+        // is more robust than reconstructing a POST.
+        $this->setInputValue("//input[@type='text' and @name='form_fname']", self::SEED_PATIENT_FNAME);
+        $this->setInputValue("//input[@type='text' and @name='form_lname']", self::SEED_PATIENT_LNAME);
+        $this->setInputValue("//input[@name='form_DOB']", self::SEED_PATIENT_DOB);
+        $this->setSelectValue("//select[@name='form_sex']", self::SEED_PATIENT_SEX);
+        $this->setSelectValue("//select[@name='form_sex_identified']", self::SEED_PATIENT_SEX);
+
+        $this->waitAndClick(
+            WebDriverBy::xpath("//*[@id='create']"),
+            'Create patient button',
+        );
+
+        // Confirm dialog renders inside a modal iframe. Switch out of
+        // the patient iframe first, then into the modal frame.
+        $client->switchTo()->defaultContent();
+        $client->waitFor("//iframe[@id='modalframe']", 30);
+        $this->switchToIFrame("//iframe[@id='modalframe']");
+        $client->wait(15)->until(
+            WebDriverExpectedCondition::elementToBeClickable(
+                WebDriverBy::xpath("//*[@id='confirmCreate']"),
+            ),
+        );
+        // Empirical stabilization — the modal form is clickable before
+        // its JS finishes wiring the confirm handler; a bare click can
+        // race and no-op. Same 5s wait the source-side PatientAddTrait
+        // uses.
+        sleep(5);
+        $client->findElement(WebDriverBy::xpath("//*[@id='confirmCreate']"))->click();
+
+        // A duplicate-check JS alert fires after confirm — accept it
+        // and continue.
+        $client->wait(15)->until(WebDriverExpectedCondition::alertIsPresent());
+        $client->switchTo()->alert()->accept();
+
+        // Switch back to defaults, into the patient iframe, wait for
+        // the Medical Record Dashboard header — proof the create
+        // succeeded and the browser landed on the summary.
+        $client->switchTo()->defaultContent();
+        $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="pat"]', 30);
+        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
+        $client->waitFor(
+            '//*[text()="Medical Record Dashboard - ' . self::SEED_PATIENT_FNAME . ' ' . self::SEED_PATIENT_LNAME . '"]',
+            30,
+        );
+    }
+
+    /**
+     * Add a fresh encounter for the just-created patient via the
+     * per-patient New-Encounter shortcut in the shell. Mirrors the
+     * source-side EncounterAddTrait: click the shell's New-Encounter
+     * link, fill the encounter form's category + reason, save, wait
+     * for the encounter forms iframe to render the encounter title.
+     *
+     * Post-condition on return: browser is inside the forms iframe
+     * with the navbar rendered — same DOM location the encounter-form
+     * navbar assertion needs. Caller does NOT need to re-navigate.
+     */
+    protected function addEncounterViaUi(): void
+    {
+        $client = $this->requireClient();
+        $client->switchTo()->defaultContent();
+
+        // Click the "New Encounter" shortcut in the outer shell (not
+        // inside an iframe — it lives in the patient-context bar).
+        $this->waitAndClick(
+            WebDriverBy::xpath('//a[@title="New Encounter"]'),
+            'New Encounter shell shortcut',
+        );
+
+        // Switch into the encounter iframe where the create form
+        // renders.
+        $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="enc"]', 30);
+        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="enc"]');
+        $client->wait(15)->until(
+            WebDriverExpectedCondition::elementToBeClickable(
+                WebDriverBy::xpath("//button[@id='saveEncounter']"),
+            ),
+        );
+
+        // Set the required-by-form fields via JS. CATID=5 matches the
+        // source-side EncounterTestData; REASON is arbitrary.
+        $this->setSelectValue("//select[@name='pc_catid']", self::SEED_ENCOUNTER_CATEGORY_ID);
+        $this->setInputValue("//*[@name='reason']", self::SEED_ENCOUNTER_REASON);
+
+        $client->findElement(WebDriverBy::xpath("//button[@id='saveEncounter']"))->click();
+
+        // Post-save the browser lands inside the encounter forms
+        // iframe with the navbar rendered. Wait for the navbar title
+        // to confirm the encounter is open (and, incidentally, that
+        // the assertion caller doesn't need to re-navigate).
+        $client->switchTo()->defaultContent();
+        $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="enc"]', 30);
+        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="enc"]');
+        $client->waitFor('//iframe[@src="forms.php"]', 30);
+        $this->switchToIFrame('//iframe[@src="forms.php"]');
+        $client->waitFor(
+            '//span[@id="navbarEncounterTitle" and contains(text(), "Encounter for '
+                . self::SEED_PATIENT_FNAME . ' ' . self::SEED_PATIENT_LNAME . '")]',
+            30,
+        );
+    }
+
+    /**
+     * Set a text input's value via JS + fire an `input`/`change` event
+     * so any bound listeners run. More robust inside iframes than
+     * ->sendKeys() for forms that read via JS event listeners.
+     */
+    protected function setInputValue(string $xpath, string $value): void
+    {
+        $client = $this->requireClient();
+        $client->executeScript(
+            <<<'JS_WRAP'
+                var xpath = arguments[0];
+                var value = arguments[1];
+                var el = document.evaluate(
+                    xpath,
+                    document,
+                    null,
+                    XPathResult.FIRST_ORDERED_NODE_TYPE,
+                    null,
+                ).singleNodeValue;
+                if (el) {
+                    el.value = value;
+                    el.dispatchEvent(new Event('input', { bubbles: true }));
+                    el.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+            JS_WRAP,
+            [$xpath, $value],
+        );
+    }
+
+    /**
+     * Set a <select>'s value + fire change so any bound listeners run.
+     * The category dropdown on the encounter form conditionally reveals
+     * fields based on the chosen category, so the change event is
+     * necessary for the form to accept the selection.
+     */
+    protected function setSelectValue(string $xpath, string $value): void
+    {
+        $client = $this->requireClient();
+        $client->executeScript(
+            <<<'JS_WRAP'
+                var xpath = arguments[0];
+                var value = arguments[1];
+                var el = document.evaluate(
+                    xpath,
+                    document,
+                    null,
+                    XPathResult.FIRST_ORDERED_NODE_TYPE,
+                    null,
+                ).singleNodeValue;
+                if (el) {
+                    el.value = value;
+                    el.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+            JS_WRAP,
+            [$xpath, $value],
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Refactor checkpoint between the completed Small-tier 4e ports
(AaLogin, GgUserMenu, FrontPaymentCssContrast, KkEncounterFormNavbarUrl,
plus the earlier E2eCriticalPath pattern-establisher) and the upcoming
Medium-tier ports (Bb/Cc/Dd/Ee/Ff/SvcCode). Consolidates the login,
Knockout-ready gate, Product Registration modal dismissal, iframe
switching, and patient/encounter UI-seeding helpers that grew inline
across the 5 shipped tests into reusable `tests/Acceptance/Support/`
infrastructure, so Medium-tier ports consume from day one instead
of re-duplicating.

**No new tests, no changed assertions, consolidation only.** All 5
existing tests still pass locally against the booted release image
with the same 93 assertions in the same ~49s (baseline was ~47s).

## Shape

Hybrid: **abstract base class** for near-universal infrastructure +
**opt-in trait** for UI-driven seeding.

New files under `tests/Acceptance/Support/`:

- **`PantherAcceptanceTestCase.php`** -- abstract base extending
  `PHPUnit\Framework\TestCase`. Provides:
  - `tearDown()` Chrome-quit discipline
  - `requireClient()` nullable-narrow accessor
  - `performLoginAsAdmin()` -- title -> `#mainMenu` -> Knockout-ready
    three-gate wait chain with diagnostic `self::fail` on each gate
  - `dismissProductRegistrationModalIfPresent()` -- split try/catch
    scope (presence-wait catches Timeout benignly; dismissal + fade-out
    propagate)
  - `switchToIFrame()`, `waitAndClick()`, `assertActiveTab()`
  - Constants for login/shell titles, XPaths, JS gates
- **`UiSeedingTrait.php`** -- `addPatientViaUi()`, `addEncounterViaUi()`,
  `setInputValue()`, `setSelectValue()`, plus fixture-identity constants
  (Ftest Ltest, DOB, sex, category id, reason). Kept as a trait so
  Small-tier tests that don't need seeding don't load it.

Refactored the 5 existing tests to consume the new Support/:

- `E2eCriticalPathTest` -- extends base, uses `performLoginAsAdmin`
- `AaLoginAcceptanceTest` -- extends base for lifecycle + constants
  (auth-negative flows don't call the login helper)
- `GgUserMenuLinksAcceptanceTest` -- extends base, uses login helper +
  `assertActiveTab` + `waitAndClick`
- `FrontPaymentCssContrastAcceptanceTest` -- extends base for lifecycle;
  keeps its scoped-down login inline because the direct GET flow
  doesn't need the Knockout-ready gate or modal dismiss
- `KkEncounterFormNavbarUrlAcceptanceTest` -- extends base + `use
  UiSeedingTrait`; deletes inline seeding + iframe helpers

Preserved exactly: every assertion, group attribute (`#[Group('fresh-install')]`),
test method name, and every WHY comment (release-image XPath gotchas,
race-condition anti-flake reasoning, XPath calibration notes,
`<div class="menuLabel">` discovery, jQuery-guard rationale).

## LOC delta

5 test files: 1647 -> 808 (-839, -50.9%). Support/ additions total 682.
Net -157 LOC across tests + support.

## Verification

Local run against booted release image on port 8580:

```
PHPUnit 11.5.55
..........                                                        10 / 10 (100%)
Time: 00:49.668, Memory: 36.50 MB
OK (10 tests, 93 assertions)
```

Static analysis:

- `openemr-cmd worktree exec phase-4e-support-extract pst` -- level 10 clean
- `openemr-cmd worktree exec phase-4e-support-extract pr` -- phpcs clean
  for the 7 touched files (pre-existing sqlconf.php lint warnings are
  unrelated to this PR)
- `openemr-cmd worktree exec phase-4e-support-extract rd` -- rector clean
  for the 7 touched files (pre-existing flatted.php + sqlconf.php
  suggestions are unrelated to this PR)

Pre-commit hooks all passed on the commit.

## Test plan

- [ ] CI acceptance workflow runs green on this PR
- [ ] The 5 tests still show the same assertion count in CI
- [ ] Nothing regressed under fresh-install group timing budget
- [ ] Medium-tier ports (Bb/Cc/Dd/Ee/Ff/SvcCode) can consume
  `PantherAcceptanceTestCase` + `UiSeedingTrait` from day one