### PR TITLE
fix(immunization): enable patient selection for transmission

### DIFF
--- a/interface/modules/zend_modules/module/Immunization/src/Immunization/Controller/ImmunizationController.php
+++ b/interface/modules/zend_modules/module/Immunization/src/Immunization/Controller/ImmunizationController.php
@@ -15,6 +15,7 @@ namespace Immunization\Controller;
 use Application\Listener\Listener;
 use Immunization\Form\ImmunizationForm;
 use Immunization\Model\ImmunizationTable;
+use Immunization\Model\PatientSelectionMarker;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 use OpenEMR\Common\Utils\ValidationUtils;
@@ -140,8 +141,12 @@ class ImmunizationController extends AbstractActionController
         $details = $this->getImmunizationTable()->immunizedPatientDetails($params);
         $rows = [];
         foreach ($details as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
             $rows[] = $row;
         }
+        $rows = PatientSelectionMarker::markFirstRowForEachPatient($rows);
 
         $params['res_count'] = $count;
         $params['total_pages'] = $totalpages;

--- a/interface/modules/zend_modules/module/Immunization/src/Immunization/Model/PatientSelectionMarker.php
+++ b/interface/modules/zend_modules/module/Immunization/src/Immunization/Model/PatientSelectionMarker.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * interface/modules/zend_modules/module/Immunization/src/Immunization/Model/PatientSelectionMarker.php
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace Immunization\Model;
+
+class PatientSelectionMarker
+{
+    /**
+     * Mark only the first immunization row for each patient as selectable.
+     *
+     * @param list<array<mixed, mixed>> $rows
+     * @return list<array<mixed, mixed>>
+     */
+    public static function markFirstRowForEachPatient(array $rows): array
+    {
+        $seenPatientIds = [];
+
+        foreach ($rows as &$row) {
+            $patientId = $row['patientid'] ?? '';
+            $patientKey = 'patient:' . (is_scalar($patientId) ? (string) $patientId : '');
+            $row['isPatientSelectable'] = !isset($seenPatientIds[$patientKey]);
+            $seenPatientIds[$patientKey] = true;
+        }
+        unset($row);
+
+        return $rows;
+    }
+}

--- a/interface/modules/zend_modules/module/Immunization/view/immunization/immunization/index.phtml
+++ b/interface/modules/zend_modules/module/Immunization/view/immunization/immunization/index.phtml
@@ -124,7 +124,11 @@ $form->prepare();
                 ?>
                 <tr>
                         <td style="height: 17px;"><label><?php echo $slno;?>)</label></td>
-                        <td><input class="check_pid check_pid_<?php echo $this->escapeHtml($value['patientid']); ?>" type="checkbox" name="ccda_pid[]" value="<?php echo $this->escapeHtml($value['patientid']); ?>"></td>
+                        <td>
+                            <?php if ($value['isPatientSelectable']) { ?>
+                                <input class="check_pid check_pid_<?php echo $this->escapeHtml($value['patientid']); ?>" type="checkbox" name="ccda_pid[]" value="<?php echo $this->escapeHtml($value['patientid']); ?>" aria-label="<?php echo $this->escapeHtmlAttr($listener->z_xlt('Select patient') . ': ' . $value['patientname']); ?>">
+                            <?php } ?>
+                        </td>
                         <td width="10%"><?php echo $this->escapeHtml($value['patientid']); ?></td>
                         <td><?php echo $this->escapeHtml($value['patientname']); ?></td>
                         <td><?php echo $this->escapeHtml($value['cvx_code']); ?></td>

--- a/interface/modules/zend_modules/module/Immunization/view/immunization/immunization/index.phtml
+++ b/interface/modules/zend_modules/module/Immunization/view/immunization/immunization/index.phtml
@@ -110,6 +110,7 @@ $form->prepare();
            <table class="responsive">
                 <tr class="se_in_9">
                         <th width="2%">#</th>
