### PR TITLE
fix(labcorp): seed the M and D requisition record arrays

### DIFF
--- a/.phpstan/baseline/offsetAccess.notFound.php
+++ b/.phpstan/baseline/offsetAccess.notFound.php
@@ -352,11 +352,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/procedure_tools/labcorp/ereq_form.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset 1 might not exist on array\\{0\\: \'D\', 1\\?\\: non\\-falsy\\-string\\}\\.$#',
-    'count' => 4,
-    'path' => __DIR__ . '/../../interface/procedure_tools/labcorp/gen_hl7_order.inc.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Offset \'adjustments\' might not exist on array\\{insname\\: string, ptname\\?\\: string, pid\\: mixed, count\\?\\: \\(float\\|int\\), id\\?\\: mixed, encounter\\?\\: mixed, invnumber\\?\\: mixed, custid\\?\\: mixed, \\.\\.\\.\\}\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/reports/collections_report.php',

--- a/interface/procedure_tools/labcorp/gen_hl7_order.inc.php
+++ b/interface/procedure_tools/labcorp/gen_hl7_order.inc.php
@@ -159,61 +159,44 @@ function labcorp_gen_hl7_order(int $orderid): Hl7OrderResult
 
     $today = time();
     $out = '';
-    // init 2d barcode req record arrays
-    for ($i = 0; $i < 98; $i++) {
-        if ($i < 6) {
-            $H[$i] = '';
-        }
-        if ($i < 9) {
-            $G[$i] = '';
-        }
-        if ($i < 27) {
-            $C[$i] = '';
-        }
-        if ($i < 41) {
-            $A[$i] = '';
-            $T[$i] = '';
-        }
-        $P[$i] = '';
-    }
-    $H[0] = 'H';
-    $C[0] = 'C';
-    $C[19] = '^';
-    $A[0] = 'A';
-    $M[0] = 'M';
-    $T[0] = 'T';
-    $O[0] = 'O';
-    $S[0] = 'S';
-    $G[0] = 'G';
-    $D[0] = 'D';
-    $L[0] = 'L';
-    $E[0] = 'E';
-    $A[21] = "^^";
-    $A[22] = "^";
-    $A[23] = "^";
-    $A[29] = "^";
-    $A[30] = "^^^^^";
-    $A[33] = "^^^";
-    $G[1] = "^";
-    $S[1] = "^^^^^^";
-    $P[0] = 'P';
-    $P[36] = "^";
-    $P[45] = "^";
-    $P[54] = "^^^^^^^^^^^^^^";
-    $P[55] = "^^^^^^^";
-    $P[72] = "^^";
-    $P[73] = "^^";
-    $P[74] = "^^";
-    $P[75] = "^^";
-    $P[79] = "^";
-    $P[85] = "^";
-    $P[86] = "^^^^";
-    $P[89] = "^";
-    $P[94] = "^";
-    $P[95] = "^^";
-    $B = "B|||||||||||||||||||||";
-    $K = "K|^|||||||||||||||^^^^||||||";
-    $I = "I|^^|^^|^^|^^|^^|^^|^^|^^|";
+    // The 2D barcode requisition records. Each is a fixed-width run of
+    // fields joined on '|' when the requisition is assembled at the end of
+    // this function, so the widths below are the widths that assembly
+    // reads and the two must stay in step. Fields the record always
+    // carries -- the leading record-type letter, and the separator-only
+    // placeholders -- are declared here; everything else defaults to ''
+    // and is filled in from the order as it is built.
+    $H = array_replace(array_fill(0, 6, ''), [0 => 'H']);
+    $C = array_replace(array_fill(0, 27, ''), [0 => 'C', 19 => '^']);
+    $M = array_replace(array_fill(0, 6, ''), [0 => 'M']);
+    $D = array_replace(array_fill(0, 2, ''), [0 => 'D']);
+    $T = array_replace(array_fill(0, 41, ''), [0 => 'T']);
+    $A = array_replace(array_fill(0, 41, ''), [
+        0 => 'A',
+        21 => '^^',
+        22 => '^',
+        23 => '^',
+        29 => '^',
+        30 => '^^^^^',
+        33 => '^^^',
+    ]);
+    $P = array_replace(array_fill(0, 98, ''), [
+        0 => 'P',
+        36 => '^',
+        45 => '^',
+        54 => '^^^^^^^^^^^^^^',
+        55 => '^^^^^^^',
+        72 => '^^',
+        73 => '^^',
+        74 => '^^',
+        75 => '^^',
+        79 => '^',
+        85 => '^',
+        86 => '^^^^',
+        89 => '^',
+        94 => '^',
+        95 => '^^',
+    ]);
 
     $porow = sqlQuery(
         "SELECT " .

--- a/tests/Tests/Services/ProcedureOrder/GenHl7OrderIntegrationTest.php
+++ b/tests/Tests/Services/ProcedureOrder/GenHl7OrderIntegrationTest.php
@@ -335,10 +335,7 @@ class GenHl7OrderIntegrationTest extends TestCase
             'Record types and their order'
         );
 
-        $byType = array_combine(
-            array_map(static fn (string $record): string => substr($record, 0, 1), $records),
-            $records
-        );
+        $byType = self::requisitionRecordsByType($requisition);
 
         $this->assertStringContainsString(
             strtoupper($this->patientColumn('lname')),
@@ -354,6 +351,52 @@ class GenHl7OrderIntegrationTest extends TestCase
         $this->assertStringContainsString('E78.5', $byType['D'], 'D record carries the order diagnosis');
         $this->assertMatchesRegularExpression('/^L\|\d+\|$/', $byType['L'], 'L record carries the record length');
         $this->assertSame('E|0|', $byType['E']);
+    }
+
+    /**
+     * An order carrying no diagnosis at all — neither `order_diagnosis` on the
+     * order nor `diagnoses` on any of its codes — still has to produce a
+     * requisition, with an empty diagnosis field on the D record.
+     *
+     * Regression test for #13546. The D and M record arrays were omitted from
+     * the loop that seeds every other record array, so on this path `$D[1]` was
+     * never created and trimming its trailing '^' separator passed null to
+     * strlen() and substr(). PHP reports that as a deprecation rather than an
+     * exception, so the requisition string itself was unaffected — the only
+     * symptom was the diagnostics, which under `failOnDeprecation` take the
+     * PHPUnit process exit code to 1 without marking any test failed. Assert on
+     * the diagnostics directly so a regression is a red test rather than an
+     * exit code nobody reads.
+     */
+    #[Test]
+    public function testLabCorpRequisitionIsDiagnosticFreeForAnOrderWithNoDiagnoses(): void
+    {
+        $this->setOrderColumns(['order_diagnosis' => '']);
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE procedure_order_code SET diagnoses = ? WHERE procedure_order_id = ?',
+            ['', $this->orderId]
+        );
+
+        /** @var list<string> $diagnostics */
+        $diagnostics = [];
+        set_error_handler(
+            static function (int $severity, string $message) use (&$diagnostics): bool {
+                $diagnostics[] = $severity . ': ' . $message;
+                return true;
+            },
+            E_WARNING | E_DEPRECATED
+        );
+        try {
+            $requisition = labcorp_gen_hl7_order($this->orderId)->requisitionData;
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $diagnostics, 'Generating the requisition must raise no warnings or deprecations');
+
+        $byType = self::requisitionRecordsByType($requisition);
+        $this->assertSame('D|||', $byType['D'], 'The D record carries an empty diagnosis list');
+        $this->assertSame('M||||||', $byType['M'], 'The M record is empty but still has all six of its fields');
     }
 
     #[Test]
