### PR TITLE
fix(release): let validate-release-targets tolerate not-yet-created tags on release-finalize PRs

### DIFF
--- a/.github/workflows/docker-validate-release-targets.yml
+++ b/.github/workflows/docker-validate-release-targets.yml
@@ -74,7 +74,19 @@ jobs:
       # Detect release-finalize/<rel-branch> PRs so ref-resolution failures
       # downgrade from error to warning. See workflow header for the full
       # rationale (openemr/openemr#13580).
-      IS_FINALIZE_PR: ${{ startsWith(github.head_ref, 'release-finalize/') }}
+      #
+      # Three-way guard: (1) branch-name prefix, (2) head repo == this repo
+      # (blocks fork PRs spoofing the prefix), (3) opener is the release-App
+      # bot (blocks an org member manually pushing a `release-finalize/foo`
+      # branch to get lax validation). Legitimate finalize PRs are always
+      # opened by openemr-release-bot from the openemr/openemr repository
+      # itself -- see release-prep.yml's `peter-evans/create-pull-request`
+      # step. All three signals must line up before the lax-validation
+      # exception fires.
+      IS_FINALIZE_PR: >-
+        ${{ startsWith(github.head_ref, 'release-finalize/')
+            && github.event.pull_request.head.repo.full_name == github.repository
+            && github.event.pull_request.user.login == 'openemr-release-bot[bot]' }}
     steps:
     - uses: actions/checkout@v7
 
@@ -120,7 +132,12 @@ jobs:
                --silent 2>&1); then
             echo "✓ $BRANCH: openemr_version_ref '$REF' resolves."
           elif echo "$err_output" | grep -qE 'HTTP 404|Not Found'; then
-            if [ "${IS_FINALIZE_PR}" = "true" ]; then
+            # The lax "unresolvable is a warning" branch only applies to
+            # non-master rows on finalize PRs. Master row's ref should
+            # always be `master` (which cannot 404); a master row with a
+            # non-master ref is a real bug that must be caught even on a
+            # finalize PR.
+            if [ "${IS_FINALIZE_PR}" = "true" ] && [ "$BRANCH" != "master" ]; then
               echo "::warning::Row '$BRANCH': openemr_version_ref '$REF' not yet resolvable — expected on release-finalize PR (tag will be created by conductor merge)."
             else
               echo "::error::Row '$BRANCH': openemr_version_ref '$REF' does not resolve in openemr/openemr"
@@ -186,8 +203,13 @@ jobs:
               # this row's alignment check with a warning instead of failing.
               # The sibling ref-resolution step above already downgrades the
               # 404 to a warning on finalize PRs -- this keeps the two steps
-              # in lockstep. See workflow header (openemr/openemr#13580).
-              if [ "${IS_FINALIZE_PR}" = "true" ]; then
+              # in lockstep. Guarded to non-master rows only: master row is
+              # handled by the local-checkout path above (REF == "master"),
+              # and any 404 that reaches here for a `branch: master` row
+              # means someone put a non-master ref there, which is a real
+              # bug even on a finalize PR. See workflow header
+              # (openemr/openemr#13580).
+              if [ "${IS_FINALIZE_PR}" = "true" ] && [ "$BRANCH" != "master" ]; then
                 echo "::warning::Row '$BRANCH': openemr_version_ref '$REF' not yet resolvable — skipping alignment check on release-finalize PR."
                 continue
               fi

--- a/.github/workflows/docker-validate-release-targets.yml
+++ b/.github/workflows/docker-validate-release-targets.yml
@@ -34,6 +34,19 @@
 # stay ready-to-flip-live. Consumers (orchestrator, dockerhub readme
 # pusher, demo_farm bumper) are responsible for skipping these rows -- the
 # validator does not.
+#
+# **release-finalize/* PR special case (openemr/openemr#13580).** The
+# `release-finalize/<rel-branch>` PR (opened by release-prep.yml alongside
+# the conductor PR) proposes adding a row like `openemr_version_ref:
+# v8_3_0` whose tag DOES NOT exist yet -- the conductor merge is what
+# creates the tag. On those PRs, ref-resolution failures degrade from
+# error to warning (the unresolvable row is expected pre-tag), and the
+# row's alignment check is skipped since we can't fetch version.php from
+# a non-existent tag. Every other check (shape, dedup, alignment for
+# resolvable rows, master-row alignment via local checkout) still
+# applies. Detected via `github.head_ref` starting with
+# `release-finalize/`. All non-finalize PRs and master pushes keep the
+# strict "must resolve" gate.
 
 name: Validate release-targets.yml
 
@@ -57,6 +70,11 @@ jobs:
   validate:
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr'
     runs-on: ubuntu-24.04
+    env:
+      # Detect release-finalize/<rel-branch> PRs so ref-resolution failures
+      # downgrade from error to warning. See workflow header for the full
+      # rationale (openemr/openemr#13580).
+      IS_FINALIZE_PR: ${{ startsWith(github.head_ref, 'release-finalize/') }}
     steps:
     - uses: actions/checkout@v7
 
@@ -102,8 +120,12 @@ jobs:
                --silent 2>&1); then
             echo "✓ $BRANCH: openemr_version_ref '$REF' resolves."
           elif echo "$err_output" | grep -qE 'HTTP 404|Not Found'; then
-            echo "::error::Row '$BRANCH': openemr_version_ref '$REF' does not resolve in openemr/openemr"
-            exit 1
+            if [ "${IS_FINALIZE_PR}" = "true" ]; then
+              echo "::warning::Row '$BRANCH': openemr_version_ref '$REF' not yet resolvable — expected on release-finalize PR (tag will be created by conductor merge)."
+            else
+              echo "::error::Row '$BRANCH': openemr_version_ref '$REF' does not resolve in openemr/openemr"
+              exit 1
+            fi
           else
             echo "::error::Row '$BRANCH': failed to check openemr_version_ref '$REF' (not a 404): $err_output"
             exit 1
