### PR TITLE
Merge commit from fork (backport 069c4a7f52 to rel-830)

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -10102,11 +10102,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$filePath of method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\:\\:sendFile\\(\\) expects string, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$filePath of static method OpenEMR\\\\Common\\\\Utils\\\\FileUtils\\:\\:fileGetMimeType\\(\\) expects string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
@@ -10119,11 +10114,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$filename of function file_get_contents expects string, mixed given\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$filename of function file_put_contents expects string, mixed given\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
@@ -10143,7 +10133,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$filename of function unlink expects string, mixed given\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
@@ -10309,11 +10299,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$filename of function file_exists expects string, mixed given\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$filename of function file_put_contents expects string, mixed given\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -793,7 +793,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 25,
+    'count' => 22,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -803,12 +803,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 28,
+    'count' => 27,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 11,
+    'count' => 9,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -1148,7 +1148,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 23,
+    'count' => 21,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
@@ -1158,12 +1158,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 19,
+    'count' => 17,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 25,
+    'count' => 23,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenErrorLog.php
+++ b/.phpstan/baseline/openemr.forbiddenErrorLog.php
@@ -68,7 +68,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 10,
+    'count' => 7,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -652,11 +652,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\:\\:disposeDocument\\(\\) should return string but returns string\\|false\\.$#',
-    'count' => 15,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\EtherFaxActions\\:\\:fetchReminderCount\\(\\) should return string but returns string\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
@@ -707,11 +702,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\:\\:disposeDocument\\(\\) should return string but returns string\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\RCFaxClient\\:\\:fetchTextMessage\\(\\) should return string but returns int\\<min, 0\\>\\|int\\<2, max\\>\\|string\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
@@ -749,11 +739,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\SignalWireClient\\:\\:assignFax\\(\\) should return string but returns string\\|false\\.$#',
     'count' => 6,
