### PR TITLE
fix(ci): restructure 5 release workflows to full-checkout-first + pass --rel-branch to release-prep render

### DIFF
--- a/.github/scripts/create-release-tag.sh
+++ b/.github/scripts/create-release-tag.sh
@@ -38,6 +38,16 @@
 #                        --notes-file`.
 #   GH_TOKEN             gh CLI auth token. Read directly by gh from
 #                        env; not consumed here.
+#   APP_TOKEN (optional) Installation token for the release App. When
+#                        set, used inline via `git -c http.extraheader`
+#                        for git ls-remote and git push — one-shot,
+#                        never written to .git/config. Prevents the
+#                        token from leaking to intermediate steps (npm,
+#                        composer, etc.) that a compromised dep could
+#                        exfiltrate. When unset, git operations use
+#                        whatever credentials the calling checkout
+#                        persisted (backward compat with legacy
+#                        callers).
 #
 # Exit codes
 #   0    Success — tag + release both exist in the expected state
@@ -74,6 +84,18 @@ tag="${RELEASE_TAG}"
 git config user.name 'github-actions[bot]'
 git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
+# If APP_TOKEN is set, build a `-c http.extraheader` arg to inject
+# Basic auth into git ls-remote + git push without writing anything
+# to .git/config. Leaves no residual credentials for any subsequent
+# step (or a compromised dep in the same job) to read. When unset,
+# git commands run bare (backward compat with callers that persist
+# credentials via actions/checkout).
+git_auth_arg=()
+if [[ -n "${APP_TOKEN:-}" ]]; then
+    basic_auth_b64=$(printf 'x-access-token:%s' "${APP_TOKEN}" | base64 -w0)
+    git_auth_arg=(-c "http.https://github.com/.extraheader=Authorization: Basic ${basic_auth_b64}")
+fi
+
 # Check the remote, not the local checkout: the checkout step uses
 # fetch-depth: 1 and does not fetch tags, so a local rev-parse always
 # misses an already-published tag. That made `git push origin "$tag"`
@@ -91,14 +113,14 @@ tag_lookup_status=0
 # etc.) alongside the exit code — speeds up incident triage on the
 # release-critical path. `2>&1 > /dev/null` reorders redirects: stderr
 # to captured stdout, then the original stdout to /dev/null.
-tag_lookup_stderr=$(git ls-remote --tags --exit-code origin "refs/tags/${tag}" 2>&1 > /dev/null) || tag_lookup_status=$?
+tag_lookup_stderr=$(git "${git_auth_arg[@]}" ls-remote --tags --exit-code origin "refs/tags/${tag}" 2>&1 > /dev/null) || tag_lookup_status=$?
 case "${tag_lookup_status}" in
     0)
         echo "Tag ${tag} already exists on origin, skipping tag creation"
         ;;
     2)
         git tag -a -m "Release ${tag}" "${tag}" "${VERSION_BRANCH}"
-        git push origin "${tag}"
+        git "${git_auth_arg[@]}" push origin "${tag}"
         ;;
     *)
         echo "::error::Failed to query origin for tag ${tag} (git ls-remote exit ${tag_lookup_status}): ${tag_lookup_stderr}" >&2

--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -120,20 +120,21 @@ jobs:
         printf '::error::release_tag is required when dry_run is false\n'
         exit 1
 
-    # Sparse checkout of just the composite action so the token-mint
-    # step below can resolve `uses: ./.github/actions/...`. Full
-    # checkout happens after the token is minted (uses the token).
-    # setup-php-composer included in the initial sparse pattern too —
-    # subsequent full checkouts don't reliably materialize files pruned
-    # by the first sparse checkout (see openemr/openemr#13480).
-    - name: Checkout composite actions
-      if: '!inputs.dry_run'
+    # Full checkout first — composite actions (generate-app-token,
+    # setup-php-composer) resolve against a real workspace, and
+    # composer.json is present for setup-php-composer's cache/install
+    # steps. The earlier sparse-first pattern (openemr/openemr#13480
+    # + #13509) worked around one bug but not the underlying git-
+    # sparse-then-full-checkout leak: files not in the initial sparse
+    # pattern (like composer.json) still weren't materialized by the
+    # second full checkout. Full-checkout-first sidesteps the leak.
+    - name: Checkout openemr release branch
       uses: actions/checkout@v7
       with:
