### PR TITLE
refactor(acceptance): yank the dead unhandledPromptBehavior grid capability

### DIFF
--- a/tests/Acceptance/Support/BrowserSession.php
+++ b/tests/Acceptance/Support/BrowserSession.php
@@ -88,19 +88,11 @@ final class BrowserSession
         // and passing it via $options is silently ignored, which
         // reports as "invalid argument" from ChromeDriver on the first
         // relative-URL request because get() tries to load "/login...").
-        // Note on unhandledPromptBehavior=accept: #13355 tried to add
-        // it here as a mirror of the grid path below, aiming to
-        // auto-accept the Medical Record Dashboard's "New Due Clinical
-        // Reminders" alert emitted from library/clinical_rules.php.
-        // The capability had no observable effect on this driver path
-        // in CI (Panther's bundled ChromeDriver ignores it or the
-        // plumbing loses it — verified by post-13355 CI still throwing
-        // UnexpectedAlertOpenException with the reminders alert text).
-        // The alert is now handled at the JS layer instead via
-        // UiSeedingTrait::muzzleBrowserPrompts, so this path no longer
-        // needs the capability. Left here as a comment so a future
-        // maintainer chasing "should we add unhandledPromptBehavior to
-        // the local path?" has the answer.
+        // See the grid-path createGridClient() below for the full
+        // note on unhandledPromptBehavior=accept — neither path sets
+        // it anymore. Muzzling at the JS layer via
+        // UiSeedingTrait::muzzleBrowserPrompts is the single
+        // mechanism.
         return Client::createChromeClient(
             null,
             self::CHROME_ARGS,
@@ -122,10 +114,29 @@ final class BrowserSession
 
         $capabilities = DesiredCapabilities::chrome();
         $capabilities->setCapability('goog:chromeOptions', ['args' => self::CHROME_ARGS]);
-        // Auto-accept unexpected JS alerts — matches E2e BaseTrait's
-        // choice; acceptance tests shouldn't be blocked by a stray
-        // prompt they didn't ask for.
-        $capabilities->setCapability('unhandledPromptBehavior', 'accept');
+        // Note on unhandledPromptBehavior=accept: added here 2026-07-25
+        // in #13196 as a mirror of source-side E2e/Base/BaseTrait's
+        // stance (added there 2025-07-05 in #8555 as a defensive
+        // capability during the Selenium-grid transition). Neither
+        // add was motivated by a specific known-firing alert. The
+        // only alert we've since found in an acceptance-touched flow
+        // is the Medical Record Dashboard's clinical-reminders popup
+        // (library/clinical_rules.php via <img onload=alert(...)>),
+        // and that's now handled at the JS layer via
+        // UiSeedingTrait::muzzleBrowserPrompts — the capability was
+        // never observed catching it (verified in #13355 where the
+        // local-path copy of this capability produced
+        // UnexpectedAlertOpenException in CI regardless).
+        //
+        // The birthday popup at interface/patient_file/summary/
+        // demographics.php uses dlgopen() (Bootstrap modal / iframe
+        // dialog) — DOM-level, not a native browser alert, so
+        // unhandledPromptBehavior wouldn't cover it either.
+        //
+        // Removed from both paths in this commit. Left as a comment
+        // so a future maintainer chasing "should we set
+        // unhandledPromptBehavior?" has the answer without re-
+        // running the experiment.
 
         return Client::createSeleniumClient(
             "http://{$host}:4444/wd/hub",

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -182,9 +182,10 @@ trait UiSeedingTrait
      * dashboard's clinical-reminders widget would emit a native
      * browser alert (see library/clinical_rules.php), but
      * muzzleBrowserPrompts() has already overridden window.alert
-     * to a no-op so no popup fires. The grid path in BrowserSession
-     * also sets unhandledPromptBehavior=accept as an independent
-     * safety net for any prompt the JS override doesn't cover.
+     * to a no-op so no popup fires. The muzzle is the sole
+     * mechanism — see BrowserSession's grid + local paths for
+     * why the previously-attempted unhandledPromptBehavior=accept
+     * capability was yanked.
      *
      * XPath discoveries from KkEncounterFormNavbarUrl port:
      *


### PR DESCRIPTION
## Summary

Removes `unhandledPromptBehavior=accept` from the grid path of `BrowserSession`. The local-path copy was already yanked in #13358 (proven dead code — the muzzle in `UiSeedingTrait` handles the clinical-reminders alert at JS level). This drops the grid-path copy for consistency.

## Why both paths turn out to be dead code

Traced the history:
- **Local path**: added in #13355 (2026-08-02) trying to auto-accept the clinical-reminders alert. CI proved it took no observable effect on Panther's bundled ChromeDriver. Yanked in #13358.
- **Grid path**: added in #13196 (2026-07-25) mirroring source-side `E2e/Base/BaseTrait`'s stance. That source-side add came in #8555 (2025-07-05) as a defensive capability during the broad Selenium-grid transition — NOT motivated by any specific known-firing alert. Both are pure defense.

The only alert an acceptance-touched flow actually emits is the Medical Record Dashboard's clinical-reminders popup (`library/clinical_rules.php` via `<img onload="alert(...)">`) — that's now muzzled at the JS layer via `UiSeedingTrait::muzzleBrowserPrompts`. The birthday popup (`interface/patient_file/summary/demographics.php:856` via `dlgopen()`) is a Bootstrap modal, not a native browser alert, so `unhandledPromptBehavior` doesn't cover it either.

## Left behind

Replaced the setCapability call with a detailed comment describing:
- When each path added the capability + why (both defensive, neither motivated by a known-firing alert)
- Where the actual alert-handling now lives (JS muzzle)
- Why birthday popup is out of scope

So a future maintainer chasing "should we add unhandledPromptBehavior?" has the answer without re-running the experiment.

## Test plan

- [ ] CI green on acceptance-docker + acceptance-package × both arches (Kk should stay non-flaky per the muzzle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)