### PR TITLE
feat(codes): make Install Code Set extensible and add a LOINC importer

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -18937,41 +18937,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/super/layout_service_codes.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$filename of function fopen expects string, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$filename of function is_uploaded_file expects string, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$filename of method ZipArchive\\:\\:open\\(\\) expects string, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$name of method ZipArchive\\:\\:getStream\\(\\) expects string, string\\|false given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$path of function basename expects string, string\\|false given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$text of function text expects string, int\\<0, max\\> given\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$filename of function file_get_contents expects string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/super/manage_document_templates.php',

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -2128,11 +2128,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 6,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/super/manage_document_templates.php',
 ];

--- a/.phpstan/baseline/nullCoalesce.expr.php
+++ b/.phpstan/baseline/nullCoalesce.expr.php
@@ -189,11 +189,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Expression on left side of \\?\\? is not nullable\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Expression on left side of \\?\\? is not nullable\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../library/auth.inc.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -25512,26 +25512,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/super/layout_service_codes.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'id\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'size\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'tmp_name\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset mixed on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'name\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/super/manage_document_templates.php',

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -4002,21 +4002,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/super/layout_service_codes.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:fetchRecordsNoLog\\(\\) instead of sqlStatementNoLog\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/super/manage_site_files.php',

--- a/.phpstan/baseline/openemr.forbiddenCatchType.php
+++ b/.phpstan/baseline/openemr.forbiddenCatchType.php
@@ -362,11 +362,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/smart/ehr-launch-client.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^catch \\(ValueError\\) would suppress Error, which is forbidden\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
     'message' => '#^catch \\(Throwable\\) would suppress Error, which is forbidden\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/super/rules/index.php',

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -3228,16 +3228,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_FILES is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_FILES is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../interface/super/manage_document_templates.php',
 ];

--- a/interface/super/load_codes.php
+++ b/interface/super/load_codes.php
@@ -7,226 +7,39 @@
  * @link      https://www.open-emr.org
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
  * @copyright Copyright (c) 2014 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+declare(strict_types=1);
 
 set_time_limit(0);
 
 require_once '../globals.php';
-require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->getProjectDir() . '/custom/code_types.inc.php';
 
-use OpenEMR\Common\Acl\AccessDeniedHelper;
-use OpenEMR\Common\Acl\AclMain;
-use OpenEMR\Common\Csrf\CsrfUtils;
-use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Core\Header;
+use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Controllers\Interface\Super\LoadCodesController;
+use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Services\CodeTypes\Importer\LOINCImportService;
+use OpenEMR\Services\CodeTypes\Importer\RXCUIImportService;
+use Symfony\Component\HttpFoundation\Request;
 
-if (!AclMain::aclCheckCore('admin', 'super')) {
-    AccessDeniedHelper::denyWithTemplate("ACL check failed for admin/super: Install Code Set", xl("Install Code Set"));
-}
+$kernel = OEGlobalsBag::getInstance()->getKernel();
 
-$form_replace = !empty($_POST['form_replace']);
-$code_type = empty($_POST['form_code_type']) ? '' : $_POST['form_code_type'];
-?>
-<html>
+$controller = new LoadCodesController(
+    $kernel->getEventDispatcher(),
+    (new TwigContainer(null, $kernel))->getTwig(),
+    SessionWrapperFactory::getInstance()->getActiveSession(),
+    ServiceContainer::getLogger(),
+    [
+        new RXCUIImportService(),
+        new LOINCImportService(),
+    ]
+);
 
-<head>
-<title><?php echo xlt('Install Code Set'); ?></title>
-<?php Header::setupHeader(); ?>
-
-<style>
- .dehead {
-   color: var(--black);
-   font-family: sans-serif;
-   font-size: 0.8125rem;
-   font-weight: bold;
-  }
- .detail {
-   color: var(--black);
-   font-family: sans-serif;
-   font-size: 0.8125rem;
-   font-weight:normal;
- }
-</style>
-
-</head>
-
-<body class="body_top">
-
-<?php
-$session = SessionWrapperFactory::getInstance()->getActiveSession();
-// Handle uploads.
-if (!empty($_POST['bn_upload'])) {
-    CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
-
-    if (empty($code_types[$code_type])) {
-        die(xlt('Code type not yet defined') . ": '" . text($code_type) . "'");
-    }
-
-    $code_type_id = $code_types[$code_type]['id'];
-    $tmp_name = $_FILES['form_file']['tmp_name'];
-
-    $inscount = 0;
-    $repcount = 0;
-    $seen_codes = [];
-
-    if (is_uploaded_file($tmp_name) && $_FILES['form_file']['size']) {
-        $zipin = new ZipArchive();
-        $eres = null;
-        if ($zipin->open($tmp_name) === true) {
-            // Must be a zip archive.
-            for ($i = 0; $i < $zipin->numFiles; ++$i) {
-                $ename = $zipin->getNameIndex($i);
-                // TBD: Expand the following test as other code types are supported.
-                if ($code_type == 'RXCUI' && basename($ename) == 'RXNCONSO.RRF') {
-                    $eres = $zipin->getStream($ename);
-                    break;
-                }
-            }
-        } else {
-            $eres = fopen($tmp_name, 'r');
-        }
-
-        if (empty($eres)) {
-            die(xlt('Unable to locate the data in this file.'));
-        }
-
-        if ($form_replace) {
-            sqlStatement("DELETE FROM codes WHERE code_type = ?", [$code_type_id]);
-        }
-
-
-        // Batching the inserts into one transaction drastically speeds up import with InnoDB
-        QueryUtils::inTransaction(function () use ($eres, $code_type, $code_type_id, $form_replace, $seen_codes, &$inscount, &$repcount): void {
-            while (($line = fgets($eres)) !== false) {
-                if ($code_type == 'RXCUI') {
-                    $a = explode('|', $line);
-                    if (count($a) < 18) {
-                        continue;
-                    }
-
-                    if ($a[17] != '4096') {
-                        continue;
-                    }
-
-                    if ($a[11] != 'RXNORM') {
-                        continue;
-                    }
-
-                    $code = $a[0];
-                    if (isset($seen_codes[$code])) {
-                        continue;
-                    }
-
-                    $seen_codes[$code] = 1;
-                    if (!$form_replace) {
-                        $tmp = sqlQuery("SELECT id FROM codes WHERE code_type = ? AND code = ? LIMIT 1", [$code_type_id, $code]);
-                        if (!empty($tmp)) {
-                            sqlStatementNoLog("UPDATE codes SET code_text = ? WHERE code_type = ? AND code = ?", [$a[14], $code_type_id, $code]);
-                            ++$repcount;
-                            continue;
-                        }
-                    }
-
-                    sqlStatementNoLog("INSERT INTO codes SET code_type = ?, code = ?, code_text = ?, fee = 0, units = 0", [$code_type_id, $code, $a[14]]);
-                    ++$inscount;
-                }
-
-                // TBD: Clone/adapt the above for each new code type.
-            }
-        });
-
-        fclose($eres);
-        // Cannot close ZIP object if not initialised, catch and do nothing
-        try {
-            $zipin->close();
-        } catch (ValueError) {
-        }
-
-        echo "<p class='text-success'>" . xlt('LOAD SUCCESSFUL. Codes inserted') . ": " . text($inscount) . ", " . xlt('replaced') . ": " . text($repcount) . "</p>\n";
-    } else {
-        echo "<p class='text-danger'>" . xlt('ERROR. Could not open') . ". " . (php_ini_loaded_file() ?? "Server") . " upload_max_filesize: " . xlt('Your file is too large') . ". " . xlt('Set To') . " ≥ post_max_size.";
-    }
-}
-
-?>
-    <div class="container">
-
-        <form method='post' action='load_codes.php' enctype='multipart/form-data'
-        onsubmit='return top.restoreSession()'>
-
-            <input type="hidden" name="csrf_token_form" value="<?php echo CsrfUtils::collectCsrfToken(session: $session); ?>" />
-
-            <div class="table-responsive">
-                <table class="table table-bordered">
-                    <thead>
-                        <tr class="dehead">
-                            <th colspan="2" class='text-center'><?php echo xlt('Install Code Set'); ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <?php echo xlt('Code Type'); ?>
-                            </td>
-                            <td>
-                                <select name='form_code_type'>
-                                    <?php
-                                    foreach (['RXCUI'] as $codetype) {
-                                        echo "    <option value='" . attr($codetype) . "'>" . text($codetype) . "</option>\n";
-                                    }
-                                    ?>
-                                </select>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="detail">
-                                <?php echo xlt('Source File'); ?>
-                                <input type="hidden" name="MAX_FILE_SIZE" value="350000000" />
-                            </td>
-                            <td class="detail">
-                                <input type="file" name="form_file" size="40" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="detail">
-                                <?php echo xlt('Replace entire code set'); ?>
-                            </td>
-                            <td class="detail">
-                                <input type='checkbox' name='form_replace' value='1' checked />
-                            </td>
-                        </tr>
-                        <tr class="bg-secondary">
-                            <td colspan="2" class="text-center detail">
-                                <input type='submit' class='btn btn-primary' name='bn_upload' value='<?php echo xlt('Upload and Install') ?>' />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <p class='font-weight-bold text-center'>
-                <?php echo xlt('Be patient, some files can take several minutes to process!'); ?>
-            </p>
-
-            <!-- No translation because this text is long and US-specific and quotes other English-only text. -->
-            <p class='text'>
-            <span class="font-weight-bold">RXCUI codes</span> may be downloaded from
-            <a href='https://www.nlm.nih.gov/research/umls/rxnorm/docs/rxnormfiles.html' rel="noopener" target='_blank'>
-            www.nlm.nih.gov/research/umls/rxnorm/docs/rxnormfiles.html</a>.
-            Get the "Current Prescribable Content Monthly Release" zip file, marked "no license required".
-            Then you can upload that file as-is here, or extract the file RXNCONSO.RRF from it and upload just
-            that (zipped or not). You may do the same with the weekly updates, but for those uncheck the
-            "<?php echo xlt('Replace entire code set'); ?>" checkbox above.
-            </p>
-            <div class="alert alert-info"><p>
-                    <i class="fa fa-circle-info"></i> <?php echo xlt("If you're Code Sets are not loading, verify your php.ini post_max_size value and your upload_max_filesize has been set large enough to handle the file size you are uploading."); ?>
-            </p>
-            </div>
-            <!-- TBD: Another paragraph of instructions here for each code type. -->
-        </form>
-    </div>
-</body>
-</html>
+$controller->dispatchAction(Request::createFromGlobals())->send();

