### PR TITLE
fix(calendar): #13528 calendar inject styles/scripts

### DIFF
--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -780,6 +780,9 @@ function postcalendar_userapi_buildView($args)
         $bodyClassSession = SessionWrapperFactory::getInstance()->getActiveSession()->get('language_direction');
         $renderData['body_class'] = is_string($bodyClassSession) ? $bodyClassSession : '';
 
+        $renderData['HEADER_SCRIPTS'] = $calendarScripts->getScripts();
+        $renderData['HEADER_STYLES'] = $calendarStyles->getStyles();
+
         $newTpl = CalendarRenderer::create();
         foreach ($renderData as $k => $v) {
             $newTpl->assign($k, $v);


### PR DESCRIPTION
Injecting the calendar styles and scripts into the OpenEMR calendar after the twig refactor in order to fix the bug with them not displaying.

Fixes #13528.