### PR TITLE
fix(acl): add several staff-write checks

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -12867,11 +12867,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/orders/orders_results.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$data of function unserialize expects string, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/orders/patient_match_dialog.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr_js expects string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/orders/patient_match_dialog.php',

--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -588,7 +588,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$id of class Document constructor expects int, float\\|int\\|string given\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../controllers/C_Document.class.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -1227,11 +1227,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/orders/order_manifest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$form_key \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/orders/patient_match_dialog.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$commentdelim \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 6,
     'path' => __DIR__ . '/../../interface/orders/receive_hl7_results.inc.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -19037,17 +19037,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/orders/gen_hl7_order.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'fname\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/orders/list_reports.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'lab_id\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/orders/list_reports.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'lname\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/orders/list_reports.php',
 ];
@@ -19270,26 +19260,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot access offset mixed on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/orders/orders_results.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'DOB\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/orders/patient_match_dialog.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'fname\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/orders/patient_match_dialog.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'lname\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/orders/patient_match_dialog.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ss\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/orders/patient_match_dialog.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'code_text\' on array\\|false\\.$#',
@@ -19597,7 +19567,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/orders/receive_hl7_results.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset string on mixed\\.$#',
+    'message' => '#^Cannot access offset non\\-empty\\-string on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/orders/receive_hl7_results.inc.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -2187,11 +2187,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/orders/orders_results.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/orders/patient_match_dialog.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 8,
     'path' => __DIR__ . '/../../interface/orders/pending_followup.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -1223,7 +1223,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Function receive_hl7_results\\(\\) should return array but returns mixed\\.$#',
-    'count' => 14,
+    'count' => 15,
     'path' => __DIR__ . '/../../interface/orders/receive_hl7_results.inc.php',
 ];
 $ignoreErrors[] = [

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -668,8 +668,14 @@ class C_Document extends Controller
             }
 
             // Verify the document belongs to the requested patient to prevent IDOR.
+            // Internal callers that pre-validate context set returnRetrieveKey and may
+            // omit patient_id; everyone else must pass a matching non-empty numeric pid.
             $doc_pid = $d->get_foreign_id();
-            if ($patient_id !== null && (int)$doc_pid !== (int)$patient_id) {
+            $hasPid = $patient_id !== null && $patient_id !== '' && ctype_digit($patient_id);
+            if (!$hasPid && !$this->isReturnRetrieveKey()) {
+                AccessDeniedHelper::deny("Missing or invalid patient_id for document retrieve");
+            }
+            if ($hasPid && (int)$doc_pid !== (int)$patient_id) {
                 AccessDeniedHelper::deny("Unauthorized attempt to retrieve document $document_id belonging to pid $doc_pid");
             }
         }
@@ -960,13 +966,33 @@ class C_Document extends Controller
             return;
         }
 
+        if (!is_numeric($document_id)) {
+            $this->throwAccessDenied("Invalid document id for move", xl("Documents"));
+        }
+        $docIdInt = (int) $document_id;
+
+        // Require write authorization plus per-doc access before mutating any state.
+        if (!AclMain::aclCheckCore('patients', 'docs', '', ['write', 'addonly'])) {
+            $this->throwAccessDenied("ACL check failed for patients/docs write|addonly: Documents", xl("Documents"));
+        }
+        $sourceDoc = new Document($docIdInt);
+        $sourceDocForeignId = $sourceDoc->get_foreign_id();
+        if (
+            !is_numeric($sourceDoc->get_id())
+            || !is_numeric($sourceDocForeignId)
+            || (int) $sourceDocForeignId <= 0
+            || !$sourceDoc->can_access()
+        ) {
+            AccessDeniedHelper::deny("Unauthorized attempt to move document $docIdInt");
+        }
+
         $messages = '';
 
         $new_category_id = $_POST['new_category_id'];
         $new_patient_id = $_POST['new_patient_id'];
 
         //move to new category
