### PR TITLE
fix(api): scope REST WRITE endpoints by patient/encounter

### DIFF
--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -5087,11 +5087,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/AllergyIntoleranceRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method deleteAppointmentRecord\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/AppointmentRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getAppointment\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/AppointmentRestController.php',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -33237,26 +33237,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/ListRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\ListRestController\\:\\:put\\(\\) has parameter \\$data with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/ListRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\ListRestController\\:\\:put\\(\\) has parameter \\$list_id with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/ListRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\ListRestController\\:\\:put\\(\\) has parameter \\$list_type with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/ListRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\ListRestController\\:\\:put\\(\\) has parameter \\$pid with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/ListRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\MessageRestController\\:\\:delete\\(\\) has parameter \\$mid with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/MessageRestController.php',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -32032,11 +32032,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/AllergyIntoleranceRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\AppointmentRestController\\:\\:delete\\(\\) has parameter \\$eid with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/AppointmentRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\AppointmentRestController\\:\\:getAllForPatientByUuid\\(\\) has parameter \\$puuid with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/AppointmentRestController.php',
@@ -38628,11 +38623,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\ListService\\:\\:searchLists\\(\\) has parameter \\$search with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/ListService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\ListService\\:\\:update\\(\\) has parameter \\$data with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/ListService.php',
 ];

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -22092,11 +22092,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/EncounterService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\EncounterService\\:\\:updateSoapNote\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/EncounterService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\EncounterService\\:\\:updateVital\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/EncounterService.php',
@@ -24138,11 +24133,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\ListService\\:\\:insert\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/ListService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\ListService\\:\\:update\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/ListService.php',
 ];

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -20957,11 +20957,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/ApiApplication.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\AppointmentRestController\\:\\:delete\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/AppointmentRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\AppointmentRestController\\:\\:getAllForPatientByUuid\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/AppointmentRestController.php',
@@ -21483,11 +21478,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\AppointmentService\\:\\:createEncounterForAppointment\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/AppointmentService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\AppointmentService\\:\\:deleteAppointmentRecord\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/AppointmentService.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -45283,21 +45283,16 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'begdate\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/ListService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'diagnosis\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/ListService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'enddate\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/ListService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'id\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/ListService.php',
 ];
