### PR TITLE
test(procedure-order): cover all four HL7 order generators

### DIFF
--- a/tests/Tests/Fixtures/ProcedureOrderFixtureManager.php
+++ b/tests/Tests/Fixtures/ProcedureOrderFixtureManager.php
@@ -1,0 +1,311 @@
+<?php
+
+/**
+ * Manages test fixtures for procedure orders.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Fixtures;
+
+use OpenEMR\Common\Database\QueryUtils;
+
+/**
+ * Manages test fixtures for procedure orders
+ *
+ * This class handles installation and removal of test procedure order
+ * records along with associated procedure codes and form entries.
+ * It coordinates with patient, encounter, and provider fixtures.
+ */
+class ProcedureOrderFixtureManager extends BaseFixtureManager
+{
+    /** Default ordering provider when no fixture user is present. */
+    private const DEFAULT_PROVIDER_ID = 1;
+
+    private readonly EncounterFixtureManager $encounterFixtureManager;
+
+    private readonly ProcedureProviderFixtureManager $procedureProviderFixtureManager;
+
+    /** @var list<int> Procedure order IDs created by this manager */
+    private array $installedOrderIds = [];
+
+    /**
+     * Initialize the fixture manager for procedure orders
+     *
+     * The patient fixtures are owned by the encounter manager, which installs and
+     * removes them as part of its own lifecycle. The patient manager is therefore
+     * only wired through to a default-constructed encounter manager; passing an
+     * encounter manager makes this argument redundant.
+     *
+     * @param FixtureManager|null $patientFixtureManager Optional patient fixture manager
+     * @param EncounterFixtureManager|null $encounterFixtureManager Optional encounter fixture manager
+     * @param ProcedureProviderFixtureManager|null $procedureProviderFixtureManager Optional provider fixture manager
+     */
+    public function __construct(
+        ?FixtureManager $patientFixtureManager = null,
+        ?EncounterFixtureManager $encounterFixtureManager = null,
+        ?ProcedureProviderFixtureManager $procedureProviderFixtureManager = null
+    ) {
+        parent::__construct('procedure-orders.php', 'procedure_order');
+
+        $this->encounterFixtureManager = $encounterFixtureManager
+            ?? new EncounterFixtureManager(null, $patientFixtureManager ?? new FixtureManager());
+        $this->procedureProviderFixtureManager = $procedureProviderFixtureManager
+            ?? new ProcedureProviderFixtureManager();
+    }
+
+    /**
+     * Install procedure order fixtures into the database
+     *
+     * Installs patient, encounter, and provider dependencies first,
+     * then creates procedure orders with associated codes and form entries.
+     *
+     * @return int Number of fixtures installed
+     * @throws \OpenEMR\Common\Database\SqlQueryException If a database write fails
+     * @throws \RuntimeException If a required dependent fixture is missing
+     */
+    public function installFixtures(): int
+    {
+        // Install dependencies first. The encounter manager installs the patient
+        // and facility fixtures it depends on; installing them again here would
+        // duplicate every patient row and break the encounter insert's pubpid
+        // subquery with "Subquery returns more than 1 row".
+        $this->encounterFixtureManager->installFixtures();
+        $this->procedureProviderFixtureManager->installFixtures();
+
+        $patientId = self::requireId(
+            QueryUtils::fetchSingleValue(
+                <<<'SQL'
+                SELECT pid FROM patient_data WHERE pubpid LIKE ? LIMIT 1
+                SQL,
+                'pid',
+                [self::FIXTURE_PREFIX . '-%']
+            ),
+            'a patient fixture'
+        );
+
+        $encounterRecords = QueryUtils::fetchRecords(
+            <<<'SQL'
+            SELECT encounter FROM form_encounter WHERE reason LIKE ? LIMIT 1
+            SQL,
+            [self::FIXTURE_PREFIX . '-%']
+        );
+        if ($encounterRecords === []) {
+            throw new \RuntimeException('Procedure order fixtures require an encounter fixture');
+        }
+        $encounterId = self::requireId($encounterRecords[0]['encounter'] ?? null, 'an encounter fixture');
+
+        $orderingProviderId = QueryUtils::fetchSingleValue(
+            <<<'SQL'
+            SELECT id FROM users WHERE username LIKE ? ORDER BY id LIMIT 1
+            SQL,
+            'id',
+            [self::FIXTURE_PREFIX . '-%']
+        );
+        $orderingProviderId = is_numeric($orderingProviderId)
+            ? (int) $orderingProviderId
+            : self::DEFAULT_PROVIDER_ID;
+
+        $providers = $this->procedureProviderFixtureManager->getInstalledProviders();
+
+        $insertCount = 0;
+        foreach ($this->getFixturesFromFile() as $fixture) {
+            $fixture['patient_id'] = $patientId;
+            $fixture['encounter_id'] = $encounterId;
+            $fixture['provider_id'] = $orderingProviderId;
+
+            // Point the order at the first installed lab unless the fixture names one itself.
+            if (($fixture['lab_id'] ?? null) === null && $providers !== []) {
+                $fixture['lab_id'] = $providers[0]['ppid'] ?? null;
+            }
+
+            // The forms row carries the order's own date. form_encounter.date is not
+            // usable here: encounters.php does not set it, so it is NULL for every
+            // installed encounter.
+            $orderDate = $fixture['date_ordered'] ?? null;
+
+            $orderId = $this->insertProcedureOrder($fixture);
+            $this->installedOrderIds[] = $orderId;
+            $this->installProcedureOrderCodes($orderId);
+            $this->createFormEntry($patientId, $encounterId, $orderId, is_string($orderDate) ? $orderDate : null);
+            $insertCount++;
+        }
+
+        return $insertCount;
+    }
+
+    /**
+     * Insert a single procedure order record into the database
+     *
+     * @param array<string, mixed> $fixture Order data to insert
+     * @return int Inserted order ID (procedure_order_id)
+     * @throws \OpenEMR\Common\Database\SqlQueryException If the database insert fails
+     */
+    private function insertProcedureOrder(array $fixture): int
+    {
+        $assignments = [];
+        $binds = [];
+
+        foreach ($fixture as $column => $value) {
+            if ($column === 'procedure_order_id') {
+                continue;
+            }
+            $assignments[] = $column . ' = ?';
+            $binds[] = $value;
+        }
+
+        return QueryUtils::sqlInsert('INSERT INTO procedure_order SET ' . implode(', ', $assignments), $binds);
+    }
+
+    /**
+     * Install procedure order codes for a given order
+     *
+     * Loads procedure codes from the PHP fixture file and associates
+     * them with the specified order ID.
+     *
+     * @param int $orderId The procedure order ID
+     * @throws \OpenEMR\Common\Database\SqlQueryException If the database insert fails
+     */
+    private function installProcedureOrderCodes(int $orderId): void
+    {
+        foreach ($this->loadPhpFile('procedure-order-codes.php') as $codeFixture) {
+            $codeFixture['procedure_order_id'] = $orderId;
+
+            $assignments = [];
+            $binds = [];
+            foreach ($codeFixture as $column => $value) {
+                $assignments[] = $column . ' = ?';
+                $binds[] = $value;
+            }
+
+            QueryUtils::sqlInsert(
+                'INSERT INTO procedure_order_code SET ' . implode(', ', $assignments),
+                $binds
+            );
+        }
+    }
+
+    /**
+     * Create a forms table entry for the procedure order
+     *
+     * Links the procedure order to an encounter via the forms table.
+     *
+     * @param int $patientId Patient ID
+     * @param int $encounterId Encounter ID
+     * @param int $orderId Procedure order ID
+     * @param string|null $date Order date, or null to leave forms.date unset
+     * @throws \OpenEMR\Common\Database\SqlQueryException If the database insert fails
+     */
+    private function createFormEntry(int $patientId, int $encounterId, int $orderId, ?string $date): void
+    {
+        QueryUtils::sqlInsert(
+            <<<'SQL'
+            INSERT INTO forms
+            SET date = ?, encounter = ?, form_name = ?, form_id = ?, pid = ?,
+                user = ?, groupname = ?, authorized = ?, formdir = ?
+            SQL,
+            [
+                $date,
+                $encounterId,
+                'Procedure Order',
+                $orderId,
+                $patientId,
+                'admin',
+                'Default',
+                1,
+                'procedure_order',
+            ]
+        );
+    }
+
+    /**
+     * Get all installed procedure order IDs
+     *
+     * @return list<int> Procedure order IDs created by this manager
+     */
+    public function getInstalledOrderIds(): array
+    {
+        return $this->installedOrderIds;
+    }
+
+    /**
+     * Remove all installed fixtures from the database
+     */
+    public function removeFixtures(): void
+    {
+        parent::removeFixtures();
+    }
+
+    /**
+     * Delete all test fixture order records from the database
+     *
+     * Removes procedure orders, procedure order codes, and associated
+     * form entries. Also cleans up dependent fixtures (providers,
+     * encounters, patients).
+     *
+     * @throws \OpenEMR\Common\Database\SqlQueryException If a database deletion fails
+     */
+    protected function removeInstalledFixtures(): void
+    {
+        $fixturePrefix = self::FIXTURE_PREFIX . '-%';
+
+        try {
+            QueryUtils::sqlStatementThrowException(
+                <<<'SQL'
+                DELETE FROM procedure_order_code
+                WHERE procedure_order_id IN (
+                    SELECT procedure_order_id FROM procedure_order WHERE control_id LIKE ?
+                )
+                SQL,
+                [$fixturePrefix]
+            );
+
+            QueryUtils::sqlStatementThrowException(
+                <<<'SQL'
+                DELETE FROM forms
+                WHERE formdir = 'procedure_order'
+                  AND form_id IN (
+                    SELECT procedure_order_id FROM procedure_order WHERE control_id LIKE ?
+                  )
+                SQL,
+                [$fixturePrefix]
+            );
+
+            QueryUtils::sqlStatementThrowException(
+                <<<'SQL'
+                DELETE FROM procedure_order WHERE control_id LIKE ?
+                SQL,
+                [$fixturePrefix]
+            );
+
+            $this->installedOrderIds = [];
+        } finally {
+            $this->procedureProviderFixtureManager->removeFixtures();
+            // Removes the patient and facility fixtures along with the encounters.
+            $this->encounterFixtureManager->removeFixtures();
+        }
+    }
+
+    /**
+     * Convert a database identifier read back as an untyped value into an int
+     *
+     * ADODB returns bigint columns as numeric strings, so the value has to be
+     * narrowed before it can be passed on as an int.
+     *
+     * @throws \RuntimeException If the dependent fixture was not found
+     */
+    private static function requireId(mixed $value, string $description): int
+    {
+        if (!is_numeric($value)) {
+            throw new \RuntimeException('Procedure order fixtures require ' . $description);
+        }
+
+        return (int) $value;
+    }
+}