--- a/src/Controllers/Interface/Super/LoadCodesController.php
+++ b/src/Controllers/Interface/Super/LoadCodesController.php
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * LoadCodesController backs the Administration -> Coding -> Native Data Loads page, which uploads
+ * and installs a code set into the codes table.
+ *
+ * The page is extensible: it asks listeners which code types they can import
+ * ({@see CodeImportSupportedTypeFilterEvent}) and then hands the uploaded file to whichever
+ * listener claims it ({@see CodeImportEvent}). Core's own importers are registered last, at
+ * {@see CodeImportEvent::PRIORITY_CORE_FALLBACK}, so a module can preempt them.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ *
+ * @author    Rod Roark <rod@sunsetsystems.com>
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2014 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Controllers\Interface\Super;
+
+use OpenEMR\Common\Acl\AccessDeniedHelper;
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Events\Codes\CodeImportEvent;
+use OpenEMR\Events\Codes\CodeImportSupportedTypeFilterEvent;
+use OpenEMR\Services\CodeTypes\CodeImportException;
+use OpenEMR\Services\CodeTypes\Importer\BaseCodeTypeImporter;
+use OpenEMR\Services\CodeTypes\Importer\RXCUIImportService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Twig\Environment;
+
+class LoadCodesController
+{
+    public const TEMPLATE = 'super/load_codes.html.twig';
+
+    /** Mirrors the MAX_FILE_SIZE hidden input; the RxNorm monthly release is around 300MB. */
+    private const MAX_FILE_SIZE = 350000000;
+
+    /**
+     * The importers OpenEMR itself ships, keyed by the code type each one handles.
+     *
+     * @var array<string, BaseCodeTypeImporter>
+     */
+    private readonly array $coreImporters;
+
+    /**
+     * @param list<BaseCodeTypeImporter> $coreImporters
+     */
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly Environment $twig,
+        private readonly SessionInterface $session,
+        private readonly LoggerInterface $logger,
+        array $coreImporters
+    ) {
+        $keyed = [];
+        foreach ($coreImporters as $importer) {
+            $keyed[$importer->getCodeType()] = $importer;
+        }
+        $this->coreImporters = $keyed;
+    }
+
+    public function dispatchAction(Request $request): Response
+    {
+        if (!AclMain::aclCheckCore('admin', 'super')) {
+            AccessDeniedHelper::denyWithTemplate(
+                "ACL check failed for admin/super: Install Code Set",
+                xl("Install Code Set")
+            );
+        }
+
+        // Registered below every module listener so that a module can take over a code type that
+        // core also supports simply by claiming the event at the default priority.
+        $this->eventDispatcher->addListener(
+            CodeImportEvent::EVENT_NAME,
+            $this->handleCoreImport(...),
+            CodeImportEvent::PRIORITY_CORE_FALLBACK
+        );
+
+        $filterEvent = new CodeImportSupportedTypeFilterEvent(array_keys($this->coreImporters));
+        $this->eventDispatcher->dispatch($filterEvent, CodeImportSupportedTypeFilterEvent::EVENT_NAME);
+        $supportedCodeTypes = $filterEvent->getSupportedCodeTypes();
+
+        $isUpload = $request->request->get('bn_upload') !== null;
+        $codeType = $request->request->getString('form_code_type');
+        // The replace checkbox defaults to on, which is how this page has always behaved. Once the
+        // form has been submitted the posted value is what gets reflected back.
+        $isReplace = $isUpload ? $request->request->getBoolean('form_replace') : true;
+
+        $messages = [];
+        if ($isUpload) {
+            CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+            $messages = $this->handleUpload($request, $codeType, $isReplace, $supportedCodeTypes);
+        }
+
+        return $this->render([
+            'csrfToken' => CsrfUtils::collectCsrfToken(session: $this->session),
+            'messages' => $messages,
+            'supportedCodeTypes' => $supportedCodeTypes,
+            'selectedCodeType' => $codeType,
+            'formReplace' => $isReplace,
+            'maxFileSize' => self::MAX_FILE_SIZE,
+            'showRxcuiHelp' => in_array(RXCUIImportService::CODE_TYPE_NAME, $supportedCodeTypes, true),
+        ]);
+    }
+
+    /**
+     * @param list<string> $supportedCodeTypes
+     *
+     * @return array<string, list<string>>
+     */
+    private function handleUpload(
+        Request $request,
+        string $codeType,
+        bool $isReplace,
+        array $supportedCodeTypes
+    ): array {
+        if (!in_array($codeType, $supportedCodeTypes, true)) {
+            return [CodeImportEvent::MESSAGE_TYPE_ERROR => [
+                xl('No handler is available for this code type') . ': ' . $codeType,
+            ]];
+        }
+
+        $upload = $request->files->get('form_file');
+        if (!$upload instanceof UploadedFile || !$upload->isValid()) {
+            return [CodeImportEvent::MESSAGE_TYPE_ERROR => [
+                $this->describeUploadFailure($upload instanceof UploadedFile ? $upload : null),
+            ]];
+        }
+
+        $importEvent = new CodeImportEvent($codeType, $upload->getPathname(), $isReplace);
+        $this->eventDispatcher->dispatch($importEvent, CodeImportEvent::EVENT_NAME);
+
+        if (!$importEvent->isHandled()) {
+            return [CodeImportEvent::MESSAGE_TYPE_ERROR => [
+                xl('No handler is available for this code type') . ': ' . $codeType,
+            ]];
+        }
+
+        return $importEvent->getMessages();
+    }
+
+    /**
+     * Imports the code types core ships with. Runs only when no other listener claimed the event.
+     */
+    private function handleCoreImport(CodeImportEvent $event): void
+    {
+        if ($event->isHandled()) {
+            return;
+        }
+
+        $importer = $this->coreImporters[$event->getCodeType()] ?? null;
+        if ($importer === null) {
+            return;
+        }
+
+        try {
+            $result = $importer->import($event->getFilePath(), $event->isReplace());
+            $event->addMessage(CodeImportEvent::MESSAGE_TYPE_SUCCESS, xl('Code set load successful.'));
+            $event->addMessage(CodeImportEvent::MESSAGE_TYPE_SUCCESS, sprintf(
+                xl('Codes inserted: %1$d, codes updated: %2$d'),
+                $result['inserted'],
+                $result['updated']
+            ));
+        } catch (CodeImportException $exception) {
+            $this->logger->error('Code set import failed', [
+                'codeType' => $event->getCodeType(),
+                'exception' => $exception,
+            ]);
+            $event->addMessage(
+                CodeImportEvent::MESSAGE_TYPE_ERROR,
+                xl('The code set could not be imported. Check the system log for details.')
+            );
+        }
+        $event->setHandled(true);
+    }
+
+    /**
+     * PHP discards oversized uploads before the script runs, so an invalid upload here is almost
+     * always a post_max_size / upload_max_filesize problem.
+     */
+    private function describeUploadFailure(?UploadedFile $upload): string
+    {
+        if ($upload === null) {
+            return xl('No file was uploaded.');
+        }
+        return $upload->getErrorMessage() . ' ' . sprintf(
+            xl('Check the post_max_size and upload_max_filesize settings in %s.'),
+            php_ini_loaded_file() ?: xl('your php.ini')
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $templateVariables
+     */
+    private function render(array $templateVariables): Response
+    {
+        return new Response(
+            $this->twig->render(self::TEMPLATE, $templateVariables),
+            Response::HTTP_OK,
+            ['Content-Type' => 'text/html; charset=utf-8']
+        );
+    }
+}

--- a/src/Events/Codes/CodeImportEvent.php
+++ b/src/Events/Codes/CodeImportEvent.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * CodeImportEvent is dispatched when a user uploads a code set on the Install Code Set page.
+ *
+ * Listeners inspect {@see self::getCodeType()} and, if they recognise it, import the file at
+ * {@see self::getFilePath()} and claim the event by calling {@see self::setHandled()}. Claiming an
+ * event stops propagation, so at most one listener imports any given upload.
+ *
+ * OpenEMR core registers its own importers at {@see self::PRIORITY_CORE_FALLBACK}; see that
+ * constant for how a module overrides a code type core also supports.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ *
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Events\Codes;
+
+use InvalidArgumentException;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CodeImportEvent extends Event
+{
+    public const EVENT_NAME = 'code_types.import';
+
+    public const MESSAGE_TYPE_SUCCESS = 'success';
+    public const MESSAGE_TYPE_ERROR = 'error';
+
+    /**
+     * Priority at which OpenEMR core registers its own code type importers.
+     *
+     * Symfony sorts listeners in descending priority order, so any listener registered above this
+     * value -- the default priority of 0 is enough -- runs first and may claim the import by
+     * calling setHandled(true). That stops propagation before core's handler ever runs, which is
+     * how a module replaces core's handling of a code type core also supports.
+     */
+    public const PRIORITY_CORE_FALLBACK = -100;
+
+    private bool $isHandled = false;
+
+    /** @var array<string, list<string>> */
+    private array $messages = [];
+
+    /**
+     * @param string $codeType  The ct_key of the code type being imported, eg. 'RXCUI'.
+     * @param string $filePath  Absolute path to the uploaded file on disk.
+     * @param bool   $isReplace When true the entire existing code set is replaced.
+     */
+    public function __construct(
+        private readonly string $codeType,
+        private readonly string $filePath,
+        private readonly bool $isReplace
+    ) {
+    }
+
+    public function getCodeType(): string
+    {
+        return $this->codeType;
+    }
+
+    public function getFilePath(): string
+    {
+        return $this->filePath;
+    }
+
+    public function isReplace(): bool
+    {
+        return $this->isReplace;
+    }
+
+    /**
+     * Claim (or un-claim) the import. Claiming stops propagation so no other listener runs.
+     */
+    public function setHandled(bool $handled): void
+    {
+        $this->isHandled = $handled;
+        if ($handled) {
+            $this->stopPropagation();
+        }
+    }
+
+    public function isHandled(): bool
+    {
+        return $this->isHandled;
+    }
+
+    /**
+     * @param string $type One of the self::MESSAGE_TYPE_* constants.
+     *
+     * @throws InvalidArgumentException when $type is not a known message type.
+     */
+    public function addMessage(string $type, string $message): void
+    {
+        if (!in_array($type, [self::MESSAGE_TYPE_SUCCESS, self::MESSAGE_TYPE_ERROR], true)) {
+            throw new InvalidArgumentException('Invalid message type');
+        }
+        $this->messages[$type][] = $message;
+    }
+
+    /**
+     * @param string|null $type Pass a self::MESSAGE_TYPE_* constant for just that type's messages,
+     *                          or '' / null for every message keyed by type.
+     *
+     * @return ($type is non-empty-string ? list<string> : array<string, list<string>>)
+     */
+    public function getMessages(?string $type = ''): array
+    {
+        if ($type === '' || $type === null) {
+            return $this->messages;
+        }
+        return $this->messages[$type] ?? [];
+    }
+}

--- a/src/Events/Codes/CodeImportSupportedTypeFilterEvent.php
+++ b/src/Events/Codes/CodeImportSupportedTypeFilterEvent.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * CodeImportSupportedTypeFilterEvent is dispatched by the Install Code Set page to build the list
+ * of code types offered in its drop-down.
+ *
+ * A module that listens for {@see CodeImportEvent} should also listen for this event and call
+ * {@see self::addSupportedCodeType()} for each code type it can import, otherwise the type is
+ * never offered to the user.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ *
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Events\Codes;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CodeImportSupportedTypeFilterEvent extends Event
+{
+    public const EVENT_NAME = 'code_import_types.filter';
+
+    /**
+     * @param list<string> $supportedCodes
+     */
+    public function __construct(private array $supportedCodes = [])
+    {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSupportedCodeTypes(): array
+    {
+        return $this->supportedCodes;
+    }
+
+    public function addSupportedCodeType(string $codeType): void
+    {
+        if (!in_array($codeType, $this->supportedCodes, true)) {
+            $this->supportedCodes[] = $codeType;
+        }
+    }
+
+    public function removeSupportedCodeType(string $codeType): void
+    {
+        $this->supportedCodes = array_values(
+            array_filter(
+                $this->supportedCodes,
+                fn(string $type): bool => $type !== $codeType
+            )
+        );
+    }
+}

--- a/src/Services/CodeTypes/CodeImportException.php
+++ b/src/Services/CodeTypes/CodeImportException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * CodeImportException is thrown when a code set import cannot be completed.
+ *
+ * It deliberately extends \RuntimeException rather than a broader type so that consumers can
+ * catch it without also suppressing \Error / \ErrorException, which the project forbids (see
+ * tests/PHPStan/Rules/ForbiddenCatchTypeRule.php).
+ *
+ * Messages carried by this exception are intended for the system log only. Never render them to
+ * the user -- they can contain file paths and other internal details.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ *
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\CodeTypes;
+
+use RuntimeException;
+
+class CodeImportException extends RuntimeException
+{
+}

--- a/src/Services/CodeTypes/Importer/BaseCodeTypeImporter.php
+++ b/src/Services/CodeTypes/Importer/BaseCodeTypeImporter.php
@@ -1,0 +1,268 @@
+<?php
+
+/**
+ * BaseCodeTypeImporter imports a delimited code set file into the codes table.
+ *
+ * Subclasses declare which code type they handle via getCodeType() and, where the file layout
+ * differs from the default "code, description, short description" ordering, override
+ * getMappingForFile() and/or getDelimiter(). Formats that are not delimited at all should
+ * override import() outright -- see RXCUIImportService.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ *
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\CodeTypes\Importer;
+
+use Generator;
+use InvalidArgumentException;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\CodeTypes\CodeImportException;
+use Throwable;
+
+abstract class BaseCodeTypeImporter
+{
+    public const DEFAULT_DELIMITER = ',';
+    public const DEFAULT_ENCLOSURE = '"';
+    public const DEFAULT_ESCAPE = '\\';
+
+    /** Number of records written per transaction. See writeBatch(). */
+    private const COMMIT_EVERY = 1000;
+
+    abstract public function getCodeType(): string;
+
+    /**
+     * @return array{inserted: int, updated: int}
+     *
+     * @throws CodeImportException when the code type is unknown or the file cannot be read.
+     */
+    public function import(string $filePath, bool $isReplace): array
+    {
+        try {
+            return $this->runImport($filePath, $isReplace);
+        } catch (CodeImportException $exception) {
+            throw $exception;
+        } catch (Throwable $exception) {
+            // Everything below this point -- QueryUtils, the filesystem, a subclass parser --
+            // reports failure in its own currency. Normalising it here is what lets callers catch
+            // one narrow type instead of \Throwable, which ForbiddenCatchTypeRule forbids.
+            throw new CodeImportException('Failed to import code set: ' . $this->getCodeType(), previous: $exception);
+        }
+    }
+
+    /**
+     * @return array{inserted: int, updated: int}
+     */
+    private function runImport(string $filePath, bool $isReplace): array
+    {
+        $codeTypeId = $this->resolveCodeTypeId($this->getCodeType());
+
+        // readRecords() is a generator, so nothing is opened or parsed until it is first advanced.
+        // Prime it before the DELETE below: an unreadable file or an unrecognised layout must abort
+        // the import while the existing code set is still intact.
+        $records = $this->readRecords($filePath);
+        $records->rewind();
+
+        if ($isReplace) {
+            QueryUtils::sqlStatementThrowException("DELETE FROM codes WHERE code_type = ?", [$codeTypeId]);
+        }
+
+        $inserted = 0;
+        $updated = 0;
+        $batch = [];
+
+        foreach ($records as $record) {
+            $batch[] = $record;
+            if (count($batch) < self::COMMIT_EVERY) {
+                continue;
+            }
+            $this->writeBatch($codeTypeId, $batch, $isReplace, $inserted, $updated);
+            $batch = [];
+        }
+        if ($batch !== []) {
+            $this->writeBatch($codeTypeId, $batch, $isReplace, $inserted, $updated);
+        }
+
+        return ['inserted' => $inserted, 'updated' => $updated];
+    }
+
+    /**
+     * Write one batch of records inside a single transaction. Batching keeps InnoDB fast without
+     * holding one transaction open for an entire multi-hundred-megabyte file.
+     *
+     * @param list<array{code: string, code_text: string, code_text_short: string}> $records
+     */
+    private function writeBatch(
+        int $codeTypeId,
+        array $records,
+        bool $isReplace,
+        int &$inserted,
+        int &$updated
+    ): void {
+        QueryUtils::inTransaction(
+            function () use ($codeTypeId, $records, $isReplace, &$inserted, &$updated): void {
+                foreach ($records as $record) {
+                    if (!$isReplace) {
+                        $existingId = QueryUtils::fetchSingleValue(
+                            "SELECT id FROM codes WHERE code_type = ? AND code = ? LIMIT 1",
+                            'id',
+                            [$codeTypeId, $record['code']]
+                        );
+                        if ($existingId !== null) {
+                            QueryUtils::sqlStatementThrowException(
+                                "UPDATE codes SET code_text = ?, code_text_short = ? "
+                                . "WHERE code_type = ? AND code = ?",
+                                [$record['code_text'], $record['code_text_short'], $codeTypeId, $record['code']],
+                                true
+                            );
+                            $updated++;
+                            continue;
+                        }
+                    }
+
+                    QueryUtils::sqlInsert(
+                        "INSERT INTO codes SET code_type = ?, code = ?, code_text = ?, code_text_short = ?, "
+                        . "fee = 0, units = 0",
+                        [$codeTypeId, $record['code'], $record['code_text'], $record['code_text_short']]
+                    );
+                    $inserted++;
+                }
+            }
+        );
+    }
+
+    /**
+     * Parse the file into code records. Split out from import() so the parsing half of an importer
+     * can be exercised without a database.
+     *
+     * @return Generator<int, array{code: string, code_text: string, code_text_short: string}>
+     *
+     * @throws CodeImportException when the file cannot be opened or its layout is not recognised.
+     */
+    public function readRecords(string $filePath): Generator
+    {
+        $file = $this->openFile($filePath);
+        try {
+            $mapping = $this->getMappingForFile($file);
+            while (($line = $this->readFromFile($file)) !== false) {
+                $code = $this->columnValue($line, $mapping['code']);
+                // A row with no code is not importable -- this also skips the blank trailing line
+                // fgetcsv() reports as [null] at the end of most files.
+                if ($code === '') {
+                    continue;
+                }
+                yield [
+                    'code' => $code,
+                    'code_text' => $this->columnValue($line, $mapping['code_text']),
+                    'code_text_short' => $this->columnValue($line, $mapping['code_text_short']),
+                ];
+            }
+        } finally {
+            $this->closeFile($file);
+        }
+    }
+
+    /**
+     * Column positions of the three codes columns within a row of the file being imported.
+     *
+     * @param resource $file Positioned at the start of the file; implementations that read a
+     *                       header row to derive the mapping leave the handle past that row.
+     *
+     * @return array{code: int, code_text: int, code_text_short: int}
+     */
+    public function getMappingForFile(mixed $file): array
+    {
+        if (!is_resource($file)) {
+            throw new InvalidArgumentException("Invalid file resource provided.");
+        }
+        return [
+            'code' => 0,
+            'code_text' => 1,
+            'code_text_short' => 2,
+        ];
+    }
+
+    /**
+     * @return resource
+     *
+     * @throws CodeImportException when the file cannot be opened.
+     */
+    public function openFile(string $filePath): mixed
+    {
+        // Checked up front so a missing upload surfaces as an exception rather than an fopen()
+        // warning followed by an exception.
+        if (!is_file($filePath) || !is_readable($filePath)) {
+            throw new CodeImportException("File does not exist or is not readable: " . $filePath);
+        }
+        $file = fopen($filePath, 'r');
+        if ($file === false) {
+            throw new CodeImportException("Failed to open file: " . $filePath);
+        }
+        return $file;
+    }
+
+    /**
+     * @param resource $file
+     */
+    public function closeFile(mixed $file): bool
+    {
+        if (!is_resource($file)) {
+            throw new InvalidArgumentException("Invalid file resource provided.");
+        }
+        return fclose($file);
+    }
+
+    /**
+     * @param resource $file
+     *
+     * @return list<string|null>|false
+     */
+    public function readFromFile(mixed $file): array|false
+    {
+        if (!is_resource($file)) {
+            throw new InvalidArgumentException("Invalid file resource provided.");
+        }
+        // $escape is passed explicitly because PHP 8.4 deprecates relying on its default, which is
+        // slated to change. Pinning it to the current default keeps parsing identical and matches
+        // league/csv, which the other CSV reader in this codebase (HolidayCsvParser) uses.
+        return fgetcsv($file, null, $this->getDelimiter(), self::DEFAULT_ENCLOSURE, self::DEFAULT_ESCAPE);
+    }
+
+    public function getDelimiter(): string
+    {
+        return self::DEFAULT_DELIMITER;
+    }
+
+    /**
+     * Resolve a ct_key to its ct_id. Replaces the legacy `global $code_types` lookup; the filter on
+     * ct_active matches how custom/code_types.inc.php builds that array.
+     *
+     * @throws CodeImportException when the code type is not defined or not active.
+     */
+    protected function resolveCodeTypeId(string $codeTypeKey): int
+    {
+        $codeTypeId = QueryUtils::fetchSingleValue(
+            "SELECT ct_id FROM code_types WHERE ct_key = ? AND ct_active = 1",
+            'ct_id',
+            [$codeTypeKey]
+        );
+        if (!is_numeric($codeTypeId)) {
+            throw new CodeImportException("Code type is not defined or is inactive: " . $codeTypeKey);
+        }
+        return (int)$codeTypeId;
+    }
+
+    /**
+     * @param list<string|null> $line
+     */
+    private function columnValue(array $line, int $position): string
+    {
+        return $line[$position] ?? '';
+    }
+}

--- a/src/Services/CodeTypes/Importer/LOINCImportService.php
+++ b/src/Services/CodeTypes/Importer/LOINCImportService.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * LOINCImportService imports the LOINC code set from the CSV table distributed by Regenstrief.
+ *
+ * The column order of that file is not stable between releases, so the mapping is derived from the
+ * header row rather than hard coded.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ *
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\CodeTypes\Importer;
+
+use OpenEMR\Services\CodeTypes\CodeImportException;
+
+class LOINCImportService extends BaseCodeTypeImporter
+{
+    public const CODE_TYPE_NAME = 'LOINC';
+
+    public const COLUMN_CODE = 'LOINC_NUM';
+    public const COLUMN_CODE_TEXT = 'LONG_COMMON_NAME';
+    public const COLUMN_CODE_TEXT_SHORT = 'SHORTNAME';
+
+    public function getCodeType(): string
+    {
+        return self::CODE_TYPE_NAME;
+    }
+
+    /**
+     * Consumes the header row and derives the column mapping from it.
+     *
+     * @param resource $file
+     *
+     * @return array{code: int, code_text: int, code_text_short: int}
+     */
+    public function getMappingForFile(mixed $file): array
+    {
+        if (!is_resource($file)) {
+            throw new CodeImportException("Invalid file resource provided");
+        }
+
+        $header = $this->readFromFile($file);
+        if ($header === false) {
+            throw new CodeImportException("LOINC file is empty, no header row was found");
+        }
+        return $this->getMapping($header);
+    }
+
+    /**
+     * @param list<string|null> $header
+     *
+     * @return array{code: int, code_text: int, code_text_short: int}
+     *
+     * @throws CodeImportException when a required column is absent from the header.
+     */
+    protected function getMapping(array $header): array
+    {
+        $mapping = [
+            'code' => -1,
+            'code_text' => -1,
+            'code_text_short' => -1,
+        ];
+        foreach ($header as $position => $value) {
+            // Regenstrief ships Loinc.csv with a UTF-8 BOM, which lands inside the first header
+            // cell -- normally LOINC_NUM -- and would otherwise defeat an exact comparison.
+            switch ($this->normalizeHeaderCell($value)) {
+                case self::COLUMN_CODE:
+                    $mapping['code'] = $position;
+                    break;
+                case self::COLUMN_CODE_TEXT:
+                    $mapping['code_text'] = $position;
+                    break;
+                case self::COLUMN_CODE_TEXT_SHORT:
+                    $mapping['code_text_short'] = $position;
+                    break;
+            }
+        }
+        if (min($mapping['code'], $mapping['code_text'], $mapping['code_text_short']) < 0) {
+            throw new CodeImportException("LOINC is missing required columns, check file format");
+        }
+        return $mapping;
+    }
+
+    private function normalizeHeaderCell(?string $value): string
+    {
+        return strtoupper(trim(ltrim($value ?? '', "\u{FEFF}")));
+    }
+}

--- a/src/Services/CodeTypes/Importer/RXCUIImportService.php
+++ b/src/Services/CodeTypes/Importer/RXCUIImportService.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * RXCUIImportService imports RxNorm concept identifiers from the RXNCONSO.RRF table published by
+ * the National Library of Medicine, either as the raw .RRF file or still inside the release zip.
+ *
+ * RRF is pipe delimited but is not CSV -- descriptions routinely contain quote characters that a
+ * CSV reader would consume -- so this importer supplies its own row reader rather than using the
+ * delimited parsing inherited from BaseCodeTypeImporter. The row filters below reproduce the
+ * behaviour of the pre-8.1 interface/super/load_codes.php exactly.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ *
+ * @author    Rod Roark <rod@sunsetsystems.com>
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2014 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\CodeTypes\Importer;
+
+use Generator;
+use OpenEMR\Services\CodeTypes\CodeImportException;
+use ZipArchive;
+
+class RXCUIImportService extends BaseCodeTypeImporter
+{
+    public const CODE_TYPE_NAME = 'RXCUI';
+
+    /** Name of the concept-names table within the RxNorm release. */
+    public const CONSO_FILE_NAME = 'RXNCONSO.RRF';
+
+    private const RRF_DELIMITER = '|';
+
+    /** Column positions within RXNCONSO.RRF. */
+    private const COLUMN_RXCUI = 0;
+    private const COLUMN_SAB = 11;
+    private const COLUMN_STR = 14;
+    private const COLUMN_CVF = 17;
+
+    private const MINIMUM_COLUMNS = 18;
+
+    /** Only rows from the RxNorm vocabulary itself are imported. */
+    private const SOURCE_ABBREVIATION = 'RXNORM';
+
+    /** Content view flag marking the "Current Prescribable Content" subset. */
+    private const CONTENT_VIEW_FLAG = '4096';
+
+    public function getCodeType(): string
+    {
+        return self::CODE_TYPE_NAME;
+    }
+
+    /**
+     * @return Generator<int, array{code: string, code_text: string, code_text_short: string}>
+     *
+     * @throws CodeImportException when RXNCONSO.RRF cannot be located in the uploaded file.
+     */
+    public function readRecords(string $filePath): Generator
+    {
+        $zip = new ZipArchive();
+        $isZip = $zip->open($filePath) === true;
+        $stream = null;
+
+        try {
+            if ($isZip) {
+                $stream = $this->openConsoEntry($zip);
+                if (!is_resource($stream)) {
+                    throw new CodeImportException(
+                        "Unable to locate " . self::CONSO_FILE_NAME . " in the uploaded archive: " . $filePath
+                    );
+                }
+            } else {
+                $stream = $this->openFile($filePath);
+            }
+
+            $seenCodes = [];
+            while (($line = fgets($stream)) !== false) {
+                $columns = explode(self::RRF_DELIMITER, $line);
+                if (count($columns) < self::MINIMUM_COLUMNS) {
+                    continue;
+                }
+                if (trim($columns[self::COLUMN_CVF]) !== self::CONTENT_VIEW_FLAG) {
+                    continue;
+                }
+                if (trim($columns[self::COLUMN_SAB]) !== self::SOURCE_ABBREVIATION) {
+                    continue;
+                }
+
+                $code = $columns[self::COLUMN_RXCUI];
+                if ($code === '' || isset($seenCodes[$code])) {
+                    continue;
+                }
+                $seenCodes[$code] = true;
+
+                yield [
+                    'code' => $code,
+                    'code_text' => $columns[self::COLUMN_STR],
+                    'code_text_short' => '',
+                ];
+            }
+        } finally {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+            if ($isZip) {
+                $zip->close();
+            }
+        }
+    }
+
+    /**
+     * @return resource|false
+     */
+    private function openConsoEntry(ZipArchive $zip): mixed
+    {
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            $entryName = $zip->getNameIndex($i);
+            if ($entryName !== false && basename($entryName) === self::CONSO_FILE_NAME) {
+                return $zip->getStream($entryName);
+            }
+        }
+        return false;
+    }
+}

