### PR TITLE
test(acceptance): Phase 4f Medium Dd -- port DdOpenPatientTest

### DIFF
--- a/tests/Acceptance/DdOpenPatientAcceptanceTest.php
+++ b/tests/Acceptance/DdOpenPatientAcceptanceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance;
+
+use Facebook\WebDriver\WebDriverBy;
+use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+use OpenEMR\Tests\Acceptance\Support\PantherAcceptanceTestCase;
+use OpenEMR\Tests\Acceptance\Support\UiSeedingTrait;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Panther-driven acceptance port of tests/Tests/E2e/DdOpenPatientTest.
+ *
+ * Phase 4f Medium-tier port (first). Exercises the patient-open flow:
+ * type lastname into the shell's always-visible anySearchBox
+ * (frm_search_globals), submit, click the matching entry in the
+ * patient-finder iframe, land on the patient's Medical Record
+ * Dashboard. That flow is a distinct user journey from the
+ * addPatient flow already covered by KkEncounterFormNavbarUrl
+ * (which lands on the dashboard as a side effect of creation) —
+ * DdOpenPatient specifically validates the search + click-through
+ * path.
+ *
+ * Seeding note: the source-side ordered E2E suite depends on
+ * CcCreatePatientTest having run first (`#[Depends('testLoginAuthorized')]`
+ * chained with #[Depends('testPatientOpen')] elsewhere). The
+ * acceptance harness is order-agnostic, so this test seeds the
+ * patient inline via addPatientViaUi() before invoking the open
+ * flow via openPatientViaUi(). Per-instance random seed identity
+ * (from #13351 seed-identity refactor) means multiple runs against
+ * the same DB (upgrade scenario's post-upgrade phase, tests running
+ * in the same phase) each create + open a distinct patient — no
+ * cross-run collision.
+ *
+ * Dual-tagged fresh-install + post-upgrade from the start.
+ */
+#[Group('fresh-install')]
+#[Group('post-upgrade')]
+final class DdOpenPatientAcceptanceTest extends PantherAcceptanceTestCase
+{
+    use UiSeedingTrait;
+
+    /**
+     * Verify a seeded patient can be found via the shell's global
+     * search box and opened to their Medical Record Dashboard.
+     *
+     * Source: DdOpenPatientTest / PatientOpenTrait::testPatientOpen.
+     */
+    public function testOpenSeededPatient(): void
+    {
+        $this->client = BrowserSession::create();
+        $this->performLoginAsAdmin();
+
+        // Seed the patient the open flow will find. addPatientViaUi
+        // leaves the browser on the just-created patient's Medical
+        // Record Dashboard — a no-op re-open of the same dashboard
+        // would trivially pass, so openPatientViaUi's first step
+        // (switching to default content + interacting with the shell
+        // anySearchBox) exercises the search flow genuinely.
+        $this->addPatientViaUi();
+
+        $this->openPatientViaUi(
+            $this->seedPatientFname(),
+            $this->seedPatientLname(),
+        );
+
+        // openPatientViaUi's final wait already proves the dashboard
+        // rendered — this re-reads that same header and asserts on
+        // its text so the test summary carries a real, phpstan-visible
+        // assertion + guards against future changes that make the
+        // wait's XPath more permissive than intended.
+        $dashboardHeader = $this->requireClient()->findElement(
+            WebDriverBy::xpath(
+                '//*[text()="Medical Record Dashboard - '
+                . $this->seedPatientFname() . ' ' . $this->seedPatientLname() . '"]',
+            ),
+        )->getText();
+        self::assertStringContainsString(
+            $this->seedPatientLname(),
+            $dashboardHeader,
+            'Dashboard header should reference the seeded patient lastname',
+        );
+    }
+}

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -267,10 +267,14 @@ trait UiSeedingTrait
 
         // Switch into the patient-finder iframe and click the result
         // matching "Lastname, Firstname". Finder renders each hit as
-        // an <a> with exact "Lastname, Firstname" text.
+        // an <a> with exact "Lastname, Firstname" text. Names are
+        // wrapped in xpathLiteral() so a name containing ' or " (not
+        // possible for today's hex-suffix seed identities but a valid
+        // shape a future caller might pass in) does not produce an
+        // invalid XPath.
         $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="fin"]', 30);
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="fin"]');
-        $resultXpath = '//a[text()="' . $lastname . ', ' . $firstname . '"]';
+        $resultXpath = '//a[text()=' . self::xpathLiteral($lastname . ', ' . $firstname) . ']';
         $client->waitFor($resultXpath, 30);
         $client->findElement(WebDriverBy::xpath($resultXpath))->click();
 
@@ -283,9 +287,30 @@ trait UiSeedingTrait
         $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="pat"]', 30);
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
         $client->waitFor(
-            '//*[text()="Medical Record Dashboard - ' . $firstname . ' ' . $lastname . '"]',
+            '//*[text()=' . self::xpathLiteral('Medical Record Dashboard - ' . $firstname . ' ' . $lastname) . ']',
             30,
         );