--- a/tests/Tests/Fixtures/ProcedureOrderFixtureManagerTest.php
+++ b/tests/Tests/Fixtures/ProcedureOrderFixtureManagerTest.php
@@ -1,0 +1,467 @@
+<?php
+
+/**
+ * Database-backed tests for the procedure order and procedure provider fixture managers.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Fixtures;
+
+use OpenEMR\Common\Database\QueryUtils;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises ProcedureOrderFixtureManager and ProcedureProviderFixtureManager against a live database.
+ *
+ * These managers install rows across five tables (patient_data, form_encounter,
+ * procedure_providers, procedure_order, procedure_order_code, forms) and are only
+ * meaningful when those writes actually happen, so every test here talks to the
+ * database rather than a double.
+ */
+class ProcedureOrderFixtureManagerTest extends TestCase
+{
+    /** LIKE pattern matching every fixture row this suite installs. */
+    private const FIXTURE_LIKE = 'test-fixture-%';
+
+    /** Number of orders declared in procedure-orders.php. */
+    private const EXPECTED_ORDER_COUNT = 1;
+
+    /** Number of codes declared in procedure-order-codes.php, installed once per order. */
+    private const EXPECTED_CODES_PER_ORDER = 2;
+
+    /** Number of labs declared in procedure-providers.php. */
+    private const EXPECTED_PROVIDER_COUNT = 4;
+
+    /** Username of the throwaway users row that stands in for a fixture-installed provider. */
+    private const FIXTURE_USERNAME = 'test-fixture-ordering-provider';
+
+    /** Names declared in procedure-providers.php. */
+    private const EXPECTED_PROVIDER_NAMES = [
+        'test-fixture-Generic Lab',
+        'test-fixture-Ammon Lab',
+        'test-fixture-LabCorp Laboratory',
+        'test-fixture-Quest Diagnostics',
+    ];
+
+    private ProcedureProviderFixtureManager $providerFixtureManager;
+
+    private ProcedureOrderFixtureManager $fixtureManager;
+
+    protected function setUp(): void
+    {
+        $this->providerFixtureManager = new ProcedureProviderFixtureManager();
+        $this->fixtureManager = new ProcedureOrderFixtureManager(null, null, $this->providerFixtureManager);
+        // Any fixture rows left behind by an earlier failure would corrupt the
+        // counts asserted below, so start every test from a known-clean table set.
+        $this->fixtureManager->removeFixtures();
+        self::removeFixtureUser();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fixtureManager->removeFixtures();
+        self::removeFixtureUser();
+    }
+
+    public function testInstallFixturesCreatesOrdersCodesFormsAndProviders(): void
+    {
+        $installCount = $this->fixtureManager->installFixtures();
+
+        self::assertSame(self::EXPECTED_ORDER_COUNT, $installCount);
+
+        $orderIds = $this->fixtureManager->getInstalledOrderIds();
+        self::assertCount(self::EXPECTED_ORDER_COUNT, $orderIds);
+
+        self::assertSame(self::EXPECTED_ORDER_COUNT, $this->countOrders());
+        self::assertSame(
+            self::EXPECTED_ORDER_COUNT * self::EXPECTED_CODES_PER_ORDER,
+            $this->countCodesForOrders($orderIds)
+        );
+        self::assertSame(self::EXPECTED_ORDER_COUNT, $this->countFormsForOrders($orderIds));
+        self::assertSame(self::EXPECTED_PROVIDER_COUNT, $this->countProviders());
+    }
+
+    public function testGetInstalledOrderIdsMatchesTheRowsActuallyInserted(): void
+    {
+        $this->fixtureManager->installFixtures();
+
+        $installedIds = $this->fixtureManager->getInstalledOrderIds();
+        $databaseIds = array_map(
+            self::toInt(...),
+            QueryUtils::fetchTableColumn(
+                <<<'SQL'
+                SELECT procedure_order_id FROM procedure_order
+                WHERE control_id LIKE ?
+                ORDER BY procedure_order_id
+                SQL,
+                'procedure_order_id',
+                [self::FIXTURE_LIKE]
+            )
+        );
+
+        self::assertSame($databaseIds, $installedIds);
+        foreach ($installedIds as $installedId) {
+            self::assertGreaterThan(0, $installedId);
+        }
+    }
+
+    public function testInstalledOrderPointsAtRealPatientEncounterProviderAndLab(): void
+    {
+        $this->fixtureManager->installFixtures();
+
+        $orderId = $this->firstInstalledOrderId();
+        $order = $this->fetchRow(
+            <<<'SQL'
+            SELECT patient_id, encounter_id, provider_id, lab_id, date_ordered
+            FROM procedure_order WHERE procedure_order_id = ?
+            SQL,
+            [$orderId]
+        );
+
+        self::assertSame(
+            1,
+            $this->countRows('SELECT COUNT(*) AS cnt FROM patient_data WHERE pid = ?', [self::toInt($order['patient_id'])]),
+            'procedure_order.patient_id does not reference a patient_data row'
+        );
+        self::assertSame(
+            1,
+            $this->countRows(
+                'SELECT COUNT(*) AS cnt FROM form_encounter WHERE encounter = ? AND reason LIKE ?',
+                [self::toInt($order['encounter_id']), self::FIXTURE_LIKE]
+            ),
+            'procedure_order.encounter_id does not reference a fixture encounter'
+        );
+        self::assertSame(
+            1,
+            $this->countRows('SELECT COUNT(*) AS cnt FROM users WHERE id = ?', [self::toInt($order['provider_id'])]),
+            'procedure_order.provider_id does not reference a users row'
+        );
+
+        $labId = self::toInt($order['lab_id']);
+        self::assertSame(
+            1,
+            $this->countRows('SELECT COUNT(*) AS cnt FROM procedure_providers WHERE ppid = ?', [$labId]),
+            'procedure_order.lab_id does not reference a procedure_providers row'
+        );
+        $providers = $this->providerFixtureManager->getInstalledProviders();
+        self::assertSame($labId, self::toInt($providers[0]['ppid'] ?? null));
+
+        // The forms row carries the order's own date_ordered; form_encounter.date is
+        // NULL for fixture encounters and cannot supply one.
+        $formDate = QueryUtils::fetchSingleValue(
+            <<<'SQL'
+            SELECT date FROM forms WHERE formdir = ? AND form_id = ?
+            SQL,
+            'date',
+            ['procedure_order', $orderId]
+        );
+        self::assertSame($order['date_ordered'], $formDate);
+    }
+
+    public function testOrderingProviderPrefersAFixtureUserOverTheDefault(): void
+    {
+        $userId = self::toInt(QueryUtils::sqlInsert(
+            'INSERT INTO users SET username = ?, fname = ?, lname = ?, authorized = ?, active = ?',
+            [self::FIXTURE_USERNAME, 'Fixture', 'Provider', 1, 1]
+        ));
+
+        $this->fixtureManager->installFixtures();
+
+        $orderId = $this->firstInstalledOrderId();
+        $providerId = self::toInt(QueryUtils::fetchSingleValue(
+            'SELECT provider_id FROM procedure_order WHERE procedure_order_id = ?',
+            'provider_id',
+            [$orderId]
+        ));
+
+        self::assertSame($userId, $providerId);
+    }
+
+    public function testProviderManagerExposesEveryInstalledLab(): void
+    {
+        $installCount = $this->providerFixtureManager->installFixtures();
+
+        self::assertSame(self::EXPECTED_PROVIDER_COUNT, $installCount);
+
+        $providers = $this->providerFixtureManager->getInstalledProviders();
+        self::assertCount(self::EXPECTED_PROVIDER_COUNT, $providers);
+
+        $names = [];
+        foreach ($providers as $provider) {
+            $names[] = $provider['name'] ?? null;
+            $ppid = self::toInt($provider['ppid'] ?? null);
+            self::assertGreaterThan(0, $ppid);
+            self::assertSame(
+                1,
+                $this->countRows('SELECT COUNT(*) AS cnt FROM procedure_providers WHERE ppid = ?', [$ppid])
+            );
+        }
+        self::assertSame(self::EXPECTED_PROVIDER_NAMES, $names);
+    }
+
+    public function testGetProviderByNameMatchesCaseInsensitiveSubstrings(): void
+    {
+        $this->providerFixtureManager->installFixtures();
+
+        $quest = $this->providerFixtureManager->getProviderByName('quest');
+        self::assertNotNull($quest);
+        self::assertSame('test-fixture-Quest Diagnostics', $quest['name'] ?? null);
+
+        $labCorp = $this->providerFixtureManager->getProviderByName('LabCorp');
+        self::assertNotNull($labCorp);
+        self::assertSame('test-fixture-LabCorp Laboratory', $labCorp['name'] ?? null);
+
+        self::assertNull($this->providerFixtureManager->getProviderByName('no-such-laboratory'));
+    }
+
+    public function testRemoveFixturesLeavesEveryTouchedTableClean(): void
+    {
+        $this->fixtureManager->installFixtures();
+        $orderIds = $this->fixtureManager->getInstalledOrderIds();
+        self::assertNotSame([], $orderIds);
+
+        $this->fixtureManager->removeFixtures();
+
+        self::assertSame(0, $this->countOrders(), 'procedure_order rows survived removeFixtures()');
+        self::assertSame(0, $this->countCodesForOrders($orderIds), 'procedure_order_code rows were orphaned');
+        self::assertSame(0, $this->countFormsForOrders($orderIds), 'forms rows were orphaned');
+        self::assertSame(0, $this->countProviders(), 'procedure_providers rows survived removeFixtures()');
+        self::assertSame(
+            0,
+            $this->countRows('SELECT COUNT(*) AS cnt FROM form_encounter WHERE reason LIKE ?', [self::FIXTURE_LIKE]),
+            'form_encounter rows survived removeFixtures()'
+        );
+        self::assertSame(0, $this->countPatients(), 'patient_data rows survived removeFixtures()');
+
+        self::assertSame([], $this->fixtureManager->getInstalledOrderIds());
+        self::assertSame([], $this->providerFixtureManager->getInstalledProviders());
+    }
+
+    public function testInstallRemoveInstallDoesNotAccumulateOrCollide(): void
+    {
+        $this->fixtureManager->installFixtures();
+        $firstIds = $this->fixtureManager->getInstalledOrderIds();
+        $firstPatientCount = $this->countPatients();
+        self::assertGreaterThan(0, $firstPatientCount);
+        $this->fixtureManager->removeFixtures();
+
+        $secondCount = $this->fixtureManager->installFixtures();
+        $secondIds = $this->fixtureManager->getInstalledOrderIds();
+
+        self::assertSame(self::EXPECTED_ORDER_COUNT, $secondCount);
+        self::assertCount(self::EXPECTED_ORDER_COUNT, $secondIds);
+        self::assertSame([], array_intersect($firstIds, $secondIds), 'the second install reused order ids');
+
+        // A duplicated patient row is what breaks form_encounter's pubpid subquery,
+        // so assert the dependent fixtures are singular rather than doubled.
+        self::assertSame(self::EXPECTED_ORDER_COUNT, $this->countOrders());
+        self::assertSame(
+            self::EXPECTED_ORDER_COUNT * self::EXPECTED_CODES_PER_ORDER,
+            $this->countCodesForOrders($secondIds)
+        );
+        self::assertSame(self::EXPECTED_ORDER_COUNT, $this->countFormsForOrders($secondIds));
+        self::assertSame(self::EXPECTED_PROVIDER_COUNT, $this->countProviders());
+        self::assertSame(
+            $firstPatientCount,
+            $this->countPatients(),
+            'the second install duplicated the patient fixtures'
+        );
+    }
+
+    public function testDefaultConstructorInstallsItsOwnDependencies(): void
+    {
+        $manager = new ProcedureOrderFixtureManager();
+
+        $installCount = $manager->installFixtures();
+
+        self::assertSame(self::EXPECTED_ORDER_COUNT, $installCount);
+        self::assertSame(self::EXPECTED_ORDER_COUNT, $this->countOrders());
+        self::assertSame(self::EXPECTED_PROVIDER_COUNT, $this->countProviders());
+        self::assertSame(
+            self::EXPECTED_ORDER_COUNT,
+            $this->countRows('SELECT COUNT(*) AS cnt FROM form_encounter WHERE reason LIKE ?', [self::FIXTURE_LIKE])
+        );
+
+        $manager->removeFixtures();
+
+        self::assertSame(0, $this->countOrders());
+        self::assertSame(0, $this->countProviders());
+    }
+
+    public function testInstallFixturesRequiresAPatientFixture(): void
+    {
+        $encounterManager = new class extends EncounterFixtureManager {
+            public function installFixtures(): int
+            {
+                return 0;
+            }
+
+            protected function removeInstalledFixtures(): void
+            {
+            }
+        };
+        $manager = new ProcedureOrderFixtureManager(null, $encounterManager, new ProcedureProviderFixtureManager());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Procedure order fixtures require a patient fixture');
+
+        $manager->installFixtures();
+    }
+
+    public function testInstallFixturesRequiresAnEncounterFixture(): void
+    {
+        $encounterManager = new class (new FixtureManager()) extends EncounterFixtureManager {
+            public function __construct(private readonly FixtureManager $patientFixtureManager)
+            {
+                parent::__construct();
+            }
+
+            public function installFixtures(): int
+            {
+                $this->patientFixtureManager->installPatientFixtures();
+                return 0;
+            }
+
+            protected function removeInstalledFixtures(): void
+            {
+                $this->patientFixtureManager->removePatientFixtures();
+            }
+        };
+        $manager = new ProcedureOrderFixtureManager(null, $encounterManager, new ProcedureProviderFixtureManager());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Procedure order fixtures require an encounter fixture');
+
+        $manager->installFixtures();
+    }
+
+    private function countOrders(): int
+    {
+        return $this->countRows(
+            'SELECT COUNT(*) AS cnt FROM procedure_order WHERE control_id LIKE ?',
+            [self::FIXTURE_LIKE]
+        );
+    }
+
+    private function firstInstalledOrderId(): int
+    {
+        $orderIds = $this->fixtureManager->getInstalledOrderIds();
+        self::assertArrayHasKey(0, $orderIds);
+
+        return $orderIds[0];
+    }
+
+    /**
+     * Clear by the same prefix the manager looks up with, not by the exact
+     * username. The manager takes the lowest-id `test-fixture-%` user, so a
+     * row left behind by another suite would win the lookup and this test
+     * would assert against the wrong provider.
+     */
+    private static function removeFixtureUser(): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM users WHERE username LIKE ?',
+            [self::FIXTURE_LIKE]
+        );
+    }
+
+    private function countPatients(): int
+    {
+        return $this->countRows(
+            'SELECT COUNT(*) AS cnt FROM patient_data WHERE pubpid LIKE ?',
+            [self::FIXTURE_LIKE]
+        );
+    }
+
+    private function countProviders(): int
+    {
+        return $this->countRows(
+            'SELECT COUNT(*) AS cnt FROM procedure_providers WHERE name LIKE ?',
+            [self::FIXTURE_LIKE]
+        );
+    }
+
+    /**
+     * Count procedure_order_code rows attached to the given orders.
+     *
+     * Counting by order id rather than by joining procedure_order matters after a
+     * removal: a join would report zero simply because the parent orders are gone,
+     * hiding orphaned code rows.
+     *
+     * @param list<int> $orderIds
+     */
+    private function countCodesForOrders(array $orderIds): int
+    {
+        return $this->countRows(
+            'SELECT COUNT(*) AS cnt FROM procedure_order_code WHERE procedure_order_id IN ('
+                . self::placeholders($orderIds) . ')',
+            $orderIds
+        );
+    }
+
+    /**
+     * Count forms rows attached to the given orders, orphans included.
+     *
+     * @param list<int> $orderIds
+     */
+    private function countFormsForOrders(array $orderIds): int
+    {
+        return $this->countRows(
+            'SELECT COUNT(*) AS cnt FROM forms WHERE formdir = ? AND form_id IN ('
+                . self::placeholders($orderIds) . ')',
+            array_merge(['procedure_order'], $orderIds)
+        );
+    }
+
+    /**
+     * @param list<int> $values
+     */
+    private static function placeholders(array $values): string
+    {
+        return implode(', ', array_fill(0, count($values), '?'));
+    }
+
+    /**
+     * @param list<mixed> $binds
+     */
+    private function countRows(string $sql, array $binds, string $message = ''): int
+    {
+        return self::toInt(QueryUtils::fetchSingleValue($sql, 'cnt', $binds), $message);
+    }
+
+    /**
+     * @param list<mixed> $binds
+     * @return array<mixed>
+     */
+    private function fetchRow(string $sql, array $binds): array
+    {
+        $records = QueryUtils::fetchRecords($sql, $binds);
+        self::assertArrayHasKey(0, $records);
+
+        return $records[0];
+    }
+
+    /**
+     * Narrow a value read back from ADODB, which returns numeric columns as strings.
+     */
+    private static function toInt(mixed $value, string $message = ''): int
+    {
+        if (!is_numeric($value)) {
+            // @codeCoverageIgnoreStart
+            // Defensive — every call site reads a NOT NULL numeric column, so a
+            // non-numeric value means the query itself changed shape, which is not
+            // a path normal CI exercises.
+            self::fail($message !== '' ? $message : 'Expected a numeric value from the database');
+            // @codeCoverageIgnoreEnd
+        }
+
+        return (int) $value;
+    }
+}

