### PR TITLE
feat(audit): record OAuth client identity in the API audit log

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -60422,11 +60422,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/SMART/ScopePermissionParser.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#12 \\$api of method OpenEMR\\\\Common\\\\Logging\\\\EventAuditLogger\\:\\:recordLogItem\\(\\) expects array\\{user_id\\: int, patient_id\\: int, method\\: string, request\\: string, request_url\\: string, request_body\\: string, response\\: string\\}\\|null, array\\{user_id\\: int, patient_id\\: int, method\\: string, request\\: string, request_url\\: string, request_body\\: string\\|false, response\\: string\\|false\\} given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/Subscriber/ApiResponseLoggerListener.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#3 \\$user of method OpenEMR\\\\Common\\\\Logging\\\\EventAuditLogger\\:\\:recordLogItem\\(\\) expects string\\|null, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/Subscriber/ApiResponseLoggerListener.php',

--- a/interface/logview/logview.php
+++ b/interface/logview/logview.php
@@ -183,6 +183,7 @@ if (!empty($_GET)) {
                                             <?php
                                             echo " <option value=''>" . xlt('All') . "</option>\n";
                                             $clientRows = \OpenEMR\Common\Database\QueryUtils::fetchRecords("SELECT `client_id`, `client_name` FROM `oauth_clients` ORDER BY `client_name` ASC");
+                                            $clientOptionFound = false;
                                             foreach ($clientRows as $clientRow) {
                                                 $optionClientId = is_string($clientRow['client_id'] ?? null) ? $clientRow['client_id'] : '';
                                                 if ($optionClientId === '') {
@@ -190,10 +191,19 @@ if (!empty($_GET)) {
                                                 }
                                                 $optionClientName = is_string($clientRow['client_name'] ?? null) ? $clientRow['client_name'] : '';
                                                 echo " <option value='" . attr($optionClientId) . "'";
-                                                if ($optionClientId == $form_client_id) {
+                                                if ($optionClientId === $form_client_id) {
+                                                    $clientOptionFound = true;
                                                     echo " selected";
                                                 }
                                                 echo ">" . text($optionClientName !== '' ? $optionClientName : $optionClientId) . "</option>\n";
+                                            }
+                                            // A filtered client id may no longer exist in oauth_clients
+                                            // (deleted/decommissioned integration reached via a saved URL).
+                                            // Render it as a selected option so the UI reflects the active
+                                            // filter and resubmitting the form preserves it.
+                                            if ($form_client_id !== '' && !$clientOptionFound) {
+                                                echo " <option value='" . attr($form_client_id) . "' selected>"
+                                                    . text($form_client_id) . " (" . xlt('unregistered') . ")</option>\n";
                                             }
                                             ?>
                                         </select>

--- a/interface/logview/logview.php
+++ b/interface/logview/logview.php
@@ -109,7 +109,8 @@ if (!empty($_GET)) {
 
                         $form_patient = $_GET["form_patient"] ?? '';
                         $form_user = $_REQUEST['form_user'] ?? '';
-                        $form_client_id = filter_input(INPUT_GET, 'form_client_id') ?: '';
+                        $form_client_id = filter_input(INPUT_GET, 'form_client_id');
+                        $form_client_id = is_string($form_client_id) ? $form_client_id : '';
                         $form_pid = $_REQUEST['form_pid'] ?? '';
                         if (empty($form_patient)) {
                             $form_pid = '';
@@ -410,7 +411,11 @@ if (!empty($_GET)) {
                                             }
                                         }
 
-                                        if (($eventname == "disclosure") || ($gev == "")) {
+                                        // Disclosures live in extended_log, which has no API client
+                                        // attribution -- they are recorded via the UI disclosure feature,
+                                        // never by an API client. When filtering by API client, skip them
+                                        // rather than mixing unfiltered rows into a filtered view.
+                                        if ((($eventname == "disclosure") || ($gev == "")) && $form_client_id === '') {
                                             $eventname = "disclosure";
                                             if ($ret = EventAuditLogger::getInstance()->getEvents(['sdate' => $start_date, 'edate' => $end_date, 'user' => $form_user, 'patient' => $form_pid, 'sortby' => $_GET['sortby'], 'event' => $eventname])) {
                                                 while ($iter = sqlFetchArray($ret)) {

--- a/interface/logview/logview.php
+++ b/interface/logview/logview.php
@@ -109,6 +109,7 @@ if (!empty($_GET)) {
 
                         $form_patient = $_GET["form_patient"] ?? '';
                         $form_user = $_REQUEST['form_user'] ?? '';
+                        $form_client_id = filter_input(INPUT_GET, 'form_client_id') ?: '';
                         $form_pid = $_REQUEST['form_pid'] ?? '';
                         if (empty($form_patient)) {
                             $form_pid = '';
@@ -171,6 +172,27 @@ if (!empty($_GET)) {
                                                     echo ", " . text($urow['fname']);
                                                 }
                                                 echo "</option>\n";
+                                            }
+                                            ?>
+                                        </select>
+                                    </div>
+                                    <label class="col-sm-1 col-form-label" for="form_client_id"><?php echo xlt('API Client'); ?>:</label>
+                                    <div class="col-sm-3">
+                                        <select name='form_client_id' id='form_client_id' class='form-control'>
+                                            <?php
+                                            echo " <option value=''>" . xlt('All') . "</option>\n";
+                                            $clientRows = \OpenEMR\Common\Database\QueryUtils::fetchRecords("SELECT `client_id`, `client_name` FROM `oauth_clients` ORDER BY `client_name` ASC");
+                                            foreach ($clientRows as $clientRow) {
+                                                $optionClientId = is_string($clientRow['client_id'] ?? null) ? $clientRow['client_id'] : '';
+                                                if ($optionClientId === '') {
+                                                    continue;
+                                                }
+                                                $optionClientName = is_string($clientRow['client_name'] ?? null) ? $clientRow['client_name'] : '';
+                                                echo " <option value='" . attr($optionClientId) . "'";
+                                                if ($optionClientId == $form_client_id) {
+                                                    echo " selected";
+                                                }
+                                                echo ">" . text($optionClientName !== '' ? $optionClientName : $optionClientId) . "</option>\n";
                                             }
                                             ?>
                                         </select>
@@ -307,7 +329,7 @@ if (!empty($_GET)) {
                                             $gev = $getevent;
                                         }
 
-                                        if ($ret = EventAuditLogger::getInstance()->getEvents(['sdate' => $start_date, 'edate' => $end_date, 'user' => $form_user, 'patient' => $form_pid, 'sortby' => $_GET['sortby'], 'levent' => $gev, 'tevent' => $tevent, 'direction' => $_GET['direction']])) {
+                                        if ($ret = EventAuditLogger::getInstance()->getEvents(['sdate' => $start_date, 'edate' => $end_date, 'user' => $form_user, 'patient' => $form_pid, 'sortby' => $_GET['sortby'], 'levent' => $gev, 'tevent' => $tevent, 'direction' => $_GET['direction'], 'client_id' => $form_client_id])) {
                                             // Set up crypto object (object will increase performance since caches used keys)
                                             $cryptoGen = ServiceContainer::getCrypto();
 

--- a/interface/logview/logview.php
+++ b/interface/logview/logview.php
@@ -362,8 +362,17 @@ if (!empty($_GET)) {
                                                     <td><?php echo text($iter["groupname"]); ?></td>
                                                     <td><?php echo text($iter["patient_id"]); ?></td>
                                                     <td><?php echo text($iter["success"]); ?></td>
-                                                    <?php if (!empty($iter["ip_address"])) { ?>
-                                                        <td><?php echo text($iter["ip_address"]) . ", " . text($iter["method"]) . ", " . text($iter["request"]); ?></td>
+                                                    <?php if (!empty($iter["ip_address"])) {
+                                                        // prefer the registered client name; fall back to the raw client id for
+                                                        // clients registered before the client_id column existed or since deleted
+                                                        $apiClientName = $iter["client_name"] ?? null;
+                                                        $apiClientId = $iter["client_id"] ?? null;
+                                                        $apiClient = is_string($apiClientName) ? $apiClientName : '';
+                                                        if ($apiClient === '') {
+                                                            $apiClient = is_string($apiClientId) ? $apiClientId : '';
+                                                        }
+                                                        ?>
+                                                        <td><?php echo text($iter["ip_address"]) . ", " . text($iter["method"]) . ", " . text($iter["request"]) . ($apiClient !== '' ? ", " . xlt('client') . ": " . text($apiClient) : ""); ?></td>
                                                     <?php } else { ?>
                                                         <td></td>
                                                     <?php } ?>

--- a/interface/reports/audit_log_tamper_report.php
+++ b/interface/reports/audit_log_tamper_report.php
@@ -252,7 +252,8 @@ $check_sum = isset($_GET['check_sum']);
             $checkSumOldApi = $iter['checksum_api'];
             $checkSumNewApi = '';
             if (!empty($checkSumOldApi)) {
-                $checkSumNewApi = hash('sha3-512', $iter['log_id_api'] . $iter['user_id'] . $iter['patient_id_api'] . $iter['ip_address'] . $iter['method'] . $iter['request'] . $iter['request_url'] . $iter['request_body'] . $iter['response'] . $iter['created_time']);
+                $apiClientId = $iter['client_id'] ?? null;
+                $checkSumNewApi = hash('sha3-512', $iter['log_id_api'] . $iter['user_id'] . (is_string($apiClientId) ? $apiClientId : '') . $iter['patient_id_api'] . $iter['ip_address'] . $iter['method'] . $iter['request'] . $iter['request_url'] . $iter['request_body'] . $iter['response'] . $iter['created_time']);
             }
 
             $dispCheck = false;

--- a/sql/8_2_0-to-8_3_0_upgrade.sql
+++ b/sql/8_2_0-to-8_3_0_upgrade.sql
@@ -112,3 +112,7 @@
 --  #IfMBOEncounterNeeded
 --    desc: Add encounter to the form_misc_billing_options table
 --    arguments: none
+
+#IfMissingColumn api_log client_id
+ALTER TABLE `api_log` ADD COLUMN `client_id` varchar(80) NOT NULL DEFAULT '' COMMENT 'oauth_clients.client_id of the API client that made the request' AFTER `user_id`;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -93,6 +93,7 @@ CREATE TABLE `api_log` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `log_id` int(11) NOT NULL,
   `user_id` bigint(20) NOT NULL,
+  `client_id` varchar(80) NOT NULL DEFAULT '' COMMENT 'oauth_clients.client_id of the API client that made the request',
   `patient_id` bigint(20) NOT NULL,
   `ip_address` varchar(255) NOT NULL,
   `method` varchar(20) NOT NULL,

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3,7 +3,7 @@
 --
 -- Keep v_database in sync with $v_database in version.php.
 -- CI will fail if they don't match.
--- v_database: 541
+-- v_database: 542
 --
 
 --

--- a/src/Common/Logging/Audit/Event.php
+++ b/src/Common/Logging/Audit/Event.php
@@ -18,6 +18,7 @@ namespace OpenEMR\Common\Logging\Audit;
  * (inferred from ApiResponseLoggerListener)
  * @phpstan-type ApiData array{
  *   user_id: int,
+ *   client_id?: string,
  *   patient_id: int,
  *   method: string,
  *   request: string,

--- a/src/Common/Logging/Audit/LogTablesSink.php
+++ b/src/Common/Logging/Audit/LogTablesSink.php
@@ -71,6 +71,9 @@ readonly class LogTablesSink implements SinkInterface
             $apiLogData = [
                 'log_id' => $lastLogId,
                 'user_id' => $api['user_id'],
+                // Empty-string default keeps checksums of rows logged before the
+                // client_id column existed verifiable by the tamper report.
+                'client_id' => $api['client_id'] ?? '',
                 'patient_id' => $api['patient_id'],
                 'ip_address' => $ipAddress,
                 'method' => $api['method'],

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -301,7 +301,7 @@ class EventAuditLogger implements AuditLoggerInterface
         // parse the parameters
         $cols = "DISTINCT l.`date`, l.`event`, l.`category`, l.`user`, l.`groupname`, l.`patient_id`, l.`success`, l.`comments`, l.`user_notes`, l.`crt_user`, l.`log_from`, l.`menu_item_id`, l.`ccda_doc_id`, l.`id`,
                  el.`encrypt`, el.`checksum`, el.`checksum_api`, el.`version`, el.`log_id` as `log_id_hash`,
-                 al.`log_id` as log_id_api, al.`user_id`, al.`patient_id` as patient_id_api, al.`ip_address`, al.`method`, al.`request`, al.`request_url`, al.`request_body`, al.`response`, al.`created_time` ";
+                 al.`log_id` as log_id_api, al.`user_id`, al.`client_id`, oc.`client_name`, al.`patient_id` as patient_id_api, al.`ip_address`, al.`method`, al.`request`, al.`request_url`, al.`request_body`, al.`response`, al.`created_time` ";
         if (isset($params['cols']) && $params['cols'] != "") {
             $cols = $params['cols'];
         }
@@ -401,6 +401,7 @@ class EventAuditLogger implements AuditLoggerInterface
             $sql = "SELECT $cols FROM `log_comment_encrypt` as el " .
                 "LEFT OUTER JOIN `log` as l ON el.`log_id` = l.`id` " .
                 "LEFT OUTER JOIN `api_log` as al ON el.`log_id` = al.`log_id` " .
+                "LEFT OUTER JOIN `oauth_clients` as oc ON al.`client_id` = oc.`client_id` " .
                 "WHERE (l.`date` IS NULL OR (l.`date` >= ? AND l.`date` <= ?))";
             array_push($sqlBindArray, $date1, $date2);
 

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -353,6 +353,11 @@ class EventAuditLogger implements AuditLoggerInterface
             $event = $params['event'];
         }
 
+        $apiClientId = "";
+        if (is_array($params) && isset($params['client_id']) && is_string($params['client_id'])) {
+            $apiClientId = $params['client_id'];
+        }
+
         if ($event != "") {
             if ($sortby == "comments") {
                 $sortby = "description";
@@ -423,6 +428,15 @@ class EventAuditLogger implements AuditLoggerInterface
             if ($tevent != "") {
                 $sql .= " AND l.`event` LIKE ?";
                 array_push($sqlBindArray, "%" . $tevent);
+            }
+
+            if ($apiClientId != "") {
+                // equality, not LIKE: client ids are opaque identifiers selected
+                // from the registered-clients dropdown. Also intentionally turns
+                // the api_log LEFT JOIN into a match requirement, restricting
+                // results to API events from this client.
+                $sql .= " AND al.`client_id` = ?";
+                array_push($sqlBindArray, $apiClientId);
             }
 
             if ($sortby != "") {

--- a/src/RestControllers/Subscriber/ApiResponseLoggerListener.php
+++ b/src/RestControllers/Subscriber/ApiResponseLoggerListener.php
@@ -60,8 +60,10 @@ class ApiResponseLoggerListener implements EventSubscriberInterface
                 // Do not log the response and requestBody
                 $logResponse = '';
             } else if ($this->shouldLogResponse($response)) {
-                // If the response is a Symfony Response, we can get the content directly
-                $logResponse = $response->getContent();
+                // If the response is a Symfony Response, we can get the content directly.
+                // getContent() returns false for streamed responses, which we log as empty.
+                $content = $response->getContent();
+                $logResponse = is_string($content) ? $content : '';
             } else {
                 $logResponse = '';
                 $this->getSystemLogger()->debug("ApiResponseLoggerListener::onRequestTerminated skipping log of response, not a json response");
@@ -76,6 +78,7 @@ class ApiResponseLoggerListener implements EventSubscriberInterface
             $userId = (int)($session->get('authUserID', 0));
             $api = [
                 'user_id' => $userId,
+                'client_id' => $request->getClientId() ?? '',
                 'patient_id' => $patientId,
                 'method' => $method,
                 'request' => $request->getResource() ?? '',

--- a/tests/Tests/Isolated/Common/Logging/Audit/LogTablesSinkTest.php
+++ b/tests/Tests/Isolated/Common/Logging/Audit/LogTablesSinkTest.php
@@ -54,6 +54,19 @@ class LogTablesSinkTest extends TestCase
         );
     }
 
+    /**
+     * Narrow a captured insert value (mixed) to its string form for
+     * checksum recomputation, mirroring how PHP string concatenation
+     * treats the raw values inside LogTablesSink.
+     *
+     * @param array<array-key, mixed> $data
+     */
+    private static function field(array $data, string $key): string
+    {
+        $value = $data[$key] ?? null;
+        return is_scalar($value) ? (string)$value : '';
+    }
+
     public function testRecordInsertsIntoLogTable(): void
     {
         $event = $this->createEvent();
@@ -344,5 +357,114 @@ class LogTablesSinkTest extends TestCase
         self::assertIsArray($capturedLogCommentData);
         self::assertIsString($capturedLogCommentData['checksum_api']);
         self::assertSame(128, strlen($capturedLogCommentData['checksum_api']));
+    }
+
+    /**
+     * The stored api checksum must be reproducible by the exact field
+     * concatenation the audit log tamper report uses
+     * (interface/reports/audit_log_tamper_report.php). If the sink's field
+     * order and the tamper report's recompute ever diverge, every new
+     * api_log row will be reported as tampered.
+     */
+    public function testRecordApiChecksumMatchesTamperReportRecompute(): void
+    {
+        $event = $this->createEvent(api: $this->createApiData());
+
+        $capturedLogCommentData = null;
+        $capturedApiLogData = null;
+        $this->connection->expects($this->exactly(3))
+            ->method('insert')
+            ->willReturnCallback(function (string $table, array $data) use (&$capturedLogCommentData, &$capturedApiLogData): int {
+                if ($table === 'log_comment_encrypt') {
+                    $capturedLogCommentData = $data;
+                }
+                if ($table === 'api_log') {
+                    $capturedApiLogData = $data;
+                }
+                return 1;
+            });
+
+        $this->connection->method('lastInsertId')->willReturn('55');
+
+        $sink = new LogTablesSink(conn: $this->connection);
+
+        $sink->record($event);
+
+        self::assertIsArray($capturedLogCommentData);
+        self::assertIsArray($capturedApiLogData);
+
+        // mirror the tamper report's recompute, field by field
+        $recompute = hash(
+            'sha3-512',
+            self::field($capturedApiLogData, 'log_id')
+            . self::field($capturedApiLogData, 'user_id')
+            . self::field($capturedApiLogData, 'client_id')
+            . self::field($capturedApiLogData, 'patient_id')
+            . self::field($capturedApiLogData, 'ip_address')
+            . self::field($capturedApiLogData, 'method')
+            . self::field($capturedApiLogData, 'request')
+            . self::field($capturedApiLogData, 'request_url')
+            . self::field($capturedApiLogData, 'request_body')
+            . self::field($capturedApiLogData, 'response')
+            . self::field($capturedApiLogData, 'created_time')
+        );
+
+        self::assertSame($recompute, $capturedLogCommentData['checksum_api']);
+    }
+
+    /**
+     * Rows logged by callers that do not provide client_id (the state of the
+     * world before the column existed, and any older recordLogItem callers)
+     * must produce a checksum identical to the legacy formula that omitted
+     * client_id entirely -- the empty-string fallback contributes nothing to
+     * the hash. This is what keeps pre-upgrade audit rows verifiable in the
+     * tamper report.
+     */
+    public function testRecordApiChecksumWithoutClientIdMatchesLegacyFormula(): void
+    {
+        $apiData = $this->createApiData();
+        unset($apiData['client_id']);
+        $event = $this->createEvent(api: $apiData);
+
+        $capturedLogCommentData = null;
+        $capturedApiLogData = null;
+        $this->connection->expects($this->exactly(3))
+            ->method('insert')
+            ->willReturnCallback(function (string $table, array $data) use (&$capturedLogCommentData, &$capturedApiLogData): int {
+                if ($table === 'log_comment_encrypt') {
+                    $capturedLogCommentData = $data;
+                }
+                if ($table === 'api_log') {
+                    $capturedApiLogData = $data;
+                }
+                return 1;
+            });
+
+        $this->connection->method('lastInsertId')->willReturn('55');
+
+        $sink = new LogTablesSink(conn: $this->connection);
+
+        $sink->record($event);
+
+        self::assertIsArray($capturedLogCommentData);
+        self::assertIsArray($capturedApiLogData);
+        self::assertSame('', $capturedApiLogData['client_id'], 'missing client_id must be stored as empty string');
+
+        // the legacy checksum formula, exactly as it existed before client_id
+        $legacyRecompute = hash(
+            'sha3-512',
+            self::field($capturedApiLogData, 'log_id')
+            . self::field($capturedApiLogData, 'user_id')
+            . self::field($capturedApiLogData, 'patient_id')
+            . self::field($capturedApiLogData, 'ip_address')
+            . self::field($capturedApiLogData, 'method')
+            . self::field($capturedApiLogData, 'request')
+            . self::field($capturedApiLogData, 'request_url')
+            . self::field($capturedApiLogData, 'request_body')
+            . self::field($capturedApiLogData, 'response')
+            . self::field($capturedApiLogData, 'created_time')
+        );
+
+        self::assertSame($legacyRecompute, $capturedLogCommentData['checksum_api']);
     }
 }

--- a/tests/Tests/Isolated/Common/Logging/Audit/LogTablesSinkTest.php
+++ b/tests/Tests/Isolated/Common/Logging/Audit/LogTablesSinkTest.php
@@ -232,6 +232,7 @@ class LogTablesSinkTest extends TestCase
     {
         return [
             'user_id' => 1,
+            'client_id' => 'test-client-id',
             'patient_id' => 123,
             'method' => 'GET',
             'request' => '/api/patient',
@@ -307,6 +308,7 @@ class LogTablesSinkTest extends TestCase
         self::assertNotNull($capturedApiLogData);
         self::assertSame('55', $capturedApiLogData['log_id']);
         self::assertSame(1, $capturedApiLogData['user_id']);
+        self::assertSame('test-client-id', $capturedApiLogData['client_id']);
         self::assertSame(123, $capturedApiLogData['patient_id']);
         self::assertSame('GET', $capturedApiLogData['method']);
         self::assertSame('/api/patient', $capturedApiLogData['request']);

--- a/tests/Tests/Isolated/RestControllers/Subscriber/ApiResponseLoggerListenerTest.php
+++ b/tests/Tests/Isolated/RestControllers/Subscriber/ApiResponseLoggerListenerTest.php
@@ -60,6 +60,7 @@ class ApiResponseLoggerListenerTest extends TestCase
                 $this->assertEquals('', $user_notes, 'User notes should be empty');
                 $this->assertEquals([
                     'user_id' => $session->get('authUserID'),
+                    'client_id' => '',
                     'patient_id' => $session->get('pid'),
                     'method' => $request->getMethod(),
                     'request' => $request->getResource(),
@@ -96,6 +97,7 @@ class ApiResponseLoggerListenerTest extends TestCase
         $session->set('pid', 123); // Set a patient ID for testing
         $request->setSession($session);
         $request->setResource('test');
+        $request->setClientId('test-oauth-client');
 
         $jsonDataResponse = [
             'message' => 'Test response',
@@ -123,6 +125,7 @@ class ApiResponseLoggerListenerTest extends TestCase
                 $this->assertEquals('', $user_notes, 'User notes should be empty');
                 $this->assertEquals([
                     'user_id' => $session->get('authUserID'),
+                    'client_id' => 'test-oauth-client',
                     'patient_id' => $session->get('pid'),
                     'method' => $request->getMethod(),
                     'request' => $request->getResource(),

--- a/tests/Tests/Isolated/RestControllers/Subscriber/ApiResponseLoggerListenerTest.php
+++ b/tests/Tests/Isolated/RestControllers/Subscriber/ApiResponseLoggerListenerTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorageFactory;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 class ApiResponseLoggerListenerTest extends TestCase
@@ -137,6 +138,55 @@ class ApiResponseLoggerListenerTest extends TestCase
             });
         $apiResponseLoggerListener = new ApiResponseLoggerListener();
         $apiResponseLoggerListener->setSystemLogger($this->createMock(LoggerInterface::class));
+        $apiResponseLoggerListener->setEventAuditLogger($auditLogger);
+        $apiResponseLoggerListener->onRequestTerminated($terminatedEvent);
+    }
+
+    /**
+     * StreamedResponse::getContent() returns false rather than the content.
+     * The listener must normalize that to an empty string so the audit row
+     * (and its checksum) never receives a boolean.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testOnRequestTerminatedWithStreamedResponseLogsEmptyBody(): void
+    {
+        $globalsBag = new OEGlobalsBag([
+            'api_log_option' => 2, // response logging enabled: exercises the getContent() path
+        ]);
+        $kernel = $this->createMock(OEHttpKernel::class);
+        $kernel->method('getGlobalsBag')
+            ->willReturn($globalsBag);
+        $request = HttpRestRequest::create('/api/test');
+        $mockSessionFactory = new MockFileSessionStorageFactory();
+        $session = new Session($mockSessionFactory->createStorage(null));
+        $session->set('authUser', 'test_user');
+        $session->set('authUserID', 1);
+        $session->set('authProvider', 'Default');
+        $session->set('pid', 123);
+        $request->setSession($session);
+        $request->setResource('test');
+        $request->setClientId('test-oauth-client');
+
+        $response = new StreamedResponse(function (): void {
+            echo '{"status": "streamed"}';
+        }, Response::HTTP_OK, ['Content-Type' => 'application/json']);
+        $terminatedEvent = new TerminateEvent($kernel, $request, $response);
+        $auditLogger = $this->createMock(EventAuditLogger::class);
+        $auditLogger
+            ->expects($this->once())
+            ->method('recordLogItem')
+            ->withAnyParameters()
+            ->willReturnCallback(function ($success, $event, $user, $group, $comments, $patientId, $category, $logFrom, $menuItemId, $ccdaDocId, $user_notes, $api): void {
+                $this->assertIsArray($api);
+                $this->assertSame('', $api['request_body'], 'Streamed response body must be logged as empty string');
+                $this->assertSame('', $api['response'], 'Streamed response must be logged as empty string');
+                $this->assertSame('test-oauth-client', $api['client_id'], 'Client id must still be recorded for streamed responses');
+                // void return
+            });
+        $apiResponseLoggerListener = new ApiResponseLoggerListener();
+        $apiResponseLoggerListener->setLogger($this->createMock(LoggerInterface::class));
         $apiResponseLoggerListener->setEventAuditLogger($auditLogger);
         $apiResponseLoggerListener->onRequestTerminated($terminatedEvent);
     }

--- a/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
@@ -410,6 +410,7 @@ final class EventAuditLoggerTest extends TestCase
             '', // crt_user
             [
                 'user_id' => 1,
+                'client_id' => '',
                 'patient_id' => 1,
                 'method' => 'foo',
                 'request' => 'foo',
@@ -540,6 +541,7 @@ final class EventAuditLoggerTest extends TestCase
 
         $apiData = [
             'user_id' => 1,
+            'client_id' => 'test-oauth-client',
             'patient_id' => 123,
             'method' => 'GET',
             'request' => '/api/patient/123',

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@ $v_realpatch = '0';
 //
 // Keep in sync with the v_database comment in sql/database.sql.
 // CI will fail if they don't match.
-$v_database = 541;
+$v_database = 542;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
Adds the OAuth client identity to the API audit log. Every standard REST/FHIR request is already authenticated as a specific registered client, but `api_log` only recorded the user, so an auditor cannot see *which application* performed an action -- e.g. distinguish a clinician's direct activity from writes made by a connected third-party app using that clinician's delegated token. This came out of recent community discussion around AI scribe / integration clients see [forum thread on ambient AI scribe and OIDC/AI integration](https://community.open-emr.org/t/feedback-requested-generic-oidc-login-and-ai-integration-for-openemr/26915/2), but it applies to any registered API client.


#### Changes proposed in this pull request:
After this change, the Logs Viewer API column shows the registered client name (from `oauth_clients`) next to IP/method/request, and the raw `client_id` is stored on each `api_log` row.

##### What this deliberately does not do
- No delegation semantics (user-vs-agent within one client) -- that is a larger OAuth token-exchange discussion; this PR is just the  attribution floor.
- No change to local/internal API calls, which have no OAuth client and are already skipped by `ApiResponseLoggerListener::isLocalApi()`.

##### Audit integrity

`api_log` rows are checksummed and verified by the audit log tamper report. The new column uses `DEFAULT ''` and is inserted at the same position in both the checksum generation (LogTablesSink) and the recompute (audit_log_tamper_report.php), so rows written before the upgrade still verify: an empty string contributes nothing to the hash. 


#### Was AI used? Yes, claude.ai
<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
