### PR TITLE
test(api): add coverage for the patient document endpoints and validate the pid

### DIFF
--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -5222,26 +5222,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/ConditionRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method getAllAtPath\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/DocumentRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method getFile\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/DocumentRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method insertAtPath\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/DocumentRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method setSession\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/DocumentRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getAll\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/DrugRestController.php',

--- a/.phpstan/baseline/missingType.property.php
+++ b/.phpstan/baseline/missingType.property.php
@@ -28997,11 +28997,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/Config/RestConfig.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\RestControllers\\\\DocumentRestController\\:\\:\\$documentService has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/DocumentRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\RestControllers\\\\DrugRestController\\:\\:\\$drugService has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/DrugRestController.php',

--- a/src/RestControllers/DocumentRestController.php
+++ b/src/RestControllers/DocumentRestController.php
@@ -22,13 +22,13 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class DocumentRestController
 {
-    private $documentService;
+    private readonly DocumentService $documentService;
     private readonly PatientService $patientService;
 
-    public function __construct()
+    public function __construct(?DocumentService $documentService = null, ?PatientService $patientService = null)
     {
-        $this->documentService = new DocumentService();
-        $this->patientService = new PatientService();
+        $this->documentService = $documentService ?? new DocumentService();
+        $this->patientService = $patientService ?? new PatientService();
     }
 
     /**
@@ -153,7 +153,24 @@ class DocumentRestController
             return $this->invalidPidResponse();
         }
 
-        $serviceResult = $this->documentService->insertAtPath($pid, $path, $fileData, $eid);
+        // insertAtPath() reads tmp_name and name straight off the upload and would fail on a
+        // request that carried no file, so the upload is checked before it gets that far.
+        $tmpName = is_array($fileData) ? ($fileData['tmp_name'] ?? null) : null;
+        $name = is_array($fileData) ? ($fileData['name'] ?? null) : null;
+        if (!is_string($tmpName) || !is_string($name)) {
+            return RestControllerHelper::responseHandler(
+                ['validationErrors' => ['document' => ['A document file is required']]],
+                null,
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+
+        $serviceResult = $this->documentService->insertAtPath(
+            $pid,
+            $path,
+            ['tmp_name' => $tmpName, 'name' => $name],
+            $eid
+        );
         return RestControllerHelper::responseHandler($serviceResult, null, 200);
     }
 

--- a/src/RestControllers/DocumentRestController.php
+++ b/src/RestControllers/DocumentRestController.php
@@ -15,6 +15,7 @@ namespace OpenEMR\RestControllers;
 use OpenApi\Attributes as OA;
 use OpenEMR\RestControllers\RestControllerHelper;
 use OpenEMR\Services\DocumentService;
+use OpenEMR\Services\PatientService;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -22,10 +23,35 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 class DocumentRestController
 {
     private $documentService;
+    private readonly PatientService $patientService;
 
     public function __construct()
     {
         $this->documentService = new DocumentService();
+        $this->patientService = new PatientService();
+    }
+
+    /**
+     * Every document endpoint is scoped to a patient, so a pid that does not resolve to a patient
+     * is a bad request rather than an empty result. Without this check a document can be uploaded
+     * against a pid that has no patient, leaving a row that no patient chart will ever surface.
+     */
+    private function isValidPid(mixed $pid): bool
+    {
+        if (!is_scalar($pid)) {
+            return false;
+        }
+
+        return $this->patientService->getUuid((string)$pid) !== false;
+    }
+
+    private function invalidPidResponse(): Response
+    {
+        return RestControllerHelper::responseHandler(
+            ['validationErrors' => ['pid' => ['Invalid pid']]],
+            null,
+            Response::HTTP_BAD_REQUEST
+        );
     }
 
     /**
@@ -67,6 +93,10 @@ class DocumentRestController
     )]
     public function getAllAtPath($pid, $path)
     {
+        if (!$this->isValidPid($pid)) {
+            return $this->invalidPidResponse();
+        }
+
         $serviceResult = $this->documentService->getAllAtPath($pid, $path);
         return RestControllerHelper::responseHandler($serviceResult, null, 200);
     }
@@ -119,6 +149,10 @@ class DocumentRestController
     )]
     public function postWithPath($pid, $path, $fileData, $eid)
     {
+        if (!$this->isValidPid($pid)) {
+            return $this->invalidPidResponse();
+        }
+
         $serviceResult = $this->documentService->insertAtPath($pid, $path, $fileData, $eid);
         return RestControllerHelper::responseHandler($serviceResult, null, 200);
     }
@@ -155,6 +189,10 @@ class DocumentRestController
     )]
     public function downloadFile($pid, $did)
     {
+        if (!$this->isValidPid($pid)) {
+            return $this->invalidPidResponse();
+        }
+
         $results = $this->documentService->getFile($pid, $did);
 
         if (!empty($results)) {

--- a/src/RestControllers/DocumentRestController.php
+++ b/src/RestControllers/DocumentRestController.php
@@ -153,13 +153,25 @@ class DocumentRestController
             return $this->invalidPidResponse();
         }
 
-        // insertAtPath() reads tmp_name and name straight off the upload and would fail on a
-        // request that carried no file, so the upload is checked before it gets that far.
-        $tmpName = is_array($fileData) ? ($fileData['tmp_name'] ?? null) : null;
-        $name = is_array($fileData) ? ($fileData['name'] ?? null) : null;
-        if (!is_string($tmpName) || !is_string($name)) {
+        // insertAtPath() reads tmp_name and name straight off the upload, so the upload is
+        // checked before it gets that far. PHP populates those two keys even when the upload
+        // failed -- a partial transfer carries UPLOAD_ERR_PARTIAL alongside whatever bytes did
+        // arrive, and a missing or oversized file leaves tmp_name as an empty string -- so the
+        // error code has to be honoured or a truncated file is stored as though it were whole.
+        $upload = is_array($fileData) ? $fileData : [];
+        $tmpName = $upload['tmp_name'] ?? null;
+        $name = $upload['name'] ?? null;
+        // a caller that built the array itself rather than handing over a $_FILES entry has no
+        // error key, and there is no failed upload to report in that case.
+        $uploadError = $upload['error'] ?? UPLOAD_ERR_OK;
+        if (
+            $uploadError !== UPLOAD_ERR_OK
+            || !is_string($tmpName) || $tmpName === ''
+            || !is_string($name) || $name === ''
+            || !is_file($tmpName)
+        ) {
             return RestControllerHelper::responseHandler(
-                ['validationErrors' => ['document' => ['A document file is required']]],
+                ['validationErrors' => ['document' => ['A valid document file is required']]],
                 null,
                 Response::HTTP_BAD_REQUEST
             );

--- a/tests/Tests/Api/ApiTestClient.php
+++ b/tests/Tests/Api/ApiTestClient.php
@@ -392,6 +392,28 @@ class ApiTestClient
     }
 
     /**
+     * Submits a HTTP POST Request encoded as multipart/form-data.
+     *
+     * Guzzle generates the Content-Type header (including the boundary) for
+     * multipart requests, so the client's default JSON Content-Type is dropped
+     * for this request only.
+     *
+     * @param array<string, mixed>[] $multipart Guzzle multipart entries, each with at least `name` and `contents`
+     * @param array<string, mixed> $query
+     */
+    public function postMultipart(string $url, array $multipart, array $query = []): ResponseInterface
+    {
+        $headers = $this->headers;
+        unset($headers["Content-Type"]);
+
+        return $this->client->post($url, [
+            "headers" => $headers,
+            "query" => $query,
+            "multipart" => $multipart,
+        ]);
+    }
+
+    /**
      * Submits a HTTP PUT Request.
      *
      * @param array<string, mixed> $body

--- a/tests/Tests/Api/DocumentApiTest.php
+++ b/tests/Tests/Api/DocumentApiTest.php
@@ -61,12 +61,23 @@ class DocumentApiTest extends TestCase
         $this->pid = $this->intColumn($patient, 'pid');
     }
 
+    /**
+     * PHPUnit runs tearDown() even when setUp() throws part way through, so each cleanup is
+     * guarded on the property it needs. Touching an unassigned typed property would raise an
+     * Error that masks the original setUp() failure and skips the cleanup that could still run.
+     */
     protected function tearDown(): void
     {
-        $this->removeDocumentsForFixturePatient();
-        $this->fixtureManager->removePatientFixtures();
-        $this->testClient->cleanupRevokeAuth();
-        $this->testClient->cleanupClient();
+        if (isset($this->pid)) {
+            $this->removeDocumentsForFixturePatient();
+        }
+        if (isset($this->fixtureManager)) {
+            $this->fixtureManager->removePatientFixtures();
+        }
+        if (isset($this->testClient)) {
+            $this->testClient->cleanupRevokeAuth();
+            $this->testClient->cleanupClient();
+        }
     }
 
     #[Test]
@@ -177,6 +188,26 @@ class DocumentApiTest extends TestCase
         $validationErrors = $body['validationErrors'];
         $this->assertIsArray($validationErrors);
         $this->assertArrayHasKey('pid', $validationErrors);
+    }
+
+    #[Test]
+    public function testPostDocumentWithoutAFile(): void
+    {
+        $response = $this->testClient->postMultipart(
+            $this->documentEndpoint(),
+            [['name' => 'not_the_document_field', 'contents' => self::FILE_CONTENTS]],
+            ['path' => self::CATEGORY_PATH]
+        );
+
+        $this->assertEquals(
+            400,
+            $response->getStatusCode(),
+            "A request that carries no document file should be a bad request"
+        );
+        $this->assertNull(
+            $this->fetchRow("SELECT `id` FROM `documents` WHERE `foreign_id` = ?", [$this->pid]),
+            "No document should be stored when the request carried no file"
+        );
     }
 
     #[Test]