@@ -45308,7 +45303,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'title\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/ListService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -40022,18 +40022,13 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'id\' on mixed\\.$#',
+    'message' => '#^Cannot access offset \'pid\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/ListRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'pid\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/RestControllers/ListRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'type\' on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/ListRestController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -6943,7 +6943,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../src/Services/EncounterService.php',
 ];
 $ignoreErrors[] = [
@@ -7088,7 +7088,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../src/Services/ListService.php',
 ];
 $ignoreErrors[] = [

--- a/apis/routes/_rest_routes_standard.inc.php
+++ b/apis/routes/_rest_routes_standard.inc.php
@@ -309,7 +309,7 @@ return [
 
         return $return;
     },
-    "PUT /api/patient/:pid/medication/:mid" => function ($pid, $mid, HttpRestRequest $request) {
+    "PUT /api/patient/:pid/medication/:mid" => function (string $pid, string $mid, HttpRestRequest $request) {
         RestConfig::request_authorization_check($request, "patients", "med");
         $data = (array) (json_decode(file_get_contents("php://input")));
         $return = (new ListRestController())->put($pid, $mid, "medication", $data);
@@ -354,7 +354,7 @@ return [
 
         return $return;
     },
-    "PUT /api/patient/:pid/surgery/:sid" => function ($pid, $sid, HttpRestRequest $request) {
+    "PUT /api/patient/:pid/surgery/:sid" => function (string $pid, string $sid, HttpRestRequest $request) {
         RestConfig::request_authorization_check($request, "patients", "med");
         $data = (array) (json_decode(file_get_contents("php://input")));
         $return = (new ListRestController())->put($pid, $sid, "surgery", $data);
@@ -387,7 +387,7 @@ return [
 
         return $return;
     },
-    "PUT /api/patient/:pid/dental_issue/:did" => function ($pid, $did, HttpRestRequest $request) {
+    "PUT /api/patient/:pid/dental_issue/:did" => function (string $pid, string $did, HttpRestRequest $request) {
         RestConfig::request_authorization_check($request, "patients", "med");
         $data = (array) (json_decode(file_get_contents("php://input")));
         $return = (new ListRestController())->put($pid, $did, "dental", $data);

--- a/apis/routes/_rest_routes_standard.inc.php
+++ b/apis/routes/_rest_routes_standard.inc.php
@@ -419,7 +419,7 @@ return [
 
         return $return;
     },
-    "DELETE /api/patient/:pid/appointment/:eid" => function ($pid, $eid, HttpRestRequest $request) {
+    "DELETE /api/patient/:pid/appointment/:eid" => function (string $pid, string $eid, HttpRestRequest $request) {
         RestConfig::request_authorization_check($request, "patients", "appt");
         $return = (new AppointmentRestController())->delete($pid, $eid);
 

--- a/apis/routes/_rest_routes_standard.inc.php
+++ b/apis/routes/_rest_routes_standard.inc.php
@@ -421,7 +421,7 @@ return [
     },
     "DELETE /api/patient/:pid/appointment/:eid" => function ($pid, $eid, HttpRestRequest $request) {
         RestConfig::request_authorization_check($request, "patients", "appt");
-        $return = (new AppointmentRestController())->delete($eid);
+        $return = (new AppointmentRestController())->delete($pid, $eid);
 
         return $return;
     },

--- a/src/RestControllers/AppointmentRestController.php
+++ b/src/RestControllers/AppointmentRestController.php
@@ -288,6 +288,7 @@ class AppointmentRestController
             new OA\Response(response: '200', ref: '#/components/responses/standard'),
             new OA\Response(response: '400', ref: '#/components/responses/badrequest'),
             new OA\Response(response: '401', ref: '#/components/responses/unauthorized'),
+            new OA\Response(response: '404', ref: '#/components/responses/uuidnotfound'),
         ],
         security: [['openemr_auth' => []]]
     )]

--- a/src/RestControllers/AppointmentRestController.php
+++ b/src/RestControllers/AppointmentRestController.php
@@ -18,6 +18,7 @@ use OpenEMR\RestControllers\RestControllerHelper;
 use OpenEMR\Services\AppointmentService;
 use OpenEMR\Services\PatientService;
 use OpenEMR\Validators\ProcessingResult;
+use Symfony\Component\HttpFoundation\Response;
 
 class AppointmentRestController
 {
@@ -290,13 +291,10 @@ class AppointmentRestController
         ],
         security: [['openemr_auth' => []]]
     )]
-    public function delete(mixed $pid, mixed $eid)
+    public function delete(string $pid, string $eid): Response
     {
         try {
-            // Verify the appointment belongs to the patient asserted by the URL
-            // before deleting, so an attacker who knows an eid cannot target a
-            // record on another patient's chart. Mirrors the pre-write ownership
-            // check pattern in EncounterService::updateVital().
+            // Scope deletion by pid so a leaked eid can't reach another patient's chart.
             $service = $this->appointmentService;
             assert($service instanceof AppointmentService);
             $existing = $service->getAppointment($eid);
@@ -306,7 +304,9 @@ class AppointmentRestController
             if (!is_numeric($existingPidRaw) || !is_numeric($pid) || (int) $existingPidRaw !== (int) $pid) {
                 return RestControllerHelper::responseHandler(['message' => 'record not found'], null, 404);
             }
-            $service->deleteAppointmentRecord($eid);
+            if (!$service->deleteAppointmentRecord($eid, (int) $pid)) {
+                return RestControllerHelper::responseHandler(['message' => 'record not found'], null, 404);
+            }
             $serviceResult = ['message' => 'record deleted'];
         } catch (\Throwable $exception) {
             ServiceContainer::getLogger()->error($exception->getMessage(), ['exception' => $exception, 'eid' => $eid]);

--- a/src/RestControllers/AppointmentRestController.php
+++ b/src/RestControllers/AppointmentRestController.php
@@ -290,10 +290,23 @@ class AppointmentRestController
         ],
         security: [['openemr_auth' => []]]
     )]
-    public function delete($eid)
+    public function delete(mixed $pid, mixed $eid)
     {
         try {
-            $this->appointmentService->deleteAppointmentRecord($eid);
+            // Verify the appointment belongs to the patient asserted by the URL
+            // before deleting, so an attacker who knows an eid cannot target a
+            // record on another patient's chart. Mirrors the pre-write ownership
+            // check pattern in EncounterService::updateVital().
+            $service = $this->appointmentService;
+            assert($service instanceof AppointmentService);
+            $existing = $service->getAppointment($eid);
+            $existingPidRaw = (is_array($existing) && isset($existing[0]) && is_array($existing[0]))
+                ? ($existing[0]['pid'] ?? null)
+                : null;
+            if (!is_numeric($existingPidRaw) || !is_numeric($pid) || (int) $existingPidRaw !== (int) $pid) {
+                return RestControllerHelper::responseHandler(['message' => 'record not found'], null, 404);
+            }
+            $service->deleteAppointmentRecord($eid);
             $serviceResult = ['message' => 'record deleted'];
         } catch (\Throwable $exception) {
             ServiceContainer::getLogger()->error($exception->getMessage(), ['exception' => $exception, 'eid' => $eid]);

--- a/src/RestControllers/EncounterRestController.php
+++ b/src/RestControllers/EncounterRestController.php
@@ -797,6 +797,7 @@ class EncounterRestController
             new OA\Response(response: '200', ref: '#/components/responses/standard'),
             new OA\Response(response: '400', ref: '#/components/responses/badrequest'),
             new OA\Response(response: '401', ref: '#/components/responses/unauthorized'),
+            new OA\Response(response: '404', ref: '#/components/responses/uuidnotfound'),
         ],
         security: [['openemr_auth' => []]]
     )]

--- a/src/RestControllers/ListRestController.php
+++ b/src/RestControllers/ListRestController.php
@@ -327,8 +327,7 @@ class ListRestController
             return $validationHandlerResult;
         }
 
-
-        $serviceResult = $this->listService->update($data);
+        $serviceResult = $this->listService->update($pid, $list_id, $list_type, $data);
         return RestControllerHelper::responseHandler($serviceResult, ['id' => $list_id], 200);
     }
 

