### PR TITLE
fix(payments): Fix rendering bug in authorize.net payments

### DIFF
--- a/interface/patient_file/front_payment.php
+++ b/interface/patient_file/front_payment.php
@@ -1582,7 +1582,7 @@ function make_insurance() {
             // Important: gateway_api_key is NOT a sensitive value when used with Authorize.net (not true for other gateways!)
             ?>
             <script>
-                var ccerr = <?php echo xlj('Invalid Credit Card Number'); ?>
+                var ccerr = <?php echo xlj('Invalid Credit Card Number'); ?>;
                 var apiLoginID = <?php echo json_encode($cryptoGen->decryptFromDatabase($globalsBag->getString('gateway_api_key'))); ?>;
 
                     // In House CC number Validation

--- a/portal/portal_payment.php
+++ b/portal/portal_payment.php
@@ -1173,7 +1173,7 @@ if (($_POST['form_save'] ?? null) || ($_REQUEST['receipt'] ?? null)) {
         </div>
     </div>
     <script>
-        var ccerr = <?php echo xlj('Invalid Credit Card Number'); ?>
+        var ccerr = <?php echo xlj('Invalid Credit Card Number'); ?>;
 
         // In House CC number Validation
         /*$('#cardNumber').validateCreditCard(function (result) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:

front_payment.php — from openemr/openemr:8.0.0.3

Upstream bug: line ~1597 omits the semicolon after
`var ccerr = <?php echo xlj('Invalid Credit Card Number'); ?>`.
PHP's `?>` swallows the following newline, so ccerr and apiLoginID render on
one line with no separator -> "Uncaught SyntaxError: Unexpected token 'var'".
The whole <script> block fails to parse and sendPaymentDataToAnet() is never
defined, so Authorize.Net payments silently do nothing.

Only triggers when payment_gateway == 'AuthorizeNet'.
Still unfixed in upstream master as of 2026-08.
portal/portal_payment.php has the same omission but a blank line saves it.

#### Changes proposed in this pull request:

Simply adding the missing ";" to fix the bug.

#### Was an AI assistant used? Yes / No

I found the bug, and Claude found the file with the missing semi-colon, so I suppose it did assist, though I would have just grep-ed this in the past 🤷 .