@@ -160,6 +182,15 @@ jobs:
             # transient failures. Same G19 pattern as the sibling step
             # above and docker-build-release.yml's fetch.
             if grep -qE 'HTTP 404|Not Found' /tmp/gh-api-err; then
+              # release-finalize/* PR carrying a not-yet-created tag: skip
+              # this row's alignment check with a warning instead of failing.
+              # The sibling ref-resolution step above already downgrades the
+              # 404 to a warning on finalize PRs -- this keeps the two steps
+              # in lockstep. See workflow header (openemr/openemr#13580).
+              if [ "${IS_FINALIZE_PR}" = "true" ]; then
+                echo "::warning::Row '$BRANCH': openemr_version_ref '$REF' not yet resolvable — skipping alignment check on release-finalize PR."
+                continue
+              fi
               echo "::error::Row '$BRANCH': openemr_version_ref '$REF' does not resolve in openemr/openemr"
             else
               echo "::error::Row '$BRANCH': failed to fetch version.php at ref '$REF' (not a 404):"


### PR DESCRIPTION
## Summary

Closes #13580. Makes `docker-validate-release-targets.yml` finalize-PR-aware: on `release-finalize/*` PRs, ref-resolution failures on a row's `openemr_version_ref` downgrade from error to warning (the tag is expected to not exist yet — the conductor merge creates it). Every other validation still applies. All non-finalize PRs and master pushes keep the strict "must resolve" gate.

## Why

The release-finalize PR (opened by release-prep.yml alongside the conductor PR) proposes adding a row like:

```yaml
- branch: rel-830
  openemr_version_ref: v8_3_0
```

but `v8_3_0` doesn't exist yet — the conductor merge is what creates the tag. So on the finalize PR at preflight time:

- `validate` = FAILURE (ref doesn't resolve; alignment step can't fetch version.php from a nonexistent ref)
- `All Checks Passed` = FAILURE (aggregator inherits validate)
- `mergeStateStatus` = BLOCKED (required check failing at GitHub's level)

Ship-release preflight then blocks — and no operator-side workaround via `ignore_checks` fully fixes it. #13570 wired ignore-list to the individual check enumeration, #13574 taught mergeStateStatus to accept UNSTABLE when the rollup clears via ignore-list — but BLOCKED (required check failing) is deliberately not conditionally-acceptable. The only workarounds were: (a) add `validate` to master's `all-checks-passed.yml` ignore-list (loosens the aggregator on ALL master PRs) or (b) admin-merge the conductor manually.

This PR fixes the root cause instead of adding tech-debt workarounds.

## What changed

- **Job-level env `IS_FINALIZE_PR`** = `startsWith(github.head_ref, 'release-finalize/')`. Only meaningful in PR context (the workflow only fires on `pull_request`).
- **Step 2 (`Verify every openemr_version_ref resolves`)**: on 404, if IS_FINALIZE_PR then `::warning::` + continue; otherwise `::error::` + exit 1 (unchanged for non-finalize PRs and master pushes).
- **Step 3 (`Cross-check docker_tag version against version.php`)**: on 404 for a non-master row, if IS_FINALIZE_PR then `::warning::` + skip that row's alignment check; otherwise unchanged.

**Not loosened on finalize PRs (still strict):**
- Shape checks (all rows have required fields)
- Duplicate docker_tag check (would still catch push races)
- Master-row alignment (uses local checkout — always resolvable)
- Alignment for rows whose refs DO resolve (existing rel-8X0 rows still get validated even on finalize PRs)

## Design notes

- **Why per-PR detection, not per-row heuristic.** Could have written "if any row's ref fails to resolve, skip it silently." But that would silently accept genuine ref typos in NON-finalize PRs (e.g., someone hand-edits release-targets.yml with a wrong ref). Per-PR gating keeps the strict validation everywhere except the one PR type where a not-yet-existing ref is expected.
- **Why warning not silent.** Warnings show up in the PR check-run output — helpful for the operator to visually confirm which rows are pre-tag placeholders (should just be the newly-added one).
- **Ship-release semantics preserved.** After this lands, ship-release preflight on the finalize PR should clear naturally: validate → SUCCESS (with warnings), All Checks Passed → SUCCESS, mergeStateStatus → CLEAN. No changes needed to ship-release itself. The `PHP 8.6 - Isolated Tests` in `ignore_checks` is still needed until upstream PHP fixes the bug (per the memory checklist), but `validate,All Checks Passed,codecov/project` all drop off the operator's per-run CSV.

## Test plan

- [x] `actionlint` (via pre-commit) — clean
- [ ] Runtime: after landing, if any rel-830 push force-pushes #13485 (via release-prep re-firing), the new logic runs. Should see `::warning::Row 'rel-830': openemr_version_ref 'v8_3_0' not yet resolvable — expected on release-finalize PR (tag will be created by conductor merge).` in the validate log, and the job should conclude SUCCESS.
- [ ] Post-tag validation: once conductor merges and `v8_3_0` exists, if the finalize PR is refreshed the warning goes away and full alignment check runs.

## Related

- Issue: #13580
- Ship-release ignore-list PRs: #13570 (individual check enumeration), #13574 (mergeStateStatus=UNSTABLE conditional)
- Same-shape sibling still open: #13573 (acceptance-harness FROM_VERSION calibration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)