--- a/src/RestControllers/ListRestController.php
+++ b/src/RestControllers/ListRestController.php
@@ -277,6 +277,7 @@ class ListRestController
             new OA\Response(response: '200', ref: '#/components/responses/standard'),
             new OA\Response(response: '400', ref: '#/components/responses/badrequest'),
             new OA\Response(response: '401', ref: '#/components/responses/unauthorized'),
+            new OA\Response(response: '404', ref: '#/components/responses/uuidnotfound'),
         ],
         security: [['openemr_auth' => []]]
     )]
@@ -296,6 +297,7 @@ class ListRestController
             new OA\Response(response: '200', ref: '#/components/responses/standard'),
             new OA\Response(response: '400', ref: '#/components/responses/badrequest'),
             new OA\Response(response: '401', ref: '#/components/responses/unauthorized'),
+            new OA\Response(response: '404', ref: '#/components/responses/uuidnotfound'),
         ],
         security: [['openemr_auth' => []]]
     )]
@@ -315,6 +317,7 @@ class ListRestController
             new OA\Response(response: '200', ref: '#/components/responses/standard'),
             new OA\Response(response: '400', ref: '#/components/responses/badrequest'),
             new OA\Response(response: '401', ref: '#/components/responses/unauthorized'),
+            new OA\Response(response: '404', ref: '#/components/responses/uuidnotfound'),
         ],
         security: [['openemr_auth' => []]]
     )]

