### PR TITLE
fix(ci): detect-mode falls back to build_locally=false on orphaned base SHA

### DIFF
--- a/.github/scripts/detect-acceptance-mode.sh
+++ b/.github/scripts/detect-acceptance-mode.sh
@@ -208,6 +208,27 @@ if [[ -z "${BASE}" || "${BASE}" == "0000000000000000000000000000000000000000" ]]
     emit_to_version "false"
     exit 0
 fi
+# Verify BASE is reachable in the local clone. If the branch was
+# force-pushed or regenerated (bot-authored sync PRs like master->rel-*,
+# rebase-and-push, etc.) the push event's before-SHA can point at an
+# orphaned commit no longer in any ref. actions/checkout fetch-depth: 0
+# clones all refs but not orphaned commits (those live only in the
+# server-side reflog). Try to fetch the specific SHA — GitHub retains
+# force-pushed commits for ~90 days and supports fetch-by-SHA — and if
+# it still can't be resolved, treat as branch-creation-style and default
+# to build_locally=false. Preserves fail-loud on genuinely broken git
+# state (see git diff error handling below) while gracefully handling
+# the force-push-orphaned-base case that was blocking legitimate reruns.
+if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+    echo "==> BASE ${BASE} not present locally; attempting server-side fetch-by-SHA"
+    git fetch --depth=1 --no-tags origin "${BASE}" 2>/dev/null || true
+    if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+        echo "==> BASE ${BASE} not fetchable (force-push + reflog GC?): defaulting build_locally=false"
+        echo "build_locally=false" >> "${GITHUB_OUTPUT}"
+        emit_to_version "false"
+        exit 0
+    fi
+fi
 # Trigger the local-build path when the PR touches anything
 # PackageAssembler consumes at build time: the assembler code
 # itself, the phing buildfile that owns the prune target list,

--- a/.github/scripts/detect-acceptance-mode.sh
+++ b/.github/scripts/detect-acceptance-mode.sh
@@ -231,7 +231,7 @@ if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
         echo "==> BASE ${BASE} still not reachable after fetch attempt: defaulting build_locally=false"
         echo "==> (may indicate: force-push + reflog GC, auth failure, or transient network — see fetch output below)"
         if [[ -n "${fetch_stderr}" ]]; then
-            sed 's/^/==>   fetch: /' <<< "${fetch_stderr}"
+            awk '{ print "==>   fetch: " $0 }' <<< "${fetch_stderr}"
         fi
         echo "build_locally=false" >> "${GITHUB_OUTPUT}"
         emit_to_version "false"

--- a/.github/scripts/detect-acceptance-mode.sh
+++ b/.github/scripts/detect-acceptance-mode.sh
@@ -221,9 +221,18 @@ fi
 # the force-push-orphaned-base case that was blocking legitimate reruns.
 if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
     echo "==> BASE ${BASE} not present locally; attempting server-side fetch-by-SHA"
-    git fetch --depth=1 --no-tags origin "${BASE}" 2>/dev/null || true
+    # Capture stderr so a failed fetch (auth, transient network, unknown
+    # SHA) surfaces in the fall-back log below rather than being silently
+    # masked. Not retried or fatal — we still want to unblock legitimate
+    # force-pushed reruns — but operators reading the log can distinguish
+    # "reflog GC" from "auth failure" without spelunking through the run.
+    fetch_stderr=$(git fetch --depth=1 --no-tags origin "${BASE}" 2>&1 >/dev/null) || true
     if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
-        echo "==> BASE ${BASE} not fetchable (force-push + reflog GC?): defaulting build_locally=false"
+        echo "==> BASE ${BASE} still not reachable after fetch attempt: defaulting build_locally=false"
+        echo "==> (may indicate: force-push + reflog GC, auth failure, or transient network — see fetch output below)"
+        if [[ -n "${fetch_stderr}" ]]; then
+            sed 's/^/==>   fetch: /' <<< "${fetch_stderr}"
+        fi
         echo "build_locally=false" >> "${GITHUB_OUTPUT}"
         emit_to_version "false"
         exit 0

--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -196,6 +196,29 @@ jobs:
           echo "build_locally=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
+        # Verify BASE is reachable in the local clone. If the branch was
+        # force-pushed or regenerated (bot-authored sync PRs like
+        # master->rel-*, rebase-and-push, etc.) the push event's
+        # before-SHA can point at an orphaned commit no longer in any
+        # ref. actions/checkout fetch-depth: 0 clones all refs but not
+        # orphaned commits (those live only in the server-side reflog).
+        # Try to fetch the specific SHA -- GitHub retains force-pushed
+        # commits for ~90 days and supports fetch-by-SHA -- and if it
+        # still can't be resolved, treat as branch-creation-style and
+        # default to build_locally=false. Preserves fail-loud on
+        # genuinely broken git state (see git diff error handling
+        # below) while gracefully handling the force-push-orphaned-base
+        # case. Same fix applied to detect-acceptance-mode.sh for the
+        # tarball prong.
+        if ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+          echo "==> BASE $BASE not present locally; attempting server-side fetch-by-SHA"
+          git fetch --depth=1 --no-tags origin "$BASE" 2>/dev/null || true
+          if ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+            echo "==> BASE $BASE not fetchable (force-push + reflog GC?): defaulting build_locally=false"
+            echo "build_locally=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+        fi
         # Capture git diff separately from the grep so a git-side
         # failure (unresolvable range after a force-push + reflog GC,
         # etc.) exits loudly. Under set -euo pipefail the pipeline's

