### PR TITLE
fix(edi): correct 278 service rendering

### DIFF
--- a/library/edihistory/edih_278_html.php
+++ b/library/edihistory/edih_278_html.php
@@ -759,8 +759,8 @@ function edih_278_transaction_html($obj278, $bht03)
                     }
 
                     if ($elem01 && $ct > 2) {
-                        for ($i = 2; $i < $ct; $i++) {
-                            $elem01 .= ' ' . $ar01[$i];
+                        for ($j = 2; $j < $ct; $j++) {
+                            $elem01 .= ' ' . $ar01[$j];
                         }
                     }
                 } elseif (isset($sar[1]) && $sar[1]) {
@@ -802,8 +802,8 @@ function edih_278_transaction_html($obj278, $bht03)
                     }
 
                     if ($elem01 && count($ar01) > 2) {
-                        for ($i = 2; $i < $ct; $i++) {
-                            $elem01 .= ' ' . $ar01[$i];
+                        for ($j = 2; $j < $ct; $j++) {
+                            $elem01 .= ' ' . $ar01[$j];
                         }
                     }
                 } elseif (isset($sar[1]) && $sar[1]) {
@@ -811,11 +811,11 @@ function edih_278_transaction_html($obj278, $bht03)
                 }
 
                 $elem02 = (isset($sar[2]) && $sar[2]) ? edih_format_money($sar[2]) : "";
-                $elem03 = (isset($sar[3]) && $sar[3]) ? $cd27x->get_271_code('SV103', $ar01[3]) : "";
+                $elem03 = (isset($sar[3]) && $sar[3]) ? $cd27x->get_271_code('SV103', $sar[3]) : "";
                 $elem04 = (isset($sar[4]) && $sar[4]) ? $sar[4] : "";
                 $elem05 = (isset($sar[5]) && $sar[5]) ? $sar[5] : "";
                 $elem06 = (isset($sar[6]) && $sar[6]) ? edih_format_money($sar[6]) : "";
-                $elem10 = (isset($sar[20]) && $sar[20]) ? $cd27x->get_271_code('SV120', $ar01[20]) : "";
+                $elem10 = (isset($sar[20]) && $sar[20]) ? $cd27x->get_271_code('SV120', $sar[20]) : "";
                 //
                 $svc_html .= ($elem01) ? "<tr class='" . attr($cls) . "'><td><em>Inst Service</em></td><td colspan=3>" . text($elem01 . " " . $elem02) . "</td></tr>" . PHP_EOL : "";
                 $svc_html .= ($elem03 || $elem04) ? "<tr class='" . attr($cls) . "'><td>&gt;</td><td colspan=3>" . text($elem03 . " " . $elem04 . " " . $elem05 . " " . $elem06) . "</td></tr>" . PHP_EOL : "";

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,6 +26,10 @@ parameters:
     # where phpstan runs. Nothing else references these files at build
     # time, so excluding from analysis is appropriate.
     - tests/Acceptance/bin/*.php
+    # Runtime-only guarded globals for the isolated EDI 278 renderer test.
+    # PHPStan scans their production declarations; analysing these test doubles
+    # would report duplicate global functions that may not be defined.
+    - tests/Tests/Isolated/Billing/EdiHistory/edi_278_renderer_runtime_stubs.php
     analyse:
     # Generated FHIR R4 parser map: a single ~61k-line constant array
     # (PHPFHIRParserMap::$_bigDumbMap) produced by the php-fhir generator and never

--- a/tests/Tests/Isolated/Billing/EdiHistory/Edi278RendererTest.php
+++ b/tests/Tests/Isolated/Billing/EdiHistory/Edi278RendererTest.php
@@ -102,9 +102,9 @@ namespace OpenEMR\Tests\Isolated\Billing\EdiHistory {
         }
     }
 
-    final class Edi278RendererX12
+    final readonly class Edi278RendererX12
     {
-        public function __construct(private readonly array $transactions)
+        public function __construct(private array $transactions)
         {
         }
 

--- a/tests/Tests/Isolated/Billing/EdiHistory/Edi278RendererTest.php
+++ b/tests/Tests/Isolated/Billing/EdiHistory/Edi278RendererTest.php
@@ -11,40 +11,7 @@
 declare(strict_types=1);
 
 namespace {
-    if (!function_exists('text')) {
-        function text($value): string
-        {
-            return htmlspecialchars((string) $value, ENT_NOQUOTES);
-        }
-    }
-
-    if (!function_exists('attr')) {
-        function attr($value): string
-        {
-            return htmlspecialchars((string) $value, ENT_QUOTES);
-        }
-    }
-
-    if (!function_exists('xlt')) {
-        function xlt($value): string
-        {
-            return (string) $value;
-        }
-    }
-
-    if (!function_exists('edih_format_money')) {
-        function edih_format_money($value): string
-        {
-            return (string) $value;
-        }
-    }
-
-    if (!function_exists('edih_format_date')) {
-        function edih_format_date($value, $format = 'Y-m-d'): string
-        {
-            return (string) $value;
-        }
-    }
+    require_once __DIR__ . '/edi_278_renderer_runtime_stubs.php';
 }
 
 namespace OpenEMR\Tests\Isolated\Billing\EdiHistory {
@@ -75,6 +42,7 @@ namespace OpenEMR\Tests\Isolated\Billing\EdiHistory {
 
             $html = \edih_278_transaction_html($x12, 'DUPLICATE');
 
+            self::assertIsString($html);
             self::assertStringContainsString('SECOND-TRANSACTION-RENDERED', $html);
         }
 
@@ -97,6 +65,7 @@ namespace OpenEMR\Tests\Isolated\Billing\EdiHistory {
 
             $html = \edih_278_transaction_html($x12, 'SV2-LOOKUP');
 
+            self::assertIsString($html);
             self::assertStringContainsString('Minutes', $html);
             self::assertStringContainsString('Nursing Facility (NF)', $html);
         }
@@ -104,15 +73,24 @@ namespace OpenEMR\Tests\Isolated\Billing\EdiHistory {
 
     final readonly class Edi278RendererX12
     {
+        /**
+         * @param list<list<string>> $transactions
+         */
         public function __construct(private array $transactions)
         {
         }
 
