### PR TITLE
fix(rector): gather scattered use statements into a single block

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -202,7 +202,10 @@ repos:
       library helpers) or .php (new code).
     language: fail
     files: \.inc$
-    exclude: ^tests/Rector/Rules/Fixture/[^/]+\.php\.inc$
+    # Rector's fixture format is fixed at .php.inc, and each rule needs its own
+    # fixture directory so one rule's test does not pick up another's fixtures.
+    # These are test data, never served.
+    exclude: ^tests/Rector/Rules/Fixture[^/]*/[^/]+\.php\.inc$
 
   - id: php-syntax-check
     name: PHP Syntax Check

--- a/custom/export_qrda_xml.php
+++ b/custom/export_qrda_xml.php
@@ -22,19 +22,19 @@
  * @link    https://www.open-emr.org
  */
 
-require_once("../interface/globals.php");
 use OpenEMR\BC\ServiceContainer;
-require_once("../library/patient.inc.php");
-require_once "../library/options.inc.php";
-require_once("../library/clinical_rules.php");
-require_once "qrda_functions.php";
-
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FacilityService;
+
+require_once("../interface/globals.php");
+require_once("../library/patient.inc.php");
+require_once "../library/options.inc.php";
+require_once("../library/clinical_rules.php");
+require_once "qrda_functions.php";
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 CsrfUtils::checkCsrfInput(INPUT_GET, dieOnFail: true);

--- a/interface/forms/clinical_notes/new.php
+++ b/interface/forms/clinical_notes/new.php
@@ -17,13 +17,17 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once("../../globals.php");
-
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Events\Core\TemplatePageEvent;
+use OpenEMR\Services\ClinicalNotesService;
+use OpenEMR\Services\ListService;
+use OpenEMR\Services\PatientService;
+
+require_once("../../globals.php");
 
 // Hoist legacy `globals.php` locals so PHPStan can see them (#11792 Phase 5).
 $srcdir = OEGlobalsBag::getInstance()->getSrcDir();
@@ -32,10 +36,6 @@ require_once("$srcdir/api.inc.php");
 require_once("$srcdir/formatting.inc.php");
 require_once("$srcdir/patient.inc.php");
 require_once("$srcdir/options.inc.php");
-use OpenEMR\Events\Core\TemplatePageEvent;
-use OpenEMR\Services\ClinicalNotesService;
-use OpenEMR\Services\ListService;
-use OpenEMR\Services\PatientService;
 
 $returnurl = 'encounter_top.php';
 $formid = (int)($_GET['id'] ?? 0);

--- a/interface/main/finder/dynamic_finder.php
+++ b/interface/main/finder/dynamic_finder.php
@@ -16,20 +16,20 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(__DIR__ . "/../../globals.php");
-
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
-
-require_once OEGlobalsBag::getInstance()->getSrcDir() . "/options.inc.php";
 use OpenEMR\Events\UserInterface\PageHeadingRenderEvent;
 use OpenEMR\Menu\BaseMenuItem;
 use OpenEMR\OeUI\OemrUI;
 use OpenEMR\Services\PatientService;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+
+require_once(__DIR__ . "/../../globals.php");
+
+require_once OEGlobalsBag::getInstance()->getSrcDir() . "/options.inc.php";
 
 $uspfx = 'patient_finder.'; //substr(__FILE__, strlen($webserver_root)) . '.';
 $patient_finder_exact_search = prevSetting($uspfx, 'patient_finder_exact_search', 'patient_finder_exact_search', ' ');

--- a/portal/add_edit_event_user.php
+++ b/portal/add_edit_event_user.php
@@ -22,6 +22,7 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Services\AppointmentService;
 
 // Will start the (patient) portal OpenEMR session/cookie.
 // Need access to classes, so run autoloader now instead of in globals.php.
@@ -49,8 +50,6 @@ require_once("../interface/globals.php");
 require_once("$srcdir/patient.inc.php");
 require_once("$srcdir/forms.inc.php");
 require_once("$srcdir/appointments.inc.php");
-
-use OpenEMR\Services\AppointmentService;
 
 // Things that might be passed by our opener.
 //

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@
 declare(strict_types=1);
 
 use OpenEMR\Rector\Rules\CatchExceptionToThrowableRector;
