### PR TITLE
test(acceptance): Bb -- modal-close recovery via users-table row oracle

### DIFF
--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -893,16 +893,55 @@ trait UiSeedingTrait
         // top-level document — the modalframe iframe disappearing IS
         // the signal we want.
         $client->switchTo()->defaultContent();
-        $client->wait(30)->until(
-            WebDriverExpectedCondition::invisibilityOfElementLocated(
-                WebDriverBy::xpath("//iframe[@id='modalframe']"),
-            ),
-        );
+        // On success the server echoes an empty response body and the
+        // AJAX .done() handler fires dlgclose('reload'), which closes
+        // the modal + reloads the admin iframe with the new users
+        // list. Historically the AJAX-handler-to-dlgclose chain has
+        // a ~30% single-shot flake rate (source-side Bb test masks
+        // this with a 3-retry-whole-test loop; verified via rel-820
+        // sync PR #13390 exhibiting 2/6 failures at exactly this
+        // wait). The recovery block below turns the flake into a
+        // benign retry: if the modal-close wait times out, force-
+        // clean modal DOM + refresh admin iframe, then let the
+        // downstream users-table row wait act as the oracle. If the
+        // user was actually created (typical flake mode: server
+        // succeeded, JS handler race lost dlgclose), the row wait
+        // succeeds and the test passes. If the user was NOT created
+        // (real regression), the row wait fails and the test surfaces
+        // the underlying issue.
+        try {
+            $client->wait(30)->until(
+                WebDriverExpectedCondition::invisibilityOfElementLocated(
+                    WebDriverBy::xpath("//iframe[@id='modalframe']"),
+                ),
+            );
+        } catch (TimeoutException) {
+            // STDERR breadcrumb so CI logs show when the recovery
+            // path fired — lets us track the flake rate over time
+            // without needing a green-vs-red signal.
+            fwrite(
+                STDERR,
+                "[acceptance/Bb] Modal-close wait timed out after Save; entering recovery path "
+                . "(the AJAX-handler-to-dlgclose chain has a documented flake mode).\n",
+            );
+            // Force-clean modal DOM (dlgclose didn't fire; strip
+            // Bootstrap modal wrappers manually).
+            $this->dismissAnyOpenModals();
+            // Refresh the admin iframe so its content is fresh —
+            // if the user was created, the reload will populate the
+            // users table with the new row.
+            $client->switchTo()->defaultContent();
+            $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="adm"]', 30);
+            $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="adm"]');
+            $client->executeScript('window.location.reload();');
+            $client->switchTo()->defaultContent();
+        }
 
-        // Modal closed → dlgclose('reload') fired → admin iframe
-        // reloaded. Switch into it and wait for the new user row to
-        // appear in the users table (the row is a link with the
-        // username as text, matching the source-side assertion).
+        // Users-table row wait serves as the final oracle regardless
+        // of which path we took (clean modal-close OR recovery). If
+        // the user exists, the row is there. If not (real regression
+        // OR AJAX response was actually an error masked by muzzled
+        // alert), this wait times out and surfaces the failure.
         $client->waitFor('//*[@id="framesDisplay"]//iframe[@name="adm"]', 30);
         $this->switchToIFrame('//*[@id="framesDisplay"]//iframe[@name="adm"]');
         $client->waitFor("//table//a[text()=" . self::xpathLiteral($username) . "]", 30);


### PR DESCRIPTION
## Summary

Rel-820 sync PR #13390 exposed a **~30% single-shot flake rate** on Bb's post-Save modal-close wait: server returns 200 with empty body (dlgclose signal), but the AJAX `.done()` handler intermittently races the actual DOM modal removal. Source-side `BbCreateStaffTest` masks this with a 3-retry-whole-test loop, keeping master workflow-visible failure to <5% while the underlying single-shot rate is ~30%.

The acceptance-side port had no such recovery, so on rel-820 sync CI (first run to include Bb) 2/6 acceptance jobs failed at exactly that wait.

## Fix: scoped recovery block

1. Wrap the modal-close wait in `try/catch` on `TimeoutException`.
2. On timeout: emit a STDERR breadcrumb (so CI logs show flake rate over time), force-clean modal DOM via `dismissAnyOpenModals`, refresh the admin iframe via JS `window.location.reload()`.
3. Fall through to the **existing users-table row wait** as the final oracle — if the user was actually created (typical flake mode: server succeeded, JS handler race lost `dlgclose`), the row wait succeeds and the test passes. If NOT created (real regression OR AJAX response was actually an error masked by the muzzled `alert`), the row wait fails and surfaces the real issue.

## Why not just add a retry loop like source-side?

The row-wait oracle already discriminates create-succeeded from create-failed. A retry-whole-test loop would add ceremony without additional signal — worse, it could mask real regressions if the create-failure mode is itself intermittent.

**Black-box discipline preserved** (no DB queries — oracle is still the rendered users-table).
**Regression signal preserved** (missing user row = hard fail).

## Local validation

- PHP lint + PHPStan level 10 clean
- **Happy path smoke-tested locally** — modal closes cleanly, test passes as before

Recovery path only fires when the underlying race actually happens; can't reliably reproduce that locally. STDERR breadcrumb lets us track how often it fires in CI without needing a red/green change.

## Test plan

- [ ] All 6 acceptance jobs pass on this PR (proves happy path unchanged)
- [ ] Watch subsequent rel-820 sync PRs for Bb-related failures — expect the recovery path to fire but tests to stay green (STDERR breadcrumb in CI logs = observed flake rate)

Assisted-by: Claude Code