+        /**
+         * @return list<list<string>>
+         */
         public function edih_x12_transaction(string $reference): array
         {
             return $this->transactions;
         }
 
+        /**
+         * @return array{e: string, s: string, r: string}
+         */
         public function edih_delimiters(): array
         {
             return ['e' => '*', 's' => ':', 'r' => '^'];

--- a/tests/Tests/Isolated/Billing/EdiHistory/Edi278RendererTest.php
+++ b/tests/Tests/Isolated/Billing/EdiHistory/Edi278RendererTest.php
@@ -50,7 +50,7 @@ namespace OpenEMR\Tests\Isolated\Billing\EdiHistory {
         {
             $sv2 = array_fill(0, 21, '');
             $sv2[0] = 'SV2';
-            $sv2[1] = '0300';
+            $sv2[1] = '0300:CODE:MOD1:MOD2';
             $sv2[2] = '125';
             $sv2[3] = 'MJ';
             $sv2[20] = '7';
@@ -61,6 +61,11 @@ namespace OpenEMR\Tests\Isolated\Billing\EdiHistory {
                     'HL*1**SS*0',
                     implode('*', $sv2),
                 ],
+                [
+                    'BHT*0007*13*SV2-LOOKUP*20260102',
+                    'HL*2**SS*0',
+                    'MSG*SECOND-SV2-TRANSACTION-RENDERED',
+                ],
             ]);
 
             $html = \edih_278_transaction_html($x12, 'SV2-LOOKUP');
@@ -68,6 +73,7 @@ namespace OpenEMR\Tests\Isolated\Billing\EdiHistory {
             self::assertIsString($html);
             self::assertStringContainsString('Minutes', $html);
             self::assertStringContainsString('Nursing Facility (NF)', $html);
+            self::assertStringContainsString('SECOND-SV2-TRANSACTION-RENDERED', $html);
         }
     }
 