+use OpenEMR\Rector\Rules\ConsolidateImportsRector;
 use OpenEMR\Rector\Rules\OEGlobalsBagTypedGettersRector;
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
@@ -97,6 +98,7 @@ return RectorConfig::configure()
     ->withRules([
         CallUserFuncArrayToVariadicRector::class,
         CatchExceptionToThrowableRector::class,
+        ConsolidateImportsRector::class,
         OEGlobalsBagTypedGettersRector::class,
         SimplifyIfElseToTernaryRector::class,
         UnnecessaryTernaryExpressionRector::class,

--- a/tests/Rector/Rules/ConsolidateImportsRector.php
+++ b/tests/Rector/Rules/ConsolidateImportsRector.php
@@ -124,12 +124,6 @@ CODE_SAMPLE
             $leading[] = array_shift($rest);
         }
 
-        // With a leading declare the file docblock already sits at the top of
-        // the file, attached to that declare; only hoist when imports lead.
-        if ($leading === []) {
-            $this->hoistFileDocblock($rest, $uses[0]);
-        }
-
         // PSR-12 wants class, then function, then const imports grouped by
         // kind. Partition stably so relative order survives within each group.
         $byType = [];
@@ -141,6 +135,16 @@ CODE_SAMPLE
         }
         ksort($byType);
         $uses = array_merge(...array_values($byType));
+
+        // Hoist only after partitioning: grouping by kind can promote a later
+        // import ahead of the one that led in statement order, and the docblock
+        // has to land on whichever import actually ends up first.
+        //
+        // With a leading declare the file docblock already sits at the top of
+        // the file, attached to that declare; only hoist when imports lead.
+        if ($leading === []) {
+            $this->hoistFileDocblock($rest, $uses[0]);
+        }
 
         // Drop the original-node link so the printer re-emits the imports
         // fresh. Otherwise it preserves the blank line that used to separate

--- a/tests/Rector/Rules/ConsolidateImportsRector.php
+++ b/tests/Rector/Rules/ConsolidateImportsRector.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * Rector rule to gather scattered use statements into a single block
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Rector\Rules;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Declare_;
+use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Use_;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\PhpParser\Node\FileNode;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Legacy global-namespace files often carry a `use` block below a bootstrap
+ * `require_once`. Name importing inserts new imports directly after `<?php`,
+ * leaving two disjoint `use` regions with code between them.
+ *
+ * That shape is actively dangerous, not merely untidy: the phpcbf fixer for
+ * SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses rewrites the whole
+ * span from the first `use` to the last and silently deletes every statement in
+ * between. On openemr/openemr that destroyed 26 files in one pass, including the
+ * X-Frame-Options and CSP frame-ancestors headers in interface/login/login.php.
+ * phpcs does not report the two-region shape, so nothing catches it.
+ *
+ * Collecting the imports into one contiguous block makes the sort a no-op
+ * hazard-wise, and puts the file docblock back above them. Relative order is
+ * preserved -- phpcbf sorts safely once there is a single region.
+ *
+ * @see \OpenEMR\Rector\Rules\ConsolidateImportsRectorTest
+ */
+class ConsolidateImportsRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Gather scattered use statements into a single contiguous block below the file docblock',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Vendor\Beta;
+
+/**
+ * File docblock.
+ */
+
+require_once __DIR__ . '/globals.php';
+
+use Vendor\Alpha;
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+/**
+ * File docblock.
+ */
+
+use Vendor\Beta;
+use Vendor\Alpha;
+
+require_once __DIR__ . '/globals.php';
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FileNode::class, Namespace_::class];
+    }
+
+    /**
+     * @param FileNode|Namespace_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $stmts = $node->stmts;
+
+        $useIndexes = [];
+        foreach ($stmts as $index => $stmt) {
+            if ($this->isImport($stmt)) {
+                $useIndexes[] = $index;
+            }
+        }
+
+        // Nothing to gather, or the imports already form one contiguous run.
+        $count = count($useIndexes);
+        if ($count < 2 || ($useIndexes[$count - 1] - $useIndexes[0] + 1) === $count) {
+            return null;
+        }
+
+        $uses = [];
+        $rest = [];
+        foreach ($stmts as $stmt) {
+            if ($this->isImport($stmt)) {
+                $uses[] = $stmt;
+            } else {
+                $rest[] = $stmt;
+            }
+        }
+
+        // `declare(strict_types=1)` must remain the very first statement, so
+        // any leading declares stay ahead of the imports.
+        $leading = [];
+        while ($rest !== [] && $rest[0] instanceof Declare_) {
+            $leading[] = array_shift($rest);
+        }
+
+        // With a leading declare the file docblock already sits at the top of
+        // the file, attached to that declare; only hoist when imports lead.
+        if ($leading === []) {
+            $this->hoistFileDocblock($rest, $uses[0]);
+        }
+
+        // PSR-12 wants class, then function, then const imports grouped by
+        // kind. Partition stably so relative order survives within each group.
+        $byType = [];
+        foreach ($uses as $use) {
+            // A GroupUse without an explicit `function`/`const` keyword carries
+            // TYPE_UNKNOWN; for ordering it is a plain class import.
+            $type = $use->type === Use_::TYPE_UNKNOWN ? Use_::TYPE_NORMAL : $use->type;
+            $byType[$type][] = $use;
+        }
+        ksort($byType);
+        $uses = array_merge(...array_values($byType));
+
+        // Drop the original-node link so the printer re-emits the imports
+        // fresh. Otherwise it preserves the blank line that used to separate
+        // the two regions, and PSR12.Files.FileHeader still sees two blocks.
+        // GroupUse keeps its link so multi-line groups are not reflowed onto
+        // one line, which would be pure diff noise.
+        foreach ($uses as $use) {
+            if (!$use instanceof GroupUse) {
+                $use->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            }
+        }
+
+        $node->stmts = [...$leading, ...$uses, ...$rest];
+
+        return $node;
+    }
+
+    /**
+     * `use A\B;` parses as Use_, `use A\{B, C};` as GroupUse. Both are imports
+     * and both count toward the non-contiguous shape phpcbf mishandles, so
+     * both have to be gathered.
+     */
+    private function isImport(Node $stmt): bool
+    {
+        return $stmt instanceof Use_ || $stmt instanceof GroupUse;
+    }
+
+    /**
+     * Move the file-level docblock onto the first import so it stays at the top
+     * of the file. Only a leading doc comment moves; trailing line comments
+     * describe the statement they sit on and stay with it.
+     *
+     * @param list<Node\Stmt> $rest
+     */
+    private function hoistFileDocblock(array $rest, Use_|GroupUse $firstUse): void
+    {
+        if ($rest === [] || $firstUse->getComments() !== []) {
+            return;
+        }
+
+        $first = $rest[0];
+        $comments = $first->getComments();
+        if ($comments === [] || !$comments[0] instanceof Doc) {
+            return;
+        }
+
+        $docblock = array_shift($comments);
+        $first->setAttribute('comments', $comments);
+        $firstUse->setAttribute('comments', [$docblock]);
+    }
+}

