### PR TITLE
fix(acceptance): bump post-navigation content-render waits 30s to 60s in UiSeedingTrait

### DIFF
--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -288,9 +288,14 @@ trait UiSeedingTrait
         $client->switchTo()->defaultContent();
         $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="pat"]', 30);
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
+        // 60s (not the Panther-default 30s) — the post-submit
+        // dashboard render includes the reminders-widget compute
+        // which can slip past 30s on slow ARM CI runners. Matches
+        // the ARM-tolerance ceiling established for the alert wait
+        // in #13348.
         $client->waitFor(
             '//*[text()="Medical Record Dashboard - ' . $this->seedPatientFname() . ' ' . $this->seedPatientLname() . '"]',
-            30,
+            60,
         );
     }
 
@@ -357,9 +362,11 @@ trait UiSeedingTrait
         $client->switchTo()->defaultContent();
         $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="pat"]', 30);
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
+        // 60s tolerance for the ARM-CI-runner-slow dashboard render —
+        // matches the addPatientViaUi() pattern above.
         $client->waitFor(
             '//*[text()=' . self::xpathLiteral('Medical Record Dashboard - ' . $firstname . ' ' . $lastname) . ']',
-            30,
+            60,
         );
     }
 
@@ -433,10 +440,13 @@ trait UiSeedingTrait
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="enc"]');
         $client->waitFor('//iframe[@src="forms.php"]', 30);
         $this->switchToIFrame('//iframe[@src="forms.php"]');
+        // 60s tolerance for ARM-CI-runner-slow encounter render —
+        // same class of post-navigation content-render wait as the
+        // dashboard-header waits above.
         $client->waitFor(
             '//span[@id="navbarEncounterTitle" and contains(text(), "Encounter for '
                 . $this->seedPatientFname() . ' ' . $this->seedPatientLname() . '")]',
-            30,
+            60,
         );
     }
 


### PR DESCRIPTION
## Summary

Bumps three post-navigation content-render waits in `UiSeedingTrait` from Panther's default 30s to 60s to absorb ARM CI runner slowness. Sibling to #13348's alert-wait bump — same ARM-tolerance envelope pattern.

**The three bumped waits:**
- `addPatientViaUi` — dashboard header after form submit (line 293)
- `openPatientViaUi` — dashboard header after finder click (line 361)
- `addEncounterViaUi` — encounter navbar title after save (line 439)

All three are the same shape: wait for a specific text element to appear AFTER a navigation that includes server-side compute (patient dashboard rendering, reminders widget compute, encounter form rendering). All three failed intermittently at 30s on `ubuntu-24.04-arm` CI runners; local dev + amd64 CI runners consistently completed well under 30s.

## Why not the source-side retry pattern

`PatientAddTrait` on source-side wraps the whole test in a retry-3-times-on-TimeoutException loop with fresh browser session each attempt. That was checked as reference — deliberately NOT adopted here:

- **Retry pattern is a code smell that exists on source-side because they don't know which wait is slow.** We do — dashboard-header specifically.
- **Fresh-session-per-retry costs ~15-20s login × 3 attempts = ~60s wasted.** Bumping the wait costs zero on the happy path (returns as soon as element appears).
- **Scoped fix is diagnostic-friendly** — if we hit ANOTHER wait timeout in future, we know it's a different wait and can address it specifically.

If 60s isn't enough later, we can iterate. Retry is available as nuclear option.

## Iframe waits kept at 30s

Only the post-navigation content-render waits bumped. iframe-presence waits (`iframe[@name="pat"]`, `iframe[@id="modalframe"]`, etc.) stay at 30s — those load fast, never observed to slow-fail.

## Test plan

- [ ] CI green on acceptance-docker × both arches (Kk + Dd should stop timing out on the ARM cells)
- [ ] Happy-path timing unchanged (waits return as soon as element appears, not on timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)