### PR TITLE
test(acceptance): Phase 4f Medium Ff -- port FfOpenEncounterTest

### DIFF
--- a/tests/Acceptance/FfOpenEncounterAcceptanceTest.php
+++ b/tests/Acceptance/FfOpenEncounterAcceptanceTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance;
+
+use Facebook\WebDriver\WebDriverBy;
+use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+use OpenEMR\Tests\Acceptance\Support\PantherAcceptanceTestCase;
+use OpenEMR\Tests\Acceptance\Support\UiSeedingTrait;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Panther-driven acceptance port of tests/Tests/E2e/FfOpenEncounterTest.
+ *
+ * Phase 4f Medium-tier port (second, after DdOpenPatient #13354).
+ * Exercises the encounter-open flow: seed a patient + encounter,
+ * navigate back to the patient dashboard, click the shell's Past
+ * Encounters dropdown, pick the first Office Visit entry, land inside
+ * the encounter forms iframe with the encounter navbar rendered. That
+ * flow is a distinct user journey from the addEncounter flow already
+ * covered by KkEncounterFormNavbarUrlAcceptanceTest (which lands
+ * inside the encounter navbar as a side effect of creation) — Ff
+ * specifically validates the pastEncounters dropdown → select →
+ * open path.
+ *
+ * Seeding: source-side test relies on CcCreatePatientTest +
+ * EeCreateEncounterTest having seeded via the source-side ordered
+ * suite. Acceptance harness is order-agnostic, so this test seeds
+ * patient + encounter inline via addPatientViaUi + addEncounterViaUi
+ * before invoking the open flow via openPatientViaUi (to navigate
+ * back to the dashboard) + openEncounterViaUi. Per-instance random
+ * seed identity (from #13351 seed-identity refactor) means multiple
+ * runs against the same DB (upgrade scenario's post-upgrade phase,
+ * tests running in the same phase) each seed a distinct
+ * patient/encounter — no cross-run collision.
+ *
+ * Dual-tagged fresh-install + post-upgrade from the start.
+ */
+#[Group('fresh-install')]
+#[Group('post-upgrade')]
+final class FfOpenEncounterAcceptanceTest extends PantherAcceptanceTestCase
+{
+    use UiSeedingTrait;
+
+    /**
+     * Verify a seeded encounter for a seeded patient can be re-opened
+     * from the patient dashboard's Past Encounters dropdown.
+     *
+     * Source: FfOpenEncounterTest / EncounterOpenTrait::testEncounterOpen.
+     */
+    public function testOpenSeededEncounter(): void
+    {
+        $this->client = BrowserSession::create();
+        $this->performLoginAsAdmin();
+
+        // Seed: create the patient + encounter this test will re-open.
+        // addPatientViaUi leaves the browser on the patient's Medical
+        // Record Dashboard; addEncounterViaUi navigates into the
+        // encounter and leaves the browser inside the encounter forms
+        // iframe with the navbar rendered. A no-op "encounter already
+        // open" would trivially pass the final assertion, so
+        // openPatientViaUi below navigates back to the patient
+        // dashboard to force the pastEncounters dropdown path.
+        $this->addPatientViaUi();
+        $this->addEncounterViaUi();
+
+        // Navigate back to the patient's Medical Record Dashboard so
+        // the shell's Past Encounters dropdown is reachable.
+        // openPatientViaUi exercises the search + finder-click path
+        // that Dd validates independently, so a genuine open here
+        // gates that flow as an implicit dependency.
+        $this->openPatientViaUi(
+            $this->seedPatientFname(),
+            $this->seedPatientLname(),
+        );
+
+        // The open-encounter flow itself: click Past Encounters →
+        // click first Office Visit entry → wait for the encounter
+        // navbar for THIS specific patient. openEncounterViaUi's
+        // final wait proves the encounter is open (and, incidentally,
+        // that the assertion caller doesn't need to re-navigate).
+        $this->openEncounterViaUi();
+
+        // openEncounterViaUi's final wait already proves the navbar
+        // rendered — this re-reads that same header and asserts on
+        // its text so the test summary carries a real, phpstan-visible
+        // assertion + guards against future changes that make the
+        // wait's XPath more permissive than intended. Mirrors Dd's
+        // dashboard-header re-read pattern.
+        $navbarTitle = $this->requireClient()->findElement(
+            WebDriverBy::xpath('//span[@id="navbarEncounterTitle"]'),
+        )->getText();
+        self::assertStringContainsString(
+            'Encounter for ' . $this->seedPatientFname() . ' ' . $this->seedPatientLname(),
+            $navbarTitle,
+            'Encounter navbar title should reference the seeded patient',
+        );
+    }
+}

--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -547,6 +547,73 @@ trait UiSeedingTrait
     }
 
     /**
+     * Open an existing encounter for the currently-open patient via
+     * the shell's Past Encounters dropdown. Mirrors the source-side
+     * EncounterOpenTrait::encounterOpenIfExist minus the DB-existence
+     * pre-check — that check queries the database directly, which
+     * violates the acceptance suite's black-box discipline; the caller
+     * is responsible for having seeded the encounter (typically via
+     * addEncounterViaUi() earlier in the same test) and for having
+     * navigated back to the patient dashboard so the Past Encounters
+     * button is reachable in the shell.
+     *
+     * Post-condition on return: browser is inside the encounter forms
+     * iframe with the navbar rendered — same DOM location the
+     * encounter-navbar assertion needs. Caller does NOT need to
+     * re-navigate.
+     *
+     * Note: the "first Office Visit entry in the dropdown" match is
+     * intentional — the acceptance seed identity uses category id 5
+     * (Office Visit) via SEED_ENCOUNTER_CATEGORY_ID + a single
+     * encounter per test instance, so the first Office Visit li is
+     * unambiguously the seeded encounter. If a future test seeds
+     * multiple encounters per patient, this helper needs a name/date
+     * discriminator to select the right entry.
+     */
+    protected function openEncounterViaUi(): void
+    {
+        $client = $this->requireClient();
+        $client->switchTo()->defaultContent();
+        // Belt-and-suspenders — nuke any leftover modals from the
+        // preceding openPatientViaUi (dashboard load can open reminders
+        // / birthday Bootstrap modals that intercept the pastEncounters
+        // dropdown button click).
+        $this->dismissAnyOpenModals();
+
+        // Click the Past Encounters dropdown button in the shell.
+        // Source-side XPath: //button[@id="pastEncounters"].
+        $this->waitAndClick(
+            WebDriverBy::xpath('//button[@id="pastEncounters"]'),
+            'Past Encounters dropdown button',
+        );
+
+        // Click the first Office Visit entry in the dropdown menu.
+        // Source-side XPath:
+        //   //ul[contains(@class, "dropdown-menu")]/li[1]/a[1]/span[text()="Office Visit"]
+        $this->waitAndClick(
+            WebDriverBy::xpath(
+                '//ul[contains(@class, "dropdown-menu")]/li[1]/a[1]/span[text()="Office Visit"]',
+            ),
+            'First Office Visit entry in Past Encounters dropdown',
+        );
+
+        // Switch into the encounter iframe → forms iframe → wait for
+        // the navbar title for THIS specific patient. Mirrors
+        // addEncounterViaUi's final frame-switch chain so the
+        // post-condition is identical between "created and opened"
+        // and "opened after creation".
+        $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="enc"]', 30);
+        $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="enc"]');
+        $client->waitFor('//iframe[@src="forms.php"]', 30);
+        $this->switchToIFrame('//iframe[@src="forms.php"]');
+        $client->waitFor(
+            '//span[@id="navbarEncounterTitle" and contains(text(), "Encounter for '
+                . $this->seedPatientFname() . ' ' . $this->seedPatientLname() . '")]',
+            30,
+        );
+    }
+
+    /**
      * Set a text input's value via JS + fire an `input`/`change` event
      * so any bound listeners run. More robust inside iframes than
      * ->sendKeys() for forms that read via JS event listeners.


### PR DESCRIPTION
## Summary

- Add `openEncounterViaUi()` helper to `UiSeedingTrait` — clicks the shell's Past Encounters dropdown, selects the first Office Visit entry, switches into the enc → forms iframe chain, waits for the encounter navbar for the seeded patient.
- New `tests/Acceptance/FfOpenEncounterAcceptanceTest.php` — Panther-driven port of source-side `tests/Tests/E2e/FfOpenEncounterTest`. Seeds patient + encounter, navigates back to the dashboard via `openPatientViaUi`, re-opens via `openEncounterViaUi`, asserts on the encounter navbar title.
- Dual-tagged `fresh-install` + `post-upgrade` from the start.

## Distinct user journey vs existing acceptance coverage

- **KkEncounterFormNavbarUrl** lands inside the encounter navbar as a *side effect* of creation (addEncounterViaUi). Ff specifically validates the `#pastEncounters` dropdown → select-first-Office-Visit → open path — a different DOM trigger against a different code path.
- **Dd (openPatientViaUi)** is exercised implicitly here as the way back to the dashboard between encounter-create and encounter-open. A Dd regression would surface first via Dd itself; Ff would surface next as a downstream gate.

## Second Medium-tier port

- First was **Dd** (openPatientViaUi) #13354.
- Remaining real-coverage Medium ports: Bb (staff-user create — new area) and Svc (service-tier / DB-touch flow, pending scoping). Cc + Ee marked PERMANENTLY SKIPPED in the plan doc — attribution-only ports with no functional coverage gain since Kk/Dd already exercise the underlying flows on every acceptance CI run.

## Local validation

- PHP lint clean on both changed files
- PHPStan level 10 clean on both changed files

## Test plan

- [ ] fresh-install acceptance job passes on both amd64 + arm64
- [ ] post-upgrade acceptance job passes on both amd64 + arm64
- [ ] rel-820 sync-byte-identical CI passes with the new test present

Assisted-by: Claude Code