### PR TITLE
fix(release): branch-cut mutator emits gate_with_acceptance: true on new rel row

### DIFF
--- a/src/Common/Command/ReleasePrep/Mutator/BranchCutReleaseTargetsMutator.php
+++ b/src/Common/Command/ReleasePrep/Mutator/BranchCutReleaseTargetsMutator.php
@@ -345,6 +345,11 @@ final readonly class BranchCutReleaseTargetsMutator implements MutatorInterface
 
     /**
      * Render the row's lines. Tag list at cut time: `<X.Y.0>,next`.
+     * `gate_with_acceptance: true` because every freshly-cut rel branch
+     * carries the acceptance surface (added by Phase 12 / #13332); this
+     * field was introduced after the mutator shipped and needs to be
+     * back-patched here so future cuts don't drop it (as happened on
+     * rel-830 in openemr/openemr#13484).
      *
      * @return list<string>
      */
@@ -355,6 +360,7 @@ final readonly class BranchCutReleaseTargetsMutator implements MutatorInterface
             '- branch: ' . $relBranch,
             '  docker_tags: ' . $versionTag . ',next',
             '  openemr_version_ref: ' . $relBranch,
+            '  gate_with_acceptance: true',
         ];
     }
 

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/BranchCutReleaseTargetsMutatorTest.php
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/BranchCutReleaseTargetsMutatorTest.php
@@ -166,6 +166,12 @@ final class BranchCutReleaseTargetsMutatorTest extends TestCase
         self::assertSame('8.2.0,next', $byBranch['rel-820']['docker_tags']);
         self::assertSame('rel-820', $byBranch['rel-820']['openemr_version_ref']);
         self::assertSame('8.1.1,latest', $byBranch['rel-810']['docker_tags']);
+        // Every freshly-cut rel branch carries the acceptance surface
+        // (Phase 12 / #13332). Mutator must set gate_with_acceptance
+        // on the new row — omitted in the initial mutator shipped
+        // pre-Phase-12, back-patched after openemr/openemr#13484 caught
+        // the drop on rel-830's cut.
+        self::assertTrue($byBranch['rel-820']['gate_with_acceptance']);
     }
 
     public function testMasterWithoutNextStillBumpsMinor(): void

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/branch_cut_targets/canonical_rel820_expected.yml
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/branch_cut_targets/canonical_rel820_expected.yml
@@ -9,6 +9,7 @@
 - branch: rel-820
   docker_tags: 8.2.0,next
   openemr_version_ref: rel-820
+  gate_with_acceptance: true
 
 - branch: rel-810
   docker_tags: 8.1.1,latest


### PR DESCRIPTION
## The bug

Omission — Phase 12 (#13332, 2026-08-01) introduced \`gate_with_acceptance: true\` as the per-row flag driving pre-publish acceptance-docker gates, and back-patched every existing \`- branch: rel-<X>\` row in \`.github/release-targets.yml\`. \`BranchCutReleaseTargetsMutator\` shipped 2026-06-30, before the flag existed, so its \`renderRelRowLines()\` never learned to emit it.

Surfaced today on the rel-830 cut: #13484 (master-side branch-cut PR) opened with the new \`- branch: rel-830\` block missing the flag:

\`\`\`diff
+- branch: rel-830
+  docker_tags: 8.3.0,next
+  openemr_version_ref: rel-830
+  # ← missing: gate_with_acceptance: true
\`\`\`

If merged as-is, docker-release-orchestrator wouldn't gate rel-830's publishes on acceptance-docker — silent downgrade of release quality for the newest rel branch.

## Fix

Append \`'  gate_with_acceptance: true'\` to \`renderRelRowLines()\`. Every freshly-cut rel branch carries the acceptance surface (that's what Phase 12 enforces at rel-820+), so the flag is unconditional here.

## Test coverage

- Existing canonical-cut fixture \`canonical_rel820_expected.yml\` updated to include the new line under the rel-820 row (the fixture tests the exact byte-for-byte output of a canonical cut).
- \`testNormalCutPathBumpsMasterAndAddsRelRow\` gets an explicit \`assertTrue($byBranch['rel-820']['gate_with_acceptance'])\` — semantic assertion that survives fixture reformatting.

Verified locally: 4345/4345 isolated tests pass (the 2 failures visible in a prior run were fixture-out-of-date — resolved by the fixture update in this PR).

## Self-heal for #13484

After this lands, run:

\`\`\`console
gh workflow run branch-cut-automation.yml --ref rel-830 --repo openemr/openemr
\`\`\`

That re-fires branch-cut. The master-side mutator run happens against master-checkout (which by then has the fix), regenerates the row correctly, and peter-evans updates #13484 in place with the missing line. Rel-side (#13482) regen is a no-op (nothing about that side changed).

Confirms end-to-end that the mutator fix works AND heals #13484 without a direct patch — same pattern as the earlier rel-830 release-mechanism recovery today.

Assisted-by: Claude Code