### PR TITLE
perf(i18n): short-circuit English dates and defer unused label work

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -22227,11 +22227,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/custom_template/share_template.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\<min, \\-1\\>\\|int\\<1, max\\>\\|string given\\.$#',
-    'count' => 5,
-    'path' => __DIR__ . '/../../library/date_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$s of function escape_limit expects string, mixed given\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../library/dated_reminder_functions.php',

--- a/library/date_functions.php
+++ b/library/date_functions.php
@@ -26,36 +26,41 @@ function dateformat(string|int $strtime = '', bool $with_dow = false): string
         $strtime = strtotime('now');
     }
 
+    // Callers pass the timestamp as either an int or a numeric string; normalise
+    // once so the date() calls below receive the int they declare.
+    $timestamp = (int) $strtime;
+
     // name the day of the week for different languages
-    $day = (int) date("w", $strtime); // 0 sunday -> 6 saturday
+    $day = (int) date("w", $timestamp); // 0 sunday -> 6 saturday
     $dow = DayOfWeek::from($day)->label();
 
     // name of the month in different languages
-    $month = (int) date('m', $strtime);
+    $month = (int) date('m', $timestamp);
     $nom = Month::from($month)->label();
 
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
     $languageChoice = $session->get('language_choice');
+    // getLanguageTitle() treats an unset choice as language 1, so mirror that.
+    $languageId = is_numeric($languageChoice) ? (int) $languageChoice : 1;
 
     // English is both the default and the common case, and reaching the English
     // arms below costs three lang_languages queries per formatted date -- two of
     // them just to discover that language 1 is called "English". Short-circuit it.
