### PR TITLE
ci(isolated-tests): port #13554 to rel-830 (PHP 8.6 non-blocking) — unblocks 8.3.0 release

### DIFF
--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -26,6 +26,11 @@ jobs:
     runs-on: ubuntu-24.04
 
     strategy:
+      # A failure on one PHP version says nothing about the others, and 8.6 is
+      # still in development — its nightly builds regress from time to time.
+      # Cancelling the production versions on an 8.6 failure hides whether the
+      # supported versions actually pass.
+      fail-fast: false
       matrix:
         php-version:
         - '8.3'
@@ -34,6 +39,11 @@ jobs:
         - '8.6'
 
     name: PHP ${{ matrix.php-version }} - Isolated Tests
+
+    # PHP 8.6 is not released yet, so it runs against a nightly build that can
+    # regress underneath us. Report those failures as warnings rather than
+    # blocking every PR on an upstream php-src bug. Drop this once 8.6 ships.
+    continue-on-error: ${{ matrix.php-version == '8.6' }}
 
     steps:
     - uses: actions/checkout@v7


### PR DESCRIPTION
Straight cherry-pick of #13554 onto rel-830. Byte-equal to master via \`git patch-id --stable\`:

\`\`\`
master #13554  (ad464e4e11): b47df200c5ec5e705bf99ef1c65697151d92c396
rel-830 port   (32ccce4aa8): b47df200c5ec5e705bf99ef1c65697151d92c396
\`\`\`

## Why on rel-830

\`.github/workflows/isolated-tests.yml\` is NOT byte-identical-enforced (checked \`.github/byte-identical.yml\`), so #13554 doesn't propagate to rel-830 via the sync PR mechanism. Manual port needed.

The rel-830 branch runs its own copy of \`isolated-tests.yml\` on any push/PR — including release-prep #13483 and release-finalize #13485. Ship-release preflight blocks on any non-SUCCESS check conclusion (\`tools/release/src/GhPullRequestApi.php:255-256\`, no override flag), so the PHP 8.6 red on rel-830 was gating the imminent 8.3.0 release.

After this merges, the next release-prep re-run on rel-830 should surface 8.6 as \`SUCCESS\` (via \`continue-on-error: true\`), unblocking the ship-release preflight.

## Test plan

- [ ] Once merged, next release-prep regen on rel-830 → PHP 8.6 Isolated Tests reports SUCCESS on #13483 + #13485.
- [ ] ship-release dry-run for 8.3.0 clears the 8.6 blocker.

Assisted-by: Claude Code + Michael A. Smith (original commit)