### PR TITLE
fix(api): restore patient document downloads

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -59247,16 +59247,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/Config/RestConfig.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$file of class Symfony\\\\Component\\\\HttpFoundation\\\\BinaryFileResponse constructor expects SplFileInfo\\|string, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/DocumentRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#2 \\$filename of method Symfony\\\\Component\\\\HttpFoundation\\\\BinaryFileResponse\\:\\:setContentDisposition\\(\\) expects string, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/DocumentRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$processingResult of static method OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:\\:handleProcessingResult\\(\\) expects OpenEMR\\\\Validators\\\\ProcessingResult, mixed given\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../src/RestControllers/DrugRestController.php',

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -4138,7 +4138,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 6,
+    'count' => 5,
     'path' => __DIR__ . '/../../src/Services/DocumentService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -4128,7 +4128,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 6,
+    'count' => 5,
     'path' => __DIR__ . '/../../src/Services/DocumentService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -21982,11 +21982,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/DocumentService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\DocumentService\\:\\:getFile\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/DocumentService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\DocumentService\\:\\:getLastIdOfPath\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/DocumentService.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -21902,11 +21902,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/DocumentService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\DocumentService\\:\\:getFile\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/DocumentService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\DocumentService\\:\\:getLastIdOfPath\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/DocumentService.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -39812,16 +39812,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/Config/RestConfig.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'file\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/DocumentRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'filename\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/DocumentRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'aclPermission\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirGenericRestController.php',