--- a/templates/super/load_codes.html.twig
+++ b/templates/super/load_codes.html.twig
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>{{ 'Install Code Set'|xlt }}</title>
+    {{ setupHeader() }}
+
+    <style>
+        .dehead {
+            color: var(--black);
+            font-family: sans-serif;
+            font-size: 0.8125rem;
+            font-weight: bold;
+        }
+        .detail {
+            color: var(--black);
+            font-family: sans-serif;
+            font-size: 0.8125rem;
+            font-weight: normal;
+        }
+    </style>
+
+</head>
+
+<body class="body_top">
+<div class="container">
+    {% if messages %}
+    <div class="row">
+        <div class="col">
+            {% for key, messageList in messages %}
+                {% for message in messageList %}
+                    <p class="text-{{ key == 'success' ? 'success' : 'danger' }}">{{ message|text }}</p>
+                {% endfor %}
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+    <form method='post' action='load_codes.php' enctype='multipart/form-data'
+          onsubmit='return top.restoreSession()'>
+
+        <input type="hidden" name="csrf_token_form" value="{{ csrfToken|attr }}" />
+        <div class="table-responsive">
+            <table class="table table-bordered">
+                <thead>
+                <tr class="dehead">
+                    <th colspan="2" class='text-center'>{{ 'Install Code Set'|xlt }}</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td>
+                        {{ 'Code Type'|xlt }}
+                    </td>
+                    <td>
+                        <select name='form_code_type'>
+                            {% for codeType in supportedCodeTypes %}
+                                <option value='{{ codeType|attr }}' {% if codeType == selectedCodeType %}selected="selected"{% endif %}
+                                >{{ codeType|text }}</option>
+                            {% endfor %}
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="detail">
+                        {{ 'Source File'|xlt }}
+                        <input type="hidden" name="MAX_FILE_SIZE" value="{{ maxFileSize|attr }}" />
+                    </td>
+                    <td class="detail">
+                        <input type="file" name="form_file" size="40" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="detail">
+                        {{ 'Replace entire code set'|xlt }}
+                    </td>
+                    <td class="detail">
+                        <input type='checkbox' name='form_replace' value='1' {% if formReplace %}checked{% endif %} />
+                    </td>
+                </tr>
+                <tr class="bg-secondary">
+                    <td colspan="2" class="text-center detail">
+                        <input type='submit' class='btn btn-primary' name='bn_upload' value='{{ 'Upload and Install'|xla }}' />
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <p class='font-weight-bold text-center'>
+            {{ 'Be patient, some files can take several minutes to process!'|xlt }}
+        </p>
+
+        <!-- No translation because this text is long and US-specific and quotes other English-only text. -->
+        {% if showRxcuiHelp %}
+        <p class='text'>
+            <span class="font-weight-bold">RXCUI codes</span> may be downloaded from
+            <a href='https://www.nlm.nih.gov/research/umls/rxnorm/docs/rxnormfiles.html' rel="noopener" target='_blank'>
+                www.nlm.nih.gov/research/umls/rxnorm/docs/rxnormfiles.html</a>.
+            Get the "Current Prescribable Content Monthly Release" zip file, marked "no license required".
+            Then you can upload that file as-is here, or extract the file RXNCONSO.RRF from it and upload just
+            that (zipped or not). You may do the same with the weekly updates, but for those uncheck the
+            "{{ 'Replace entire code set'|xlt }}" checkbox above.
+
+            Note you will need to ensure the RXCUI code type is enabled from the Admin -&gt; Forms -&gt; Lists -&gt; Code Types
+            page before you can upload RXCUI codes.
+        </p>
+        {% endif %}
+        <div class="alert alert-info"><p>
+                <i class="fa fa-circle-info"></i> {{ "If your code sets are not loading, verify your php.ini post_max_size value and your upload_max_filesize has been set large enough to handle the file size you are uploading."|xlt }}
+            </p>
+        </div>
+    </form>
+</div>
+</body>
+</html>

