### PR TITLE
fix(audit): categorize form table events correctly

### DIFF
--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -535,11 +535,12 @@ class EventAuditLogger implements AuditLoggerInterface
                 $eventCategory = $eventCategoryMatch;
                 $category = $this->eventCategoryFinder($comments, $eventCategory->value, $table);
                 break;
-            } elseif (str_contains($truncated_sql, "form_")) {
-                $eventCategory = EventCategory::PatientRecord;
-                $category = $this->eventCategoryFinder($comments, $eventCategory->value, $table);
-                break;
             }
+        }
+
+        if ($eventCategory === EventCategory::Other && str_contains($truncated_sql, "form_")) {
+            $eventCategory = EventCategory::PatientRecord;
+            $category = $this->eventCategoryFinder($comments, $eventCategory->value, "form_");
         }
 
         // Now that we know _what_ to log, check _if_ it should be logged

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -327,4 +327,67 @@ class EventAuditLoggerTest extends TestCase
 
         $logger->auditSQLEvent('UPDATE patient_data SET committed = 1 WHERE pid = 1', true);
     }
+
+    /**
+     * @return array<string, array{sql: string, event: string, category: string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function formTableProvider(): array
+    {
+        return [
+            'mapped form table' => [
+                'sql' => 'INSERT INTO form_vitals (pid) VALUES (1)',
+                'event' => 'patient-record-insert',
+                'category' => 'Vitals',
+            ],
+            'unmapped custom form table' => [
+                'sql' => 'UPDATE form_custom_observation SET value = 1 WHERE id = 1',
+                'event' => 'patient-record-update',
+                'category' => 'Encounter Form',
+            ],
+        ];
+    }
+
+    #[DataProvider('formTableProvider')]
+    public function testAuditSQLEventCategorizesFormTables(
+        string $sql,
+        string $expectedEvent,
+        string $expectedCategory,
+    ): void {
+        $sink = $this->createMock(SinkInterface::class);
+        $sink->expects($this->once())
+            ->method('record')
+            ->with(self::callback(function (Event $event) use ($expectedEvent, $expectedCategory): bool {
+                self::assertSame($expectedEvent, $event->event);
+                self::assertSame($expectedCategory, $event->category);
+                self::assertNotSame('Billing', $event->category);
+                return true;
+            }));
+
+        $this->session->method('get')
+            ->willReturnCallback(fn (string $key): ?string => match ($key) {
+                'authUser' => 'testuser',
+                'authProvider' => 'default',
+                default => null,
+            });
+
+        $config = new AuditConfig(
+            enabled: true,
+            forceBreakglass: false,
+            queryEvents: true,
+            httpRequestEvents: false,
+            enabledEventTypes: [EventCategory::PatientRecord],
+        );
+
+        $logger = new EventAuditLogger(
+            sink: $sink,
+            session: $this->session,
+            config: $config,
+            breakglassChecker: $this->breakglassChecker,
+            clock: $this->clock,
+        );
+
+        $logger->auditSQLEvent($sql, true);
+    }
 }

--- a/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
+++ b/tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php
@@ -329,7 +329,7 @@ class EventAuditLoggerTest extends TestCase
     }
 
     /**
-     * @return array<string, array{sql: string, event: string, category: string}>
+     * @return array<string, array{sql: string, expectedEvent: string, expectedCategory: string}>
      *
      * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
@@ -338,13 +338,13 @@ class EventAuditLoggerTest extends TestCase
         return [
             'mapped form table' => [
                 'sql' => 'INSERT INTO form_vitals (pid) VALUES (1)',
-                'event' => 'patient-record-insert',
-                'category' => 'Vitals',
+                'expectedEvent' => 'patient-record-insert',
+                'expectedCategory' => 'Vitals',
             ],
             'unmapped custom form table' => [
                 'sql' => 'UPDATE form_custom_observation SET value = 1 WHERE id = 1',
-                'event' => 'patient-record-update',
-                'category' => 'Encounter Form',
+                'expectedEvent' => 'patient-record-update',
+                'expectedCategory' => 'Encounter Form',
             ],
         ];
     }


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #12809. SQL writes against explicitly mapped `form_*` tables are no longer short-circuited to the `Billing` audit category by the generic form-table fallback.

#### Changes proposed in this pull request:

- evaluate every explicit `LOG_TABLES` mapping before applying the generic `form_*` fallback
- pass `form_` to `eventCategoryFinder()` for unmatched form tables so they receive the existing `Encounter Form` category
- add isolated sink regression coverage proving:
  - `form_vitals` is logged as `patient-record-insert` / `Vitals`
  - an unmapped custom form table is logged as `patient-record-update` / `Encounter Form`

Validation completed locally:

- `php -l src/Common/Logging/EventAuditLogger.php`
- `php -l tests/Tests/Isolated/Common/Logging/EventAuditLoggerTest.php`
- `composer php-syntax-check`
- `composer validate --no-check-publish`
- `git diff --check`
- independent Codex review: APPROVE

The focused PHPUnit binary was unavailable in the worktree because Composer dependencies are not installed. GitHub CI will run the isolated test matrix.

#### Was an AI assistant used? Yes

Codex was used for implementation and independent review. The commit includes `Assisted-by: Codex`.