+    }
+
+    /**
+     * Encode an arbitrary string as an XPath 1.0 string literal safe
+     * to embed inside a larger XPath expression. XPath 1.0 has no
+     * built-in escape mechanism, so a string containing both ' and "
+     * must be composed via concat(). Standard pattern used across
+     * WebDriver / Selenium ecosystems.
+     */
+    private static function xpathLiteral(string $value): string
+    {
+        if (!str_contains($value, "'")) {
+            return "'" . $value . "'";
+        }
+        if (!str_contains($value, '"')) {
+            return '"' . $value . '"';
+        }
+        // Both quote types present — concat() the pieces around every '.
+        // e.g. "Foo's \"Bar\"" -> concat('Foo', "'", 's "Bar"').
+        $parts = explode("'", $value);
+        return "concat('" . implode("', \"'\", '", $parts) . "')";
     }
 
     /**

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -225,6 +225,70 @@ trait UiSeedingTrait
     }
 
     /**
+     * Search for an existing patient by lastname via the shell's
+     * always-visible anySearchBox (frm_search_globals), click the
+     * matching result in the patient-finder iframe, wait for that
+     * patient's Medical Record Dashboard. Mirrors source-side
+     * PatientOpenTrait::patientOpenIfExist minus the DB-existence
+     * pre-check — that check queries the database directly, which
+     * violates the acceptance suite's black-box discipline; the
+     * caller is responsible for having seeded the patient (typically
+     * via addPatientViaUi() earlier in the same test).
+     *
+     * Post-condition on return: browser is inside the pat iframe
+     * with the Medical Record Dashboard rendered for the opened
+     * patient. Callers that need to navigate elsewhere should
+     * switchTo()->defaultContent() first.
+     */
+    protected function openPatientViaUi(string $firstname, string $lastname): void
+    {
+        $client = $this->requireClient();
+        $client->switchTo()->defaultContent();
+
+        // Type lastname into anySearchBox. Source-side uses the
+        // crawler filterXPath+form API; WebDriver findElement +
+        // clear + sendKeys is cleaner and doesn't rely on the
+        // crawler being freshly refreshed.
+        $anySearchBoxXpath = "//form[@name='frm_search_globals']//input[@name='anySearchBox']";
+        $client->wait(15)->until(
+            WebDriverExpectedCondition::elementToBeClickable(
+                WebDriverBy::xpath($anySearchBoxXpath),
+            ),
+        );
+        $anySearchBox = $client->findElement(WebDriverBy::xpath($anySearchBoxXpath));
+        $anySearchBox->clear();
+        $anySearchBox->sendKeys($lastname);
+
+        // Submit the global-search form.
+        $this->waitAndClick(
+            WebDriverBy::xpath("//button[@id='search_globals']"),
+            'Global patient-search submit button',
+        );
+
+        // Switch into the patient-finder iframe and click the result
+        // matching "Lastname, Firstname". Finder renders each hit as
+        // an <a> with exact "Lastname, Firstname" text.
+        $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="fin"]', 30);
+        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="fin"]');
+        $resultXpath = '//a[text()="' . $lastname . ', ' . $firstname . '"]';
+        $client->waitFor($resultXpath, 30);
+        $client->findElement(WebDriverBy::xpath($resultXpath))->click();
+
+        // Back to default, into the patient iframe, wait for the
+        // Medical Record Dashboard header for THIS specific patient.
+        // Same assertion shape as addPatientViaUi's post-create wait —
+        // the header only renders for the patient we opened, so
+        // reaching this wait passing = search+open succeeded.
+        $client->switchTo()->defaultContent();
+        $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="pat"]', 30);
+        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
+        $client->waitFor(
+            '//*[text()="Medical Record Dashboard - ' . $firstname . ' ' . $lastname . '"]',
+            30,
+        );
+    }
+
+    /**
      * Add a fresh encounter for the just-created patient via the
      * per-patient New-Encounter shortcut in the shell. Mirrors the
      * source-side EncounterAddTrait: click the shell's New-Encounter


### PR DESCRIPTION
## Summary

First **Medium-tier** port after the seed-identity + wait-widening enablers landed. Ports `DdOpenPatientTest` / `PatientOpenTrait` — the patient-open flow — as `DdOpenPatientAcceptanceTest`.

**Flow tested:** type lastname into the shell's always-visible `anySearchBox` (`frm_search_globals`) → submit → switch into patient-finder iframe → click the result matching `Lastname, Firstname` → land on Medical Record Dashboard.

Distinct signal from what's already covered:
- `KkEncounterFormNavbarUrlAcceptanceTest` lands on the dashboard as a **side effect** of creation (via `addPatientViaUi`)
- **Dd specifically exercises the search + finder-click flow** — the user journey a returning provider takes to reach an existing patient's record

## New helper: `openPatientViaUi(fname, lname)`

Added to `UiSeedingTrait`. Mirrors source-side `PatientOpenTrait::patientOpenIfExist` minus the DB-existence pre-check (that queries the database directly and violates black-box discipline; caller is responsible for having seeded the patient upstream, typically via `addPatientViaUi()`).

Reusable — future Medium-tier ports that need to reach an existing patient's dashboard (Ff for encounter-open, any test that navigates back to a patient) will consume it.

## Seeding + collision resistance

Test seeds a patient via `addPatientViaUi()` inline (source-side depends on `CcCreatePatientTest` having run first in the ordered suite; acceptance is order-agnostic). Per-instance random seed identity (from #13351) means:

- Multiple tests in the same phase each create + open a distinct patient (no collision)
- Post-upgrade phase against the pre-upgrade-seeded DB creates a fresh patient, doesn't try to open the surviving pre-upgrade seed
- The wait-widening from #13348 covers any residual timing flake in the create step

Dual-tagged `fresh-install` + `post-upgrade` from the start — safe now that seed identity is per-instance.

## Test plan

- [ ] CI green on all acceptance-docker + acceptance-package scenarios × both archs
- [ ] Dd shows up in the upgrade scenario's post-upgrade phase (not just fresh-install)
- [ ] Verify `anySearchBox` / `search_globals` / `iframe[@name="fin"]` / result-link XPaths match the release image's shell (may need live-probe iteration if release-image labels differ from dev like they did for Kk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)