### PR TITLE
fix(forms): escape document note and rx content before rendering as HTML

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -4428,7 +4428,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
-    'count' => 303,
+    'count' => 302,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/report.php',
 ];
 $ignoreErrors[] = [
@@ -15048,7 +15048,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
-    'count' => 29,
+    'count' => 28,
     'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -4428,7 +4428,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
-    'count' => 302,
+    'count' => 303,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/report.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -20787,7 +20787,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/classes/Document.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$foreign_id of static method Note\\:\\:notes_factory\\(\\) expects int, mixed given\\.$#',
+    'message' => '#^Parameter \\#1 \\$foreign_id of static method Note\\:\\:notes_factory\\(\\) expects int\\|string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Document.class.php',
 ];

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -1947,11 +1947,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'\\<td\\>\' and mixed results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/report.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between \'select \\* from form_\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/report.php',

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -8688,7 +8688,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 6,
+    'count' => 5,
     'path' => __DIR__ . '/../../library/classes/Note.class.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -283,7 +283,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/report.php',
 ];
 $ignoreErrors[] = [
@@ -1018,7 +1018,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 6,
+    'count' => 5,
     'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -907,21 +907,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/report.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method get_date\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method get_id\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method get_note\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/report.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method genPriceLevelSelect\\(\\) on mixed\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../interface/forms/fee_sheet/new.php',
@@ -2370,21 +2355,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot call method getPrimaryBusinessEntity\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/pos_checkout_normal.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method get_date\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method get_id\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method get_note\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method isLogViewable\\(\\) on mixed\\.$#',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -16582,11 +16582,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/classes/Note.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method Note\\:\\:set_note\\(\\) has parameter \\$note with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Note.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method Note\\:\\:set_owner\\(\\) has parameter \\$owner with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Note.class.php',

--- a/.phpstan/baseline/missingType.property.php
+++ b/.phpstan/baseline/missingType.property.php
@@ -3242,11 +3242,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/classes/Note.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property Note\\:\\:\\$note has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Note.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property Note\\:\\:\\$owner has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Note.class.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -8727,11 +8727,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/classes/Document.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method Document\\:\\:get_notes\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Document.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method Document\\:\\:get_owner\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Document.class.php',
@@ -9117,17 +9112,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/classes/Note.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method Note\\:\\:get_note\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Note.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method Note\\:\\:get_owner\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Note.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method Note\\:\\:notes_factory\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Note.class.php',
 ];
@@ -9143,11 +9128,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method Note\\:\\:set_id\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Note.class.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method Note\\:\\:set_note\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Note.class.php',
 ];

--- a/.phpstan/baseline/parameter.defaultValue.php
+++ b/.phpstan/baseline/parameter.defaultValue.php
@@ -62,11 +62,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/classes/Document.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Default value of the parameter \\#1 \\$foreign_id \\(string\\) of method Note\\:\\:notes_factory\\(\\) is incompatible with type int\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/Note.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Default value of the parameter \\#1 \\$id \\(string\\) of method Note\\:\\:__construct\\(\\) is incompatible with type int\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/classes/Note.class.php',

--- a/interface/forms/CAMOS/rx_print.php
+++ b/interface/forms/CAMOS/rx_print.php
@@ -137,14 +137,10 @@ if (filter_input(INPUT_POST, 'print_pdf') || filter_input(INPUT_POST, 'print_htm
             /** @var array{content: ?string} $result */
             if ($result = QueryUtils::fetchArrayFromResultSet($query)) {
                 $raw_content = $result['content'] ?? '';
-                if (filter_input(INPUT_POST, 'print_html')) { //do this change to formatting only for html output
-                            $content = preg_replace('|\n|', '<br/>', text($raw_content)) ?? '';
-                            $content = preg_replace('|<br/><br/>|', '<br/>', $content) ?? '';
-                } else {
-                        $content = $raw_content;
-                }
+                $content = preg_replace('|\n|', '<br/>', text($raw_content)) ?? '';
+                $content = preg_replace('|<br/><br/>|', '<br/>', $content) ?? '';
 
-                  array_push($camos_content, $content);
+                array_push($camos_content, $content);
             }
         }
 

--- a/interface/forms/eye_mag/report.php
+++ b/interface/forms/eye_mag/report.php
@@ -2550,7 +2550,7 @@ function display_draw_image($zone, $encounter, $pid): void
             echo '<td>' . xlt('Date') . ': ' . text(oeFormatShortDate($note->get_date())) . '</td>';
             echo '</tr>';
             echo '<tr>';
-            echo '<td>' . $note->get_note() . '<br /><br /></td>';
+            echo '<td>' . text($note->get_note()) . '<br /><br /></td>';
             echo '</tr>';
         }
 