--- a/tests/Rector/Rules/ConsolidateImportsRectorTest.php
+++ b/tests/Rector/Rules/ConsolidateImportsRectorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Tests for ConsolidateImportsRector
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Rector\Rules;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+class ConsolidateImportsRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureConsolidateImports');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/consolidate-imports.php';
+    }
+}

--- a/tests/Rector/Rules/FixtureConsolidateImports/already_contiguous_no_change.php.inc
+++ b/tests/Rector/Rules/FixtureConsolidateImports/already_contiguous_no_change.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * File docblock.
+ *
+ * @package Demo
+ */
+
+use Vendor\Alpha;
+use Vendor\Beta;
+
+require_once __DIR__ . '/globals.php';
+
+?>

--- a/tests/Rector/Rules/FixtureConsolidateImports/groups_group_use_with_function_import.php.inc
+++ b/tests/Rector/Rules/FixtureConsolidateImports/groups_group_use_with_function_import.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Vendor\Alpha;
+
+use function Vendor\helper;
+
+require_once __DIR__ . '/globals.php';
+
+use Vendor\Nested\{
+    Beta,
+    Gamma,
+};
+
+return [Alpha::class, Beta::class, Gamma::class, helper(...)];
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+use Vendor\Alpha;
+
+use Vendor\Nested\{
+    Beta,
+    Gamma,
+};
+use function Vendor\helper;
+require_once __DIR__ . '/globals.php';
+
+return [Alpha::class, Beta::class, Gamma::class, helper(...)];
+
+?>

--- a/tests/Rector/Rules/FixtureConsolidateImports/hoists_docblock_onto_first_import_after_grouping.php.inc
+++ b/tests/Rector/Rules/FixtureConsolidateImports/hoists_docblock_onto_first_import_after_grouping.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+use function Vendor\helper;
+
+/**
+ * File docblock.
+ *
+ * @package Demo
+ */
+
+require_once __DIR__ . '/globals.php';
+
+use Vendor\Alpha;
+
+echo Alpha::run() . helper();
+
+?>
+-----
+<?php
+
+/**
+ * File docblock.
+ *
+ * @package Demo
+ */
+use Vendor\Alpha;
+use function Vendor\helper;
+require_once __DIR__ . '/globals.php';
+
+echo Alpha::run() . helper();
+
+?>

--- a/tests/Rector/Rules/FixtureConsolidateImports/keeps_declare_first.php.inc
+++ b/tests/Rector/Rules/FixtureConsolidateImports/keeps_declare_first.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Vendor\Beta;
+
+require_once __DIR__ . '/globals.php';
+
+use Vendor\Alpha;
+
+echo Alpha::run() . Beta::run();
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+use Vendor\Beta;
+use Vendor\Alpha;
+
+require_once __DIR__ . '/globals.php';
+
+echo Alpha::run() . Beta::run();
+
+?>

