### PR TITLE
ci(all-checks-passed): ignore the pre-release PHP 8.6 check run

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -19,6 +19,20 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         running-workflow-name: All Checks Passed
-        ignore-checks: codecov/project,codecov/patch
+        # The PHP 8.6 job in isolated-tests.yml already carries continue-on-error
+        # because 8.6 is unreleased and its nightly builds regress from time to
+        # time. That keeps the workflow green, but the individual check run still
+        # concludes "failure", and this action gates on check-run conclusions --
+        # so the pre-release job has to be ignored here too, or every PR in the
+        # repo stays blocked.
+        #
+        # Entries are split on commas, stripped, and compared for exact equality
+        # against the whole check-run name. "PHP 8.6 - Isolated Tests" is the name
+        # isolated-tests.yml renders from its job-level `name:`. If the matrix
+        # moves to a newer pre-release without this entry being updated, the new
+        # job blocks PRs again -- noisy and obvious, not a silent hole in the gate.
+        #
+        # Drop this entry, and the matching continue-on-error, once 8.6 ships.
+        ignore-checks: 'codecov/project,codecov/patch,PHP 8.6 - Isolated Tests'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 30


### PR DESCRIPTION
#13554 added `continue-on-error` to the PHP 8.6 isolated-tests job so a nightly php-src regression could not fail the workflow. That fixed the workflow conclusion but not the check run: `PHP 8.6 - Isolated Tests` still concludes `failure`, and `All Checks Passed` gates on check-run conclusions via `lewagon/wait-on-check-action`. Confirmed on #13544 and #13545 — 76 success, 2 failure, the two being the 8.6 job and `All Checks Passed`. Every PR in the repo is currently blocked by this.

This adds that check-run name to the action's existing `ignore-checks` list. Reading the action at `v1.9.0` rather than its README: `entrypoint.rb` splits the list on commas and strips surrounding whitespace, and `github_checks_verifier.rb` filters with `Array#include?` against the full check-run name — exact whole-name equality, not substring. So supported versions are unaffected and still gate merges, and there is no risk of the entry accidentally matching `PHP 8.5 - Isolated Tests`. PHP 8.6 stays visible as a red, non-blocking warning.

`continue-on-error` and `fail-fast: false` are retained. They work at a different level: `continue-on-error` makes the workflow run conclude `success`, while `ignore-checks` handles the check run, which independently still concludes `failure`. Removing either re-opens half the problem.

Known tradeoff, recorded in a comment at the call site: the version string now appears in two files, and the comparison is exact, so bumping the matrix to a newer pre-release without updating this entry would make the new job block PRs again. That fails loudly and is a one-line fix, rather than silently weakening the gate — which is why this is a comment and not a refactor to a version-independent check name.

The entry and the matching `continue-on-error` come out together once 8.6 ships.
