### PR TITLE
chore(tooling): drop .inc handling and forbid new .inc filenames

### DIFF
--- a/.github/workflows/filenames.yml
+++ b/.github/workflows/filenames.yml
@@ -38,4 +38,4 @@ jobs:
 
     - uses: j178/prek-action@v2
       with:
-        extra_args: --all-files forbid-inc-extension
+        extra-args: --all-files forbid-inc-extension

--- a/.github/workflows/filenames.yml
+++ b/.github/workflows/filenames.yml
@@ -1,0 +1,41 @@
+# Filename-policy checks.
+#
+# Kept separate from pre-commit.yml because that workflow is `paths:`-filtered
+# to workflow/hook-config changes -- a PR that adds a forbidden filename and
+# nothing else would never trigger it. This one runs on every PR, with no
+# `paths:` filter, so it can safely be made a required check.
+#
+# The rules themselves live in .pre-commit-config.yaml so contributors get the
+# same verdict locally at commit time; this workflow just runs those hooks
+# against the whole tree. They are `language: fail` hooks, so no PHP, Node or
+# Python toolchain is needed.
+name: Filenames
+
+on:
+  push:
+    branches:
+    - master
+    - rel-*
+  pull_request:
+    branches:
+    - master
+    - rel-*
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  filenames:
+    name: Check filenames
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - uses: j178/prek-action@v2
+      with:
+        extra_args: --all-files forbid-inc-extension

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -43,4 +43,4 @@ jobs:
       env:
         SKIP: php-syntax-check,composer-validate,composer-normalize,phpcbf,phpcs,phpstan,rector,composer-require-checker,conventional-commits
       with:
-        extra_args: --all-files
+        extra-args: --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -184,6 +184,26 @@ repos:
 
 - repo: local
   hooks:
+  # OpenEMR once used a bare `.inc` extension for PHP includes, relying on the
+  # webserver not serving them. That is a fragile defence -- any server that is
+  # not configured to deny `.inc` hands the source out verbatim -- so the files
+  # were migrated to `.inc.php` (#5897) and the leftover redirect stubs deleted
+  # (#10495). No tracked file uses a bare `.inc` extension any more; this hook
+  # keeps it that way.
+  #
+  # The Rector rule fixtures are the one legitimate exception: Rector's
+  # AbstractRectorTestCase discovers fixtures by the `*.php.inc` suffix, and
+  # they are test data that is never included at runtime.
+  - id: forbid-inc-extension
+    name: Forbid bare .inc file extension
+    entry: >-
+      Files ending in .inc are not allowed: a misconfigured webserver serves
+      them as plain text, leaking source. Name PHP includes .inc.php (legacy
+      library helpers) or .php (new code).
+    language: fail
+    files: \.inc$
+    exclude: ^tests/Rector/Rules/Fixture/[^/]+\.php\.inc$
+
   - id: php-syntax-check
     name: PHP Syntax Check
     entry: php -l

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,7 +4,7 @@
 
   <!-- Runtime settings -->
   <ini name="memory_limit" value="4G" />
-  <arg name="extensions" value="php,inc"/>
+  <arg name="extensions" value="php"/>
   <arg name="tab-width" value="4"/>
   <arg name="report-width" value="120"/>
   <arg name="warning-severity" value="0" />


### PR DESCRIPTION
Bare `.inc` PHP includes relied on the webserver refusing to serve the extension — a fragile defence, since any server not explicitly configured to deny `.inc` hands the source out verbatim. Those files were migrated to `.inc.php` in #5897 and the leftover redirect stubs removed in #10495, so no tracked file has used the extension for years.

phpcs was still configured to sniff it (`extensions="php,inc"`). Besides being dead config, it had a live side effect: it pulled Rector's `*.php.inc` rule fixtures — deliberately non-conforming test data — into the style run.

## Changes

- **`phpcs.xml.dist`** — narrow `extensions` to `php`. Verified a full `composer phpcs` still passes, and that the Rector fixtures are now out of scope.
- **`.pre-commit-config.yaml`** — add a `language: fail` hook rejecting any new file ending in `.inc`. The Rector fixture directory is excluded: `AbstractRectorTestCase` discovers fixtures by the `*.php.inc` suffix, and they are test data never included at runtime.
- **`.github/workflows/filenames.yml`** — run that hook over the whole tree on every PR.

## Why a separate workflow

`pre-commit.yml` is `paths:`-filtered to `.github/workflows/*.yml` and `.pre-commit-config.yaml`, so a PR that adds a forbidden filename and nothing else would never trigger it. `filenames.yml` has no `paths:` filter and is therefore safe to make a required check. The hook needs no PHP, Node or Python toolchain, so the job is a checkout plus one action.

Verified the hook passes on a clean tree, allows `tests/Rector/Rules/Fixture/*.php.inc`, and rejects both a bare `.inc` file and a stray `.php.inc` outside the fixture directory — under both `prek` and `pre-commit`.
