### PR TITLE
chore(phpstan): make G10 trait suite-prefix helper deterministic

### DIFF
--- a/.phpstan/baseline/identical.alwaysFalse.php
+++ b/.phpstan/baseline/identical.alwaysFalse.php
@@ -207,11 +207,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/Search/SearchFieldStatementResolver.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Strict comparison using \\=\\=\\= between \'g10_certification\' and \'us_core_v311\' will always evaluate to false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Certification/HIT1/G10_Certification/SinglePatientApi/CapabilityStatementTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Strict comparison using \\=\\=\\= between OpenEMR\\\\FHIR\\\\R4\\\\FHIRElement\\\\FHIRCode and \'11341\\-5\' will always evaluate to false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/FHIR/Observation/FhirObservationEmployerServiceTest.php',

--- a/tests/Tests/Certification/HIT1/G10_Certification/Trait/G10ApiTestTrait.php
+++ b/tests/Tests/Certification/HIT1/G10_Certification/Trait/G10ApiTestTrait.php
@@ -118,13 +118,25 @@ trait G10ApiTestTrait
 
     protected function getTestSuitePrefix(): string
     {
-        if (self::TEST_SUITE === self::TEST_SUITE_US_CORE_V311) {
-            return 'us_core_v311-us_core_v311_fhir_api-us_core_v311_';
-        } elseif (self::TEST_SUITE === self::TEST_SUITE_G10_CERTIFICATION) {
-            return 'g10_certification-';
-        } else {
-            throw new \Exception("Unknown test suite: " . self::TEST_SUITE);
-        }
+        return self::prefixForSuite(self::TEST_SUITE);
+    }
+
+    /**
+     * Suite-name → id-prefix mapping. Extracted from getTestSuitePrefix() so
+     * the branching runs against a `string` parameter rather than the class-
+     * scoped `self::TEST_SUITE` constant. PHPStan can narrow a constant to a
+     * literal per consuming class, which produces environment-dependent
+     * always-true / always-false diagnostics (the specific class attribution
+     * changes with scan order). A string parameter stays opaque, so no
+     * always-anything report fires.
+     */
+    private static function prefixForSuite(string $suite): string
+    {
+        return match ($suite) {
+            self::TEST_SUITE_US_CORE_V311 => 'us_core_v311-us_core_v311_fhir_api-us_core_v311_',
+            self::TEST_SUITE_G10_CERTIFICATION => 'g10_certification-',
+            default => throw new \Exception("Unknown test suite: $suite"),
+        };
     }
     protected function renderResults(array $results, string $assertMessage, array $testIdsToSkipFailures = []): void
     {


### PR DESCRIPTION
Extract the suite-prefix lookup in `G10ApiTestTrait::getTestSuitePrefix()` to a private helper that takes the suite name as a `string` parameter, rather than branching on the class-scoped `self::TEST_SUITE` constant.

## Why

The prior form used

```php
if (self::TEST_SUITE === self::TEST_SUITE_US_CORE_V311) { ... }
elseif (self::TEST_SUITE === self::TEST_SUITE_G10_CERTIFICATION) { ... }
```

`self::TEST_SUITE` resolves to a literal per consuming class, so PHPStan sees one branch as always-false and the other as always-true. The always-false was baselined at `identical.alwaysFalse.php`, but the *specific class attribution* drifted with PHPStan's file/scan order across environments. Dev container libc, CI libc, Turbo extension on/off, and worker count all changed which concrete class "won" the attribution — I observed at least four different paths for the same diagnostic across five environments while working on #13333.

Every regeneration produced a different `identical.alwaysFalse.php`, which the baseline-stability check (added in #10703) correctly rejected.

## Fix

Route the branching through a helper that takes the suite name as a `string` parameter:

```php
protected function getTestSuitePrefix(): string
{
    return self::prefixForSuite(self::TEST_SUITE);
}

private static function prefixForSuite(string $suite): string
{
    return match ($suite) {
        self::TEST_SUITE_US_CORE_V311 => 'us_core_v311-us_core_v311_fhir_api-us_core_v311_',
        self::TEST_SUITE_G10_CERTIFICATION => 'g10_certification-',
        default => throw new \Exception("Unknown test suite: \$suite"),
    };
}
```

PHPStan cannot narrow a `string` parameter down to a specific literal at the helper's call site, so no always-anything diagnostic fires in any environment. The `identical.alwaysFalse.php` baseline entry that used to cover the branch is dropped as no-longer-needed.

## No behavior change

Same suite → prefix mapping applies. Unknown-suite exception message preserved.