--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -212,9 +212,19 @@ jobs:
         # tarball prong.
         if ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
           echo "==> BASE $BASE not present locally; attempting server-side fetch-by-SHA"
-          git fetch --depth=1 --no-tags origin "$BASE" 2>/dev/null || true
+          # Capture stderr so a failed fetch (auth, transient network,
+          # unknown SHA) surfaces in the fall-back log below rather than
+          # being silently masked. Not retried or fatal -- we still want
+          # to unblock legitimate force-pushed reruns -- but operators
+          # reading the log can distinguish "reflog GC" from "auth
+          # failure" without spelunking through the run.
+          fetch_stderr=$(git fetch --depth=1 --no-tags origin "$BASE" 2>&1 >/dev/null) || true
           if ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
-            echo "==> BASE $BASE not fetchable (force-push + reflog GC?): defaulting build_locally=false"
+            echo "==> BASE $BASE still not reachable after fetch attempt: defaulting build_locally=false"
+            echo "==> (may indicate: force-push + reflog GC, auth failure, or transient network -- see fetch output below)"
+            if [[ -n "$fetch_stderr" ]]; then
+              sed 's/^/==>   fetch: /' <<< "$fetch_stderr"
+            fi
             echo "build_locally=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -223,7 +223,7 @@ jobs:
             echo "==> BASE $BASE still not reachable after fetch attempt: defaulting build_locally=false"
             echo "==> (may indicate: force-push + reflog GC, auth failure, or transient network -- see fetch output below)"
             if [[ -n "$fetch_stderr" ]]; then
-              sed 's/^/==>   fetch: /' <<< "$fetch_stderr"
+              awk '{ print "==>   fetch: " $0 }' <<< "$fetch_stderr"
             fi
             echo "build_locally=false" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
## Summary

Fix a latent bug in both acceptance-test detect-mode call sites that surfaces when a bot-authored PR is regenerated via force-push.

**Symptom:** #13342 (auto-generated master→rel-820 sync PR) was re-run to gather more data on the KkEncounter WebDriver-alert flake. The rerun failed at detect-mode — before the acceptance-scenario matrix could execute — with `fatal: Invalid revision range 540dab2..16799921`. All downstream jobs (build-image, acceptance-scenario matrix) got SKIPPED, so the rerun produced zero acceptance data.

**Root cause:** `actions/checkout` with `fetch-depth: 0` clones every named ref but not orphaned commits. When a branch is force-pushed / regenerated (bot-authored sync PRs regenerate the tree; rebase-and-push replaces the tip; auto-sync flows commonly do both) the push event's `github.event.before` SHA can point at a commit that's now orphaned — retained only in GitHub's server-side reflog for ~90 days but not in any ref.

The existing script pattern intentionally exits loudly on `git diff BASE..HEAD` failure to prevent a subtle grep-masks-git-failure bug (a `git diff | grep -q` pipeline would silently report "no relevant change" → `build_locally=false` with no `::error::`). That fail-loud behavior is correct for genuinely broken git state but blocks legitimate reruns of force-pushed PRs.

**Fix:** After the existing branch-creation zero-SHA check, verify BASE is reachable via `git cat-file -e`. If not, try one server-side fetch-by-SHA (GitHub supports fetching arbitrary reachable SHAs against retained reflog entries). If still unreachable, treat as branch-creation-style and default to `build_locally=false` with a clear warning. The existing `git diff` error-handling branch is untouched — it still fails loud on any git-side error that survives the new reachability check.

Applied to both call sites:
- `.github/scripts/detect-acceptance-mode.sh` (tarball prong, extracted in Phase 10e-4 as #13306)
- `.github/workflows/acceptance-docker.yml` (docker prong, inline `detect-mode` job)

`detect-acceptance-mode.sh` is already in `.github/byte-identical.yml` (line 305, exclude-branches `[rel-800, rel-704]`), so the fix will propagate to rel-820+ on next byte-identical sync run.

## Test plan

- [ ] CI green on this PR (no `push` before-SHA problems on a straight-line branch)
- [ ] Re-run #13342 after this lands + next sync regenerates it — verify `detect-mode` no longer fails on orphaned BASE (either resolves via fetch-by-SHA and diffs, or logs the "not fetchable" line and defaults to `build_locally=false`)
- [ ] Confirm the existing loud-fail on genuinely bad git state still fires (indirect: inspect that the `git diff` error-handling branch is untouched below the new reachability check)

Related to #13342 investigation; unblocks getting new acceptance data for the KkEncounter flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)