### PR TITLE
fix(docker): pass --from to sql_upgrade.php instead of sed-patching it

### DIFF
--- a/docker/binary/upgrade/fsupgrade-1.sh
+++ b/docker/binary/upgrade/fsupgrade-1.sh
@@ -50,12 +50,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "/input type='submit'/d" \
-            -e "s/!empty(\$_POST\['form_submit'\])/empty(\$_POST\['form_submit'\])/" \
-            -e "s/^[   ]*\$form_old_version[   =].*$/\$form_old_version = \"${priorOpenemrVersion}\";/" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-2.sh
+++ b/docker/binary/upgrade/fsupgrade-2.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-3.sh
+++ b/docker/binary/upgrade/fsupgrade-3.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-4.sh
+++ b/docker/binary/upgrade/fsupgrade-4.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-5.sh
+++ b/docker/binary/upgrade/fsupgrade-5.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-6.sh
+++ b/docker/binary/upgrade/fsupgrade-6.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-7.sh
+++ b/docker/binary/upgrade/fsupgrade-7.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-8.sh
+++ b/docker/binary/upgrade/fsupgrade-8.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/utilities/devtoolsLibrary.source
+++ b/docker/binary/utilities/devtoolsLibrary.source
@@ -284,18 +284,13 @@ demoData() {
 #
 # ----------------------------------------------------------------------------
 upgradeOpenEMR() {
-    # Create a modified version of sql_upgrade.php that auto-submits
-    # Replace form submission check with 'true' to bypass user interaction
-    sed -e "s@!empty(\$_POST\['form_submit'\])@true@" < /var/www/localhost/htdocs/openemr/sql_upgrade.php > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Set the old version parameter directly instead of reading from POST
-    sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${1}';@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Inject site context at the beginning of the file
-    sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Execute the modified upgrade script
-    run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    # Inject site context, then run the standard upgrade via its CLI interface
+    {
+        echo "<?php \$_GET['site'] = 'default'; ?>"
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    # Execute the upgrade script with the from-version argument
+    run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"
 
     # Clean up temporary file
     rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php

--- a/docker/release/upgrade/fsupgrade-1.sh
+++ b/docker/release/upgrade/fsupgrade-1.sh
@@ -50,12 +50,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "/input type='submit'/d" \
-            -e "s/!empty(\$_POST\['form_submit'\])/empty(\$_POST\['form_submit'\])/" \
-            -e "s/^[   ]*\$form_old_version[   =].*$/\$form_old_version = \"${priorOpenemrVersion}\";/" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-10.sh
+++ b/docker/release/upgrade/fsupgrade-10.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-11.sh
+++ b/docker/release/upgrade/fsupgrade-11.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-12.sh
+++ b/docker/release/upgrade/fsupgrade-12.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-13.sh
+++ b/docker/release/upgrade/fsupgrade-13.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-2.sh
+++ b/docker/release/upgrade/fsupgrade-2.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-3.sh
+++ b/docker/release/upgrade/fsupgrade-3.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-4.sh
+++ b/docker/release/upgrade/fsupgrade-4.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-5.sh
+++ b/docker/release/upgrade/fsupgrade-5.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-6.sh
+++ b/docker/release/upgrade/fsupgrade-6.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-7.sh
+++ b/docker/release/upgrade/fsupgrade-7.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-8.sh
+++ b/docker/release/upgrade/fsupgrade-8.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-9.sh
+++ b/docker/release/upgrade/fsupgrade-9.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/utilities/devtoolsLibrary.source
+++ b/docker/release/utilities/devtoolsLibrary.source
@@ -284,18 +284,13 @@ demoData() {
 #
 # ----------------------------------------------------------------------------
 upgradeOpenEMR() {
-    # Create a modified version of sql_upgrade.php that auto-submits
-    # Replace form submission check with 'true' to bypass user interaction
-    sed -e "s@!empty(\$_POST\['form_submit'\])@true@" < /var/www/localhost/htdocs/openemr/sql_upgrade.php > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Set the old version parameter directly instead of reading from POST
-    sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${1}';@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Inject site context at the beginning of the file
-    sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Execute the modified upgrade script
-    run_php_as_apache php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    # Inject site context, then run the standard upgrade via its CLI interface
+    {
+        echo "<?php \$_GET['site'] = 'default'; ?>"
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    # Execute the upgrade script with the from-version argument
+    run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"
 
     # Clean up temporary file
     rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-11.sh
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-11.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
The fsupgrade scripts and the devtools upgradeOpenEMR() helper injected
the from-version by sed-replacing
  \$form_old_version = \$_POST['form_old_version'];
which no longer exists (refactored to a ??-chain reading \$cliFromVersion).
sed silently matched nothing, \$form_old_version resolved to '', and every
upgrade hop replayed the full chain from 2_9_0 (observed: 7.0.2->8.2.0
production upgrade, 6 hops, ~23min instead of ~4min).

sql_upgrade.php already provides a --from=VERSION CLI argument, and CLI
mode already satisfies the form_submit gate, so all sed substitutions
are obsolete (including fsupgrade-1's variant block and its cosmetic
input-tag stripping). Use the real interface; keep the temp file solely
for the \$_GET['site'] prelude.

Updates all fsupgrade scripts (binary + release, incl. the 8.3.0
scaffold fsupgrade-13), both devtoolsLibrary.source copies, and the
ReleasePrep docker_upgrade fixtures."

#### Was an AI assistant used? Yes, guess who :)

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