--- a/src/RestControllers/ListRestController.php
+++ b/src/RestControllers/ListRestController.php
@@ -258,6 +258,9 @@ class ListRestController
         return RestControllerHelper::responseHandler($serviceResult, ['id' => $serviceResult], 201);
     }
 
+    /**
+     * @param array<int|string, mixed> $data
+     */
     #[OA\Put(
         path: '/api/patient/{pid}/dental_issue/{did}',
         description: 'Edit a dental issue',
@@ -315,7 +318,7 @@ class ListRestController
         ],
         security: [['openemr_auth' => []]]
     )]
-    public function put($pid, $list_id, $list_type, $data)
+    public function put(string $pid, string $list_id, string $list_type, array $data)
     {
         $data['type'] = $list_type;
         $data['pid'] = $pid;

--- a/src/Services/AppointmentService.php
+++ b/src/Services/AppointmentService.php
@@ -496,8 +496,10 @@ class AppointmentService extends BaseService
         }
         $affected = QueryUtils::affectedRows();
         $deleted = is_int($affected) && $affected > 0;
-        $servicePostDeleteEvent = new ServiceDeleteEvent($this, $eid);
-        $this->getEventDispatcher()->dispatch($servicePostDeleteEvent, ServiceDeleteEvent::EVENT_POST_DELETE);
+        if ($deleted) {
+            $servicePostDeleteEvent = new ServiceDeleteEvent($this, $eid);
+            $this->getEventDispatcher()->dispatch($servicePostDeleteEvent, ServiceDeleteEvent::EVENT_POST_DELETE);
+        }
         return $deleted;
     }
 

--- a/src/Services/AppointmentService.php
+++ b/src/Services/AppointmentService.php
@@ -482,13 +482,23 @@ class AppointmentService extends BaseService
         }
     }
 
-    public function deleteAppointmentRecord($eid)
+    public function deleteAppointmentRecord($eid, ?int $pid = null): bool
     {
         $servicePreDeleteEvent = new ServiceDeleteEvent($this, $eid);
         $this->getEventDispatcher()->dispatch($servicePreDeleteEvent, ServiceDeleteEvent::EVENT_PRE_DELETE);
-        QueryUtils::sqlStatementThrowException("DELETE FROM openemr_postcalendar_events WHERE pc_eid = ?", $eid);
+        if ($pid !== null) {
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM openemr_postcalendar_events WHERE pc_eid = ? AND pc_pid = ?",
+                [$eid, $pid]
+            );
+        } else {
+            QueryUtils::sqlStatementThrowException("DELETE FROM openemr_postcalendar_events WHERE pc_eid = ?", $eid);
+        }
+        $affected = QueryUtils::affectedRows();
+        $deleted = is_int($affected) && $affected > 0;
         $servicePostDeleteEvent = new ServiceDeleteEvent($this, $eid);
         $this->getEventDispatcher()->dispatch($servicePostDeleteEvent, ServiceDeleteEvent::EVENT_POST_DELETE);
