### PR TITLE
Merge commit from fork (backport 31e13ee2d9 to rel-830)

### DIFF
--- a/.phpstan/baseline/encapsedStringPart.nonString.php
+++ b/.phpstan/baseline/encapsedStringPart.nonString.php
@@ -2972,11 +2972,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/DocumentTemplates/DocumentTemplateService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Part \\$default_warehouse \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/DrugSalesService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Part \\$patient_id \\(mixed\\) of encapsed string cannot be cast to string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/DrugSalesService.php',

--- a/interface/forms/fee_sheet/new.php
+++ b/interface/forms/fee_sheet/new.php
@@ -22,6 +22,7 @@ require_once("$srcdir/options.inc.php");
 
 use OpenEMR\Billing\BillingUtilities;
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -37,6 +38,23 @@ if (!AclMain::aclCheckForm('fee_sheet')) { ?>
 }
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
+
+// CSRF protection for every state-changing POST to this endpoint (saving the
+// fee sheet, the AJAX save/dx-update variants, and reopening a checked-out
+// visit).  The token is emitted as a hidden field in the fee sheet form below,
+// so the normal submit and the form-derived AJAX posts (jQuery serialize() and
+// FormData) all carry it.  Read-only refreshes (running_as_ajax without a save
+// flag) change nothing and are intentionally not gated.
+$postFieldPresent = static fn(string $name): bool => filter_input(INPUT_POST, $name) !== null;
+$isStateChangingPost = $postFieldPresent('bn_save')
+    || $postFieldPresent('bn_save_close')
+    || $postFieldPresent('bn_save_stay')
+    || $postFieldPresent('bn_reopen')
+    || $postFieldPresent('form_reopen')
+    || ($postFieldPresent('running_as_ajax') && $postFieldPresent('dx_update'));
+if ($isStateChangingPost) {
+    CsrfUtils::checkCsrfInput(INPUT_POST, $session, dieOnFail: true);
+}
 
 // Some table cells will not be displayed unless insurance billing is used.
 $usbillstyle = OEGlobalsBag::getInstance()->get('ippf_specific') ? " style='display:none'" : "";
@@ -1005,6 +1023,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                 <form method="post" name="fee_sheet_form" id="fee_sheet_form" action="<?php echo $rootdir; ?>/forms/fee_sheet/new.php?<?php
                 echo "rde=" . attr_url($rapid_data_entry) . "&addmore=" . attr_url($add_more_items); ?>"
                 onsubmit="return validate(this)">
+                    <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken($session)); ?>" />
                     <input type='hidden' name='newcodes' value='' />
                     <?php
                     $isBilled = !$add_more_items && BillingUtilities::isEncounterBilled($fs->pid, $fs->encounter);

--- a/src/Services/DrugSalesService.php
+++ b/src/Services/DrugSalesService.php
@@ -304,9 +304,14 @@ class DrugSalesService extends BaseService
         $total_on_hand = 0;
         $gotexpired = false;
 
-        // If the user has a default warehouse, sort those lots first.
+        // If the user has a default warehouse, sort those lots first.  The
+        // warehouse value is attacker-controllable (it originates from Fee Sheet
+        // POST data), so it must be bound as a parameter rather than interpolated
+        // into the ORDER BY clause.  Its placeholder is appended to $sqlarr below,
+        // after any WHERE-clause warehouse filter, so the parameter order matches
+        // the placeholder order in the final SQL string.
         $orderby = ($default_warehouse === '') ?
-            "" : "di.warehouse_id != '$default_warehouse', ";
+            "" : "di.warehouse_id != ?, ";
         $orderby .= "lo.seq, di.expiration, di.lot_number, di.inventory_id";
 
         // Retrieve lots in order of expiration date within warehouse preference.
@@ -323,6 +328,9 @@ class DrugSalesService extends BaseService
         }
 
         $query .= "ORDER BY $orderby";
+        if ($default_warehouse !== '') {
+            $sqlarr[] = $default_warehouse;
+        }
         $res = QueryUtils::sqlStatementThrowException($query, $sqlarr);
 
         // First pass.  Pick out lots to be used in filling this order, figure out

