### PR TITLE
fix(acceptance): invoke srcConfirmSave directly in addPatientViaUi, revert content-render wait bump

### DIFF
--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -313,19 +313,31 @@ trait UiSeedingTrait
             'Confirm-create modal rendered but #confirmCreate onclick lost the srcConfirmSave callback wiring — modal-side regression',
         );
 
-        // Bypass-strategy: invoke dlgclose("srcConfirmSave", false)
-        // directly via executeScript from the modalframe context —
-        // that's LITERALLY what the button's onclick attribute is
-        // (verified above). Does the FULL callback flow:
-        // dlgclose → hide modal + cleanup wrapper divs → post-hide
-        // callback fires srcConfirmSave() → document.forms[0].submit()
-        // → server redirect. Preserves all the modal-cleanup semantics
-        // dlgclose owns (which are non-trivial: Bootstrap modal-hide
-        // animation, wrapper div removal via hidden.bs.modal handler,
-        // iframe removal) so subsequent clicks on the shell aren't
-        // blocked by leftover DOM. Only the racy WebDriver-side
-        // button-click resolution is skipped.
-        $client->executeScript('dlgclose("srcConfirmSave", false);');
+        // Two-step bypass — cleanup then submit:
+        //
+        // (1) Aggressive top-level DOM cleanup — dlgclose stores the
+        // callback on a scope we can't reach from executeScript, so
+        // invoking it doesn't fire srcConfirmSave. Instead, manually
+        // rip out ALL Bootstrap modal wrappers (.dialogModal,
+        // .modal-dialog, .modal-backdrop) plus the modalframe iframe,
+        // and reset body classes that Bootstrap's modal-open uses.
+        // Prevents leftover DOM from intercepting subsequent shell
+        // clicks (Kk's "New Encounter" button, Dd's anySearchBox).
+        //
+        // (2) Submit the form directly from the pat iframe context —
+        // srcConfirmSave() is `document.forms[0].submit()` in
+        // new_comprehensive.php (loaded inside pat iframe). Calling
+        // submit() from that iframe's context is equivalent + no
+        // scope-lookup dependency.
+        $client->switchTo()->defaultContent();
+        $client->executeScript(
+            'document.querySelectorAll(".dialogModal, .modal-backdrop, iframe#modalframe").forEach(function (e) { e.remove(); });'
+            . 'document.body.classList.remove("modal-open");'
+            . 'document.body.style.overflow = "";'
+            . 'document.body.style.paddingRight = "";'
+        );
+        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
+        $client->executeScript('document.forms[0].submit();');
 
         // Switch back to defaults, into the patient iframe, wait for
         // the Medical Record Dashboard header — proof the create

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -254,49 +254,71 @@ trait UiSeedingTrait
             'Create patient button',
         );
 
-        // Confirm dialog renders inside a modal iframe. Switch out of
-        // the patient iframe first, then into the modal frame.
+        // Confirm-create: assert the modal + button rendered as a
+        // regression signal, then invoke srcConfirmSave() directly.
+        //
+        // The source-side pattern of finding + clicking #confirmCreate
+        // inside the modalframe iframe hits a wiring race where the
+        // button becomes WebDriver-clickable before its onclick
+        // handler (`dlgclose("srcConfirmSave", false)`) is wired to
+        // dlgclose → window[callback] → srcConfirmSave() → form.submit.
+        // When the race bites, the click no-ops, the form is never
+        // submitted, no redirect, dashboard-header wait times out
+        // with no diagnostic signal (source-side E2e/Patient/
+        // PatientAddTrait masks the same class of failure with a
+        // 3-retry-whole-test loop; per user 2026-08-03 the failure
+        // predates any capability / muzzle work we did on the
+        // acceptance side).
+        //
+        // The confirmCreate button's onclick is a single-line
+        // `dlgclose("srcConfirmSave", false)` whose only purpose is
+        // to close the modal + invoke the parent's srcConfirmSave()
+        // callback. srcConfirmSave() itself is `document.forms[0].
+        // submit()` (see interface/new/new_comprehensive.php:979).
+        // Calling it directly:
+        //  - Skips the modalframe-button click-handler wiring race
+        //  - Skips the dlgclose iframe/modal cleanup dance
+        //  - Skips the window[callback] indirection
+        //  - No sleep(5), no elementToBeClickable wait, no race
+        //
+        // Cleanup: the modal stays open in the DOM, but the
+        // post-submit redirect to demographics.php destroys the
+        // whole page anyway. Not a concern.
+        //
+        // Modal-regression signal: because we're skipping the click,
+        // we ALSO skip any modal-rendering / button-wiring surface
+        // coverage the click would have provided. Compensate with a
+        // scoped assertion: switch into the modalframe, verify the
+        // #confirmCreate button is present and carries the expected
+        // dlgclose onclick, then switch back and invoke the callback.
+        // This catches "modal template broke" or "confirmCreate
+        // onclick regressed" without depending on click propagation.
+        //
+        // Phase 13 back-port candidate: source-side PatientAddTrait
+        // could adopt the same modal-verify + direct-invoke pattern
+        // and drop its 3-retry loop entirely.
         $client->switchTo()->defaultContent();
         $client->waitFor("//iframe[@id='modalframe']", 30);
         $this->switchToIFrame("//iframe[@id='modalframe']");