+                        <th width="3%"><?php echo $listener->z_xlt('Select'); ?></th>
                         <th width="10%" ><?php echo $listener->z_xlt('Patient Id'); ?></th>
                         <th width="15%"><?php echo $listener->z_xlt('Patient Name'); ?></th>
                         <th width="18%"><?php echo $listener->z_xlt('Immunization Code'); ?></th>
@@ -123,6 +124,7 @@ $form->prepare();
                 ?>
                 <tr>
                         <td style="height: 17px;"><label><?php echo $slno;?>)</label></td>
+                        <td><input class="check_pid check_pid_<?php echo $this->escapeHtml($value['patientid']); ?>" type="checkbox" name="ccda_pid[]" value="<?php echo $this->escapeHtml($value['patientid']); ?>"></td>
                         <td width="10%"><?php echo $this->escapeHtml($value['patientid']); ?></td>
                         <td><?php echo $this->escapeHtml($value['patientname']); ?></td>
                         <td><?php echo $this->escapeHtml($value['cvx_code']); ?></td>
@@ -131,7 +133,7 @@ $form->prepare();
                 </tr>
                  <?php endforeach; ?>
                 <tr>
-                    <th colspan="6">
+                    <th colspan="7">
                     <?php echo $listener->z_xlt('Total Number of Immunizations').':'; ?>
                     <?php echo $this->escapeHtml(sizeof($res));?>
                     </th>

--- a/tests/Tests/Isolated/Immunization/ImmunizationSelectionContractTest.php
+++ b/tests/Tests/Isolated/Immunization/ImmunizationSelectionContractTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Immunization;
+
+use PHPUnit\Framework\TestCase;
+
+class ImmunizationSelectionContractTest extends TestCase
+{
+    private string $template;
+    private string $sendToScript;
+
+    protected function setUp(): void
+    {
+        $projectRoot = realpath(__DIR__ . '/../../../..');
+        self::assertIsString($projectRoot);
+
+        $template = file_get_contents(
+            $projectRoot . '/interface/modules/zend_modules/module/Immunization/view/immunization/immunization/index.phtml'
+        );
+        self::assertIsString($template);
+        $this->template = $template;
+
+        $sendToScript = file_get_contents(
+            $projectRoot . '/interface/modules/zend_modules/public/js/application/sendTo.js'
+        );
+        self::assertIsString($sendToScript);
+        $this->sendToScript = $sendToScript;
+    }
+
+    public function testImmunizationRowsExposeEscapedPatientSelectionToSendTo(): void
+    {
+        $checkboxContract = <<<'HTML'
+<input class="check_pid check_pid_<?php echo $this->escapeHtml($value['patientid']); ?>" type="checkbox" name="ccda_pid[]" value="<?php echo $this->escapeHtml($value['patientid']); ?>">
+HTML;
+
+        self::assertStringContainsString($checkboxContract, $this->template);
+        self::assertStringContainsString(
+            "document.getElementsByName('ccda_pid[]')",
+            $this->sendToScript
+        );
+    }
+
+    public function testSelectionColumnUsesTranslatedLabelAndMatchingFooterSpan(): void
+    {
+        self::assertStringContainsString("z_xlt('Select')", $this->template);
+        self::assertStringContainsString('<th colspan="7">', $this->template);
+    }
+}

--- a/tests/Tests/Isolated/Immunization/ImmunizationSelectionContractTest.php
+++ b/tests/Tests/Isolated/Immunization/ImmunizationSelectionContractTest.php
@@ -10,7 +10,11 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Isolated\Immunization;
 
+use Immunization\Model\PatientSelectionMarker;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../../interface/modules/zend_modules/module/Immunization/src/Immunization/Model/PatientSelectionMarker.php';
 
 class ImmunizationSelectionContractTest extends TestCase
 {
@@ -35,17 +39,60 @@ class ImmunizationSelectionContractTest extends TestCase
         $this->sendToScript = $sendToScript;
     }
 