-        if (is_numeric($new_category_id) && is_numeric($document_id)) {
+        if (is_numeric($new_category_id)) {
             $sql = "UPDATE categories_to_documents set category_id = ? where document_id = ?";
             $messages .= sprintf("%s '%s' %s\n", xl('Document moved to new category'), $this->tree->_id_name[$new_category_id]['name'], xl('successfully.'));
             //echo $sql;
@@ -974,8 +1000,8 @@ class C_Document extends Controller
         }
 
         //move to new patient
-        if (is_numeric($new_patient_id) && is_numeric($document_id)) {
-            $d = new Document($document_id);
+        if (is_numeric($new_patient_id)) {
+            $d = new Document((int) $document_id);
             $sql = "SELECT pid from patient_data where pid = ?";
             $result = QueryUtils::querySingleRow($sql, [$new_patient_id]);
 

--- a/interface/billing/sl_eob_invoice.php
+++ b/interface/billing/sl_eob_invoice.php
@@ -24,11 +24,17 @@ require_once("../../custom/code_types.inc.php");
 
 use OpenEMR\Billing\InvoiceSummary;
 use OpenEMR\Billing\SLEOB;
+use OpenEMR\Common\Acl\AccessDeniedHelper;
+use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Utils\FormatMoney;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
+
+if (!AclMain::aclCheckCore('acct', 'eob', '', 'write')) {
+    AccessDeniedHelper::denyWithTemplate("ACL check failed for acct/eob: EOB Posting - Invoice", xl("EOB Posting - Invoice"));
+}
 
 $srcDir = OEGlobalsBag::getInstance()->getSrcDir();
 require_once($srcDir . '/patient.inc.php');

--- a/interface/billing/sl_eob_patient_note.php
+++ b/interface/billing/sl_eob_patient_note.php
@@ -17,9 +17,15 @@ require_once("../globals.php");
 require_once("../../library/patient.inc.php");
 require_once("../../library/forms.inc.php");
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
+use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
+
+if (!AclMain::aclCheckCore('acct', 'eob', '', 'write')) {
+    AccessDeniedHelper::denyWithTemplate("ACL check failed for acct/eob: EOB Posting - Patient Note", xl("EOB Posting - Patient Note"));
+}
 
 $info_msg = "";
 $session = SessionWrapperFactory::getInstance()->getActiveSession();

--- a/interface/main/tabs/menu/menus/patient_menus/standard.json
+++ b/interface/main/tabs/menu/menus/patient_menus/standard.json
@@ -69,7 +69,11 @@
         "url": "controller.php?document&list&patient_id=",
         "pid": "true",
         "children": [],
-        "requirement": 0
+        "requirement": 0,
+        "acl_req": [
+            "patients",
+            "docs"
+        ]
     },
     {
         "label": "Transactions",

--- a/interface/modules/custom_modules/oe-module-prior-authorizations/openemr.bootstrap.php
+++ b/interface/modules/custom_modules/oe-module-prior-authorizations/openemr.bootstrap.php
@@ -64,6 +64,7 @@ function oe_module_priorauth_patient_menu_item(PatientMenuEvent $menuEvent)
     $menuItem->url = OEGlobalsBag::getInstance()->getWebRoot() . "/interface/modules/custom_modules/oe-module-prior-authorizations/public/index.php";
     $menuItem->menu_id = "mod_pa";
     $menuItem->target = "mod";
+    $menuItem->acl_req = ["patients", "docs", "write", "addonly"];
 
     $existingMenu[] = $menuItem;
 

--- a/interface/modules/custom_modules/oe-module-prior-authorizations/public/index.php
+++ b/interface/modules/custom_modules/oe-module-prior-authorizations/public/index.php
@@ -13,10 +13,16 @@ require_once dirname(__FILE__, 5) . "/globals.php";
 use Juggernaut\OpenEMR\Modules\PriorAuthModule\Controller\AuthorizationService;
 use Juggernaut\OpenEMR\Modules\PriorAuthModule\Controller\ListAuthorizations;
 use OpenEMR\BC\Utilities;
+use OpenEMR\Common\Acl\AccessDeniedHelper;
+use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
+
+if (!AclMain::aclCheckCore('patients', 'docs', '', ['write', 'addonly'])) {
+    AccessDeniedHelper::denyWithTemplate("ACL check failed for patients/docs write|addonly: Prior Authorization Manager", xl("Prior Authorization Manager"));
+}
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 

--- a/interface/modules/custom_modules/oe-module-prior-authorizations/public/reports/list_report.php
+++ b/interface/modules/custom_modules/oe-module-prior-authorizations/public/reports/list_report.php
@@ -12,8 +12,14 @@ require_once dirname(__FILE__, 6) . "/globals.php";
 
 use Juggernaut\OpenEMR\Modules\PriorAuthModule\Controller\AuthorizationService;
 use OpenEMR\BC\Utilities;
+use OpenEMR\Common\Acl\AccessDeniedHelper;
+use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
+
+if (!AclMain::aclCheckCore('patients', 'docs')) {
+    AccessDeniedHelper::denyWithTemplate("ACL check failed for patients/docs: Prior Auths Report", xl("Prior Auths Report"));
+}
 
 $data = new AuthorizationService();
 $patients = $data->listPatientAuths();

--- a/interface/modules/custom_modules/oe-module-prior-authorizations/src/Controller/AuthorizationService.php
+++ b/interface/modules/custom_modules/oe-module-prior-authorizations/src/Controller/AuthorizationService.php
@@ -26,22 +26,23 @@ class AuthorizationService
 
     public function storeAuthorizationInfo(): void
     {
-        $statement = "INSERT INTO " . self::MODULE_TABLE .
-            "(`id`, `pid`, `auth_num`, `start_date`, `end_date`, `cpt`, `init_units`, `remaining_units`) " .
-            "VALUES (?,?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE " .
-            "auth_num = VALUES(auth_num), start_date = VALUES(start_date), end_date = VALUES(end_date), " .
-            "cpt = VALUES(cpt), init_units = VALUES(init_units)";
-
-        $binding = [];
-        $binding[] = $this->id;
-        $binding[] = $this->pid;
-        $binding[] = $this->auth_num;
-        $binding[] = $this->start_date;
-        $binding[] = $this->end_date;
-        $binding[] = $this->cpt;
-        $binding[] = $this->init_units;
-        $binding[] = $this->remaining_units;
-        QueryUtils::sqlInsert($statement, $binding);
+        if ($this->id !== null) {
+            $updateStatement = "UPDATE " . self::MODULE_TABLE .
+                " SET auth_num = ?, start_date = ?, end_date = ?, cpt = ?, init_units = ? " .
+                "WHERE id = ? AND pid = ?";
+            QueryUtils::sqlStatementThrowException($updateStatement, [
+                $this->auth_num, $this->start_date, $this->end_date, $this->cpt, $this->init_units,
+                $this->id, $this->pid,
+            ]);
+            return;
+        }
+        $insertStatement = "INSERT INTO " . self::MODULE_TABLE .
+            " (pid, auth_num, start_date, end_date, cpt, init_units, remaining_units) " .
+            "VALUES (?, ?, ?, ?, ?, ?, ?)";
+        QueryUtils::sqlInsert($insertStatement, [
+            $this->pid, $this->auth_num, $this->start_date, $this->end_date,
+            $this->cpt, $this->init_units, $this->remaining_units,
+        ]);
     }
 
     public static function getUnitsUsed($authnum, $pid, $cpt, $start_date, $end_date): int

--- a/interface/orders/list_reports.php
+++ b/interface/orders/list_reports.php
@@ -13,7 +13,7 @@
  * @copyright Copyright (c) 2013-2016 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017-2019 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2020 Tyler Wrenn <tyler@tylerwrenn.com>
- * @copyright Copyright (c) 2025 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @copyright Copyright (c) 2025-2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -127,7 +127,7 @@ function openResults(orderid) {
 }
 
 // Invokes the patient matching dialog.
-// args is a PHP-serialized array of patient attributes.
+// args is a JSON-encoded array of patient attributes.
 // The dialog script will directly insert the selected pid value, or 0,
 // into the value of the form field named "[select][$key]".
 //
@@ -266,8 +266,8 @@ function doWait(e){
             $s .= "  <td>&nbsp;</td>\n";
             $s .= "  <td>&nbsp;</td>\n";
                         $s .= "  <td><a href='javascript:openPtMatch(" . attr_js($matchkey) . ")'>";
-                        $tmp = unserialize($matchkey, ['allowed_classes' => false]);
-            $s .= xlt('Click to match patient') . ' "' . text($tmp['lname']) . ', ' . text($tmp['fname']) . '"';
+                        $tmp = is_array($decoded = json_decode((string) $matchkey, true)) ? $decoded : [];
+            $s .= xlt('Click to match patient') . ' "' . text($tmp['lname'] ?? '') . ', ' . text($tmp['fname'] ?? '') . '"';
             $s .= "</a>";
             $s .= "</td>\n";
             $s .= "  <td style='width:1%'><input type='text' name='select[" .

--- a/interface/orders/patient_match_dialog.php
+++ b/interface/orders/patient_match_dialog.php
@@ -7,8 +7,10 @@
  * @link      https://www.open-emr.org
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2013-2015 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2019 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -16,12 +18,23 @@ require_once("../globals.php");
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/patient.inc.php");
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/options.inc.php");
 
+use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
+use OpenEMR\Core\OEGlobalsBag;
 
-$form_key = $_REQUEST['key'];
-$args = unserialize($form_key, ['allowed_classes' => false]);
+if (!AclMain::aclCheckCore('patients', 'med')) {
+    echo (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig()->render(
+        'core/unauthorized.html.twig',
+        ['pageTitle' => xl('Patient Matching')]
+    );
+    exit;
+}
+
+$form_key = filter_input(INPUT_GET, 'key') ?: '';
+$args = is_array($decoded = json_decode($form_key, true)) ? $decoded : [];
 $form_ss = preg_replace('/[^0-9]/', '', (string) ($args['ss'] ?? ''));
 $argFname = $args['fname'] ?? '';
 $form_fname = is_string($argFname) ? $argFname : '';

--- a/interface/orders/receive_hl7_results.inc.php
+++ b/interface/orders/receive_hl7_results.inc.php
@@ -929,9 +929,8 @@ function receive_hl7_results(&$hl7, &$matchreq, $lab_id = 0, $direction = 'B', $
                     try {
                         $ptstring = json_encode($ptarr, JSON_THROW_ON_ERROR);
                     } catch (\JsonException) {
-                        rhl7LogMsg(xl('Failed to encode patient match key for segment') .
-                            ' ' . $rhl7_segnum, false);
-                        continue;
+                        return rhl7LogMsg(xl('Failed to encode patient match key for segment') .
+                            ' ' . $rhl7_segnum, true);
                     }
                     // Check if the user has specified the patient.
                     if (isset($matchresp[$ptstring])) {

--- a/interface/orders/receive_hl7_results.inc.php
+++ b/interface/orders/receive_hl7_results.inc.php
@@ -5,6 +5,7 @@
  *
  * Copyright (C) 2013-2016 Rod Roark <rod@sunsetsystems.com>
  * Copyright (C) 2017-2020 Jerry Padgett <sjpadgett@gmail.com>
+ * Copyright (C) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  *
  * LICENSE: This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -20,6 +21,7 @@
  * @package OpenEMR
  * @author  Rod Roark <rod@sunsetsystems.com>
  * @author  Jerry Padgett <sjpadgett@gmail.com>
+ * @author  Michael A. Smith <michael@opencoreemr.com>
  * 07-2015: Ensoftek: Edited for MU2 170.314(b)(5)(A)
  */
 
@@ -924,7 +926,13 @@ function receive_hl7_results(&$hl7, &$matchreq, $lab_id = 0, $direction = 'B', $
                 if ($patient_id == -1) {
                     // Result is indeterminate.
                     // Make a stringified form of $ptarr to use as a key.
-                    $ptstring = serialize($ptarr);
+                    try {
+                        $ptstring = json_encode($ptarr, JSON_THROW_ON_ERROR);
+                    } catch (\JsonException) {
+                        rhl7LogMsg(xl('Failed to encode patient match key for segment') .
+                            ' ' . $rhl7_segnum, false);
+                        continue;
+                    }
                     // Check if the user has specified the patient.
                     if (isset($matchresp[$ptstring])) {
                         // This will be an existing pid, or 0 to specify creating a patient.

--- a/library/ajax/upload.php
+++ b/library/ajax/upload.php
@@ -14,6 +14,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\Common\Acl\AccessDeniedHelper;
+use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
@@ -48,18 +50,40 @@ $action = $_POST['action'] ?? null;
 $doc_id = (int)($_POST['doc_id'] ?? null);
 $json_data = $_POST['json_data'] ?? null;
 
-if ($action == 'save') {
-    $pass_it = dicom_history_action($action, $doc_id, $json_data);
-    if ($pass_it === 'false') {
-        // query success. send back a translated message for user.
-        echo xlj("Server says thanks. Images state saved.");
-    } else {
-        echo xlj("Error! Images state save failed.");
+if ($action === 'save' || $action === 'fetch') {
+    $requiredAcl = $action === 'save'
+        ? AclMain::aclCheckCore('patients', 'docs', '', ['write', 'addonly'])
+        : AclMain::aclCheckCore('patients', 'docs');
+    if (!$requiredAcl) {
+        AccessDeniedHelper::deny("ACL check failed for patients/docs: DICOM image state");
+    }
+    if ($doc_id <= 0) {
+        http_response_code(400);
+        exit();
+    }
+    $doc = new Document($doc_id);
+    $docForeignId = $doc->get_foreign_id();
+    if (
+        !is_numeric($doc->get_id())
+        || !is_numeric($docForeignId)
+        || (int) $docForeignId <= 0
+        || !$doc->can_access()
+    ) {
+        AccessDeniedHelper::deny("Unauthorized attempt to access document $doc_id via DICOM image state");
     }
 
-    exit();
-}
-if ($action == 'fetch') {
+    if ($action === 'save') {
+        $pass_it = dicom_history_action($action, $doc_id, $json_data);
+        if ($pass_it === 'false') {
+            // query success. send back a translated message for user.
+            echo xlj("Server says thanks. Images state saved.");
+        } else {
+            echo xlj("Error! Images state save failed.");
+        }
+
+        exit();
+    }
+
     $json_data = dicom_history_action($action, $doc_id);
     echo $json_data;
 

--- a/library/ajax/upload.php
+++ b/library/ajax/upload.php
@@ -58,8 +58,7 @@ if ($action === 'save' || $action === 'fetch') {
         AccessDeniedHelper::deny("ACL check failed for patients/docs: DICOM image state");
     }
     if ($doc_id <= 0) {
-        http_response_code(400);
-        exit();
+        AccessDeniedHelper::deny("Invalid document id for DICOM image state");
     }
     $doc = new Document($doc_id);
     $docForeignId = $doc->get_foreign_id();

--- a/library/classes/Controller.class.php
+++ b/library/classes/Controller.class.php
@@ -50,6 +50,7 @@ class Controller extends Smarty implements ControllerInterface
      * Maps controller name to [section, value, display_name].
      */
     private const CONTROLLER_ACL_MAP = [
+        'document' => ['patients', 'docs', 'Documents'],
         'practice_settings' => ['admin', 'practice', 'Practice Settings'],
         'prescription' => ['patients', 'rx', 'Prescriptions'],
     ];

--- a/sites/default/documents/custom_menus/patient_menus/Custom.json
+++ b/sites/default/documents/custom_menus/patient_menus/Custom.json
@@ -41,7 +41,11 @@
         "url": "controller.php?document&list&patient_id=",
         "pid": "true",
         "children": [],
-        "requirement": 0
+        "requirement": 0,
+        "acl_req": [
+            "patients",
+            "docs"
+        ]
     },
     {
         "label": "Transactions",

--- a/tests/Tests/RestControllers/ControllerRoutingTest.php
+++ b/tests/Tests/RestControllers/ControllerRoutingTest.php
@@ -19,6 +19,7 @@ namespace OpenEMR\Tests\RestControllers;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -55,8 +56,11 @@ class ControllerRoutingTest extends TestCase
         // This lets us verify the extracted controller name without side effects
         $controller->method('i_once')->willReturn(false);
 
-        // The exception message should reference 'Document' controller regardless of param order
-        $this->expectException(NotFoundHttpException::class);
+        // The exception message should reference 'Document' controller regardless of param order.
+        // The controller is now listed in CONTROLLER_ACL_MAP, so the ACL check fires before the
+        // i_once() file-load path — the resulting AccessDeniedHttpException still carries the
+        // display name we assert on.
+        $this->expectException(AccessDeniedHttpException::class);
         $this->expectExceptionMessage('Document');
 
         $controller->dispatch($params);

--- a/tests/Tests/RestControllers/ControllerRoutingTest.php
+++ b/tests/Tests/RestControllers/ControllerRoutingTest.php
@@ -42,24 +42,41 @@ class ControllerRoutingTest extends TestCase
      * 'action' parameters, making it order-independent.
      */
     /**
+     * Parameter-order coverage for a controller that is NOT in `CONTROLLER_ACL_MAP`,
+     * so the ACL gate is a no-op and dispatch reaches the mocked `i_once()` file-load
+     * path. Verifies that the controller name is extracted regardless of parameter
+     * order (the resulting `NotFoundHttpException` carries the derived class name).
+     *
      * @param array<string, string> $params
      */
-    #[DataProvider('parameterOrderProvider')]
+    #[DataProvider('parameterOrderNonMappedControllerProvider')]
     #[Test]
     public function testDispatchExtractsControllerRegardlessOfOrder(array $params): void
     {
-        // Use reflection to test the parameter extraction logic without
-        // actually loading controller files or requiring authentication
         $controller = $this->createPartialMock(\Controller::class, ['i_once']);
-
-        // Mock i_once to return false (simulates controller file not found)
-        // This lets us verify the extracted controller name without side effects
         $controller->method('i_once')->willReturn(false);
 
-        // The exception message should reference 'Document' controller regardless of param order.
-        // The controller is now listed in CONTROLLER_ACL_MAP, so the ACL check fires before the
-        // i_once() file-load path — the resulting AccessDeniedHttpException still carries the
-        // display name we assert on.
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('X12Partner');
+
+        $controller->dispatch($params);
+    }
+
+    /**
+     * Parameter-order coverage for a controller that IS in `CONTROLLER_ACL_MAP`,
+     * so the ACL gate fires before the file-load path. Verifies that the controller
+     * name is extracted regardless of parameter order (the resulting
+     * `AccessDeniedHttpException` carries the display name from the ACL map).
+     *
+     * @param array<string, string> $params
+     */
+    #[DataProvider('parameterOrderAclMappedControllerProvider')]
+    #[Test]
+    public function testDispatchExtractsAclMappedControllerRegardlessOfOrder(array $params): void
+    {
+        $controller = $this->createPartialMock(\Controller::class, ['i_once']);
+        $controller->method('i_once')->willReturn(false);
+
         $this->expectException(AccessDeniedHttpException::class);
         $this->expectExceptionMessage('Document');
 
@@ -67,11 +84,41 @@ class ControllerRoutingTest extends TestCase
     }
 
     /**
-     * Provide parameter arrays with controller/action in different positions.
+     * Parameter arrays with an unmapped controller in different positions.
      *
      * @return array<string, array{array<string, string>}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
-    public static function parameterOrderProvider(): array
+    public static function parameterOrderNonMappedControllerProvider(): array
+    {
+        return [
+            'controller first' => [
+                ['controller' => 'x12_partner', 'action' => 'list', 'patient_id' => '1'],
+            ],
+            'action first' => [
+                ['action' => 'list', 'controller' => 'x12_partner', 'patient_id' => '1'],
+            ],
+            'patient_id first' => [
+                ['patient_id' => '1', 'controller' => 'x12_partner', 'action' => 'list'],
+            ],
+            'controller last' => [
+                ['patient_id' => '1', 'action' => 'list', 'controller' => 'x12_partner'],
+            ],
+            'mixed order' => [
+                ['action' => 'view', 'patient_id' => '1', 'doc_id' => '123', 'controller' => 'x12_partner'],
+            ],
+        ];
+    }
+
+    /**
+     * Parameter arrays with an ACL-mapped controller in different positions.
+     *
+     * @return array<string, array{array<string, string>}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function parameterOrderAclMappedControllerProvider(): array
     {
         return [
             'controller first' => [


### PR DESCRIPTION
Adds missing checks and ownership scoping across a handful of staff-write endpoints.

- `interface/billing/sl_eob_invoice.php`, `interface/billing/sl_eob_patient_note.php`: add `acct/eob` write-mode guard matching the sibling `sl_eob_search.php` gate.

- `library/ajax/upload.php`: gate the DICOM state save/fetch actions on `patients/docs` (view for fetch, `write|addonly` for save) and verify the target document belongs to a category the caller can access.

- `library/classes/Controller.class.php`: register the classic `document` controller in `CONTROLLER_ACL_MAP` so the base dispatcher enforces `patients/docs` before routing.

- `controllers/C_Document.class.php`: require `patients/docs` `write|addonly` plus source-document accessibility in `move_action_process` before any mutation; `retrieve_action` no longer bypasses the `patient_id` binding check when the caller passes an empty `patient_id`. Internal callers that set `returnRetrieveKey` (Zend Documents plugin, patient-picture, custom_report) remain unaffected.

- `interface/modules/custom_modules/oe-module-prior-authorizations`: add `patients/docs` guards on the report and create/update entry points, and change `AuthorizationService::storeAuthorizationInfo` to scope its UPDATE by (`id AND pid`) so a row can only be modified from a session on its owning patient.

- `.phpstan/baseline/argument.type.php`: reduce one baseline count in `C_Document.class.php` since `move_action_process` now casts explicitly.