### PR TITLE
fix(reports): reject inverted AMC date ranges

### DIFF
--- a/library/ajax/execute_cdr_report.php
+++ b/library/ajax/execute_cdr_report.php
@@ -17,6 +17,7 @@ use OpenEMR\ClinicalDecisionRules\AMC\CertificationReportTypes;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Reports\AMC\DateRangeValidator;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
@@ -53,6 +54,15 @@ if (!empty($_POST['execute_report_id'])) {
         //   need to send a manual data entry option (number of labs)
         $array_date['dateBegin'] = $_POST['date_begin'] ?? null;
         $array_date['dateTarget'] = $target_date;
+
+        $begin_date = is_string($array_date['dateBegin']) ? $array_date['dateBegin'] : null;
+        $end_date = is_string($array_date['dateTarget']) ? $array_date['dateTarget'] : null;
+        if (DateRangeValidator::isInverted($begin_date, $end_date)) {
+            http_response_code(400);
+            echo xlt('Begin Date cannot be later than End Date.');
+            exit;
+        }
+
         $options = ['labs_manual' => $_POST['labs'] ?? 0];
     } else {
         // For others, use the unmodified target date array and send an empty options array

--- a/library/js/CqmDateRangeValidator.js
+++ b/library/js/CqmDateRangeValidator.js
@@ -1,0 +1,39 @@
+/**
+ * Calendar-safe validation helpers for CQM/AMC report timestamps.
+ *
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+(function (root, factory) {
+    const validator = factory();
+    if (typeof module === 'object' && module.exports) {
+        module.exports = validator;
+    }
+    root.CqmDateRangeValidator = validator;
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    function isSupportedTimestamp(value) {
+        if (typeof value !== 'string') {
+            return false;
+        }
+
+        const match = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/.exec(value);
+        if (match === null) {
+            return false;
+        }
+
+        const parts = match.slice(1).map(Number);
+        const date = new Date(0);
+        date.setUTCHours(parts[3], parts[4], parts[5], 0);
+        date.setUTCFullYear(parts[0], parts[1] - 1, parts[2]);
+
+        return date.getUTCFullYear() === parts[0] &&
+            date.getUTCMonth() === parts[1] - 1 &&
+            date.getUTCDate() === parts[2] &&
+            date.getUTCHours() === parts[3] &&
+            date.getUTCMinutes() === parts[4] &&
+            date.getUTCSeconds() === parts[5];
+    }
+
+    return { isSupportedTimestamp };
+}));

--- a/src/Reports/AMC/DateRangeValidator.php
+++ b/src/Reports/AMC/DateRangeValidator.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Validates date range ordering for Automated Measure Calculation reports.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Reports\AMC;
+
+use DateTimeImmutable;
+
+final class DateRangeValidator
+{
+    private const TIMESTAMP_FORMAT = 'Y-m-d H:i:s';
+
+    /**
+     * Returns true only when both values are supported timestamps and begin is after end.
+     *
+     * Empty and malformed values are deliberately left to the report engine's existing
+     * handling; this check is limited to rejecting inverted date ranges.
+     */
+    public static function isInverted(?string $begin, ?string $end): bool
+    {
+        $beginDate = self::parseTimestamp($begin);
+        $endDate = self::parseTimestamp($end);
+
+        return $beginDate !== null && $endDate !== null && $beginDate > $endDate;
+    }
+
+    private static function parseTimestamp(?string $value): ?DateTimeImmutable
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $date = DateTimeImmutable::createFromFormat('!' . self::TIMESTAMP_FORMAT, $value);
+        $errors = DateTimeImmutable::getLastErrors();
+        if ($date === false || ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))) {
+            return null;
+        }
+
+        return $date->format(self::TIMESTAMP_FORMAT) === $value ? $date : null;
+    }
+}

--- a/src/Reports/AMC/DateRangeValidator.php
+++ b/src/Reports/AMC/DateRangeValidator.php
@@ -8,6 +8,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Reports\AMC;
 
 use DateTimeImmutable;

--- a/templates/reports/cqm/cqm.html.twig
+++ b/templates/reports/cqm/cqm.html.twig
@@ -3,6 +3,7 @@
 <head>
     <title>{{ heading_title|text }}</title>
     {{ setupHeader(['datetime-picker']) }}
+    <script src="{{ webroot|attr }}/library/js/CqmDateRangeValidator.js?v={{ assetVersion|attr_url }}"></script>
     <script>
 
         {{ DateToYYYYMMDD_js() }}
@@ -14,11 +15,14 @@
             {{ jqueryDateTimePicker('.datepicker',true,true,true) }}
         });
 
