### PR TITLE
fix(release): unbreak release-mechanism workflows post-#13287 (blocks rel-830 cut)

### DIFF
--- a/.github/workflows/branch-cut-automation.yml
+++ b/.github/workflows/branch-cut-automation.yml
@@ -52,13 +52,21 @@ jobs:
         php-version:
         - '8.5'
     steps:
-    # Sparse checkout of just the composite action so the token-mint
-    # step below can resolve `uses: ./.github/actions/...`. Full
-    # checkouts happen later against the master/new-rel-branch refs.
-    - name: Checkout composite action
+    # Sparse checkout of just the composite actions this job's
+    # workspace-root uses/... references resolve against —
+    # generate-app-token (Mint step below) and setup-php-composer
+    # (Setup PHP step below). Local composite paths resolve against
+    # GITHUB_WORKSPACE at step-load time; a second full checkout
+    # doesn't reliably materialize files pruned by the first sparse
+    # checkout, so include everything the workspace-root needs in the
+    # first sparse pattern. Per-side mutator work uses rel-checkout/
+    # and master-checkout/ (below), which are their own full checkouts.
+    - name: Checkout composite actions
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-app-token
+        sparse-checkout: |
+          .github/actions/generate-app-token
+          .github/actions/setup-php-composer
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
@@ -135,18 +143,6 @@ jobs:
           echo "target-version=${target_version}"
           echo "prev-rel-branch=${prev_rel_branch}"
         } >> "$GITHUB_OUTPUT"
-
-    # Initial checkout at the workflow's default working directory so
-    # `./.github/actions/setup-php-composer` resolves (composite actions
-    # must live under GITHUB_WORKSPACE before they can be referenced).
-    # The mutator runs use the per-side checkouts below; this checkout
-    # is just for the composite action source.
-    - name: Checkout master (for composite action source)
-      uses: actions/checkout@v7
-      with:
-        ref: master
-        fetch-depth: 1
-        persist-credentials: false
 
     - name: Setup PHP and Composer (shared)
       uses: ./.github/actions/setup-php-composer

--- a/.github/workflows/patch-prep-automation.yml
+++ b/.github/workflows/patch-prep-automation.yml
@@ -59,14 +59,21 @@ jobs:
         php-version:
         - '8.5'
     steps:
-    # Sparse checkout of just the composite action so the token-mint
-    # step below can resolve `uses: ./.github/actions/...`. Full
-    # checkout happens later (the two later checkouts here use the
-    # rel branch, not master, so we can't collapse them into this).
-    - name: Checkout composite action
+    # Sparse checkout of just the composite actions this job's
+    # workspace-root uses/... references resolve against —
+    # generate-app-token (Mint step below) and setup-php-composer
+    # (Setup PHP step below). Local composite paths resolve against
+    # GITHUB_WORKSPACE at step-load time; a second full checkout
+    # doesn't reliably materialize files pruned by the first sparse
+    # checkout, so include everything the workspace-root needs in the
+    # first sparse pattern. Per-side mutator work uses rel-checkout/
+    # and master-checkout/ (below), which are their own full checkouts.
+    - name: Checkout composite actions
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-app-token
+        sparse-checkout: |
+          .github/actions/generate-app-token
+          .github/actions/setup-php-composer
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
@@ -249,18 +256,6 @@ jobs:
           echo "target-version=${target_version}"
           echo "prev-version=${prev_version}"
         } >> "$GITHUB_OUTPUT"
-
-    # Initial checkout at the workflow's default working directory so
-    # `./.github/actions/setup-php-composer` resolves (composite actions
-    # must live under GITHUB_WORKSPACE before they can be referenced).
-    # The mutator runs use the per-side checkouts below; this checkout
-    # is just for the composite action source.
-    - name: Checkout master (for composite action source)
-      if: steps.resolve.outputs.should-run == 'true'
-      uses: actions/checkout@v7
-      with:
-        ref: master
-        fetch-depth: 1
 
     - name: Setup PHP and Composer (shared)
       if: steps.resolve.outputs.should-run == 'true'

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -248,6 +248,10 @@ jobs:
       env:
         VERSION: ${{ steps.resolve.outputs.version }}
         REL_BRANCH: ${{ steps.resolve.outputs.branch }}