+        return $deleted;
     }
 
     /**

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -542,14 +542,17 @@ class EncounterService extends BaseService
             return null;
         }
 
-        $sql = " UPDATE form_soap SET";
-        $sql .= "     date=NOW(),";
-        $sql .= "     activity=1,";
-        $sql .= "     subjective=?,";
-        $sql .= "     objective=?,";
-        $sql .= "     assessment=?,";
-        $sql .= "     plan=?";
-        $sql .= " WHERE id=? AND encounter=? AND pid=?";
+        // form_soap has no encounter column; join forms.form_id and filter
+        // through forms.encounter (matches getSoapNote).
+        $sql = " UPDATE form_soap AS fs";
+        $sql .= " JOIN forms AS fo ON fo.form_id = fs.id AND fo.formdir = 'soap'";
+        $sql .= " SET fs.date=NOW(),";
+        $sql .= "     fs.activity=1,";
+        $sql .= "     fs.subjective=?,";
+        $sql .= "     fs.objective=?,";
+        $sql .= "     fs.assessment=?,";
+        $sql .= "     fs.plan=?";
+        $sql .= " WHERE fs.id=? AND fo.encounter=? AND fs.pid=?";
 
         return sqlStatement(
             $sql,

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -565,8 +565,9 @@ class EncounterService extends BaseService
                 $pid,
             ]
         );
-        $affected = QueryUtils::affectedRows();
-        return is_int($affected) && $affected > 0 ? $affected : 0;
+        // Pre-check confirmed the row exists; treat as success even if MySQL
+        // reports 0 changed rows (client resubmitted identical values).
+        return 1;
     }
 
     public function updateVital($pid, $eid, $vid, $data)

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -532,14 +532,13 @@ class EncounterService extends BaseService
         return [$soapResults, $formResults];
     }
 
-    public function updateSoapNote($pid, $eid, $sid, $data)
+    public function updateSoapNote($pid, $eid, $sid, $data): int
     {
-        // Verify the SOAP note belongs to this patient/encounter before updating
-        // to prevent IDOR where an attacker supplies another record's sid; matches
-        // the ownership pre-check pattern in updateVital().
+        // Scope by pid+eid so a leaked sid can't rewrite another record.
+        // Returns affected-row count so the REST caller can distinguish 200 from 404.
         $existingSoapNote = $this->getSoapNote($pid, $eid, $sid);
         if (!is_array($existingSoapNote) || ($existingSoapNote === [])) {
-            return null;
+            return 0;
         }
 
         // form_soap has no encounter column; join forms.form_id and filter
@@ -554,7 +553,7 @@ class EncounterService extends BaseService
         $sql .= "     fs.plan=?";
         $sql .= " WHERE fs.id=? AND fo.encounter=? AND fs.pid=?";
 
-        return sqlStatement(
+        QueryUtils::sqlStatementThrowException(
             $sql,
             [
                 $data["subjective"],
@@ -566,6 +565,8 @@ class EncounterService extends BaseService
                 $pid,
             ]
         );
+        $affected = QueryUtils::affectedRows();
+        return is_int($affected) && $affected > 0 ? $affected : 0;
     }
 
     public function updateVital($pid, $eid, $vid, $data)

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -534,25 +534,33 @@ class EncounterService extends BaseService
 
     public function updateSoapNote($pid, $eid, $sid, $data)
     {
+        // Verify the SOAP note belongs to this patient/encounter before updating
+        // to prevent IDOR where an attacker supplies another record's sid; matches
+        // the ownership pre-check pattern in updateVital().
+        $existingSoapNote = $this->getSoapNote($pid, $eid, $sid);
+        if (!is_array($existingSoapNote) || ($existingSoapNote === [])) {
+            return null;
+        }
+
         $sql = " UPDATE form_soap SET";
         $sql .= "     date=NOW(),";
         $sql .= "     activity=1,";
-        $sql .= "     pid=?,";
         $sql .= "     subjective=?,";
         $sql .= "     objective=?,";
         $sql .= "     assessment=?,";
         $sql .= "     plan=?";
-        $sql .= "     where id=?";
+        $sql .= " WHERE id=? AND encounter=? AND pid=?";
 
         return sqlStatement(
             $sql,
             [
-                $pid,
                 $data["subjective"],
                 $data["objective"],
                 $data["assessment"],
                 $data["plan"],
-                $sid
+                $sid,
+                $eid,
+                $pid,
             ]
         );
     }

--- a/src/Services/ListService.php
+++ b/src/Services/ListService.php
@@ -214,8 +214,17 @@ class ListService
     public function update(string $pid, string $list_id, string $list_type, array $data): int
     {
         // Scope by pid+type so a leaked list_id can't rewrite a record on
-        // another patient's chart or under a different list type. Returns
-        // affected-row count so the REST caller can distinguish 200 from 404.
+        // another patient's chart or under a different list type. Pre-check
+        // via SELECT drives the 200/404 outcome — affected rows would falsely
+        // 404 when the client resubmits identical values.
+        $existing = QueryUtils::querySingleRow(
+            "SELECT id FROM lists WHERE id=? AND pid=? AND type=?",
+            [$list_id, $pid, $list_type]
+        );
+        if (!is_array($existing) || $existing === []) {
+            return 0;
+        }
+
         $sql  = " UPDATE lists SET";
         $sql .= "     title=?,";
         $sql .= "     begdate=?,";
@@ -235,8 +244,7 @@ class ListService
                 $list_type,
             ]
         );
-        $affected = QueryUtils::affectedRows();
-        return is_int($affected) && $affected > 0 ? $affected : 0;
+        return 1;
     }
 
     public function delete($pid, $list_id, $list_type)

--- a/src/Services/ListService.php
+++ b/src/Services/ListService.php
@@ -211,10 +211,11 @@ class ListService
     /**
      * @param array<string, mixed> $data
      */