@@ -510,6 +553,21 @@ class GenHl7OrderIntegrationTest extends TestCase
             $segments,
             static fn (string $segment): bool => str_starts_with($segment, $segmentId . '|')
         ));
+    }
+
+    /**
+     * Index the records of a LabCorp 2D barcode requisition by their leading
+     * record-type letter.
+     *
+     * @return array<string, string>
+     */
+    private static function requisitionRecordsByType(string $requisition): array
+    {
+        $records = self::segments($requisition);
+        return array_combine(
+            array_map(static fn (string $record): string => substr($record, 0, 1), $records),
+            $records
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes #13546.

The loop that pre-initializes the LabCorp 2D barcode requisition record arrays seeds `H`, `G`, `C`, `A`, `T` and `P` but omits `M` and `D`, which only ever receive their record-type letter. Reading `$M[1..5]` when assembling the M record and appending to `$D[1]` therefore raise undefined-array-key warnings on every LabCorp order. Worse, an order with no `order_diagnosis` and no per-code diagnoses never creates `$D[1]` at all, so trimming its trailing separator passes null to `strlen()` and `substr()` — those are deprecations rather than warnings, and under `phpunit.xml`'s `failOnDeprecation` they take the process exit code to 1 *without marking any test failed*. `A` and `T` are safe only because they are seeded; their use sites are structurally identical.

Each record is now declared in one place instead:

```php
$C = array_replace(array_fill(0, 27, ''), [0 => 'C', 19 => '^']);
```

The old initializer looped 98 times and used a descending cascade of `if ($i < N)` guards to build seven arrays of six different lengths, then scattered thirty-odd indexed assignments below it to place the record-type letters and the separator-only placeholders. A record's width was implied by where it fell out of the cascade, and its constant fields lived twenty lines further down. That is how `M` and `D` went missing without anyone noticing — there was no line to read that said how long `M` was meant to be. Each record now states its width and its constant fields in one place.

That also made eight dead variables visible: `$B`, `$K`, `$I`, `$G`, `$O`, `$S`, `$L` and `$E` are assigned and never read anywhere in the function. They are removed. (Note the `L` record in the output comes from a literal `"L|$l|"`, not from `$L`.)

`array_replace()` rather than the `+` union operator, deliberately. Union takes the left operand's keys first, so a sparse literal leaves the array in a different key order than the fill — `0, 19, 1, 2, …` instead of `0, 1, 2, …`. Values by index are unaffected and the assembly reads by index, so output would have been the same, but the arrays would no longer be `===` to what the old code produced, and `json_encode()` and `array_values()` would differ. The natural next cleanup of those assembly loops is `implode('|', $P)`, which would then silently emit fields out of order. `array_replace()` preserves the filled array's key order, so each record is strictly identical to what the scattered assignments produced.

The change is output-neutral on every count. `substr($D[1], 0, strlen($D[1]) - 1)` yields `''` whether `$D[1]` is undefined or seeded to `''`, and an unset `$M[$i]` concatenates as `''` exactly as a seeded one does — verified by comparing the generated requisition string on the with-diagnoses and no-diagnoses paths, byte-identical before and after. Each reconstructed record was checked `===` against the original construction. Removing a variable that is never read cannot affect the result.

Adds a regression test for an order with no diagnoses. It installs a scoped error handler around the generate call and asserts zero warnings and deprecations, plus the expected `D|||` and `M||||||` record shapes. Asserting the diagnostics directly is deliberate: the symptom is an exit code that marks no test failed, so a shape-only assertion would have stayed green. Verified red before the fix (`Failures: 1`) and green after (`OK, 41 tests, 560 assertions`).

Also drops the PHPStan baseline entry the omission was responsible for — `Offset 1 might not exist on array{0: 'D', 1?: non-falsy-string}`, 4 errors. Regenerated with `composer phpstan-baseline`; the diff is 5 deletions and no additions.
