### PR TITLE
refactor(acceptance): per-test-instance seed identity in UiSeedingTrait

### DIFF
--- a/tests/Acceptance/KkEncounterFormNavbarUrlAcceptanceTest.php
+++ b/tests/Acceptance/KkEncounterFormNavbarUrlAcceptanceTest.php
@@ -63,6 +63,7 @@ use PHPUnit\Framework\Attributes\Group;
  * against the release artifact.
  */
 #[Group('fresh-install')]
+#[Group('post-upgrade')]
 final class KkEncounterFormNavbarUrlAcceptanceTest extends PantherAcceptanceTestCase
 {
     use UiSeedingTrait;

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -62,21 +62,23 @@ trait UiSeedingTrait
     protected const SEED_PATIENT_DOB = '1958-05-02';
     protected const SEED_PATIENT_SEX = 'Male';
 
-    private ?string $seedPatientFname = null;
-    private ?string $seedPatientLname = null;
+    private ?string $seedPatientSuffix = null;
 
     /**
-     * First name for the seeded patient — base + random suffix,
-     * generated once per test instance and cached so patient-add
-     * calls and downstream assertions see the same value.
+     * First name for the seeded patient — base + shared random
+     * suffix, generated once per test instance and cached so
+     * patient-add calls and downstream assertions see the same
+     * value. fname and lname share the SAME suffix so the pair
+     * correlates cleanly in DB rows + logs ("which test seeded
+     * Ftestabc123 / Ltestabc123?" → obvious grep target).
      *
      * Multiple test instances (PHPUnit creates one per test method)
-     * each generate their own identity, so tests running in the
+     * each generate their own suffix, so tests running in the
      * same phase against the same DB never collide.
      */
     protected function seedPatientFname(): string
     {
-        return $this->seedPatientFname ??= self::SEED_PATIENT_FNAME_BASE . self::seedRandomSuffix();
+        return self::SEED_PATIENT_FNAME_BASE . $this->seedPatientSuffix();
     }
 
     /**
@@ -84,12 +86,12 @@ trait UiSeedingTrait
      */
     protected function seedPatientLname(): string
     {
-        return $this->seedPatientLname ??= self::SEED_PATIENT_LNAME_BASE . self::seedRandomSuffix();
+        return self::SEED_PATIENT_LNAME_BASE . $this->seedPatientSuffix();
     }
 
-    private static function seedRandomSuffix(): string
+    private function seedPatientSuffix(): string
     {
-        return bin2hex(random_bytes(3));
+        return $this->seedPatientSuffix ??= bin2hex(random_bytes(3));
     }
 
     /**

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -43,15 +43,54 @@ use Facebook\WebDriver\WebDriverExpectedCondition;
 trait UiSeedingTrait
 {
     /**
-     * Default fixture identity used by the encounter-form navbar port
-     * (Ftest/Ltest matches the source-side PatientAddTrait's chosen
-     * fixture name, kept as a shared constant so Medium-tier ports
-     * that assert on patient-name-in-DOM can reuse the same string).
+     * Base names for the seeded patient. Actual identity is
+     * base + random suffix, generated per test instance and
+     * returned by seedPatientFname() / seedPatientLname().
+     *
+     * Ftest/Ltest bases match the source-side PatientAddTrait's
+     * chosen fixture names so grep across suites still ties back
+     * to the same convention; the suffix isolates each test's
+     * seed from every other test's + from prior runs against a
+     * persisted DB (upgrade scenario's post-upgrade phase).
+     *
+     * DOB + SEX stay fixed — patient uniqueness is by
+     * (fname, lname, DOB), and varying fname/lname is enough to
+     * make each seed unique.
      */
-    protected const SEED_PATIENT_FNAME = 'Ftest';
-    protected const SEED_PATIENT_LNAME = 'Ltest';
+    protected const SEED_PATIENT_FNAME_BASE = 'Ftest';
+    protected const SEED_PATIENT_LNAME_BASE = 'Ltest';
     protected const SEED_PATIENT_DOB = '1958-05-02';
     protected const SEED_PATIENT_SEX = 'Male';
+
+    private ?string $seedPatientFname = null;
+    private ?string $seedPatientLname = null;
+
+    /**
+     * First name for the seeded patient — base + random suffix,
+     * generated once per test instance and cached so patient-add
+     * calls and downstream assertions see the same value.
+     *
+     * Multiple test instances (PHPUnit creates one per test method)
+     * each generate their own identity, so tests running in the
+     * same phase against the same DB never collide.
+     */
+    protected function seedPatientFname(): string
+    {
+        return $this->seedPatientFname ??= self::SEED_PATIENT_FNAME_BASE . self::seedRandomSuffix();
+    }
+
+    /**
+     * Last name for the seeded patient — see seedPatientFname().
+     */
+    protected function seedPatientLname(): string
+    {
+        return $this->seedPatientLname ??= self::SEED_PATIENT_LNAME_BASE . self::seedRandomSuffix();
+    }
+
+    private static function seedRandomSuffix(): string
+    {
+        return bin2hex(random_bytes(3));
+    }
 
     /**
      * Encounter category id — matches source-side EncounterTestData's
@@ -67,8 +106,12 @@ trait UiSeedingTrait
     protected const SEED_ENCOUNTER_REASON = 'Testing encounter';
 
     /**
-     * Add a fresh patient (Ftest Ltest by default) via the "Patient/
-     * Client → New/Search" main-menu path. Mirrors the source-side
+     * Add a fresh patient (Ftest<suffix> Ltest<suffix>) via the
+     * "Patient/Client → New/Search" main-menu path. Identity is
+     * per-test-instance via seedPatientFname/seedPatientLname so
+     * multiple tests seeding in the same phase and post-upgrade
+     * runs against an already-seeded DB never collide on a
+     * pre-existing patient. Mirrors the source-side
      * PatientAddTrait flow shape: open New/Search tab → fill the DEM
      * form in the patient iframe → click Create → confirm in the modal
      * iframe → accept the resulting duplicate-check alert → wait for
@@ -129,8 +172,8 @@ trait UiSeedingTrait
         // inside iframes, and this form has enough JS-bound side effects
         // (sex/sex_identified twinning) that submitting the form element
         // is more robust than reconstructing a POST.
-        $this->setInputValue("//input[@type='text' and @name='form_fname']", self::SEED_PATIENT_FNAME);
-        $this->setInputValue("//input[@type='text' and @name='form_lname']", self::SEED_PATIENT_LNAME);
+        $this->setInputValue("//input[@type='text' and @name='form_fname']", $this->seedPatientFname());
+        $this->setInputValue("//input[@type='text' and @name='form_lname']", $this->seedPatientLname());
         $this->setInputValue("//input[@name='form_DOB']", self::SEED_PATIENT_DOB);
         $this->setSelectValue("//select[@name='form_sex']", self::SEED_PATIENT_SEX);
         $this->setSelectValue("//select[@name='form_sex_identified']", self::SEED_PATIENT_SEX);
@@ -174,7 +217,7 @@ trait UiSeedingTrait
         $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="pat"]', 30);
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
         $client->waitFor(
-            '//*[text()="Medical Record Dashboard - ' . self::SEED_PATIENT_FNAME . ' ' . self::SEED_PATIENT_LNAME . '"]',
+            '//*[text()="Medical Record Dashboard - ' . $this->seedPatientFname() . ' ' . $this->seedPatientLname() . '"]',
             30,
         );
     }
@@ -230,7 +273,7 @@ trait UiSeedingTrait
         $this->switchToIFrame('//iframe[@src="forms.php"]');
         $client->waitFor(
             '//span[@id="navbarEncounterTitle" and contains(text(), "Encounter for '
-                . self::SEED_PATIENT_FNAME . ' ' . self::SEED_PATIENT_LNAME . '")]',
+                . $this->seedPatientFname() . ' ' . $this->seedPatientLname() . '")]',
             30,
         );
     }


### PR DESCRIPTION
## Summary

Converts `UiSeedingTrait`'s fixed patient seed identity (`Ftest` / `Ltest` / fixed DOB) to per-test-instance identity: base name + `bin2hex(random_bytes(3))` suffix, exposed via `seedPatientFname()` / `seedPatientLname()` accessors. PHPUnit creates a fresh test instance per method, so each `addPatientViaUi` call generates a unique patient. DOB / SEX / encounter category / encounter reason stay fixed (uniqueness by tuple; varying fname+lname suffix is enough).

**Fixes two collision scenarios flagged during #13348:**

1. **Upgrade scenario post-upgrade phase against an already-seeded DB** — fresh-install-group ran during pre-flight and seeded patient A, upgrade preserved the DB, post-upgrade-group would then try to seed patient A again against an existing record → different alert flow, current helper doesn't handle.

2. **Multiple Medium-tier tests in the same phase each seeding a patient** — Bb/Cc/Dd/Ee/Ff/Svc all seed patients; with fixed identity the second test onward collided.

**Also:** re-adds `#[Group('post-upgrade')]` to `KkEncounterFormNavbarUrlAcceptanceTest`. Held out of the post-upgrade dual-tag backfill (#13345) previously pending this refactor. Kk now runs in both pre-upgrade and post-upgrade phases, each with fresh identity.

**Bonus flake stress-test:** every run now seeds a fresh patient, so any residual flakiness in the create flow surfaces at the seeding step instead of masking behind a same-patient dup-check path. Doubles as validation for #13348's wait-widening.

## Test plan

- [ ] CI green on all acceptance-docker + acceptance-package scenarios
- [ ] Kk now shows up in the upgrade scenario's post-upgrade phase (previously fresh-install-only)
- [ ] No collision failures across scenarios
- [ ] Multiple re-runs against rel-820 after landing to confirm the fresh-seed-per-run doesn't surface a new class of flake

**Unblocks Medium tier** (Bb/Cc/Dd/Ee/Ff/Svc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)