### PR TITLE
fix(procedure-order-fixtures): install practitioners and match them by fname

### DIFF
--- a/tests/Tests/Fixtures/ProcedureOrderFixtureManager.php
+++ b/tests/Tests/Fixtures/ProcedureOrderFixtureManager.php
@@ -25,15 +25,17 @@ use OpenEMR\Common\Database\QueryUtils;
  */
 class ProcedureOrderFixtureManager extends BaseFixtureManager
 {
-    /** Default ordering provider when no fixture user is present. */
-    private const DEFAULT_PROVIDER_ID = 1;
-
     private readonly EncounterFixtureManager $encounterFixtureManager;
 
     private readonly ProcedureProviderFixtureManager $procedureProviderFixtureManager;
 
+    private readonly PractitionerFixtureManager $practitionerFixtureManager;
+
     /** @var list<int> Procedure order IDs created by this manager */
     private array $installedOrderIds = [];
+
+    /** True once this manager installed the practitioner fixtures itself. */
+    private bool $ownsPractitionerFixtures = false;
 
     /**
      * Initialize the fixture manager for procedure orders
@@ -58,12 +60,17 @@ class ProcedureOrderFixtureManager extends BaseFixtureManager
             ?? new EncounterFixtureManager(null, $patientFixtureManager ?? new FixtureManager());
         $this->procedureProviderFixtureManager = $procedureProviderFixtureManager
             ?? new ProcedureProviderFixtureManager();
+        // The ordering provider has to be a real practitioner with an NPI, and nothing
+        // else in this dependency chain installs one: the encounter manager brings the
+        // patient and facility fixtures only. This manager therefore owns the
+        // practitioner fixtures itself.
+        $this->practitionerFixtureManager = new PractitionerFixtureManager();
     }
 
     /**
      * Install procedure order fixtures into the database
      *
-     * Installs patient, encounter, and provider dependencies first,
+     * Installs patient, encounter, lab, and practitioner dependencies first,
      * then creates procedure orders with associated codes and form entries.
      *
      * @return int Number of fixtures installed
@@ -101,16 +108,12 @@ class ProcedureOrderFixtureManager extends BaseFixtureManager
         }
         $encounterId = self::requireId($encounterRecords[0]['encounter'] ?? null, 'an encounter fixture');
 
-        $orderingProviderId = QueryUtils::fetchSingleValue(
-            <<<'SQL'
-            SELECT id FROM users WHERE username LIKE ? ORDER BY id LIMIT 1
-            SQL,
-            'id',
-            [self::FIXTURE_PREFIX . '-%']
-        );
-        $orderingProviderId = is_numeric($orderingProviderId)
-            ? (int) $orderingProviderId
-            : self::DEFAULT_PROVIDER_ID;
+        $orderingProviderId = $this->findFixturePractitionerId();
+        if ($orderingProviderId === null) {
+            $this->practitionerFixtureManager->installPractitionerFixtures();
+            $this->ownsPractitionerFixtures = true;
+            $orderingProviderId = self::requireId($this->findFixturePractitionerId(), 'a practitioner fixture');
+        }
 
         $providers = $this->procedureProviderFixtureManager->getInstalledProviders();
 
@@ -138,6 +141,35 @@ class ProcedureOrderFixtureManager extends BaseFixtureManager
         }
 
         return $insertCount;
+    }
+
+    /**
+     * Find the fixture practitioner to record as the ordering provider
+     *
+     * PractitionerFixtureManager stamps the fixture prefix onto `fname`, not
+     * `username` — the fixture usernames are plain (kperez, lcohen, jmoses,
+     * cjones, ajenane) — and its own teardown deletes by `fname` for the same
+     * reason. Matching on `username` never selects a row.
+     *
+     * The NPI filter is what makes the result usable: HL7 order generation reads
+     * the ordering provider's NPI, and the built-in admin user has none.
+     *
+     * @return int|null The practitioner's users.id, or null when no fixture practitioner is installed
+     */
+    private function findFixturePractitionerId(): ?int
+    {
+        $practitionerId = QueryUtils::fetchSingleValue(
+            <<<'SQL'
+            SELECT id FROM users
+            WHERE fname LIKE ? AND npi IS NOT NULL AND npi <> ''
+            ORDER BY id
+            LIMIT 1
+            SQL,
+            'id',
+            [self::FIXTURE_PREFIX . '-%']
+        );
+
+        return is_numeric($practitionerId) ? (int) $practitionerId : null;
     }
 
     /**
@@ -246,8 +278,8 @@ class ProcedureOrderFixtureManager extends BaseFixtureManager
      * Delete all test fixture order records from the database
      *
      * Removes procedure orders, procedure order codes, and associated
-     * form entries. Also cleans up dependent fixtures (providers,
-     * encounters, patients).
+     * form entries. Also cleans up dependent fixtures (practitioners,
+     * labs, encounters, patients).
      *
      * @throws \OpenEMR\Common\Database\SqlQueryException If a database deletion fails
      */
@@ -286,6 +318,12 @@ class ProcedureOrderFixtureManager extends BaseFixtureManager
 
             $this->installedOrderIds = [];
         } finally {
+            // Only tear down the practitioners this manager put there. When the
+            // caller installed them first, they belong to the caller.
+            if ($this->ownsPractitionerFixtures) {
+                $this->practitionerFixtureManager->removePractitionerFixtures();
+                $this->ownsPractitionerFixtures = false;
+            }
             $this->procedureProviderFixtureManager->removeFixtures();
             // Removes the patient and facility fixtures along with the encounters.
             $this->encounterFixtureManager->removeFixtures();

--- a/tests/Tests/Fixtures/ProcedureOrderFixtureManagerTest.php
+++ b/tests/Tests/Fixtures/ProcedureOrderFixtureManagerTest.php
@@ -39,8 +39,14 @@ class ProcedureOrderFixtureManagerTest extends TestCase
     /** Number of labs declared in procedure-providers.php. */
     private const EXPECTED_PROVIDER_COUNT = 4;
 
-    /** Username of the throwaway users row that stands in for a fixture-installed provider. */
-    private const FIXTURE_USERNAME = 'test-fixture-ordering-provider';
+    /** Number of practitioners declared in practitioners.php. */
+    private const EXPECTED_PRACTITIONER_COUNT = 5;
+
+    /** NPI carried by every practitioner in practitioners.php. */
+    private const EXPECTED_PRACTITIONER_NPI = '0123456789';
+
+    /** The built-in administrator: has no NPI, and is what a broken practitioner lookup used to select. */
+    private const ADMIN_USER_ID = 1;
 
     /** Names declared in procedure-providers.php. */
     private const EXPECTED_PROVIDER_NAMES = [
@@ -54,20 +60,25 @@ class ProcedureOrderFixtureManagerTest extends TestCase
 
     private ProcedureOrderFixtureManager $fixtureManager;
 
+    private PractitionerFixtureManager $practitionerFixtureManager;
+
     protected function setUp(): void
     {
         $this->providerFixtureManager = new ProcedureProviderFixtureManager();
         $this->fixtureManager = new ProcedureOrderFixtureManager(null, null, $this->providerFixtureManager);
+        $this->practitionerFixtureManager = new PractitionerFixtureManager();
         // Any fixture rows left behind by an earlier failure would corrupt the
         // counts asserted below, so start every test from a known-clean table set.
         $this->fixtureManager->removeFixtures();
-        self::removeFixtureUser();
+        // The manager only removes practitioners it installed itself, so clear any
+        // strays here rather than relying on that ownership check.
+        $this->practitionerFixtureManager->removePractitionerFixtures();
     }
 
     protected function tearDown(): void
     {
         $this->fixtureManager->removeFixtures();
-        self::removeFixtureUser();
+        $this->practitionerFixtureManager->removePractitionerFixtures();
     }
 
     public function testInstallFixturesCreatesOrdersCodesFormsAndProviders(): void
@@ -165,23 +176,64 @@ class ProcedureOrderFixtureManagerTest extends TestCase
         self::assertSame($order['date_ordered'], $formDate);
     }
 
-    public function testOrderingProviderPrefersAFixtureUserOverTheDefault(): void
+    public function testOrderingProviderIsAFixturePractitionerCarryingAnNpi(): void
     {
-        $userId = self::toInt(QueryUtils::sqlInsert(
-            'INSERT INTO users SET username = ?, fname = ?, lname = ?, authorized = ?, active = ?',
-            [self::FIXTURE_USERNAME, 'Fixture', 'Provider', 1, 1]
-        ));
+        $this->fixtureManager->installFixtures();
+
+        self::assertSame(
+            self::EXPECTED_PRACTITIONER_COUNT,
+            $this->countPractitioners(),
+            'installFixtures() did not install the practitioner fixtures'
+        );
+
+        $provider = $this->fetchRow(
+            <<<'SQL'
+            SELECT u.id, u.fname, u.npi
+            FROM procedure_order po
+            JOIN users u ON u.id = po.provider_id
+            WHERE po.procedure_order_id = ?
+            SQL,
+            [$this->firstInstalledOrderId()]
+        );
+
+        self::assertNotSame(
+            self::ADMIN_USER_ID,
+            self::toInt($provider['id']),
+            'the ordering provider fell back to the admin user instead of a fixture practitioner'
+        );
+        $fname = $provider['fname'];
+        self::assertIsString($fname);
+        self::assertStringStartsWith(PractitionerFixtureManager::FIXTURE_PREFIX, $fname);
+        // A populated NPI is the whole point: HL7 order generation reads it, and a
+        // null there is what produced the str_replace() deprecations.
+        self::assertSame(self::EXPECTED_PRACTITIONER_NPI, $provider['npi']);
+    }
+
+    public function testInstallReusesPractitionersTheCallerAlreadyInstalled(): void
+    {
+        $this->practitionerFixtureManager->installPractitionerFixtures();
 
         $this->fixtureManager->installFixtures();
 
-        $orderId = $this->firstInstalledOrderId();
-        $providerId = self::toInt(QueryUtils::fetchSingleValue(
-            'SELECT provider_id FROM procedure_order WHERE procedure_order_id = ?',
-            'provider_id',
-            [$orderId]
-        ));
+        self::assertSame(
+            self::EXPECTED_PRACTITIONER_COUNT,
+            $this->countPractitioners(),
+            'installFixtures() installed a second copy of the practitioner fixtures'
+        );
 
-        self::assertSame($userId, $providerId);
+        // Practitioners this manager did not install are not its to remove.
+        $this->fixtureManager->removeFixtures();
+        self::assertSame(self::EXPECTED_PRACTITIONER_COUNT, $this->countPractitioners());
+    }
+
+    public function testRemoveFixturesTearsDownThePractitionersItInstalled(): void
+    {
+        $this->fixtureManager->installFixtures();
+        self::assertSame(self::EXPECTED_PRACTITIONER_COUNT, $this->countPractitioners());
+
+        $this->fixtureManager->removeFixtures();
+
+        self::assertSame(0, $this->countPractitioners(), 'practitioner rows survived removeFixtures()');
     }
 
     public function testProviderManagerExposesEveryInstalledLab(): void
@@ -359,15 +411,14 @@ class ProcedureOrderFixtureManagerTest extends TestCase
     }
 
     /**
-     * Clear by the same prefix the manager looks up with, not by the exact
-     * username. The manager takes the lowest-id `test-fixture-%` user, so a
-     * row left behind by another suite would win the lookup and this test
-     * would assert against the wrong provider.
+     * Count practitioner fixtures by `fname`, the column that actually carries the
+     * prefix. PractitionerFixtureManager leaves `username` plain (kperez, lcohen,
+     * ...), so counting by username always returns zero.
      */
