### PR TITLE
test(acceptance): Bb -- add happy-path breadcrumb to modal-close recovery

### DIFF
--- a/tests/Acceptance/Support/UiSeedingTrait.php
+++ b/tests/Acceptance/Support/UiSeedingTrait.php
@@ -915,6 +915,16 @@ trait UiSeedingTrait
                     WebDriverBy::xpath("//iframe[@id='modalframe']"),
                 ),
             );
+            // Positive-path breadcrumb. Paired with the recovery-path
+            // breadcrumb in the catch block below — together they let
+            // us confirm the recovery mechanism is running end-to-end
+            // by grepping CI logs. Without the happy-path breadcrumb,
+            // "0 recovery-path breadcrumbs across 18 runs" is ambiguous:
+            // could mean "Bb never flaked" OR "the recovery logic was
+            // wired wrong and always short-circuits." Emitting on the
+            // clean path proves the wait actually completed via the
+            // expected non-catch code path.
+            fwrite(STDERR, "[acceptance/Bb] Modal-close wait passed cleanly.\n");
         } catch (TimeoutException) {
             // STDERR breadcrumb so CI logs show when the recovery
             // path fired — lets us track the flake rate over time


### PR DESCRIPTION
## Summary

Adds a positive-path STDERR breadcrumb (\"Modal-close wait passed cleanly\") that pairs with the existing recovery-path breadcrumb (\"Modal-close wait timed out after Save; entering recovery path\") from #13391.

## Why

With only the recovery-path breadcrumb, an empty log history is ambiguous:
- \"0 recovery-path breadcrumbs across 18 runs\" could mean **Bb never flaked**, OR **the recovery logic was wired wrong and always short-circuits**.

Emitting on the clean path too proves the wait actually completed via the expected non-catch code path. Future observers can grep for either breadcrumb and confirm the mechanism is running end-to-end.

## Local validation

- PHPStan level 10 clean
- **Smoke-verified locally** — happy-path run emits the new breadcrumb via a Panther-driven single-test invocation against the dev stack

## Test plan

- [ ] After landing, next few acceptance CI runs should show the \"passed cleanly\" breadcrumb in every log — confirming the mechanism is running end-to-end
- [ ] Whenever the flake finally hits (weeks-to-months organic timeline), we'll see the \"timed out\" breadcrumb alongside a passing test — the recovery-verification moment

Assisted-by: Claude Code