--- a/tests/Tests/Services/DrugSalesServiceTest.php
+++ b/tests/Tests/Services/DrugSalesServiceTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * DrugSalesServiceTest.php
+ *
+ * Regression coverage for an authenticated SQL injection in the Fee Sheet
+ * inventory check: the warehouse value was interpolated directly into the
+ * ORDER BY clause of the drug-inventory lookup in DrugSalesService::sellDrug().
+ * These tests prove the value is now bound as a parameter and can no longer
+ * break out of the SQL statement.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2026 Discover and Change
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\DrugSalesService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class DrugSalesServiceTest extends TestCase
+{
+    private DrugSalesService $service;
+
+    private int $drugId;
+
+    protected function setUp(): void
+    {
+        $this->service = new DrugSalesService();
+        // A dispensable product is required to reach the inventory lookup that
+        // holds the vulnerable ORDER BY clause; non-dispensable products return
+        // earlier and never run it.
+        $this->drugId = (int) QueryUtils::sqlInsert(
+            "INSERT INTO drugs (name, dispensable) VALUES (?, 1)",
+            ['Fee Sheet inventory ORDER BY regression product']
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        QueryUtils::sqlStatementThrowException("DELETE FROM drugs WHERE drug_id = ?", [$this->drugId]);
+    }
+
+    /**
+     * The warehouse value originates from attacker-controlled Fee Sheet POST data
+     * (prod[N][warehouse]).  Before the fix it was interpolated into the ORDER BY
+     * clause, so a value carrying an unbalanced quote broke out of the string
+     * literal and produced a SQL syntax error - the throwing symptom of the
+     * injection.  After the fix the value is bound as a parameter, so it is
+     * treated as an ordinary (here nonexistent) warehouse id: the query executes
+     * cleanly and, finding no matching inventory, reports the product as
+     * unfillable (false) instead of throwing.
+     */
+    #[Test]
+    #[DataProvider('maliciousWarehouseProvider')]
+    public function warehouseValueCannotBreakOutOfOrderByClause(string $maliciousWarehouse): void
+    {
+        // "test only" mode runs the inventory lookup but performs no writes and
+        // skips the encounter sanity check, so no encounter/patient fixtures are
+        // needed to exercise the vulnerable query.
+        $result = $this->service->sellDrug(
+            $this->drugId,
+            1,                  // quantity
+            0,                  // fee
+            1,                  // patient_id
+            0,                  // encounter_id (unused in test-only mode)
+            0,                  // prescription_id
+            '',                 // sale_date
+            '',                 // user (falls back to the session user)
+            $maliciousWarehouse, // default_warehouse - the injection vector
+            true                // testonly
+        );
+
+        $this->assertFalse(
+            $result,
+            'sellDrug() must treat the warehouse value as bound data and report insufficient inventory, '
+            . 'not execute (or fail to parse) injected SQL'
+        );
+    }
+
+    /**
+     * Warehouse payloads whose unbalanced quote would break out of the ORDER BY
+     * string literal if the value were interpolated instead of bound.  Each one
+     * raises a SQL syntax error against the pre-fix code and is handled as an
+     * inert literal against the fixed code.
+     *
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function maliciousWarehouseProvider(): array
+    {
+        return [
+            'lone quote'                => ["'"],
+            'single trailing quote'     => ["1'"],
+            'quote then extra sort term' => ["1',(SELECT 1)"],
+            'quote then tautology'      => ["1' OR 1=1"],
+        ];
+    }
+}


### PR DESCRIPTION
Backport of master commit 31e13ee2d9d32cc186faff3603f7c17996e78065 to rel-830.

The drug-inventory lookup in DrugSalesService::sellDrug() interpolated the
warehouse value directly into the ORDER BY clause. That value originates from
attacker-controllable Fee Sheet POST data (prod[N][warehouse]), so any
authenticated user with Fee Sheet access could inject SQL and read the whole
database via a blind ORDER BY timing oracle (CWE-89). The value is now bound as
a query parameter.

warehouse_id is a varchar option_id (e.g. 'onsite'), so the value is bound
rather than cast to int; this closes the injection while preserving existing
multi-warehouse behavior. A stale PHPStan baseline entry for the removed
interpolation is dropped.

DrugSalesServiceTest exercises the sink with quote-breaking warehouse payloads:
they raise a SQL syntax error against the vulnerable code and are handled as
inert bound literals against the fix.

The Fee Sheet save path (interface/forms/fee_sheet/new.php) also performed
state-changing actions with no CSRF protection (CWE-352). A csrf_token_form
field is now emitted in the form and verified for every state-changing POST
(save, the AJAX save/dx-update variants, and reopen); read-only refreshes are
intentionally not gated.

Assisted-by: Claude Code

Co-authored-by: Discover and Change AI Worker <ai-worker@discoverandchange.com>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>