### PR TITLE
fix(acceptance): swallow shopt -p exit code so extract-zip helper survives set -e

### DIFF
--- a/tests/Acceptance/bin/lib/extract-zip.sh
+++ b/tests/Acceptance/bin/lib/extract-zip.sh
@@ -104,8 +104,22 @@ extract_zip_flattening_single_top_level_dir() {
     # Helper is sourced — save the caller's nullglob+dotglob state so
     # we can restore it before returning. `shopt -p` emits shopt
     # commands that recreate the current state; eval replays them.
+    #
+    # `|| true` because `shopt -p X Y` exits 1 when any listed option
+    # is disabled — the DEFAULT bash state, and the state every real
+    # caller (boot-package.sh, upgrade-package.sh) runs under. Without
+    # `|| true` the caller's `set -e` kills the script silently right
+    # here (stderr is empty because the exit status is the only signal
+    # and stdout of shopt is captured into the variable). Landed in
+    # #13286 (Phase 10d shared helper) + #13287 shopt-leak fix — sat
+    # undetected because the auto-fire acceptance push matrix uses the
+    # published-artifact path and never reaches this helper; only the
+    # build_locally paths (workflow_dispatch, or docker/release/
+    # tools/release/** PRs) do. First exercised on today's rel-830
+    # release-prep dispatch. See extract.bats "caller runs under set
+    # -euo pipefail" for the regression guard.
     local shopt_saved
-    shopt_saved="$(shopt -p nullglob dotglob)"
+    shopt_saved="$(shopt -p nullglob dotglob || true)"
 
     local zip_roots
     shopt -s nullglob dotglob

--- a/tests/bats/ci-scripts/extract-zip/extract.bats
+++ b/tests/bats/ci-scripts/extract-zip/extract.bats
@@ -293,3 +293,35 @@ teardown() {
     [[ -f "${DEST_DIR}/marker" ]]
     [[ ! -d "${DEST_DIR}/arbitrary-name" ]]
 }
+
+@test "caller runs under set -euo pipefail with default shopts: extract still succeeds" {
+    # Regression guard for the shopt-p-under-set-e bug: production
+    # callers (boot-package.sh, upgrade-package.sh) source this helper
+    # under `set -euo pipefail` with nullglob + dotglob at their bash-
+    # default OFF state. The helper's `shopt_saved="$(shopt -p nullglob
+    # dotglob)"` capture step used to fail silently there — `shopt -p X
+    # Y` exits 1 when any listed option is disabled, and under set -e
+    # the caller's script died with no stderr (the exit status was the
+    # only signal; stdout of shopt was captured into the variable).
+    #
+    # Reproduces the exact caller shape rather than going through
+    # run_extract() (which invokes bash without set -e) so the guard
+    # actually catches the regression.
+    mkdir -p "${STAGING_DIR}/openemr-8.2.0"
+    echo "x" >"${STAGING_DIR}/openemr-8.2.0/marker"
+    make_zip strict openemr-8.2.0
+
+    run bash -c "
+        set -euo pipefail
+        shopt -u nullglob dotglob
+        source '${EXTRACT_ZIP_LIB}'
+        extract_zip_flattening_single_top_level_dir \
+            '${ZIP_DIR}/strict.zip' \
+            '${DEST_DIR}' \
+            'extract-zip-strict.XXXXXX' \
+            'strict-mode test context'
+    "
+
+    [[ ${status} -eq 0 ]]
+    [[ -f "${DEST_DIR}/marker" ]]
+}


### PR DESCRIPTION
## Summary

The zip-extract helper at \`tests/Acceptance/bin/lib/extract-zip.sh\` was silently killing its callers under \`set -euo pipefail\`. Root cause + fix + regression guard.

## The bug

\`\`\`bash
shopt_saved=\"\$(shopt -p nullglob dotglob)\"
\`\`\`

\`shopt -p X Y\` exits **1 when any listed option is disabled** — the DEFAULT bash state, and the state every production caller (\`boot-package.sh\`, \`upgrade-package.sh\`) runs under. Verified locally:

\`\`\`console
\$ bash
\$ set -euo pipefail
\$ x=\"\$(shopt -p nullglob dotglob)\"
\$ echo \$?
1
# script would have died silently HERE under set -e
\$ echo \"\$x\"
shopt -u nullglob
shopt -u dotglob
\`\`\`

The command substitution captured stdout of \`shopt\` into the variable and dropped exit status on the floor of the assignment — but under \`set -e\` the caller's script terminated at that line. Stderr was empty (shopt writes state to stdout), no \`::error::\` message, no helper output past boot-package.sh's earlier \`==> Extracting into ...\` line. From a CI log perspective the extraction just vanished.

## Why it took this long to surface

Landed in #13287 (\"preserve caller shopt state in extract-zip helper\", 2026-07-30). The bug shipped to master and byte-identical-synced to rel-branches. Never triggered in the auto-fire acceptance matrix because:

- **Master push + scheduled runs** resolve \`build_locally=false\`. The \"zip\" matrix cell then downloads the from-hub \`.tar.gz\` (not a zip) and never reaches this helper — the format label is only used for how PackageAssembler-built PR artifacts get named.
- **Only \`build_locally=true\` paths** (\`workflow_dispatch\` with the input, or \`docker/release/\`/\`tools/release/**\` PR events) actually build a zip and reach this helper.

Today's rel-830 release-prep tip acceptance-package dispatch was the first real invocation. Every zip cell (fresh-install, wizard-install, upgrade, wizard-upgrade) died silently in run [31578014196](https://github.com/openemr/openemr/actions/runs/31578014196).

## Fix

Append \`|| true\` to the shopt capture:

\`\`\`diff
-shopt_saved=\"\$(shopt -p nullglob dotglob)\"
+shopt_saved=\"\$(shopt -p nullglob dotglob || true)\"
\`\`\`

Output content is identical across all four enabled/disabled combinations (verified) — we only care about *recreating* the state on the way out, not confirming both were enabled coming in.

## Regression guard

Added an extract.bats test that runs the helper under \`set -euo pipefail\` with both shopts explicitly disabled, matching real caller shape. Crucially, it does **NOT** go through the existing \`run_extract()\` wrapper — that wrapper invokes bash **without** \`set -e\`, which is why the 16 pre-existing tests all passed while production died. Verified locally: the new test fails with the shopt fix reverted, passes with it applied.

## Test plan

- [x] 17/17 bats tests pass locally with fix
- [x] Regression test fails with fix reverted (confirms it catches the bug)
- [ ] Next release-prep tip / branch-cut PR shows zip cells green in acceptance-package
- [ ] byte-identical sync propagates fix + test to rel-810 / rel-820

Assisted-by: Claude Code