### PR TITLE
fix(health): stop sql.inc.php clobbering the $config install flag

### DIFF
--- a/library/sql.inc.php
+++ b/library/sql.inc.php
@@ -42,6 +42,8 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
  * @var string $secure_login
  * @var string $secure_pass
  * @var string $secure_dbase
+ * @var int    $config Install flag: 0 = setup required, 1 = installed.
+ *                     Must not be reassigned in this file or anything it loads.
  */
 
 if (!defined('ADODB_FETCH_ASSOC')) {
@@ -56,9 +58,12 @@ $ADODB_LASTDB = 'mysqli_log';
 // The OPENEMR_STATIC_ANALYSIS constant can be defined in static analysis tool bootstrap files
 if (!defined('OPENEMR_STATIC_ANALYSIS') || !OPENEMR_STATIC_ANALYSIS) {
     // Note: too early to use OEGlobalsBag reliably here.
-    $config = DatabaseConnectionOptions::forSite($GLOBALS['OE_SITE_DIR']);
+    // Do not name this $config: sqlconf.php owns that global as the int install
+    // flag, and consumers (index.php, setup.php, admin.php, Installer.class.php,
+    // the /meta/health/readyz probe) read it after bootstrap.
+    $connectionOptions = DatabaseConnectionOptions::forSite($GLOBALS['OE_SITE_DIR']);
     $persistent = DatabaseConnectionFactory::detectConnectionPersistenceFromGlobalState();
-    $database = DatabaseConnectionFactory::createAdodb($config, $persistent);
+    $database = DatabaseConnectionFactory::createAdodb($connectionOptions, $persistent);
     $GLOBALS['adodb']['db'] = $database;
     $GLOBALS['dbh'] = $database->_connectionID;
 

--- a/tests/Tests/Api/HealthEndpointTest.php
+++ b/tests/Tests/Api/HealthEndpointTest.php
@@ -84,7 +84,11 @@ class HealthEndpointTest extends TestCase
     }
 
     /**
-     * Test that readyz returns proper health check structure when installed
+     * Test that readyz returns proper health check structure
+     *
+     * The API suite runs against an installed instance, so these assertions are
+     * unconditional. Guarding them behind a status check let issue #13202 pass
+     * CI silently.
      */
     public function testReadyzReturnsHealthChecks(): void
     {
@@ -92,10 +96,35 @@ class HealthEndpointTest extends TestCase
         $body = json_decode((string) $response->getBody(), true);
         self::assertIsArray($body);
 
-        // If status is 'ready', we should have checks
-        if ($body['status'] === 'ready') {
-            $this->assertArrayHasKey('checks', $body, 'readyz response should have checks when ready');
-            $this->assertIsArray($body['checks'], 'checks should be an array');
-        }
+        $this->assertArrayHasKey('checks', $body, 'readyz response should have checks');
+        $this->assertIsArray($body['checks'], 'checks should be an array');
+    }
+
+    /**
+     * Regression test for issue #13202
+     *
+     * library/sql.inc.php reassigned the $config global during bootstrap,
+     * overwriting the sqlconf.php install flag with a DatabaseConnectionOptions
+     * object. InstallationCheck read the global after bootstrap, so a fully
+     * installed instance reported "setup_required" with installed: false while
+     * every other check passed.
+     */
+    public function testReadyzReportsInstalledOnAnInstalledInstance(): void
+    {
+        $response = $this->client->get('/meta/health/readyz');
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+
+        $this->assertArrayHasKey('checks', $body, 'readyz response should have checks');
+        $this->assertArrayHasKey('installed', $body['checks'], 'readyz checks should include installed');
+        $this->assertTrue(
+            $body['checks']['installed'],
+            'installed should be true on an installed instance (issue #13202)'
+        );
+        $this->assertEquals(
+            'ready',
+            $body['status'],
+            'readyz status should be "ready" on an installed instance (issue #13202)'
+        );
     }
 }

--- a/tests/Tests/Api/HealthEndpointTest.php
+++ b/tests/Tests/Api/HealthEndpointTest.php
@@ -116,6 +116,7 @@ class HealthEndpointTest extends TestCase
         self::assertIsArray($body);
 
         $this->assertArrayHasKey('checks', $body, 'readyz response should have checks');
+        self::assertIsArray($body['checks'], 'checks should be an array');
         $this->assertArrayHasKey('installed', $body['checks'], 'readyz checks should include installed');
         $this->assertTrue(
             $body['checks']['installed'],


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #13202. `GET /meta/health/readyz` reported `status: setup_required`
and `checks.installed: false` on a fully installed instance, while every
other check passed.

`sqlconf.php` owns `$config` as an int install flag (`0` = setup required,
`1` = installed). `library/sql.inc.php` reused the same name at global scope
for a `DatabaseConnectionOptions` object, overwriting the flag during
bootstrap. `InstallationCheck` reads the global *after* bootstrap, so it saw
the object rather than the flag and failed its `$config !== 1` test.

Only the health endpoint was affected: `index.php`, `setup.php`, `admin.php`
and `Installer.class.php` all read `$config` immediately after including
`sqlconf.php`, before bootstrap. `index.php` already documents the contract
with `@var int $config Defined in sqlconf.php`.

#### Changes proposed in this pull request:

1. **`fix(health)`** — rename the local in `library/sql.inc.php` to
   `$connectionOptions`, and document `$config` in that file's
   "Variables set by sqlconf.php" docblock, where it was missing.

   Verified safe: a repo-wide grep finds only two readers of the global —
   `meta/health/index.php:49` and `InstallationCheck:32` — and inside
   `sql.inc.php` the object is used only on the two adjacent lines. Nothing
   read `$config` expecting a `DatabaseConnectionOptions`. The only other
   global-scope `$config = 1` in `library/` is inside the single-quoted
   template string in `Installer.class.php` that generates `sqlconf.php`, so
   it is not an executed assignment.

2. **`test(health)`** — `testReadyzReturnsHealthChecks` guarded its assertions
   behind `if ($body['status'] === 'ready')`, so on a broken instance it
   passed by asserting nothing. That is why CI never caught this. The `api`
   suite runs after a CLI install, so those assertions are now unconditional,
   plus a dedicated regression test asserting `status: ready` and
   `checks.installed: true`.

#### Was an AI assistant used? Yes

`Assisted-by: Claude` trailer is on each commit.

---

## Noticed while working on this — possible separate issue

`HealthChecker::getResultsArray()` derives `status` **solely** from the
installation check:

```php
if ($result->name === InstallationCheck::NAME && !$result->healthy) {
    $isInstalled = false;
}
```

So a readiness probe returns `status: ready` even when `database`,
`session`, `oauth_keys` or `cache` report `false` — arguably worse than the
bug above, since Kubernetes would keep routing traffic to a pod with a dead
database. Not changed here because it alters the endpoint's contract and
would need a decision on what the degraded status should be. Happy to open a
separate issue if that's useful.