-        $client->wait(15)->until(
-            WebDriverExpectedCondition::elementToBeClickable(
-                WebDriverBy::xpath("//*[@id='confirmCreate']"),
-            ),
+        $confirmButton = $client->findElement(
+            WebDriverBy::xpath("//*[@id='confirmCreate']"),
         );
-        // Empirical stabilization — the modal form is clickable before
-        // its JS finishes wiring the confirm handler. Same 5s wait the
-        // source-side PatientAddTrait uses.
-        sleep(5);
-        $client->findElement(WebDriverBy::xpath("//*[@id='confirmCreate']"))->click();
+        self::assertStringContainsString(
+            'srcConfirmSave',
+            (string) $confirmButton->getAttribute('onclick'),
+            'Confirm-create modal rendered but #confirmCreate onclick lost the srcConfirmSave callback wiring — modal-side regression',
+        );
+        $client->switchTo()->defaultContent();
+        $client->executeScript('srcConfirmSave();');
 
-        // No explicit alert-wait: after form submit the browser
-        // navigates to the new patient's Medical Record Dashboard,
-        // where a "New Due Clinical Reminders" alert(...) would fire
-        // from library/clinical_rules.php via <img onload>. The
-        // muzzleBrowserPrompts() call at the top of this method has
-        // already overridden window.alert to a no-op via CDP, so
-        // the emitter fires but produces no popup. Prior versions
-        // tried to explicitly wait for the alert (5s → 15s → 60s)
-        // and misread it as a dup-check alert, accumulating layers
-        // of wrong-shape mitigation (#13348) — see this file's git log.
-        // Waiting for the real post-condition (the dashboard header)
-        // is deterministic.
-        //
         // Switch back to defaults, into the patient iframe, wait for
         // the Medical Record Dashboard header — proof the create
         // succeeded and the browser landed on the summary.
-        $client->switchTo()->defaultContent();
         $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="pat"]', 30);
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
-        // 60s (not the Panther-default 30s) — the post-submit
-        // dashboard render includes the reminders-widget compute
-        // which can slip past 30s on slow ARM CI runners. Matches
-        // the ARM-tolerance ceiling established for the alert wait
-        // in #13348.
         $client->waitFor(
             '//*[text()="Medical Record Dashboard - ' . $this->seedPatientFname() . ' ' . $this->seedPatientLname() . '"]',
-            60,
+            30,
         );
     }
 
@@ -363,11 +385,9 @@ trait UiSeedingTrait
         $client->switchTo()->defaultContent();
         $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="pat"]', 30);
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
-        // 60s tolerance for the ARM-CI-runner-slow dashboard render —
-        // matches the addPatientViaUi() pattern above.
         $client->waitFor(
             '//*[text()=' . self::xpathLiteral('Medical Record Dashboard - ' . $firstname . ' ' . $lastname) . ']',
-            60,
+            30,
         );
     }
 
@@ -441,13 +461,10 @@ trait UiSeedingTrait
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="enc"]');
         $client->waitFor('//iframe[@src="forms.php"]', 30);
         $this->switchToIFrame('//iframe[@src="forms.php"]');