-    private static function removeFixtureUser(): void
+    private function countPractitioners(): int
     {
-        QueryUtils::sqlStatementThrowException(
-            'DELETE FROM users WHERE username LIKE ?',
+        return $this->countRows(
+            'SELECT COUNT(*) AS cnt FROM users WHERE fname LIKE ?',
             [self::FIXTURE_LIKE]
         );
     }


### PR DESCRIPTION
Closes #13549.

`ProcedureOrderFixtureManager` resolved its ordering provider with `SELECT id FROM users WHERE username LIKE 'test-fixture-%'`, which never matched. Two independent reasons: `PractitionerFixtureManager` carries the fixture prefix on `fname`, not `username` (practitioner usernames are plain — `kperez`, `lcohen`, …), and nothing in the procedure-order install chain invoked `PractitionerFixtureManager` at all. The lookup fell through to a hardcoded `DEFAULT_PROVIDER_ID = 1`, so every fixture order was written against `admin`, whose `npi` is NULL.

Changing only the column would have been a no-op — both forms return zero rows. The fix is the pair: install practitioner fixtures as part of the dependency chain, and match on the column that actually carries the prefix.

- Adds a privately-constructed `PractitionerFixtureManager`. No public API change: the constructor, `installFixtures()`, `getInstalledOrderIds()`, `getInstalledProviders()`, `getProviderByName()` and `removeFixtures()` are untouched.
- `findFixturePractitionerId()` requires `fname LIKE 'test-fixture-%' AND npi IS NOT NULL AND npi <> ''` — presence alone is not enough, the row has to be usable.
- Installs practitioners only when none are found, tracks ownership, and tears down only what it installed, so a caller that installed its own practitioners keeps them.
- Removes `DEFAULT_PROVIDER_ID`. A missing practitioner fixture is now an error rather than a silent fallback to admin.

The visible consequence of the old behaviour: HL7 order generators read `users.npi` for the ordering provider, so a NULL NPI meant `hl7Text()` received null and raised `str_replace(): Passing null` deprecations — which, under `phpunit.xml`'s `failOnDeprecation`, take the process exit code to 1 without marking any test failed.

Tests drop the scaffolding that existed only to prop up the branch that never fired (`FIXTURE_USERNAME`, `removeFixtureUser()`, and the test that inserted its own `users` row) and assert the real behaviour instead: the ordering provider is a fixture practitioner carrying an NPI and is not admin, an already-installed practitioner set is reused rather than duplicated, and teardown removes only self-installed rows.

21 tests / 881 assertions. Line coverage stays at 100% on both managers (113/113 and 27/27).

Note for reviewers: `practitioners.php` declares explicit negative ids (`-1`…`-5`), so `ORDER BY id LIMIT 1` selects `-5`. `users.id` is a signed bigint and nothing downstream assumes positivity, but it is worth knowing.
