### PR TITLE
fix(reports): include full Superbill end date

### DIFF
--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -3523,16 +3523,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/custom_report_range.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/custom_report_range.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../interface/reports/daily_summary_report.php',
 ];

--- a/interface/reports/custom_report_range.php
+++ b/interface/reports/custom_report_range.php
@@ -19,6 +19,7 @@ use OpenEMR\Billing\BillingUtilities;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -272,20 +273,20 @@ if (!(empty($_POST['start']) || empty($_POST['end']))) {
 </p>
     <?php
         $sqlBindArray = [];
-        $res_query =    "select * from forms where " .
+        $resQuery =    "select * from forms where " .
                         "form_name = 'New Patient Encounter' and " .
                         "date >= ? and date < DATE_ADD(?, INTERVAL 1 DAY) " ;
                 array_push($sqlBindArray, $startdate, $enddate);
     if ($form_pid) {
-        $res_query .= " and pid=? ";
+        $resQuery .= " and pid=? ";
         array_push($sqlBindArray, $form_pid);
     }
 
-        $res_query .=     " order by date DESC" ;
-        $res = sqlStatement($res_query, $sqlBindArray);
+        $resQuery .=     " order by date DESC" ;
+        $results = QueryUtils::fetchRecords($resQuery, $sqlBindArray);
 
     $pids = [];
-    while ($result = sqlFetchArray($res)) {
+    foreach ($results as $result) {
         if ($result["form_name"] == "New Patient Encounter") {
             $newpatient[] = $result["form_id"] . ":" . $result["encounter"];
             $pids[] = $result["pid"];

--- a/interface/reports/custom_report_range.php
+++ b/interface/reports/custom_report_range.php
@@ -274,7 +274,7 @@ if (!(empty($_POST['start']) || empty($_POST['end']))) {
         $sqlBindArray = [];
         $res_query =    "select * from forms where " .
                         "form_name = 'New Patient Encounter' and " .
-                        "date between ? and ? " ;
+                        "date >= ? and date < DATE_ADD(?, INTERVAL 1 DAY) " ;
                 array_push($sqlBindArray, $startdate, $enddate);
     if ($form_pid) {
         $res_query .= " and pid=? ";

--- a/tests/Tests/Isolated/Reports/SuperbillDateRangeTest.php
+++ b/tests/Tests/Isolated/Reports/SuperbillDateRangeTest.php
@@ -33,7 +33,7 @@ class SuperbillDateRangeTest extends TestCase
     public function productionQueryUsesAnIndexFriendlyInclusiveEndDate(): void
     {
         $queryPattern = <<<'REGEX'
-            /\$res_query\s*=\s*
+            /\$resQuery\s*=\s*
             "select\s+\*\s+from\s+forms\s+where\s*"\s*\.\s*
             "form_name\s*=\s*'New\s+Patient\s+Encounter'\s+and\s*"\s*\.\s*
             .*?;
@@ -49,6 +49,8 @@ class SuperbillDateRangeTest extends TestCase
             $queryConstruction
         );
         self::assertDoesNotMatchRegularExpression('/DATE\s*\(\s*date\s*\)/i', $queryConstruction);
+        self::assertStringContainsString('QueryUtils::fetchRecords($resQuery, $sqlBindArray)', $this->reportSource);
+        self::assertStringNotContainsString('sqlStatement($resQuery', $this->reportSource);
 
         $sourceAfterQuery = substr($this->reportSource, $queryOffset + strlen($queryConstruction));
         self::assertMatchesRegularExpression(

--- a/tests/Tests/Isolated/Reports/SuperbillDateRangeTest.php
+++ b/tests/Tests/Isolated/Reports/SuperbillDateRangeTest.php
@@ -32,14 +32,28 @@ class SuperbillDateRangeTest extends TestCase
     #[Test]
     public function productionQueryUsesAnIndexFriendlyInclusiveEndDate(): void
     {
+        $queryPattern = <<<'REGEX'
+            /\$res_query\s*=\s*
+            "select\s+\*\s+from\s+forms\s+where\s*"\s*\.\s*
+            "form_name\s*=\s*'New\s+Patient\s+Encounter'\s+and\s*"\s*\.\s*
+            .*?;
+            /isx
+            REGEX;
+        $matchCount = preg_match_all($queryPattern, $this->reportSource, $queryMatches, PREG_OFFSET_CAPTURE);
+
+        self::assertSame(1, $matchCount, 'Expected exactly one Superbill forms query construction');
+        [$queryConstruction, $queryOffset] = $queryMatches[0][0];
+
         self::assertMatchesRegularExpression(
             '/date\s*>=\s*\?\s+and\s+date\s*<\s*DATE_ADD\s*\(\s*\?\s*,\s*INTERVAL\s+1\s+DAY\s*\)/i',
-            $this->reportSource
+            $queryConstruction
         );
-        self::assertDoesNotMatchRegularExpression('/DATE\s*\(\s*date\s*\)/i', $this->reportSource);
-        self::assertStringContainsString(
-            'array_push($sqlBindArray, $startdate, $enddate);',
-            $this->reportSource
+        self::assertDoesNotMatchRegularExpression('/DATE\s*\(\s*date\s*\)/i', $queryConstruction);
+
+        $sourceAfterQuery = substr($this->reportSource, $queryOffset + strlen($queryConstruction));
+        self::assertMatchesRegularExpression(
+            '/^\s*array_push\s*\(\s*\$sqlBindArray\s*,\s*\$startdate\s*,\s*\$enddate\s*\)\s*;/',
+            $sourceAfterQuery
         );
     }
 
@@ -48,6 +62,8 @@ class SuperbillDateRangeTest extends TestCase
      * production SQL: [start date, day after end date).
      *
      * @return iterable<string, array{string, string, string, bool}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
     public static function dateRangeCases(): iterable
     {

--- a/tests/Tests/Isolated/Reports/SuperbillDateRangeTest.php
+++ b/tests/Tests/Isolated/Reports/SuperbillDateRangeTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Tests the inclusive date range used by the Visits -> Superbill report.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Reports;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class SuperbillDateRangeTest extends TestCase
+{
+    private string $reportSource;
+
+    protected function setUp(): void
+    {
+        $path = dirname(__DIR__, 4) . '/interface/reports/custom_report_range.php';
+        $source = file_get_contents($path);
+        self::assertNotFalse($source, "Could not read {$path}");
+        $this->reportSource = $source;
+    }
+
+    #[Test]
+    public function productionQueryUsesAnIndexFriendlyInclusiveEndDate(): void
+    {
+        self::assertMatchesRegularExpression(
+            '/date\s*>=\s*\?\s+and\s+date\s*<\s*DATE_ADD\s*\(\s*\?\s*,\s*INTERVAL\s+1\s+DAY\s*\)/i',
+            $this->reportSource
+        );
+        self::assertDoesNotMatchRegularExpression('/DATE\s*\(\s*date\s*\)/i', $this->reportSource);
+        self::assertStringContainsString(
+            'array_push($sqlBindArray, $startdate, $enddate);',
+            $this->reportSource
+        );
+    }
+
+    /**
+     * These examples independently exercise the boundary represented by the
+     * production SQL: [start date, day after end date).
+     *
+     * @return iterable<string, array{string, string, string, bool}>
+     */
+    public static function dateRangeCases(): iterable
+    {
+        yield 'same-day afternoon is included' => [
+            '2026-08-13',
+            '2026-08-13',
+            '2026-08-13 15:30:00',
+            true,
+        ];
+        yield 'midnight of the following day is excluded' => [
+            '2026-08-13',
+            '2026-08-13',
+            '2026-08-14 00:00:00',
+            false,
+        ];
+        yield 'afternoon of a multi-day end date is included' => [
+            '2026-08-11',
+            '2026-08-13',
+            '2026-08-13 23:59:59',
+            true,
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('dateRangeCases')]
+    public function halfOpenBoundsPreserveInclusiveDateSemantics(
+        string $startDate,
+        string $endDate,
+        string $formDate,
+        bool $expected
+    ): void {
+        $start = new DateTimeImmutable($startDate);
+        $exclusiveEnd = (new DateTimeImmutable($endDate))->modify('+1 day');
+        $formDateTime = new DateTimeImmutable($formDate);
+
+        self::assertSame($expected, $formDateTime >= $start && $formDateTime < $exclusiveEnd);
+    }
+}


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #13411. The Visits → Superbill report now treats the selected End Date as an inclusive calendar date.

The report previously compared the `forms.date` datetime column using `BETWEEN` with date-only start/end values. When both dates were identical, the upper bound was midnight at the start of that day, excluding encounters later that day.

The query now uses an index-friendly half-open range:

```sql
date >= ? AND date < DATE_ADD(?, INTERVAL 1 DAY)
```

This includes all encounters on the selected end date while excluding the following day. Existing patient filtering, form filtering, ordering, displayed dates, and default date behavior remain unchanged.

#### Does this resolve an issue?

Fixes #13411

#### Does this need specific testing?

Yes. Verify the Superbill report with:

- identical Start and End dates containing an afternoon encounter;
- a multi-day range containing encounters late on the End Date;
- an encounter exactly on the following day, which must remain excluded;
- optional patient filtering enabled and disabled.

#### Tests run:

- PHP syntax checks for production and regression-test files
- Composer strict validation
- Repository PHP syntax check
- Focused standalone source-contract and boundary harness
- Mutation check proving the old `BETWEEN` predicate fails the contract
- `git diff --check`
- Independent read-only review: approved with no findings

Full PHPUnit was unavailable locally because this worktree has no installed `vendor/bin/phpunit`; upstream CI will run the repository suites.
