### PR TITLE
refactor(portal): use HTMLPurifier for document template content and drop dead GET branch (backport #13541 to rel-830)

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -24718,7 +24718,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
-    'count' => 6,
+    'count' => 5,
     'path' => __DIR__ . '/../../portal/import_template.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -2303,7 +2303,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 9,
+    'count' => 10,
     'path' => __DIR__ . '/../../portal/import_template.php',
 ];
 $ignoreErrors[] = [
@@ -3103,7 +3103,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 8,
+    'count' => 4,
     'path' => __DIR__ . '/../../src/Services/DocumentTemplates/DocumentTemplateService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -2998,7 +2998,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 17,
+    'count' => 16,
     'path' => __DIR__ . '/../../portal/import_template.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -3912,18 +3912,13 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/import_template.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../portal/import_template.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
     'count' => 41,
     'path' => __DIR__ . '/../../portal/import_template.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 13,
+    'count' => 12,
     'path' => __DIR__ . '/../../portal/import_template.php',
 ];
 $ignoreErrors[] = [

--- a/portal/import_template.php
+++ b/portal/import_template.php
@@ -6,13 +6,16 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2016-2026 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -309,8 +312,6 @@ if (($_REQUEST['mode'] ?? '') === 'editor_render_html') {
     } else {
         die(xlt('Invalid File'));
     }
-} elseif (!empty($_GET['templateHtml'] ?? null)) {
-    renderEditorHtml($_REQUEST['docid'], $_GET['templateHtml']);
 }
 
 /**
@@ -321,6 +322,13 @@ function renderEditorHtml($template_id, $content): void
 {
     global $authUploadTemplates;
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
+
+    // Purify on render as well as on write — Summernote loads the textarea
+    // value as HTML, and older rows may pre-date write-time purification.
+    // Look up the stored mime so PDF and other binary templates skip HTML sanitization.
+    $existing = QueryUtils::querySingleRow('SELECT `mime` FROM `document_templates` WHERE `id` = ?', [$template_id]);
+    $mimetype = is_array($existing) && is_string($existing['mime'] ?? null) ? $existing['mime'] : null;
+    $content = DocumentTemplateService::purifyTemplateContent((string) $content, $mimetype);
 
     $lists = [
         '{ParseAsHTML}', '{ParseAsText}', '{styleBlockStart}', '{styleBlockEnd}', '{SignaturesRequired}', '{TextInput}', '{sizedTextInput:120px}', '{smTextInput}', '{TextBox:03x080}', '{CheckMark}', '{RadioGroup:option1_many...}', '{RadioGroupInline:option1_many...}', '{ynRadioGroup}', '{TrueFalseRadioGroup}', '{DatePicker}', '{DateTimePicker}', '{StandardDatePicker}', '{CurrentDate:"global"}', '{CurrentTime}', '{DOS}', '{ReferringDOC}', '{PatientID}', '{PatientName}', '{PatientSex}', '{PatientDOB}', '{PatientPhone}', '{Address}', '{City}', '{State}', '{Zip}', '{PatientSignature}', '{AdminSignature}', '{WitnessSignature}', '{AcknowledgePdf:pdf name or id:title}', '{EncounterForm:LBF}', '{Questionnaire:name or id}', '{Medications}', '{ProblemList}', '{Allergies}', '{ChiefComplaint}', '{DEM: }', '{HIS: }', '{LBF: }', '{GRP}{/GRP}'

--- a/src/Services/DocumentTemplates/DocumentTemplateService.php
+++ b/src/Services/DocumentTemplates/DocumentTemplateService.php
@@ -6,15 +6,20 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2021-2022 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 namespace OpenEMR\Services\DocumentTemplates;
 
 use Exception;
+use HTMLPurifier;
+use HTMLPurifier_Config;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\QuestionnaireService;
 use RuntimeException;
 
@@ -574,10 +579,9 @@ class DocumentTemplateService extends QuestionnaireService
      */
     public function insertTemplate($pid, $category, $template, $content, $mimetype = null, $profile = null): int
     {
-        // prevent template save if unsafe. Check for escaped and unescaped content.
-        if (stripos((string) $content, text('<script')) !== false || stripos((string) $content, '<script') !== false) {
-            throw new RuntimeException(xlt("Template rejected. JavaScript not allowed"));
-        }
+        // Purify template content before persistence — Summernote loads the
+        // stored value into a textarea as HTML. See purifyTemplateContent().
+        $content = self::purifyTemplateContent((string) $content, $mimetype);
 
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
@@ -593,7 +597,7 @@ class DocumentTemplateService extends QuestionnaireService
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE `pid` = ?, `provider`= ?, `template_content`= ?, `size`= ?, `modified_date` = NOW(), `mime` = ?";
 
-        return sqlInsert($sql, [$pid, $session->get('authUserID'), ($profile ?: ''), $category ?: '', $template, $name, 'New', $content, strlen((string) $content), $mimetype, $pid, $session->get('authUserID'), $content, strlen((string) $content), $mimetype]);
+        return sqlInsert($sql, [$pid, $session->get('authUserID'), ($profile ?: ''), $category ?: '', $template, $name, 'New', $content, strlen($content), $mimetype, $pid, $session->get('authUserID'), $content, strlen($content), $mimetype]);
     }
 
     /**
@@ -700,12 +704,49 @@ class DocumentTemplateService extends QuestionnaireService
      */
     public function updateTemplateContent($id, $content)
     {
-        // prevent template save if unsafe. Check for escaped and unescaped content.
-        if (stripos((string) $content, text('<script')) !== false || stripos((string) $content, '<script') !== false) {
-            throw new RuntimeException(xlt("Template rejected. JavaScript not allowed"));
-        }
+        // Same purification as insertTemplate() — see purifyTemplateContent().
+        // Look up the stored mime so PDF and other binary templates skip HTML sanitization.
+        $existing = QueryUtils::querySingleRow('SELECT `mime` FROM `document_templates` WHERE `id` = ?', [$id]);
+        $mimetype = is_array($existing) && is_string($existing['mime'] ?? null) ? $existing['mime'] : null;
+        $content = self::purifyTemplateContent((string) $content, $mimetype);
 
         return sqlQuery('UPDATE `document_templates` SET `template_content` = ?, modified_date = NOW() WHERE `id` = ?', [$content, $id]);
+    }
+
+    /**
+     * Sanitize document-template content with HTMLPurifier.
+     *
+     * Strips <script>, event-handler attributes, and javascript: URLs while
+     * preserving the rich-text markup the WYSIWYG editor needs. PDF and other
+     * binary mime types are returned untouched — purifying them would corrupt
+     * the file. Template directives written as {DirectiveName} are restored
+     * after purification, since HTMLPurifier URL-encodes braces inside URIs.
+     */
+    public static function purifyTemplateContent(?string $content, ?string $mimetype = null): string
+    {
+        $content ??= '';
+
+        if ($content === '' || $mimetype === 'application/pdf') {
+            return $content;
+        }
+
+        $config = HTMLPurifier_Config::createDefault();
+        $config->set('Core.Encoding', 'UTF-8');
+        $purifyTempDir = OEGlobalsBag::getInstance()->getString('temporary_files_dir')
+            . DIRECTORY_SEPARATOR . 'htmlpurifier';
+        if (is_dir($purifyTempDir) || mkdir($purifyTempDir, 0700, true) || is_dir($purifyTempDir)) {
+            $config->set('Cache.SerializerPath', $purifyTempDir);
+        } else {
+            // Skip caching rather than fall back to HTMLPurifier's default path,
+            // which writes inside vendor/ — typically read-only and noisy.
+            $config->set('Cache.DefinitionImpl', null);
+        }
+
+        $purified = (new HTMLPurifier($config))->purify($content);
+
+        // HTMLPurifier percent-encodes braces that appear in URIs; the renderer
+        // expects literal {Directive} markers, so swap them back.
+        return str_replace(['%7B', '%7D'], ['{', '}'], $purified);
     }
 
     /**


### PR DESCRIPTION
Cherry-pick of #13541 (`ba316dd1d8`) onto `rel-830`. Patch-id verified equal (`8ed1804cd5…`).

Original PR body:

Replace the old `stripos('<script')` substring check in
`DocumentTemplateService::insertTemplate()` and `updateTemplateContent()`
with `HTMLPurifier` — the substring check missed event-handler attributes
(`onerror`, `onload`, ...) and `javascript:` URLs. Applied on both write and
render paths so legacy rows in `document_templates.template_content` get
sanitized on reopen in Summernote. PDF templates skip purification.
Template directives `{Directive}` are restored after HTMLPurifier
percent-encodes braces in URIs.

Drop the unused `templateHtml` GET branch in `portal/import_template.php`
— the only production render path is the `editor_render_html` POST
branch above it.