@@ -304,11 +335,15 @@ class DocumentApiTest extends TestCase
     }
 
     /**
-     * A pid that is well formed but has no patient behind it.
+     * A pid that is well formed but has no patient behind it. Derived from the highest stored pid
+     * so that it cannot collide with a patient in a heavily seeded database.
      */
     private function unknownPid(): int
     {
-        return $this->pid + 1000000;
+        $row = $this->fetchRow("SELECT MAX(`pid`) AS `max_pid` FROM `patient_data`", []);
+        $maxPid = $row === null ? null : ($row['max_pid'] ?? null);
+
+        return (is_numeric($maxPid) ? (int)$maxPid : $this->pid) + 1;
     }
 
     /**

--- a/tests/Tests/Api/DocumentApiTest.php
+++ b/tests/Tests/Api/DocumentApiTest.php
@@ -210,6 +210,35 @@ class DocumentApiTest extends TestCase
         );
     }
 
+    /**
+     * A MAX_FILE_SIZE field ahead of the file makes PHP reject the upload with
+     * UPLOAD_ERR_FORM_SIZE. This is the shape a failed upload actually takes: $_FILES still
+     * carries the original `name`, and only `tmp_name` comes back empty, so checking that both
+     * keys hold strings is not enough to catch it -- the `error` code has to be read.
+     */
+    #[Test]
+    public function testPostDocumentWithAFailedUpload(): void
+    {
+        $response = $this->testClient->postMultipart(
+            $this->documentEndpoint(),
+            [
+                ['name' => 'MAX_FILE_SIZE', 'contents' => '4'],
+                ['name' => 'document', 'contents' => self::FILE_CONTENTS, 'filename' => self::FILE_NAME],
+            ],
+            ['path' => self::CATEGORY_PATH]
+        );
+
+        $this->assertEquals(
+            400,
+            $response->getStatusCode(),
+            "An upload PHP reported an error for should be a bad request"
+        );
+        $this->assertNull(
+            $this->fetchRow("SELECT `id` FROM `documents` WHERE `foreign_id` = ?", [$this->pid]),
+            "No document should be stored when the upload failed"
+        );
+    }
+
     #[Test]
     public function testPostDocumentWithoutAuthorization(): void
     {

--- a/tests/Tests/Api/DocumentApiTest.php
+++ b/tests/Tests/Api/DocumentApiTest.php
@@ -1,0 +1,418 @@
+<?php
+
+/**
+ * Patient Document API Endpoint Test Cases.
+ *
+ * Covers the standard (non-FHIR) patient document endpoints:
+ * - POST /api/patient/:pid/document
+ * - GET  /api/patient/:pid/document
+ * - GET  /api/patient/:pid/document/:did
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2026 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Api;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Tests\Fixtures\FixtureManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+class DocumentApiTest extends TestCase
+{
+    /**
+     * A category path is a slash delimited list of `categories`.`name` values where spaces in the
+     * name are represented by underscores. `/Categories/Medical_Record` is installed by default.
+     */
+    private const CATEGORY_PATH = "/Categories/Medical_Record";
+    private const INVALID_CATEGORY_PATH = "/Categories/No_Such_Category_Exists";
+
+    private const FILE_CONTENTS = "OpenEMR patient document API test payload.\n";
+    private const FILE_NAME = "document-api-test.txt";
+
+    private ApiTestClient $testClient;
+    private FixtureManager $fixtureManager;
+    private int $pid;
+
+    protected function setUp(): void
+    {
+        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
+        $this->testClient = new ApiTestClient($baseUrl, false);
+        $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+
+        $this->fixtureManager = new FixtureManager();
+        $patientFixture = $this->fixtureManager->getSinglePatientFixture();
+        $this->fixtureManager->installSinglePatientFixture($patientFixture);
+
+        $patient = $this->fetchRow(
+            "SELECT `pid` FROM `patient_data` WHERE `pubpid` = ?",
+            [$patientFixture['pubpid']]
+        );
+        if ($patient === null) {
+            self::fail("Patient fixture should have been installed");
+        }
+        $this->pid = $this->intColumn($patient, 'pid');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDocumentsForFixturePatient();
+        $this->fixtureManager->removePatientFixtures();
+        $this->testClient->cleanupRevokeAuth();
+        $this->testClient->cleanupClient();
+    }
+
+    #[Test]
+    public function testPostDocument(): void
+    {
+        $response = $this->postDocument();
+
+        $this->assertEquals(
+            200,
+            $response->getStatusCode(),
+            "Uploading a patient document should succeed: " . $response->getBody()
+        );
+        $this->assertTrue(
+            json_decode((string)$response->getBody(), true),
+            "The upload endpoint responds with a bare boolean rather than the created document"
+        );
+    }
+
+    #[Test]
+    public function testPostDocumentPersistsFileAgainstThePatientAndCategory(): void
+    {
+        $this->assertEquals(200, $this->postDocument()->getStatusCode());
+
+        $document = $this->fetchRow(
+            "SELECT d.`id`, d.`name`, d.`mimetype`, d.`deleted`, ctd.`category_id`
+             FROM `documents` d
+             JOIN `categories_to_documents` ctd ON ctd.`document_id` = d.`id`
+             WHERE d.`foreign_id` = ?",
+            [$this->pid]
+        );
+
+        if ($document === null) {
+            self::fail("The uploaded document should be persisted for the patient");
+        }
+        $this->assertEquals(self::FILE_NAME, $this->stringColumn($document, 'name'));
+        $this->assertEquals("text/plain", $this->stringColumn($document, 'mimetype'));
+        $this->assertEquals(0, $this->intColumn($document, 'deleted'));
+
+        $category = $this->fetchRow(
+            "SELECT `name` FROM `categories` WHERE `id` = ?",
+            [$this->intColumn($document, 'category_id')]
+        );
+        if ($category === null) {
+            self::fail("The document should be filed under an existing category");
+        }
+        $this->assertEquals(
+            "Medical Record",
+            $this->stringColumn($category, 'name'),
+            "The document should be filed under the category named in the path query parameter"
+        );
+    }
+
+    #[Test]
+    public function testPostDocumentWithEncounterId(): void
+    {
+        $encounterId = $this->createEncounter();
+
+        $response = $this->postDocument(['path' => self::CATEGORY_PATH, 'eid' => (string)$encounterId]);
+        $this->assertEquals(200, $response->getStatusCode(), (string)$response->getBody());
+
+        $document = $this->fetchRow(
+            "SELECT `encounter_id` FROM `documents` WHERE `foreign_id` = ?",
+            [$this->pid]
+        );
+        if ($document === null) {
+            self::fail("The uploaded document should be persisted for the patient");
+        }
+        $this->assertEquals(
+            $encounterId,
+            $this->intColumn($document, 'encounter_id'),
+            "The eid query parameter should tag the document with the encounter"
+        );
+    }
+
+    #[Test]
+    public function testPostDocumentWithInvalidCategoryPath(): void
+    {
+        $response = $this->postDocument(['path' => self::INVALID_CATEGORY_PATH]);
+
+        $this->assertEquals(
+            404,
+            $response->getStatusCode(),
+            "Uploading to a category that does not exist should be rejected"
+        );
+        $this->assertNull(
+            $this->fetchRow("SELECT `id` FROM `documents` WHERE `foreign_id` = ?", [$this->pid]),
+            "No document should be stored when the category path is invalid"
+        );
+    }
+
+    #[Test]
+    public function testPostDocumentWithUnknownPid(): void
+    {
+        $response = $this->testClient->postMultipart(
+            "/apis/default/api/patient/" . $this->unknownPid() . "/document",
+            [['name' => 'document', 'contents' => self::FILE_CONTENTS, 'filename' => self::FILE_NAME]],
+            ['path' => self::CATEGORY_PATH]
+        );
+
+        $this->assertEquals(
+            400,
+            $response->getStatusCode(),
+            "Uploading against a pid with no patient should be a bad request"
+        );
+        $body = json_decode((string)$response->getBody(), true);
+        $this->assertIsArray($body);
+        $this->assertArrayHasKey('validationErrors', $body);
+        $validationErrors = $body['validationErrors'];
+        $this->assertIsArray($validationErrors);
+        $this->assertArrayHasKey('pid', $validationErrors);
+    }
+
+    #[Test]
+    public function testPostDocumentWithoutAuthorization(): void
+    {
+        $this->testClient->removeAuthToken();
+        $response = $this->postDocument();
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function testGetAllAtPath(): void
+    {
+        $this->assertEquals(200, $this->postDocument()->getStatusCode());
+
+        $response = $this->testClient->get($this->documentEndpoint(), ['path' => self::CATEGORY_PATH]);
+        $this->assertEquals(200, $response->getStatusCode(), (string)$response->getBody());
+
+        $documents = json_decode((string)$response->getBody(), true);
+        $this->assertIsArray($documents);
+        $this->assertCount(1, $documents);
+
+        $document = $documents[0];
+        $this->assertIsArray($document);
+        $this->assertEquals(self::FILE_NAME, $document['filename']);
+        $this->assertEquals("text/plain", $document['mimetype']);
+        $this->assertNotEmpty($document['id']);
+        $this->assertNotEmpty($document['hash']);
+    }
+
+    #[Test]
+    public function testGetAllAtPathWithInvalidCategoryPath(): void
+    {
+        $response = $this->testClient->get($this->documentEndpoint(), ['path' => self::INVALID_CATEGORY_PATH]);
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function testGetAllAtPathWithUnknownPid(): void
+    {
+        $response = $this->testClient->get(
+            "/apis/default/api/patient/" . $this->unknownPid() . "/document",
+            ['path' => self::CATEGORY_PATH]
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function testGetAllAtPathWithoutAuthorization(): void
+    {
+        $this->testClient->removeAuthToken();
+        $response = $this->testClient->get($this->documentEndpoint(), ['path' => self::CATEGORY_PATH]);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    /**
+     * Pre-existing bug: `GET /api/patient/:pid/document/:did` is unusable over the REST API.
+     *
+     * DocumentService::getFile() constructs C_Document, whose constructor calls
+     * CsrfUtils::collectCsrfToken() against the active session. OAuth2AuthorizationListener only
+     * seeds `csrf_private_key` for `/oauth2/...` requests (its shouldProcessRequest() matches on a
+     * `/oauth2` base path), and AuthorizationController strips the key from the API session, so a
+     * bearer token request to `/apis/...` has no key. The constructor therefore throws and the
+     * request fails with a 500 before the document is ever read.
+     *
+     * This is not reachable through the UI download path (controller.php), which runs under a
+     * fully bootstrapped browser session. Once the API session carries a CSRF key, this endpoint
+     * serves the file correctly, so when that is fixed this test should assert a 200 with the
+     * uploaded bytes and a `Content-Disposition` attachment header carrying the stored filename.
+     */
+    #[Test]
+    public function testDownloadFileFailsBecauseTheApiSessionHasNoCsrfKey(): void
+    {
+        $this->assertEquals(200, $this->postDocument()->getStatusCode());
+        $documentId = $this->getUploadedDocumentId();
+
+        $response = $this->testClient->getOne($this->documentEndpoint(), (string)$documentId);
+
+        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertNotEquals(
+            self::FILE_CONTENTS,
+            (string)$response->getBody(),
+            "The endpoint fails before it reads the document"
+        );
+    }
+
+    #[Test]
+    public function testDownloadFileWithUnknownPid(): void
+    {
+        $this->assertEquals(200, $this->postDocument()->getStatusCode());
+        $documentId = $this->getUploadedDocumentId();
+
+        $response = $this->testClient->getOne(
+            "/apis/default/api/patient/" . $this->unknownPid() . "/document",
+            (string)$documentId
+        );
+
+        $this->assertEquals(
+            400,
+            $response->getStatusCode(),
+            "A document may not be retrieved through a pid that has no patient"
+        );
+        $this->assertNotEquals(self::FILE_CONTENTS, (string)$response->getBody());
+    }
+
+    #[Test]
+    public function testDownloadFileWithoutAuthorization(): void
+    {
+        $this->assertEquals(200, $this->postDocument()->getStatusCode());
+        $documentId = $this->getUploadedDocumentId();
+
+        $this->testClient->removeAuthToken();
+        $response = $this->testClient->getOne($this->documentEndpoint(), (string)$documentId);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    private function documentEndpoint(): string
+    {
+        return "/apis/default/api/patient/" . $this->pid . "/document";
+    }
+
+    /**
+     * A pid that is well formed but has no patient behind it.
+     */
+    private function unknownPid(): int
+    {
+        return $this->pid + 1000000;
+    }
+
+    /**
+     * @param array<string, string>|null $query
+     */
+    private function postDocument(?array $query = null): ResponseInterface
+    {
+        return $this->testClient->postMultipart(
+            $this->documentEndpoint(),
+            [
+                [
+                    'name' => 'document',
+                    'contents' => self::FILE_CONTENTS,
+                    'filename' => self::FILE_NAME,
+                    'headers' => ['Content-Type' => 'text/plain'],
+                ],
+            ],
+            $query ?? ['path' => self::CATEGORY_PATH]
+        );
+    }
+
+    private function getUploadedDocumentId(): int
+    {
+        $document = $this->fetchRow("SELECT `id` FROM `documents` WHERE `foreign_id` = ?", [$this->pid]);
+        if ($document === null) {
+            self::fail("Expected an uploaded document for the fixture patient");
+        }
+
+        return $this->intColumn($document, 'id');
+    }
+
+    private function createEncounter(): int
+    {
+        $encounterId = QueryUtils::sqlInsert(
+            "INSERT INTO `form_encounter` (`date`, `encounter`, `pid`, `reason`) VALUES (NOW(), ?, ?, ?)",
+            [1, $this->pid, 'document-api-test']
+        );
+        $this->assertGreaterThan(0, $encounterId, "Expected an encounter to be created for the fixture patient");
+
+        return $encounterId;
+    }
+
+    /**
+     * Removes any documents created against the fixture patient, including the files written to disk.
+     */
+    private function removeDocumentsForFixturePatient(): void
+    {
+        $documents = QueryUtils::fetchRecords(
+            "SELECT `id`, `url` FROM `documents` WHERE `foreign_id` = ?",
+            [$this->pid]
+        );
+        foreach ($documents as $document) {
+            $url = $document['url'] ?? null;
+            $filePath = is_string($url) ? preg_replace("|^file://|", "", $url) : null;
+            if ($filePath !== null && $filePath !== '' && is_file($filePath)) {
+                unlink($filePath);
+            }
+            $documentId = $this->intColumn($document, 'id');
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM `categories_to_documents` WHERE `document_id` = ?",
+                [$documentId]
+            );
+            QueryUtils::sqlStatementThrowException("DELETE FROM `documents` WHERE `id` = ?", [$documentId]);
+        }
+
+        QueryUtils::sqlStatementThrowException("DELETE FROM `form_encounter` WHERE `pid` = ?", [$this->pid]);
+    }
+
+    /**
+     * Fetches the first matching row, or null when the query matched nothing.
+     *
+     * @param list<mixed> $binds
+     * @return array<array-key, mixed>|null
+     */
+    private function fetchRow(string $sql, array $binds): ?array
+    {
+        $records = QueryUtils::fetchRecords($sql, $binds);
+
+        return $records[0] ?? null;
+    }
+
+    /**
+     * @param array<array-key, mixed> $row
+     */
+    private function stringColumn(array $row, string $column): string
+    {
+        $value = $row[$column] ?? null;
+        if (!is_string($value)) {
+            self::fail(sprintf("Expected column `%s` to be a string, got %s", $column, get_debug_type($value)));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<array-key, mixed> $row
+     */
+    private function intColumn(array $row, string $column): int
+    {
+        $value = $row[$column] ?? null;
+        if (!is_numeric($value)) {
+            self::fail(sprintf("Expected column `%s` to be numeric, got %s", $column, get_debug_type($value)));
+        }
+
+        return (int)$value;
+    }
+}


### PR DESCRIPTION
Fixes #13407

### What is being fixed

**1. Pid validation on the patient document endpoints**

`DocumentRestController` now rejects a `pid` that does not resolve to a patient with a `400` and a validation error, on all three endpoints. Previously `postWithPath()` passed the pid straight to `DocumentService::insertAtPath()` with no check, so an upload against a nonexistent pid returned `200` and wrote a `documents` row with `foreign_id` set to that pid — a stored document no patient chart would ever surface (repro and evidence in the issue).

The check uses `PatientService::getUuid()`, which is typed `false|string`, rather than `findByPid()` whose `@return PatientDataRow` docblock claims a non-nullable array but returns `false` at runtime.

**2. Test coverage, which is what surfaced the above**

These endpoints had none. `tests/Tests/Services/DocumentTest.php` covers the `\Document` model only; nothing exercised `DocumentRestController`, `DocumentService::insertAtPath()/getAllAtPath()/getFile()`, or the routes.

`DocumentApiTest` adds 13 tests:

- upload succeeds, and the document is persisted against the patient and filed under the category named in `path`
- the `eid` query parameter tags the document with the encounter
- an invalid category path is rejected and stores nothing
- an unknown pid returns `400` on all three endpoints
- an unauthenticated request returns `401` on all three endpoints
- listing returns the uploaded document with filename, mimetype and hash

`ApiTestClient` gains `postMultipart()` — it had no multipart support, so a file upload could not be exercised at all.

### Known issue deliberately not fixed here

`GET /api/patient/{pid}/document/{did}` returns a `500` for every API caller. `DocumentService::getFile()` constructs `C_Document`, whose constructor calls `CsrfUtils::collectCsrfToken()`; `OAuth2AuthorizationListener::shouldProcessRequest()` only seeds `csrf_private_key` for `/oauth2` requests and `AuthorizationController` strips it from the API session, so the constructor throws before the document is read. The UI path through `controller.php` is unaffected.

`testDownloadFileFailsBecauseTheApiSessionHasNoCsrfKey` records that behaviour and its root cause, so the test fails loudly when the endpoint starts working rather than drifting silently. This is called out in the issue and should be fixed separately.

### Testing

- `vendor/bin/phpunit --testsuite api` — 147 tests, 1122 assertions, passing (the one warning is pre-existing in `IntrospectionTest`)
- `prek run` over the changed files — codespell, `php -l`, phpcbf, PHP_CodeSniffer, PHPStan, Rector and Composer Require Checker all pass
- PHPStan level 10 clean with no new baseline entries