--- a/tests/Rector/Rules/FixtureConsolidateImports/single_import_no_change.php.inc
+++ b/tests/Rector/Rules/FixtureConsolidateImports/single_import_no_change.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * File docblock.
+ *
+ * @package Demo
+ */
+
+require_once __DIR__ . '/globals.php';
+
+use Vendor\Alpha;
+
+echo Alpha::run();
+
+?>

--- a/tests/Rector/Rules/FixtureConsolidateImports/two_regions_with_docblock.php.inc
+++ b/tests/Rector/Rules/FixtureConsolidateImports/two_regions_with_docblock.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+use Vendor\Beta;
+
+/**
+ * File docblock.
+ *
+ * @package Demo
+ */
+
+// prevent UI redressing
+header('X-Frame-Options: DENY');
+
+use Vendor\Alpha;
+
+require_once __DIR__ . '/globals.php';
+
+?>
+-----
+<?php
+
+/**
+ * File docblock.
+ *
+ * @package Demo
+ */
+use Vendor\Beta;
+use Vendor\Alpha;
+// prevent UI redressing
+header('X-Frame-Options: DENY');
+
+require_once __DIR__ . '/globals.php';
+
+?>

--- a/tests/Rector/Rules/config/consolidate-imports.php
+++ b/tests/Rector/Rules/config/consolidate-imports.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenEMR\Rector\Rules\ConsolidateImportsRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([
+        ConsolidateImportsRector::class,
+    ]);


### PR DESCRIPTION
A file with two non-contiguous `use` regions is not merely untidy in this codebase — it is a data-loss hazard.

The phpcbf fixer for `SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses` rewrites the entire span from the first `use` to the last and **silently deletes every statement in between**, then exits reporting success. This is [slevomat/coding-standard#1837](https://github.com/slevomat/coding-standard/issues/1837), still open upstream, and originally reported against this repository's own `sphere/process_response.php`.

Minimal reproduction, on slevomat 8.31.1 / PHP_CodeSniffer 4.0.4:

```php
<?php

use B;

echo 'important';

use A;
```

```console
$ vendor/bin/phpcbf --standard=<ruleset with only AlphabeticallySortedUses> repro.php
```

```php
<?php

use A;
use B;
```

`echo 'important';` is gone.

## Why this is worth a rule

Running phpcbf over an automated name-importing refactor destroyed 26 files locally. Real losses included every `require_once` in `interface/reports/amc_full_report.php`, the `require_once` for `C_Document.class.php` in `library/documents.php`, and the file docblock plus **both clickjacking headers** in `interface/login/login.php` — `header('X-Frame-Options: DENY')` and the CSP `frame-ancestors 'none'` header.

Critically, **phpcs does not report the two-region shape at all.** `login.php` was destroyed without ever being flagged, so fixing only the files phpcs complains about would not have saved it. Once the code is gone the file is "clean" and the diff reads as a plausible import reshuffle.

`ConsolidateImportsRector` removes the trigger rather than the symptom: with imports gathered into one contiguous block, the sort fixer has no span to eat. It also restores the file docblock to the top when imports had displaced it.

## Details, each covered by a fixture

- `declare(strict_types=1)` must remain the very first statement, so leading declares stay ahead of the imports.
- `use A\{B, C}` parses as `GroupUse`, not `Use_`. Treating it as a non-import both mis-ordered it against `use function` (PSR-12 wants class, then function, then const) and made 17 already-contiguous files look scattered, producing pointless rewrites. Catching this dropped the diff from 21 files to 4.
- `GroupUse` keeps its original-node link so multi-line groups are not reflowed onto one line; plain imports drop theirs, otherwise the printer preserves the blank line that used to separate the regions and `PSR12.Files.FileHeader` still sees two header blocks.
- No-op when imports are already contiguous, and when there is a single import, so the rule is idempotent.

## Scope

Four files in the tree have genuinely scattered imports and are consolidated here. Relative order is preserved within each import kind; phpcbf sorts safely once there is a single region.

## Verification

- `rector-rules` suite: 13/13
- `composer phpcs`, `composer rector-check`, PHPStan, and `php -l` clean on all changed files
- Per-file line counts, after stripping `use` lines and blank lines, are unchanged — the check that caught the original destruction. It has to run **after phpcbf**, not just after rector, since phpcbf is what does the deleting:

```bash
for f in $(git diff --name-only); do
  b=$(git show "HEAD:$f" | grep -vE '^\s*use .*;\s*$' | grep -cvE '^\s*$')
  a=$(grep -vE '^\s*use .*;\s*$' "$f" | grep -cvE '^\s*$')
  [ "$b" != "$a" ] && echo "DELTA $f: $b -> $a"
done
```