-    'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Modules\\\\FaxSMS\\\\Controller\\\\SignalWireClient\\:\\:disposeDocument\\(\\) should return string but returns string\\|false\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php',
 ];
 $ignoreErrors[] = [

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Contracts/FaxDocumentDisposalInterface.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Contracts/FaxDocumentDisposalInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Contract for fax vendor clients that expose the shared document-disposal
+ * endpoint. Implemented via FaxDocumentDisposalTrait so every fax client
+ * disposes documents through the same authorised, path-confined routine.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2026 Discover and Change, Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\FaxSMS\Contracts;
+
+interface FaxDocumentDisposalInterface
+{
+    /**
+     * Stage (action=setup) or stream (action=download) a fax document, after
+     * authorising the caller and confining the request-supplied path to the
+     * module's temporary base directory.
+     *
+     * @return string JSON status, or streams the file and exits (download)
+     */
+    public function disposeDocument(): string;
+}

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
@@ -19,14 +19,17 @@ use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Contracts\FaxChannelInterface;
+use OpenEMR\Modules\FaxSMS\Contracts\FaxDocumentDisposalInterface;
 use OpenEMR\Modules\FaxSMS\EtherFax\EtherFaxClient;
 use OpenEMR\Modules\FaxSMS\EtherFax\FaxResult;
 use OpenEMR\Modules\FaxSMS\Service\FaxMailer;
 use OpenEMR\Modules\FaxSMS\Service\FaxUploadStaging;
 use OpenEMR\Services\ImageUtilities\HandleImageService;
 
-class EtherFaxActions extends AppDispatch implements FaxChannelInterface
+class EtherFaxActions extends AppDispatch implements FaxChannelInterface, FaxDocumentDisposalInterface
 {
+    use FaxDocumentDisposalTrait;
+
     public static $timeZone;
     protected string $baseDir = '';
     protected $uriDir;
@@ -633,183 +636,6 @@ class EtherFaxActions extends AppDispatch implements FaxChannelInterface
         $formatted_document = $control->convertImageToPdf($encodedFax, '');
 
         return $formatted_document ? base64_encode($formatted_document) : false;
-    }
-
-    /**
-     * @return string
-     */
-
-    public function disposeDocument(): string
-    {
-        if (!$this->authenticate()) {
-            http_response_code(403);
-            return json_encode(['success' => false, 'message' => xlt('Unauthorized')]);
-        }
-
-        $response = ['success' => false, 'message' => '', 'url' => ''];
-        $where = (string)($this->getRequest('file_path') ?? $this->getSession('where') ?? '');
-
-        if (empty($where)) {
-            return json_encode(['success' => false, 'message' => xlt('No file path specified')]);
-        }
-        $allowedRoot = realpath($this->baseDir) ?: $this->baseDir;
-        $targetPath = $this->normalizePath($where);
-
-        if (!$this->isPathAllowed($targetPath, $allowedRoot)) {
-            error_log("SECURITY: Fax disposeDocument path violation: {$targetPath}");
-            http_response_code(403);
-            return json_encode(['success' => false, 'message' => xlt('Access denied')]);
-        }
-
-        $content = (string)$this->getRequest('content', '');
-        $action = (string)$this->getRequest('action', '');
-
-        if ($action === 'download') {
-            // Only allow download from allowed root
-            if (!is_file($targetPath)) {
-                return json_encode(['success' => false, 'message' => xlt('File not found')]);
-            }
-            $this->sendFile($targetPath);
-            // Best effort cleanup for temp files created by this controller
-            @unlink($targetPath);
-            return json_encode(['success' => true, 'url' => $targetPath]);
-        }
-
-        if (!empty($content) && $action === 'setup') {
-            // Only allow fax-safe extensions
-            $ext = strtolower(pathinfo($targetPath, PATHINFO_EXTENSION));
-            $allowedExtensions = ['pdf', 'tif', 'tiff', 'txt'];
-            if (!in_array($ext, $allowedExtensions, true)) {
-                error_log("SECURITY: Disallowed file extension in disposeDocument: .{$ext}");
-                return json_encode(['success' => false, 'message' => xlt('Invalid file type')]);
-            }
-
-            $decoded = base64_decode($content, true);
-            if ($decoded === false) {
-                return json_encode(['success' => false, 'message' => xlt('Invalid content encoding')]);
-            }
-
-            // Simple executable content guard (PHP tags, HTML script). This is a defense-in-depth measure.
-            if ($this->containsExecutableCode($decoded)) {
-                error_log("SECURITY: Executable content blocked in disposeDocument");
-                return json_encode(['success' => false, 'message' => xlt('Malicious content detected')]);
-            }
-
-            // Ensure directory exists
-            $dir = dirname($targetPath);
-            if (!is_dir($dir) && !mkdir($dir, 0770, true)) {
-                return json_encode(['success' => false, 'message' => xlt('Failed to create directory')]);
-            }
-
-            // Write atomically; encrypt-at-rest so the download branch's
-            // sendFile call (which decrypts via decryptFileBytes) is the
-            // only path that ever sees the plaintext bytes on disk.
-            $tmp = tempnam($dir, 'fax_');
-            if ($tmp === false) {
-                return json_encode(['success' => false, 'message' => xlt('Failed to create temp file')]);
-            }
-            $bytes = file_put_contents($tmp, $this->crypto->encryptForFilesystem($decoded), LOCK_EX);
-            if ($bytes === false) {
-                @unlink($tmp);
-                return json_encode(['success' => false, 'message' => xlt('Failed to write file')]);
-            }
-            // Move to destination
-            if (!@rename($tmp, $targetPath)) {
-                @unlink($tmp);
-                return json_encode(['success' => false, 'message' => xlt('Failed to finalize file')]);
-            }
-            @chmod($targetPath, 0660);
-
-            $response['success'] = true;
-            $response['url'] = $targetPath;
-            return json_encode($response);
-        } elseif ($action === 'setup') {
-            // Setup without content should not create files; just acknowledge if path is allowed
-            $response['success'] = true;
-            $response['url'] = $targetPath;
-            return json_encode($response);
-        }
-
-        // Default: unsupported action
-        return json_encode(['success' => false, 'message' => xlt('Unsupported action')]);
-    }
-
-    /**
-     * Normalize a filesystem path without resolving symlinks from user input.
-     */
-    private function normalizePath(string $path): string
-    {
-        $parts = [];
-        foreach (explode(DIRECTORY_SEPARATOR, $path) as $segment) {
-            if ($segment === '' || $segment === '.') {
-                continue;
-            }
-            if ($segment === '..') {
-                array_pop($parts);
-            } else {
-                $parts[] = $segment;
-            }
-        }
-        $prefix = DIRECTORY_SEPARATOR;
-        $isWindowsDrive = strlen($path) >= 3 && ctype_alpha($path[0]) && $path[1] === ':' && ($path[2] === DIRECTORY_SEPARATOR);
-        if ($isWindowsDrive) {
-            $prefix = '';
-        }
-        return $prefix . implode(DIRECTORY_SEPARATOR, $parts);
-    }
-
-    /**
-     * Enforce that target path is at or below allowed root.
-     */
-    private function isPathAllowed(string $targetPath, string $allowedRoot): bool
-    {
-        $allowed = realpath($allowedRoot) ?: $allowedRoot;
-        $real = realpath($targetPath);
-        if ($real === false) {
-            // If file does not exist yet, check its directory
-            $real = realpath(dirname($targetPath));
-            if ($real === false) {
-                // Directory might not exist; check against intended dir under allowed
-                $intended = $this->normalizePath(dirname($targetPath));
-                return str_starts_with($intended, $allowed);
-            }
-        }
-        return str_starts_with($real, $allowed);
-    }
-
-    /**
-     * Lightweight detector for executable content we never expect for fax artifacts.
-     */
-    private function containsExecutableCode(string $data): bool
-    {
-        // Check for PHP tags or HTML/JS script tags in first 1MB to be safe.
-        $snippet = substr($data, 0, 1024 * 1024);
-        return (bool)preg_match('/<\?(php|=)|<script\b/i', $snippet);
-    }
-
-    /**
-     * Decrypt the at-rest fax file and stream it to the browser. Legacy
-     * plaintext files flow through unchanged via decryptFromFilesystem's
-     * version-prefix check.
-     */
-    private function sendFile(string $filePath): void
-    {
-        $payload = $this->uploadStaging->decryptFileBytes($filePath);
-        if ($payload === null) {
-            http_response_code(500);
-            echo xlt('Failed to read fax file');
-            exit;
-        }
-        ob_end_clean();
-        header("Cache-Control: public");
-        header("Content-Description: File Transfer");
-        header("Content-Disposition: attachment; filename=" . basename($filePath));
-        header("Content-Type: application/pdf");
-        header("Content-Transfer-Encoding: binary");
-        header('Content-Length: ' . strlen($payload));
-
-        echo $payload;
-        exit;
     }
 
     /**

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/FaxDocumentDisposalTrait.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/FaxDocumentDisposalTrait.php
@@ -1,0 +1,262 @@
+<?php
+
+/**
+ * Shared fax document disposal (stage/download) for fax vendor clients.
+ *
+ * Consolidates the hardened disposeDocument() flow into a single implementation
+ * shared by every fax vendor client (EtherFax, RingCentral, SignalWire) instead
+ * of a per-vendor copy that can drift. The routine authorises the caller against
+ * the patients/docs ACL, confines the request-supplied file_path to the module's
+ * temporary base directory, restricts writes to fax-safe artifacts, and only
+ * ever streams decrypted bytes for files inside that directory. Keeping one
+ * implementation means a new vendor cannot reintroduce the authenticated
+ * arbitrary file read/write that the divergent copies had drifted into.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2018-2026 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 Discover and Change, Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\FaxSMS\Controller;
+
+use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Acl\AclMain;
+
+/**
+ * @internal Used by AppDispatch subclasses that expose $baseDir, $crypto and
+ *           $uploadStaging plus the getRequest()/getSession() accessors.
+ */
+trait FaxDocumentDisposalTrait
+{
+    /**
+     * Stage (action=setup) or stream (action=download) a fax document.
+     *
+     * The request-supplied file_path is authorised and confined before any
+     * filesystem access: the caller must hold the patients/docs ACL and the
+     * resolved path must sit inside the module's temporary base directory.
+     *
+     * @return string JSON status (setup / errors) or streams the file (download)
+     */
+    public function disposeDocument(): string
+    {
+        if (!$this->authorizeDocumentAccess()) {
+            http_response_code(403);
+            return $this->disposalResponse(['success' => false, 'message' => xlt('Unauthorized')]);
+        }
+
+        $whereRaw = $this->getRequest('file_path') ?? $this->getSession('where') ?? '';
+        $where = is_string($whereRaw) ? $whereRaw : '';
+
+        if ($where === '') {
+            return $this->disposalResponse(['success' => false, 'message' => xlt('No file path specified')]);
+        }
+
+        $allowedRoot = realpath($this->baseDir) ?: $this->baseDir;
+        $targetPath = $this->normalizePath($where);
+
+        if (!$this->isPathAllowed($targetPath, $allowedRoot)) {
+            ServiceContainer::getLogger()->warning(
+                'Fax disposeDocument denied: path outside allowed root',
+                ['target' => $targetPath]
+            );
+            http_response_code(403);
+            return $this->disposalResponse(['success' => false, 'message' => xlt('Access denied')]);
+        }
+
+        $contentRaw = $this->getRequest('content', '');
+        $content = is_string($contentRaw) ? $contentRaw : '';
+        $actionRaw = $this->getRequest('action', '');
+        $action = is_string($actionRaw) ? $actionRaw : '';
+
+        if ($action === 'download') {
+            // Only allow download of an existing file inside the allowed root.
+            if (!is_file($targetPath)) {
+                return $this->disposalResponse(['success' => false, 'message' => xlt('File not found')]);
+            }
+            // sendFile() streams the decrypted bytes, removes the staged temp
+            // and exits, so the return below is only for the type system.
+            $this->sendFile($targetPath);
+            return $this->disposalResponse(['success' => true, 'url' => $targetPath]);
+        }
+
+        if ($content !== '' && $action === 'setup') {
+            // Only allow fax-safe extensions.
+            $ext = strtolower(pathinfo((string) $targetPath, PATHINFO_EXTENSION));
+            $allowedExtensions = ['pdf', 'tif', 'tiff', 'txt'];
+            if (!in_array($ext, $allowedExtensions, true)) {
+                ServiceContainer::getLogger()->warning(
+                    'Fax disposeDocument denied: disallowed file extension',
+                    ['extension' => $ext]
+                );
+                return $this->disposalResponse(['success' => false, 'message' => xlt('Invalid file type')]);
+            }
+
+            $decoded = base64_decode($content, true);
+            if ($decoded === false) {
+                return $this->disposalResponse(['success' => false, 'message' => xlt('Invalid content encoding')]);
+            }
+
+            // Simple executable content guard (PHP tags, HTML script). This is a
+            // defense-in-depth measure on top of the extension allowlist.
+            if ($this->containsExecutableCode($decoded)) {
+                ServiceContainer::getLogger()->warning('Fax disposeDocument denied: executable content blocked');
+                return $this->disposalResponse(['success' => false, 'message' => xlt('Malicious content detected')]);
+            }
+
+            // Ensure directory exists (still inside the allowed root).
+            $dir = dirname((string) $targetPath);
+            if (!is_dir($dir) && !mkdir($dir, 0770, true)) {
+                return $this->disposalResponse(['success' => false, 'message' => xlt('Failed to create directory')]);
+            }
+
+            // Write atomically; encrypt-at-rest so the download branch's
+            // sendFile call (which decrypts via decryptFileBytes) is the only
+            // path that ever sees the plaintext bytes on disk.
+            $tmp = tempnam($dir, 'fax_');
+            if ($tmp === false) {
+                return $this->disposalResponse(['success' => false, 'message' => xlt('Failed to create temp file')]);
+            }
+            $bytes = file_put_contents($tmp, $this->crypto->encryptForFilesystem($decoded), LOCK_EX);
+            if ($bytes === false) {
+                @unlink($tmp);
+                return $this->disposalResponse(['success' => false, 'message' => xlt('Failed to write file')]);
+            }
+            if (!@rename($tmp, $targetPath)) {
+                @unlink($tmp);
+                return $this->disposalResponse(['success' => false, 'message' => xlt('Failed to finalize file')]);
+            }
+            @chmod($targetPath, 0660);
+
+            return $this->disposalResponse(['success' => true, 'message' => '', 'url' => $targetPath]);
+        }
+
+        if ($action === 'setup') {
+            // Setup without content should not create files; just acknowledge
+            // that the (already validated) path is allowed.
+            return $this->disposalResponse(['success' => true, 'message' => '', 'url' => $targetPath]);
+        }
+
+        // Default: unsupported action.
+        return $this->disposalResponse(['success' => false, 'message' => xlt('Unsupported action')]);
+    }
+
+    /**
+     * Authorise the caller for fax-document disposal. A fax artifact is a
+     * patient document, so this requires the patients/docs ACL — the same
+     * permission the outbound send path enforces — independent of any vendor
+     * API authentication.
+     */
+    protected function authorizeDocumentAccess(): bool
+    {
+        return AclMain::aclCheckCore('patients', 'docs');
+    }
+
+    /**
+     * Encode a disposal status payload. JSON_THROW_ON_ERROR guarantees a string
+     * return (the scalar controller responses here never fail to encode).
+     *
+     * @param array<string, bool|string> $payload
+     */
+    private function disposalResponse(array $payload): string
+    {
+        return json_encode($payload, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Normalize a filesystem path without resolving symlinks from user input.
+     */
+    private function normalizePath(string $path): string
+    {
+        $parts = [];
+        foreach (explode(DIRECTORY_SEPARATOR, $path) as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+            if ($segment === '..') {
+                array_pop($parts);
+            } else {
+                $parts[] = $segment;
+            }
+        }
+        $prefix = DIRECTORY_SEPARATOR;
+        $isWindowsDrive = strlen($path) >= 3 && ctype_alpha($path[0]) && $path[1] === ':' && ($path[2] === DIRECTORY_SEPARATOR);
+        if ($isWindowsDrive) {
+            $prefix = '';
+        }
+        return $prefix . implode(DIRECTORY_SEPARATOR, $parts);
+    }
+
+    /**
+     * Enforce that the target path is at or below the allowed root. The
+     * comparison is boundary-aware: a sibling directory that merely shares the
+     * root as a string prefix (e.g. "<root>_evil") is rejected.
+     */
+    private function isPathAllowed(string $targetPath, string $allowedRoot): bool
+    {
+        $allowed = realpath($allowedRoot) ?: $allowedRoot;
+        $real = realpath($targetPath);
+        if ($real === false) {
+            // File does not exist yet: fall back to its (possibly not-yet-created)
+            // directory, resolving as far as the filesystem allows.
+            $real = realpath(dirname($targetPath));
+            if ($real === false) {
+                $intended = $this->normalizePath(dirname($targetPath));
+                return $this->pathWithinRoot($intended, $allowed);
+            }
+        }
+        return $this->pathWithinRoot($real, $allowed);
+    }
+
+    /**
+     * True when $path is the root itself or lives strictly beneath it, using a
+     * trailing-separator boundary so a prefix-only sibling never passes.
+     */
+    private function pathWithinRoot(string $path, string $root): bool
+    {
+        $root = rtrim($root, DIRECTORY_SEPARATOR);
+        return $path === $root || str_starts_with($path, $root . DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * Lightweight detector for executable content we never expect for fax
+     * artifacts.
+     */
+    private function containsExecutableCode(string $data): bool
+    {
+        // Check for PHP tags or HTML/JS script tags in first 1MB to be safe.
+        $snippet = substr($data, 0, 1024 * 1024);
+        return (bool)preg_match('/<\?(php|=)|<script\b/i', $snippet);
+    }
+
+    /**
+     * Decrypt the at-rest fax file and stream it to the browser, then remove the
+     * staged temp copy. Legacy plaintext files flow through unchanged via
+     * decryptFromFilesystem's version-prefix check.
+     */
+    protected function sendFile(string $filePath): void
+    {
+        $payload = $this->uploadStaging->decryptFileBytes($filePath);
+        if ($payload === null) {
+            http_response_code(500);
+            echo xlt('Failed to read fax file');
+            exit;
+        }
+        ob_end_clean();
+        header("Cache-Control: public");
+        header("Content-Description: File Transfer");
+        header("Content-Disposition: attachment; filename=" . basename($filePath));
+        header("Content-Type: application/pdf");
+        header("Content-Transfer-Encoding: binary");
+        header('Content-Length: ' . strlen($payload));
+
+        echo $payload;
+        @unlink($filePath);
+        exit;
+    }
+}

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
@@ -18,15 +18,17 @@ use OpenEMR\Common\Utils\FileUtils;
 use OpenEMR\Common\ValueObjects\PhoneNumber;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Contracts\FaxChannelInterface;
+use OpenEMR\Modules\FaxSMS\Contracts\FaxDocumentDisposalInterface;
 use OpenEMR\Modules\FaxSMS\Contracts\SmsChannelInterface;
 use OpenEMR\Modules\FaxSMS\Service\FaxMailer;
 use OpenEMR\Modules\FaxSMS\Service\FaxUploadStaging;
 use OpenEMR\Services\ImageUtilities\HandleImageService;
 use RingCentral\SDK\Http\ApiException;
 
-class RCFaxClient extends AppDispatch implements FaxChannelInterface, SmsChannelInterface
+class RCFaxClient extends AppDispatch implements FaxChannelInterface, SmsChannelInterface, FaxDocumentDisposalInterface
 {
     use AuthenticateTrait;
+    use FaxDocumentDisposalTrait;
 
     public string $baseDir = '';
     public $uriDir;
@@ -659,71 +661,6 @@ class RCFaxClient extends AppDispatch implements FaxChannelInterface, SmsChannel
         $formatted_document = $control->convertImageToPdf($encodedFax, '');
 
         return $formatted_document ? base64_encode($formatted_document) : false;
-    }
-
-    /**
-     * @return string
-     */
-    public function disposeDocument(): string
-    {
-        $response = ['success' => false, 'message' => '', 'url' => ''];
-        $where = $this->getRequest('file_path') ?? $this->getSession('where');
-
-        if (empty($where)) {
-            die(xlt('Problem with download. Use browser back button'));
-        }
-
-        $content = $this->getRequest('content', '');
-        $action = $this->getRequest('action');
-
-        if ($action == 'download') {
-            $this->sendFile($where);
-            sleep(2);
-            unlink($where);
-            exit;
-        }
-
-        if (!empty($content) && $action == 'setup') {
-            $decodedContent = base64_decode((string)$content);
-            // Write encrypted-at-rest; the download branch's sendFile
-            // call decrypts via FaxUploadStaging::decryptFileBytes.
-            if (file_put_contents($where, $this->crypto->encryptForFilesystem($decodedContent)) !== false) {
-                $response['success'] = true;
-                $response['url'] = $where;
-            } else {
-                $response['message'] = 'Failed to write file';
-            }
-        } elseif ($action == 'setup') {
-            $response['success'] = true;
-            $response['url'] = $where;
-        }
-
-        return json_encode($response);
-    }
-
-    /**
-     * Decrypt the at-rest fax file and stream it to the browser. Legacy
-     * plaintext files flow through unchanged via decryptFromFilesystem's
-     * version-prefix check.
-     */
-    private function sendFile(string $filePath): void
-    {
-        $payload = $this->uploadStaging->decryptFileBytes($filePath);
-        if ($payload === null) {
-            http_response_code(500);
-            echo xlt('Failed to read fax file');
-            exit;
-        }
-        ob_end_clean();
-        header("Cache-Control: public");
-        header("Content-Description: File Transfer");
-        header("Content-Disposition: attachment; filename=" . basename($filePath));
-        header("Content-Type: application/pdf");
-        header("Content-Transfer-Encoding: binary");
-        header('Content-Length: ' . strlen($payload));
-
-        echo $payload;
-        exit;
     }
 
     /**

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
@@ -19,13 +19,16 @@ use OpenEMR\Common\Crypto\CryptoInterface;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Modules\FaxSMS\Contracts\FaxChannelInterface;
+use OpenEMR\Modules\FaxSMS\Contracts\FaxDocumentDisposalInterface;
 use OpenEMR\Modules\FaxSMS\RestClient\SignalWire\Rest\Client;
 use OpenEMR\Modules\FaxSMS\RestClient\SignalWire\Rest\FaxInstance;
 use OpenEMR\Modules\FaxSMS\Service\FaxMailer;
 use OpenEMR\Modules\FaxSMS\Service\FaxUploadStaging;
 
-class SignalWireClient extends AppDispatch implements FaxChannelInterface
+class SignalWireClient extends AppDispatch implements FaxChannelInterface, FaxDocumentDisposalInterface
 {
+    use FaxDocumentDisposalTrait;
+
     const debugLogging = false; // Set to true to enable detailed debug logging in error_log
     /** Max faxes to pull from the SignalWire API in a single check. */
     private const FAX_LIST_LIMIT = 100;
@@ -514,72 +517,6 @@ class SignalWireClient extends AppDispatch implements FaxChannelInterface
         $filePath = $dir . DIRECTORY_SEPARATOR . 'Fax_' . $jobId . '.pdf';
         file_put_contents($filePath, $this->crypto->encryptForFilesystem($data));
         return $filePath;
-    }
-
-    /**
-     * Download handoff for the shared getDocument() download branch. Mirrors the
-     * vendor contract: action=setup writes/echoes the temp path; action=download
-     * streams the staged file and removes it.
-     *
-     * @return string JSON (setup) or streams the file (download)
-     */
-    public function disposeDocument(): string
-    {
-        $response = ['success' => false, 'message' => '', 'url' => ''];
-        $where = $this->getRequest('file_path') ?: $this->getSession('where');
-
-        if (empty($where)) {
-            die(xlt('Problem with download. Use browser back button'));
-        }
-
-        $content = $this->getRequest('content', '');
-        $action = $this->getRequest('action');
-
-        if ($action == 'download') {
-            // sendFile() streams the file and exits, removing the staged temp
-            // after a successful stream, so no cleanup is reachable here.
-            $this->sendFile((string)$where);
-            exit;
-        }
-
-        if (!empty($content) && $action == 'setup') {
-            $decodedContent = base64_decode((string)$content);
-            if (file_put_contents($where, $this->crypto->encryptForFilesystem($decodedContent)) !== false) {
-                $response['success'] = true;
-                $response['url'] = $where;
-            } else {
-                $response['message'] = 'Failed to write file';
-            }
-        } elseif ($action == 'setup') {
-            // PDF path: viewFax already staged the encrypted file; hand it back.
-            $response['success'] = true;
-            $response['url'] = $where;
-        }
-
-        return json_encode($response);
-    }
-
-    /**
-     * Decrypt the at-rest temp file and stream it to the browser as a download.
-     */
-    private function sendFile(string $filePath): void
-    {
-        $payload = $this->uploadStaging->decryptFileBytes($filePath);
-        if ($payload === null) {
-            http_response_code(500);
-            echo xlt('Failed to read fax file');
-            exit;
-        }
-        ob_end_clean();
-        header("Cache-Control: public");
-        header("Content-Description: File Transfer");
-        header("Content-Disposition: attachment; filename=" . basename($filePath));
-        header("Content-Type: application/pdf");
-        header("Content-Transfer-Encoding: binary");
-        header('Content-Length: ' . strlen($payload));
-        echo $payload;
-        @unlink($filePath);
-        exit;
     }
 
     /**

--- a/tests/Tests/Isolated/Modules/FaxSMS/Controller/FaxDisposeDocumentContainmentTest.php
+++ b/tests/Tests/Isolated/Modules/FaxSMS/Controller/FaxDisposeDocumentContainmentTest.php
@@ -1,0 +1,367 @@
+<?php
+
+/**
+ * Isolated tests for the shared fax document disposal guard
+ * (FaxDocumentDisposalTrait::disposeDocument()).
+ *
+ * disposeDocument() takes a request-supplied file_path and either streams it
+ * (action=download) or writes decoded content to it (action=setup). Without
+ * containment this is an authenticated arbitrary file read/write. These tests
+ * pin the two guarantees the trait must uphold for every fax vendor client:
+ *   - the caller must pass the document authorisation gate, and
+ *   - the resolved path must stay inside the module's temporary base directory,
+ * for both the read (download) and write (setup) branches.
+ *
+ * The clients are driven through a partial mock: the original constructor is
+ * disabled (no OEGlobalsBag/session/crypto/vendor SDK wiring), the ACL gate
+ * (authorizeDocumentAccess) and the streaming seam (sendFile) are stubbed, and
+ * the request/baseDir/crypto collaborators are injected by reflection. An
+ * identity xlt() stub declared in the controller namespace (matching
+ * ServiceTypeTest's in-namespace style) keeps the suite free of OpenEMR's
+ * gettext/DB bootstrap.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2026 Discover and Change, Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\FaxSMS\Controller {
+    // The disposal guard's rejection paths call xlt(); an identity stub declared
+    // IN the controller namespace resolves the unqualified call here instead of
+    // OpenEMR's DB-backed translation layer, which is absent in the isolated suite.
+    if (!function_exists('OpenEMR\Modules\FaxSMS\Controller\xlt')) {
+        function xlt(string $s): string
+        {
+            return $s;
+        }
+    }
+}
+
+namespace {
+    spl_autoload_register(static function (string $class): void {
+        $prefix = 'OpenEMR\\Modules\\FaxSMS\\';
+        if (!str_starts_with($class, $prefix)) {
+            return;
+        }
+        $relative = str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
+        $file = __DIR__
+            . '/../../../../../../interface/modules/custom_modules/oe-module-faxsms/src/'
+            . $relative;
+        if (is_file($file)) {
+            require_once $file;
+        }
+    });
+}
+
+namespace OpenEMR\Tests\Isolated\Modules\FaxSMS\Controller {
+
+    use OpenEMR\Common\Crypto\CryptoInterface;
+    use OpenEMR\Modules\FaxSMS\Contracts\FaxDocumentDisposalInterface;
+    use OpenEMR\Modules\FaxSMS\Controller\EtherFaxActions;
+    use OpenEMR\Modules\FaxSMS\Controller\RCFaxClient;
+    use OpenEMR\Modules\FaxSMS\Controller\SignalWireClient;
+    use PHPUnit\Framework\Attributes\DataProvider;
+    use PHPUnit\Framework\MockObject\MockObject;
+    use PHPUnit\Framework\TestCase;
+
+    final class FaxDisposeDocumentContainmentTest extends TestCase
+    {
+        private string $baseDir = '';
+
+        /** @var list<string> Absolute paths created outside baseDir, cleaned up after each test. */
+        private array $outsidePaths = [];
+
+        protected function setUp(): void
+        {
+            $this->baseDir = sys_get_temp_dir() . '/faxdispose_' . uniqid('', true);
+            if (!mkdir($this->baseDir, 0700, true) && !is_dir($this->baseDir)) {
+                self::fail('Could not create test base directory.');
+            }
+            $this->baseDir = realpath($this->baseDir) ?: $this->baseDir;
+            $this->outsidePaths = [];
+        }
+
+        protected function tearDown(): void
+        {
+            foreach ($this->outsidePaths as $path) {
+                if (is_file($path)) {
+                    @unlink($path);
+                }
+            }
+            if (is_dir($this->baseDir)) {
+                foreach (glob($this->baseDir . '/*') ?: [] as $file) {
+                    @unlink($file);
+                }
+                @rmdir($this->baseDir);
+            }
+        }
+
+        /**
+         * @return array<string, array{class-string}>
+         *
+         * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+         */
+        public static function clientProvider(): array
+        {
+            return [
+                'EtherFax' => [EtherFaxActions::class],
+                'RingCentral' => [RCFaxClient::class],
+                'SignalWire' => [SignalWireClient::class],
+            ];
+        }
+
+        /**
+         * A download whose path escapes the base directory must be rejected
+         * before any bytes are streamed, even when the target is a real,
+         * readable file.
+         *
+         * @param class-string $class
+         */
+        #[DataProvider('clientProvider')]
+        public function testDownloadOutsideBaseDirIsBlockedBeforeStreaming(string $class): void
+        {
+            $secret = dirname($this->baseDir) . '/secret_' . uniqid('', true) . '.txt';
+            file_put_contents($secret, 'top-secret-db-credentials');
+            $this->outsidePaths[] = $secret;
+
+            $client = $this->makeClient($class, true);
+            // The read must be refused before it ever reaches the streaming seam.
+            $client->expects($this->never())->method('sendFile');
+            $this->setRequest($client, ['file_path' => $secret, 'action' => 'download']);
+
+            $result = $this->dispose($client);
+            self::assertFalse($result['success']);
+            // The out-of-bounds file must be untouched (not streamed, not unlinked).
+            self::assertFileExists($secret);
+        }
+
+        /**
+         * A download of an existing file inside the base directory streams
+         * normally.
+         *
+         * @param class-string $class
+         */
+        #[DataProvider('clientProvider')]
+        public function testDownloadInsideBaseDirStreams(string $class): void
+        {
+            $target = $this->baseDir . '/Fax_1.pdf';
+            file_put_contents($target, 'encrypted-bytes');
+
+            $client = $this->makeClient($class, true);
+            $client->expects($this->once())->method('sendFile')->with($target);
+            $this->setRequest($client, ['file_path' => $target, 'action' => 'download']);
+
+            $result = $this->dispose($client);
+            self::assertTrue($result['success']);
+        }
+
+        /**
+         * A setup write whose path escapes the base directory must be refused
+         * and must not create the out-of-bounds file.
+         *
+         * @param class-string $class
+         */
+        #[DataProvider('clientProvider')]
+        public function testSetupWriteOutsideBaseDirIsRejected(string $class): void
+        {
+            $target = dirname($this->baseDir) . '/pwned_' . uniqid('', true) . '.pdf';
+            $this->outsidePaths[] = $target;
+
+            $client = $this->makeClient($class, true);
+            $this->setRequest($client, [
+                'file_path' => $target,
+                'action' => 'setup',
+                'content' => base64_encode('%PDF-1.4 payload'),
+            ]);
+
+            $result = $this->dispose($client);
+            self::assertFalse($result['success']);
+            self::assertFileDoesNotExist($target);
+        }
+
+        /**
+         * A traversal payload (../ escaping the base directory) must be
+         * normalized and rejected, not followed.
+         *
+         * @param class-string $class
+         */
+        #[DataProvider('clientProvider')]
+        public function testSetupWriteTraversalIsRejected(string $class): void
+        {
+            $escaped = dirname($this->baseDir) . '/pwned_' . uniqid('', true) . '.pdf';
+            $this->outsidePaths[] = $escaped;
+            $traversal = $this->baseDir . '/../' . basename($escaped);
+
+            $client = $this->makeClient($class, true);
+            $this->setRequest($client, [
+                'file_path' => $traversal,
+                'action' => 'setup',
+                'content' => base64_encode('%PDF-1.4 payload'),
+            ]);
+
+            $result = $this->dispose($client);
+            self::assertFalse($result['success']);
+            self::assertFileDoesNotExist($escaped);
+        }
+
+        /**
+         * A setup write inside the base directory with an allowed extension
+         * writes the (encrypted-at-rest) file.
+         *
+         * @param class-string $class
+         */
+        #[DataProvider('clientProvider')]
+        public function testSetupWriteInsideBaseDirSucceeds(string $class): void
+        {
+            $target = $this->baseDir . '/Fax_42.pdf';
+
+            $client = $this->makeClient($class, true);
+            $this->setRequest($client, [
+                'file_path' => $target,
+                'action' => 'setup',
+                'content' => base64_encode('hello-fax'),
+            ]);
+
+            $result = $this->dispose($client);
+            self::assertTrue($result['success']);
+            self::assertSame($target, $result['url']);
+            self::assertFileExists($target);
+            // Identity crypto stub -> on-disk bytes equal the decoded content.
+            self::assertSame('hello-fax', file_get_contents($target));
+        }
+
+        /**
+         * Even inside the base directory, a non-fax extension is refused.
+         *
+         * @param class-string $class
+         */
+        #[DataProvider('clientProvider')]
+        public function testSetupWriteRejectsDisallowedExtension(string $class): void
+        {
+            $target = $this->baseDir . '/shell.php';
+
+            $client = $this->makeClient($class, true);
+            $this->setRequest($client, [
+                'file_path' => $target,
+                'action' => 'setup',
+                'content' => base64_encode('plain'),
+            ]);
+
+            $result = $this->dispose($client);
+            self::assertFalse($result['success']);
+            self::assertFileDoesNotExist($target);
+        }
+
+        /**
+         * Executable content is refused even with an allowed extension inside
+         * the base directory.
+         *
+         * @param class-string $class
+         */
+        #[DataProvider('clientProvider')]
+        public function testSetupWriteRejectsExecutableContent(string $class): void
+        {
+            $target = $this->baseDir . '/Fax_evil.pdf';
+
+            $client = $this->makeClient($class, true);
+            $this->setRequest($client, [
+                'file_path' => $target,
+                'action' => 'setup',
+                'content' => base64_encode('<?php system($_GET["c"]); ?>'),
+            ]);
+
+            $result = $this->dispose($client);
+            self::assertFalse($result['success']);
+            self::assertFileDoesNotExist($target);
+        }
+
+        /**
+         * A caller who fails the document authorisation gate gets nothing, and
+         * no filesystem side effect occurs.
+         *
+         * @param class-string $class
+         */
+        #[DataProvider('clientProvider')]
+        public function testUnauthorizedCallerIsRejectedWithoutFilesystemAccess(string $class): void
+        {
+            $target = $this->baseDir . '/Fax_99.pdf';
+
+            $client = $this->makeClient($class, false);
+            $client->expects($this->never())->method('sendFile');
+            $this->setRequest($client, [
+                'file_path' => $target,
+                'action' => 'setup',
+                'content' => base64_encode('hello-fax'),
+            ]);
+
+            $result = $this->dispose($client);
+            self::assertFalse($result['success']);
+            self::assertFileDoesNotExist($target);
+        }
+
+        /**
+         * Build a fax client partial mock with the ACL gate and streaming seam
+         * stubbed, and baseDir/crypto injected.
+         *
+         * @param class-string $class
+         * @return MockObject
+         */
+        private function makeClient(string $class, bool $authorized): MockObject
+        {
+            $client = $this->getMockBuilder($class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['authorizeDocumentAccess', 'sendFile'])
+                ->getMock();
+            $client->method('authorizeDocumentAccess')->willReturn($authorized);
+
+            $crypto = $this->createMock(CryptoInterface::class);
+            $crypto->method('encryptForFilesystem')->willReturnArgument(0);
+
+            $this->setProp($client, 'baseDir', $this->baseDir);
+            $this->setProp($client, 'crypto', $crypto);
+
+            return $client;
+        }
+
+        /**
+         * @param array<string, string> $request
+         */
+        private function setRequest(MockObject $client, array $request): void
+        {
+            $this->setProp($client, '_request', $request);
+        }
+
+        /**
+         * Narrow the mock to the disposal contract, invoke it, and decode the
+         * JSON status payload.
+         *
+         * @return array<array-key, mixed>
+         */
+        private function dispose(MockObject $client): array
+        {
+            self::assertInstanceOf(FaxDocumentDisposalInterface::class, $client);
+            $decoded = json_decode($client->disposeDocument(), true);
+            self::assertIsArray($decoded);
+
+            return $decoded;
+        }
+
+        private function setProp(object $obj, string $name, mixed $value): void
+        {
+            $class = new \ReflectionClass($obj);
+            while (!$class->hasProperty($name)) {
+                $parent = $class->getParentClass();
+                if ($parent === false) {
+                    self::fail("Property {$name} not found on " . $obj::class);
+                }
+                $class = $parent;
+            }
+            $prop = new \ReflectionProperty($class->getName(), $name);
+            $prop->setValue($obj, $value);
+        }
+    }
+}


### PR DESCRIPTION
Consolidate disposeDocument() for every fax vendor client (EtherFax,
RingCentral, SignalWire) into a shared FaxDocumentDisposalTrait that
authorises the caller against patients/docs, confines the request-supplied
file_path to the module's temporary base directory, restricts writes to
fax-safe extensions, and blocks executable content before writing.

RingCentral and SignalWire previously read file_path straight from the
request with no authorization or path check, so an authenticated user
could read or write files anywhere the web user could reach. EtherFax
already had these guards but the copies had diverged; a single shared
implementation closes the gap and keeps a new vendor from reintroducing
it. The path check is also boundary-aware so a sibling directory sharing
the root as a string prefix can no longer pass.

Adds an isolated regression test exercising the download (read) and
setup (write) branches for all three clients, and introduces
FaxDocumentDisposalInterface to formalise the shared contract.

Assisted-by: Claude Code

Co-authored-by: Discover and Change AI Worker <ai-worker@discoverandchange.com>
Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

Backport of master commit 069c4a7f52 to rel-830. Includes an extra rel-830-only baseline reconciliation: removes the stale RCFaxClient::disposeDocument return.type baseline entry that #11399 already removed on master (unbackported on rel-830, and rendered stale here by the trait extraction). Otherwise identical to master.

Assisted-by: Claude Code
