### PR TITLE
fix(docker): pass --from to sql_upgrade.php instead of sed-patching it (backport #13583 to rel-830)

### DIFF
--- a/docker/binary/upgrade/fsupgrade-1.sh
+++ b/docker/binary/upgrade/fsupgrade-1.sh
@@ -50,12 +50,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "/input type='submit'/d" \
-            -e "s/!empty(\$_POST\['form_submit'\])/empty(\$_POST\['form_submit'\])/" \
-            -e "s/^[   ]*\$form_old_version[   =].*$/\$form_old_version = \"${priorOpenemrVersion}\";/" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-2.sh
+++ b/docker/binary/upgrade/fsupgrade-2.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-3.sh
+++ b/docker/binary/upgrade/fsupgrade-3.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-4.sh
+++ b/docker/binary/upgrade/fsupgrade-4.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-5.sh
+++ b/docker/binary/upgrade/fsupgrade-5.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-6.sh
+++ b/docker/binary/upgrade/fsupgrade-6.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-7.sh
+++ b/docker/binary/upgrade/fsupgrade-7.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-8.sh
+++ b/docker/binary/upgrade/fsupgrade-8.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/utilities/devtoolsLibrary.source
+++ b/docker/binary/utilities/devtoolsLibrary.source
@@ -284,18 +284,13 @@ demoData() {
 #
 # ----------------------------------------------------------------------------
 upgradeOpenEMR() {
-    # Create a modified version of sql_upgrade.php that auto-submits
-    # Replace form submission check with 'true' to bypass user interaction
-    sed -e "s@!empty(\$_POST\['form_submit'\])@true@" < /var/www/localhost/htdocs/openemr/sql_upgrade.php > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Set the old version parameter directly instead of reading from POST
-    sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${1}';@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Inject site context at the beginning of the file
-    sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Execute the modified upgrade script
-    run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    # Inject site context, then run the standard upgrade via its CLI interface
+    {
+        echo "<?php \$_GET['site'] = 'default'; ?>"
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    # Execute the upgrade script with the from-version argument
+    run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"
 
     # Clean up temporary file
     rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php

--- a/docker/release/upgrade/fsupgrade-1.sh
+++ b/docker/release/upgrade/fsupgrade-1.sh
@@ -50,12 +50,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "/input type='submit'/d" \
-            -e "s/!empty(\$_POST\['form_submit'\])/empty(\$_POST\['form_submit'\])/" \
-            -e "s/^[   ]*\$form_old_version[   =].*$/\$form_old_version = \"${priorOpenemrVersion}\";/" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-10.sh
+++ b/docker/release/upgrade/fsupgrade-10.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-11.sh
+++ b/docker/release/upgrade/fsupgrade-11.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-12.sh
+++ b/docker/release/upgrade/fsupgrade-12.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-13.sh
+++ b/docker/release/upgrade/fsupgrade-13.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-2.sh
+++ b/docker/release/upgrade/fsupgrade-2.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-3.sh
+++ b/docker/release/upgrade/fsupgrade-3.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-4.sh
+++ b/docker/release/upgrade/fsupgrade-4.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-5.sh
+++ b/docker/release/upgrade/fsupgrade-5.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-6.sh
+++ b/docker/release/upgrade/fsupgrade-6.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-7.sh
+++ b/docker/release/upgrade/fsupgrade-7.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-8.sh
+++ b/docker/release/upgrade/fsupgrade-8.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-9.sh
+++ b/docker/release/upgrade/fsupgrade-9.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/utilities/devtoolsLibrary.source
+++ b/docker/release/utilities/devtoolsLibrary.source
@@ -284,18 +284,13 @@ demoData() {
 #
 # ----------------------------------------------------------------------------
 upgradeOpenEMR() {
-    # Create a modified version of sql_upgrade.php that auto-submits
-    # Replace form submission check with 'true' to bypass user interaction
-    sed -e "s@!empty(\$_POST\['form_submit'\])@true@" < /var/www/localhost/htdocs/openemr/sql_upgrade.php > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Set the old version parameter directly instead of reading from POST
-    sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${1}';@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Inject site context at the beginning of the file
-    sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Execute the modified upgrade script
-    run_php_as_apache php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    # Inject site context, then run the standard upgrade via its CLI interface
+    {
+        echo "<?php \$_GET['site'] = 'default'; ?>"
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    # Execute the upgrade script with the from-version argument
+    run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"
 
     # Clean up temporary file
     rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-11.sh
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-11.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done


### PR DESCRIPTION
Backport of #13583 to rel-830 — required before the 8.3.0 docker image builds, otherwise every fresh 8.3.0 install upgrading from a prior version hits the sed no-op bug (docker fsupgrade scripts sed-patch a sql_upgrade.php line that was refactored away — silently no-ops, \`\$form_old_version\` ends up empty, upgrade chain replays from 2.9.0 on every hop).

## Verification

Cherry-picked from master's landed \`fa4337ecd15bb929b0de82948b5dadfde6d1b923\` with \`git cherry-pick -x\`. Applied cleanly — no conflicts. All 25 files touched on master exist on rel-830 with byte-identical pre-fix content, so the diff applied verbatim.

**Byte-equivalence confirmed via \`git patch-id --stable\`:**
\`\`\`
a9b40da3ad057e6dca6d312e31e06a15644c39ee   (rel-830 backport HEAD)
a9b40da3ad057e6dca6d312e31e06a15644c39ee   (master fa4337ecd1)
\`\`\`

## Scope on rel-830

- \`docker/binary/upgrade/fsupgrade-{1..8}.sh\` (8 files)
- \`docker/release/upgrade/fsupgrade-{1..13}.sh\` (13 files, includes fsupgrade-13.sh for 8.2.0→8.3.0 which is the one that would run on 8.3.0 upgrade installs)
- \`docker/binary/utilities/devtoolsLibrary.source\`
- \`docker/release/utilities/devtoolsLibrary.source\`
- ReleasePrep test fixtures (\`fsupgrade-11.sh\`, \`fsupgrade-12.sh.expected\`) — synced surface, present on rel-830

## Related

- Master PR: #13583 (landed)
- Same-shape backport for rel-820 planned separately (8.2.0 docker already shipped with the bug — 8.2.x patch releases will need this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)