### PR TITLE
fix(calendar): restore module extension assets

### DIFF
--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -14,6 +14,7 @@
 
 use OpenEMR\Common\Calendar\Month;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Appointments\CalendarFilterEvent;
 use OpenEMR\Events\Appointments\CalendarUserGetEventsFilter;
@@ -779,6 +780,10 @@ function postcalendar_userapi_buildView($args)
         // right LTR/RTL class on body.
         $bodyClassSession = SessionWrapperFactory::getInstance()->getActiveSession()->get('language_direction');
         $renderData['body_class'] = is_string($bodyClassSession) ? $bodyClassSession : '';
+        $renderData['CALENDAR_EXTENSION_ASSETS'] = Header::createModuleAssetElements(
+            $calendarScripts->getScripts(),
+            $calendarStyles->getStyles()
+        );
 
         $newTpl = CalendarRenderer::create();
         foreach ($renderData as $k => $v) {

--- a/src/Core/Header.php
+++ b/src/Core/Header.php
@@ -383,7 +383,37 @@ class Header
                 $path .= "?v={$v}";
             }
         }
-        return str_replace("%path%", $path, $template);
+        return str_replace("%path%", attr($path), $template);
+    }
+
+    /**
+     * Render module assets that have already passed through the filter events.
+     *
+     * @param array<array-key, mixed> $scripts
+     * @param array<array-key, mixed> $styles
+     */
+    public static function createModuleAssetElements(array $scripts, array $styles): string
+    {
+        $output = '';
+        if ($scripts !== []) {
+            $output .= '<!-- Module Scripts Started -->';
+            foreach ($scripts as $script) {
+                if (is_string($script)) {
+                    $output .= self::createElement($script, 'script', false);
+                }
+            }
+            $output .= '<!-- Module Scripts Ended -->';
+        }
+        if ($styles !== []) {
+            $output .= '<!-- Module Styles Started -->';
+            foreach ($styles as $style) {
+                if (is_string($style)) {
+                    $output .= self::createElement($style, 'style', false);
+                }
+            }
+            $output .= '<!-- Module Styles Ended -->';
+        }
+        return $output;
     }
 
     /**

--- a/src/Core/Header.php
+++ b/src/Core/Header.php
@@ -376,11 +376,20 @@ class Header
         $template = ($type == 'script') ? $script : $link;
         if (!$alreadyBuilt) {
             $v = OEGlobalsBag::getInstance()->get('v_js_includes');
-            // need to handle header elements that may already have a ? in the parameter.
-            if (strrpos($path, "?") !== false) {
-                $path .= "&v={$v}";
+            $fragmentPosition = strpos($path, '#');
+            if ($fragmentPosition === false) {
+                $url = $path;
+                $fragment = '';
             } else {
-                $path .= "?v={$v}";
+                $url = substr($path, 0, $fragmentPosition);
+                $fragment = substr($path, $fragmentPosition);
+            }
+            // Add the cache version to the query, never to the fragment.
+            if (str_contains($url, '?')) {
+                $separator = (str_ends_with($url, '?') || str_ends_with($url, '&')) ? '' : '&';
+                $path = $url . $separator . "v={$v}" . $fragment;
+            } else {
+                $path = $url . "?v={$v}" . $fragment;
             }
         }
         return str_replace("%path%", attr($path), $template);

--- a/templates/calendar/default/views/_extension_assets.html.twig
+++ b/templates/calendar/default/views/_extension_assets.html.twig
@@ -1,0 +1,3 @@
+{% if CALENDAR_EXTENSION_ASSETS is not empty %}
+    {{ CALENDAR_EXTENSION_ASSETS|raw }}
+{% endif %}

--- a/templates/calendar/default/views/day_print/outlook_ajax_template.html.twig
+++ b/templates/calendar/default/views/day_print/outlook_ajax_template.html.twig
@@ -26,7 +26,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    {% include 'calendar/default/views/_extension_assets.html.twig' %}
+    {{ setupHeader(['no_bootstrap', 'no_fontawesome', 'no_main-theme', 'no_dialog']) }}
     <style>
         a { text-decoration: none; }
         td { font-family: Arial, Helvetica, sans-serif; }
@@ -61,7 +61,7 @@
         .event_noshow      { position: absolute; background-color: pink;  overflow: hidden; border: 1px solid blue; width: 100%; font-size: 0.8em; }
         .event_reserved    { position: absolute; background-color: pink;  overflow: hidden; border: 1px solid blue; width: 100%; font-size: 0.8em; }
     </style>
-    {{ setupHeader(['no_bootstrap', 'no_fontawesome', 'no_main-theme', 'no_dialog']) }}
+    {% include 'calendar/default/views/_extension_assets.html.twig' %}
 </head>
 <body>
 

--- a/templates/calendar/default/views/day_print/outlook_ajax_template.html.twig
+++ b/templates/calendar/default/views/day_print/outlook_ajax_template.html.twig
@@ -26,6 +26,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    {% include 'calendar/default/views/_extension_assets.html.twig' %}
     <style>
         a { text-decoration: none; }
         td { font-family: Arial, Helvetica, sans-serif; }

--- a/templates/calendar/default/views/header.html.twig
+++ b/templates/calendar/default/views/header.html.twig
@@ -6,21 +6,7 @@
     <!--[if IE]>
         <link rel="stylesheet" href="{{ webroot }}/interface/themes/ajax_calendar_ie.css">
     <![endif]-->
-    {# Module-supplied scripts/styles. Filtered to same-origin in pnadmin.php / pnuserapi.php before assignment. #}
-    {% if HEADER_SCRIPTS is defined and HEADER_SCRIPTS %}
-        <!-- Module Scripts Started -->
-        {% for script in HEADER_SCRIPTS %}
-            <script src="{{ script|safe_href }}" type="text/javascript"></script>
-        {% endfor %}
-        <!-- Module Scripts Ended -->
-    {% endif %}
-    {% if HEADER_STYLES is defined and HEADER_STYLES %}
-        <!-- Module Styles Started -->
-        {% for cssSrc in HEADER_STYLES %}
-            <link rel="stylesheet" href="{{ cssSrc|safe_href }}" type="text/css" />
-        {% endfor %}
-        <!-- Module Styles Ended -->
-    {% endif %}
+    {% include 'calendar/default/views/_extension_assets.html.twig' %}
     <!-- the javascript used for the ajax_* style calendars -->
     <script src="{{ webroot }}/library/js/calendarDirectSelect.js"></script>
 </head>

--- a/templates/calendar/default/views/month_print/outlook_ajax_template.html.twig
+++ b/templates/calendar/default/views/month_print/outlook_ajax_template.html.twig
@@ -27,7 +27,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    {% include 'calendar/default/views/_extension_assets.html.twig' %}
     {{ setupHeader(['no_bootstrap', 'no_fontawesome', 'no_main-theme', 'no_textformat', 'no_dialog']) }}
     <style>
         a { text-decoration: none; }
@@ -88,6 +87,7 @@
         .event_in { background-color: white; width: 100%; }
         .event_out { background-color: pink; width: 100%; }
     </style>
+    {% include 'calendar/default/views/_extension_assets.html.twig' %}
 </head>
 <body>
 

--- a/templates/calendar/default/views/month_print/outlook_ajax_template.html.twig
+++ b/templates/calendar/default/views/month_print/outlook_ajax_template.html.twig
@@ -27,6 +27,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    {% include 'calendar/default/views/_extension_assets.html.twig' %}
     {{ setupHeader(['no_bootstrap', 'no_fontawesome', 'no_main-theme', 'no_textformat', 'no_dialog']) }}
     <style>
         a { text-decoration: none; }

--- a/templates/calendar/default/views/week_print/outlook_ajax_template.html.twig
+++ b/templates/calendar/default/views/week_print/outlook_ajax_template.html.twig
@@ -27,6 +27,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    {% include 'calendar/default/views/_extension_assets.html.twig' %}
     <style>
         a { text-decoration: none; }
         td { font-family: Arial, Helvetica, sans-serif; }

--- a/templates/calendar/default/views/week_print/outlook_ajax_template.html.twig
+++ b/templates/calendar/default/views/week_print/outlook_ajax_template.html.twig
@@ -27,7 +27,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    {% include 'calendar/default/views/_extension_assets.html.twig' %}
+    {{ setupHeader(['no_bootstrap', 'no_fontawesome', 'no_main-theme', 'no_dialog']) }}
     <style>
         a { text-decoration: none; }
         td { font-family: Arial, Helvetica, sans-serif; }
@@ -59,7 +59,7 @@
         #datePicker .tdMonthName-small { font-size: 12px; text-align: center; }
         #datePicker .currentDate { border: 1px solid blue; background-color: blue; color: lightblue; }
     </style>
-    {{ setupHeader(['no_bootstrap', 'no_fontawesome', 'no_main-theme', 'no_dialog']) }}
+    {% include 'calendar/default/views/_extension_assets.html.twig' %}
 </head>
 <body>
 

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-print-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-print-empty.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <!-- setupHeader stub -->
     <style>
         a { text-decoration: none; }
         td { font-family: Arial, Helvetica, sans-serif; }
@@ -35,8 +36,7 @@
         .event_noshow      { position: absolute; background-color: pink;  overflow: hidden; border: 1px solid blue; width: 100%; font-size: 0.8em; }
         .event_reserved    { position: absolute; background-color: pink;  overflow: hidden; border: 1px solid blue; width: 100%; font-size: 0.8em; }
     </style>
-    <!-- setupHeader stub -->
-</head>
+    </head>
 <body>
 
 <div id="bigCalHeader">

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
@@ -7,7 +7,7 @@
     <!--[if IE]>
         <link rel="stylesheet" href="/interface/themes/ajax_calendar_ie.css">
     <![endif]-->
-                <!-- the javascript used for the ajax_* style calendars -->
+        <!-- the javascript used for the ajax_* style calendars -->
     <script src="/library/js/calendarDirectSelect.js"></script>
 </head>
 <body class=" calsearch_body w-100">

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-print-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-print-empty.html
@@ -62,7 +62,7 @@
         .event_in { background-color: white; width: 100%; }
         .event_out { background-color: pink; width: 100%; }
     </style>
-</head>
+    </head>
 <body>
 
 

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
@@ -7,7 +7,7 @@
     <!--[if IE]>
         <link rel="stylesheet" href="/interface/themes/ajax_calendar_ie.css">
     <![endif]-->
-                <!-- the javascript used for the ajax_* style calendars -->
+        <!-- the javascript used for the ajax_* style calendars -->
     <script src="/library/js/calendarDirectSelect.js"></script>
 </head>
 <body class=" calsearch_body w-100">

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-print-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-print-empty.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <!-- setupHeader stub -->
     <style>
         a { text-decoration: none; }
         td { font-family: Arial, Helvetica, sans-serif; }
@@ -32,8 +33,7 @@
         #datePicker .tdMonthName-small { font-size: 12px; text-align: center; }
         #datePicker .currentDate { border: 1px solid blue; background-color: blue; color: lightblue; }
     </style>
-    <!-- setupHeader stub -->
-</head>
+    </head>
 <body>
 
 <div id="bigCal">

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
@@ -7,7 +7,7 @@
     <!--[if IE]>
         <link rel="stylesheet" href="/interface/themes/ajax_calendar_ie.css">
     <![endif]-->
-                <!-- the javascript used for the ajax_* style calendars -->
+        <!-- the javascript used for the ajax_* style calendars -->
     <script src="/library/js/calendarDirectSelect.js"></script>
 </head>
 <body class=" calsearch_body w-100">

--- a/tests/Tests/Isolated/PostCalendar/CalendarRendererTest.php
+++ b/tests/Tests/Isolated/PostCalendar/CalendarRendererTest.php
@@ -14,7 +14,6 @@ namespace OpenEMR\Tests\Isolated\PostCalendar;
 
 use OpenEMR\Core\Header;
 use OpenEMR\PostCalendar\CalendarRenderer;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
@@ -141,49 +140,42 @@ final class CalendarRendererTest extends TestCase
         self::assertSame('1/2/3', $renderer->render('t.twig'));
     }
 
-    /**
-     * @return array<string, array{string}>
-     *
-     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
-     */
-    public static function calendarViewProvider(): array
+    public function testModuleAssetsPreserveOrderVersionFragmentsAndEscaping(): void
     {
-        return [
-            'month screen' => ['month'],
-            'week screen' => ['week'],
-            'day screen' => ['day'],
-            'month print' => ['month_print'],
-            'week print' => ['week_print'],
-            'day print' => ['day_print'],
-        ];
-    }
-
-    #[DataProvider('calendarViewProvider')]
-    public function testEveryCalendarViewRendersSharedExtensionAssetsOnce(string $view): void
-    {
-        $partial = (string) file_get_contents(
-            dirname(__DIR__, 4) . '/templates/calendar/default/views/_extension_assets.html.twig'
+        $html = Header::createModuleAssetElements(
+            [
+                '/modules/example/first.js#fragment',
+                '/modules/example/second.js?mode=compact&name="quoted"#',
+                'https://example.test/third.js?',
+                '/modules/example/fourth.js#fragment?unchanged=yes',
+            ],
+            [
+                '/modules/example/first.css?theme=light#section',
+                '/modules/example/second.css?theme=dark&',
+            ]
         );
-        $renderer = $this->buildRenderer([
-            'calendar/default/views/_extension_assets.html.twig' => $partial,
-            $view . '.twig' => "<head>{% include 'calendar/default/views/_extension_assets.html.twig' %}</head>",
-        ]);
-        $renderer->assign('CALENDAR_EXTENSION_ASSETS', Header::createModuleAssetElements(
-            ['/modules/example/calendar.js?mode=compact&name="quoted"'],
-            ['/modules/example/calendar.css?theme=light&name="quoted"']
-        ));
-
-        $html = $renderer->render($view . '.twig');
 
         self::assertSame(1, substr_count($html, '<!-- Module Scripts Started -->'));
         self::assertSame(1, substr_count($html, '<!-- Module Styles Started -->'));
         self::assertStringContainsString(
-            '<script src="/modules/example/calendar.js?mode=compact&amp;name=&quot;quoted&quot;&amp;v=test-version"></script>',
+            '<script src="/modules/example/first.js?v=test-version#fragment"></script>',
             $html
         );
         self::assertStringContainsString(
-            '<link rel="stylesheet"  href="/modules/example/calendar.css?theme=light&amp;name=&quot;quoted&quot;&amp;v=test-version" />',
+            '<script src="/modules/example/second.js?mode=compact&amp;name=&quot;quoted&quot;&amp;v=test-version#"></script>',
             $html
+        );
+        self::assertStringContainsString('src="https://example.test/third.js?v=test-version"', $html);
+        self::assertStringContainsString('src="/modules/example/fourth.js?v=test-version#fragment?unchanged=yes"', $html);
+        self::assertStringContainsString('href="/modules/example/first.css?theme=light&amp;v=test-version#section"', $html);
+        self::assertStringContainsString('href="/modules/example/second.css?theme=dark&amp;v=test-version"', $html);
+        self::assertLessThan(
+            strpos($html, '/modules/example/second.js'),
+            strpos($html, '/modules/example/first.js')
+        );
+        self::assertLessThan(
+            strpos($html, '/modules/example/second.css'),
+            strpos($html, '/modules/example/first.css')
         );
     }
 
@@ -213,11 +205,36 @@ final class CalendarRendererTest extends TestCase
         self::assertStringContainsString('$calendarScripts->getScripts()', $source);
         self::assertStringContainsString('$calendarStyles->getStyles()', $source);
 
-        foreach (['header', 'month_print/outlook_ajax_template', 'week_print/outlook_ajax_template', 'day_print/outlook_ajax_template'] as $template) {
+        $templates = ['header', 'month_print/outlook_ajax_template', 'week_print/outlook_ajax_template', 'day_print/outlook_ajax_template'];
+        foreach ($templates as $template) {
             $templateSource = (string) file_get_contents(
                 dirname(__DIR__, 4) . '/templates/calendar/default/views/' . $template . '.html.twig'
             );
             self::assertSame(1, substr_count($templateSource, "include 'calendar/default/views/_extension_assets.html.twig'"));
+            $setupPosition = strpos($templateSource, 'setupHeader(');
+            $assetsPosition = strpos($templateSource, "include 'calendar/default/views/_extension_assets.html.twig'");
+            self::assertNotFalse($setupPosition);
+            self::assertNotFalse($assetsPosition);
+            self::assertLessThan(
+                $assetsPosition,
+                $setupPosition,
+                $template . ' must load core assets before extension assets'
+            );
+        }
+
+        foreach (array_slice($templates, 1) as $template) {
+            $templateSource = (string) file_get_contents(
+                dirname(__DIR__, 4) . '/templates/calendar/default/views/' . $template . '.html.twig'
+            );
+            $stylePosition = strpos($templateSource, '</style>');
+            $assetsPosition = strpos($templateSource, "include 'calendar/default/views/_extension_assets.html.twig'");
+            self::assertNotFalse($stylePosition);
+            self::assertNotFalse($assetsPosition);
+            self::assertLessThan(
+                $assetsPosition,
+                $stylePosition,
+                $template . ' must load extension styles after built-in calendar styles'
+            );
         }
     }
 }