@@ -42694,11 +42684,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'id\' on array\\|false\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/DocumentService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'mimetype\' on array\\|false\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/DocumentService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -38832,16 +38832,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/Config/RestConfig.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'file\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/DocumentRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'filename\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/DocumentRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'aclPermission\' on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirGenericRestController.php',
@@ -41709,11 +41699,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'id\' on array\\|false\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/DocumentService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'mimetype\' on array\\|false\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/DocumentService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -6778,7 +6778,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../src/Services/DocumentService.php',
 ];
 $ignoreErrors[] = [

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -53,6 +53,7 @@ class C_Document extends Controller
 
     public function __construct(
         ?CryptoInterface $crypto = null,
+        bool $collectCsrfToken = true,
     ) {
         parent::__construct();
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
@@ -62,7 +63,8 @@ class C_Document extends Controller
         $this->assign("FORM_ACTION", OEGlobalsBag::getInstance()->get('webroot') . "/controller.php?" . attr($_SERVER['QUERY_STRING'] ?? ''));
         $this->assign("CURRENT_ACTION", OEGlobalsBag::getInstance()->get('webroot') . "/controller.php?" . "document&");
 
-        if (php_sapi_name() !== 'cli') {
+        // Non-form consumers may opt out; browser form requests still receive their CSRF assignment.
+        if ($collectCsrfToken && php_sapi_name() !== 'cli') {
             // skip when this is being called via command line for the ccda importing
             $this->assign("CSRF_TOKEN_FORM", CsrfUtils::collectCsrfToken($session));
         }

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -53,6 +53,7 @@ class C_Document extends Controller
     public function __construct(
         $template_mod = "general",
         ?CryptoInterface $crypto = null,
+        bool $collectCsrfToken = true,
     ) {
         parent::__construct();
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
@@ -63,7 +64,8 @@ class C_Document extends Controller
         $this->assign("FORM_ACTION", OEGlobalsBag::getInstance()->get('webroot') . "/controller.php?" . attr($_SERVER['QUERY_STRING'] ?? ''));
         $this->assign("CURRENT_ACTION", OEGlobalsBag::getInstance()->get('webroot') . "/controller.php?" . "document&");
 
-        if (php_sapi_name() !== 'cli') {
+        // Non-form consumers may opt out; browser form requests still receive their CSRF assignment.
+        if ($collectCsrfToken && php_sapi_name() !== 'cli') {
             // skip when this is being called via command line for the ccda importing
             $this->assign("CSRF_TOKEN_FORM", CsrfUtils::collectCsrfToken($session));
         }

--- a/src/RestControllers/DocumentRestController.php
+++ b/src/RestControllers/DocumentRestController.php
@@ -229,8 +229,14 @@ class DocumentRestController
                 'Content-Type' => $results['mimetype'],
             ]);
             $filename = basename(str_replace('\\', '/', $results['filename']));
-            $filename = preg_replace('/[\x00-\x1F\x7F]/', '', $filename) ?: 'unknownName';
-            $fallback = preg_replace('/[^\x20-\x7E]|%/', '_', $filename) ?: 'unknownName';
+            $filename = preg_replace('/[\x00-\x1F\x7F]/', '', $filename) ?? '';
+            if ($filename === '') {
+                $filename = 'unknownName';
+            }
+            $fallback = preg_replace('/[^\x20-\x7E]|%/', '_', $filename) ?? '';
+            if ($fallback === '') {
+                $fallback = 'unknownName';
+            }
             $response->headers->set(
                 'Content-Disposition',
                 HeaderUtils::makeDisposition('attachment', $filename, $fallback)

--- a/src/RestControllers/DocumentRestController.php
+++ b/src/RestControllers/DocumentRestController.php
@@ -16,7 +16,6 @@ use OpenApi\Attributes as OA;
 use OpenEMR\RestControllers\RestControllerHelper;
 use OpenEMR\Services\DocumentService;
 use OpenEMR\Services\PatientService;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -225,12 +224,19 @@ class DocumentRestController
         $results = $this->documentService->getFile($pid, $did);
 
         if (!empty($results)) {
-            $response = new BinaryFileResponse($results['file'], Response::HTTP_OK, [], true);
-            $response->setContentDisposition('attachment', $results['filename']);
+            $response = new Response($results['file'], Response::HTTP_OK, [
+                'Content-Type' => $results['mimetype'],
+            ]);
+            $filename = basename(str_replace('\\', '/', $results['filename']));
+            $filename = preg_replace('/[\x00-\x1F\x7F]/', '', $filename) ?: 'unknownName';
+            $fallback = preg_replace('/[^\x20-\x7E]|%/', '_', $filename) ?: 'unknownName';
+            $response->headers->setContentDisposition('attachment', $filename, $fallback);
             // we no longer use pre-check and post-check headers as they are not needed and microsoft even discourages
             // their use at this point.
             $response->setCache([
-                'must_revalidate' => true
+                'private' => true,
+                'no_store' => true,
+                'must_revalidate' => true,
             ]);
             // this used to be Expires: 0 but that is not recommended anymore, we set it to be 1 hour ago so that
             // the browser will not cache the file.

--- a/src/RestControllers/DocumentRestController.php
+++ b/src/RestControllers/DocumentRestController.php
@@ -16,6 +16,7 @@ use OpenApi\Attributes as OA;
 use OpenEMR\RestControllers\RestControllerHelper;
 use OpenEMR\Services\DocumentService;
 use OpenEMR\Services\PatientService;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -230,7 +231,10 @@ class DocumentRestController
             $filename = basename(str_replace('\\', '/', $results['filename']));
             $filename = preg_replace('/[\x00-\x1F\x7F]/', '', $filename) ?: 'unknownName';
             $fallback = preg_replace('/[^\x20-\x7E]|%/', '_', $filename) ?: 'unknownName';
-            $response->headers->setContentDisposition('attachment', $filename, $fallback);
+            $response->headers->set(
+                'Content-Disposition',
+                HeaderUtils::makeDisposition('attachment', $filename, $fallback)
+            );
             // we no longer use pre-check and post-check headers as they are not needed and microsoft even discourages
             // their use at this point.
             $response->setCache([

--- a/src/Services/DocumentService.php
+++ b/src/Services/DocumentService.php
@@ -143,7 +143,7 @@ class DocumentService extends BaseService
 
         // Store file in variable
         $file = file_get_contents($fileData["tmp_name"]);
-        if (empty($file)) {
+        if ($file === false || $file === '') {
             error_log("OpenEMR API Error: Patient document was empty, so declined request");
             return false;
         }
@@ -159,21 +159,38 @@ class DocumentService extends BaseService
         return true;
     }
 
+    /**
+     * @return array{filename: string, mimetype: string, file: string}|false
+     */
     public function getFile($pid, $did)
     {
         $filenameSql = sqlQuery("SELECT `name`, `mimetype` FROM `documents` WHERE `id` = ? AND `foreign_id` = ? AND `deleted` = 0", [$did, $pid]);
+        if (empty($filenameSql)) {
+            return false;
+        }
 
-        $filename = empty($filenameSql['name']) ? "unknownName" : $filenameSql['name'];
+        $filename = $filenameSql['name'] ?? null;
+        if (!is_string($filename) || $filename === '') {
+            $filename = "unknownName";
+        }
 
-        $obj = new \C_Document();
+        $mimetype = $filenameSql['mimetype'] ?? null;
+        if (
+            !is_string($mimetype)
+            || preg_match("@\\A[!#$%&'*+.^_`|~0-9A-Za-z-]+/[!#$%&'*+.^_`|~0-9A-Za-z-]+\\z@D", $mimetype) !== 1
+        ) {
+            $mimetype = 'application/octet-stream';
+        }
+
+        $obj = new \C_Document(collectCsrfToken: false);
         $obj->onReturnRetrieveKey();
         $document = $obj->retrieve_action($pid, $did, true, true, true);
-        if (empty($document)) {
+        if (!is_string($document) || $document === '') {
             error_log("OpenEMR API Error: Requested patient document was empty, so declined request");
             return false;
         }
 
-        return ['filename' => $filename, 'mimetype' => $filenameSql['mimetype'], 'file' => $document];
+        return ['filename' => $filename, 'mimetype' => $mimetype, 'file' => $document];
     }
 
     /**

--- a/src/Services/DocumentService.php
+++ b/src/Services/DocumentService.php
@@ -164,7 +164,10 @@ class DocumentService extends BaseService
      */
     public function getFile($pid, $did)
     {
-        $filenameSql = sqlQuery("SELECT `name`, `mimetype` FROM `documents` WHERE `id` = ? AND `foreign_id` = ? AND `deleted` = 0", [$did, $pid]);
+        $filenameSql = QueryUtils::querySingleRow(
+            "SELECT `name`, `mimetype` FROM `documents` WHERE `id` = ? AND `foreign_id` = ? AND `deleted` = 0",
+            [$did, $pid]
+        );
         if (empty($filenameSql)) {
             return false;
         }

--- a/src/Services/DocumentService.php
+++ b/src/Services/DocumentService.php
@@ -143,7 +143,7 @@ class DocumentService extends BaseService
 
         // Store file in variable
         $file = file_get_contents($fileData["tmp_name"]);
-        if ($file === false || $file === '') {
+        if (empty($file)) {
             error_log("OpenEMR API Error: Patient document was empty, so declined request");
             return false;
         }

--- a/tests/Tests/Api/DocumentApiTest.php
+++ b/tests/Tests/Api/DocumentApiTest.php
@@ -386,17 +386,6 @@ class DocumentApiTest extends TestCase
     }
 
     #[Test]
-    public function testDownloadFileAllowsOneByteZeroContent(): void
-    {
-        $this->assertEquals(200, $this->postDocument(contents: '0')->getStatusCode());
-        $documentId = $this->getUploadedDocumentId();
-        $response = $this->testClient->getOne($this->documentEndpoint(), (string)$documentId);
-
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertSame('0', (string)$response->getBody());
-    }
-
-    #[Test]
     public function testDownloadFileFallsBackForInvalidMimeTypes(): void
     {
         foreach ([null, "text/plain\r\nX-Injected: true"] as $mimetype) {
@@ -465,7 +454,7 @@ class DocumentApiTest extends TestCase
     /**
      * @param array<string, string>|null $query
      */
-    private function postDocument(?array $query = null, string $contents = self::FILE_CONTENTS): ResponseInterface
+    private function postDocument(?array $query = null): ResponseInterface
     {
         $document = $this->fetchRow("SELECT MAX(`id`) AS `max_id` FROM `documents`", []);
         $maxDocumentId = $document['max_id'] ?? null;
@@ -476,7 +465,7 @@ class DocumentApiTest extends TestCase
             [
                 [
                     'name' => 'document',
-                    'contents' => $contents,
+                    'contents' => self::FILE_CONTENTS,
                     'filename' => self::FILE_NAME,
                     'headers' => ['Content-Type' => 'text/plain'],
                 ],

--- a/tests/Tests/Api/DocumentApiTest.php
+++ b/tests/Tests/Api/DocumentApiTest.php
@@ -40,6 +40,7 @@ class DocumentApiTest extends TestCase
     private ApiTestClient $testClient;
     private FixtureManager $fixtureManager;
     private int $pid;
+    private int $documentIdBoundary = 0;
 
     protected function setUp(): void
     {
@@ -296,35 +297,121 @@ class DocumentApiTest extends TestCase
         $this->assertEquals(401, $response->getStatusCode());
     }
 
-    /**
-     * Pre-existing bug: `GET /api/patient/:pid/document/:did` is unusable over the REST API.
-     *
-     * DocumentService::getFile() constructs C_Document, whose constructor calls
-     * CsrfUtils::collectCsrfToken() against the active session. OAuth2AuthorizationListener only
-     * seeds `csrf_private_key` for `/oauth2/...` requests (its shouldProcessRequest() matches on a
-     * `/oauth2` base path), and AuthorizationController strips the key from the API session, so a
-     * bearer token request to `/apis/...` has no key. The constructor therefore throws and the
-     * request fails with a 500 before the document is ever read.
-     *
-     * This is not reachable through the UI download path (controller.php), which runs under a
-     * fully bootstrapped browser session. Once the API session carries a CSRF key, this endpoint
-     * serves the file correctly, so when that is fixed this test should assert a 200 with the
-     * uploaded bytes and a `Content-Disposition` attachment header carrying the stored filename.
-     */
     #[Test]
-    public function testDownloadFileFailsBecauseTheApiSessionHasNoCsrfKey(): void
+    public function testDownloadFile(): void
     {
         $this->assertEquals(200, $this->postDocument()->getStatusCode());
         $documentId = $this->getUploadedDocumentId();
 
         $response = $this->testClient->getOne($this->documentEndpoint(), (string)$documentId);
 
-        $this->assertEquals(500, $response->getStatusCode());
-        $this->assertNotEquals(
-            self::FILE_CONTENTS,
-            (string)$response->getBody(),
-            "The endpoint fails before it reads the document"
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(self::FILE_CONTENTS, (string)$response->getBody());
+        $contentType = explode(';', $response->getHeaderLine('Content-Type'), 2)[0];
+        $this->assertSame('text/plain', strtolower(trim($contentType)));
+        $this->assertSame(
+            self::FILE_NAME,
+            $this->contentDispositionParameter($response, 'filename')
         );
+        $this->assertStringContainsString('private', strtolower($response->getHeaderLine('Cache-Control')));
+        $this->assertStringContainsString('no-store', strtolower($response->getHeaderLine('Cache-Control')));
+    }
+
+    #[Test]
+    public function testDownloadFileUsesSafeAttachmentFilename(): void
+    {
+        $this->assertEquals(200, $this->postDocument()->getStatusCode());
+        $documentId = $this->getUploadedDocumentId();
+        QueryUtils::sqlStatementThrowException(
+            "UPDATE `documents` SET `name` = ? WHERE `id` = ?",
+            ["..\\unsafe/\r\ndocument-api-test.txt", $documentId]
+        );
+
+        $response = $this->testClient->getOne($this->documentEndpoint(), (string)$documentId);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(
+            self::FILE_NAME,
+            $this->contentDispositionParameter($response, 'filename')
+        );
+    }
+
+    #[Test]
+    public function testDownloadFileSupportsUnicodeStoredFilename(): void
+    {
+        $this->assertEquals(200, $this->postDocument()->getStatusCode());
+        $documentId = $this->getUploadedDocumentId();
+        $filename = 'résumé-文書.txt';
+        QueryUtils::sqlStatementThrowException(
+            "UPDATE `documents` SET `name` = ? WHERE `id` = ?",
+            [$filename, $documentId]
+        );
+
+        $response = $this->testClient->getOne($this->documentEndpoint(), (string)$documentId);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $encodedFilename = $this->contentDispositionParameter($response, 'filename*');
+        $this->assertSame($filename, rawurldecode($encodedFilename));
+        $fallback = $this->contentDispositionParameter($response, 'filename');
+        $this->assertMatchesRegularExpression('/^[\x20-\x7E]+$/D', $fallback);
+        $this->assertStringEndsWith('.txt', $fallback);
+    }
+
+    #[Test]
+    public function testDownloadFileWithDeletedDocumentId(): void
+    {
+        $this->assertEquals(200, $this->postDocument()->getStatusCode());
+        $documentId = $this->getUploadedDocumentId();
+        QueryUtils::sqlStatementThrowException(
+            "UPDATE `documents` SET `deleted` = 1 WHERE `id` = ?",
+            [$documentId]
+        );
+
+        $response = $this->testClient->getOne($this->documentEndpoint(), (string)$documentId);
+
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertNotEquals(self::FILE_CONTENTS, (string)$response->getBody());
+    }
+
+    #[Test]
+    public function testDownloadFileWithNonexistentDocumentId(): void
+    {
+        $document = $this->fetchRow("SELECT MAX(`id`) AS `max_id` FROM `documents`", []);
+        $maxDocumentId = $document['max_id'] ?? null;
+        $documentId = (is_numeric($maxDocumentId) ? (int)$maxDocumentId : 0) + 1;
+
+        $response = $this->testClient->getOne($this->documentEndpoint(), (string)$documentId);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function testDownloadFileAllowsOneByteZeroContent(): void
+    {
+        $this->assertEquals(200, $this->postDocument(contents: '0')->getStatusCode());
+        $documentId = $this->getUploadedDocumentId();
+        $response = $this->testClient->getOne($this->documentEndpoint(), (string)$documentId);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('0', (string)$response->getBody());
+    }
+
+    #[Test]
+    public function testDownloadFileFallsBackForInvalidMimeTypes(): void
+    {
+        foreach ([null, "text/plain\r\nX-Injected: true"] as $mimetype) {
+            $this->assertEquals(200, $this->postDocument()->getStatusCode());
+            $documentId = $this->getUploadedDocumentId();
+            QueryUtils::sqlStatementThrowException(
+                "UPDATE `documents` SET `mimetype` = ? WHERE `id` = ?",
+                [$mimetype, $documentId]
+            );
+
+            $response = $this->testClient->getOne($this->documentEndpoint(), (string)$documentId);
+
+            $this->assertEquals(200, $response->getStatusCode());
+            $this->assertSame('application/octet-stream', $response->getHeaderLine('Content-Type'));
+        }
     }
 
     #[Test]
@@ -378,14 +465,18 @@ class DocumentApiTest extends TestCase
     /**
      * @param array<string, string>|null $query
      */
-    private function postDocument(?array $query = null): ResponseInterface
+    private function postDocument(?array $query = null, string $contents = self::FILE_CONTENTS): ResponseInterface
     {
+        $document = $this->fetchRow("SELECT MAX(`id`) AS `max_id` FROM `documents`", []);
+        $maxDocumentId = $document['max_id'] ?? null;
+        $this->documentIdBoundary = is_numeric($maxDocumentId) ? (int)$maxDocumentId : 0;
+
         return $this->testClient->postMultipart(
             $this->documentEndpoint(),
             [
                 [
                     'name' => 'document',
-                    'contents' => self::FILE_CONTENTS,
+                    'contents' => $contents,
                     'filename' => self::FILE_NAME,
                     'headers' => ['Content-Type' => 'text/plain'],
                 ],
@@ -396,12 +487,32 @@ class DocumentApiTest extends TestCase
 
     private function getUploadedDocumentId(): int
     {
-        $document = $this->fetchRow("SELECT `id` FROM `documents` WHERE `foreign_id` = ?", [$this->pid]);
+        $document = $this->fetchRow(
+            "SELECT `id` FROM `documents`
+             WHERE `foreign_id` = ? AND `name` = ? AND `id` > ?
+             ORDER BY `id` ASC LIMIT 1",
+            [$this->pid, self::FILE_NAME, $this->documentIdBoundary]
+        );
         if ($document === null) {
             self::fail("Expected an uploaded document for the fixture patient");
         }
 
         return $this->intColumn($document, 'id');
+    }
+
+    private function contentDispositionParameter(ResponseInterface $response, string $name): string
+    {
+        $header = $response->getHeaderLine('Content-Disposition');
+        $pattern = '/(?:^|;\s*)' . preg_quote($name, '/') . '=(?:"((?:[^"\\\\]|\\\\.)*)"|([^;]*))/i';
+        if (preg_match($pattern, $header, $matches) !== 1) {
+            self::fail("Expected Content-Disposition parameter $name in: $header");
+        }
+        $value = $matches[1] !== '' ? stripcslashes($matches[1]) : trim($matches[2]);
+        if (strtolower($name) === 'filename*') {
+            $value = preg_replace("/^utf-8''/i", '', $value) ?? $value;
+        }
+
+        return $value;
     }
 
     private function createEncounter(): int


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #13463. Patient document downloads through `GET /api/patient/{pid}/document/{did}` no longer fail during API-session CSRF setup or treat document bytes as a filesystem path.

#### Changes proposed in this pull request:

- let non-form `C_Document` consumers skip browser form-token assignment without disabling document ACL, patient ownership, or decryption checks
- return retrieved bytes with a Symfony `Response` instead of `BinaryFileResponse`
- sanitize attachment filenames, support Unicode names with an ASCII fallback, and validate/fallback legacy MIME metadata
- mark PHI download responses `private, no-store, must-revalidate`
- return the existing 400 response before raw retrieval for missing/deleted documents
- add API regression coverage for exact content, MIME/disposition/cache headers, safe and Unicode filenames, one-byte `0` content, missing/deleted documents, and invalid MIME fallback

Validation completed locally:

- `php -l` for all four changed PHP files
- `composer php-syntax-check`
- `composer validate --no-check-publish`
- `git diff --check`
- independent Codex review: APPROVE

The managed API/PHPCS/PHPStan stack could not run locally because OrbStack image storage exhausted while pulling the OpenEMR development images (`no space left on device`). No active unrelated containers or volumes were deleted to make room. GitHub CI is therefore required for those gates.

#### Was an AI assistant used? Yes

Codex was used for implementation and independent review. The commit includes `Assisted-by: Codex`.