-    public function update(string $pid, string $list_id, string $list_type, array $data)
+    public function update(string $pid, string $list_id, string $list_type, array $data): int
     {
         // Scope by pid+type so a leaked list_id can't rewrite a record on
-        // another patient's chart or under a different list type.
+        // another patient's chart or under a different list type. Returns
+        // affected-row count so the REST caller can distinguish 200 from 404.
         $sql  = " UPDATE lists SET";
         $sql .= "     title=?,";
         $sql .= "     begdate=?,";
@@ -222,7 +223,7 @@ class ListService
         $sql .= "     diagnosis=?";
         $sql .= " WHERE id=? AND pid=? AND type=?";
 
-        return sqlStatement(
+        QueryUtils::sqlStatementThrowException(
             $sql,
             [
                 $data["title"],
@@ -234,6 +235,8 @@ class ListService
                 $list_type,
             ]
         );
+        $affected = QueryUtils::affectedRows();
+        return is_int($affected) && $affected > 0 ? $affected : 0;
     }
 
     public function delete($pid, $list_id, $list_type)

--- a/src/Services/ListService.php
+++ b/src/Services/ListService.php
@@ -208,14 +208,20 @@ class ListService
         );
     }
 
-    public function update($data)
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function update(mixed $pid, mixed $list_id, mixed $list_type, array $data)
     {
+        // Scope by pid+type so an attacker who knows a list_id cannot rewrite
+        // a record on another patient's chart or under a different list type
+        // (medication vs surgery vs dental). Signature mirrors delete() above.
         $sql  = " UPDATE lists SET";
         $sql .= "     title=?,";
         $sql .= "     begdate=?,";
         $sql .= "     enddate=?,";
         $sql .= "     diagnosis=?";
-        $sql .= " WHERE id=?";
+        $sql .= " WHERE id=? AND pid=? AND type=?";
 
         return sqlStatement(
             $sql,
@@ -224,7 +230,9 @@ class ListService
                 $data["begdate"],
                 $data["enddate"],
                 $data["diagnosis"],
-                $data["id"]
+                $list_id,
+                $pid,
+                $list_type,
             ]
         );
     }

--- a/src/Services/ListService.php
+++ b/src/Services/ListService.php
@@ -211,11 +211,10 @@ class ListService
     /**
      * @param array<string, mixed> $data
      */
