### PR TITLE
ci(isolated-tests): temporarily mark PHP 8.6 non-blocking (upstream bug — release-gating)

### DIFF
--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -25,13 +25,30 @@ jobs:
   isolated-tests:
     runs-on: ubuntu-24.04
 
+    # TEMPORARY: PHP 8.6 marked experimental (non-blocking) pending
+    # upstream fix. The 8.6 leg is currently red on a known upstream
+    # PHP 8.6 bug we cannot resolve at the OpenEMR layer. The
+    # ship-release preflight (tools/release/src/GhPullRequestApi.php)
+    # treats ANY check with conclusion != SUCCESS/NEUTRAL/SKIPPED as
+    # a hard blocker and has no override flag, so the 8.6 red
+    # otherwise gates the imminent 8.3.0 release. `continue-on-error`
+    # on the experimental leg reports the check as SUCCESS even when
+    # the test step exits non-zero, letting ship-release proceed
+    # while preserving the 8.6 signal in the run log for tracking.
+    # REVERT this block once upstream PHP 8.6 stabilizes (drop the
+    # `include` + `continue-on-error`, restore hard gating).
     strategy:
+      fail-fast: false
       matrix:
         php-version:
         - '8.3'
         - '8.4'
         - '8.5'
         - '8.6'
+        include:
+        - php-version: '8.6'
+          experimental: true
+    continue-on-error: ${{ matrix.experimental == true }}
 
     name: PHP ${{ matrix.php-version }} - Isolated Tests
 


### PR DESCRIPTION
## Why (temporary — needed to unblock 8.3.0 release)

The PHP 8.6 isolated-tests matrix leg is currently red on a known upstream PHP 8.6 bug we cannot resolve at the OpenEMR layer.

ship-release preflight ([\`tools/release/src/GhPullRequestApi.php\`](https://github.com/openemr/openemr/blob/master/tools/release/src/GhPullRequestApi.php#L255) at lines 255-256) treats **any** check with conclusion != \`SUCCESS\`/\`NEUTRAL\`/\`SKIPPED\` as a hard blocker and has **no override flag**. So the 8.6 red gates the imminent 8.3.0 release out of rel-830 — surfaced by today's ship-release dry-run against rel-830, which failed preflight on the 8.6 conclusion.

## What

Add \`continue-on-error: true\` on the 8.6 matrix leg only. The leg still runs (we keep the signal in the run log for tracking + can watch for the upstream fix landing), but the check reports as \`SUCCESS\` to ship-release's preflight, letting the release proceed.

Also added \`fail-fast: false\` — without it, an 8.6 failure could cancel the 8.3/8.4/8.5 cells before completion (which was actually observed on release-finalize PR #13485's run today: 8.3/8.4/8.5 CANCELLED after 8.6 FAILURE, per the dry-run output).

## Revert plan

Once upstream PHP 8.6 stabilizes and the leg goes back to reliably green:
1. Drop the \`include:\` block that sets \`experimental: true\` on 8.6
2. Drop the \`continue-on-error: \${{ matrix.experimental == true }}\` line
3. (Optionally) drop \`fail-fast: false\` too if the original matrix behavior is preferred

\`strategy.matrix.php-version\` list stays as-is either way — we want to keep exercising 8.6 throughout.

## Test plan

- [ ] Rerun the dry-run of ship-release for 8.3.0 after this lands — preflight should now clear the 8.6 red on #13483 + #13485.
- [ ] Independently verify the check appears as SUCCESS (green) on both PRs after the workflow re-runs.

Assisted-by: Claude Code