### PR TITLE
fix(ci): pass valid integration coverage driver

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -83,7 +83,8 @@ jobs:
     - name: Setup PHP and Composer
       uses: ./.github/actions/setup-php-composer
       with:
-        coverage: ${{ env.COLLECT_COVERAGE }}
+        # Action inputs are strings; map the env flag to a supported driver.
+        coverage: ${{ env.COLLECT_COVERAGE == 'true' && 'xdebug' || 'none' }}
         php-version: ${{ matrix.php.version }}
 
     - name: Run CLI installer


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #12572. The integration-test workflow now maps its string-valued coverage flag to a valid coverage driver before calling the shared PHP setup action:

- selected coverage matrix arm → `xdebug`
- all other matrix arms → `none`

Previously the action received `true` or `false`, despite its `none|xdebug|pcov` input contract.

The matrix, PHPUnit coverage flags, Codecov upload condition, and shared composite action remain unchanged.

#### Related issue(s):

#12572

#### How to test:

```bash
actionlint .github/workflows/integration-tests.yml
ruby -e "require 'yaml'; YAML.parse_file('.github/workflows/integration-tests.yml')"
git diff --check
```

Expected matrix behavior:

- PHP 8.5 + MariaDB 12: `coverage: xdebug`
- every other arm: `coverage: none`

The existing PHPUnit and coverage-upload steps use the same `env.COLLECT_COVERAGE == 'true'` predicate.

#### Checklist:

- [x] The setup action receives only a supported coverage driver string.
- [x] Coverage remains limited to one matrix arm.
- [x] Workflow syntax passes `actionlint` and YAML parsing.
- [x] Independent read-only review approved the expression semantics.
