### PR TITLE
fix(calendar): preserve facility across date navigation

### DIFF
--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -538,7 +538,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -533,7 +533,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -458,11 +458,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/index.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
 ];

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -453,11 +453,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/index.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -10832,16 +10832,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnMod.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'id\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/main/calendar/index.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset 0 on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/index.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'catid\' on mixed\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -9932,16 +9932,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnMod.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'id\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/main/calendar/index.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset 0 on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/index.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'catid\' on mixed\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -1393,17 +1393,17 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_COOKIE is forbidden\\. Use Symfony\'s Request object instead\\.$#',
-    'count' => 4,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object instead\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object instead\\.$#',
-    'count' => 6,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -1397,11 +1397,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/index.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -1397,11 +1397,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/index.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object instead\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -1393,17 +1393,17 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_COOKIE is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 4,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 6,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',
 ];
 $ignoreErrors[] = [

--- a/interface/main/calendar/index.php
+++ b/interface/main/calendar/index.php
@@ -54,7 +54,20 @@ $facilityCookieEnabled = OEGlobalsBag::getInstance()->getBoolean('set_facility_c
 $restrictUserFacility = $session->get('userauthorized') != 1
     && OEGlobalsBag::getInstance()->getBoolean('restrict_user_facility');
 $facilities = $restrictUserFacility ? getUserFacilities($session->get('authUserID')) : [];
-$allowedFacilityIds = array_column($facilities, 'id');
+/** @var list<int|string> $allowedFacilityIds */
+$allowedFacilityIds = [];
+if (is_array($facilities)) {
+    foreach ($facilities as $facility) {
+        if (!is_array($facility)) {
+            continue;
+        }
+
+        $facilityId = $facility['id'] ?? null;
+        if (is_int($facilityId) || is_string($facilityId)) {
+            $allowedFacilityIds[] = $facilityId;
+        }
+    }
+}
 
 $sessionSetArray['pc_facility'] = CalendarFacilityResolver::resolve(
     $session->get('pc_facility'),

--- a/interface/main/calendar/index.php
+++ b/interface/main/calendar/index.php
@@ -78,7 +78,10 @@ SessionUtil::setSession($sessionSetArray);
 
 if ($facilityCookieEnabled && !$loginIntoFacility && $sessionSetArray['pc_facility'] !== null) {
     // Persist the value selected by this request, including 0 (All Facilities).
-    setcookie("pc_facility", (string) $sessionSetArray['pc_facility'], ['expires' => time() + (3600 * 365)]);
+    setcookie("pc_facility", (string) $sessionSetArray['pc_facility'], [
+        'expires' => time() + (3600 * 365),
+        'path' => OEGlobalsBag::getInstance()->getWebRoot(),
+    ]);
 }
 
 // start PN

--- a/interface/main/calendar/index.php
+++ b/interface/main/calendar/index.php
@@ -23,11 +23,13 @@ use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\PostCalendar\CalendarFacilityResolver;
+use Symfony\Component\HttpFoundation\Request;
 
 require_once(OEGlobalsBag::getInstance()->getSrcDir() . "/patient.inc.php");
 require_once 'includes/pnAPI.php';
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
+$request = Request::createFromGlobals();
 
 // these will be used in below SessionUtil::setSession to set applicable session variables
 $sessionSetArray = [];
@@ -39,7 +41,7 @@ if (isset($_POST['pc_username'])) {
 
 //(CHEMED) Facility filter
 if (isset($_POST['all_users'])) {
-    $sessionSetArray['pc_username'] = $_POST['all_users'];
+    $sessionSetArray['pc_username'] = $request->request->all()['all_users'];
 }
 
 // bug fix to allow default selection of a provider
@@ -71,8 +73,8 @@ if (is_array($facilities)) {
 
 $sessionSetArray['pc_facility'] = CalendarFacilityResolver::resolve(
     $session->get('pc_facility'),
-    $_POST,
-    $_GET,
+    $request->request->all()['pc_facility'] ?? null,
+    $request->query->all()['pc_facility'] ?? null,
     $loginIntoFacility,
     $session->get('facilityId'),
     $facilityCookieEnabled,

--- a/interface/main/calendar/index.php
+++ b/interface/main/calendar/index.php
@@ -22,6 +22,7 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\PostCalendar\CalendarFacilityResolver;
 
 require_once(OEGlobalsBag::getInstance()->getSrcDir() . "/patient.inc.php");
 require_once 'includes/pnAPI.php';
@@ -48,47 +49,24 @@ if (isset($_REQUEST['pc_username']) && $_REQUEST['pc_username']) {
 }
 
 // FACILITY FILTERING (lemonsoftware) (CHEMED)
-$sessionSetArray['pc_facility'] = 0;
+$loginIntoFacility = OEGlobalsBag::getInstance()->getBoolean('login_into_facility');
+$facilityCookieEnabled = OEGlobalsBag::getInstance()->getBoolean('set_facility_cookie');
+$restrictUserFacility = $session->get('userauthorized') != 1
+    && OEGlobalsBag::getInstance()->getBoolean('restrict_user_facility');
+$facilities = $restrictUserFacility ? getUserFacilities($session->get('authUserID')) : [];
+$allowedFacilityIds = array_column($facilities, 'id');
 
-if (OEGlobalsBag::getInstance()->getBoolean('login_into_facility')) {
-    $sessionSetArray['pc_facility'] = $session->get('facilityId');
-} else {
-    if (isset($_COOKIE['pc_facility']) && OEGlobalsBag::getInstance()->getBoolean('set_facility_cookie')) {
-        $sessionSetArray['pc_facility'] = $_COOKIE['pc_facility'];
-    }
-}
-
-// override the cookie if the user doesn't have access to that facility any more
-if ($session->get('userauthorized') != 1 && OEGlobalsBag::getInstance()->getBoolean('restrict_user_facility')) {
-    $facilities = getUserFacilities($session->get('authUserID'));
-    // use the first facility the user has access to, unless...
-    $sessionSetArray['pc_facility'] = $facilities[0]['id'];
-    // if the cookie is in the users' facilities, use that.
-    foreach ($facilities as $facrow) {
-        if (($facrow['id'] == $_COOKIE['pc_facility']) && OEGlobalsBag::getInstance()->getBoolean('set_facility_cookie')) {
-            $sessionSetArray['pc_facility'] = $_COOKIE['pc_facility'];
-        }
-    }
-}
-
-if (isset($_POST['pc_facility'])) {
-    $sessionSetArray['pc_facility'] = $_POST['pc_facility'];
-}
-
-/********************************************************************/
-
-if (isset($_GET['pc_facility'])) {
-    $sessionSetArray['pc_facility'] = $_GET['pc_facility'];
-}
-
-if (OEGlobalsBag::getInstance()->getBoolean('set_facility_cookie')) {
-    $pc_facility = $session->get('pc_facility');
-    if (!OEGlobalsBag::getInstance()->getBoolean('login_into_facility') && ($pc_facility ?? 0) > 0) {
-        // If login_into_facility is turn on $_COOKIE['pc_facility'] was saved in the login process.
-        // In the case that login_into_facility is turn on you don't want to save different facility than the selected in the login screen.
-        setcookie("pc_facility", (string) $pc_facility, ['expires' => time() + (3600 * 365)]);
-    }
-}
+$sessionSetArray['pc_facility'] = CalendarFacilityResolver::resolve(
+    $session->get('pc_facility'),
+    $_POST,
+    $_GET,
+    $loginIntoFacility,
+    $session->get('facilityId'),
+    $facilityCookieEnabled,
+    $_COOKIE['pc_facility'] ?? null,
+    $restrictUserFacility,
+    $allowedFacilityIds
+);
 
 // Simplifying by just using request variable instead of checking for both post and get - KHY
 if (isset($_REQUEST['viewtype'])) {
@@ -97,6 +75,11 @@ if (isset($_REQUEST['viewtype'])) {
 
 // Set the session variables
 SessionUtil::setSession($sessionSetArray);
+
+if ($facilityCookieEnabled && !$loginIntoFacility && $sessionSetArray['pc_facility'] !== null) {
+    // Persist the value selected by this request, including 0 (All Facilities).
+    setcookie("pc_facility", (string) $sessionSetArray['pc_facility'], ['expires' => time() + (3600 * 365)]);
+}
 
 // start PN
 pnInit();

--- a/src/PostCalendar/CalendarFacilityResolver.php
+++ b/src/PostCalendar/CalendarFacilityResolver.php
@@ -29,20 +29,20 @@ final class CalendarFacilityResolver
         array $allowedFacilityIds
     ): int|string|null {
         if ($loginIntoFacility) {
-            return self::scalarFacility($loginFacility);
-        }
+            $facility = self::scalarFacility($loginFacility);
+        } else {
+            $facility = self::scalarFacility($currentFacility);
+            if ($facility === null && $facilityCookieEnabled) {
+                $facility = self::scalarFacility($cookieFacility);
+            }
+            $facility ??= 0;
 
-        $facility = self::scalarFacility($currentFacility);
-        if ($facility === null && $facilityCookieEnabled) {
-            $facility = self::scalarFacility($cookieFacility);
-        }
-        $facility ??= 0;
-
-        if (isset($post['pc_facility'])) {
-            $facility = self::scalarFacility($post['pc_facility']) ?? $facility;
-        }
-        if (isset($get['pc_facility'])) {
-            $facility = self::scalarFacility($get['pc_facility']) ?? $facility;
+            if (isset($post['pc_facility'])) {
+                $facility = self::scalarFacility($post['pc_facility']) ?? $facility;
+            }
+            if (isset($get['pc_facility'])) {
+                $facility = self::scalarFacility($get['pc_facility']) ?? $facility;
+            }
         }
 
         if (!$restrictUserFacility) {

--- a/src/PostCalendar/CalendarFacilityResolver.php
+++ b/src/PostCalendar/CalendarFacilityResolver.php
@@ -12,15 +12,11 @@ namespace OpenEMR\PostCalendar;
 
 final class CalendarFacilityResolver
 {
-    /**
-     * @param array<string, mixed> $post
-     * @param array<string, mixed> $get
-     * @param list<int|string>     $allowedFacilityIds
-     */
+    /** @param list<int|string> $allowedFacilityIds */
     public static function resolve(
         mixed $currentFacility,
-        array $post,
-        array $get,
+        mixed $postFacility,
+        mixed $getFacility,
         bool $loginIntoFacility,
         mixed $loginFacility,
         bool $facilityCookieEnabled,
@@ -37,11 +33,11 @@ final class CalendarFacilityResolver
             }
             $facility ??= 0;
 
-            if (isset($post['pc_facility'])) {
-                $facility = self::scalarFacility($post['pc_facility']) ?? $facility;
+            if ($postFacility !== null) {
+                $facility = self::scalarFacility($postFacility) ?? $facility;
             }
-            if (isset($get['pc_facility'])) {
-                $facility = self::scalarFacility($get['pc_facility']) ?? $facility;
+            if ($getFacility !== null) {
+                $facility = self::scalarFacility($getFacility) ?? $facility;
             }
         }
 

--- a/src/PostCalendar/CalendarFacilityResolver.php
+++ b/src/PostCalendar/CalendarFacilityResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\PostCalendar;
+
+final class CalendarFacilityResolver
+{
+    /**
+     * @param array<string, mixed> $post
+     * @param array<string, mixed> $get
+     * @param list<int|string>     $allowedFacilityIds
+     */
+    public static function resolve(
+        mixed $currentFacility,
+        array $post,
+        array $get,
+        bool $loginIntoFacility,
+        mixed $loginFacility,
+        bool $facilityCookieEnabled,
+        mixed $cookieFacility,
+        bool $restrictUserFacility,
+        array $allowedFacilityIds
+    ): int|string|null {
+        if ($loginIntoFacility) {
+            return self::scalarFacility($loginFacility);
+        }
+
+        $facility = self::scalarFacility($currentFacility);
+        if ($facility === null && $facilityCookieEnabled) {
+            $facility = self::scalarFacility($cookieFacility);
+        }
+        $facility ??= 0;
+
+        if (isset($post['pc_facility'])) {
+            $facility = self::scalarFacility($post['pc_facility']) ?? $facility;
+        }
+        if (isset($get['pc_facility'])) {
+            $facility = self::scalarFacility($get['pc_facility']) ?? $facility;
+        }
+
+        if (!$restrictUserFacility) {
+            return $facility;
+        }
+
+        foreach ($allowedFacilityIds as $allowedFacilityId) {
+            if ($allowedFacilityId == $facility) {
+                return $facility;
+            }
+        }
+
+        return $allowedFacilityIds[0] ?? null;
+    }
+
+    private static function scalarFacility(mixed $facility): int|string|null
+    {
+        if (!is_int($facility) && !is_string($facility)) {
+            return null;
+        }
+
+        return $facility === '' ? 0 : $facility;
+    }
+}

--- a/tests/Tests/Isolated/PostCalendar/CalendarFacilityResolverTest.php
+++ b/tests/Tests/Isolated/PostCalendar/CalendarFacilityResolverTest.php
@@ -20,42 +20,42 @@ use PHPUnit\Framework\TestCase;
 final class CalendarFacilityResolverTest extends TestCase
 {
     /**
-     * @return iterable<string, array{mixed, array<string, mixed>, array<string, mixed>, int|string}>
+     * @return iterable<string, array{mixed, mixed, mixed, int|string}>
      *
      * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
     public static function selectionProvider(): iterable
     {
-        yield 'date-only request preserves session selection' => [7, [], ['date' => '20260813'], 7];
-        yield 'POST changes selection' => [7, ['pc_facility' => '9'], [], '9'];
-        yield 'GET changes selection' => [7, [], ['pc_facility' => '11'], '11'];
-        yield 'GET retains precedence over POST' => [7, ['pc_facility' => '9'], ['pc_facility' => '11'], '11'];
-        yield 'integer zero resets selection' => [7, ['pc_facility' => 0], [], 0];
-        yield 'string zero resets selection' => [7, [], ['pc_facility' => '0'], '0'];
-        yield 'empty selection resets selection' => [7, ['pc_facility' => ''], [], 0];
-        yield 'array POST selection is ignored' => [7, ['pc_facility' => ['9']], [], 7];
-        yield 'array GET selection is ignored' => [7, [], ['pc_facility' => ['11']], 7];
-        yield 'malformed scalar session selection is preserved' => ['facility-seven', [], [], 'facility-seven'];
+        yield 'date-only request preserves session selection' => [7, null, null, 7];
+        yield 'POST changes selection' => [7, '9', null, '9'];
+        yield 'GET changes selection' => [7, null, '11', '11'];
+        yield 'GET retains precedence over POST' => [7, '9', '11', '11'];
+        yield 'integer zero resets selection' => [7, 0, null, 0];
+        yield 'string zero resets selection' => [7, null, '0', '0'];
+        yield 'empty selection resets selection' => [7, '', null, 0];
+        yield 'array POST selection is ignored' => [7, ['9'], null, 7];
+        yield 'array GET selection is ignored' => [7, null, ['11'], 7];
+        yield 'malformed scalar session selection is preserved' => ['facility-seven', null, null, 'facility-seven'];
         yield 'malformed scalar request selection is preserved' => [
             7,
-            ['pc_facility' => 'facility-nine'],
-            [],
+            'facility-nine',
+            null,
             'facility-nine',
         ];
-        yield 'null session without cookies selects all facilities' => [null, [], [], 0];
+        yield 'null session without cookies selects all facilities' => [null, null, null, 0];
     }
 
     #[DataProvider('selectionProvider')]
     public function testExplicitAndImplicitSelection(
         mixed $currentFacility,
-        array $post,
-        array $get,
+        mixed $postFacility,
+        mixed $getFacility,
         int|string $expected
     ): void {
         self::assertSame($expected, CalendarFacilityResolver::resolve(
             $currentFacility,
-            $post,
-            $get,
+            $postFacility,
+            $getFacility,
             false,
             3,
             false,
@@ -69,8 +69,8 @@ final class CalendarFacilityResolverTest extends TestCase
     {
         self::assertSame(3, CalendarFacilityResolver::resolve(
             7,
-            ['pc_facility' => 9],
-            ['pc_facility' => 11],
+            9,
+            11,
             true,
             3,
             true,
@@ -84,8 +84,8 @@ final class CalendarFacilityResolverTest extends TestCase
     {
         self::assertSame(5, CalendarFacilityResolver::resolve(
             7,
-            ['pc_facility' => 9],
-            ['pc_facility' => 11],
+            9,
+            11,
             true,
             3,
             true,
@@ -99,8 +99,8 @@ final class CalendarFacilityResolverTest extends TestCase
     {
         self::assertSame('3', CalendarFacilityResolver::resolve(
             7,
-            ['pc_facility' => 9],
-            ['pc_facility' => 11],
+            9,
+            11,
             true,
             '3',
             true,
@@ -114,8 +114,8 @@ final class CalendarFacilityResolverTest extends TestCase
     {
         self::assertSame('5', CalendarFacilityResolver::resolve(
             null,
-            [],
-            [],
+            null,
+            null,
             false,
             null,
             true,
@@ -125,8 +125,8 @@ final class CalendarFacilityResolverTest extends TestCase
         ));
         self::assertSame(0, CalendarFacilityResolver::resolve(
             0,
-            [],
-            [],
+            null,
+            null,
             false,
             null,
             true,
@@ -140,8 +140,8 @@ final class CalendarFacilityResolverTest extends TestCase
     {
         self::assertSame('7', CalendarFacilityResolver::resolve(
             5,
-            ['pc_facility' => '7'],
-            [],
+            '7',
+            null,
             false,
             null,
             true,
@@ -151,8 +151,8 @@ final class CalendarFacilityResolverTest extends TestCase
         ));
         self::assertSame(5, CalendarFacilityResolver::resolve(
             7,
-            ['pc_facility' => 99],
-            [],
+            99,
+            null,
             false,
             null,
             false,
@@ -166,8 +166,8 @@ final class CalendarFacilityResolverTest extends TestCase
     {
         self::assertSame('7', CalendarFacilityResolver::resolve(
             null,
-            ['pc_facility' => '7'],
-            [],
+            '7',
+            null,
             false,
             null,
             false,
@@ -181,8 +181,8 @@ final class CalendarFacilityResolverTest extends TestCase
     {
         self::assertSame(5, CalendarFacilityResolver::resolve(
             0,
-            [],
-            [],
+            null,
+            null,
             false,
             null,
             false,
@@ -196,8 +196,8 @@ final class CalendarFacilityResolverTest extends TestCase
     {
         self::assertNull(CalendarFacilityResolver::resolve(
             7,
-            [],
-            [],
+            null,
+            null,
             false,
             null,
             false,

--- a/tests/Tests/Isolated/PostCalendar/CalendarFacilityResolverTest.php
+++ b/tests/Tests/Isolated/PostCalendar/CalendarFacilityResolverTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\PostCalendar;
+
+use OpenEMR\PostCalendar\CalendarFacilityResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+#[Group('postcalendar')]
+final class CalendarFacilityResolverTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{int|string, array<string, mixed>, array<string, mixed>, int|string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function selectionProvider(): iterable
+    {
+        yield 'date-only request preserves session selection' => [7, [], ['date' => '20260813'], 7];
+        yield 'POST changes selection' => [7, ['pc_facility' => '9'], [], '9'];
+        yield 'GET changes selection' => [7, [], ['pc_facility' => '11'], '11'];
+        yield 'GET retains precedence over POST' => [7, ['pc_facility' => '9'], ['pc_facility' => '11'], '11'];
+        yield 'integer zero resets selection' => [7, ['pc_facility' => 0], [], 0];
+        yield 'string zero resets selection' => [7, [], ['pc_facility' => '0'], '0'];
+        yield 'empty selection resets selection' => [7, ['pc_facility' => ''], [], 0];
+    }
+
+    #[DataProvider('selectionProvider')]
+    public function testExplicitAndImplicitSelection(
+        int|string $currentFacility,
+        array $post,
+        array $get,
+        int|string $expected
+    ): void {
+        self::assertSame($expected, CalendarFacilityResolver::resolve(
+            $currentFacility,
+            $post,
+            $get,
+            false,
+            3,
+            false,
+            null,
+            false,
+            []
+        ));
+    }
+
+    public function testLoginFacilityCannotBeOverriddenByRequestOrSession(): void
+    {
+        self::assertSame(3, CalendarFacilityResolver::resolve(
+            7,
+            ['pc_facility' => 9],
+            ['pc_facility' => 11],
+            true,
+            3,
+            true,
+            5,
+            false,
+            []
+        ));
+    }
+
+    public function testCookieIsOnlyUsedAsAnUnsetSessionDefault(): void
+    {
+        self::assertSame('5', CalendarFacilityResolver::resolve(
+            null,
+            [],
+            [],
+            false,
+            null,
+            true,
+            '5',
+            false,
+            []
+        ));
+        self::assertSame(0, CalendarFacilityResolver::resolve(
+            0,
+            [],
+            [],
+            false,
+            null,
+            true,
+            '5',
+            false,
+            []
+        ));
+    }
+
+    public function testRestrictedUserKeepsAllowedSelectionAndFallsBackFromDisallowedSelection(): void
+    {
+        self::assertSame('7', CalendarFacilityResolver::resolve(
+            5,
+            ['pc_facility' => '7'],
+            [],
+            false,
+            null,
+            true,
+            '9',
+            true,
+            [5, 7]
+        ));
+        self::assertSame(5, CalendarFacilityResolver::resolve(
+            7,
+            ['pc_facility' => 99],
+            [],
+            false,
+            null,
+            false,
+            null,
+            true,
+            [5, 7]
+        ));
+    }
+}

--- a/tests/Tests/Isolated/PostCalendar/CalendarFacilityResolverTest.php
+++ b/tests/Tests/Isolated/PostCalendar/CalendarFacilityResolverTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
 final class CalendarFacilityResolverTest extends TestCase
 {
     /**
-     * @return iterable<string, array{int|string, array<string, mixed>, array<string, mixed>, int|string}>
+     * @return iterable<string, array{mixed, array<string, mixed>, array<string, mixed>, int|string}>
      *
      * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
@@ -33,11 +33,21 @@ final class CalendarFacilityResolverTest extends TestCase
         yield 'integer zero resets selection' => [7, ['pc_facility' => 0], [], 0];
         yield 'string zero resets selection' => [7, [], ['pc_facility' => '0'], '0'];
         yield 'empty selection resets selection' => [7, ['pc_facility' => ''], [], 0];
+        yield 'array POST selection is ignored' => [7, ['pc_facility' => ['9']], [], 7];
+        yield 'array GET selection is ignored' => [7, [], ['pc_facility' => ['11']], 7];
+        yield 'malformed scalar session selection is preserved' => ['facility-seven', [], [], 'facility-seven'];
+        yield 'malformed scalar request selection is preserved' => [
+            7,
+            ['pc_facility' => 'facility-nine'],
+            [],
+            'facility-nine',
+        ];
+        yield 'null session without cookies selects all facilities' => [null, [], [], 0];
     }
 
     #[DataProvider('selectionProvider')]
     public function testExplicitAndImplicitSelection(
-        int|string $currentFacility,
+        mixed $currentFacility,
         array $post,
         array $get,
         int|string $expected
@@ -67,6 +77,36 @@ final class CalendarFacilityResolverTest extends TestCase
             5,
             false,
             []
+        ));
+    }
+
+    public function testRestrictedDisallowedLoginFacilityFallsBackToFirstAllowedFacility(): void
+    {
+        self::assertSame(5, CalendarFacilityResolver::resolve(
+            7,
+            ['pc_facility' => 9],
+            ['pc_facility' => 11],
+            true,
+            3,
+            true,
+            13,
+            true,
+            [5, 7]
+        ));
+    }
+
+    public function testRestrictedAllowedLoginFacilityCannotBeOverriddenByRequestValues(): void
+    {
+        self::assertSame('3', CalendarFacilityResolver::resolve(
+            7,
+            ['pc_facility' => 9],
+            ['pc_facility' => 11],
+            true,
+            '3',
+            true,
+            13,
+            true,
+            [3, 5]
         ));
     }
 
@@ -119,6 +159,51 @@ final class CalendarFacilityResolverTest extends TestCase
             null,
             true,
             [5, 7]
+        ));
+    }
+
+    public function testRestrictedMatchingRetainsLooseNumericCandidateType(): void
+    {
+        self::assertSame('7', CalendarFacilityResolver::resolve(
+            null,
+            ['pc_facility' => '7'],
+            [],
+            false,
+            null,
+            false,
+            null,
+            true,
+            [7]
+        ));
+    }
+
+    public function testRestrictedAllFacilitiesSelectionFallsBackToFirstAllowedFacility(): void
+    {
+        self::assertSame(5, CalendarFacilityResolver::resolve(
+            0,
+            [],
+            [],
+            false,
+            null,
+            false,
+            null,
+            true,
+            [5, 7]
+        ));
+    }
+
+    public function testRestrictedEmptyAllowedListPreservesLegacyNullFallback(): void
+    {
+        self::assertNull(CalendarFacilityResolver::resolve(
+            7,
+            [],
+            [],
+            false,
+            null,
+            false,
+            null,
+            true,
+            []
         ));
     }
 }

--- a/tests/Tests/Isolated/PostCalendar/CalendarIndexFacilityCookieContractTest.php
+++ b/tests/Tests/Isolated/PostCalendar/CalendarIndexFacilityCookieContractTest.php
@@ -17,6 +17,25 @@ use PHPUnit\Framework\TestCase;
 #[Group('postcalendar')]
 final class CalendarIndexFacilityCookieContractTest extends TestCase
 {
+    public function testAllowedFacilityIdsAreSafelyExtractedFromMixedData(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../../../interface/main/calendar/index.php');
+        self::assertIsString($source);
+
+        self::assertStringNotContainsString('array_column($facilities', $source);
+        self::assertMatchesRegularExpression(
+            '/\/\*\* @var list<int\|string> \$allowedFacilityIds \*\/\s*'
+            . '\$allowedFacilityIds = \[\];\s*'
+            . 'if \(is_array\(\$facilities\)\) \{\s*'
+            . 'foreach \(\$facilities as \$facility\) \{\s*'
+            . 'if \(!is_array\(\$facility\)\).*?'
+            . '\$facilityId = \$facility\[\'id\'\] \?\? null;\s*'
+            . 'if \(is_int\(\$facilityId\) \|\| is_string\(\$facilityId\)\) \{\s*'
+            . '\$allowedFacilityIds\[\] = \$facilityId;/s',
+            $source
+        );
+    }
+
     public function testResolvedFacilityCookieIsWrittenAfterSessionWithApplicationRootPath(): void
     {
         $source = file_get_contents(__DIR__ . '/../../../../interface/main/calendar/index.php');

--- a/tests/Tests/Isolated/PostCalendar/CalendarIndexFacilityCookieContractTest.php
+++ b/tests/Tests/Isolated/PostCalendar/CalendarIndexFacilityCookieContractTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\PostCalendar;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+#[Group('postcalendar')]
+final class CalendarIndexFacilityCookieContractTest extends TestCase
+{
+    public function testResolvedFacilityCookieIsWrittenAfterSessionWithApplicationRootPath(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../../../interface/main/calendar/index.php');
+        self::assertIsString($source);
+
+        $sessionWritePosition = strpos($source, 'SessionUtil::setSession($sessionSetArray);');
+        $cookieWritePosition = strpos($source, 'setcookie("pc_facility"');
+
+        self::assertNotFalse($sessionWritePosition);
+        self::assertNotFalse($cookieWritePosition);
+        self::assertGreaterThan($sessionWritePosition, $cookieWritePosition);
+
+        $cookieContract = substr($source, $cookieWritePosition, 350);
+        self::assertMatchesRegularExpression(
+            '/setcookie\(\s*["\']pc_facility["\']\s*,\s*\(string\)\s*\$sessionSetArray\[["\']pc_facility["\']\]/',
+            $cookieContract
+        );
+        self::assertStringContainsString("'path' => OEGlobalsBag::getInstance()->getWebRoot()", $cookieContract);
+
+        $guard = substr($source, max(0, $cookieWritePosition - 220), 220);
+        self::assertStringContainsString("\$sessionSetArray['pc_facility'] !== null", $guard);
+        self::assertStringNotContainsString("\$sessionSetArray['pc_facility'] > 0", $guard);
+    }
+}


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #13410. The Calendar now preserves the selected Facility when navigating to another date through the mini-calendar.

The calendar entry point previously initialized `pc_facility` to `0` on every request. Date-only navigation does not include a facility parameter, so that default overwrote the existing session selection with All Facilities.

This change introduces a focused facility-state resolver with the existing precedence and authorization behavior:

- login-enforced facility selection remains authoritative;
- explicit GET/POST facility selections, including All Facilities, still update state;
- date-only navigation preserves the current session facility;
- cookies are used only when session state is not established;
- restricted-user selections are validated against their allowed facilities;
- the resolved cookie value is written after the session update at the application-root path.

#### Does this resolve an issue?

Fixes #13410

#### Does this need specific testing?

Yes. Verify:

- selecting a facility and changing dates with the mini-calendar preserves it;
- explicitly selecting All Facilities resets the filter;
- login-enforced facility mode cannot be overridden by calendar requests;
- restricted users cannot retain or request a disallowed facility;
- facility cookie persistence works across calendar navigation and a new session.

#### Tests run:

- Changed-file PHP syntax checks
- Repository PHP syntax check
- Composer strict validation
- Focused resolver and calendar-entry source-contract harnesses
- Targeted mutation checks for state precedence, authorization, safe mixed-data narrowing, cookie value/path/timing, and old reset behavior
- Exact PHPStan baseline source/count enumeration
- `git diff --check`
- Independent read-only reviews, including final approval with no findings

Full PHPUnit, PHPStan, and Rector execution was unavailable locally because this worktree has no installed binaries; upstream CI will run the repository suites.