-    // getLanguageTitle() treats an empty choice as language 1, so this matches.
-    if (empty($languageChoice) || (int) $languageChoice === 1) {
-        $dt = date("F j, Y", $strtime);
+    if ($languageId === 1) {
+        $dt = date("F j, Y", $timestamp);
 
         return $with_dow ? "$dow, $dt" : $dt;
     }
 
-    $day_num = date("d", $strtime);
-    $year = date("Y", $strtime);
+    $day_num = date("d", $timestamp);
+    $year = date("Y", $timestamp);
 
     // Date string format
     // First, get current language title
-    $languageTitle = getLanguageTitle($languageChoice);
+    $languageTitle = getLanguageTitle($languageId);
     $dt = match ($languageTitle) {
         // standard english first
-        getLanguageTitle(1) => date("F j, Y", $strtime),
+        getLanguageTitle(1) => date("F j, Y", $timestamp),
         "Swedish" => "$year $nom $day_num",
         "Dutch",
         "German",

--- a/library/date_functions.php
+++ b/library/date_functions.php
@@ -35,11 +35,24 @@ function dateformat(string|int $strtime = '', bool $with_dow = false): string
     $nom = Month::from($month)->label();
 
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
-    // Date string format
-    // First, get current language title
-    $languageTitle = getLanguageTitle($session->get('language_choice'));
+    $languageChoice = $session->get('language_choice');
+
+    // English is both the default and the common case, and reaching the English
+    // arms below costs three lang_languages queries per formatted date -- two of
+    // them just to discover that language 1 is called "English". Short-circuit it.
+    // getLanguageTitle() treats an empty choice as language 1, so this matches.
+    if (empty($languageChoice) || (int) $languageChoice === 1) {
+        $dt = date("F j, Y", $strtime);
+
+        return $with_dow ? "$dow, $dt" : $dt;
+    }
+
     $day_num = date("d", $strtime);
     $year = date("Y", $strtime);
+
+    // Date string format
+    // First, get current language title
+    $languageTitle = getLanguageTitle($languageChoice);
     $dt = match ($languageTitle) {
         // standard english first
         getLanguageTitle(1) => date("F j, Y", $strtime),

--- a/library/date_functions.php
+++ b/library/date_functions.php
@@ -44,9 +44,6 @@ function dateformat(?int $timestamp = null, bool $with_dow = false): string
     $month = (int) date('m', $timestamp);
     $nom = Month::from($month)->label();
 
-    // English is both the default and the common case, and reaching the English
-    // arms below costs three lang_languages queries per formatted date -- two of
-    // them just to discover that language 1 is called "English". Short-circuit it.
     $day_num = date("d", $timestamp);
     $year = date("Y", $timestamp);
 

--- a/library/date_functions.php
+++ b/library/date_functions.php
@@ -11,7 +11,7 @@ use OpenEMR\Common\Session\SessionWrapperFactory;
  * the session's 'language_choice' value. The format varies by language and can optionally
  * include the day of the week.
  *
- * @param string|int $strtime Unix timestamp or date string. If empty, uses current time.
+ * @param ?int $timestamp Unix timestamp, defaulting to now
  * @param bool $with_dow Whether to include the day of the week in the output.
  * @return string The formatted date string.
  *
@@ -19,16 +19,12 @@ use OpenEMR\Common\Session\SessionWrapperFactory;
  * @note For Hebrew, displays English calendar, NOT Jewish calendar
  * @note Last modified 10.07.2007 - dateformat accepts now an argument
  */
-function dateformat(string|int $strtime = '', bool $with_dow = false): string
+function dateformat(?int $timestamp = null, bool $with_dow = false): string
 {
     // without an argument, display current date
-    if (!$strtime) {
-        $strtime = strtotime('now');
+    if ($timestamp === null) {
+        $timestamp = time();
     }
-
-    // Callers pass the timestamp as either an int or a numeric string; normalise
-    // once so the date() calls below receive the int they declare.
-    $timestamp = (int) $strtime;
 
     // name the day of the week for different languages
     $day = (int) date("w", $timestamp); // 0 sunday -> 6 saturday

--- a/library/date_functions.php
+++ b/library/date_functions.php
@@ -26,28 +26,27 @@ function dateformat(?int $timestamp = null, bool $with_dow = false): string
         $timestamp = time();
     }
 
-    // name the day of the week for different languages
-    $day = (int) date("w", $timestamp); // 0 sunday -> 6 saturday
-    $dow = DayOfWeek::from($day)->label();
+    // Perf optimization: short-circuit English, see #13497/#13507
+    $session = SessionWrapperFactory::getInstance()->getActiveSession();
+    $languageChoice = $session->get('language_choice');
+    // getLanguageTitle() treats an unset choice as language 1, so mirror that.
+    $languageId = is_numeric($languageChoice) ? (int) $languageChoice : 1;
+    if ($languageId === 1) {
+        $dt = date("F j, Y", $timestamp);
+        if ($with_dow) {
+            $dow = DayOfWeek::from((int) date('w', $timestamp))->label();
+            return "$dow, $dt";
+        }
+        return $dt;
+    }
 
     // name of the month in different languages
     $month = (int) date('m', $timestamp);
     $nom = Month::from($month)->label();
 
-    $session = SessionWrapperFactory::getInstance()->getActiveSession();
-    $languageChoice = $session->get('language_choice');
-    // getLanguageTitle() treats an unset choice as language 1, so mirror that.
-    $languageId = is_numeric($languageChoice) ? (int) $languageChoice : 1;
-
     // English is both the default and the common case, and reaching the English
     // arms below costs three lang_languages queries per formatted date -- two of
     // them just to discover that language 1 is called "English". Short-circuit it.
-    if ($languageId === 1) {
-        $dt = date("F j, Y", $timestamp);
-
-        return $with_dow ? "$dow, $dt" : $dt;
-    }
-
     $day_num = date("d", $timestamp);
     $year = date("Y", $timestamp);
 
@@ -68,6 +67,10 @@ function dateformat(?int $timestamp = null, bool $with_dow = false): string
     };
 
     if ($with_dow) {
+        // name the day of the week for different languages
+        $day = (int) date("w", $timestamp); // 0 sunday -> 6 saturday
+        $dow = DayOfWeek::from($day)->label();
+
         $separator = match ($languageTitle) {
             getLanguageTitle(1), "Hebrew" => ", ",
             default => " ",


### PR DESCRIPTION
#### Short description of what this changes or resolves:

**This is a workaround, not a fix.** It avoids the problem described in #13497 for the common case; it does not correct the underlying design. #13497 should stay open.

`dateformat()` issues up to three `lang_languages` queries per formatted date. Two of them exist only to look up a constant: `getLanguageTitle(1)` appears in two `match` arms, querying the database to discover that language id 1 is called "English" so the result can be string-compared against the session language's title.

This short-circuits the English path — the default and the common case — before any lookup happens, so English sessions issue none of the three. Measured on a calendar month view, roughly 171 queries originated here.

While in the function, it also tightens the signature and defers work (translation lookups) that was previously done unconditionally.

Partial solve for #13497, but the root cause remains for non-English sessions. Ideally this goes away entirely in favor of native or at least existing localization tools; there's not a lot of touch points.

#### Changes proposed in this pull request:

- **Short-circuit English.** Resolve the session's `language_choice` to an int up front and return the English format directly when it is language 1, skipping all three lookups. Non-English sessions take the unchanged path.
- **Defer the day-of-week label.** `DayOfWeek::from(...)->label()` was computed on every call; it is now computed only when `$with_dow` is set, which is the minority of calls.
- **Defer the month label.** `Month::from(...)->label()` is now computed only on the non-English path, which is the only place it is used.
- **Tighten the signature.** `dateformat(string|int $strtime = '', ...)` becomes `dateformat(?int $timestamp = null, ...)`. The parameter is always a Unix timestamp in current usage; the previous `string|int` invited numeric strings that were then coerced. This also removed five baselined `date()` argument-type errors rather than adding a sixth.
- Baseline shrinks by 5 entries; none added.

#### What this does not address

Everything #13497 actually reports remains true:

- **Non-English sessions still issue queries per formatted date.** They take the unchanged path.
- **Format selection is still keyed on human-readable titles**, which is install-dependent. A base install describes language 1 as `English`; the full language pack describes it as `English (Standard)`. Any comparison against a stored title varies by install.
- **The unreachable `"Spanish"` arm is still there.** No `lang_languages` row is named plain `Spanish` — the pack has `Spanish (Spain)` and `Spanish (Latin American)`.
- **The two `getLanguageTitle(1)` match arms are now dead code.** Because the function returns early for language 1, `$languageTitle` can no longer equal `getLanguageTitle(1)` when those matches run — barring two languages sharing a description, which nothing enforces against. They are left in place deliberately, to be removed with the rest of the title-matching rather than piecemeal.
- **The hand-rolled per-language date layouts remain.** A locale-aware formatter is the better destination and is not attempted here.

#### Was an AI assistant used? Yes