-    public function update(mixed $pid, mixed $list_id, mixed $list_type, array $data)
+    public function update(string $pid, string $list_id, string $list_type, array $data)
     {
-        // Scope by pid+type so an attacker who knows a list_id cannot rewrite
-        // a record on another patient's chart or under a different list type
-        // (medication vs surgery vs dental). Signature mirrors delete() above.
+        // Scope by pid+type so a leaked list_id can't rewrite a record on
+        // another patient's chart or under a different list type.
         $sql  = " UPDATE lists SET";
         $sql .= "     title=?,";
         $sql .= "     begdate=?,";

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -1556,6 +1556,8 @@ paths:
           $ref: '#/components/responses/badrequest'
         401:
           $ref: '#/components/responses/unauthorized'
+        404:
+          $ref: '#/components/responses/uuidnotfound'
       security:
         -
           openemr_auth: {  }
@@ -1730,6 +1732,8 @@ paths:
           $ref: '#/components/responses/badrequest'
         401:
           $ref: '#/components/responses/unauthorized'
+        404:
+          $ref: '#/components/responses/uuidnotfound'
       security:
         -
           openemr_auth: {  }
@@ -1981,6 +1985,8 @@ paths:
           $ref: '#/components/responses/badrequest'
         401:
           $ref: '#/components/responses/unauthorized'
+        404:
+          $ref: '#/components/responses/uuidnotfound'
       security:
         -
           openemr_auth: {  }
@@ -2270,6 +2276,8 @@ paths:
           $ref: '#/components/responses/badrequest'
         401:
           $ref: '#/components/responses/unauthorized'
+        404:
+          $ref: '#/components/responses/uuidnotfound'
       security:
         -
           openemr_auth: {  }
@@ -2509,6 +2517,8 @@ paths:
           $ref: '#/components/responses/badrequest'
         401:
           $ref: '#/components/responses/unauthorized'
+        404:
+          $ref: '#/components/responses/uuidnotfound'
       security:
         -
           openemr_auth: {  }

--- a/tests/Tests/Isolated/RestControllers/EncounterRestControllerTest.php
+++ b/tests/Tests/Isolated/RestControllers/EncounterRestControllerTest.php
@@ -391,7 +391,7 @@ class EncounterRestControllerTest extends TestCase
         $this->encounterService->expects($this->once())
             ->method('updateSoapNote')
             ->with('1', '2', '3', ['subjective' => 'updated'])
-            ->willReturn(true);
+            ->willReturn(1);
 
         $response = $this->controller->putSoapNote('1', '2', '3', ['subjective' => 'updated']);
 


### PR DESCRIPTION
Several `/api/patient/:pid/...` write endpoints accepted the `:pid` in the URL but the underlying service method's SQL `WHERE` clause did not include it, so a caller who knew a record's primary key could rewrite or delete it regardless of which patient the URL asserted. Mirror the read-side WHERE clause (or add a pre-write ownership check) so writes are bound to the URL-asserted patient/encounter.

## Affected service methods (5 REST endpoints, 3 service edits)

- **`EncounterService::updateSoapNote`** — was `UPDATE ... WHERE id=?` and wrote `pid=?` in `SET` (letting the caller reassign the note to any patient). Now pre-check via `getSoapNote()` and `UPDATE ... WHERE id=? AND encounter=? AND pid=?` (drop `pid=?` from `SET`).
  Route: `PUT /api/patient/:pid/encounter/:eid/soap_note/:sid`

- **`ListService::update`** — was `UPDATE lists ... WHERE id=?` with no patient or type scoping despite the controller populating those in `$data`. Now `WHERE id=? AND pid=? AND type=?`, signature mirrors `delete()` above (`$pid, $list_id, $list_type, $data`).
  Routes: `PUT /api/patient/:pid/{medication,surgery,dental_issue}/:mid`

- **`AppointmentRestController::delete`** — was passing only `$eid` to `AppointmentService::deleteAppointmentRecord` (which deletes by `pc_eid` alone). Now the controller pre-checks via `getAppointment()` and only deletes when `pd.pid` matches the URL-asserted patient.
  Route: `DELETE /api/patient/:pid/appointment/:eid`

## Already-safe write endpoints (verified, no change)

- `MessageService::update` and `delete` (`WHERE pid=? AND id=?`)
- `ListService::delete` (`WHERE pid=? AND id=? AND type=?`)
- `EncounterService::updateVital` (explicit pre-write ownership check)

## Baselines

3 files shrink (fewer mixed-offset / method-on-mixed / missing-parameter suppressions needed once the WHERE clauses and signatures are tightened).