--- a/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
+++ b/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
@@ -361,6 +361,41 @@ class TwigTemplateRenderTest extends TestCase
             ],
             $fixtureDir . '/appointments-with-future.html',
         ];
+
+        // Install Code Set page. The first case covers the post-upload render (messages of both
+        // types, a selected code type, the replace checkbox reflecting an unchecked submission and
+        // the RXCUI help paragraph); the second covers a module-only install where core's own
+        // importers have been filtered out.
+        yield 'super/load_codes with messages' => [
+            'super/load_codes.html.twig',
+            [
+                'csrfToken'          => 'test-csrf-token',
+                'messages'           => [
+                    'success' => ['Code set load successful.', 'Codes inserted: 12, codes updated: 3'],
+                    'error'   => ['The code set could not be imported. Check the system log for details.'],
+                ],
+                'supportedCodeTypes' => ['RXCUI', 'LOINC', 'ICPC2'],
+                'selectedCodeType'   => 'LOINC',
+                'formReplace'        => false,
+                'maxFileSize'        => 350000000,
+                'showRxcuiHelp'      => true,
+            ],
+            $fixtureDir . '/load-codes-with-messages.html',
+        ];
+
+        yield 'super/load_codes without rxcui' => [
+            'super/load_codes.html.twig',
+            [
+                'csrfToken'          => 'test-csrf-token',
+                'messages'           => [],
+                'supportedCodeTypes' => ['ICPC2'],
+                'selectedCodeType'   => '',
+                'formReplace'        => true,
+                'maxFileSize'        => 350000000,
+                'showRxcuiHelp'      => false,
+            ],
+            $fixtureDir . '/load-codes-no-rxcui.html',
+        ];
     }
 
     /**

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/load-codes-no-rxcui.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/load-codes-no-rxcui.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Install Code Set</title>
+    <!-- setupHeader stub -->
+
+    <style>
+        .dehead {
+            color: var(--black);
+            font-family: sans-serif;
+            font-size: 0.8125rem;
+            font-weight: bold;
+        }
+        .detail {
+            color: var(--black);
+            font-family: sans-serif;
+            font-size: 0.8125rem;
+            font-weight: normal;
+        }
+    </style>
+
+</head>
+
+<body class="body_top">
+<div class="container">
+        <form method='post' action='load_codes.php' enctype='multipart/form-data'
+          onsubmit='return top.restoreSession()'>
+
+        <input type="hidden" name="csrf_token_form" value="test-csrf-token" />
+        <div class="table-responsive">
+            <table class="table table-bordered">
+                <thead>
+                <tr class="dehead">
+                    <th colspan="2" class='text-center'>Install Code Set</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td>
+                        Code Type
+                    </td>
+                    <td>
+                        <select name='form_code_type'>
+                                                            <option value='ICPC2'                                 >ICPC2</option>
+                                                    </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="detail">
+                        Source File
+                        <input type="hidden" name="MAX_FILE_SIZE" value="350000000" />
+                    </td>
+                    <td class="detail">
+                        <input type="file" name="form_file" size="40" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="detail">
+                        Replace entire code set
+                    </td>
+                    <td class="detail">
+                        <input type='checkbox' name='form_replace' value='1' checked />
+                    </td>
+                </tr>
+                <tr class="bg-secondary">
+                    <td colspan="2" class="text-center detail">
+                        <input type='submit' class='btn btn-primary' name='bn_upload' value='Upload and Install' />
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <p class='font-weight-bold text-center'>
+            Be patient, some files can take several minutes to process!
+        </p>
+
+        <!-- No translation because this text is long and US-specific and quotes other English-only text. -->
+                <div class="alert alert-info"><p>
+                <i class="fa fa-circle-info"></i> If your code sets are not loading, verify your php.ini post_max_size value and your upload_max_filesize has been set large enough to handle the file size you are uploading.
+            </p>
+        </div>
+    </form>
+</div>
+</body>
+</html>

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/load-codes-with-messages.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/load-codes-with-messages.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Install Code Set</title>
+    <!-- setupHeader stub -->
+
+    <style>
+        .dehead {
+            color: var(--black);
+            font-family: sans-serif;
+            font-size: 0.8125rem;
+            font-weight: bold;
+        }
+        .detail {
+            color: var(--black);
+            font-family: sans-serif;
+            font-size: 0.8125rem;
+            font-weight: normal;
+        }
+    </style>
+
+</head>
+
+<body class="body_top">
+<div class="container">
+        <div class="row">
+        <div class="col">
+                                                <p class="text-success">Code set load successful.</p>
+                                    <p class="text-success">Codes inserted: 12, codes updated: 3</p>
+                                                                <p class="text-danger">The code set could not be imported. Check the system log for details.</p>
+                                    </div>
+    </div>
+        <form method='post' action='load_codes.php' enctype='multipart/form-data'
+          onsubmit='return top.restoreSession()'>
+
+        <input type="hidden" name="csrf_token_form" value="test-csrf-token" />
+        <div class="table-responsive">
+            <table class="table table-bordered">
+                <thead>
+                <tr class="dehead">
+                    <th colspan="2" class='text-center'>Install Code Set</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td>
+                        Code Type
+                    </td>
+                    <td>
+                        <select name='form_code_type'>
+                                                            <option value='RXCUI'                                 >RXCUI</option>
+                                                            <option value='LOINC' selected="selected"                                >LOINC</option>
+                                                            <option value='ICPC2'                                 >ICPC2</option>
+                                                    </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="detail">
+                        Source File
+                        <input type="hidden" name="MAX_FILE_SIZE" value="350000000" />
+                    </td>
+                    <td class="detail">
+                        <input type="file" name="form_file" size="40" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="detail">
+                        Replace entire code set
+                    </td>
+                    <td class="detail">
+                        <input type='checkbox' name='form_replace' value='1'  />
+                    </td>
+                </tr>
+                <tr class="bg-secondary">
+                    <td colspan="2" class="text-center detail">
+                        <input type='submit' class='btn btn-primary' name='bn_upload' value='Upload and Install' />
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <p class='font-weight-bold text-center'>
+            Be patient, some files can take several minutes to process!
+        </p>
+
+        <!-- No translation because this text is long and US-specific and quotes other English-only text. -->
+                <p class='text'>
+            <span class="font-weight-bold">RXCUI codes</span> may be downloaded from
+            <a href='https://www.nlm.nih.gov/research/umls/rxnorm/docs/rxnormfiles.html' rel="noopener" target='_blank'>
+                www.nlm.nih.gov/research/umls/rxnorm/docs/rxnormfiles.html</a>.
+            Get the "Current Prescribable Content Monthly Release" zip file, marked "no license required".
+            Then you can upload that file as-is here, or extract the file RXNCONSO.RRF from it and upload just
+            that (zipped or not). You may do the same with the weekly updates, but for those uncheck the
+            "Replace entire code set" checkbox above.
+
+            Note you will need to ensure the RXCUI code type is enabled from the Admin -&gt; Forms -&gt; Lists -&gt; Code Types
+            page before you can upload RXCUI codes.
+        </p>
+                <div class="alert alert-info"><p>
+                <i class="fa fa-circle-info"></i> If your code sets are not loading, verify your php.ini post_max_size value and your upload_max_filesize has been set large enough to handle the file size you are uploading.
+            </p>
+        </div>
+    </form>
+</div>
+</body>
+</html>

--- a/tests/Tests/Isolated/Events/CodeImportEventTest.php
+++ b/tests/Tests/Isolated/Events/CodeImportEventTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Isolated tests for the CodeImportEvent DTO
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Events;
+
+use InvalidArgumentException;
+use OpenEMR\Events\Codes\CodeImportEvent;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+class CodeImportEventTest extends TestCase
+{
+    public function testConstructorSetsProperties(): void
+    {
+        $event = new CodeImportEvent('LOINC', '/tmp/loinc.csv', true);
+
+        $this->assertSame('LOINC', $event->getCodeType());
+        $this->assertSame('/tmp/loinc.csv', $event->getFilePath());
+        $this->assertTrue($event->isReplace());
+        $this->assertFalse($event->isHandled());
+        $this->assertSame([], $event->getMessages());
+    }
+
+    public function testSetHandledStopsPropagation(): void
+    {
+        $event = new CodeImportEvent('LOINC', '/tmp/loinc.csv', false);
+        $this->assertFalse($event->isPropagationStopped());
+
+        $event->setHandled(true);
+
+        $this->assertTrue($event->isHandled());
+        $this->assertTrue($event->isPropagationStopped());
+    }
+
+    public function testSetHandledFalseDoesNotStopPropagation(): void
+    {
+        $event = new CodeImportEvent('LOINC', '/tmp/loinc.csv', false);
+
+        $event->setHandled(false);
+
+        $this->assertFalse($event->isHandled());
+        $this->assertFalse($event->isPropagationStopped());
+    }
+
+    public function testMessagesAreGroupedByTypeAndKeepInsertionOrder(): void
+    {
+        $event = new CodeImportEvent('LOINC', '/tmp/loinc.csv', false);
+        $event->addMessage(CodeImportEvent::MESSAGE_TYPE_SUCCESS, 'first');
+        $event->addMessage(CodeImportEvent::MESSAGE_TYPE_ERROR, 'oops');
+        $event->addMessage(CodeImportEvent::MESSAGE_TYPE_SUCCESS, 'second');
+
+        $this->assertSame(
+            [
+                CodeImportEvent::MESSAGE_TYPE_SUCCESS => ['first', 'second'],
+                CodeImportEvent::MESSAGE_TYPE_ERROR => ['oops'],
+            ],
+            $event->getMessages()
+        );
+        $this->assertSame(['first', 'second'], $event->getMessages(CodeImportEvent::MESSAGE_TYPE_SUCCESS));
+        $this->assertSame(['oops'], $event->getMessages(CodeImportEvent::MESSAGE_TYPE_ERROR));
+    }
+
+    public function testGetMessagesForUnusedTypeReturnsEmptyList(): void
+    {
+        $event = new CodeImportEvent('LOINC', '/tmp/loinc.csv', false);
+
+        $this->assertSame([], $event->getMessages(CodeImportEvent::MESSAGE_TYPE_ERROR));
+    }
+
+    public function testAddMessageRejectsUnknownType(): void
+    {
+        $event = new CodeImportEvent('LOINC', '/tmp/loinc.csv', false);
+
+        $this->expectException(InvalidArgumentException::class);
+        $event->addMessage('warning', 'not a supported type');
+    }
+
+    public function testCoreFallbackPriorityIsBelowTheDefaultListenerPriority(): void
+    {
+        // Modules register at the default priority of 0; core must sort after them so a module can
+        // claim a code type core also supports.
+        $this->assertLessThan(0, CodeImportEvent::PRIORITY_CORE_FALLBACK);
+    }
+}

--- a/tests/Tests/Isolated/Events/CodeImportSupportedTypeFilterEventTest.php
+++ b/tests/Tests/Isolated/Events/CodeImportSupportedTypeFilterEventTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Isolated tests for the CodeImportSupportedTypeFilterEvent DTO
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Events;
+
+use OpenEMR\Events\Codes\CodeImportSupportedTypeFilterEvent;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+class CodeImportSupportedTypeFilterEventTest extends TestCase
+{
+    public function testConstructorSeedsTheSupportedTypes(): void
+    {
+        $event = new CodeImportSupportedTypeFilterEvent(['RXCUI', 'LOINC']);
+
+        $this->assertSame(['RXCUI', 'LOINC'], $event->getSupportedCodeTypes());
+    }
+
+    public function testAddAppendsInOrder(): void
+    {
+        $event = new CodeImportSupportedTypeFilterEvent(['RXCUI']);
+        $event->addSupportedCodeType('LOINC');
+        $event->addSupportedCodeType('ICPC2');
+
+        $this->assertSame(['RXCUI', 'LOINC', 'ICPC2'], $event->getSupportedCodeTypes());
+    }
+
+    public function testAddIsIdempotent(): void
+    {
+        $event = new CodeImportSupportedTypeFilterEvent(['RXCUI']);
+        $event->addSupportedCodeType('RXCUI');
+
+        $this->assertSame(['RXCUI'], $event->getSupportedCodeTypes());
+    }
+
+    public function testRemoveReindexesTheList(): void
+    {
+        $event = new CodeImportSupportedTypeFilterEvent(['RXCUI', 'LOINC', 'ICPC2']);
+        $event->removeSupportedCodeType('LOINC');
+
+        // assertSame on the whole array compares keys as well as values, so a gappy array left
+        // behind by array_filter() (keys 0 and 2) fails here. Callers rely on this being a list.
+        $this->assertSame(['RXCUI', 'ICPC2'], $event->getSupportedCodeTypes());
+    }
+
+    public function testRemoveOfAnAbsentTypeIsANoOp(): void
+    {
+        $event = new CodeImportSupportedTypeFilterEvent(['RXCUI']);
+        $event->removeSupportedCodeType('SNOMED');
+
+        $this->assertSame(['RXCUI'], $event->getSupportedCodeTypes());
+    }
+}

--- a/tests/Tests/Isolated/Services/CodeTypes/Importer/BaseCodeTypeImporterTest.php
+++ b/tests/Tests/Isolated/Services/CodeTypes/Importer/BaseCodeTypeImporterTest.php
@@ -1,0 +1,222 @@
+<?php
+
+/**
+ * Isolated tests for the parsing half of BaseCodeTypeImporter.
+ *
+ * readRecords() is deliberately separate from import() so the file handling and column mapping can
+ * be exercised without a database.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\CodeTypes\Importer;
+
+use OpenEMR\Services\CodeTypes\CodeImportException;
+use OpenEMR\Services\CodeTypes\Importer\BaseCodeTypeImporter;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+class BaseCodeTypeImporterTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+        $this->tempFiles = [];
+    }
+
+    public function testDefaultMappingReadsCodeDescriptionShortDescription(): void
+    {
+        $importer = new TestCommaImporter();
+        $path = $this->writeTempFile("A01,Long description,Short\nA02,Another one,Other\n");
+
+        $this->assertSame(
+            [
+                ['code' => 'A01', 'code_text' => 'Long description', 'code_text_short' => 'Short'],
+                ['code' => 'A02', 'code_text' => 'Another one', 'code_text_short' => 'Other'],
+            ],
+            iterator_to_array($importer->readRecords($path), false)
+        );
+    }
+
+    public function testAlternateDelimiterAndRepeatedColumnMapping(): void
+    {
+        // This is the shape the Ireland module's CH07 importer uses: '%' delimited, with the short
+        // description mapped onto the same column as the long one.
+        $importer = new TestPercentImporter();
+        $path = $this->writeTempFile("Z01%Health category one\nZ02%Health category two\n");
+
+        $this->assertSame(
+            [
+                ['code' => 'Z01', 'code_text' => 'Health category one', 'code_text_short' => 'Health category one'],
+                ['code' => 'Z02', 'code_text' => 'Health category two', 'code_text_short' => 'Health category two'],
+            ],
+            iterator_to_array($importer->readRecords($path), false)
+        );
+    }
+
+    public function testBlankAndCodelessRowsAreSkipped(): void
+    {
+        $importer = new TestCommaImporter();
+        $path = $this->writeTempFile("A01,First,Short\n\n,No code here,Short\nA02,Second,Short\n");
+
+        $records = iterator_to_array($importer->readRecords($path), false);
+
+        $this->assertCount(2, $records);
+        $this->assertSame(['A01', 'A02'], array_column($records, 'code'));
+    }
+
+    public function testMissingTrailingColumnsBecomeEmptyStrings(): void
+    {
+        $importer = new TestCommaImporter();
+        $path = $this->writeTempFile("A01,Only a long description\nA02\n");
+
+        $this->assertSame(
+            [
+                ['code' => 'A01', 'code_text' => 'Only a long description', 'code_text_short' => ''],
+                ['code' => 'A02', 'code_text' => '', 'code_text_short' => ''],
+            ],
+            iterator_to_array($importer->readRecords($path), false)
+        );
+    }
+
+    public function testFileHandleIsClosedAfterFullIteration(): void
+    {
+        $importer = new TestCommaImporter();
+        $path = $this->writeTempFile("A01,First,Short\n");
+
+        iterator_to_array($importer->readRecords($path), false);
+
+        $this->assertNotNull($importer->openedHandle);
+        $this->assertFalse(is_resource($importer->openedHandle));
+    }
+
+    public function testFileHandleIsClosedWhenIterationStopsEarly(): void
+    {
+        $importer = new TestCommaImporter();
+        $path = $this->writeTempFile("A01,First,Short\nA02,Second,Short\nA03,Third,Short\n");
+
+        foreach ($importer->readRecords($path) as $record) {
+            $this->assertSame('A01', $record['code']);
+            break;
+        }
+        // Dropping the last reference destroys the generator, which runs its finally block.
+        gc_collect_cycles();
+
+        $this->assertNotNull($importer->openedHandle);
+        $this->assertFalse(is_resource($importer->openedHandle));
+    }
+
+    public function testUnreadableFileThrowsCodeImportException(): void
+    {
+        $importer = new TestCommaImporter();
+
+        $this->expectException(CodeImportException::class);
+        iterator_to_array($importer->readRecords(sys_get_temp_dir() . '/does-not-exist-' . uniqid() . '.csv'), false);
+    }
+
+    public function testReplaceModeValidatesTheFileBeforeDeletingAnything(): void
+    {
+        // readRecords() is a generator, so nothing is parsed until it is advanced. import() must
+        // prime it before the DELETE that replace mode performs, otherwise an unreadable upload
+        // wipes an existing code set and inserts nothing.
+        //
+        // The code-type lookup is stubbed so the first real database access left in the path is
+        // that DELETE. There is no database in an isolated test, so if the ordering regressed the
+        // failure would come from the DELETE and carry the generic wrapper message. Asserting on
+        // the file-level message is what pins the ordering.
+        $importer = new TestImporterWithStubbedCodeType();
+        $missing = sys_get_temp_dir() . '/does-not-exist-' . uniqid() . '.csv';
+
+        $this->expectException(CodeImportException::class);
+        $this->expectExceptionMessage('File does not exist or is not readable');
+        $importer->import($missing, true);
+    }
+
+    public function testImportNormalizesUnexpectedFailuresIntoCodeImportException(): void
+    {
+        // resolveCodeTypeId() reaches for a database that an isolated test does not have. Whatever
+        // that throws, callers must only ever have to catch CodeImportException.
+        $importer = new TestCommaImporter();
+
+        $this->expectException(CodeImportException::class);
+        $importer->import($this->writeTempFile("A01,First,Short\n"), false);
+    }
+
+    private function writeTempFile(string $contents): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'oe-code-import-');
+        self::assertIsString($path);
+        file_put_contents($path, $contents);
+        $this->tempFiles[] = $path;
+        return $path;
+    }
+}
+
+/**
+ * Minimal importer exercising the inherited defaults, with the opened handle exposed so tests can
+ * assert it was closed.
+ */
+class TestCommaImporter extends BaseCodeTypeImporter
+{
+    /** @var resource|null */
+    public mixed $openedHandle = null;
+
+    public function getCodeType(): string
+    {
+        return 'TEST-COMMA';
+    }
+
+    public function openFile(string $filePath): mixed
+    {
+        return $this->openedHandle = parent::openFile($filePath);
+    }
+}
+
+/**
+ * Stubs out the only database access that precedes the replace-mode DELETE, so a test can pin the
+ * order of "parse the file" against "delete the existing code set".
+ */
+class TestImporterWithStubbedCodeType extends BaseCodeTypeImporter
+{
+    public function getCodeType(): string
+    {
+        return 'TEST-STUBBED';
+    }
+
+    protected function resolveCodeTypeId(string $codeTypeKey): int
+    {
+        return 1;
+    }
+}
+
+class TestPercentImporter extends BaseCodeTypeImporter
+{
+    public function getCodeType(): string
+    {
+        return 'TEST-PERCENT';
+    }
+
+    public function getDelimiter(): string
+    {
+        return '%';
+    }
+
+    public function getMappingForFile(mixed $file): array
+    {
+        return ['code' => 0, 'code_text' => 1, 'code_text_short' => 1];
+    }
+}

