### PR TITLE
fix(reports): preserve AMC summary base path

### DIFF
--- a/templates/reports/cqm/amc-full-report.html.twig
+++ b/templates/reports/cqm/amc-full-report.html.twig
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 <head>
     <title>{{ title|text }}</title>

--- a/templates/reports/cqm/amc-full-report.html.twig
+++ b/templates/reports/cqm/amc-full-report.html.twig
@@ -30,7 +30,7 @@
 <div id="container_div" class="container-fluid mt-3">
     <div class="btn-group float-right mb-2" role="group">
         <a href='#' class='btn btn-secondary btn-print d-print-none' id='printbutton'>{{ 'Print'|xlt }}</a>
-        <a href='/interface/reports/cqm.php?report_id={{ report_id|attr_url }}&back=list' class='btn btn-secondary btn-transmit d-print-none'>{{ 'Return to Summary'|xlt }}</a>
+        <a href='{{ webroot|attr }}/interface/reports/cqm.php?report_id={{ report_id|attr_url }}&back=list' class='btn btn-secondary btn-transmit d-print-none'>{{ 'Return to Summary'|xlt }}</a>
     </div>
     <h1 class="title">{{ 'Report'|xlt }} - {{ title|text }} - {{ "Date of Report"|xlt }}: {{ reportDate|text }}</h1>
 

--- a/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
+++ b/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
@@ -397,6 +397,19 @@ class TwigTemplateRenderTest extends TestCase
             $fixtureDir . '/load-codes-no-rxcui.html',
         ];
 
+        yield 'reports/cqm/amc-full-report with non-root webroot' => [
+            'reports/cqm/amc-full-report.html.twig',
+            [
+                'webroot' => '/openemr',
+                'report_id' => 'AMC 2026/A&B?',
+                'title' => 'AMC Full Report',
+                'reportDate' => '2026-08-13',
+                'subTitle' => '',
+                'datasheet' => [],
+            ],
+            $fixtureDir . '/amc-full-report-non-root-webroot.html',
+        ];
+
         $reasonCodeStatii = [
             '' => ['code' => '', 'description' => 'Select a status code'],
             'negated' => ['code' => 'negated', 'description' => 'Negated'],

--- a/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
+++ b/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
@@ -425,6 +425,19 @@ class TwigTemplateRenderTest extends TestCase
             $fixtureDir . '/load-codes-no-rxcui.html',
         ];
 
+        yield 'reports/cqm/amc-full-report with non-root webroot' => [
+            'reports/cqm/amc-full-report.html.twig',
+            [
+                'webroot' => '/openemr',
+                'report_id' => 'AMC 2026/A&B?',
+                'title' => 'AMC Full Report',
+                'reportDate' => '2026-08-13',
+                'subTitle' => '',
+                'datasheet' => [],
+            ],
+            $fixtureDir . '/amc-full-report-non-root-webroot.html',
+        ];
+
         $reasonCodeStatii = [
             '' => ['code' => '', 'description' => 'Select a status code'],
             'negated' => ['code' => 'negated', 'description' => 'Negated'],

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/amc-full-report-non-root-webroot.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/amc-full-report-non-root-webroot.html
@@ -1,0 +1,73 @@
+<html>
+<head>
+    <title>AMC Full Report</title>
+    <!-- setupHeader stub -->
+    <script>
+
+        $(function () {
+            var win = top.printLogSetup ? top : opener.top;
+            win.printLogSetup(document.getElementById('printbutton'));
+        });
+    </script>
+    <style>
+        .amc-action-label {
+            width: 25rem;
+        }
+        .amc-demographic-label {
+            width: 15rem;
+        }
+        @media print {
+            .amc-action-label {
+                width: 20rem;
+            }
+            .amc-demographic-label {
+                width: 10rem;
+            }
+        }
+    </style>
+</head>
+<body class="body_top">
+<div id="container_div" class="container-fluid mt-3">
+    <div class="btn-group float-right mb-2" role="group">
+        <a href='#' class='btn btn-secondary btn-print d-print-none' id='printbutton'>Print</a>
+        <a href='/openemr/interface/reports/cqm.php?report_id=AMC+2026%2FA%26B%3F&back=list' class='btn btn-secondary btn-transmit d-print-none'>Return to Summary</a>
+    </div>
+    <h1 class="title">Report - AMC Full Report - Date of Report: 2026-08-13</h1>
+
+
+        <div id="report_results">
+    <table class="table text-center">
+        <thead class='thead-light'>
+        <tr>
+            <th>
+                Title
+            </th>
+            <th>
+                Total Patients
+            </th>
+            <th>
+                Denominator
+            </th>
+            <th>
+                Numerator
+            </th>
+            <th>
+                Failed
+            </th>
+            <th>
+                Performance Percentage
+            </th>
+        </tr>
+        </thead>
+        <tbody>
+</tbody>
+
+    </table>
+</div>
+
+    <h3 class='title'>Patient Details Report</h3>
+
+
+</div>
+</body>
+</html>

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/amc-full-report-non-root-webroot.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/amc-full-report-non-root-webroot.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 <head>
     <title>AMC Full Report</title>

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/amc-full-report-non-root-webroot.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/amc-full-report-non-root-webroot.html
@@ -34,8 +34,7 @@
     </div>
     <h1 class="title">Report - AMC Full Report - Date of Report: 2026-08-13</h1>
 
-
-        <div id="report_results">
+            <div id="report_results">
     <table class="table text-center">
         <thead class='thead-light'>
         <tr>
@@ -61,13 +60,10 @@
         </thead>
         <tbody>
 </tbody>
-
     </table>
 </div>
 
     <h3 class='title'>Patient Details Report</h3>
-
-
-</div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #13415. The AMC Detailed Report’s **Return to Summary** link now includes OpenEMR’s configured `webroot`, so installations hosted below a path such as `/openemr` return to the report summary instead of requesting the server-root `/interface/...` URL and receiving a 404.

The report ID remains URL-encoded and `back=list` behavior is unchanged.

#### Related issue(s):

#13415

#### How to test:

```bash
vendor/bin/phpunit -c phpunit-isolated.xml \
  tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php \
  --filter 'amc-full-report with non-root webroot'
```

Manual path on a subdirectory installation:

1. Generate an AMC report.
2. Open **AMC Detailed Report**.
3. Click **Return to Summary**.
4. Confirm the browser returns through the configured OpenEMR base path to the same report summary.

The render fixture verifies:

```text
/openemr/interface/reports/cqm.php?report_id=AMC+2026%2FA%26B%3F&back=list
```

#### Validation performed:

```bash
php -l tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
composer validate --strict
composer php-syntax-check
git diff --check
```

The worktree lacks installed `vendor/bin/phpunit`, so the Twig render suite could not execute locally. The fixture was checked against the current template includes, Twig test stubs, `attr_url()` implementation, and existing fixture normalization, then independently reviewed and approved. Upstream CI will execute the isolated Twig suite.

#### Checklist:

- [x] Root installations preserve the existing `/interface/...` URL.
- [x] Subdirectory installations include `webroot`.
- [x] Report IDs remain URL-encoded.
- [x] Focused full-render regression coverage is included.