--- a/tests/Tests/Isolated/PostCalendar/CalendarRendererTest.php
+++ b/tests/Tests/Isolated/PostCalendar/CalendarRendererTest.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\PostCalendar;
 
+use OpenEMR\Core\Header;
 use OpenEMR\PostCalendar\CalendarRenderer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
@@ -22,6 +24,23 @@ use Twig\Loader\ArrayLoader;
 #[Group('postcalendar')]
 final class CalendarRendererTest extends TestCase
 {
+    private mixed $versionBackup;
+
+    protected function setUp(): void
+    {
+        $this->versionBackup = $GLOBALS['v_js_includes'] ?? null;
+        $GLOBALS['v_js_includes'] = 'test-version';
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->versionBackup === null) {
+            unset($GLOBALS['v_js_includes']);
+        } else {
+            $GLOBALS['v_js_includes'] = $this->versionBackup;
+        }
+    }
+
     /**
      * @param  array<string, string> $templates
      */
@@ -120,5 +139,85 @@ final class CalendarRendererTest extends TestCase
         $renderer->assign(['b' => '2', 'c' => '3']);
 
         self::assertSame('1/2/3', $renderer->render('t.twig'));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function calendarViewProvider(): array
+    {
+        return [
+            'month screen' => ['month'],
+            'week screen' => ['week'],
+            'day screen' => ['day'],
+            'month print' => ['month_print'],
+            'week print' => ['week_print'],
+            'day print' => ['day_print'],
+        ];
+    }
+
+    #[DataProvider('calendarViewProvider')]
+    public function testEveryCalendarViewRendersSharedExtensionAssetsOnce(string $view): void
+    {
+        $partial = (string) file_get_contents(
+            dirname(__DIR__, 4) . '/templates/calendar/default/views/_extension_assets.html.twig'
+        );
+        $renderer = $this->buildRenderer([
+            'calendar/default/views/_extension_assets.html.twig' => $partial,
+            $view . '.twig' => "<head>{% include 'calendar/default/views/_extension_assets.html.twig' %}</head>",
+        ]);
+        $renderer->assign('CALENDAR_EXTENSION_ASSETS', Header::createModuleAssetElements(
+            ['/modules/example/calendar.js?mode=compact&name="quoted"'],
+            ['/modules/example/calendar.css?theme=light&name="quoted"']
+        ));
+
+        $html = $renderer->render($view . '.twig');
+
+        self::assertSame(1, substr_count($html, '<!-- Module Scripts Started -->'));
+        self::assertSame(1, substr_count($html, '<!-- Module Styles Started -->'));
+        self::assertStringContainsString(
+            '<script src="/modules/example/calendar.js?mode=compact&amp;name=&quot;quoted&quot;&amp;v=test-version"></script>',
+            $html
+        );
+        self::assertStringContainsString(
+            '<link rel="stylesheet"  href="/modules/example/calendar.css?theme=light&amp;name=&quot;quoted&quot;&amp;v=test-version" />',
+            $html
+        );
+    }
+
+    public function testEmptyExtensionListsRenderNoMarkup(): void
+    {
+        $renderer = $this->buildRenderer([
+            'assets.twig' => "before{% include 'calendar/default/views/_extension_assets.html.twig' %}after",
+            'calendar/default/views/_extension_assets.html.twig' => (string) file_get_contents(
+                dirname(__DIR__, 4) . '/templates/calendar/default/views/_extension_assets.html.twig'
+            ),
+        ]);
+        $renderer->assign('CALENDAR_EXTENSION_ASSETS', Header::createModuleAssetElements([], []));
+
+        self::assertSame('beforeafter', trim($renderer->render('assets.twig')));
+    }
+
+    public function testCalendarEntryPointPreservesDispatchContextAndPropagatesAssets(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__, 4) . '/interface/main/calendar/modules/PostCalendar/pnuserapi.php'
+        );
+
+        self::assertSame(1, substr_count($source, "new ScriptFilterEvent('pnuserapi.php')"));
+        self::assertSame(1, substr_count($source, "new StyleFilterEvent('pnuserapi.php')"));
+        self::assertSame(2, substr_count($source, "setContextArgument('viewtype', \$viewtype)"));
+        self::assertStringContainsString('Header::createModuleAssetElements(', $source);
+        self::assertStringContainsString('$calendarScripts->getScripts()', $source);
+        self::assertStringContainsString('$calendarStyles->getStyles()', $source);
+
+        foreach (['header', 'month_print/outlook_ajax_template', 'week_print/outlook_ajax_template', 'day_print/outlook_ajax_template'] as $template) {
+            $templateSource = (string) file_get_contents(
+                dirname(__DIR__, 4) . '/templates/calendar/default/views/' . $template . '.html.twig'
+            );
+            self::assertSame(1, substr_count($templateSource, "include 'calendar/default/views/_extension_assets.html.twig'"));
+        }
     }
 }


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes #13528. The PostCalendar Twig path now renders module-provided scripts and styles collected through the existing `ScriptFilterEvent` and `StyleFilterEvent` extension points.