-        // 60s tolerance for ARM-CI-runner-slow encounter render —
-        // same class of post-navigation content-render wait as the
-        // dashboard-header waits above.
         $client->waitFor(
             '//span[@id="navbarEncounterTitle" and contains(text(), "Encounter for '
                 . $this->seedPatientFname() . ' ' . $this->seedPatientLname() . '")]',
-            60,
+            30,
         );
     }
 

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -168,6 +168,41 @@ trait UiSeedingTrait
     }
 
     /**
+     * Rip every Bootstrap-modal-related DOM element out of the
+     * top-level document. Motivation: OpenEMR's dashboard opens
+     * modals via dlgopen() from multiple triggers (dup-check
+     * pop-up on patient add, clinical-reminders widget on
+     * dashboard load, potentially birthday-popup depending on
+     * globals). Leftover modal wrappers intercept subsequent
+     * shell clicks even after their content is closed — Bootstrap
+     * modal-hide sets display:none but leaves the wrapper div in
+     * place, and its child .modal-body sits over the shell z-order.
+     *
+     * Called at the point of each seeding helper (before/after
+     * navigations that trigger dashboard-load modal opens) to
+     * keep the shell clickable. Cheap (a single executeScript);
+     * safe (only affects test-side DOM; caller may have already
+     * cleared them, in which case this is a no-op).
+     */
+    private function dismissAnyOpenModals(): void
+    {
+        $client = $this->requireClient();
+        $client->switchTo()->defaultContent();
+        $client->executeScript(
+            // Shotgun — every Bootstrap modal class + dlgopen
+            // wrappers + backdrop + our specific modalframe iframe.
+            'document.querySelectorAll('
+            . '".dialogModal, .modal, .modal-dialog, .modal-content, '
+            . '.modal-body, .modal-header, .modal-footer, '
+            . '.modal-backdrop, iframe#modalframe"'
+            . ').forEach(function (e) { e.remove(); });'
+            . 'document.body.classList.remove("modal-open");'
+            . 'document.body.style.overflow = "";'
+            . 'document.body.style.paddingRight = "";'
+        );
+    }
+
+    /**
      * Add a fresh patient (Ftest<suffix> Ltest<suffix>) via the
      * "Patient/Client → New/Search" main-menu path. Identity is
      * per-test-instance via seedPatientFname/seedPatientLname so
@@ -329,23 +364,7 @@ trait UiSeedingTrait
         // new_comprehensive.php (loaded inside pat iframe). Calling
         // submit() from that iframe's context is equivalent + no
         // scope-lookup dependency.
-        $client->switchTo()->defaultContent();
-        $client->executeScript(
-            // Shotgun modal cleanup: nuke every Bootstrap modal
-            // class present. .dialogModal alone isn't enough —
-            // .modal-dialog / .modal-body / .modal-backdrop live
-            // outside its subtree in dlgopen's structure and keep
-            // intercepting clicks otherwise (verified across
-            // multiple #13372 CI iterations).
-            'document.querySelectorAll('
-            . '".dialogModal, .modal, .modal-dialog, .modal-content, '
-            . '.modal-body, .modal-header, .modal-footer, '
-            . '.modal-backdrop, iframe#modalframe"'
-            . ').forEach(function (e) { e.remove(); });'
-            . 'document.body.classList.remove("modal-open");'
-            . 'document.body.style.overflow = "";'
-            . 'document.body.style.paddingRight = "";'
-        );
+        $this->dismissAnyOpenModals();
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
         $client->executeScript('document.forms[0].submit();');
 
@@ -359,6 +378,17 @@ trait UiSeedingTrait
             '//*[text()="Medical Record Dashboard - ' . $this->seedPatientFname() . ' ' . $this->seedPatientLname() . '"]',
             30,
         );
+        // Second cleanup pass — the dashboard load itself opens more
+        // Bootstrap modals (clinical-reminders widget dlgopen, possibly
+        // birthday-alert modal for patients with birthday-relevant
+        // globals set). These aren't blocked by the CDP alert muzzle
+        // — different mechanism (DOM modal, not native window.alert).
+        // Nuke them so the next step in the caller's flow
+        // (addEncounterViaUi → New Encounter click, openPatientViaUi
+        // → search box, or a downstream test's shell click) isn't
+        // intercepted.
+        $client->switchTo()->defaultContent();
+        $this->dismissAnyOpenModals();
     }
 
     /**
@@ -382,6 +412,10 @@ trait UiSeedingTrait
         $client = $this->requireClient();
         $this->muzzleBrowserPrompts();
         $client->switchTo()->defaultContent();
+        // Belt-and-suspenders — nuke any leftover modals from prior
+        // seeding calls (dashboard load can open reminders / birthday
+        // Bootstrap modals that intercept the anySearchBox click).
+        $this->dismissAnyOpenModals();
 
         // Type lastname into anySearchBox. Source-side uses the
         // crawler filterXPath+form API; WebDriver findElement +
@@ -466,6 +500,11 @@ trait UiSeedingTrait
     {
         $client = $this->requireClient();
         $client->switchTo()->defaultContent();
+        // Belt-and-suspenders — nuke any leftover modals from the
+        // preceding addPatientViaUi (dashboard load can open reminders
+        // / birthday Bootstrap modals that intercept the "New
+        // Encounter" shell click).
+        $this->dismissAnyOpenModals();
 
         // Click the "New Encounter" shortcut in the outer shell (not
         // inside an iframe — it lives in the patient-context bar).

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -300,6 +300,10 @@ trait UiSeedingTrait
         $client->switchTo()->defaultContent();
         $client->waitFor("//iframe[@id='modalframe']", 30);
         $this->switchToIFrame("//iframe[@id='modalframe']");
+        // Wait for the button to appear before findElement — the
+        // modalframe iframe may still be loading its inner document
+        // when we switch into it (rabbit round-1 on #13372).
+        $client->waitFor("//*[@id='confirmCreate']", 15);
         $confirmButton = $client->findElement(
             WebDriverBy::xpath("//*[@id='confirmCreate']"),
         );
@@ -308,12 +312,22 @@ trait UiSeedingTrait
             (string) $confirmButton->getAttribute('onclick'),
             'Confirm-create modal rendered but #confirmCreate onclick lost the srcConfirmSave callback wiring — modal-side regression',
         );
+
+        // srcConfirmSave is defined in new_comprehensive.php which
+        // loads INSIDE the pat iframe, NOT the top-level document.
+        // Switch back to the pat iframe (where the form lives) then
+        // submit directly — equivalent to what srcConfirmSave does
+        // (`document.forms[0].submit()` per new_comprehensive.php:979)
+        // but no scope-lookup dependency on the srcConfirmSave name
+        // being defined in whatever context we happen to be in.
         $client->switchTo()->defaultContent();
-        $client->executeScript('srcConfirmSave();');
+        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
+        $client->executeScript('document.forms[0].submit();');
 
         // Switch back to defaults, into the patient iframe, wait for
         // the Medical Record Dashboard header — proof the create
         // succeeded and the browser landed on the summary.
+        $client->switchTo()->defaultContent();
         $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="pat"]', 30);
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
         $client->waitFor(

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -331,7 +331,17 @@ trait UiSeedingTrait
         // scope-lookup dependency.
         $client->switchTo()->defaultContent();
         $client->executeScript(
-            'document.querySelectorAll(".dialogModal, .modal-backdrop, iframe#modalframe").forEach(function (e) { e.remove(); });'
+            // Shotgun modal cleanup: nuke every Bootstrap modal
+            // class present. .dialogModal alone isn't enough —
+            // .modal-dialog / .modal-body / .modal-backdrop live
+            // outside its subtree in dlgopen's structure and keep
+            // intercepting clicks otherwise (verified across
+            // multiple #13372 CI iterations).
+            'document.querySelectorAll('
+            . '".dialogModal, .modal, .modal-dialog, .modal-content, '
+            . '.modal-body, .modal-header, .modal-footer, '
+            . '.modal-backdrop, iframe#modalframe"'
+            . ').forEach(function (e) { e.remove(); });'
             . 'document.body.classList.remove("modal-open");'
             . 'document.body.style.overflow = "";'
             . 'document.body.style.paddingRight = "";'

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -313,14 +313,27 @@ trait UiSeedingTrait
             'Confirm-create modal rendered but #confirmCreate onclick lost the srcConfirmSave callback wiring — modal-side regression',
         );
 
+        // Dismiss the modal at top level BEFORE the direct submit —
+        // dlgclose normally does .modal("hide") + iframe removal as
+        // part of the callback dance we're bypassing. Skipping that
+        // cleanup leaves the modalframe iframe in the top-level DOM,
+        // which intercepts subsequent clicks on the shell (broke
+        // addEncounterViaUi's "New Encounter" click; broke Dd's
+        // finder anySearchBox interaction — both in the pat iframe
+        // sit BEHIND the top-level modal overlay).
+        $client->switchTo()->defaultContent();
+        $client->executeScript(
+            'if (window.jQuery) { jQuery(".dialogModal").modal("hide"); }'
+            . 'document.querySelectorAll("iframe#modalframe").forEach(function (f) { f.remove(); });'
+        );
+
         // srcConfirmSave is defined in new_comprehensive.php which
         // loads INSIDE the pat iframe, NOT the top-level document.
-        // Switch back to the pat iframe (where the form lives) then
+        // Switch into the pat iframe (where the form lives) and
         // submit directly — equivalent to what srcConfirmSave does
         // (`document.forms[0].submit()` per new_comprehensive.php:979)
         // but no scope-lookup dependency on the srcConfirmSave name
         // being defined in whatever context we happen to be in.
-        $client->switchTo()->defaultContent();
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
         $client->executeScript('document.forms[0].submit();');
 

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -313,29 +313,19 @@ trait UiSeedingTrait
             'Confirm-create modal rendered but #confirmCreate onclick lost the srcConfirmSave callback wiring — modal-side regression',
         );
 
-        // Dismiss the modal at top level BEFORE the direct submit —
-        // dlgclose normally does .modal("hide") + iframe removal as
-        // part of the callback dance we're bypassing. Skipping that
-        // cleanup leaves the modalframe iframe in the top-level DOM,
-        // which intercepts subsequent clicks on the shell (broke
-        // addEncounterViaUi's "New Encounter" click; broke Dd's
-        // finder anySearchBox interaction — both in the pat iframe
-        // sit BEHIND the top-level modal overlay).
-        $client->switchTo()->defaultContent();
-        $client->executeScript(
-            'if (window.jQuery) { jQuery(".dialogModal").modal("hide"); }'
-            . 'document.querySelectorAll("iframe#modalframe").forEach(function (f) { f.remove(); });'
-        );
-
-        // srcConfirmSave is defined in new_comprehensive.php which
-        // loads INSIDE the pat iframe, NOT the top-level document.
-        // Switch into the pat iframe (where the form lives) and
-        // submit directly — equivalent to what srcConfirmSave does
-        // (`document.forms[0].submit()` per new_comprehensive.php:979)
-        // but no scope-lookup dependency on the srcConfirmSave name
-        // being defined in whatever context we happen to be in.
-        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="pat"]');
-        $client->executeScript('document.forms[0].submit();');
+        // Bypass-strategy: invoke dlgclose("srcConfirmSave", false)
+        // directly via executeScript from the modalframe context —
+        // that's LITERALLY what the button's onclick attribute is
+        // (verified above). Does the FULL callback flow:
+        // dlgclose → hide modal + cleanup wrapper divs → post-hide
+        // callback fires srcConfirmSave() → document.forms[0].submit()
+        // → server redirect. Preserves all the modal-cleanup semantics
+        // dlgclose owns (which are non-trivial: Bootstrap modal-hide
+        // animation, wrapper div removal via hidden.bs.modal handler,
+        // iframe removal) so subsequent clicks on the shell aren't
+        // blocked by leftover DOM. Only the racy WebDriver-side
+        // button-click resolution is skipped.
+        $client->executeScript('dlgclose("srcConfirmSave", false);');
 
         // Switch back to defaults, into the patient iframe, wait for
         // the Medical Record Dashboard header — proof the create


### PR DESCRIPTION
## Summary

Root-cause fix for the click-wiring race that manifests as "post-submit dashboard-header wait times out" flake in `KkEncounterFormNavbarUrlAcceptanceTest` and `DdOpenPatientAcceptanceTest`. Replaces the modal-button-click theater with direct form submit + Bootstrap-modal DOM cleanup at 4 strategic points in `UiSeedingTrait`. Also reverts #13365's 30s→60s wait bumps since the race was the actual cause, not runner slowness.

## Root cause

Container HTTP logs on multiple #13352 failing runs: after the `new_search_popup.php` dup-check popup loads, 60+ seconds of server silence follow — no `POST /new_comprehensive_save.php`, no redirect, dashboard wait had nothing to wait for. **The `#confirmCreate` click doesn't propagate** through `dlgclose → window[callback] → srcConfirmSave() → form.submit()`. Wiring race — button becomes WebDriver-clickable before its full onclick chain is wired.

Per user 2026-08-03: this same failure predates our capability / muzzle work. Source-side E2e `PatientAddTrait` masks the same class with a 3-retry-whole-test loop (never diagnosed).

## Approach

Skip the click entirely. Manually do what the button's click chain would do:

1. **Verify modal + button rendered** (regression signal — assert `#confirmCreate` present with `srcConfirmSave` in its onclick) — catches "modal template broke" or "onclick wiring regressed" without depending on click propagation.

2. **Rip out all Bootstrap modal DOM** via `dismissAnyOpenModals()` — shotgun cleanup of `.dialogModal, .modal, .modal-dialog, .modal-content, .modal-body, .modal-header, .modal-footer, .modal-backdrop, iframe#modalframe` + body class/style reset. Necessary because dlgclose's cleanup dance (Bootstrap modal-hide animation + `hidden.bs.modal` handler removing wrapper divs) leaves DOM in place if we bypass it.

3. **Switch into the pat iframe** and `executeScript('document.forms[0].submit()')` — equivalent to what `srcConfirmSave()` does (see `new_comprehensive.php:979`) but no scope-lookup dependency on the callback name being defined in whatever context we happen to be in.

## `dismissAnyOpenModals()` called at 4 points

Because OpenEMR's dashboard opens ADDITIONAL modals AFTER the create-patient redirect (clinical-reminders widget's dlgopen; potentially birthday-popup depending on globals) — those modals also intercept subsequent shell clicks.

- **Middle of `addPatientViaUi`** — before form submit; clears the dup-check modal
- **End of `addPatientViaUi`** — after dashboard-header wait; clears dashboard-load modals (reminders widget, etc.)
- **Start of `openPatientViaUi`** — belt-and-suspenders before shell anySearchBox interaction (Dd's flow)
- **Start of `addEncounterViaUi`** — belt-and-suspenders before New Encounter shell click (Kk's flow)

## Trade-off: modal-render coverage

Bypassing the click also bypasses the modal-render / button-wiring surface. Compensated with the scoped assertion right before the DOM cleanup — switch into modalframe, verify `#confirmCreate` present + has `srcConfirmSave` in onclick. Catches modal-template / onclick-wiring regressions without depending on click propagation.

Source-side E2e `PatientAddTrait` deliberately keeps the real click + retry-3x pattern for full workflow-through-modal coverage (per user direction 2026-08-03). Two suites, two objectives — see Phase 13 back-port candidates in `docs/artifact-acceptance-testing-plan.md` for the split rationale.

## Wait bumps reverted

#13365 bumped 3 waits 30s → 60s to tolerate "slow dashboard render." Turns out the "slow render" was actually "form never submitted, wait had nothing to wait for." With the click race gone, 30s is plenty. All three reverted:
- `addPatientViaUi` dashboard-header wait
- `openPatientViaUi` dashboard-header wait
- `addEncounterViaUi` encounter-navbar wait

## Iteration log (for the future maintainer)

Six iterations, each surfaced a new obstacle:

1. `switchTo()->defaultContent(); executeScript('srcConfirmSave()')` → `srcConfirmSave is not defined` (function is in pat iframe scope)
2. Switch to pat iframe, `document.forms[0].submit()` → form submitted, but `ElementClickInterceptedException` — leftover modalframe iframe blocks subsequent shell clicks
3. Add limited modal cleanup (`.dialogModal` + iframe removal) → still intercepted by `<div class="modal-body>` (not nested inside `.dialogModal`)
4. Call `dlgclose("srcConfirmSave", false)` directly via executeScript → no form submit (dlgclose's callback scope not reachable via executeScript)
5. Two-step: shotgun modal cleanup + pat-iframe `form.submit()` → still `ElementClickIntercepted` by a `.dialogModal` with a NEW hash (dashboard-load reminders widget modal)
6. Per-point `dismissAnyOpenModals()` at 4 strategic points — this state

## Test plan

- [ ] CI green on acceptance-docker + acceptance-package × both arches
- [ ] Kk + Dd no longer hit the "form submit never fires" flake
- [ ] Modal-regression assertion still catches a hypothetical `#confirmCreate` template regression
- [ ] Rerun multiple times to confirm the intermittent modal-block on subsequent shell interactions is truly resolved (not just papered over)

## Phase 13 back-port candidate

Source-side `PatientAddTrait` could adopt the same modal-verify + direct-submit + dismissAnyOpenModals pattern and drop its 3-retry loop entirely — BUT deliberate divergence: source-side keeps the real click for full workflow coverage. This trait's approach is acceptance-optimized (zero-flakiness + short runtime), not to be back-ported wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)