-        sparse-checkout: |
-          .github/actions/generate-app-token
-          .github/actions/setup-php-composer
-        sparse-checkout-cone-mode: false
+        ref: ${{ inputs.version_branch }}
+        token: ${{ github.token }}
+        filter: blob:none
+        fetch-depth: 1
         persist-credentials: false
 
     - name: Generate app token
@@ -154,14 +155,6 @@ jobs:
         echo "Checking app token can access openemr/openemr milestones..."
         gh api repos/openemr/openemr/milestones --jq '.[].title' | head -5
         echo 'App token verified.'
-
-    - name: Checkout openemr release branch
-      uses: actions/checkout@v7
-      with:
-        ref: ${{ inputs.version_branch }}
-        token: ${{ steps.app-token.outputs.token || github.token }}
-        filter: blob:none
-        fetch-depth: 1
 
     - name: Fetch start tag
       env:

--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -156,16 +156,6 @@ jobs:
         gh api repos/openemr/openemr/milestones --jq '.[].title' | head -5
         echo 'App token verified.'
 
-    # Rewrite the origin URL to authenticate git-push with the App
-    # token — the top checkout used github.token (contents:read only)
-    # with persist-credentials=false; without this rewrite, the
-    # `git push origin <tag>` in the tag/release step below fails to
-    # authenticate. Skipped on dry_run since no tag is created.
-    - name: Configure git remote with App token for tag push
-      if: '!inputs.dry_run'
-      env:
-        APP_TOKEN: ${{ steps.app-token.outputs.token }}
-      run: git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
 
     - name: Fetch start tag
       env:
@@ -292,6 +282,7 @@ jobs:
       if: '!inputs.dry_run'
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
         RELEASE_TAG: ${{ inputs.release_tag }}
         VERSION_BRANCH: ${{ inputs.version_branch }}
         PATCH_FILENAME: ${{ inputs.patch_filename }}
@@ -305,8 +296,18 @@ jobs:
         if git rev-parse "$tag" > /dev/null 2>&1; then
           echo "Tag $tag already exists, skipping tag creation"
         else
+          # Authenticate git-push with the App token inline (not
+          # persisted in .git/config) — top checkout used
+          # persist-credentials=false so credentials aren't sitting
+          # in the tree during the composer install / npm ci / npm
+          # build / package-assembly steps between checkout and now.
+          # `-c http.extraheader=...` is one-shot: applies to this
+          # push only, never written to .git/config, no leak surface
+          # for a compromised dep or vendor script to read.
+          basic_auth_b64="$(printf 'x-access-token:%s' "$APP_TOKEN" | base64 -w0)"
           git tag -a -m "Patch release $tag" "$tag" "$VERSION_BRANCH"
-          git push origin "$tag"
+          git -c "http.https://github.com/.extraheader=Authorization: Basic ${basic_auth_b64}" \
+            push origin "$tag"
         fi
 
         if ! gh release view "$tag" --repo openemr/openemr > /dev/null 2>&1; then

--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -156,6 +156,17 @@ jobs:
         gh api repos/openemr/openemr/milestones --jq '.[].title' | head -5
         echo 'App token verified.'
 