--- a/tests/Tests/Isolated/Services/CodeTypes/Importer/LOINCImportServiceTest.php
+++ b/tests/Tests/Isolated/Services/CodeTypes/Importer/LOINCImportServiceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Isolated tests for LOINCImportService's header-driven column mapping.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\CodeTypes\Importer;
+
+use OpenEMR\Services\CodeTypes\CodeImportException;
+use OpenEMR\Services\CodeTypes\Importer\LOINCImportService;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+class LOINCImportServiceTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+        $this->tempFiles = [];
+    }
+
+    public function testCodeTypeIsLoinc(): void
+    {
+        $this->assertSame('LOINC', (new LOINCImportService())->getCodeType());
+    }
+
+    public function testColumnsAreLocatedByHeaderNameNotPosition(): void
+    {
+        // Columns deliberately out of order and interleaved with columns we do not import.
+        $path = $this->writeTempFile(
+            "COMPONENT,SHORTNAME,LOINC_NUM,CLASS,LONG_COMMON_NAME\n"
+            . "Glucose,Glucose SerPl-mCnc,2345-7,CHEM,\"Glucose [Mass/volume] in Serum or Plasma\"\n"
+            . "Sodium,Sodium SerPl-sCnc,2951-2,CHEM,\"Sodium [Moles/volume] in Serum or Plasma\"\n"
+        );
+
+        $this->assertSame(
+            [
+                [
+                    'code' => '2345-7',
+                    'code_text' => 'Glucose [Mass/volume] in Serum or Plasma',
+                    'code_text_short' => 'Glucose SerPl-mCnc',
+                ],
+                [
+                    'code' => '2951-2',
+                    'code_text' => 'Sodium [Moles/volume] in Serum or Plasma',
+                    'code_text_short' => 'Sodium SerPl-sCnc',
+                ],
+            ],
+            iterator_to_array((new LOINCImportService())->readRecords($path), false)
+        );
+    }
+
+    public function testHeaderCellsAreNormalizedBeforeMatching(): void
+    {
+        // Regenstrief ships the file with a UTF-8 BOM, which becomes part of the first header cell.
+        $path = $this->writeTempFile(
+            "\u{FEFF}LOINC_NUM, LONG_COMMON_NAME ,shortname\n"
+            . "2345-7,Glucose,Gluc\n"
+        );
+
+        $this->assertSame(
+            [['code' => '2345-7', 'code_text' => 'Glucose', 'code_text_short' => 'Gluc']],
+            iterator_to_array((new LOINCImportService())->readRecords($path), false)
+        );
+    }
+
+    public function testHeaderOnlyFileYieldsNoRecords(): void
+    {
+        $path = $this->writeTempFile("LOINC_NUM,LONG_COMMON_NAME,SHORTNAME\n");
+
+        $this->assertSame([], iterator_to_array((new LOINCImportService())->readRecords($path), false));
+    }
+
+    public function testMissingRequiredColumnThrows(): void
+    {
+        $path = $this->writeTempFile("LOINC_NUM,LONG_COMMON_NAME\n2345-7,Glucose\n");
+
+        $this->expectException(CodeImportException::class);
+        iterator_to_array((new LOINCImportService())->readRecords($path), false);
+    }
+
+    public function testEmptyFileThrows(): void
+    {
+        $path = $this->writeTempFile('');
+
+        $this->expectException(CodeImportException::class);
+        iterator_to_array((new LOINCImportService())->readRecords($path), false);
+    }
+
+    private function writeTempFile(string $contents): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'oe-loinc-');
+        self::assertIsString($path);
+        file_put_contents($path, $contents);
+        $this->tempFiles[] = $path;
+        return $path;
+    }
+}

