### PR TITLE
ci(byte-identical): sync src/Common/Command/ReleasePrep tests + fixtures too

### DIFF
--- a/.github/byte-identical.yml
+++ b/.github/byte-identical.yml
@@ -267,6 +267,15 @@ files:
   exclude-branches: [rel-800, rel-704]
 - path: tests/Tests/Isolated/Release/**
   exclude-branches: [rel-800, rel-704]
+# Isolated tests + fixtures for src/Common/Command/ReleasePrep/**
+# (mirrors the production namespace under PSR-4). Kept in sync so
+# byte-identical propagation of a mutator change (e.g. #13496 adding
+# gate_with_acceptance: true) doesn't strand rel branches with a
+# stale expected-output fixture — that shape broke rel-820's sync PR
+# (openemr/openemr#13498) when the mutator PHP synced without its
+# fixture/test file.
+- path: tests/Tests/Isolated/Common/Command/ReleasePrep/**
+  exclude-branches: [rel-800, rel-704]
 
 # Artifact acceptance surface (added 2026-07-24 -- see
 # docs/artifact-acceptance-testing-plan.md for the full architecture


### PR DESCRIPTION
## The gap

Manifest carried the production namespace (\`src/Common/Command/ReleasePrep/**\`) and its command entry point (\`src/Common/Command/ReleasePrepCommand.php\`) but omitted the parallel isolated test tree at \`tests/Tests/Isolated/Common/Command/ReleasePrep/**\` — the PSR-4 mirror where every mutator's unit test + fixture files live.

## What broke on today's rel-830 recovery

#13496 (mutator fix adding \`gate_with_acceptance: true\` to \`renderRelRowLines()\`) landed 3 files:

1. \`src/Common/Command/ReleasePrep/Mutator/BranchCutReleaseTargetsMutator.php\` — the fix
2. \`tests/Tests/Isolated/Common/Command/ReleasePrep/Mutator/BranchCutReleaseTargetsMutatorTest.php\` — new assertion
3. \`tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/branch_cut_targets/canonical_rel820_expected.yml\` — updated expected shape

Byte-identical sync PR #13498 propagated **only** file 1 to rel-820. Test + fixture stayed at rel-820's stale pre-#13496 content. Mutator now emits the new line; fixture still expects the old shape; isolated tests fail on rel-820. Any future mutator change touching its own test/fixture would trip the same gap.

## Fix

Add \`tests/Tests/Isolated/Common/Command/ReleasePrep/**\` to the manifest with the same \`exclude-branches: [rel-800, rel-704]\` the production namespace carries (those branches predate the ReleasePrep namespace entirely).

## Rollout

Once merged:
1. Byte-identical sync fires on this master push, targets rel-810/rel-820/rel-830
2. Updates #13498's head to add the missing test + fixture files → isolated-tests check on rel-820 goes green → #13498 merges cleanly

## Test plan

- [x] Pre-commit clean (actionlint + trim/EOF + codespell + conventional-commits)
- [ ] After merge, #13498 auto-updates and turns green

Assisted-by: Claude Code