### PR TITLE
ci(all-checks-passed): port #13558 to rel-830 (ignore PHP 8.6 check) — companion to #13557

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -19,6 +19,20 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         running-workflow-name: All Checks Passed
-        ignore-checks: codecov/project,codecov/patch
+        # The PHP 8.6 job in isolated-tests.yml already carries continue-on-error
+        # because 8.6 is unreleased and its nightly builds regress from time to
+        # time. That keeps the workflow green, but the individual check run still
+        # concludes "failure", and this action gates on check-run conclusions --
+        # so the pre-release job has to be ignored here too, or every PR in the
+        # repo stays blocked.
+        #
+        # Entries are split on commas, stripped, and compared for exact equality
+        # against the whole check-run name. "PHP 8.6 - Isolated Tests" is the name
+        # isolated-tests.yml renders from its job-level `name:`. If the matrix
+        # moves to a newer pre-release without this entry being updated, the new
+        # job blocks PRs again -- noisy and obvious, not a silent hole in the gate.
+        #
+        # Drop this entry, and the matching continue-on-error, once 8.6 ships.
+        ignore-checks: 'codecov/project,codecov/patch,PHP 8.6 - Isolated Tests'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 30


### PR DESCRIPTION
Straight cherry-pick of #13558 onto rel-830. Byte-equal to master via \`git patch-id --stable\`:

\`\`\`
master #13558  (33eff5ec25): 9533c7e2b8be789d353a6a3b98fa5479045fc61e
rel-830 port   (b70a46d54b): 9533c7e2b8be789d353a6a3b98fa5479045fc61e
\`\`\`

## Why on rel-830

Companion to #13557 (which ported #13554 — the \`continue-on-error\` on the 8.6 matrix leg). Without this second port, \`all-checks-passed.yml\` on rel-830 still gates on the individual \`PHP 8.6 - Isolated Tests\` check-run conclusion, which stays FAILURE even when \`continue-on-error\` keeps the workflow green. Result: the aggregator \`All Checks Passed\` on rel-830 PRs (#13483 + #13485) would remain red, and ship-release preflight (which blocks on any non-SUCCESS check) would still refuse to fire.

\`.github/workflows/all-checks-passed.yml\` is NOT byte-identical-enforced, so #13558 doesn't propagate to rel-830 via the sync PR mechanism. Manual port needed, matching the pattern from #13557.

## Test plan

- [ ] After merge, next release-prep regen on rel-830 → \`All Checks Passed\` reports SUCCESS on #13483 + #13485 despite PHP 8.6 still concluding FAILURE.
- [ ] ship-release dry-run for 8.3.0 clears both the individual 8.6 check (via #13557's continue-on-error) AND the aggregator (via this PR).

Assisted-by: Claude Code + Michael A. Smith (original commit)