### PR TITLE
fix(acceptance): auto-accept alerts at driver level, drop wait dance in addPatientViaUi

### DIFF
--- a/tests/Acceptance/Support/BrowserSession.php
+++ b/tests/Acceptance/Support/BrowserSession.php
@@ -91,7 +91,22 @@ final class BrowserSession
         return Client::createChromeClient(
             null,
             self::CHROME_ARGS,
-            [],
+            [
+                // Auto-accept unexpected JS alerts — matches the grid
+                // path below (and the source-side E2e BaseTrait).
+                // Acceptance tests shouldn't be blocked by out-of-box
+                // popups they didn't ask for: OpenEMR's Medical Record
+                // Dashboard fires a "New Due Clinical Reminders"
+                // alert(...) via <img onload> as soon as the widget
+                // computes, which raced against a 60s explicit alert
+                // wait on slow ARM CI runners (see #13348 flake
+                // investigation). Driver-level accept means the alert
+                // fires + closes transparently; tests just wait for
+                // the real post-condition (dashboard header rendered).
+                'capabilities' => [
+                    'unhandledPromptBehavior' => 'accept',
+                ],
+            ],
             ArtifactBrowser::baseUrl(),
         );
     }

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -116,8 +116,14 @@ trait UiSeedingTrait
      * pre-existing patient. Mirrors the source-side
      * PatientAddTrait flow shape: open New/Search tab → fill the DEM
      * form in the patient iframe → click Create → confirm in the modal
-     * iframe → accept the resulting duplicate-check alert → wait for
-     * the Medical Record Dashboard header to appear.
+     * iframe → wait for the Medical Record Dashboard header.
+     *
+     * Post-condition is the dashboard header. On landing, the
+     * dashboard's clinical-reminders widget fires a native browser
+     * alert (see library/clinical_rules.php); BrowserSession sets
+     * unhandledPromptBehavior=accept on both driver paths so the
+     * alert fires + auto-closes transparently, without racing the
+     * test's own timing.
      *
      * XPath discoveries from KkEncounterFormNavbarUrl port:
      *

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -197,21 +197,23 @@ trait UiSeedingTrait
         );
         // Empirical stabilization — the modal form is clickable before
         // its JS finishes wiring the confirm handler. Same 5s wait the
-        // source-side PatientAddTrait uses. Multi-click retry does not
-        // recover (see #13348: once a click lands during the wire race
-        // the button ends up in a state subsequent clicks can't rescue,
-        // so retrying makes the flake worse not better) — only widening
-        // the *post-click* alert wait helps, since the handler may fire
-        // the alert well after the 15s prior ceiling on a slow runner.
+        // source-side PatientAddTrait uses.
         sleep(5);
         $client->findElement(WebDriverBy::xpath("//*[@id='confirmCreate']"))->click();
 
-        // A duplicate-check JS alert fires after confirm — accept it
-        // and continue. Bumped 15s → 60s to absorb slow-runner cases
-        // where the wire slipped past the 5s stabilization above.
-        $client->wait(60)->until(WebDriverExpectedCondition::alertIsPresent());
-        $client->switchTo()->alert()->accept();
-
+        // No explicit alert-wait: after form submit the browser
+        // navigates to the new patient's Medical Record Dashboard,
+        // where a "New Due Clinical Reminders" alert(...) fires from
+        // library/clinical_rules.php via <img onload>. That alert is
+        // driver-level auto-accepted (unhandledPromptBehavior: accept
+        // capability in BrowserSession) and needs no test-side
+        // handling. Prior versions tried to explicitly wait for the
+        // alert (5s → 15s → 60s) — flaky because reminder compute
+        // time varies with runner load, and once misread as a
+        // dup-check alert, the wait pattern accreted layers of
+        // wrong-shape mitigation (see #13348). Waiting for the real
+        // post-condition — the dashboard header — is deterministic.
+        //
         // Switch back to defaults, into the patient iframe, wait for
         // the Medical Record Dashboard header — proof the create
         // succeeded and the browser landed on the summary.


### PR DESCRIPTION
## Summary

Third-and-hopefully-last iteration on the KkEncounter flake, this time with a **correctly identified root cause**.

## What the alert actually is

The alert waited for in `UiSeedingTrait::addPatientViaUi` is NOT a "duplicate check" as the pre-existing comment claimed. It's the **Medical Record Dashboard's "New Due Clinical Reminders" popup**, emitted from `library/clinical_rules.php:208`:

```php
echo '<img src="../../pic/empty.gif" onload="alert(...)" />';
```

Fires when the dashboard's clinical reminders widget finishes computing due reminders for the freshly-created patient (age-triggered rules like weight measurement, cancer screening, vaccines, etc.). Gated by two globals (`enable_alert_log` and `enable_cdr_new_crp`), both defaulting to `1` in out-of-box installs.

**Compute time varies wildly with runner load**: 3-7s typical, 30-60s+ tail on slow ARM CI runners. Prior iterations of this fix (15s wait → 60s wait → click-retry helper) all failed to zero out the flake because the underlying signal is fundamentally unpredictable.

## The correct fix — driver-level auto-accept

Already discovered: the **grid path** in `BrowserSession.php:117` already sets:

```php
$capabilities->setCapability('unhandledPromptBehavior', 'accept');
```

with comment "matches E2e BaseTrait's choice; acceptance tests shouldn't be blocked by a stray prompt they didn't ask for."

The **local ChromeDriver path** (`createLocalClient`) did NOT set it. CI uses the local path (installs Chrome via `browser-actions/setup-chrome`), which is why the flake surfaces in CI but not local dev (which typically uses grid via the selenium container).

## Changes

1. **`BrowserSession::createLocalClient`** — pass `capabilities` option to `createChromeClient` with `unhandledPromptBehavior: 'accept'`. Verified via Panther's `ChromeManager.php`: the option iterates into `DesiredCapabilities::setCapability`, which is the correct plumbing path (not a Chrome-specific option under `goog:chromeOptions`).

2. **`UiSeedingTrait::addPatientViaUi`** — remove the explicit alert-wait + accept dance. With driver-level auto-accept the alert fires and closes transparently; the real success signal is the Medical Record Dashboard header wait that runs immediately after.

## What this preserves

**Out-of-box behavior**. Both `enable_alert_log` and `enable_cdr_new_crp` remain enabled. The clinical reminders alert still fires on the patient's dashboard exactly as a real user would see it. Only the test-side handling changes — from a timing-fragile explicit wait to the driver's native behavior.

Not testing an artificial configuration; testing what actually ships.

## Follow-ups

- **Birthday popup**: OpenEMR's shell fires a birthday popup for the logged-in user on their birthday. Bootstrap DOM modal, not a browser alert, so `unhandledPromptBehavior` doesn't cover it. Separate concern if it starts affecting tests. Someone reportedly fixed this in the source-side E2e suite recently — worth cross-referencing when we get to it.
- **Source-side `PatientAddTrait`**: still has the same explicit alert-wait pattern (was the model our acceptance code copied). If we like this approach in practice, worth a follow-up PR to apply the same simplification there.

## Test plan

- [ ] CI green on all acceptance-docker + acceptance-package scenarios × both archs
- [ ] Kk passes across multiple re-runs (this was the flake's home)
- [ ] Existing tests using `addPatientViaUi` (Kk, Dd once #13354 lands) don't regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)