+        let executeRequest = null;
+        let pollingActive = false;
+        let pollingTimer = null;
+
         function runReport() {
 
             // Validate first
-            if (!(validateForm())) {
-                alert({{ "Rule Set and Plan Set selections are not consistent. Please fix and Submit again."|xlj }});
+            if (!validateForm()) {
                 return false;
             }
 
@@ -39,17 +43,15 @@
             // Collect an id string via an ajax request
             top.restoreSession();
             $.get("../../library/ajax/collect_new_report_id.php",
-                {csrf_token_form: {{ csrfTokenRaw()|js_escape }} },
-                function (data) {
+                {csrf_token_form: {{ csrfTokenRaw()|js_escape }} })
+                .done(function (data) {
                     // Set the report id in page form
                     $("#form_new_report_id").attr("value", data);
 
-                    // Start collection status checks
-                    collectStatus($("#form_new_report_id").val());
-
                     // Run the report
                     top.restoreSession();
-                    $.post("../../library/ajax/execute_cdr_report.php",
+                    pollingActive = true;
+                    executeRequest = $.post("../../library/ajax/execute_cdr_report.php",
                         {
                             provider: $("#form_provider").val(),
                             type: $("#form_rule_filter").val(),
@@ -61,11 +63,49 @@
                             pat_prov_rel: $("#form_pat_prov_rel").val(),
                             execute_report_id: $("#form_new_report_id").val(),
                             csrf_token_form: {{ csrfTokenRaw()|js_escape }}
+                        })
+                        .fail(function (xhr) {
+                            stopPolling();
+                            restoreReportForm();
+                            const responseText = xhr.status === 400 && xhr.responseText
+                                ? xhr.responseText.trim().slice(0, 500)
+                                : '';
+                            alert(responseText || {{ "Unable to run report."|xlj }});
                         });
+
+                    // The execution request is long-running, so poll while it remains open.
+                    if (pollingActive) {
+                        collectStatus($("#form_new_report_id").val());
+                    }
+                })
+                .fail(function () {
+                    restoreReportForm();
+                    alert({{ "Unable to run report."|xlj }});
                 });
+
+            return false;
+        }
+
+        function stopPolling() {
+            pollingActive = false;
+            if (pollingTimer !== null) {
+                clearTimeout(pollingTimer);
+                pollingTimer = null;
+            }
+        }
+
+        function restoreReportForm() {
+            $("#processing").hide();
+            $("#submit_button, #xmla_button, #xmlb_button, #xmlc_button, #print_button, #genQRDA").show();
+            $("#instructions_text").show();
+            $('#status_span').text('');
         }
 
         function collectStatus(report_id) {
+            if (!pollingActive) {
+                return;
+            }
+
             // Collect the status string via an ajax request and place in DOM at timed intervals
             top.restoreSession();
             // Do not send the skip_timeout_reset parameter, so don't close window before report is done.
@@ -75,10 +115,14 @@
                     csrf_token_form: {{ csrfTokenRaw()|js_escape }}
                 },
                 function (data) {
+                    if (!pollingActive) {
+                        return;
+                    }
                     if (data == "PENDING") {
                         // Place the pending string in the DOM
                         $('#status_span').replaceWith("<span id='status_span'>{{ "Preparing To Run Report"|xlt }}</span>");
                     } else if (data == "COMPLETE") {
+                        stopPolling();
                         // Go into the results page
                         top.restoreSession();
                         link_report = "cqm.php?report_id=" + encodeURIComponent(report_id);
@@ -89,7 +133,11 @@
                     }
                 });
             // run status check every 10 seconds
-            var repeater = setTimeout("collectStatus(" + report_id + ")", 10000);
+            if (pollingActive) {
+                pollingTimer = setTimeout(function () {
+                    collectStatus(report_id);
+                }, 10000);
+            }
         }
 
         function GenXml(sNested) {
@@ -114,21 +162,38 @@
             dlgopen(sLoc, '_blank', 600, 500);
         }
 
-        function validateForm() {
+        function getValidationError() {
+            {% if not report_id and is_amc_report %}
+            const beginDate = DateToYYYYMMDDHHMMSS_js($("#form_begin_date").val());
+            const endDate = DateToYYYYMMDDHHMMSS_js($("#form_target_date").val());
+            if (CqmDateRangeValidator.isSupportedTimestamp(beginDate) &&
+                CqmDateRangeValidator.isSupportedTimestamp(endDate) && beginDate > endDate) {
+                return {{ "Begin Date cannot be later than End Date."|xlj }};
+            }
+            {% endif %}
             {% if not report_id and type_report == "cqm" %}
             // If this is a cqm and plan set not set to ignore, then need to ensure consistent with the rules set
             if ($("#form_plan_filter").val() != '') {
                 if ($("#form_rule_filter").val() == $("#form_plan_filter").val()) {
-                    return true;
+                    return null;
                 } else {
-                    return false;
+                    return {{ "Rule Set and Plan Set selections are not consistent. Please fix and Submit again."|xlj }};
                 }
             } else {
-                return true;
+                return null;
             }
             {% else %}
-            return true;
+            return null;
             {% endif %}
+        }
+
+        function validateForm() {
+            const validationError = getValidationError();
+            if (validationError !== null) {
+                alert(validationError);
+                return false;
+            }
+            return true;
         }
 
     </script>

--- a/tests/Tests/Isolated/Reports/AMC/DateRangeValidatorTest.php
+++ b/tests/Tests/Isolated/Reports/AMC/DateRangeValidatorTest.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Tests\Isolated\Reports\AMC;
 
 use OpenEMR\Reports\AMC\DateRangeValidator;

--- a/tests/Tests/Isolated/Reports/AMC/DateRangeValidatorTest.php
+++ b/tests/Tests/Isolated/Reports/AMC/DateRangeValidatorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Isolated\Reports\AMC;
+
+use OpenEMR\Reports\AMC\DateRangeValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DateRangeValidatorTest extends TestCase
+{
+    public function testBeginBeforeEndIsNotInverted(): void
+    {
+        self::assertFalse(DateRangeValidator::isInverted('2025-01-01 00:00:00', '2025-12-31 23:59:59'));
+    }
+
+    public function testEqualTimestampsAreNotInverted(): void
+    {
+        self::assertFalse(DateRangeValidator::isInverted('2025-06-15 12:30:45', '2025-06-15 12:30:45'));
+    }
+
+    public function testBeginAfterEndIsInverted(): void
+    {
+        self::assertTrue(DateRangeValidator::isInverted('2025-12-31 23:59:59', '2025-01-01 00:00:00'));
+    }
+
+    #[DataProvider('unsupportedTimestampProvider')]
+    public function testEmptyAndMalformedTimestampsDoNotChangeLegacyHandling(?string $begin, ?string $end): void
+    {
+        self::assertFalse(DateRangeValidator::isInverted($begin, $end));
+    }
+
+    /**
+     * @return array<string, array{0: ?string, 1: ?string}>
+     */
+    public static function unsupportedTimestampProvider(): array
+    {
+        return [
+            'empty begin' => ['', '2025-12-31 23:59:59'],
+            'null end' => ['2025-01-01 00:00:00', null],
+            'unsupported shape' => ['12/31/2025 23:59:59', '2025-01-01 00:00:00'],
+            'invalid calendar date' => ['2025-02-30 00:00:00', '2025-01-01 00:00:00'],
+        ];
+    }
+}

--- a/tests/js/cqm-date-range-validator.test.js
+++ b/tests/js/cqm-date-range-validator.test.js
@@ -1,0 +1,26 @@
+/**
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+const validator = require('../../library/js/CqmDateRangeValidator');
+
+describe('CQM date range timestamp validation', () => {
+    test.each([
+        '2024-02-29 23:59:59',
+        '2025-01-01 00:00:00',
+        '0001-01-01 00:00:00',
+    ])('accepts exact normalized calendar-valid timestamp %s', (value) => {
+        expect(validator.isSupportedTimestamp(value)).toBe(true);
+    });
+
+    test.each([
+        undefined,
+        '',
+        '2025-02-29 00:00:00',
+        '2025-04-31 00:00:00',
+        '2025-01-01 24:00:00',
+        '2025-1-01 00:00:00',
+        '2025-01-01T00:00:00',
+    ])('ignores unsupported timestamp %s', (value) => {
+        expect(validator.isSupportedTimestamp(value)).toBe(false);
+    });
+});


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #13416. New AMC reports now reject a Begin Date later than the End Date before reserving a report ID, with a specific localized validation message.

The report execution endpoint independently validates direct AMC POST requests and returns HTTP 400 before invoking the report engine. Client failure handling stops status polling and restores the form, including synchronous request rejection and expected server-side validation failures.

#### Related issue(s):

#13416

#### How to test:

```bash
vendor/bin/phpunit -c phpunit-isolated.xml tests/Tests/Isolated/Reports/AMC/DateRangeValidatorTest.php
npm run test:js -- tests/js/cqm-date-range-validator.test.js --runInBand
```

Manual path:

1. Open **Reports → Clinic → Automated Measures (AMC)**.
2. Set Begin Date later than End Date.
3. Click Submit.
4. Confirm the specific date-range message appears and no report starts.
5. Set Begin Date equal to or before End Date and confirm normal report generation starts.

Direct endpoint requests with inverted normalized AMC timestamps return HTTP 400 before report execution.

#### Validation performed:

```bash
php -l library/ajax/execute_cdr_report.php
php -l src/Reports/AMC/DateRangeValidator.php
php -l tests/Tests/Isolated/Reports/AMC/DateRangeValidatorTest.php
node --check library/js/CqmDateRangeValidator.js
node --check tests/js/cqm-date-range-validator.test.js
composer validate --strict
composer php-syntax-check
git diff --check
```

Dependency-free PHP and Node harnesses also passed date ordering, malformed inputs, leap dates, boundary years, and synchronous polling-state reasoning. PHPUnit and Jest executables were unavailable in this worktree because dependencies are not installed; upstream CI will run repository gates.

#### Checklist:

- [x] Client validation occurs before report-ID reservation.
- [x] Server validation occurs before report execution.
- [x] Non-AMC report behavior is unchanged.
- [x] Focused PHP and JavaScript regression tests are included.
- [x] Independent read-only review approved the final diff.
