### PR TITLE
ci(isolated-tests): don't let the pre-release PHP 8.6 job cancel or block the supported versions

### DIFF
--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -26,6 +26,11 @@ jobs:
     runs-on: ubuntu-24.04
 
     strategy:
+      # A failure on one PHP version says nothing about the others, and 8.6 is
+      # still in development — its nightly builds regress from time to time.
+      # Cancelling the production versions on an 8.6 failure hides whether the
+      # supported versions actually pass.
+      fail-fast: false
       matrix:
         php-version:
         - '8.3'

--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -40,6 +40,11 @@ jobs:
 
     name: PHP ${{ matrix.php-version }} - Isolated Tests
 
+    # PHP 8.6 is not released yet, so it runs against a nightly build that can
+    # regress underneath us. Report those failures as warnings rather than
+    # blocking every PR on an upstream php-src bug. Drop this once 8.6 ships.
+    continue-on-error: ${{ matrix.php-version == '8.6' }}
+
     steps:
     - uses: actions/checkout@v7
 


### PR DESCRIPTION
The `Isolated Tests` matrix ran with the default `fail-fast`, so a failure on any one PHP version cancelled the others. PHP 8.6 has no stable release yet — that job builds against a nightly that can regress independently of anything in this repo — so when 8.6 fails first, 8.4 and 8.5 get cancelled and the run reports nothing about the versions OpenEMR actually supports.

That is happening on master right now. A php-src regression landed in the 8.6 nightly on 2026-08-12 and makes 15 Twig render-fixture tests fail; the last three master runs are red with 8.4 and 8.5 cancelled.

Two changes:

1. `fail-fast: false`, so every PHP version reports independently. `syntax.yml` and `test-scheduled.yml` already do this.
2. `continue-on-error` on the 8.6 matrix entry only, so a pre-release-PHP regression surfaces as a warning instead of gating every PR through `All Checks Passed`. Revert that once 8.6 ships.

### The underlying php-src regression

Not an OpenEMR bug, and worth knowing about because it is queued for stable releases.

[`0ccff76`](https://github.com/php/php-src/commit/0ccff767634b4c453f2971d256de86cc433c37fe) ("Fix GH-15375: nested `yield from` skips items after valid()/next()") makes a three-level `yield from` chain emit a value twice when the middle generator ends with `yield from []`. Twig compiles every template's `doDisplay()` to end with exactly `yield from [];`, so rendering any template containing a block or include duplicates all output emitted after that block.

Confirmed by bisection: building php-src at the failing nightly commit reproduces all 15 failures locally with no Xdebug; reverse-applying only that commit's `Zend/zend_generators.c` hunks and rebuilding restores 22/22 passing. Reduced to a 20-line pure-PHP repro with no Twig involved.

The commit is on the PHP-8.4 and PHP-8.5 branches as well, so 8.4.26 and 8.5.11 are expected to break Twig rendering unless it is reverted upstream first. Reported at php/php-src#23301.