--- a/tests/Tests/Isolated/Billing/EdiHistory/Edi278RendererTest.php
+++ b/tests/Tests/Isolated/Billing/EdiHistory/Edi278RendererTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Isolated regression tests for the legacy EDI 278 HTML renderer.
+ *
+ * @package OpenEMR
+ * @link    https://www.open-emr.org
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace {
+    if (!function_exists('text')) {
+        function text($value): string
+        {
+            return htmlspecialchars((string) $value, ENT_NOQUOTES);
+        }
+    }
+
+    if (!function_exists('attr')) {
+        function attr($value): string
+        {
+            return htmlspecialchars((string) $value, ENT_QUOTES);
+        }
+    }
+
+    if (!function_exists('xlt')) {
+        function xlt($value): string
+        {
+            return (string) $value;
+        }
+    }
+
+    if (!function_exists('edih_format_money')) {
+        function edih_format_money($value): string
+        {
+            return (string) $value;
+        }
+    }
+
+    if (!function_exists('edih_format_date')) {
+        function edih_format_date($value, $format = 'Y-m-d'): string
+        {
+            return (string) $value;
+        }
+    }
+}
+
+namespace OpenEMR\Tests\Isolated\Billing\EdiHistory {
+    use PHPUnit\Framework\TestCase;
+
+    final class Edi278RendererTest extends TestCase
+    {
+        public static function setUpBeforeClass(): void
+        {
+            require_once __DIR__ . '/../../../../../library/edihistory/codes/edih_271_code_class.php';
+            require_once __DIR__ . '/../../../../../library/edihistory/edih_278_html.php';
+        }
+
+        public function testCompositeServiceDoesNotSkipDuplicateReferenceTransaction(): void
+        {
+            $x12 = new Edi278RendererX12([
+                [
+                    'BHT*0007*13*DUPLICATE*20260101',
+                    'HL*1**SS*0',
+                    'SV1*HC:CODE:MOD1:MOD2:MOD3*10',
+                ],
+                [
+                    'BHT*0007*13*DUPLICATE*20260102',
+                    'HL*2**SS*0',
+                    'MSG*SECOND-TRANSACTION-RENDERED',
+                ],
+            ]);
+
+            $html = \edih_278_transaction_html($x12, 'DUPLICATE');
+
+            self::assertStringContainsString('SECOND-TRANSACTION-RENDERED', $html);
+        }
+
+        public function testSv2UsesSegmentValuesForUnitAndLevelOfCareLookups(): void
+        {
+            $sv2 = array_fill(0, 21, '');
+            $sv2[0] = 'SV2';
+            $sv2[1] = '0300';
+            $sv2[2] = '125';
+            $sv2[3] = 'MJ';
+            $sv2[20] = '7';
+
+            $x12 = new Edi278RendererX12([
+                [
+                    'BHT*0007*13*SV2-LOOKUP*20260101',
+                    'HL*1**SS*0',
+                    implode('*', $sv2),
+                ],
+            ]);
+
+            $html = \edih_278_transaction_html($x12, 'SV2-LOOKUP');
+
+            self::assertStringContainsString('Minutes', $html);
+            self::assertStringContainsString('Nursing Facility (NF)', $html);
+        }
+    }
+
+    final class Edi278RendererX12
+    {
+        public function __construct(private readonly array $transactions)
+        {
+        }
+
+        public function edih_x12_transaction(string $reference): array
+        {
+            return $this->transactions;
+        }
+
+        public function edih_delimiters(): array
+        {
+            return ['e' => '*', 's' => ':', 'r' => '^'];
+        }
+
+        public function edih_filename(): string
+        {
+            return 'fixture.278';
+        }
+    }
+}

--- a/tests/Tests/Isolated/Billing/EdiHistory/edi_278_renderer_runtime_stubs.php
+++ b/tests/Tests/Isolated/Billing/EdiHistory/edi_278_renderer_runtime_stubs.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Runtime-only legacy helper stubs for Edi278RendererTest.
+ *
+ * Keep these declarations guarded: isolated tests share a process and another
+ * test may already have supplied a compatible global helper. This file is
+ * excluded from PHPStan analysis because PHPStan scans the production
+ * declarations for these helpers instead.
+ *
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+if (!function_exists('text')) {
+    function text(string $value): string
+    {
+        return htmlspecialchars($value, ENT_NOQUOTES);
+    }
+}
+
+if (!function_exists('attr')) {
+    function attr(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES);
+    }
+}
+
+if (!function_exists('xlt')) {
+    function xlt(string $value): string
+    {
+        return $value;
+    }
+}
+
+if (!function_exists('edih_format_money')) {
+    function edih_format_money(string $value): string
+    {
+        return $value;
+    }
+}
+
+if (!function_exists('edih_format_date')) {
+    function edih_format_date(string $value, string $format = 'Y-m-d'): string
+    {
+        return $value;
+    }
+}


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #13129. The EDI 278 HTML renderer no longer lets SV1/SV2 composite parsing overwrite the outer transaction counter, so later transactions sharing a BHT03 reference are still rendered. SV2 unit and level-of-care lookups now use the current segment values instead of stale composite data.

#### Related issue(s):

#13129

#### How to test:

```bash
vendor/bin/phpunit tests/Tests/Isolated/Billing/EdiHistory/Edi278RendererTest.php
```

The regression coverage exercises:

- multiple transactions sharing a BHT03 after a multi-element SV1 composite;
- SV203 unit lookup from the current SV2 segment;
- SV220 level-of-care lookup from the current SV2 segment.

Host-side validation performed:

```bash
php -l library/edihistory/edih_278_html.php
php -l tests/Tests/Isolated/Billing/EdiHistory/Edi278RendererTest.php
composer validate --no-check-publish
composer php-syntax-check
git diff --check
```

The focused tests were also run through a standalone harness; reverse-patching the two fixes reproduced both original failures. Full PHPUnit was unavailable locally because this worktree has no installed `vendor/bin/phpunit`; upstream CI will run the repository suite.

#### Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have added focused regression coverage.
- [x] I have kept the production change limited to the reported renderer defects.