-    public function testImmunizationRowsExposeEscapedPatientSelectionToSendTo(): void
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param list<bool> $expectedMarkers
+     */
+    #[DataProvider('patientRowsProvider')]
+    public function testOnlyFirstRowForEachPatientIsSelectable(array $rows, array $expectedMarkers): void
     {
-        $checkboxContract = <<<'HTML'
-<input class="check_pid check_pid_<?php echo $this->escapeHtml($value['patientid']); ?>" type="checkbox" name="ccda_pid[]" value="<?php echo $this->escapeHtml($value['patientid']); ?>">
-HTML;
+        $markedRows = PatientSelectionMarker::markFirstRowForEachPatient($rows);
 
-        self::assertStringContainsString($checkboxContract, $this->template);
-        self::assertStringContainsString(
-            "document.getElementsByName('ccda_pid[]')",
-            $this->sendToScript
+        self::assertSame(
+            array_column($rows, 'immunizationid'),
+            array_column($markedRows, 'immunizationid'),
+            'All immunization rows must be preserved in their original order'
         );
+        self::assertSame($expectedMarkers, array_column($markedRows, 'isPatientSelectable'));
+        self::assertCount(count(array_unique(array_map(
+            static fn(array $row): string => is_scalar($row['patientid']) ? (string) $row['patientid'] : '',
+            $rows
+        ))), array_filter(array_column($markedRows, 'isPatientSelectable')));
+    }
+
+    /**
+     * @return array<string, array{list<array<string, mixed>>, list<bool>}>
+     */
+    public static function patientRowsProvider(): array
+    {
+        return [
+            'empty rows' => [[], []],
+            'one patient' => [[
+                ['patientid' => 1, 'immunizationid' => 10],
+            ], [true]],
+            'repeated rows for one patient' => [[
+                ['patientid' => 1, 'immunizationid' => 10],
+                ['patientid' => '1', 'immunizationid' => 11],
+                ['patientid' => 1, 'immunizationid' => 12],
+            ], [true, false, false]],
+            'multiple distinct patients' => [[
+                ['patientid' => 'patient-2', 'immunizationid' => 20],
+                ['patientid' => '01', 'immunizationid' => 21],
+                ['patientid' => 'patient-2', 'immunizationid' => 22],
+                ['patientid' => 1, 'immunizationid' => 23],
+            ], [true, true, false, true]],
+        ];
+    }
+
+    public function testTemplateIntegratesUniqueSelectionWithTranslatedAccessibleName(): void
+    {
+        self::assertStringContainsString("if (\$value['isPatientSelectable'])", $this->template);
+        self::assertMatchesRegularExpression('/class="check_pid check_pid_<\?php.+?name="ccda_pid\[\]"/s', $this->template);
+        self::assertStringContainsString("escapeHtml(\$value['patientid'])", $this->template);
+        self::assertStringContainsString("aria-label=\"<?php echo \$this->escapeHtmlAttr(", $this->template);
+        self::assertStringContainsString("z_xlt('Select patient')", $this->template);
+        self::assertStringContainsString("\$value['patientname']", $this->template);
+        self::assertStringContainsString("document.getElementsByName('ccda_pid[]')", $this->sendToScript);
     }
 
     public function testSelectionColumnUsesTranslatedLabelAndMatchingFooterSpan(): void


### PR DESCRIPTION
## Summary

- add the established `ccda_pid[]` patient-selection control to Immunization Registry results
- expose one checkbox per patient even when the result set contains multiple immunization rows for that patient
- preserve every immunization row and its ordering while preventing duplicate patient transmissions
- add a translated, patient-specific accessible name to each selection control
- cover the template/Send To contract and unique-patient marker behavior with isolated tests

## Problem

Care Coordination > Export > Immunization displayed matching records but did not render any patient-selection controls. The shared Send To handler only discovers checked inputs named `ccda_pid[]`, so attempting to transmit or download reported “Please select at least one patient.”

## Validation

- focused isolated PHPUnit: 6 tests, 39 assertions
- broader relevant focused run: 12 tests, 61 assertions
- mutation proof: disabling unique-patient marking produced the expected failures
- PHP syntax checks
- PHPCS on changed PHP files
- targeted PHPStan: no errors
- `composer validate --strict`
- `git diff --check`
- independent read-only review: approved

No shared Send To behavior was changed.

Fixes #13418