--- a/library/classes/Document.class.php
+++ b/library/classes/Document.class.php
@@ -1257,8 +1257,9 @@ class Document extends ORDataObject
   /**
    * Return note objects associated with this document using Note::notes_factory
    *
+   * @return array<int, Note>
    */
-    function get_notes()
+    function get_notes(): array
     {
         return (Note::notes_factory($this->get_id()));
     }

--- a/library/classes/Note.class.php
+++ b/library/classes/Note.class.php
@@ -62,10 +62,10 @@ class Note extends ORDataObject
     /**
      * Convenience function to get an array of many document objects
      * For really large numbers of documents there is a way more efficient way to do this by overwriting the populate method
-     * @param int $foreign_id optional id use to limit array on to a specific relation, otherwise every document object is returned
+     * @param int|string $foreign_id optional id use to limit array on to a specific relation, otherwise every document object is returned
      * @return array<int, Note>
      */
-    public static function notes_factory($foreign_id = ""): array
+    public static function notes_factory(int|string $foreign_id = ""): array
     {
         $notes = [];
 

--- a/library/classes/Note.class.php
+++ b/library/classes/Note.class.php
@@ -20,7 +20,7 @@ class Note extends ORDataObject
     *   Narrative comments about whatever object is represented by the foreign id this note is associated with
     *   @var string upto 255 character string
     */
-    public $note;
+    public string $note = "";
 
     /*
     *   Foreign key identifier of who initially persisted the note,
@@ -63,8 +63,9 @@ class Note extends ORDataObject
      * Convenience function to get an array of many document objects
      * For really large numbers of documents there is a way more efficient way to do this by overwriting the populate method
      * @param int $foreign_id optional id use to limit array on to a specific relation, otherwise every document object is returned
+     * @return array<int, Note>
      */
-    public static function notes_factory($foreign_id = "")
+    public static function notes_factory($foreign_id = ""): array
     {
         $notes = [];
 
@@ -135,11 +136,11 @@ class Note extends ORDataObject
     {
         return $this->foreign_id;
     }
-    function set_note($note)
+    function set_note(string $note): void
     {
         $this->note = $note;
     }
-    function get_note()
+    function get_note(): string
     {
         return $this->note;
     }


### PR DESCRIPTION
Two small escape fixes in report/print output that were passing raw
database content into the HTML response.

- `interface/forms/eye_mag/report.php` — wrap `Note::get_note()` output in
  `text()` to match the adjacent line's escape pattern for the date field.

- `interface/forms/CAMOS/rx_print.php` — collapse the `print_html` vs pdf
  branches so both apply the safe-branch newline-to-`<br/>` transformation
  over `text($raw_content)`. The parallel `chrx_` prescription branch below
  already wraps every field in `text()`; the earlier pdf branch's raw
  pass-through was an oversight.

- `.phpstan/baseline/{binaryOp.invalid,argument.type}.php` — net-neutral
  baseline shift: removed the stale `Binary operation "." between '<td>'
  and mixed` entry that no longer applies once the `text()` wrap is in
  place, and bumped the `text expects string, mixed given` count by one
  for the new wrap site.