### PR TITLE
fix(rector): resolve catch type names before rewriting Exception to Throwable

### DIFF
--- a/phpunit-isolated.xml
+++ b/phpunit-isolated.xml
@@ -66,6 +66,11 @@ This file configures the kind that does not require initialization.
       <directory>tests/Tests/Isolated</directory>
     </testsuite>
 
+    <!-- Custom Rector rules: pure AST transformations, no database needed -->
+    <testsuite name="rector-rules">
+      <directory>tests/Rector</directory>
+    </testsuite>
+
     <!-- Include existing unit tests that don't require database but haven't been moved yet -->
     <testsuite name="unit-isolated">
       <directory>tests/Tests/BC</directory>

--- a/tests/Rector/Rules/CatchExceptionToThrowableRector.php
+++ b/tests/Rector/Rules/CatchExceptionToThrowableRector.php
@@ -88,19 +88,16 @@ CODE_SAMPLE
     /**
      * Check if a catch type refers to the global \Exception class.
      *
-     * After Rector's name resolution, unqualified names in a namespace
-     * become fully qualified with the namespace prefix. Only match
-     * names that resolve to exactly \Exception (no namespace prefix),
-     * or unqualified 'Exception' in the global namespace.
+     * Compare the *resolved* name, never the name as written. A bare
+     * `Exception` does not imply `\Exception`: with an import in scope
+     * (`use Doctrine\DBAL\Exception;`, or `use Foo\Bar as Exception;`) it
+     * names an unrelated class, and rewriting that catch to `\Throwable`
+     * silently widens it to swallow `\Error`. The written form carries no
+     * information at all once Rector's name importing is enabled, since
+     * that turns every fully-qualified catch type into a bare name.
      */
     private function isGlobalException(Name $type): bool
     {
-        // FullyQualified nodes: match only \Exception (toString returns 'Exception')
-        if ($type instanceof FullyQualified) {
-            return strcasecmp($type->toString(), 'Exception') === 0;
-        }
-
-        // Unqualified Name: only possible in global namespace (no namespace prefix added)
-        return strcasecmp($type->toString(), 'Exception') === 0;
+        return strcasecmp((string) $this->getName($type), 'Exception') === 0;
     }
 }

--- a/tests/Rector/Rules/Fixture/catch_aliased_exception_no_change.php.inc
+++ b/tests/Rector/Rules/Fixture/catch_aliased_exception_no_change.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace OpenEMR\Tests\Rector\Fixture;
+
+use Doctrine\DBAL\Exception\DriverException as Exception;
+
+try {
+    doSomething();
+} catch (Exception $e) {
+    handleError($e);
+}
+
+?>

--- a/tests/Rector/Rules/Fixture/catch_exception.php.inc
+++ b/tests/Rector/Rules/Fixture/catch_exception.php.inc
@@ -5,7 +5,7 @@ namespace OpenEMR\Tests\Rector\Fixture;
 use Exception;
 
 try {
-    doSomething();
+    throw new Exception('boom');
 } catch (Exception $e) {
     handleError($e);
 }
@@ -16,9 +16,10 @@ try {
 
 namespace OpenEMR\Tests\Rector\Fixture;
 
+use Exception;
 
 try {
-    doSomething();
+    throw new Exception('boom');
 } catch (\Throwable $e) {
     handleError($e);
 }

--- a/tests/Rector/Rules/Fixture/catch_global_namespace_exception.php.inc
+++ b/tests/Rector/Rules/Fixture/catch_global_namespace_exception.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+try {
+    doSomething();
+} catch (Exception $e) {
+    handleError($e);
+}
+
+?>
+-----
+<?php
+
+try {
+    doSomething();
+} catch (\Throwable $e) {
+    handleError($e);
+}
+
+?>

--- a/tests/Rector/Rules/Fixture/catch_imported_vendor_exception_no_change.php.inc
+++ b/tests/Rector/Rules/Fixture/catch_imported_vendor_exception_no_change.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+use Doctrine\DBAL\Exception;
+
+try {
+    doSomething();
+} catch (Exception $e) {
+    handleError($e);
+}
+
+?>

--- a/tests/Rector/Rules/Fixture/catch_relative_name_exception_no_change.php.inc
+++ b/tests/Rector/Rules/Fixture/catch_relative_name_exception_no_change.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+try {
+    doSomething();
+} catch (Doctrine\DBAL\Exception $e) {
+    handleError($e);
+}
+
+?>


### PR DESCRIPTION
`CatchExceptionToThrowableRector` decided whether a catch type was the global `\Exception` by inspecting the name **as written**, treating any unqualified `Exception` as global-namespace:

```php
// Unqualified Name: only possible in global namespace (no namespace prefix added)
return strcasecmp($type->toString(), 'Exception') === 0;
```

That assumption is false whenever an import is in scope. Both of these produce a bare `Exception` that names an unrelated class:

```php
use Doctrine\DBAL\Exception;
use Foo\Bar as Exception;
```

Rewriting those catches to `\Throwable` silently widens them to swallow `\Error` — a targeted handler quietly becomes one that also absorbs `TypeError` and `ParseError`.

The assumption also breaks under Rector's `withImportNames()`, which rewrites every fully-qualified catch type into a bare name plus a `use` statement. Under that flag, `catch (Doctrine\DBAL\Exception)` in `interface/main/calendar/includes/pnAPI.php` became `catch (Throwable)`, so `pnConfigInit()` would swallow an `\Error` and return `false`.

The fix compares the **resolved** name, so the rule keys off what the catch actually refers to rather than how it happens to be spelled:

```php
return strcasecmp((string) $this->getName($type), 'Exception') === 0;
```

## Test suite wiring

`tests/Rector/Rules/CatchExceptionToThrowableRectorTest.php` was not referenced by any PHPUnit suite, so it has never run in CI — and it was already failing on master, its recorded fixture having drifted to assume the unused-import removal that only the name importer performs. That is why the name-resolution bug went unnoticed.

This adds a `rector-rules` testsuite pointing at `tests/Rector` in `phpunit-isolated.xml`, which both `isolated-tests.yml` and `windows-tests.yml` pick up (they run the config without a `--testsuite` filter), and corrects the recorded expectation.

## Fixtures

New fixtures cover the cases the old check got wrong — a vendor `Exception` import, a renamed alias, and a relative name — plus bare `Exception` in the global namespace, which must still convert.

Note for reviewers: phpcs scans `.php.inc` files (`extensions="php,inc"` in `phpcs.xml.dist`), so fixture imports must be genuinely used and aliases genuinely non-redundant.

## Verification

- `rector-rules` suite: 8/8 pass
- Full isolated suite: 4358 tests, no new failures
- `composer rector-check` with a cleared `/tmp/rector` cache: exit 0 repo-wide, confirming the narrower rule proposes no new changes
