### PR TITLE
fix(ci): apply #13480 sparse-checkout fix to the remaining 5 release-mechanism workflows

### DIFF
--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -123,11 +123,16 @@ jobs:
     # Sparse checkout of just the composite action so the token-mint
     # step below can resolve `uses: ./.github/actions/...`. Full
     # checkout happens after the token is minted (uses the token).
-    - name: Checkout composite action
+    # setup-php-composer included in the initial sparse pattern too —
+    # subsequent full checkouts don't reliably materialize files pruned
+    # by the first sparse checkout (see openemr/openemr#13480).
+    - name: Checkout composite actions
       if: '!inputs.dry_run'
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-app-token
+        sparse-checkout: |
+          .github/actions/generate-app-token
+          .github/actions/setup-php-composer
         sparse-checkout-cone-mode: false
         persist-credentials: false
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -137,11 +137,16 @@ jobs:
     # Sparse checkout of just the composite action so the token-mint
     # step below can resolve `uses: ./.github/actions/...`. Full
     # checkout happens after the token is minted (uses the token).
-    - name: Checkout composite action
+    # setup-php-composer included in the initial sparse pattern too —
+    # subsequent full checkouts don't reliably materialize files pruned
+    # by the first sparse checkout (see openemr/openemr#13480).
+    - name: Checkout composite actions
       if: '!inputs.dry_run'
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-app-token
+        sparse-checkout: |
+          .github/actions/generate-app-token
+          .github/actions/setup-php-composer
         sparse-checkout-cone-mode: false
         persist-credentials: false
 

--- a/.github/workflows/notify-release-targets-changed.yml
+++ b/.github/workflows/notify-release-targets-changed.yml
@@ -34,14 +34,22 @@ jobs:
         php-version:
         - '8.5'
     steps:
-    # Sparse checkout of just the composite action so the token-mint
-    # step below can resolve `uses: ./.github/actions/...`. Full
-    # checkout happens later (in this workflow that's just for
-    # setup-php-composer's autoload).
-    - name: Checkout composite action
+    # Sparse checkout of the composite actions this job's workspace-
+    # root uses/... references resolve against — generate-app-token
+    # (Mint step below) and setup-php-composer (Setup PHP step below).
+    # Local composite paths resolve against GITHUB_WORKSPACE at step-
+    # load time; a subsequent full checkout doesn't reliably materialize
+    # files pruned by the first sparse checkout, so include everything
+    # the workspace-root needs in the first sparse pattern. Companion
+    # to the fix in openemr/openemr#13480 (branch-cut + patch-prep) —
+    # this workflow has the same shape and failed identically on the
+    # rel-830 cut's release-targets.yml push.
+    - name: Checkout composite actions
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-app-token
+        sparse-checkout: |
+          .github/actions/generate-app-token
+          .github/actions/setup-php-composer
         sparse-checkout-cone-mode: false
         persist-credentials: false
 

--- a/.github/workflows/reusable-publish-release.yml
+++ b/.github/workflows/reusable-publish-release.yml
@@ -77,13 +77,19 @@ jobs:
     # boundaries anyway (writing a token to `$GITHUB_OUTPUT` masks it
     # in logs but the value that reaches the downstream job is often
     # empty). Regenerating is the documented path.
-    # Sparse checkout of just the composite action so the token-mint
-    # step below can resolve `uses: ./.github/actions/...`. Full
+    # Sparse checkout of the composite actions this job's workspace-
+    # root uses/... references resolve against — generate-app-token
+    # (mint step below) and setup-php-composer (later step). Full
     # checkout happens after the token is minted (uses the token).
-    - name: Checkout composite action
+    # setup-php-composer included in the initial sparse pattern too —
+    # subsequent full checkouts don't reliably materialize files pruned
+    # by the first sparse checkout (see openemr/openemr#13480).
+    - name: Checkout composite actions
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-app-token
+        sparse-checkout: |
+          .github/actions/generate-app-token
+          .github/actions/setup-php-composer
         sparse-checkout-cone-mode: false
         persist-credentials: false
 

--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -110,13 +110,19 @@ jobs:
     env:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-    # Sparse checkout of just the composite action so the token-mint
-    # step below can resolve `uses: ./.github/actions/...`. Full
+    # Sparse checkout of the composite actions this job's workspace-
+    # root uses/... references resolve against — generate-app-token
+    # (mint step below) and setup-php-composer (later step). Full
     # checkout happens after the token is minted (uses the token).
-    - name: Checkout composite action
+    # setup-php-composer included in the initial sparse pattern too —
+    # subsequent full checkouts don't reliably materialize files pruned
+    # by the first sparse checkout (see openemr/openemr#13480).
+    - name: Checkout composite actions
       uses: actions/checkout@v7
       with:
-        sparse-checkout: .github/actions/generate-app-token
+        sparse-checkout: |
+          .github/actions/generate-app-token
+          .github/actions/setup-php-composer
         sparse-checkout-cone-mode: false
         persist-credentials: false
 


### PR DESCRIPTION
## Why

openemr/openemr#13480 patched \`branch-cut-automation.yml\` + \`patch-prep-automation.yml\` for the sparse-checkout leak (initial sparse-checkout of just \`generate-app-token\` leaves \`setup-php-composer\` unmaterialized; subsequent full checkouts don't reliably restore it). That fix didn't extend to the other 5 workflows sharing the same shape.

**Today's rel-830 master-side branch-cut merge fired \`notify-release-targets-changed.yml\`** (same workflow_dispatch shape as branch-cut) — failed immediately at "Setup PHP and Composer" with the identical \`Can't find action.yml under .github/actions/setup-php-composer\` signature. Email notification landed in the release maintainer's inbox.

## What changed

Same fix applied to all 5 remaining workflows:
- **notify-release-targets-changed.yml** ← already failed in production today
- build-patch.yml
- build-release.yml
- ship-release.yml
- reusable-publish-release.yml

Fix shape: expand the initial sparse-checkout pattern from just \`.github/actions/generate-app-token\` to include \`.github/actions/setup-php-composer\` too. Later full checkouts in each workflow remain as-is (they serve other purposes — repo content for release scripts, etc.).

The build-* + publish workflows haven't fired yet on today's rel-830 cascade, but they will as soon as the release-prep cycle advances to ship, so this is proactive rather than reactive for those.

Not in scope: the master-side branches-ignore fix from #13486, which was specific to acceptance-docker + acceptance-package. These workflows fire on non-bot-branch triggers (workflow_dispatch, push to master), so the duplicate-run scenario doesn't apply.

## Test plan

- [ ] Rerun the failed notify-release-targets-changed run once this lands — should now clear Setup PHP + reach the dispatch step
- [ ] Next ship-release / build-release / build-patch dispatch: verify Setup PHP step passes

Assisted-by: Claude Code