--- a/tests/Tests/Fixtures/ProcedureProviderFixtureManager.php
+++ b/tests/Tests/Fixtures/ProcedureProviderFixtureManager.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Manages test fixtures for procedure providers (labs).
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Fixtures;
+
+use OpenEMR\Common\Database\QueryUtils;
+
+/**
+ * Manages test fixtures for procedure providers (labs)
+ *
+ * This class handles installation and removal of test procedure provider
+ * records for integration testing of HL7 order generation.
+ */
+class ProcedureProviderFixtureManager extends BaseFixtureManager
+{
+    /** @var list<array<string, mixed>> Installed provider records, each with its assigned ppid */
+    private array $installedProviders = [];
+
+    /**
+     * Initialize the fixture manager for procedure providers
+     */
+    public function __construct()
+    {
+        parent::__construct('procedure-providers.php', 'procedure_providers');
+    }
+
+    /**
+     * Install procedure provider fixtures into the database
+     *
+     * Loads provider data from the PHP fixture file and inserts it into the
+     * procedure_providers table.
+     *
+     * @return int Number of fixtures installed
+     */
+    public function installFixtures(): int
+    {
+        $insertCount = 0;
+
+        foreach ($this->getFixturesFromFile() as $fixture) {
+            $fixture['ppid'] = $this->insertProcedureProvider($fixture);
+            $this->installedProviders[] = $fixture;
+            $insertCount++;
+        }
+
+        return $insertCount;
+    }
+
+    /**
+     * Insert a single procedure provider record into the database
+     *
+     * @param array<string, mixed> $fixture Provider data to insert
+     * @return int Inserted provider ID (ppid)
+     * @throws \OpenEMR\Common\Database\SqlQueryException If the database insert fails
+     */
+    private function insertProcedureProvider(array $fixture): int
+    {
+        $assignments = [];
+        $binds = [];
+
+        foreach ($fixture as $column => $value) {
+            if ($column === 'ppid') {
+                continue;
+            }
+            $assignments[] = $column . ' = ?';
+            $binds[] = $value;
+        }
+
+        return QueryUtils::sqlInsert('INSERT INTO procedure_providers SET ' . implode(', ', $assignments), $binds);
+    }
+
+    /**
+     * Get all installed provider fixtures
+     *
+     * @return list<array<string, mixed>> Provider records, each with its assigned ppid
+     */
+    public function getInstalledProviders(): array
+    {
+        return $this->installedProviders;
+    }
+
+    /**
+     * Find an installed provider by partial, case-insensitive name match
+     *
+     * @param string $nameLike Partial name to search for
+     * @return array<string, mixed>|null Provider record if found, null otherwise
+     */
+    public function getProviderByName(string $nameLike): ?array
+    {
+        foreach ($this->installedProviders as $provider) {
+            $name = $provider['name'] ?? null;
+            if (is_string($name) && stripos($name, $nameLike) !== false) {
+                return $provider;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Remove all installed fixtures from the database
+     */
+    public function removeFixtures(): void
+    {
+        parent::removeFixtures();
+    }
+
+    /**
+     * Delete all test fixture provider records from the database
+     *
+     * Removes every procedure_providers row whose name carries the fixture prefix.
+     *
+     * @throws \OpenEMR\Common\Database\SqlQueryException If the database deletion fails
+     */
+    protected function removeInstalledFixtures(): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM procedure_providers WHERE name LIKE ?',
+            [self::FIXTURE_PREFIX . '-%']
+        );
+        $this->installedProviders = [];
+    }
+}

--- a/tests/Tests/Fixtures/procedure-order-codes.php
+++ b/tests/Tests/Fixtures/procedure-order-codes.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Test fixture data.
+ *
+ * @package OpenEMR
+ * @link    https://www.open-emr.org
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+/** @return array<string, mixed>[] */
+return [
+    [
+        'procedure_order_seq' => 1,
+        'procedure_order_id' => null,
+        'procedure_code' => '80053',
+        'procedure_name' => 'Comprehensive Metabolic Panel',
+        'procedure_source' => '1',
+        'diagnoses' => 'ICD10:E78.5',
+        'do_not_send' => 0,
+        'procedure_order_title' => 'CMP',
+    ],
+    [
+        'procedure_order_seq' => 2,
+        'procedure_order_id' => null,
+        'procedure_code' => '85025',
+        'procedure_name' => 'Complete Blood Count',
+        'procedure_source' => '1',
+        'diagnoses' => '',
+        'do_not_send' => 0,
+        'procedure_order_title' => 'CBC',
+    ],
+];

--- a/tests/Tests/Fixtures/procedure-orders.php
+++ b/tests/Tests/Fixtures/procedure-orders.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Test fixture data.
+ *
+ * @package OpenEMR
+ * @link    https://www.open-emr.org
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+/** @return array<string, mixed>[] */
+return [
+    [
+        'procedure_order_id' => null,
+        'provider_id' => 1,
+        'patient_id' => null,
+        'encounter_id' => null,
+        'date_collected' => '2025-01-15 10:30:00',
+        'date_ordered' => '2025-01-15',
+        'order_priority' => 'routine',
+        'order_status' => 'pending',
+        'patient_instructions' => 'Please fast for 12 hours before the test',
+        'activity' => 1,
+        'control_id' => 'test-fixture-order-001',
+        'lab_id' => null,
+        'specimen_type' => 'blood',
+        'specimen_location' => '',
+        'specimen_volume' => '',
+        'date_transmitted' => null,
+        'clinical_hx' => 'Patient presents with elevated cholesterol',
+        'billing_type' => 'T',
+        'order_diagnosis' => 'ICD10:E78.5',
+    ],
+];

--- a/tests/Tests/Fixtures/procedure-providers.php
+++ b/tests/Tests/Fixtures/procedure-providers.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Test fixture data.
+ *
+ * @package OpenEMR
+ * @link    https://www.open-emr.org
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+/** @return array<string, mixed>[] */
+return [
+    [
+        'ppid' => null,
+        'name' => 'test-fixture-Generic Lab',
+        'npi' => '1234567890',
+        'send_app_id' => 'OpenEMR',
+        'send_fac_id' => 'FAC001',
+        'recv_app_id' => 'LabSystem',
+        'recv_fac_id' => 'LAB001',
+        'DorP' => 'P',
+        'direction' => 'B',
+        'protocol' => 'DL',
+        'remote_host' => '',
+        'login' => '',
+        'password' => '',
+        'orders_path' => '',
+        'results_path' => '',
+        'notes' => 'Test fixture for generic lab',
+    ],
+    [
+        'ppid' => null,
+        'name' => 'test-fixture-Ammon Lab',
+        'npi' => '1234567891',
+        'send_app_id' => 'OpenEMR',
+        'send_fac_id' => 'FAC002',
+        'recv_app_id' => 'AmmonLab',
+        'recv_fac_id' => 'AMMON',
+        'DorP' => 'P',
+        'direction' => 'B',
+        'protocol' => 'DL',
+        'remote_host' => '',
+        'login' => '',
+        'password' => '',
+        'orders_path' => '',
+        'results_path' => '',
+        'notes' => 'Test fixture for Ammon lab',
+    ],
+    [
+        'ppid' => null,
+        'name' => 'test-fixture-LabCorp Laboratory',
+        'npi' => '1234567892',
+        'send_app_id' => 'OpenEMR',
+        'send_fac_id' => 'FAC003',
+        'recv_app_id' => 'LabCorp',
+        'recv_fac_id' => 'LABCORP',
+        'DorP' => 'P',
+        'direction' => 'B',
+        'protocol' => 'DL',
+        'remote_host' => '',
+        'login' => '',
+        'password' => '',
+        'orders_path' => '',
+        'results_path' => '',
+        'notes' => 'Test fixture for LabCorp',
+    ],
+    [
+        'ppid' => null,
+        'name' => 'test-fixture-Quest Diagnostics',
+        'npi' => '1234567893',
+        'send_app_id' => 'OpenEMR',
+        'send_fac_id' => 'FAC004',
+        'recv_app_id' => 'QuestDx',
+        'recv_fac_id' => 'QUEST',
+        'DorP' => 'P',
+        'direction' => 'B',
+        'protocol' => 'DL',
+        'remote_host' => '',
+        'login' => '',
+        'password' => '',
+        'orders_path' => '',
+        'results_path' => '',
+        'notes' => 'Test fixture for Quest',
+    ],
+];

--- a/tests/Tests/Services/ProcedureOrder/GenHl7OrderIntegrationTest.php
+++ b/tests/Tests/Services/ProcedureOrder/GenHl7OrderIntegrationTest.php
@@ -1,0 +1,693 @@
+<?php
+
+/**
+ * Integration tests for the four vendor-specific HL7 order generators.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Services\ProcedureOrder;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Orders\Hl7OrderGenerationException;
+use OpenEMR\Common\Orders\Hl7OrderResult;
+use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Tests\Fixtures\ProcedureOrderFixtureManager;
+use OpenEMR\Tests\Fixtures\ProcedureProviderFixtureManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises every implementation of the gen_hl7_order contract against a real
+ * procedure order in the database.
+ *
+ * Historically each lab declared a global function literally named
+ * `gen_hl7_order()` with a different signature, so only one implementation
+ * could be loaded per PHP process and only one could be tested. They now have
+ * distinct names, take an `int` order id, return {@see Hl7OrderResult} and
+ * throw {@see Hl7OrderGenerationException}, so all four load together and all
+ * four are covered here.
+ */
+class GenHl7OrderIntegrationTest extends TestCase
+{
+    /** Carriage return: HL7 separates segments with CR, never LF. */
+    private const int CR = 13;
+
+    /** Line feed: must never appear in a generated message. */
+    private const int LF = 10;
+
+    /** NPI stamped onto the ordering provider so the tests can find it in the output. */
+    private const string ORDERING_PROVIDER_NPI = '9876543210';
+
+    /** Facility account code required by the LabCorp generator. */
+    private const string FACILITY_ACCOUNT = 'TESTACCT01';
+
+    /** Marker on the procedure_type rows this test owns, so tearDown can find them. */
+    private const string PROCEDURE_TYPE_MARKER = 'test-fixture-gen-hl7-order';
+
+    /** Marker on the form_vitals row this test owns, so tearDown can find it. */
+    private const string VITALS_MARKER = 'test-fixture-gen-hl7-order-vitals';
+
+    /**
+     * Procedure codes carried by tests/Tests/Fixtures/procedure-order-codes.php,
+     * keyed by code with the procedure name the fixture uses.
+     */
+    private const array PROCEDURE_CODES = [
+        '80053' => 'Comprehensive Metabolic Panel',
+        '85025' => 'Complete Blood Count',
+    ];
+
+    private ProcedureProviderFixtureManager $providerFixtures;
+
+    private ProcedureOrderFixtureManager $orderFixtures;
+
+    private int $orderId = 0;
+
+    private int $orderingProviderId = 0;
+
+    private ?string $originalOrderingProviderNpi = null;
+
+    private bool $hadSpecimenFastingRequest = false;
+
+    private ?string $originalSpecimenFastingRequest = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        // Every generator is a global function in an include file rather than a
+        // service, so load all four up front. gen_universal_hl7, labcorp and
+        // quest resolve their own includes through $webserver_root.
+        $projectDir = OEGlobalsBag::getInstance()->getProjectDir();
+        $webserver_root = $projectDir;
+        require_once $projectDir . '/interface/orders/gen_hl7_order.inc.php';
+        require_once $projectDir . '/interface/procedure_tools/gen_universal_hl7/gen_hl7_order.inc.php';
+        require_once $projectDir . '/interface/procedure_tools/labcorp/gen_hl7_order.inc.php';
+        require_once $projectDir . '/interface/procedure_tools/quest/gen_hl7_order.inc.php';
+    }
+
+    protected function setUp(): void
+    {
+        $this->providerFixtures = new ProcedureProviderFixtureManager();
+        $this->orderFixtures = new ProcedureOrderFixtureManager(null, null, $this->providerFixtures);
+        $this->orderFixtures->installFixtures();
+
+        $orderIds = $this->orderFixtures->getInstalledOrderIds();
+        $this->assertNotCount(0, $orderIds, 'Procedure order fixtures should install at least one order');
+        $this->orderId = $orderIds[0];
+
+        $this->installProcedureTypes();
+        $this->installVitals();
+        $this->stampOrderingProviderNpi();
+
+        // Self pay with a facility account code: the state in which all four
+        // generators produce a message. The insurance and missing-account
+        // branches get their own tests below.
+        $this->setOrderColumns(['billing_type' => '', 'account' => self::FACILITY_ACCOUNT]);
+
+        // The LabCorp generator reads this request parameter without guarding
+        // for its absence. The real caller is interface/forms/procedure_order,
+        // which always posts it; supply it here so the generator sees the same
+        // shape of input it does in production. Capture whatever was there
+        // first so tearDown puts the process back how it found it rather than
+        // deleting a key another test owns.
+        $existing = $_REQUEST['form_specimen_fasting'] ?? null;
+        $this->hadSpecimenFastingRequest = is_string($existing);
+        $this->originalSpecimenFastingRequest = is_string($existing) ? $existing : null;
+        $_REQUEST['form_specimen_fasting'] = 'NO';
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->hadSpecimenFastingRequest && $this->originalSpecimenFastingRequest !== null) {
+            $_REQUEST['form_specimen_fasting'] = $this->originalSpecimenFastingRequest;
+        } else {
+            unset($_REQUEST['form_specimen_fasting']);
+        }
+        $this->restoreOrderingProviderNpi();
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM procedure_type WHERE description = ?',
+            [self::PROCEDURE_TYPE_MARKER]
+        );
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM forms WHERE formdir = ? AND form_id IN (SELECT id FROM form_vitals WHERE note = ?)',
+            ['vitals', self::VITALS_MARKER]
+        );
+        QueryUtils::sqlStatementThrowException('DELETE FROM form_vitals WHERE note = ?', [self::VITALS_MARKER]);
+        $this->orderFixtures->removeFixtures();
+    }
+
+    #[Test]
+    #[DataProvider('generatorProvider')]
+    public function testGeneratorProducesWellFormedOrmMessage(Hl7OrderGenerator $generator): void
+    {
+        $result = $generator->generate($this->orderId);
+
+        $this->assertNotSame('', $result->hl7, 'Generator produced an empty HL7 message');
+        $this->assertStringNotContainsString(
+            chr(self::LF),
+            $result->hl7,
+            'HL7 segments must be separated by CR alone, never LF'
+        );
+        $this->assertStringEndsWith(chr(self::CR), $result->hl7, 'Final segment must be CR terminated');
+
+        $segments = self::segments($result->hl7);
+        $this->assertNotCount(0, $segments);
+        foreach ($segments as $segment) {
+            $this->assertMatchesRegularExpression(
+                '/^[A-Z][A-Z0-9]{2}\|/',
+                $segment,
+                'Every segment must open with a three character segment id followed by the field separator'
+            );
+        }
+
+        $msh = self::fields(self::onlySegment($segments, 'MSH'));
+        $this->assertSame('ORM^O01', $msh[8], 'MSH-9 message type');
+        $this->assertSame('2.3', $msh[11], 'MSH-12 HL7 version');
+    }
+
+    #[Test]
+    #[DataProvider('generatorProvider')]
+    public function testMshRoutingFieldsComeFromTheProcedureProvider(Hl7OrderGenerator $generator): void
+    {
+        $result = $generator->generate($this->orderId);
+        $msh = self::fields(self::onlySegment(self::segments($result->hl7), 'MSH'));
+
+        $this->assertSame('^~\\&', $msh[1], 'MSH-2 encoding characters');
+        $this->assertSame($this->providerColumn('send_app_id'), $msh[2], 'MSH-3 sending application');
+        $this->assertSame($this->providerColumn('send_fac_id'), $msh[3], 'MSH-4 sending facility');
+        $this->assertSame($this->providerColumn('recv_app_id'), $msh[4], 'MSH-5 receiving application');
+        $this->assertSame($this->providerColumn('recv_fac_id'), $msh[5], 'MSH-6 receiving facility');
+    }
+
+    /**
+     * Each generator reads its routing identifiers from whichever
+     * procedure_providers row the order points at, so pointing the order at a
+     * different lab must move the whole MSH header with it.
+     */
+    #[Test]
+    #[DataProvider('labFixtureNameProvider')]
+    public function testRoutingFollowsTheLabTheOrderPointsAt(string $labFixtureName): void
+    {
+        $lab = $this->providerFixtures->getProviderByName($labFixtureName);
+        $this->assertIsArray($lab, "Provider fixture '{$labFixtureName}' should be installed");
+        $labId = $lab['ppid'];
+        $this->assertIsInt($labId);
+
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE procedure_order SET lab_id = ? WHERE procedure_order_id = ?',
+            [$labId, $this->orderId]
+        );
+
+        foreach (Hl7OrderGenerator::cases() as $generator) {
+            $hl7 = $generator->generate($this->orderId)->hl7;
+            $msh = self::fields(self::onlySegment(self::segments($hl7), 'MSH'));
+            $this->assertSame($this->providerColumn('send_fac_id'), $msh[3], "MSH-4 for {$generator->name}");
+            $this->assertSame($this->providerColumn('recv_app_id'), $msh[4], "MSH-5 for {$generator->name}");
+            $this->assertSame($this->providerColumn('recv_fac_id'), $msh[5], "MSH-6 for {$generator->name}");
+        }
+    }
+
+    /**
+     * @param list<string> $requiredSegments
+     * @param list<string> $forbiddenSegments
+     */
+    #[Test]
+    #[DataProvider('segmentExpectationProvider')]
+    public function testGeneratorEmitsExpectedSegments(
+        Hl7OrderGenerator $generator,
+        array $requiredSegments,
+        array $forbiddenSegments
+    ): void {
+        $segments = self::segments($generator->generate($this->orderId)->hl7);
+        $segmentIds = array_map(static fn (string $segment): string => substr($segment, 0, 3), $segments);
+
+        foreach ($requiredSegments as $required) {
+            $this->assertContains($required, $segmentIds, "Missing required {$required} segment");
+        }
+        foreach ($forbiddenSegments as $forbidden) {
+            $this->assertNotContains($forbidden, $segmentIds, "Unexpected {$forbidden} segment");
+        }
+    }
+
+    #[Test]
+    #[DataProvider('generatorProvider')]
+    public function testPatientDemographicsAppearInPid(Hl7OrderGenerator $generator): void
+    {
+        $pid = self::onlySegment(self::segments($generator->generate($this->orderId)->hl7), 'PID');
+
+        $this->assertStringContainsString(
+            $this->patientColumn('lname') . '^' . $this->patientColumn('fname'),
+            $pid,
+            'PID-5 patient name'
+        );
+        $this->assertStringContainsString(
+            str_replace('-', '', $this->patientColumn('DOB')),
+            $pid,
+            'PID-7 date of birth'
+        );
+        $this->assertStringContainsString($this->patientColumn('city'), $pid, 'PID-11 city');
+        $this->assertStringContainsString($this->patientColumn('postal_code'), $pid, 'PID-11 postal code');
+    }
+
+    #[Test]
+    #[DataProvider('generatorProvider')]
+    public function testOrderingProviderAppearsInPatientVisitAndCommonOrder(Hl7OrderGenerator $generator): void
+    {
+        $segments = self::segments($generator->generate($this->orderId)->hl7);
+        $expectedProvider = self::ORDERING_PROVIDER_NPI . '^' . $this->providerLastName();
+
+        $pv1 = self::fields(self::onlySegment($segments, 'PV1'));
+        $this->assertStringStartsWith($expectedProvider, $pv1[7], 'PV1-8 attending doctor');
+
+        foreach (self::segmentsOfType($segments, 'ORC') as $orc) {
+            $this->assertStringStartsWith($expectedProvider, self::fields($orc)[12], 'ORC-12 ordering provider');
+        }
+
+        foreach (self::segmentsOfType($segments, 'OBR') as $obr) {
+            $this->assertStringContainsString($expectedProvider, $obr, 'OBR ordering provider');
+        }
+    }
+
+    #[Test]
+    #[DataProvider('generatorProvider')]
+    public function testObservationRequestsCarryEveryOrderedProcedureCode(Hl7OrderGenerator $generator): void
+    {
+        $hl7 = $generator->generate($this->orderId)->hl7;
+        $observationRequests = self::segmentsOfType(self::segments($hl7), 'OBR');
+
+        $this->assertCount(
+            count(self::PROCEDURE_CODES),
+            $observationRequests,
+            'One OBR per orderable procedure code'
+        );
+
+        $joined = implode(chr(self::CR), $observationRequests);
+        foreach (self::PROCEDURE_CODES as $code => $name) {
+            $this->assertStringContainsString($code . '^' . $name, $joined);
+        }
+    }
+
+    #[Test]
+    public function testPlacerOrderNumberFormatDiffersByGenerator(): void
+    {
+        $facility = $this->providerColumn('send_fac_id');
+        $zeroPadded = str_pad((string) $this->orderId, 4, '0', STR_PAD_LEFT);
+
+        $this->assertSame($zeroPadded, $this->placerOrderNumber(default_gen_hl7_order($this->orderId)));
+        $this->assertSame(
+            $facility . '-' . $zeroPadded,
+            $this->placerOrderNumber(universal_gen_hl7_order($this->orderId))
+        );
+        $this->assertSame(
+            $facility . '-' . $zeroPadded,
+            $this->placerOrderNumber(quest_gen_hl7_order($this->orderId))
+        );
+        $this->assertSame((string) $this->orderId, $this->placerOrderNumber(labcorp_gen_hl7_order($this->orderId)));
+    }
+
+    #[Test]
+    public function testOnlyLabCorpPopulatesRequisitionData(): void
+    {
+        $this->assertSame('', default_gen_hl7_order($this->orderId)->requisitionData);
+        $this->assertSame('', universal_gen_hl7_order($this->orderId)->requisitionData);
+        $this->assertSame('', quest_gen_hl7_order($this->orderId)->requisitionData);
+        $this->assertNotSame('', labcorp_gen_hl7_order($this->orderId)->requisitionData);
+    }
+
+    #[Test]
+    public function testLabCorpRequisitionDataIsAStructuredBarcodeRecord(): void
+    {
+        $requisition = labcorp_gen_hl7_order($this->orderId)->requisitionData;
+
+        $this->assertSame(strtoupper($requisition), $requisition, 'The 2D barcode record is uppercased');
+        $this->assertStringNotContainsString(chr(self::LF), $requisition);
+
+        $records = self::segments($requisition);
+        $this->assertSame(
+            ['H', 'P', 'C', 'A', 'T', 'M', 'D', 'L', 'E'],
+            array_map(static fn (string $record): string => substr($record, 0, 1), $records),
+            'Record types and their order'
+        );
+
+        $byType = array_combine(
+            array_map(static fn (string $record): string => substr($record, 0, 1), $records),
+            $records
+        );
+
+        $this->assertStringContainsString(
+            strtoupper($this->patientColumn('lname')),
+            $byType['P'],
+            'P record carries the patient name'
+        );
+        $this->assertStringContainsString((string) $this->orderId, $byType['P'], 'P record carries the order id');
+
+        foreach (array_keys(self::PROCEDURE_CODES) as $code) {
+            $this->assertStringContainsString((string) $code, $byType['T'], 'T record carries the ordered tests');
+        }
+
+        $this->assertStringContainsString('E78.5', $byType['D'], 'D record carries the order diagnosis');
+        $this->assertMatchesRegularExpression('/^L\|\d+\|$/', $byType['L'], 'L record carries the record length');
+        $this->assertSame('E|0|', $byType['E']);
+    }
+
+    #[Test]
+    #[DataProvider('generatorProvider')]
+    public function testUnknownOrderIdThrows(Hl7OrderGenerator $generator): void
+    {
+        $unknownOrderId = $this->orderId + 100000;
+
+        $this->expectException(Hl7OrderGenerationException::class);
+        $this->expectExceptionMessage((string) $unknownOrderId);
+        $generator->generate($unknownOrderId);
+    }
+
+    #[Test]
+    public function testLabCorpThrowsWhenFacilityAccountCodeIsMissing(): void
+    {
+        $this->setOrderColumns(['account' => '']);
+
+        $this->expectException(Hl7OrderGenerationException::class);
+        $this->expectExceptionMessage('facility location account code');
+        labcorp_gen_hl7_order($this->orderId);
+    }
+
+    #[Test]
+    #[DataProvider('insuranceBillingGeneratorProvider')]
+    public function testInsuranceBilledOrderWithoutPayersThrows(Hl7OrderGenerator $generator): void
+    {
+        $this->setOrderColumns(['billing_type' => 'T']);
+
+        $this->expectException(Hl7OrderGenerationException::class);
+        $this->expectExceptionMessage('does not have any payers on record');
+        $generator->generate($this->orderId);
+    }
+
+    #[Test]
+    public function testDefaultGeneratorIgnoresBillingTypeAndOmitsInsuranceWithoutPayers(): void
+    {
+        $this->setOrderColumns(['billing_type' => 'T']);
+
+        $segments = self::segments(default_gen_hl7_order($this->orderId)->hl7);
+        $segmentIds = array_map(static fn (string $segment): string => substr($segment, 0, 3), $segments);
+
+        $this->assertContains('MSH', $segmentIds);
+        $this->assertNotContains('IN1', $segmentIds, 'The default generator emits IN1 only for payers on file');
+    }
+
+    /**
+     * @return array<string, array{Hl7OrderGenerator}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function generatorProvider(): array
+    {
+        return [
+            'default' => [Hl7OrderGenerator::DefaultLab],
+            'universal' => [Hl7OrderGenerator::Universal],
+            'labcorp' => [Hl7OrderGenerator::LabCorp],
+            'quest' => [Hl7OrderGenerator::Quest],
+        ];
+    }
+
+    /**
+     * Partial names of the four procedure_providers fixtures, as accepted by
+     * ProcedureProviderFixtureManager::getProviderByName().
+     *
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function labFixtureNameProvider(): array
+    {
+        return [
+            'generic' => ['Generic Lab'],
+            'ammon' => ['Ammon Lab'],
+            'labcorp' => ['LabCorp'],
+            'quest' => ['Quest'],
+        ];
+    }
+
+    /**
+     * Generators that refuse to build a message when the order is billed to
+     * insurance but the patient has no payers on file.
+     *
+     * @return array<string, array{Hl7OrderGenerator}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function insuranceBillingGeneratorProvider(): array
+    {
+        return [
+            'universal' => [Hl7OrderGenerator::Universal],
+            'labcorp' => [Hl7OrderGenerator::LabCorp],
+            'quest' => [Hl7OrderGenerator::Quest],
+        ];
+    }
+
+    /**
+     * Segments each generator must and must not emit for a self pay order with
+     * no payers and no guarantor on file.
+     *
+     * @return array<string, array{Hl7OrderGenerator, list<string>, list<string>}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function segmentExpectationProvider(): array
+    {
+        return [
+            'default' => [
+                Hl7OrderGenerator::DefaultLab,
+                ['MSH', 'PID', 'NTE', 'PV1', 'GT1', 'ORC', 'OBR', 'DG1'],
+                ['IN1'],
+            ],
+            'universal' => [
+                Hl7OrderGenerator::Universal,
+                ['MSH', 'PID', 'NTE', 'PV1', 'IN1', 'GT1', 'ORC', 'OBR', 'DG1'],
+                [],
+            ],
+            'labcorp' => [
+                Hl7OrderGenerator::LabCorp,
+                ['MSH', 'PID', 'PV1', 'IN1', 'DG1', 'ZCI', 'ORC', 'OBR'],
+                ['NTE', 'GT1'],
+            ],
+            'quest' => [
+                Hl7OrderGenerator::Quest,
+                ['MSH', 'PID', 'NTE', 'PV1', 'IN1', 'GT1', 'ORC', 'OBR', 'DG1', 'OBX'],
+                [],
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function segments(string $message): array
+    {
+        return array_values(array_filter(explode(chr(self::CR), $message), static fn (string $s): bool => $s !== ''));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function fields(string $segment): array
+    {
+        return explode('|', $segment);
+    }
+
+    /**
+     * @param list<string> $segments
+     * @return list<string>
+     */
+    private static function segmentsOfType(array $segments, string $segmentId): array
+    {
+        return array_values(array_filter(
+            $segments,
+            static fn (string $segment): bool => str_starts_with($segment, $segmentId . '|')
+        ));
+    }
+
+    /**
+     * @param list<string> $segments
+     */
+    private static function onlySegment(array $segments, string $segmentId): string
+    {
+        $matches = self::segmentsOfType($segments, $segmentId);
+        self::assertCount(1, $matches, "Expected exactly one {$segmentId} segment");
+        return $matches[0];
+    }
+
+    /**
+     * ORC-2 and OBR-2 both carry the placer order number, and each generator
+     * formats it differently.
+     */
+    private function placerOrderNumber(Hl7OrderResult $result): string
+    {
+        $segments = self::segments($result->hl7);
+        $fromCommonOrder = self::fields(self::segmentsOfType($segments, 'ORC')[0])[2];
+        foreach (self::segmentsOfType($segments, 'OBR') as $obr) {
+            $this->assertSame($fromCommonOrder, self::fields($obr)[2], 'OBR-2 must match ORC-2');
+        }
+        return $fromCommonOrder;
+    }
+
+    /**
+     * Add the procedure_type rows the ordered codes refer to. The default
+     * generator joins procedure_type on the procedure name to find the
+     * specimen, and the LabCorp generator looks it up by procedure code, so
+     * without these rows neither emits an OBR the way production does.
+     */
+    private function installProcedureTypes(): void
+    {
+        foreach (self::PROCEDURE_CODES as $code => $name) {
+            QueryUtils::sqlStatementThrowException(
+                <<<'SQL'
+                INSERT INTO procedure_type
+                SET name = ?, procedure_code = ?, procedure_type = 'ord', specimen = 'BLOOD', description = ?
+                SQL,
+                [$name, (string) $code, self::PROCEDURE_TYPE_MARKER]
+            );
+        }
+    }
+
+    /**
+     * Add the encounter vitals the LabCorp generator reads for the ZCI segment
+     * and the height/weight fields of the 2D barcode requisition. Without them
+     * that generator dereferences a `false` result row.
+     */
+    private function installVitals(): void
+    {
+        $encounter = QueryUtils::fetchSingleValue(
+            <<<'SQL'
+            SELECT f.encounter
+            FROM forms f
+            WHERE f.formdir = 'procedure_order' AND f.form_id = ?
+            SQL,
+            'encounter',
+            [$this->orderId]
+        );
+        $this->assertIsInt($encounter, 'Order fixture must be linked to an encounter');
+
+        $patientId = QueryUtils::fetchSingleValue(
+            'SELECT pid FROM forms WHERE formdir = ? AND form_id = ?',
+            'pid',
+            ['procedure_order', $this->orderId]
+        );
+        $this->assertIsInt($patientId);
+
+        $vitalsId = QueryUtils::sqlInsert(
+            <<<'SQL'
+            INSERT INTO form_vitals
+            SET pid = ?, activity = 1, date = NOW(), weight = ?, height = ?, bps = ?, bpd = ?,
+                waist_circ = ?, note = ?
+            SQL,
+            [$patientId, '180.500000', '70.000000', '120', '80', '34.000000', self::VITALS_MARKER]
+        );
+
+        QueryUtils::sqlStatementThrowException(
+            <<<'SQL'
+            INSERT INTO forms
+            SET date = NOW(), encounter = ?, form_name = 'Vitals', form_id = ?, pid = ?,
+                user = 'admin', groupname = 'Default', authorized = 1, formdir = 'vitals'
+            SQL,
+            [$encounter, $vitalsId, $patientId]
+        );
+    }
+
+    /**
+     * The shared user fixture has no NPI, which leaves the provider identifier
+     * component of PV1, ORC and OBR empty. Give the ordering provider one for
+     * the duration of the test so those fields can be asserted on.
+     */
+    private function stampOrderingProviderNpi(): void
+    {
+        $providerId = QueryUtils::fetchSingleValue(
+            'SELECT provider_id FROM procedure_order WHERE procedure_order_id = ?',
+            'provider_id',
+            [$this->orderId]
+        );
+        $this->assertIsInt($providerId, 'Order fixture must reference an ordering provider');
+        $this->orderingProviderId = $providerId;
+
+        $npi = QueryUtils::fetchSingleValue('SELECT npi FROM users WHERE id = ?', 'npi', [$providerId]);
+        $this->originalOrderingProviderNpi = is_string($npi) ? $npi : null;
+
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE users SET npi = ? WHERE id = ?',
+            [self::ORDERING_PROVIDER_NPI, $providerId]
+        );
+    }
+
+    private function restoreOrderingProviderNpi(): void
+    {
+        if ($this->orderingProviderId === 0) {
+            return;
+        }
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE users SET npi = ? WHERE id = ?',
+            [$this->originalOrderingProviderNpi, $this->orderingProviderId]
+        );
+    }
+
+    /**
+     * @param array<string, string> $columns
+     */
+    private function setOrderColumns(array $columns): void
+    {
+        foreach ($columns as $column => $value) {
+            QueryUtils::sqlStatementThrowException(
+                'UPDATE procedure_order SET `' . $column . '` = ? WHERE procedure_order_id = ?',
+                [$value, $this->orderId]
+            );
+        }
+    }
+
+    private function providerLastName(): string
+    {
+        $lastName = QueryUtils::fetchSingleValue(
+            'SELECT lname FROM users WHERE id = ?',
+            'lname',
+            [$this->orderingProviderId]
+        );
+        $this->assertIsString($lastName);
+        return $lastName;
+    }
+
+    private function patientColumn(string $column): string
+    {
+        $value = QueryUtils::fetchSingleValue(
+            <<<'SQL'
+            SELECT pd.fname, pd.lname, pd.mname, pd.DOB, pd.sex, pd.city, pd.state, pd.postal_code
+            FROM procedure_order po
+            JOIN forms f ON f.formdir = 'procedure_order' AND f.form_id = po.procedure_order_id
+            JOIN patient_data pd ON pd.pid = f.pid
+            WHERE po.procedure_order_id = ?
+            SQL,
+            $column,
+            [$this->orderId]
+        );
+        $this->assertIsString($value, "patient_data.{$column} should be a string");
+        return $value;
+    }
+
+    private function providerColumn(string $column): string
+    {
+        $value = QueryUtils::fetchSingleValue(
+            <<<'SQL'
+            SELECT pp.send_app_id, pp.send_fac_id, pp.recv_app_id, pp.recv_fac_id, pp.name
+            FROM procedure_order po
+            JOIN procedure_providers pp ON pp.ppid = po.lab_id
+            WHERE po.procedure_order_id = ?
+            SQL,
+            $column,
+            [$this->orderId]
+        );
+        $this->assertIsString($value, "procedure_providers.{$column} should be a string");
+        return $value;
+    }
+}