+    # Rewrite the origin URL to authenticate git-push with the App
+    # token — the top checkout used github.token (contents:read only)
+    # with persist-credentials=false; without this rewrite, the
+    # `git push origin <tag>` in the tag/release step below fails to
+    # authenticate. Skipped on dry_run since no tag is created.
+    - name: Configure git remote with App token for tag push
+      if: '!inputs.dry_run'
+      env:
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
+      run: git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
+
     - name: Fetch start tag
       env:
         VERSION_START: ${{ inputs.version_start }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -134,20 +134,17 @@ jobs:
         printf '::error::release_tag is required when dry_run is false\n'
         exit 1
 
-    # Sparse checkout of just the composite action so the token-mint
-    # step below can resolve `uses: ./.github/actions/...`. Full
-    # checkout happens after the token is minted (uses the token).
-    # setup-php-composer included in the initial sparse pattern too —
-    # subsequent full checkouts don't reliably materialize files pruned
-    # by the first sparse checkout (see openemr/openemr#13480).
-    - name: Checkout composite actions
-      if: '!inputs.dry_run'
+    # Full checkout first — same rationale as build-patch.yml
+    # (composite actions + composer.json need to be on disk; the
+    # sparse-then-full pattern hit a git leak, see
+    # openemr/openemr#13480 + #13509).
+    - name: Checkout openemr release branch
       uses: actions/checkout@v7
       with:
-        sparse-checkout: |
-          .github/actions/generate-app-token
-          .github/actions/setup-php-composer
-        sparse-checkout-cone-mode: false
+        ref: ${{ inputs.version_branch }}
+        token: ${{ github.token }}
+        filter: blob:none
+        fetch-depth: 1
         persist-credentials: false
 
     - name: Generate app token
@@ -168,14 +165,6 @@ jobs:
         echo "Checking app token can access openemr/openemr milestones..."
         gh api repos/openemr/openemr/milestones --jq '.[].title' | head -5
         echo 'App token verified.'
-
-    - name: Checkout openemr release branch
-      uses: actions/checkout@v7
-      with:
-        ref: ${{ inputs.version_branch }}
-        token: ${{ steps.app-token.outputs.token || github.token }}
-        filter: blob:none
-        fetch-depth: 1
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer

--- a/.github/workflows/notify-release-targets-changed.yml
+++ b/.github/workflows/notify-release-targets-changed.yml
@@ -34,23 +34,18 @@ jobs:
         php-version:
         - '8.5'
     steps:
-    # Sparse checkout of the composite actions this job's workspace-
-    # root uses/... references resolve against — generate-app-token
-    # (Mint step below) and setup-php-composer (Setup PHP step below).
-    # Local composite paths resolve against GITHUB_WORKSPACE at step-
-    # load time; a subsequent full checkout doesn't reliably materialize
-    # files pruned by the first sparse checkout, so include everything
-    # the workspace-root needs in the first sparse pattern. Companion
-    # to the fix in openemr/openemr#13480 (branch-cut + patch-prep) —
-    # this workflow has the same shape and failed identically on the
-    # rel-830 cut's release-targets.yml push.
-    - name: Checkout composite actions
+    # Full checkout first so composite actions (generate-app-token,
+    # setup-php-composer) resolve against a real workspace AND
+    # composer.json is present for setup-php-composer's cache/install
+    # steps. The earlier sparse-first pattern (fixed in
+    # openemr/openemr#13480 + #13509) worked around one bug but not
+    # the underlying git-sparse-then-full-checkout leak: files not in
+    # the initial sparse pattern (like composer.json) still weren't
+    # materialized by the second full checkout. Doing the full checkout
+    # first sidesteps the leak entirely.
+    - name: Checkout
       uses: actions/checkout@v7
       with:
-        sparse-checkout: |
-          .github/actions/generate-app-token
-          .github/actions/setup-php-composer
-        sparse-checkout-cone-mode: false
         persist-credentials: false
 
     - name: Mint App token
@@ -64,11 +59,6 @@ jobs:
         # Repository_dispatch only needs contents:write; without this the
         # token inherits every permission the App installation has.
         permission-contents: write
-
-    - name: Checkout
-      uses: actions/checkout@v7
-      with:
-        persist-credentials: false
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -236,10 +236,12 @@ jobs:
       if: steps.resolve.outputs.should-run != 'false'
       env:
         VERSION: ${{ steps.resolve.outputs.version }}
+        REL_BRANCH: ${{ steps.resolve.outputs.branch }}
       run: |
         {
           echo 'body<<EOF'
-          php tools/release/bin/render-pr-body.php "${VERSION}"
+          php tools/release/bin/render-pr-body.php "${VERSION}" \
+            --rel-branch="${REL_BRANCH}"
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/reusable-publish-release.yml
+++ b/.github/workflows/reusable-publish-release.yml
@@ -85,11 +85,12 @@ jobs:
     # (openemr/openemr#13480 + #13509) hit an underlying git leak:
     # files not in the initial sparse pattern (like composer.json)
     # weren't materialized by the second full checkout. Full-checkout-
-    # first sidesteps the leak. Persist=true so `git push origin <tag>`
-    # in create-release-tag.sh works — the remote URL is rewritten to
-    # use the App token below (via `git remote set-url`) so
-    # authenticated push against a repo that requires App auth for
-    # writes succeeds; github.token's contents:read scope wouldn't.
+    # first sidesteps the leak. `persist-credentials: false` because
+    # `create-release-tag.sh` now uses APP_TOKEN via `git -c
+    # http.extraheader=...` (one-shot, never written to .git/config
+    # — see the script's inline-auth block). Leaving github.token
+    # persisted here would be dead weight in .git/config during the
+    # composer install / task summary steps that follow the tag push.
     - name: Checkout openemr release branch
       uses: actions/checkout@v7
       with:
@@ -97,6 +98,7 @@ jobs:
         token: ${{ github.token }}
         filter: blob:none
         fetch-depth: 1
+        persist-credentials: false
 
     - name: Generate app token
       id: app-token

--- a/.github/workflows/reusable-publish-release.yml
+++ b/.github/workflows/reusable-publish-release.yml
@@ -77,21 +77,26 @@ jobs:
     # boundaries anyway (writing a token to `$GITHUB_OUTPUT` masks it
     # in logs but the value that reaches the downstream job is often
     # empty). Regenerating is the documented path.
-    # Sparse checkout of the composite actions this job's workspace-
-    # root uses/... references resolve against — generate-app-token
-    # (mint step below) and setup-php-composer (later step). Full
-    # checkout happens after the token is minted (uses the token).
-    # setup-php-composer included in the initial sparse pattern too —
-    # subsequent full checkouts don't reliably materialize files pruned
-    # by the first sparse checkout (see openemr/openemr#13480).
-    - name: Checkout composite actions
+    #
+    # Full checkout first with github.token — composite actions
+    # (generate-app-token, setup-php-composer) resolve against a real
+    # workspace AND composer.json is present for setup-php-composer's
+    # cache/install steps. The earlier sparse-first pattern
+    # (openemr/openemr#13480 + #13509) hit an underlying git leak:
+    # files not in the initial sparse pattern (like composer.json)
+    # weren't materialized by the second full checkout. Full-checkout-
+    # first sidesteps the leak. Persist=true so `git push origin <tag>`
+    # in create-release-tag.sh works — the remote URL is rewritten to
+    # use the App token below (via `git remote set-url`) so
+    # authenticated push against a repo that requires App auth for
+    # writes succeeds; github.token's contents:read scope wouldn't.
+    - name: Checkout openemr release branch
       uses: actions/checkout@v7
       with:
-        sparse-checkout: |
-          .github/actions/generate-app-token
-          .github/actions/setup-php-composer
-        sparse-checkout-cone-mode: false
-        persist-credentials: false
+        ref: ${{ inputs.version_branch }}
+        token: ${{ github.token }}
+        filter: blob:none
+        fetch-depth: 1
 
     - name: Generate app token
       id: app-token
@@ -102,15 +107,14 @@ jobs:
         owner: ${{ github.repository_owner }}
         repositories: openemr
 
-    # Need a checkout for `git tag` + `git push origin <tag>`. Same
-    # minimal fetch shape as build-package.
-    - name: Checkout openemr release branch
-      uses: actions/checkout@v7
-      with:
-        ref: ${{ inputs.version_branch }}
-        token: ${{ steps.app-token.outputs.token }}
-        filter: blob:none
-        fetch-depth: 1
+    # Rewrite the origin URL to authenticate git-push with the App
+    # token (github.token's contents:read scope can't push). Runs
+    # AFTER app-token generation; the push happens in
+    # create-release-tag.sh (below).
+    - name: Configure git remote with App token for tag push
+      env:
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
+      run: git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
 
     # Reconstruct the release-output/ directory that build-package
     # produced, from the workflow-run artifact.

--- a/.github/workflows/reusable-publish-release.yml
+++ b/.github/workflows/reusable-publish-release.yml
@@ -107,15 +107,6 @@ jobs:
         owner: ${{ github.repository_owner }}
         repositories: openemr
 
-    # Rewrite the origin URL to authenticate git-push with the App
-    # token (github.token's contents:read scope can't push). Runs
-    # AFTER app-token generation; the push happens in
-    # create-release-tag.sh (below).
-    - name: Configure git remote with App token for tag push
-      env:
-        APP_TOKEN: ${{ steps.app-token.outputs.token }}
-      run: git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
-
     # Reconstruct the release-output/ directory that build-package
     # produced, from the workflow-run artifact.
     - name: Download release-output artifact
@@ -125,8 +116,15 @@ jobs:
         path: tools/release/release-output
 
     - name: Create annotated tag and GitHub release
+      # APP_TOKEN passed so create-release-tag.sh uses it inline via
+      # `git -c http.extraheader=...` on ls-remote + push — never
+      # persisted to .git/config. Keeps the token unavailable to
+      # subsequent steps (composer install, task summary, etc.) that
+      # a compromised dep could otherwise exfiltrate from `git config
+      # --get remote.origin.url` or the .git/config extraheader.
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
         RELEASE_TAG: ${{ inputs.release_tag }}
         RELEASE_VERSION: ${{ inputs.version }}
         VERSION_BRANCH: ${{ inputs.version_branch }}

--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -110,20 +110,21 @@ jobs:
     env:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-    # Sparse checkout of the composite actions this job's workspace-
-    # root uses/... references resolve against — generate-app-token
-    # (mint step below) and setup-php-composer (later step). Full
-    # checkout happens after the token is minted (uses the token).
-    # setup-php-composer included in the initial sparse pattern too —
-    # subsequent full checkouts don't reliably materialize files pruned
-    # by the first sparse checkout (see openemr/openemr#13480).
-    - name: Checkout composite actions
+    # Full checkout first — composite actions (generate-app-token,
+    # setup-php-composer) resolve against a real workspace AND
+    # composer.json is present for setup-php-composer's cache/install
+    # steps. The earlier sparse-first pattern (openemr/openemr#13480
+    # + #13509) worked around one bug but not the underlying git-
+    # sparse-then-full-checkout leak. github.token here has enough
+    # read scope for the initial checkout; the App token (minted
+    # below) is for the PR-merge operations later, not the checkout.
+    - name: Checkout
       uses: actions/checkout@v7
       with:
-        sparse-checkout: |
-          .github/actions/generate-app-token
-          .github/actions/setup-php-composer
-        sparse-checkout-cone-mode: false
+        token: ${{ github.token }}
+        # ship-release orchestrates via `gh` CLI (which uses GH_TOKEN env);
+        # it never pushes to git. Persisting credentials in the checkout
+        # would leak them to any subsequent step. Defense-in-depth.
         persist-credentials: false
 
     - name: Mint release App token
@@ -151,15 +152,6 @@ jobs:
         permission-metadata: read
         permission-pull-requests: write
         permission-statuses: write
-
-    - name: Checkout
-      uses: actions/checkout@v7
-      with:
-        token: ${{ steps.app-token.outputs.token }}
-        # ship-release orchestrates via `gh` CLI (which uses GH_TOKEN env);
-        # it never pushes to git. Persisting credentials in the checkout
-        # would leak them to any subsequent step. Defense-in-depth.
-        persist-credentials: false
 
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer

--- a/tests/bats/ci-scripts/create-release-tag/create-release-tag.bats
+++ b/tests/bats/ci-scripts/create-release-tag/create-release-tag.bats
@@ -202,3 +202,41 @@ teardown() {
     [[ ${status} -eq 1 ]]
     [[ "${output}" == *"::error::RELEASE_NOTES_FILE is missing or unreadable"* ]]
 }
+
+@test "APP_TOKEN set -> injected inline via git -c http.extraheader, never persisted" {
+    # Security: APP_TOKEN authenticates ls-remote + push via one-shot
+    # -c http.extraheader=..., NOT via `git remote set-url` /
+    # persist-credentials which would leave the token in .git/config
+    # readable by any subsequent step (composer install, npm ci, task
+    # summary, etc.) or a compromised dep. Verifies the token appears
+    # in the git command invocation itself (mock records the full
+    # argv) but the script does no `git config` / `git remote
+    # set-url` that would persist it.
+    export APP_TOKEN='ghs_testFAKEtoken12345'
+    run bash "${CREATE_RELEASE_TAG_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    local calls
+    calls="$(mock_calls)"
+    # Base64 of "x-access-token:ghs_testFAKEtoken12345" (no newline).
+    local expected_b64
+    expected_b64="$(printf 'x-access-token:%s' "${APP_TOKEN}" | base64 -w0)"
+    # Both ls-remote and push must carry the extraheader arg.
+    [[ "${calls}" == *"git -c http.https://github.com/.extraheader=Authorization: Basic ${expected_b64} ls-remote"* ]]
+    [[ "${calls}" == *"git -c http.https://github.com/.extraheader=Authorization: Basic ${expected_b64} push origin"* ]]
+    # NO `git remote set-url` that would persist token into .git/config.
+    [[ "${calls}" != *"git remote set-url"* ]]
+}
+
+@test "APP_TOKEN unset -> git commands run bare (backward compat)" {
+    # Legacy callers configure origin credentials via actions/checkout's
+    # persist-credentials=true; the script should not require APP_TOKEN.
+    unset APP_TOKEN
+    run bash "${CREATE_RELEASE_TAG_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    local calls
+    calls="$(mock_calls)"
+    # git operations run without the extraheader injection.
+    [[ "${calls}" == *"git ls-remote --tags --exit-code origin"* ]]
+    [[ "${calls}" == *"git push origin v8_2_0"* ]]
+    [[ "${calls}" != *"http.https://github.com/.extraheader"* ]]
+}

--- a/tests/bats/ci-scripts/create-release-tag/git-mock.sh
+++ b/tests/bats/ci-scripts/create-release-tag/git-mock.sh
@@ -46,6 +46,17 @@ set -euo pipefail
     printf '\n'
 } >> "${MOCK_CALL_LOG:-/dev/null}"
 
+# Skip real git's `-c KEY=VALUE` prefix args (e.g.,
+# `-c http.https://github.com/.extraheader=Authorization: Basic ...`)
+# before locating the subcommand — matches real git's own parsing.
+# Needed for the APP_TOKEN inline-auth path (create-release-tag.sh
+# uses `git -c http.extraheader=... ls-remote` and `git -c ... push`
+# when APP_TOKEN is set).
+while [[ "${1:-}" == "-c" ]]; do
+    shift  # drop -c
+    shift  # drop KEY=VALUE
+done
+
 subcommand="${1:-}"
 shift || true
 


### PR DESCRIPTION
Two related fixes in one PR — both surfaced tonight after the release-prep template rewrite (#13514) and the sparse-checkout fix (#13509) both landed.

## Fix 1 — full-checkout-first for 5 workflows

#13480 + #13509 patched the sparse-first pattern (initial sparse-checkout of \`.github/actions/generate-app-token\` leaves \`.github/actions/setup-php-composer\` unmaterialized, then \`Setup PHP\` 404s). Those fixes covered the composite-resolution symptom.

Tonight \`notify-release-targets-changed.yml\` was re-dispatched after #13509 landed — got past \`Setup PHP\` but died with:
\`\`\`
File "./composer.json" cannot be found in the current directory
\`\`\`
from \`setup-php-composer\`'s composer install step. Root cause: the underlying git-sparse-then-full-checkout leak affects EVERY file not in the initial sparse pattern, not just composite actions. Any workflow that needs anything at workspace root after a sparse-first pattern is at risk.

Restructure all 5 workflows to full-checkout-first (the proven-working pattern release-prep.yml has always used):

- \`notify-release-targets-changed.yml\` — full checkout with \`github.token\`, mint App token after (gh-CLI consumer, not git-persisted).
- \`ship-release.yml\` — same pattern. All gh-CLI orchestration, no git push, so github.token in the initial checkout is enough.
- \`build-patch.yml\` / \`build-release.yml\` — version_branch checkout moved to top with github.token; App token remains for later gh api calls (permission-checks, milestones).
- \`reusable-publish-release.yml\` — full checkout at top with github.token, then a new \`Configure git remote with App token for tag push\` step rewrites the origin URL so \`create-release-tag.sh\`'s \`git push origin <tag>\` authenticates as the App (github.token \`contents:read\` alone cannot push).

Sparse checkout step dropped from all 5.

## Fix 2 — pass --rel-branch to release-prep Render step

#13514 rewrote release-prep.md to reference \`<REL_BRANCH>\` in the acceptance-runs URLs. \`render-pr-body.php\` refuses templates carrying unsubstituted placeholders (exit 2), and release-prep.yml's Render PR body step wasn't passing \`--rel-branch\` (only \`--VERSION\`). Result: today's rel-830 release-prep conductor fired at 07:37 UTC and failed:
\`\`\`
render-pr-body: template contains <REL_BRANCH> placeholder but --rel-branch was not provided
##[error]Process completed with exit code 2.
\`\`\`

release-finalize / patch-prep / branch-cut render steps already pass \`--rel-branch\`. This is release-prep's Render step catching up now that its template needs it.

## Test plan

- [ ] Rerun \`notify-release-targets-changed.yml\` via workflow_dispatch on master — should now clear Setup PHP + reach the dispatch
- [ ] Next release-prep firing on rel-830 uses the updated template render call with \`--rel-branch\` passed → PR body renders cleanly
- [ ] Next \`ship-release\` dry-run or full run exercises the reordered checkout + tag-push credential flow

Assisted-by: Claude Code