+        # ChangelogMutator's GitHubApi shells out to `gh api` for
+        # compare + PR + GHSA lookups; without GH_TOKEN the gh CLI
+        # refuses to run under GitHub Actions.
+        GH_TOKEN: ${{ github.token }}
       run: |
         php bin/console openemr:release-prep \
           --skip-globals \
@@ -454,6 +458,7 @@ jobs:
       env:
         VERSION: ${{ steps.resolve.outputs.version }}
         REL_BRANCH: ${{ steps.resolve.outputs.branch }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         php bin/console openemr:release-prep \
           --skip-globals \
@@ -717,6 +722,7 @@ jobs:
       env:
         VERSION: ${{ steps.resolve.outputs.version }}
         REL_BRANCH: ${{ steps.resolve.outputs.branch }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         php bin/console openemr:release-prep \
           --skip-globals \


### PR DESCRIPTION
## Summary

Two release-mechanism regressions from #13287 (composite-action extraction), both surfaced live on the rel-830 branch-cut attempt this morning (2026-08-12). rel-830 was created, `branch-cut-automation.yml` fired on the create event, and failed at \`Setup PHP and Composer (shared)\` with:

\`\`\`
##[error]Can't find 'action.yml', 'action.yoml' or 'Dockerfile' under
'/home/runner/work/openemr/openemr/.github/actions/setup-php-composer'.
Did you forget to run actions/checkout before running your local action?
\`\`\`

Separately, the same rel-830 push fired the Release Prep Conductor and it failed with:

\`\`\`
gh call failed after 3 attempts (args=api /repos/openemr/openemr/compare/...):
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
\`\`\`

rel-820 was cut before #13287 landed and rel-830 was the first branch cut since — hence the delay in surfacing.

## Fixes

### 1. Sparse-checkout leak in branch-cut + patch-prep

Both workflows do:
1. Sparse checkout of \`.github/actions/generate-app-token\` (so the token-mint step can resolve the local composite)
2. \`Mint App token\`
3. \`Resolve …\`
4. Full \`actions/checkout@v7\` of master (\"for composite action source\") — intended to make \`.github/actions/setup-php-composer\` available
5. \`Setup PHP and Composer (shared)\` — 404s

The assumption in #13287's PR body was that step 4 would \"overwrite the sparse checkout transparently.\" In practice, \`git sparse-checkout disable\` clears the config, but files never written on the first pass do not reappear when the second checkout target is byte-identical at those paths — the working tree still doesn't have them, and \`uses: ./…\` resolves against the on-disk workspace at step-load time.

Fix: expand the initial sparse-checkout pattern to include \`.github/actions/setup-php-composer\` alongside \`generate-app-token\`, and drop the now-redundant \"Checkout master (for composite action source)\" step. Per-side \`rel-checkout/\` and \`master-checkout/\` full checkouts (which back the mutator runs) are unchanged.

### 2. release-prep mutators missing \`GH_TOKEN\`

\`ChangelogMutator\`'s \`GitHubApi\` shells out to \`gh api compare\` / PR / GHSA lookups. Under GitHub Actions, \`gh\` refuses to run without \`GH_TOKEN\`. Fix: add \`GH_TOKEN: \${{ github.token }}\` to the three \`Run release-prep mutators\` steps (rel scope, master scope release-finalize, master scope release-finalize post-tag).

The built-in \`github.token\` has enough read scope on this repo for the compare + GHSA endpoints — no need to burn the App token here.

Branch-cut and patch-prep mutator commands don't call \`ChangelogMutator\` (I grepped), so they don't need \`GH_TOKEN\` in their mutator env.

## Rollout plan

Once this merges to master:
1. Byte-identical sync PR fires to propagate the three files to rel-820 (and future active rel branches).
2. Delete + re-cut rel-830 from the fixed master — the create event re-fires branch-cut-automation with the fixed workflow, and this time it should open both rel-side and master-side PRs cleanly.
3. First push to rel-830 after cut re-fires the Release Prep Conductor with GH_TOKEN in place; it should complete and open the release-prep PR.

rel-830 was already deleted while this PR was in flight (no branch-specific work had accumulated on it — no PRs merged in, no branch-cut/release-prep PRs opened yet).

## Test plan

- [ ] actionlint + trim/EOF/codespell + Conventional Commits pass locally (done pre-push)
- [ ] rel-830 re-cut opens rel-side + master-side branch-cut PRs
- [ ] First push to re-cut rel-830 opens the release-prep PR
- [ ] Byte-identical sync PR merges cleanly

Assisted-by: Claude Code