### PR TITLE
fix(acceptance): unbreak to_tag cells + stop duplicate acceptance runs on release-mechanism bot PRs

### DIFF
--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -94,6 +94,19 @@ on:
         type: string
         default: 'next'
   push:
+    # Skip pushes to release-mechanism bot branches (branch-cut/,
+    # patch-prep/, release-prep/, release-finalize/). peter-evans/
+    # create-pull-request pushes to those branches AND opens a PR in
+    # one motion; both events would otherwise fire this workflow,
+    # producing a duplicate run whose "success" is misleading — the
+    # push run resolves build_locally=false and tests against Docker
+    # Hub's currently-published to_tag, not the PR-built code the PR
+    # run actually validates. Keep the pull_request run only.
+    branches-ignore:
+    - 'branch-cut/**'
+    - 'patch-prep/**'
+    - 'release-prep/**'
+    - 'release-finalize/**'
     paths:
     - '.github/workflows/acceptance-docker.yml'
     - '.github/docker/acceptance-docker-compose.yml'

--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -443,7 +443,13 @@ jobs:
         # TO_TAG is already a job-level env, but hoisted here for the
         # zero-splice-in-run: convention.
       run: |
-        LOCAL_TAG="openemr/openemr:pr-built"
+        # Tag portion only — the compose override at
+        # .github/docker/acceptance-docker-compose.yml expands this into
+        # `openemr/openemr:${OPENEMR_TAG:-latest}`. Including
+        # `openemr/openemr:` here doubles the prefix and Docker rejects
+        # the resulting `openemr/openemr:openemr/openemr:pr-built` as an
+        # invalid reference format.
+        LOCAL_TAG="pr-built"
         if [[ "$BUILD_IMAGE_RESULT" == "success" ]]; then
           BUILT="true"
         else

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -95,6 +95,19 @@ on:
         type: string
         default: ''
   push:
+    # Skip pushes to release-mechanism bot branches (branch-cut/,
+    # patch-prep/, release-prep/, release-finalize/). peter-evans/
+    # create-pull-request pushes to those branches AND opens a PR in
+    # one motion; both events would otherwise fire this workflow,
+    # producing a duplicate run whose "success" is misleading — the
+    # push run resolves build_locally=false and tests against the
+    # published to_version tarball, not the PR-built one the PR run
+    # actually validates. Keep the pull_request run only.
+    branches-ignore:
+    - 'branch-cut/**'
+    - 'patch-prep/**'
+    - 'release-prep/**'
+    - 'release-finalize/**'
     paths:
     - '.github/workflows/acceptance-package.yml'
     - '.github/docker/acceptance-package-compose.yml'


### PR DESCRIPTION
Two related fixes to the acceptance workflows, both surfaced today on the rel-830 branch-cut.

## 1. \`LOCAL_TAG\` double-prefix (acceptance-docker.yml)

The \`tags\` step set \`LOCAL_TAG=\"openemr/openemr:pr-built\"\` (full image reference), then wrote it to \`boot_tag\` for fresh-install-to / upgrade cells when \`build_locally=true\`. The boot step exported \`boot_tag\` as \`OPENEMR_TAG\`, and the compose override at \`.github/docker/acceptance-docker-compose.yml\` expands:

\`\`\`yaml
image: openemr/openemr:\${OPENEMR_TAG:-latest}
\`\`\`

So the effective image became \`openemr/openemr:openemr/openemr:pr-built\` and Docker rejected it:

\`\`\`
unable to get image 'openemr/openemr:openemr/openemr:pr-built':
Error response from daemon: invalid reference format
\`\`\`

Every to_tag matrix cell failed — visible on today's rel-830 branch-cut PRs (#13482 rel-side, #13484 master-side) and the \`release-prep/rel-830\` \`workflow_dispatch\` fire.

**Fix**: drop the prefix from \`LOCAL_TAG\` — the compose override supplies it. The image is still built + loaded as \`openemr/openemr:pr-built\` (\`build-image\` job's \`--tag openemr/openemr:pr-built\`); compose's prefix + this tag portion combine correctly.

Introduced in #13163 (Phase 2.5 build-from-codebase, 2026-07-24). Master push runs skipped the build-image path and used the Docker Hub \`to_tag\` directly, so this code path was effectively untested until a branch-cut PR fired it.

## 2. Duplicate push+PR runs on release-mechanism bot branches (acceptance-docker.yml + acceptance-package.yml)

Both workflows have \`push:\` AND \`pull_request:\` triggers with matching paths. peter-evans/create-pull-request opens release-mechanism bot PRs by first pushing to the branch AND opening a PR in one motion — both events fire the acceptance workflow.

The two runs resolve \`build_locally\` differently. On a bot-branch push, \`detect-mode\` computes \`build_locally=false\` (branch isn't a rel-branch or master; no PR context), so acceptance boots against the currently-published \`to_tag\` / \`to_version\` and passes. On the immediately-following pull_request event, \`detect-mode\` computes \`build_locally=true\` and actually builds + tests the PR artifacts.

The push-side pass is misleading — it validates Docker Hub's / the release page's currently-shipped bytes, not the PR's. Only the pull_request run is a real gate.

**Fix**: \`branches-ignore\` on the push trigger for \`branch-cut/**\`, \`patch-prep/**\`, \`release-prep/**\`, \`release-finalize/**\`. Master pushes and non-bot-branch pushes are unaffected.

## Test plan

- [ ] Trigger \`acceptance-docker.yml\` via \`workflow_dispatch\` with \`build_locally: true\` and verify to_tag cells go green
- [ ] Next branch-cut / release-prep PR opens with a single acceptance-docker run (no duplicate push-side fire)
- [ ] Master push touching the acceptance surface still fires one run

Assisted-by: Claude Code