--- a/tests/Tests/Services/ProcedureOrder/Hl7OrderGenerator.php
+++ b/tests/Tests/Services/ProcedureOrder/Hl7OrderGenerator.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Identifies one of the four vendor-specific HL7 order generators.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Services\ProcedureOrder;
+
+use OpenEMR\Common\Orders\Hl7OrderResult;
+
+/**
+ * Every implementation of the gen_hl7_order contract is a global function
+ * declared in an include file rather than a service, so a test can only name
+ * one by calling it. This enum lets a data provider name a generator without
+ * resolving it: PHPUnit builds data sets before setUpBeforeClass() has run the
+ * require_once calls, so anything that binds a function at creation time — a
+ * first class callable, a callable-string, a Closure::fromCallable() — fails
+ * with "Call to undefined function". A case is inert until {@see generate()}
+ * runs it from inside the test body, by which point the includes are loaded.
+ */
+enum Hl7OrderGenerator
+{
+    /** interface/orders/gen_hl7_order.inc.php — the generator every lab gets unless it ships its own. */
+    case DefaultLab;
+
+    /** interface/procedure_tools/gen_universal_hl7/gen_hl7_order.inc.php */
+    case Universal;
+
+    /** interface/procedure_tools/labcorp/gen_hl7_order.inc.php */
+    case LabCorp;
+
+    /** interface/procedure_tools/quest/gen_hl7_order.inc.php */
+    case Quest;
+
+    public function generate(int $orderId): Hl7OrderResult
+    {
+        return match ($this) {
+            self::DefaultLab => default_gen_hl7_order($orderId),
+            self::Universal => universal_gen_hl7_order($orderId),
+            self::LabCorp => labcorp_gen_hl7_order($orderId),
+            self::Quest => quest_gen_hl7_order($orderId),
+        };
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:

Integration coverage for all four HL7 order generators — `default_gen_hl7_order()`, `universal_gen_hl7_order()`, `labcorp_gen_hl7_order()`, and `quest_gen_hl7_order()`. These had no test coverage.

Supersedes the test half of #9178. That PR could only test one generator per process, because all four defined a global `gen_hl7_order()` with different signatures — four of its tests were `markTestSkipped` placeholders. #9207 gave them distinct names, a uniform `int` parameter, an `Hl7OrderResult` return, and `Hl7OrderGenerationException` on error, which makes testing all four in one process straightforward. There are no skipped tests here.

#### Changes proposed in this pull request:

12 test methods, 40 cases, 553 assertions:

- Well-formed ORM^O01 output — CR-terminated, no stray LF, every segment matching the segment-ID grammar, MSH-9 and MSH-12 as expected.
- MSH routing fields come from the `procedure_providers` row, and follow the lab the order actually points at.
- Expected segments present (and unexpected ones absent) per generator.
- Patient demographics in PID; ordering provider in PV1-8, ORC-12, and OBR; one OBR per orderable code.
- Placer order number format, which differs three ways across the four generators.
- LabCorp requisition data — a structured barcode record with typed rows in a fixed order. This is the path #9178 could not reach.
- The three real `throw` sites, plus confirmation that the default generator does not share the insurance-billing one.

> **Depends on #13544 — merge that one first.**
>
> This branch is built on `test-procedure-order-fixtures`, so the diff below also contains that PR's two fixture commits. Once #13544 merges, this reduces to the test file plus its enum. Reviewing alongside #13544 is fine; merging before it is not.
>
> Base is deliberately `master` rather than the parent branch. Targeting the parent looks tidier but suppresses most of CI: `test-all.yml` only triggers on `pull_request` against `master`/`rel-*`, and `integration-tests.yml` runs `--testsuite common,controllers,fixtures,validators,unit`, which excludes `services`. With a non-`master` base this test never executes and reports 0% patch coverage against a green board.

Two notes for reviewers, neither addressed here:

- Only LabCorp populates `Hl7OrderResult::$requisitionData`; the other three return the default empty string.
- LabCorp emits 6 PHP warnings on every invocation from two uninitialized arrays (`$M` and `$D` are missing from the pre-initialization loop that seeds the other nine record arrays). Filed separately — production fix, not a test change. `failOnWarning` is not set in `phpunit.xml`, so these exit 0 and do not turn CI red today — measured. But an order with no diagnosis takes a path that raises `strlen()`/`substr()` *deprecations* instead, and `failOnDeprecation` **is** set, so that path exits 1. (PHPUnit does not mark those tests failed — the summary still reads `OK, but there were issues!` and only the exit code carries the signal.) This PR does not cover that path: it would turn CI red for a production bug rather than a test defect. It is the natural regression test once #13546 lands, and it has to land in that order.

#### Does your code include anything generated by an AI Engine? Yes
