### PR TITLE
fix(docker): pass --from to sql_upgrade.php instead of sed-patching it (backport #13583 to rel-820)

### DIFF
--- a/docker/binary/upgrade/fsupgrade-1.sh
+++ b/docker/binary/upgrade/fsupgrade-1.sh
@@ -50,12 +50,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "/input type='submit'/d" \
-            -e "s/!empty(\$_POST\['form_submit'\])/empty(\$_POST\['form_submit'\])/" \
-            -e "s/^[   ]*\$form_old_version[   =].*$/\$form_old_version = \"${priorOpenemrVersion}\";/" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-2.sh
+++ b/docker/binary/upgrade/fsupgrade-2.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-3.sh
+++ b/docker/binary/upgrade/fsupgrade-3.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-4.sh
+++ b/docker/binary/upgrade/fsupgrade-4.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-5.sh
+++ b/docker/binary/upgrade/fsupgrade-5.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-6.sh
+++ b/docker/binary/upgrade/fsupgrade-6.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-7.sh
+++ b/docker/binary/upgrade/fsupgrade-7.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-8.sh
+++ b/docker/binary/upgrade/fsupgrade-8.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/utilities/devtoolsLibrary.source
+++ b/docker/binary/utilities/devtoolsLibrary.source
@@ -284,18 +284,13 @@ demoData() {
 #
 # ----------------------------------------------------------------------------
 upgradeOpenEMR() {
-    # Create a modified version of sql_upgrade.php that auto-submits
-    # Replace form submission check with 'true' to bypass user interaction
-    sed -e "s@!empty(\$_POST\['form_submit'\])@true@" < /var/www/localhost/htdocs/openemr/sql_upgrade.php > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Set the old version parameter directly instead of reading from POST
-    sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${1}';@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Inject site context at the beginning of the file
-    sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Execute the modified upgrade script
-    run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    # Inject site context, then run the standard upgrade via its CLI interface
+    {
+        echo "<?php \$_GET['site'] = 'default'; ?>"
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    # Execute the upgrade script with the from-version argument
+    run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"
 
     # Clean up temporary file
     rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php

--- a/docker/release/upgrade/fsupgrade-1.sh
+++ b/docker/release/upgrade/fsupgrade-1.sh
@@ -50,12 +50,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "/input type='submit'/d" \
-            -e "s/!empty(\$_POST\['form_submit'\])/empty(\$_POST\['form_submit'\])/" \
-            -e "s/^[   ]*\$form_old_version[   =].*$/\$form_old_version = \"${priorOpenemrVersion}\";/" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-10.sh
+++ b/docker/release/upgrade/fsupgrade-10.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-11.sh
+++ b/docker/release/upgrade/fsupgrade-11.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-12.sh
+++ b/docker/release/upgrade/fsupgrade-12.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-2.sh
+++ b/docker/release/upgrade/fsupgrade-2.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-3.sh
+++ b/docker/release/upgrade/fsupgrade-3.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-4.sh
+++ b/docker/release/upgrade/fsupgrade-4.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-5.sh
+++ b/docker/release/upgrade/fsupgrade-5.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-6.sh
+++ b/docker/release/upgrade/fsupgrade-6.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-7.sh
+++ b/docker/release/upgrade/fsupgrade-7.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-8.sh
+++ b/docker/release/upgrade/fsupgrade-8.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-9.sh
+++ b/docker/release/upgrade/fsupgrade-9.sh
@@ -37,11 +37,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/utilities/devtoolsLibrary.source
+++ b/docker/release/utilities/devtoolsLibrary.source
@@ -284,18 +284,13 @@ demoData() {
 #
 # ----------------------------------------------------------------------------
 upgradeOpenEMR() {
-    # Create a modified version of sql_upgrade.php that auto-submits
-    # Replace form submission check with 'true' to bypass user interaction
-    sed -e "s@!empty(\$_POST\['form_submit'\])@true@" < /var/www/localhost/htdocs/openemr/sql_upgrade.php > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Set the old version parameter directly instead of reading from POST
-    sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${1}';@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Inject site context at the beginning of the file
-    sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-
-    # Execute the modified upgrade script
-    run_php_as_apache php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    # Inject site context, then run the standard upgrade via its CLI interface
+    {
+        echo "<?php \$_GET['site'] = 'default'; ?>"
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    # Execute the upgrade script with the from-version argument
+    run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"
 
     # Clean up temporary file
     rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-11.sh
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-11.sh
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
@@ -30,11 +30,9 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } | sed -e "s@!empty(\$_POST\['form_submit'\])@true@" \
-            -e "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${priorOpenemrVersion}';@" \
-            > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done


### PR DESCRIPTION
Backport of #13583 to rel-820. The 8.2.0 docker image (already shipped) has the sed no-op bug — every fresh 8.2.0 install upgrading from an earlier version replays the entire chain from 2.9.0. Any future 8.2.x patch release needs this fix so patch-image upgraders don't hit it again.

## Verification

Cherry-picked from master's landed \`fa4337ecd15bb929b0de82948b5dadfde6d1b923\` with \`git cherry-pick -x\`. One expected conflict resolved: \`docker/release/upgrade/fsupgrade-13.sh\` doesn't exist on rel-820 (that script handles the 8.2.0→8.3.0 hop, which doesn't apply on rel-820). \`git rm\` on that path resolved cleanly, then continued.

**Byte-equivalence confirmed via \`git patch-id --stable\`** on the 24 shared files (all fsupgrade + devtoolsLibrary.source + test fixtures):
\`\`\`
97ee7d62a3aa28159f75c3ff5d02d8b43916ad37   (rel-820 backport HEAD)
97ee7d62a3aa28159f75c3ff5d02d8b43916ad37   (master fa4337ecd1, filtered to same 24 files)
\`\`\`

## Scope on rel-820

24 files — one less than master:

- \`docker/binary/upgrade/fsupgrade-{1..8}.sh\` (8 files)
- \`docker/release/upgrade/fsupgrade-{1..12}.sh\` (12 files — fsupgrade-13.sh doesn't exist on this branch, correctly)
- \`docker/binary/utilities/devtoolsLibrary.source\`
- \`docker/release/utilities/devtoolsLibrary.source\`
- ReleasePrep test fixtures (\`fsupgrade-11.sh\`, \`fsupgrade-12.sh.expected\`) — synced surface

## Related

- Master PR: #13583 (landed)
- rel-830 backport: #13586
- rel-810, rel-800, rel-704 do NOT need this backport — those branches predate the sql_upgrade.php refactor (openemr/openemr#11906) and their sed patches still match the pre-refactor code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)