--- a/tests/Tests/Isolated/Services/CodeTypes/Importer/RXCUIImportServiceTest.php
+++ b/tests/Tests/Isolated/Services/CodeTypes/Importer/RXCUIImportServiceTest.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * Isolated tests for RXCUIImportService's RXNCONSO.RRF parsing.
+ *
+ * The row filters asserted here are the ones the legacy interface/super/load_codes.php applied, so
+ * these tests double as a regression guard on that behaviour surviving the move into src/.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (C) 2026 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\CodeTypes\Importer;
+
+use OpenEMR\Services\CodeTypes\CodeImportException;
+use OpenEMR\Services\CodeTypes\Importer\RXCUIImportService;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+#[Group('isolated')]
+class RXCUIImportServiceTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+        $this->tempFiles = [];
+    }
+
+    public function testCodeTypeIsRxcui(): void
+    {
+        $this->assertSame('RXCUI', (new RXCUIImportService())->getCodeType());
+    }
+
+    public function testPrescribableRxnormRowsAreImportedFromARawRrfFile(): void
+    {
+        $path = $this->writeTempFile(
+            $this->rrfLine('1191', 'RXNORM', 'aspirin', '4096')
+            . $this->rrfLine('161', 'RXNORM', 'acetaminophen', '4096')
+        );
+
+        $this->assertSame(
+            [
+                ['code' => '1191', 'code_text' => 'aspirin', 'code_text_short' => ''],
+                ['code' => '161', 'code_text' => 'acetaminophen', 'code_text_short' => ''],
+            ],
+            iterator_to_array((new RXCUIImportService())->readRecords($path), false)
+        );
+    }
+
+    public function testRowsFromOtherVocabulariesAreSkipped(): void
+    {
+        $path = $this->writeTempFile(
+            $this->rrfLine('1191', 'RXNORM', 'aspirin', '4096')
+            . $this->rrfLine('9999', 'MSH', 'from another source', '4096')
+        );
+
+        $records = iterator_to_array((new RXCUIImportService())->readRecords($path), false);
+
+        $this->assertSame(['1191'], array_column($records, 'code'));
+    }
+
+    public function testRowsOutsideThePrescribableContentViewAreSkipped(): void
+    {
+        $path = $this->writeTempFile(
+            $this->rrfLine('1191', 'RXNORM', 'aspirin', '4096')
+            . $this->rrfLine('9999', 'RXNORM', 'not prescribable', '')
+        );
+
+        $records = iterator_to_array((new RXCUIImportService())->readRecords($path), false);
+
+        $this->assertSame(['1191'], array_column($records, 'code'));
+    }
+
+    public function testTruncatedRowsAreSkipped(): void
+    {
+        $path = $this->writeTempFile(
+            "1191|ENG|P|L0000001|\n"
+            . $this->rrfLine('161', 'RXNORM', 'acetaminophen', '4096')
+        );
+
+        $records = iterator_to_array((new RXCUIImportService())->readRecords($path), false);
+
+        $this->assertSame(['161'], array_column($records, 'code'));
+    }
+
+    public function testRepeatedCodesAreEmittedOnlyOnce(): void
+    {
+        $path = $this->writeTempFile(
+            $this->rrfLine('1191', 'RXNORM', 'aspirin', '4096')
+            . $this->rrfLine('1191', 'RXNORM', 'aspirin (duplicate row)', '4096')
+        );
+
+        $records = iterator_to_array((new RXCUIImportService())->readRecords($path), false);
+
+        $this->assertCount(1, $records);
+        $this->assertSame('aspirin', $records[0]['code_text']);
+    }
+
+    public function testRrfIsReadFromInsideAReleaseZip(): void
+    {
+        $path = $this->writeZip([
+            'rrf/RXNCONSO.RRF' => $this->rrfLine('1191', 'RXNORM', 'aspirin', '4096'),
+            'rrf/RXNSAT.RRF' => "unrelated\n",
+        ]);
+
+        $this->assertSame(
+            [['code' => '1191', 'code_text' => 'aspirin', 'code_text_short' => '']],
+            iterator_to_array((new RXCUIImportService())->readRecords($path), false)
+        );
+    }
+
+    public function testZipWithoutTheConsoTableThrowsInsteadOfExiting(): void
+    {
+        $path = $this->writeZip(['rrf/RXNSAT.RRF' => "unrelated\n"]);
+
+        $this->expectException(CodeImportException::class);
+        iterator_to_array((new RXCUIImportService())->readRecords($path), false);
+    }
+
+    public function testMissingFileThrows(): void
+    {
+        $this->expectException(CodeImportException::class);
+        iterator_to_array(
+            (new RXCUIImportService())->readRecords(sys_get_temp_dir() . '/no-such-file-' . uniqid() . '.rrf'),
+            false
+        );
+    }
+
+    /**
+     * Build one RXNCONSO.RRF row. Only the columns the importer reads are populated; the trailing
+     * delimiter matches the real files, which end every row with a pipe.
+     */
+    private function rrfLine(string $rxcui, string $sab, string $str, string $cvf): string
+    {
+        $columns = array_fill(0, 18, '');
+        $columns[0] = $rxcui;
+        $columns[11] = $sab;
+        $columns[14] = $str;
+        $columns[17] = $cvf;
+        return implode('|', $columns) . "|\n";
+    }
+
+    private function writeTempFile(string $contents): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'oe-rxcui-');
+        self::assertIsString($path);
+        file_put_contents($path, $contents);
+        $this->tempFiles[] = $path;
+        return $path;
+    }
+
+    /**
+     * @param array<string, string> $entries
+     */
+    private function writeZip(array $entries): string
+    {
+        $path = $this->writeTempFile('');
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($path, ZipArchive::OVERWRITE) === true);
+        foreach ($entries as $name => $contents) {
+            $zip->addFromString($name, $contents);
+        }
+        $zip->close();
+        return $path;
+    }
+}