The Smarty-to-Twig migration continued to dispatch both events but stopped passing their filtered asset lists into the rendered user calendar. This change restores that propagation without redispatching:

- preserves the existing `pnuserapi.php` page name and `viewtype` context;
- preserves event-list ordering;
- safely creates escaped, cache-versioned script and stylesheet elements;
- inserts cache versions before URL fragments while preserving existing queries;
- renders one shared extension-assets partial in month, week, and day screen/print views;
- loads module assets after core dependencies and built-in print styles;
- leaves year and calendar-admin behavior unchanged.

#### Does this resolve an issue?

Fixes #13528

#### How has this been tested?

- Focused calendar renderer tests: 13 tests, 56 assertions
- Full Twig rendering/compilation suite: 314 tests, 628 assertions
- Production-template include and dependency-order contracts
- Multiple asset ordering, escaping, query/fragment versioning, empty-list, and no-duplicate coverage
- Deliberate mutation proving a print include before `setupHeader()` fails
- PHPCS on changed PHP
- Targeted PHPStan level 10 with unchanged baseline
- Full tracked PHP syntax check
- Composer strict validation
- `git diff --check`
- Independent read-only review: approved with no findings

#### Checklist

- [x] Existing extension event dispatch and context are preserved.
- [x] All six user calendar screen/print views render filtered extension assets.
- [x] Asset URLs are escaped and cache-versioned correctly.
- [x] No event redispatch, duplicate output, or empty-list markup is introduced.
- [x] Focused regression coverage and repository validation pass.
