### PR TITLE
fix(coding): preserve inactive code state

### DIFF
--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1573,7 +1573,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 23,
+    'count' => 22,
     'path' => __DIR__ . '/../../interface/patient_file/encounter/superbill_custom_full.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1563,7 +1563,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 23,
+    'count' => 22,
     'path' => __DIR__ . '/../../interface/patient_file/encounter/superbill_custom_full.php',
 ];
 $ignoreErrors[] = [

--- a/interface/patient_file/encounter/superbill_custom_full.php
+++ b/interface/patient_file/encounter/superbill_custom_full.php
@@ -24,6 +24,7 @@ require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/options.
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Utils\CodingUtils;
 use OpenEMR\Common\Utils\FormatMoney;
 use OpenEMR\Common\Utils\PaginationUtils;
 use OpenEMR\Core\Header;
@@ -545,7 +546,7 @@ if ($fend > ($count ?? null)) {
             </div>
             <div class="col-md">
                 <input type='checkbox' name='active'
-                       value='1'<?php if (!empty($active) || ($mode == 'modify' && $active == null)) {
+                       value='1'<?php if (CodingUtils::isActiveCheckboxChecked($active, $mode)) {
                             echo ' checked';
                                 } ?> />
                 <?php echo xlt('Active'); ?>

--- a/src/Common/Utils/CodingUtils.php
+++ b/src/Common/Utils/CodingUtils.php
@@ -8,6 +8,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Common\Utils;
 
 class CodingUtils

--- a/src/Common/Utils/CodingUtils.php
+++ b/src/Common/Utils/CodingUtils.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Utilities for the Administration -> Coding interface.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Utils;
+
+class CodingUtils
+{
+    public static function isActiveCheckboxChecked(mixed $active, mixed $mode): bool
+    {
+        return !empty($active) || ($mode === 'modify' && $active === null);
+    }
+}

--- a/src/Common/Utils/CodingUtils.php
+++ b/src/Common/Utils/CodingUtils.php
@@ -14,6 +14,6 @@ class CodingUtils
 {
     public static function isActiveCheckboxChecked(mixed $active, mixed $mode): bool
     {
-        return !empty($active) || ($mode === 'modify' && $active === null);
+        return (bool) $active || ($mode === 'modify' && $active === null);
     }
 }

--- a/tests/Tests/Unit/Common/Utils/CodingUtilsTest.php
+++ b/tests/Tests/Unit/Common/Utils/CodingUtilsTest.php
@@ -8,6 +8,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Tests\Unit\Common\Utils;
 
 use OpenEMR\Common\Utils\CodingUtils;

--- a/tests/Tests/Unit/Common/Utils/CodingUtilsTest.php
+++ b/tests/Tests/Unit/Common/Utils/CodingUtilsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Tests for CodingUtils.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Unit\Common\Utils;
+
+use OpenEMR\Common\Utils\CodingUtils;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class CodingUtilsTest extends TestCase
+{
+    #[DataProvider('activeCheckboxProvider')]
+    public function testIsActiveCheckboxChecked(mixed $active, mixed $mode, bool $expected): void
+    {
+        $this->assertSame($expected, CodingUtils::isActiveCheckboxChecked($active, $mode));
+    }
+
+    /**
+     * @return array<string, array{mixed, mixed, bool}>
+     */
+    public static function activeCheckboxProvider(): array
+    {
+        return [
+            'external modify with integer zero' => [0, 'modify', false],
+            'external modify with string zero' => ['0', 'modify', false],
+            'external modify with null' => [null, 'modify', true],
+            'external modify with active integer' => [1, 'modify', true],
+            'local edit with integer zero' => [0, 'edit', false],
+            'local edit with null' => [null, 'edit', false],
+            'local edit with active integer' => [1, 'edit', true],
+        ];
+    }
+}

--- a/tests/Tests/Unit/Common/Utils/CodingUtilsTest.php
+++ b/tests/Tests/Unit/Common/Utils/CodingUtilsTest.php
@@ -24,6 +24,7 @@ class CodingUtilsTest extends TestCase
 
     /**
      * @return array<string, array{mixed, mixed, bool}>
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
     public static function activeCheckboxProvider(): array
     {

--- a/tests/Tests/Unit/Common/Utils/CodingUtilsTest.php
+++ b/tests/Tests/Unit/Common/Utils/CodingUtilsTest.php
@@ -28,13 +28,24 @@ class CodingUtilsTest extends TestCase
     public static function activeCheckboxProvider(): array
     {
         return [
+            'external modify with false' => [false, 'modify', false],
+            'external modify with empty string' => ['', 'modify', false],
+            'external modify with empty array' => [[], 'modify', false],
             'external modify with integer zero' => [0, 'modify', false],
             'external modify with string zero' => ['0', 'modify', false],
             'external modify with null' => [null, 'modify', true],
             'external modify with active integer' => [1, 'modify', true],
+            'external modify with non-empty string' => ['active', 'modify', true],
+            'external modify with non-empty array' => [[1], 'modify', true],
+            'local edit with false' => [false, 'edit', false],
+            'local edit with empty string' => ['', 'edit', false],
+            'local edit with empty array' => [[], 'edit', false],
             'local edit with integer zero' => [0, 'edit', false],
+            'local edit with string zero' => ['0', 'edit', false],
             'local edit with null' => [null, 'edit', false],
             'local edit with active integer' => [1, 'edit', true],
+            'local edit with non-empty string' => ['active', 'edit', true],
+            'local edit with non-empty array' => [[1], 'edit', true],
         ];
     }
 }


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #13413. The Coding administration page now distinguishes a genuinely missing external-code active value from an explicit inactive value. Reopening a code whose stored `active` value is `0` no longer checks the Active checkbox again.

The save path is unchanged; it already persists an omitted Active checkbox as `0`.

#### Related issue(s):

#13413

#### How to test:

```bash
vendor/bin/phpunit tests/Tests/Unit/Common/Utils/CodingUtilsTest.php
```

Manual path:

1. Open **Admin → Coding → Codes**.
2. Modify an existing code.
3. Clear **Active** and save.
4. Reopen the code.
5. Confirm **Active** remains clear.

Regression coverage verifies integer and string zero, null external values, active values, and local edit behavior.

Host-side validation performed:

```bash
php -l interface/patient_file/encounter/superbill_custom_full.php
php -l src/Common/Utils/CodingUtils.php
php -l tests/Tests/Unit/Common/Utils/CodingUtilsTest.php
composer validate --no-check-publish
composer php-syntax-check
git diff --check
```

All seven helper cases also passed through a dependency-free execution harness. Full PHPUnit was unavailable locally because this worktree has no installed `vendor/bin/phpunit`; upstream CI will run the repository suite.

#### Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have added focused regression coverage.
- [x] I have preserved existing save behavior and limited the production change to checkbox rendering.
