### PR TITLE
test(acceptance): dual-tag 4e Small-tier ports for post-upgrade coverage

### DIFF
--- a/tests/Acceptance/AaLoginAcceptanceTest.php
+++ b/tests/Acceptance/AaLoginAcceptanceTest.php
@@ -56,6 +56,7 @@ use Symfony\Component\Panther\Client;
  * artifact.
  */
 #[Group('fresh-install')]
+#[Group('post-upgrade')]
 final class AaLoginAcceptanceTest extends TestCase
 {
     private ?Client $client = null;

--- a/tests/Acceptance/E2eCriticalPathTest.php
+++ b/tests/Acceptance/E2eCriticalPathTest.php
@@ -38,13 +38,12 @@ use Symfony\Component\Panther\Client;
  * render. Adding more critical-path steps (patient add, encounter
  * start) is straightforward once the plumbing is proven in CI.
  *
- * Fires only on fresh-install for now; post-upgrade coverage is a
- * follow-up (need to think about whether Knockout menu rendering is
- * a useful upgrade-regression signal, or if it's just a duplicate
- * of fresh-install signal since the upgrade path doesn't touch the
- * post-login shell).
+ * Runs in both fresh-install and post-upgrade phases — the upgrade
+ * path doesn't rebuild the post-login SPA, but a broken menu-render
+ * after upgrade still signals a regression worth catching.
  */
 #[Group('fresh-install')]
+#[Group('post-upgrade')]
 final class E2eCriticalPathTest extends TestCase
 {
     private ?Client $client = null;

--- a/tests/Acceptance/FrontPaymentCssContrastAcceptanceTest.php
+++ b/tests/Acceptance/FrontPaymentCssContrastAcceptanceTest.php
@@ -62,6 +62,7 @@ use Symfony\Component\Panther\Client;
  * release artifact.
  */
 #[Group('fresh-install')]
+#[Group('post-upgrade')]
 final class FrontPaymentCssContrastAcceptanceTest extends TestCase
 {
     private ?Client $client = null;

--- a/tests/Acceptance/GgUserMenuLinksAcceptanceTest.php
+++ b/tests/Acceptance/GgUserMenuLinksAcceptanceTest.php
@@ -59,6 +59,7 @@ use Symfony\Component\Panther\Client;
  * artifact.
  */
 #[Group('fresh-install')]
+#[Group('post-upgrade')]
 final class GgUserMenuLinksAcceptanceTest extends TestCase
 {
     private ?Client $client = null;


### PR DESCRIPTION
## Summary

Adds `#[Group('post-upgrade')]` alongside the existing `#[Group('fresh-install')]` on 4 Small-tier acceptance ports so they run in **both** the fresh-install-* scenarios and the upgrade scenario's post-upgrade phase:

- `AaLoginAcceptanceTest`
- `GgUserMenuLinksAcceptanceTest`
- `FrontPaymentCssContrastAcceptanceTest`
- `E2eCriticalPathTest`

Before this PR, the only tests exercised by `--group=post-upgrade` were `FhirSmokeTest`, `OAuth2SmokeTest`, and `UpgradeIntegrityTest` — leaving admin-login flow, user-menu links, front-payment CSS, and Knockout menu render uncovered after upgrade. The `acceptance-docker.yml` matrix has always run `--group=post-upgrade` against the upgraded to_tag; this PR just extends what runs there.

`E2eCriticalPathTest`'s docblock is updated to remove the "Fires only on fresh-install for now" note, which is superseded here.

### Excluded from this PR

`KkEncounterFormNavbarUrlAcceptanceTest` is intentionally **not** dual-tagged in this PR. It currently exhibits a `WebDriverExpectedCondition::alertIsPresent()` timeout on the upgrade scenario's initial fresh-install pre-flight (visible in #13342). Dual-tagging now would add known-failing post-upgrade coverage. It will be dual-tagged in the same follow-up that addresses the flake root cause.

### Relationship to #13344

#13344 (Support/ extract refactor) touches the same 4 test files. Once this PR lands, #13344 will pick up the dual-tags on rebase. No coordination required beyond ordinary rebase.

## Test plan

- [ ] CI green on all three acceptance-docker scenarios (fresh-install-from, fresh-install-to, upgrade)
- [ ] Verify the 4 dual-tagged tests now appear in the upgrade scenario's post-upgrade run output (not just its initial pre-flight)
- [ ] Confirm no other CI job regresses from the added group filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)