### PR DESCRIPTION
Fixes #13465 

interface/super/load_codes.php was a 235-line procedural page with inline HTML that could import exactly one code set, RXCUI, with two "TBD: clone the above for each new code type" markers where extensibility should have been.

Replace it with a controller, a Twig template and a pluggable importer hierarchy driven by two events, so that any module can contribute a code type by listening rather than by overriding the page:

  - CodeImportSupportedTypeFilterEvent collects the drop-down entries.
  - CodeImportEvent carries the upload; a listener claims it via setHandled(), which stops propagation so exactly one importer runs.

Core registers its own importers at CodeImportEvent::PRIORITY_CORE_FALLBACK (-100). Symfony sorts listeners by descending priority, so a module listening at the default priority of 0 always gets first refusal and can pre-empt core's handling of a code type core also supports.

RXCUI keeps the legacy parse exactly - the same RXNCONSO.RRF column filters, the same zip-or-raw detection - and LOINC is added, mapping its columns from the header row because that file's column order is not stable between releases. Also see #9190 

This code was developed in a downstream module and is upstreamed here. Fixed on the way in:

  - The RXCUI importer read $_FILES directly instead of its file argument, called die() mid-import, and its catch (ValueError) was namespace-relative so \ValueError was never caught.
  - An unknown code type silently inserted rows with code_type = NULL; it now raises CodeImportException.
  - The file handle leaked whenever a row threw between open and close.
  - Batched commits counted only inserts, so an update-heavy run never committed mid-file.
  - Exception messages, which can carry file paths, were rendered to the user; they now go to the log and the user gets a generic message.
  - The replace checkbox was hardcoded checked and never reflected what was posted.

CodeImportException extends \RuntimeException deliberately: ForbiddenCatchTypeRule rejects any catch type related to \Error or \ErrorException, and since \ErrorException extends \Exception that rules out catch (\Exception) as well as catch (\Throwable).

The page no longer includes custom/code_types.inc.php. The only thing it used from that ~1100-line include was $code_types, which is replaced by a direct ct_id lookup filtered on ct_active = 1 - the same rows that array is built from.

Menus need no change: standard.json already points at this URL.

Adds isolated tests for both events and for the parsing half of each importer, plus two Twig render fixtures.

Assisted-by: Claude Code