### PR TITLE
fix(release): dedupe rollup check-runs + relax draft gate for downstream targets

### DIFF
--- a/tests/Tests/Isolated/Release/Fakes/FakePullRequestApi.php
+++ b/tests/Tests/Isolated/Release/Fakes/FakePullRequestApi.php
@@ -57,7 +57,7 @@ class FakePullRequestApi implements PullRequestApi
     /** @var array<string, int> */
     private array $releaseExistsCalls = [];
 
-    /** @var list<array{repo: string, number: int, requireApproval: bool, ignoreChecks: list<string>}> */
+    /** @var list<array{repo: string, number: int, requireApproval: bool, ignoreChecks: list<string>, requireNonDraft: bool}> */
     public array $readinessCalls = [];
 
     public function setSnapshot(string $repo, string $branch, ?PullRequestSnapshot $snapshot): void
@@ -130,12 +130,14 @@ class FakePullRequestApi implements PullRequestApi
         int $number,
         bool $requireApproval = true,
         array $ignoreChecks = [],
+        bool $requireNonDraft = true,
     ): PullRequestReadiness {
         $this->readinessCalls[] = [
             'repo' => $repo,
             'number' => $number,
             'requireApproval' => $requireApproval,
             'ignoreChecks' => $ignoreChecks,
+            'requireNonDraft' => $requireNonDraft,
         ];
         $key = $this->prKey($repo, $number);
         if (isset($this->readinessQueue[$key]) && $this->readinessQueue[$key] !== []) {

--- a/tests/Tests/Isolated/Release/GhPullRequestApiTest.php
+++ b/tests/Tests/Isolated/Release/GhPullRequestApiTest.php
@@ -396,6 +396,29 @@ final class GhPullRequestApiTest extends TestCase
         self::assertStringContainsString('IN_PROGRESS', $reasons[0]);
     }
 
+    public function testRollupDedupePreservesFirstSeenOrderWhenReplacingNewerAttempt(): void
+    {
+        // Regression: replacing a check with a newer attempt must NOT
+        // overwrite its first-seen sequence position. Order in the rollup:
+        // check A (seq 1), check B (seq 2), check A newer (seq 3, replaces).
+        // Dedupe should emit A before B — A was first seen at seq 1, even
+        // though the winning entry is a later re-run.
+        $rollup = [
+            ['name' => 'A', 'status' => 'COMPLETED', 'conclusion' => 'FAILURE',
+                'completedAt' => '2026-08-16T18:00:00Z'],
+            ['name' => 'B', 'status' => 'COMPLETED', 'conclusion' => 'FAILURE',
+                'completedAt' => '2026-08-16T18:30:00Z'],
+            ['name' => 'A', 'status' => 'COMPLETED', 'conclusion' => 'FAILURE',
+                'completedAt' => '2026-08-16T19:00:00Z'],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertCount(2, $reasons);
+        self::assertStringContainsString('A', $reasons[0]);
+        self::assertStringContainsString('B', $reasons[1]);
+    }
+
     public function testRollupDedupeAppliesToLegacyStatusesByContext(): void
     {
         // Legacy commit statuses re-post to the same context. Only the latest

--- a/tests/Tests/Isolated/Release/GhPullRequestApiTest.php
+++ b/tests/Tests/Isolated/Release/GhPullRequestApiTest.php
@@ -299,4 +299,122 @@ final class GhPullRequestApiTest extends TestCase
 
         self::assertContains('CHANGES_REQUESTED review by gatekeeper', $reasons);
     }
+
+    public function testReadinessToleratesDraftWhenRequireNonDraftIsFalse(): void
+    {
+        // Docs + Finalize PRs are auto-drafted by their generator workflows
+        // and auto-flipped by post-tag workflows. Blocking downstream targets
+        // on draft state at preflight would deadlock the ship. The orchestrator
+        // passes requireNonDraft=false for those roles.
+        $data = self::prData(isDraft: true);
+
+        $reasons = GhPullRequestApi::reasonsFromPullRequestData($data, false, [], false);
+
+        self::assertSame([], $reasons);
+    }
+
+    public function testRollupDedupesStaleFailureWhenLatestSuccessExists(): void
+    {
+        // Regression: rerunning a workflow leaves the older attempt in the
+        // rollup alongside the newer one. Ship-release must only consider the
+        // latest per check name; otherwise a stale FAILURE from before a fix
+        // landed keeps blocking preflight even after a green re-run.
+        $rollup = [
+            [
+                'name' => 'validate',
+                'status' => 'COMPLETED',
+                'conclusion' => 'FAILURE',
+                'completedAt' => '2026-08-16T18:56:00Z',
+            ],
+            [
+                'name' => 'validate',
+                'status' => 'COMPLETED',
+                'conclusion' => 'SUCCESS',
+                'completedAt' => '2026-08-16T20:14:19Z',
+            ],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertSame([], $reasons);
+    }
+
+    public function testRollupDedupeKeepsLatestFailureOverStaleSuccess(): void
+    {
+        // Symmetric: if the newest run is FAILURE and an older SUCCESS exists,
+        // the FAILURE must still block. Prevents "hide bug by re-running until
+        // green" logic errors and confirms dedupe is timestamp-based, not
+        // biased toward SUCCESS.
+        $rollup = [
+            [
+                'name' => 'phpstan',
+                'status' => 'COMPLETED',
+                'conclusion' => 'SUCCESS',
+                'completedAt' => '2026-08-16T18:00:00Z',
+            ],
+            [
+                'name' => 'phpstan',
+                'status' => 'COMPLETED',
+                'conclusion' => 'FAILURE',
+                'completedAt' => '2026-08-16T19:00:00Z',
+            ],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertCount(1, $reasons);
+        self::assertStringContainsString('phpstan', $reasons[0]);
+        self::assertStringContainsString('FAILURE', $reasons[0]);
+    }
+
+    public function testRollupDedupeUsesStartedAtWhenCompletedAtMissing(): void
+    {
+        // In-progress reruns have startedAt but no completedAt. A new
+        // IN_PROGRESS re-run of an old FAILURE should win the dedupe (it's
+        // the more recent attempt) and block preflight as pending, so the
+        // operator waits for it to complete rather than acting on a stale
+        // result.
+        $rollup = [
+            [
+                'name' => 'validate',
+                'status' => 'COMPLETED',
+                'conclusion' => 'FAILURE',
+                'completedAt' => '2026-08-16T18:56:00Z',
+                'startedAt' => '2026-08-16T18:55:00Z',
+            ],
+            [
+                'name' => 'validate',
+                'status' => 'IN_PROGRESS',
+                'conclusion' => null,
+                'startedAt' => '2026-08-16T20:14:00Z',
+            ],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertCount(1, $reasons);
+        self::assertStringContainsString('IN_PROGRESS', $reasons[0]);
+    }
+
+    public function testRollupDedupeAppliesToLegacyStatusesByContext(): void
+    {
+        // Legacy commit statuses re-post to the same context. Only the latest
+        // by createdAt should be considered.
+        $rollup = [
+            [
+                'context' => 'codecov/project',
+                'state' => 'FAILURE',
+                'createdAt' => '2026-08-16T18:00:00Z',
+            ],
+            [
+                'context' => 'codecov/project',
+                'state' => 'SUCCESS',
+                'createdAt' => '2026-08-16T20:00:00Z',
+            ],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertSame([], $reasons);
+    }
 }

--- a/tests/Tests/Isolated/Release/ShipReleaseOrchestratorTest.php
+++ b/tests/Tests/Isolated/Release/ShipReleaseOrchestratorTest.php
@@ -343,6 +343,33 @@ final class ShipReleaseOrchestratorTest extends TestCase
         self::assertFalse($byRole[self::FINALIZE_REPO . '#404']);
     }
 
+    public function testDraftGateAsymmetricConductorRequiresNonDraftDocsAndFinalizeDoNot(): void
+    {
+        // Docs + Finalize PRs are auto-drafted by their generator workflows
+        // and auto-flipped by post-tag workflows. Preflight blocking them on
+        // draft state would deadlock the ship: drafts don't flip until
+        // conductor merges, and conductor won't merge until preflight passes.
+        // The orchestrator must pass requireNonDraft=false for downstream
+        // targets (symmetric with requireApproval).
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setSnapshot(self::FINALIZE_REPO, self::FINALIZE_BRANCH, $this->open(404, 'sha-finalize'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+        $api->setReadiness(self::FINALIZE_REPO, 404, $this->ready('sha-finalize'));
+
+        $this->semiAuto($api, new FakeClock())->ship($this->targets());
+
+        $byRole = [];
+        foreach ($api->readinessCalls as $call) {
+            $byRole[$call['repo'] . '#' . $call['number']] = $call['requireNonDraft'];
+        }
+        self::assertTrue($byRole[self::CONDUCTOR_REPO . '#202']);
+        self::assertFalse($byRole[self::DOCS_REPO . '#303']);
+        self::assertFalse($byRole[self::FINALIZE_REPO . '#404']);
+    }
+
     public function testIgnoreChecksThreadedThroughToEveryReadinessCall(): void
     {
         // The orchestrator's ignore-checks list must propagate to both the

--- a/tools/release/src/GhPullRequestApi.php
+++ b/tools/release/src/GhPullRequestApi.php
@@ -240,8 +240,16 @@ final readonly class GhPullRequestApi implements PullRequestApi
                 continue;
             }
             $ts = self::checkTimestamp($check);
-            if (!isset($latest[$key]) || $ts > $latest[$key]['ts']) {
+            if (!isset($latest[$key])) {
                 $latest[$key] = ['check' => $check, 'ts' => $ts, 'seq' => $seq];
+            } elseif ($ts > $latest[$key]['ts']) {
+                // Update check + ts to the newer attempt but preserve the
+                // original first-seen seq so downstream ordering stays
+                // deterministic. Overwriting seq here would shift a re-run's
+                // check to its later position in the rollup, contradicting
+                // the "first-seen sequence per key" ordering rule below.
+                $latest[$key]['check'] = $check;
+                $latest[$key]['ts'] = $ts;
             }
         }
         // Restore original relative order (by first-seen sequence per key) so

--- a/tools/release/src/GhPullRequestApi.php
+++ b/tools/release/src/GhPullRequestApi.php
@@ -54,6 +54,7 @@ final readonly class GhPullRequestApi implements PullRequestApi
         int $number,
         bool $requireApproval = true,
         array $ignoreChecks = [],
+        bool $requireNonDraft = true,
     ): PullRequestReadiness {
         $process = new Process([
             'gh', 'pr', 'view', (string) $number,
@@ -78,7 +79,7 @@ final readonly class GhPullRequestApi implements PullRequestApi
 
         return new PullRequestReadiness(
             $data['headRefOid'],
-            self::reasonsFromPullRequestData($data, $requireApproval, $ignoreChecks),
+            self::reasonsFromPullRequestData($data, $requireApproval, $ignoreChecks, $requireNonDraft),
         );
     }
 
@@ -97,6 +98,17 @@ final readonly class GhPullRequestApi implements PullRequestApi
      * a REQUIRED check failed or review is missing, DIRTY means merge
      * conflicts, BEHIND means head is behind base, etc.
      *
+     * $requireNonDraft gates the isDraft check. Conductor PRs must be non-
+     * draft at preflight (they're the meaningful human-review artifact).
+     * Docs + Finalize PRs are bot-generated and are AUTO-drafted by their
+     * generator workflows, then auto-flipped by post-tag workflows —
+     * meaning they're structurally draft at preflight time. Blocking on
+     * that would deadlock (drafts don't flip until conductor merges, and
+     * conductor won't merge until preflight clears). The full-auto path
+     * re-checks readiness after the auto-flip via
+     * refreshDownstreamBeforeMerge, so relaxing preflight for downstream
+     * targets is safe.
+     *
      * @param array{
      *     isDraft: bool,
      *     mergeable: string,
@@ -112,9 +124,10 @@ final readonly class GhPullRequestApi implements PullRequestApi
         array $data,
         bool $requireApproval,
         array $ignoreChecks,
+        bool $requireNonDraft = true,
     ): array {
         $reasons = [];
-        if ($data['isDraft']) {
+        if ($requireNonDraft && $data['isDraft']) {
             $reasons[] = 'PR is a draft';
         }
         if ($data['mergeable'] !== 'MERGEABLE') {
@@ -155,12 +168,23 @@ final readonly class GhPullRequestApi implements PullRequestApi
     }
 
     /**
-     * Convert gh's statusCheckRollup into a list of blocking reasons. Skips
-     * any check whose context matches $ownContext — a prior ship-release run
-     * may have posted a failure status there, and the orchestrator must not
-     * gate itself on its own marker. Also skips any check whose name or
-     * context appears in $ignoreChecks (operator-supplied bypass for
-     * upstream known-broken jobs).
+     * Convert gh's statusCheckRollup into a list of blocking reasons.
+     *
+     * Deduplicates by check name (or legacy status context) first, keeping
+     * only the LATEST entry per key. GitHub returns re-run attempts as
+     * additional rollup entries — a stale FAILURE from an earlier attempt
+     * on the same head SHA would otherwise block preflight even after a
+     * successful re-run, because the enumeration would see both. Ordering
+     * uses `completedAt` (present on finished check-runs and legacy
+     * statuses via `createdAt`), falling back to `startedAt` for in-progress
+     * runs, so an in-progress newer attempt correctly wins over an older
+     * completed one.
+     *
+     * Skips any check whose context matches $ownContext — a prior ship-
+     * release run may have posted a failure status there, and the
+     * orchestrator must not gate itself on its own marker. Also skips any
+     * check whose name or context appears in $ignoreChecks (operator-
+     * supplied bypass for upstream known-broken jobs).
      *
      * @param  list<array<string, mixed>> $rollup
      * @param  list<string>               $ignoreChecks
@@ -173,7 +197,7 @@ final readonly class GhPullRequestApi implements PullRequestApi
     ): array {
         $ignore = array_flip($ignoreChecks);
         $reasons = [];
-        foreach ($rollup as $check) {
+        foreach (self::latestPerCheckKey($rollup) as $check) {
             if (($check['context'] ?? null) === $ownContext) {
                 continue;
             }
@@ -185,6 +209,60 @@ final readonly class GhPullRequestApi implements PullRequestApi
             $reasons = array_merge($reasons, self::checkBlockingReason($check));
         }
         return $reasons;
+    }
+
+    /**
+     * Collapse repeated check entries in the rollup down to the latest per
+     * name/context. `gh pr view --json statusCheckRollup` returns every
+     * check-run attempt on the head SHA, including re-runs — so an old
+     * FAILURE and a fresh SUCCESS both show up. Ordering uses `completedAt`
+     * (present on completed check-runs) falling back to `startedAt` (present
+     * on in-progress runs). Legacy commit statuses have `createdAt` (also
+     * timestamp-shaped and lexicographically ordered), which fits the same
+     * ordering rule. Entries without a resolvable timestamp compare as
+     * empty string and lose to any timestamped entry, but preserve their
+     * insertion-order relative position vs each other.
+     *
+     * @param  list<array<string, mixed>>  $rollup
+     * @return list<array<string, mixed>>
+     */
+    private static function latestPerCheckKey(array $rollup): array
+    {
+        /** @var array<string, array{check: array<string, mixed>, ts: string, seq: int}> $latest */
+        $latest = [];
+        $seq = 0;
+        foreach ($rollup as $check) {
+            $seq++;
+            $name = is_string($check['name'] ?? null) ? $check['name'] : null;
+            $context = is_string($check['context'] ?? null) ? $check['context'] : null;
+            $key = $name ?? $context;
+            if ($key === null) {
+                continue;
+            }
+            $ts = self::checkTimestamp($check);
+            if (!isset($latest[$key]) || $ts > $latest[$key]['ts']) {
+                $latest[$key] = ['check' => $check, 'ts' => $ts, 'seq' => $seq];
+            }
+        }
+        // Restore original relative order (by first-seen sequence per key) so
+        // downstream error messages remain stable across otherwise-equivalent
+        // rollups.
+        uasort($latest, static fn (array $a, array $b): int => $a['seq'] <=> $b['seq']);
+        return array_values(array_map(static fn (array $entry): array => $entry['check'], $latest));
+    }
+
+    /**
+     * @param array<string, mixed> $check
+     */
+    private static function checkTimestamp(array $check): string
+    {
+        foreach (['completedAt', 'startedAt', 'createdAt'] as $field) {
+            $value = $check[$field] ?? null;
+            if (is_string($value) && $value !== '') {
+                return $value;
+            }
+        }
+        return '';
     }
 
     public function postCommitStatus(

--- a/tools/release/src/PullRequestApi.php
+++ b/tools/release/src/PullRequestApi.php
@@ -43,6 +43,16 @@ interface PullRequestApi
      * blocking-reasons list. When it clears every rollup entry, UNSTABLE is
      * treated as CLEAN.
      *
+     * $requireNonDraft gates the isDraft check. Defaults to true (Conductor
+     * PRs must be non-draft at preflight -- they're the meaningful human-
+     * review artifact). Docs + Finalize PRs pass false: those are auto-
+     * drafted by their generator workflows and only auto-flipped by post-
+     * tag workflows (docs on `openemr-tag`; finalize by the finalize job),
+     * so they're structurally draft at preflight time. Blocking on that
+     * would deadlock -- no way for downstream to un-draft before conductor
+     * merges. Full-auto re-checks readiness after auto-flip via
+     * refreshDownstreamBeforeMerge, so the relaxation is safe.
+     *
      * @param list<string> $ignoreChecks
      */
     public function getReadiness(
@@ -50,6 +60,7 @@ interface PullRequestApi
         int $number,
         bool $requireApproval = true,
         array $ignoreChecks = [],
+        bool $requireNonDraft = true,
     ): PullRequestReadiness;
 
     /**

--- a/tools/release/src/ShipReleaseOrchestrator.php
+++ b/tools/release/src/ShipReleaseOrchestrator.php
@@ -203,6 +203,7 @@ final readonly class ShipReleaseOrchestrator
                 $snapshot->number,
                 $this->requiresApproval($target->roleLabel),
                 $this->ignoreChecks,
+                $this->requiresNonDraft($target->roleLabel),
             );
             $readiness[$key] = $check;
             if (!$check->isReady()) {
@@ -552,6 +553,7 @@ final readonly class ShipReleaseOrchestrator
             $fresh->number,
             $this->requiresApproval($target->roleLabel),
             $this->ignoreChecks,
+            $this->requiresNonDraft($target->roleLabel),
         );
         if (!$readiness->isReady()) {
             $stopReason = $conductorJustMerged
@@ -595,6 +597,25 @@ final readonly class ShipReleaseOrchestrator
      * checks skip the APPROVED requirement.
      */
     private function requiresApproval(RoleLabel $role): bool
+    {
+        return match ($role) {
+            RoleLabel::Conductor => true,
+            RoleLabel::Docs, RoleLabel::Finalize => false,
+        };
+    }
+
+    /**
+     * Conductor is a human-review artifact -- must be non-draft at preflight
+     * time (undrafted by the maintainer as the ready-to-ship signal). Docs
+     * and Finalize are AUTO-drafted by their generator workflows and only
+     * auto-flipped by post-tag workflows (docs on `openemr-tag`, finalize
+     * by the finalize job), which fire AFTER conductor merges. Preflight
+     * can't require non-draft on downstream targets without deadlocking
+     * the ship. Full-auto re-checks readiness after auto-flip via
+     * refreshDownstreamBeforeMerge, so downstream drafts are re-evaluated
+     * at the actually-safe moment.
+     */
+    private function requiresNonDraft(RoleLabel $role): bool
     {
         return match ($role) {
             RoleLabel::Conductor => true,


### PR DESCRIPTION
## Summary

Two ship-release preflight fixes surfaced by the 8.3.0 dry-runs. Both are the same "loosen a preflight gate under narrow, safe conditions" pattern as #13570 and #13574.

## Fix A — rollup dedupe

`gh pr view --json statusCheckRollup` returns every attempt on the head SHA — including re-runs. A stale FAILURE from an earlier attempt was blocking preflight even after a successful re-run because `reasonsFromStatusRollup` enumerated all entries.

Repro on 8.3.0: after #13581 landed, someone re-ran `validate` on the finalize PR (#13485), the new run turned SUCCESS, but the old FAILURE remained in the rollup. Dry-run kept blocking on `validate FAILURE`.

**Fix:** dedupe by check name (or legacy status context), keeping only the latest entry per key. Ordering uses `completedAt` → `startedAt` → `createdAt` fallback, so an in-progress newer run correctly wins over an older completed one (blocks preflight as pending — operator waits for it, doesn't act on stale result).

## Fix B — downstream draft tolerance

Ship-release preflight was unconditionally requiring non-draft on all 3 targets. But the Docs + Finalize PRs are AUTO-drafted by their generator workflows and only auto-flipped by post-tag workflows (docs on `openemr-tag`, finalize by the finalize job). Blocking on their draft state at preflight deadlocked the ship: drafts don't flip until conductor merges, and conductor won't merge until preflight clears.

The current release ONLY worked when an operator manually undrafted docs + finalize before dispatching. That's a design bug — one-command semi-auto/full-auto isn't reachable without the manual undraft.

**Fix:** `getReadiness()` accepts a `$requireNonDraft` flag (default true). Orchestrator passes false for Docs + Finalize (symmetric with the existing `requireApproval` role split). Full-auto's `refreshDownstreamBeforeMerge` still re-checks readiness AFTER auto-flip via the docs-branch push detection, so the safety net remains — downstream drafts are re-evaluated at the actually-safe moment.

## What changed

- **`GhPullRequestApi::reasonsFromStatusRollup`** — pre-dedupes rollup via new private `latestPerCheckKey()` helper before applying the existing per-check logic.
- **`GhPullRequestApi::reasonsFromPullRequestData`** — accepts `$requireNonDraft` (default true) that gates the `isDraft` check.
- **`GhPullRequestApi::getReadiness`** + **`PullRequestApi::getReadiness`** interface + **`FakePullRequestApi::getReadiness`** — new `$requireNonDraft` param plumbed through.
- **`ShipReleaseOrchestrator::requiresNonDraft(RoleLabel)`** — new helper (mirror of `requiresApproval`): true for Conductor, false for Docs/Finalize.
- Both `preflight()` and `refreshDownstreamBeforeMerge()` call sites pass the role-derived flag.

## Design notes

- **Dedupe is timestamp-based, not conclusion-biased.** If the latest run is FAILURE (real regression), it still blocks. Tested explicitly.
- **In-progress newer wins.** A rerun triggered while an old completed FAILURE exists blocks preflight as pending. Operator waits for it to complete rather than acting on stale data.
- **Empty timestamps preserve insertion-order relative position.** Entries without a resolvable timestamp compare as empty string and lose to any timestamped entry, but keep their first-seen order otherwise. Existing tests use no-timestamp rollups and continue to behave identically.
- **`requireNonDraft` mirrors `requireApproval`.** Same conceptual axis: downstream targets are auto-generated bot content whose "meaningful state" gates don't apply. Full-auto's downstream-refresh path re-checks all readiness gates after conductor merges + auto-flip fires, so the relaxation only affects the preflight moment.

## Test plan

- [x] `pit --filter '/^.*(GhPullRequestApi|ShipReleaseCli|ShipReleaseOrchestrator).*$/'` — 56 tests, 180 assertions, all pass (was 50; +6 new: 4 dedupe scenarios + draft-tolerance + orchestrator threading)
- [x] `openemr-cmd pst` — clean
- [ ] Post-merge validation: dispatch rel-830 8.3.0 dry-run with `ignore_checks='PHP 8.6 - Isolated Tests'` (drops `validate`, `All Checks Passed`, `codecov/project` since dedupe now sees only the latest — which are SUCCESS). Should preflight-clear on all 3 targets without manual undraft of docs/finalize.

## Related

- #13570 — ignore-list on individual check enumeration
- #13574 — mergeStateStatus=UNSTABLE conditional accept
- #13581 — docker-validate-release-targets finalize-PR-aware
- Post-830 followup memory (only #13573 wizard-upgrade calibration remains open + PHP 8.6 workaround backout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)