### PR TITLE
refactor(http): serve one request object per process

### DIFF
--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -598,7 +598,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 30,
+    'count' => 29,
     'path' => __DIR__ . '/../../interface/globals.php',
 ];
 $ignoreErrors[] = [

--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -18,6 +18,7 @@
 require_once "../vendor/autoload.php";
 
 use OpenEMR\BC\FallbackRouter;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\RestControllers\ApiApplication;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,6 +26,11 @@ use Symfony\Component\HttpFoundation\Response;
 // create the Request object
 try {
     $request = HttpRestRequest::createFromGlobals();
+    // Publish before anything downstream can reach for a request. globals.php is
+    // included much later (SiteSetupListener::loadApplicationGlobals) from a scope
+    // that cannot see $request, so without this it would build a second, bare
+    // instance missing the api type, scopes, and session set during the run.
+    CurrentRequest::set($request);
     FallbackRouter::handleRoutingTestIfRequested($request->getRequestUri(), 'apis');
     $apiApplication = new ApiApplication();
     $apiApplication->run($request);

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -18,13 +18,13 @@ require_once __DIR__ . '/../globals.php';
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Http\RequestTerminator;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FormService;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Process\Process;
 
@@ -36,7 +36,7 @@ require_once "$srcdir/forms.inc.php";
 require_once "$srcdir/options.inc.php";
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
-$request = Request::createFromGlobals();
+$request = CurrentRequest::get();
 $filesystem = new Filesystem();
 $userauthorized = $globalsBag->getInt('userauthorized');
 

--- a/interface/forms/CAMOS/admin.php
+++ b/interface/forms/CAMOS/admin.php
@@ -21,12 +21,12 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\HttpFoundation\Request;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
-$request = Request::createFromGlobals();
+$request = CurrentRequest::get();
 
 // Check authorization.
 if (!AclMain::aclCheckCore('admin', 'super')) {

--- a/interface/forms/care_plan/new.php
+++ b/interface/forms/care_plan/new.php
@@ -20,13 +20,13 @@
 require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Controllers\Interface\Forms\CarePlan\CarePlanController;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\Forms\CarePlanFormService;
 use OpenEMR\Services\FormService;
-use Symfony\Component\HttpFoundation\Request;
 
 $globalsBag = OEGlobalsBag::getInstance();
 $srcdir = $globalsBag->getSrcDir();
@@ -51,4 +51,4 @@ $controller = new CarePlanController(
     $globalsBag->getString('v_js_includes'),
 );
 
-$controller->newAction(Request::createFromGlobals())->send();
+$controller->newAction(CurrentRequest::get())->send();

--- a/interface/forms/care_plan/save.php
+++ b/interface/forms/care_plan/save.php
@@ -20,6 +20,7 @@
 require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
@@ -28,7 +29,6 @@ use OpenEMR\Controllers\Interface\Forms\CarePlan\CarePlanController;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\Forms\CarePlanFormService;
 use OpenEMR\Services\FormService;
-use Symfony\Component\HttpFoundation\Request;
 
 $globalsBag = OEGlobalsBag::getInstance();
 $srcdir = $globalsBag->getSrcDir();
@@ -55,7 +55,7 @@ $controller = new CarePlanController(
     $globalsBag->getString('v_js_includes'),
 );
 
-$controller->saveAction(Request::createFromGlobals(), PatientSessionUtil::getUserAuthorized())->send();
+$controller->saveAction(CurrentRequest::get(), PatientSessionUtil::getUserAuthorized())->send();
 
 formHeader("Redirecting....");
 formJump();

--- a/interface/forms/observation/delete.php
+++ b/interface/forms/observation/delete.php
@@ -24,18 +24,18 @@ require_once("$srcdir/api.inc.php");
 require_once("$srcdir/forms.inc.php");
 
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Controllers\Interface\Forms\Observation\ObservationController;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FormService;
 use OpenEMR\Services\ObservationService;
-use Symfony\Component\HttpFoundation\Request;
 
 $logger = ServiceContainer::getLogger();
 
 try {
     // Create controller and handle request
-    $request = Request::createFromGlobals();
+    $request = CurrentRequest::get();
     $service = new ObservationService();
     $formService = new FormService();
     // resolves to openemer/interface/  so that templates will be found in /forms/observation/templates

--- a/interface/forms/observation/new.php
+++ b/interface/forms/observation/new.php
@@ -24,19 +24,19 @@ require_once("$srcdir/options.inc.php");
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getProjectDir() . '/custom/code_types.inc.php');
 
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Controllers\Interface\Forms\Observation\ObservationController;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FormService;
 use OpenEMR\Services\ObservationService;
-use Symfony\Component\HttpFoundation\Request;
 
 $logger = ServiceContainer::getLogger();
 
 // Output the response
 try {
     // Create controller and handle request
-    $request = Request::createFromGlobals();
+    $request = CurrentRequest::get();
     $service = new ObservationService();
     $formService = new FormService();
     // resolves to openemer/interface/  so that templates will be found in /forms/observation/templates

--- a/interface/forms/observation/save.php
+++ b/interface/forms/observation/save.php
@@ -22,18 +22,18 @@ require_once("$srcdir/api.inc.php");
 require_once("$srcdir/forms.inc.php");
 
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Controllers\Interface\Forms\Observation\ObservationController;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FormService;
 use OpenEMR\Services\ObservationService;
-use Symfony\Component\HttpFoundation\Request;
 
 $logger = ServiceContainer::getLogger();
 
 try {
     // Create controller and handle request
-    $request = Request::createFromGlobals();
+    $request = CurrentRequest::get();
     $service = new ObservationService();
     $formService = new FormService();
     // resolves to openemer/interface/  so that templates will be found in /forms/observation/templates

--- a/interface/forms/physical_exam/new.php
+++ b/interface/forms/physical_exam/new.php
@@ -18,14 +18,13 @@ require_once(__DIR__ . "/../../globals.php");
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Forms\EncounterFormAccess;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FormService;
-use Symfony\Component\HttpFoundation\Request;
-
 use function OpenEMR\Forms\PhysicalExam\physical_exam_lines;
 use function OpenEMR\Forms\PhysicalExam\scalar_string;
 
@@ -46,7 +45,7 @@ if (!$encounter) {
 
 $returnurl = 'encounter_top.php';
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
-$request = Request::createFromGlobals();
+$request = CurrentRequest::get();
 
 // A stored checkbox value is "on" when it is non-empty and not '0'.
 $isChecked = static fn (string $value): bool => $value !== '' && $value !== '0';

--- a/interface/forms/questionnaire_assessments/view.php
+++ b/interface/forms/questionnaire_assessments/view.php
@@ -9,9 +9,9 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-use Symfony\Component\HttpFoundation\Request;
+use OpenEMR\Common\Http\CurrentRequest;
 
 $mode = 'update';
-$request = Request::createFromGlobals();
+$request = CurrentRequest::get();
 $form_id = $request->query->getInt('id');
 require("questionnaire_assessments.php");

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -244,26 +244,19 @@ $GLOBALS['OE_SITES_BASE'] = "$webserver_root/sites";
 $GLOBALS['vendor_dir'] = "$webserver_root/vendor";
 
 /*
-* If a session does not yet exist, then will start the core OpenEMR session.
-* If a session already exists, then this means portal or oauth2 or api is being used, which
-*   has already created a portal session/cookie, so will bypass setting of
-*   the core OpenEMR session/cookie.
-* $sessionAllowWrite = 1 | true | string then normal operation
-* $sessionAllowWrite = undefined | null | 0  session start for read only then auto
-*   immediate session_write_close.
-* Unless $sessionAllowWrite is true, ensure no session writes are used within the calling
-*   scope of this globals instance. Goal is to unlock session file as quickly as possible
-*   instead of waiting for calling script to complete before releasing flock.
+ * Adopt the request the entry point published, or build one on first use for a
+ * plain web request. In the REST and OAuth2 paths this file is included from
+ * SiteSetupListener, whose scope cannot see the dispatcher's $request — reading
+ * through CurrentRequest is what keeps this from becoming a second instance
+ * without the api type, token scopes, and session the run has attached.
  */
-// Adopt the request the entry point published, or build one on first use for a
-// plain web request. In the REST and OAuth2 paths this file is included from
-// SiteSetupListener, whose scope cannot see the dispatcher's $request — reading
-// through CurrentRequest is what keeps this from becoming a second instance
-// without the api type, token scopes, and session the run has attached.
 $restRequest = CurrentRequest::get();
-// OEGlobalsBag is a singleton; reassigning here is safe even if an earlier
-// include already populated it. Selected values are re-set onto the bag
-// throughout the rest of this file.
+
+/*
+ * OEGlobalsBag is a singleton; reassigning here is safe even if an earlier
+ * include already populated it. Selected values are re-set onto the bag
+ * throughout the rest of this file.
+ */
 $globalsBag = OEGlobalsBag::getInstance();
 $globalsBag->set('webserver_root', $webserver_root);
 $globalsBag->set('web_root', $web_root);
@@ -275,6 +268,19 @@ $globalsBag->set('OE_SITES_BASE', $GLOBALS['OE_SITES_BASE'] ?? "$webserver_root/
 $globalsBag->set('debug_ssl_mysql_connection', $GLOBALS['debug_ssl_mysql_connection'] ?? false);
 $globalsBag->set('eventDispatcher', $eventDispatcher ?? null);
 $globalsBag->set('ignoreAuth_onsite_portal', $ignoreAuth_onsite_portal);
+
+/*
+ * If a session does not yet exist, then will start the core OpenEMR session.
+ * If a session already exists, then this means portal or oauth2 or api is being used, which
+ *   has already created a portal session/cookie, so will bypass setting of
+ *   the core OpenEMR session/cookie.
+ * $sessionAllowWrite = 1 | true | string then normal operation
+ * $sessionAllowWrite = undefined | null | 0  session start for read only then auto
+ *   immediate session_write_close.
+ * Unless $sessionAllowWrite is true, ensure no session writes are used within the calling
+ *   scope of this globals instance. Goal is to unlock session file as quickly as possible
+ *   instead of waiting for calling script to complete before releasing flock.
+ */
 $read_only = empty($sessionAllowWrite);
 SessionWrapperFactory::getInstance()->setSessionReadOnly($read_only);
 

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -18,7 +18,7 @@ use OpenEMR\BC\Deprecation;
 use OpenEMR\BC\DeprecationMode;
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Database\QueryUtils;
-use OpenEMR\Common\Http\HttpRestRequest;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\EncounterSessionUtil;
 use OpenEMR\Common\Session\PatientSessionUtil;
@@ -255,9 +255,12 @@ $GLOBALS['vendor_dir'] = "$webserver_root/vendor";
 *   scope of this globals instance. Goal is to unlock session file as quickly as possible
 *   instead of waiting for calling script to complete before releasing flock.
  */
-if (empty($restRequest)) {
-    $restRequest = HttpRestRequest::createFromGlobals();
-}
+// Adopt the request the entry point published, or build one on first use for a
+// plain web request. In the REST and OAuth2 paths this file is included from
+// SiteSetupListener, whose scope cannot see the dispatcher's $request — reading
+// through CurrentRequest is what keeps this from becoming a second instance
+// without the api type, token scopes, and session the run has attached.
+$restRequest = CurrentRequest::get();
 // OEGlobalsBag is a singleton; reassigning here is safe even if an earlier
 // include already populated it. Selected values are re-set onto the bag
 // throughout the rest of this file.

--- a/interface/main/holidays/import_holidays.php
+++ b/interface/main/holidays/import_holidays.php
@@ -23,13 +23,13 @@ require_once('../../globals.php');
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Services\HolidayService;
 use OpenEMR\Services\InvalidHolidayCsvException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
@@ -37,7 +37,7 @@ if (!AclMain::aclCheckCore('admin', 'super')) {
     AccessDeniedHelper::denyWithTemplate('ACL check failed for admin/super: Holidays management', xl('Holidays management'));
 }
 
-$request = Request::createFromGlobals();
+$request = CurrentRequest::get();
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 $service = HolidayService::createForLegacyContext();
 

--- a/interface/modules/zend_modules/public/index.php
+++ b/interface/modules/zend_modules/public/index.php
@@ -17,13 +17,13 @@
  */
 
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Core\ModulesApplication;
 use OpenEMR\Core\OEEnvBag;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Core\Routing\ZendModuleApplication;
 use OpenEMR\Core\Routing\ZendModuleRouteLoader;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\Request;
 
 require_once(__DIR__ . "/../../../globals.php");
 require_once(__DIR__ . "/../../../../library/forms.inc.php");
@@ -62,7 +62,7 @@ if (OEEnvBag::getInstance()->getBoolean('OPENEMR__ZEND_SYMFONY_SEAM')) {
             new ZendModuleRouteLoader(__DIR__ . '/..'),
         );
 
-        $request = Request::createFromGlobals();
+        $request = CurrentRequest::get();
         if ($seam->matches($request->getPathInfo())) {
             $seam->handle($request)->send();
             return;

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -70,8 +70,12 @@ use OpenEMR\Services\Forms\CarePlanFormService;
 use OpenEMR\Services\FormService;
 use OpenEMR\Services\PatientIssuesService;
 use OpenEMR\Services\PatientService;
+use Symfony\Component\HttpFoundation\Request;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
+// Parse the incoming request once at this entry point and pass it to the cards
+// that need it, rather than having each card rebuild one from the superglobals.
+$request = Request::createFromGlobals();
 
 if (!isset($pid)) {
     $pid = $session->get('pid') ?? $_GET['pid'] ?? null;
@@ -1255,7 +1259,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
             <div class="row">
                 <?php
                 if (!in_array('card_care_team', $hiddenCards)) {
-                    $card = new CareTeamViewCard($pid, ['dispatcher' => $ed]);
+                    $card = new CareTeamViewCard($pid, $request, ['dispatcher' => $ed]);
                     $btnLabel = false;
                     if ($card->canAdd()) {
                         $btnLabel = 'Add';
@@ -1283,7 +1287,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                 // TREATMENT INTERVENTION PREFERENCES CARD
                 // ============================================================================
                 if (!in_array('card_treatment_preferences', $hiddenCards)) {
-                    $card = new TreatmentPreferenceViewCard($pid);
+                    $card = new TreatmentPreferenceViewCard($pid, $request);
                     $viewArgs = [
                         'title' => xl('Treatment Intervention Preferences'),
                         'id' => 'card_treatment_preferences',
@@ -1309,7 +1313,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                 // CARE EXPERIENCE PREFERENCES CARD
                 // ============================================================================
                 if (!in_array('card_care_experience', $hiddenCards)) {
-                    $card = new CareExperiencePreferenceViewCard($pid);
+                    $card = new CareExperiencePreferenceViewCard($pid, $request);
 
                     $viewArgs = [
                         'title' => xl('Care Experience Preferences'),
@@ -1377,7 +1381,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                     }
 
                     if (!in_array('card_insurance', $hiddenCards)) {
-                        $sectionRenderEvents->addCard(new InsuranceViewCard($pid, ['dispatcher' => $ed]));
+                        $sectionRenderEvents->addCard(new InsuranceViewCard($pid, $request, ['dispatcher' => $ed]));
                     }
 
                     // Get the cards to render

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -44,6 +44,7 @@ require_once(__DIR__ . "/../../../library/appointments.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
@@ -70,12 +71,11 @@ use OpenEMR\Services\Forms\CarePlanFormService;
 use OpenEMR\Services\FormService;
 use OpenEMR\Services\PatientIssuesService;
 use OpenEMR\Services\PatientService;
-use Symfony\Component\HttpFoundation\Request;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
-// Parse the incoming request once at this entry point and pass it to the cards
-// that need it, rather than having each card rebuild one from the superglobals.
-$request = Request::createFromGlobals();
+// Pass the request to the cards that need it rather than having each card reach
+// for one itself.
+$request = CurrentRequest::get();
 
 if (!isset($pid)) {
     $pid = $session->get('pid') ?? $_GET['pid'] ?? null;

--- a/interface/reports/cdr_log.php
+++ b/interface/reports/cdr_log.php
@@ -20,14 +20,14 @@ use OpenEMR\ClinicalDecisionRules\Interface\ControllerRouter;
 use OpenEMR\Common\Acl\AccessDeniedException;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Csrf\CsrfInvalidException;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 try {
-    $request = Request::createFromGlobals();
+    $request = CurrentRequest::get();
     if (empty($request->query->get('action'))) {
         $request->query->set('action', 'log!view');
     }

--- a/interface/smart/admin-client.php
+++ b/interface/smart/admin-client.php
@@ -22,17 +22,15 @@ use OpenEMR\Common\Acl\AccessDeniedException;
 use OpenEMR\Common\Auth\OpenIDConnect\Repositories\ClientRepository;
 use OpenEMR\Common\Csrf\CsrfInvalidException;
 use OpenEMR\Common\Csrf\CsrfUtils;
-use OpenEMR\Common\Http\HttpRestRequest;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Http\HttpSessionFactory;
 use OpenEMR\FHIR\SMART\ClientAdminController;
-use Symfony\Component\HttpFoundation\Request;
 
 try {
     // TODO: @adunsulag at some point we'd like to have a CoreApplication like the ApiApplication that will dispatch controllers, refactor this once we have that
-    $request = HttpRestRequest::createFromGlobals();
+    $request = CurrentRequest::get();
     $sessionFactory = new HttpSessionFactory($request, $oeGlobals->getString('web_root'), HttpSessionFactory::SESSION_TYPE_CORE);
     $session = $sessionFactory->createSession();
-    $request = Request::createFromGlobals();
     $router = new ClientAdminController(
         $oeGlobals,
         $session,

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -32,6 +32,7 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Auth\AuthHash;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
@@ -40,7 +41,6 @@ use OpenEMR\FHIR\Config\ServerConfig;
 use OpenEMR\OeUI\OemrUI;
 use OpenEMR\Services\Globals\GlobalSetting;
 use Ramsey\Uuid\Uuid;
-use Symfony\Component\HttpFoundation\Request;
 
 // Set up crypto object
 $cryptoGen = ServiceContainer::getCrypto();
@@ -233,7 +233,7 @@ function checkBackgroundServices(): void
 
         // Get all the globals from DB
         $old_globals = sqlGetAssoc('SELECT gl_name, gl_index, gl_value FROM `globals` ORDER BY gl_name, gl_index', [], true);
-        $postedGlobals = Request::createFromGlobals()->request;
+        $postedGlobals = CurrentRequest::get()->request;
         QueryUtils::inTransaction(function () use ($GLOBALS_METADATA, $old_globals, $cryptoGen, $postedGlobals): void {
             $i = 0;
             foreach ($GLOBALS_METADATA as $grparr) {

--- a/interface/super/load_codes.php
+++ b/interface/super/load_codes.php
@@ -21,13 +21,13 @@ set_time_limit(0);
 require_once '../globals.php';
 
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Controllers\Interface\Super\LoadCodesController;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\CodeTypes\Importer\LOINCImportService;
 use OpenEMR\Services\CodeTypes\Importer\RXCUIImportService;
-use Symfony\Component\HttpFoundation\Request;
 
 $kernel = OEGlobalsBag::getInstance()->getKernel();
 
@@ -42,4 +42,4 @@ $controller = new LoadCodesController(
     ]
 );
 
-$controller->dispatchAction(Request::createFromGlobals())->send();
+$controller->dispatchAction(CurrentRequest::get())->send();

--- a/interface/super/rules/index.php
+++ b/interface/super/rules/index.php
@@ -15,14 +15,14 @@ use OpenEMR\ClinicalDecisionRules\Interface\ControllerRouter;
 use OpenEMR\Common\Acl\AccessDeniedException;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Csrf\CsrfInvalidException;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 try {
-    $request = Request::createFromGlobals();
+    $request = CurrentRequest::get();
     $controllerRouter = new ControllerRouter();
     $response = $controllerRouter->route($request);
 } catch (AccessDeniedException | CsrfInvalidException $e) {

--- a/meta/health/index.php
+++ b/meta/health/index.php
@@ -16,12 +16,12 @@
 // Load autoloader
 require_once __DIR__ . "/../../vendor/autoload.php";
 
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Health\HealthChecker;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-$request = Request::createFromGlobals();
+$request = CurrentRequest::get();
 
 try {
     $pathInfo = $request->getPathInfo();

--- a/oauth2/authorize.php
+++ b/oauth2/authorize.php
@@ -11,6 +11,7 @@
  */
 
 use OpenEMR\BC\FallbackRouter;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\RestControllers\ApiApplication;
 
@@ -21,6 +22,9 @@ require_once "../vendor/autoload.php";
 // create the Request object
 try {
     $request = HttpRestRequest::createFromGlobals();
+    // See the note in apis/dispatch.php: globals.php loads later from a scope that
+    // cannot see $request, so publish it here or it builds a second, bare instance.
+    CurrentRequest::set($request);
     FallbackRouter::handleRoutingTestIfRequested($request->getRequestUri(), 'oauth2');
     $apiApplication = new ApiApplication();
     $apiApplication->run($request);

--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -26,6 +26,7 @@
  */
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Controllers\Portal\PatientPortalLoginController;
@@ -35,7 +36,6 @@ use OpenEMR\Controllers\Portal\SqlPortalLoginCredentialsRepository;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\Globals\UserSettingsService;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 require_once(__DIR__ . '/../vendor/autoload.php');
 
@@ -90,7 +90,7 @@ $controller = new PatientPortalLoginController(
     $auditLogger
 );
 
-$symfonyRequest = Request::createFromGlobals();
+$symfonyRequest = CurrentRequest::get();
 /** @var array<string, mixed> $post */
 $post = $symfonyRequest->request->all();
 // Controller only reads $request['redirect']; the legacy script sourced it from

--- a/src/ClinicalDecisionRules/Interface/Common.php
+++ b/src/ClinicalDecisionRules/Interface/Common.php
@@ -15,36 +15,30 @@
 
 namespace OpenEMR\ClinicalDecisionRules\Interface;
 
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Core\OEGlobalsBag;
 use Symfony\Component\HttpFoundation\Request;
 
 class Common
 {
-    private static ?Request $request = null;
-
     /**
-     * Cache the Symfony Request built from the current globals so that the
-     * many `get()`/`post()` helper invocations in CDR controllers do not
-     * each rebuild the parameter bags from scratch. The cache is bound to
-     * a single PHP process; in tests that mutate `$_GET`/`$_POST` between
-     * cases, call {@see self::resetRequestCache()} to drop the snapshot.
+     * The request being served. Previously this class kept its own cached
+     * Request; it now defers to the process-wide holder so the CDR helpers
+     * read the same instance as the rest of the request.
      */
     private static function request(): Request
     {
-        if (self::$request === null) {
-            self::$request = Request::createFromGlobals();
-        }
-        return self::$request;
+        return CurrentRequest::get();
     }
 
     /**
-     * Drop the cached Symfony Request. Tests that mutate `$_GET`/`$_POST`
-     * between cases should call this in their setUp/tearDown so subsequent
-     * `get()`/`post()` calls re-read the freshly-mutated globals.
+     * Drop the held request. Tests that mutate `$_GET`/`$_POST` between cases
+     * should call this in their setUp/tearDown so subsequent `get()`/`post()`
+     * calls re-read the freshly-mutated globals.
      */
     public static function resetRequestCache(): void
     {
-        self::$request = null;
+        CurrentRequest::reset();
     }
 
     /**

--- a/src/Common/Http/CurrentRequest.php
+++ b/src/Common/Http/CurrentRequest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Process-wide holder for the request being served.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Http;
+
+/**
+ * Holds the one request object for the current PHP process.
+ *
+ * OpenEMR's legacy entry points have no constructor to inject a request into,
+ * so before this existed each script called
+ * {@see HttpRestRequest::createFromGlobals()} for itself. That is worse than
+ * merely wasteful: `createFromGlobals()` rewrites `$_GET['_REWRITE_COMMAND']`
+ * into `$_SERVER['PATH_INFO']`/`REQUEST_URI`/`QUERY_STRING`, so the second
+ * caller in a process is not building from the same input as the first.
+ *
+ * Entry points that own a request — `apis/dispatch.php`, `oauth2/authorize.php`
+ * — call {@see self::set()} with the instance the rest of the stack will
+ * mutate (api type, access token scopes, session). Everything downstream,
+ * including `interface/globals.php`, calls {@see self::get()} and receives that
+ * same instance. For a plain web request nobody has called `set()`, so `get()`
+ * builds the request on first use.
+ *
+ * This is a transitional seam for procedural code, not a target architecture.
+ * Classes that can accept a request through their constructor should do that
+ * instead — see the patient summary cards in {@see \OpenEMR\Patient\Cards} for
+ * the shape to copy.
+ */
+final class CurrentRequest
+{
+    private static ?HttpRestRequest $request = null;
+
+    /**
+     * The request being served, built from the superglobals on first use.
+     */
+    public static function get(): HttpRestRequest
+    {
+        return self::$request ??= HttpRestRequest::createFromGlobals();
+    }
+
+    /**
+     * Adopt a request built by an entry point.
+     *
+     * Call this before anything downstream can reach {@see self::get()},
+     * otherwise the lazy path wins and the two instances diverge.
+     */
+    public static function set(HttpRestRequest $request): void
+    {
+        self::$request = $request;
+    }
+
+    /**
+     * Whether a request has been established, without building one.
+     *
+     * Lets callers distinguish "not yet set" from "set", which `get()` cannot
+     * express because it always returns a request.
+     */
+    public static function has(): bool
+    {
+        return self::$request instanceof HttpRestRequest;
+    }
+
+    /**
+     * Drop the held request so the next {@see self::get()} rebuilds it.
+     *
+     * Tests that mutate `$_GET`/`$_POST` between cases need this; nothing in
+     * application code should.
+     */
+    public static function reset(): void
+    {
+        self::$request = null;
+    }
+}

--- a/src/Common/Session/SessionWrapperFactory.php
+++ b/src/Common/Session/SessionWrapperFactory.php
@@ -15,7 +15,7 @@
 
 namespace OpenEMR\Common\Session;
 
-use OpenEMR\Common\Http\HttpRestRequest;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Http\HttpSessionFactory;
 use OpenEMR\Common\Session\Storage\ReadAndCloseNativeSessionStorage;
 use OpenEMR\Core\OEGlobalsBag;
@@ -148,7 +148,7 @@ class SessionWrapperFactory
 
     private function createPortalSession(): SessionInterface
     {
-        $request = HttpRestRequest::createFromGlobals();
+        $request = CurrentRequest::get();
         $sessionFactory = new HttpSessionFactory($request, $this->webRoot, HttpSessionFactory::SESSION_TYPE_PORTAL, $this->getEffectiveReadOnly());
         $this->activeSession = $sessionFactory->createSession();
         $this->activeStorage = $sessionFactory->getLastCreatedStorage();
@@ -157,7 +157,7 @@ class SessionWrapperFactory
 
     private function createCoreSession(): SessionInterface
     {
-        $request = HttpRestRequest::createFromGlobals();
+        $request = CurrentRequest::get();
         $sessionFactory = new HttpSessionFactory($request, $this->webRoot, HttpSessionFactory::SESSION_TYPE_CORE, $this->getEffectiveReadOnly());
         $this->activeSession = $sessionFactory->createSession();
         $this->activeStorage = $sessionFactory->getLastCreatedStorage();

--- a/src/Patient/Cards/CareExperiencePreferenceViewCard.php
+++ b/src/Patient/Cards/CareExperiencePreferenceViewCard.php
@@ -6,7 +6,9 @@
  * @package   OpenEMR
  * @link      https://www.openemr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -15,12 +17,12 @@ namespace OpenEMR\Patient\Cards;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
-use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Patient\Summary\Card\CardModel;
 use OpenEMR\Events\Patient\Summary\Card\RenderEvent;
 use OpenEMR\Services\CareExperiencePreferenceService;
+use Symfony\Component\HttpFoundation\Request;
 
 class CareExperiencePreferenceViewCard extends CardModel
 {
@@ -37,7 +39,7 @@ class CareExperiencePreferenceViewCard extends CardModel
     /**
      * @param int $pid
      */
-    public function __construct(private $pid, array $opts = [])
+    public function __construct(private $pid, private readonly Request $request, array $opts = [])
     {
         $opts = $this->setupOpts($opts);
         parent::__construct($opts);
@@ -189,7 +191,7 @@ class CareExperiencePreferenceViewCard extends CardModel
 
     private function handlePost(): void
     {
-        $request = HttpRestRequest::createFromGlobals();
+        $request = $this->request;
 
         if ($request->getMethod() !== 'POST') {
             return;

--- a/src/Patient/Cards/CareTeamViewCard.php
+++ b/src/Patient/Cards/CareTeamViewCard.php
@@ -6,7 +6,9 @@
  *
  * @author    Jerry Padgett <sjpadgett@gmail.com>
  * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -15,7 +17,6 @@ namespace OpenEMR\Patient\Cards;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
-use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Events\Patient\Summary\Card\CardModel;
@@ -24,6 +25,7 @@ use OpenEMR\Services\CareTeamService;
 use OpenEMR\Services\ContactRelationService;
 use OpenEMR\Services\ContactService;
 use OpenEMR\Services\ListService;
+use Symfony\Component\HttpFoundation\Request;
 
 class CareTeamViewCard extends CardModel
 {
@@ -38,7 +40,7 @@ class CareTeamViewCard extends CardModel
 
     private ListService $listService;
 
-    public function __construct(private $pid, array $opts = [])
+    public function __construct(private $pid, private readonly Request $request, array $opts = [])
     {
         $opts = $this->setupOpts($opts);
         parent::__construct($opts);
@@ -123,7 +125,7 @@ class CareTeamViewCard extends CardModel
 
     private function handleFormSubmission()
     {
-        $request = HttpRestRequest::createFromGlobals()->request;
+        $request = $this->request->request;
         if ($request->getString('save_care_team') !== 'true') {
             return;
         }

--- a/src/Patient/Cards/InsuranceViewCard.php
+++ b/src/Patient/Cards/InsuranceViewCard.php
@@ -6,7 +6,9 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2024 Care Management Solutions, Inc. <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -16,11 +18,11 @@ use InsuranceCompany;
 use OpenEMR\Billing\EDI270;
 use OpenEMR\Billing\InsurancePolicyTypes;
 use OpenEMR\Common\Acl\AclMain;
-use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Patient\Summary\Card\CardModel;
 use OpenEMR\Events\Patient\Summary\Card\RenderEvent;
 use OpenEMR\Services\InsuranceService;
+use Symfony\Component\HttpFoundation\Request;
 
 class InsuranceViewCard extends CardModel
 {
@@ -32,7 +34,7 @@ class InsuranceViewCard extends CardModel
 
     private $policy_types;
 
-    public function __construct(private $pid, array $opts = [])
+    public function __construct(private $pid, private readonly Request $request, array $opts = [])
     {
         $this->policy_types = InsurancePolicyTypes::getTranslatedPolicyTypes();
         $opts = $this->setupOpts($opts);
@@ -162,7 +164,7 @@ class InsuranceViewCard extends CardModel
         $output = '';
         $pid = $this->pid;
         if (OEGlobalsBag::getInstance()->getBoolean("enable_eligibility_requests")) {
-            if (HttpRestRequest::createFromGlobals()->request->getString('status_update') === 'true') {
+            if ($this->request->request->getString('status_update') === 'true') {
                 $showEligibility = true;
                 $ok = EDI270::requestEligibleTransaction($pid);
                 if ($ok === true) {

--- a/src/Patient/Cards/TreatmentPreferenceViewCard.php
+++ b/src/Patient/Cards/TreatmentPreferenceViewCard.php
@@ -6,7 +6,9 @@
  * @package   OpenEMR
  * @link      https://www.openemr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -15,12 +17,12 @@ namespace OpenEMR\Patient\Cards;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
-use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Patient\Summary\Card\CardModel;
 use OpenEMR\Events\Patient\Summary\Card\RenderEvent;
 use OpenEMR\Services\TreatmentInterventionPreferenceService;
+use Symfony\Component\HttpFoundation\Request;
 
 class TreatmentPreferenceViewCard extends CardModel
 {
@@ -37,7 +39,7 @@ class TreatmentPreferenceViewCard extends CardModel
     /**
      * @param int $pid
      */
-    public function __construct(private $pid, array $opts = [])
+    public function __construct(private $pid, private readonly Request $request, array $opts = [])
     {
         $opts = $this->setupOpts($opts);
         parent::__construct($opts);
@@ -189,7 +191,7 @@ class TreatmentPreferenceViewCard extends CardModel
 
     private function handlePost(): void
     {
-        $request = HttpRestRequest::createFromGlobals();
+        $request = $this->request;
 
         if ($request->getMethod() !== 'POST') {
             return;

--- a/tests/Tests/Isolated/Common/Http/CurrentRequestIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Http/CurrentRequestIsolatedTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Isolated CurrentRequest Test
+ *
+ * Exercises the process-wide request holder without a database.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Http;
+
+use OpenEMR\Common\Http\CurrentRequest;
+use OpenEMR\Common\Http\HttpRestRequest;
+use PHPUnit\Framework\TestCase;
+
+class CurrentRequestIsolatedTest extends TestCase
+{
+    /**
+     * Saved verbatim and restored verbatim; never indexed, so the superglobals'
+     * own `array<mixed>` shape is the honest type here.
+     *
+     * @var array<mixed>
+     */
+    private array $originalGet;
+
+    /** @var array<mixed> */
+    private array $originalServer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalGet = $_GET;
+        $this->originalServer = $_SERVER;
+        CurrentRequest::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        CurrentRequest::reset();
+        $_GET = $this->originalGet;
+        $_SERVER = $this->originalServer;
+
+        parent::tearDown();
+    }
+
+    public function testHasIsFalseUntilARequestIsEstablished(): void
+    {
+        $this->assertFalse(CurrentRequest::has());
+    }
+
+    public function testGetBuildsARequestFromTheSuperglobalsOnFirstUse(): void
+    {
+        $_GET = ['patient' => '42'];
+
+        $request = CurrentRequest::get();
+
+        $this->assertSame('42', $request->query->getString('patient'));
+        $this->assertTrue(CurrentRequest::has(), 'get() should establish the request it built');
+    }
+
+    /**
+     * The whole point of the holder: one instance per process. A second call
+     * must not rebuild, because createFromGlobals() rewrites $_GET/$_SERVER on
+     * the way through and the rebuilt request would not match the first.
+     */
+    public function testGetReturnsTheSameInstanceOnRepeatCalls(): void
+    {
+        $first = CurrentRequest::get();
+        $second = CurrentRequest::get();
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testGetReturnsTheInstanceAnEntryPointPublished(): void
+    {
+        $published = new HttpRestRequest(['site' => 'default']);
+
+        CurrentRequest::set($published);
+
+        $this->assertSame($published, CurrentRequest::get());
+        $this->assertTrue(CurrentRequest::has());
+    }
+
+    /**
+     * Mirrors the REST path: the dispatcher publishes a request, the stack
+     * mutates it, and a later reader — globals.php — must observe those
+     * mutations rather than a freshly built stand-in.
+     */
+    public function testMutationsMadeAfterPublishingAreVisibleToLaterReaders(): void
+    {
+        $published = new HttpRestRequest();
+        CurrentRequest::set($published);
+
+        $published->setApiType('fhir');
+        $published->setIsLocalApi(true);
+
+        $observed = CurrentRequest::get();
+        $this->assertSame('fhir', $observed->getApiType());
+        $this->assertTrue($observed->isLocalApi());
+    }
+
+    public function testSetReplacesAPreviouslyEstablishedRequest(): void
+    {
+        $lazilyBuilt = CurrentRequest::get();
+        $published = new HttpRestRequest();
+
+        CurrentRequest::set($published);
+
+        $this->assertNotSame($lazilyBuilt, CurrentRequest::get());
+        $this->assertSame($published, CurrentRequest::get());
+    }
+
+    public function testResetDropsTheRequestSoTheNextGetRebuilds(): void
+    {
+        $first = CurrentRequest::get();
+
+        CurrentRequest::reset();
+
+        $this->assertFalse(CurrentRequest::has());
+        $this->assertNotSame($first, CurrentRequest::get());
+    }
+}


### PR DESCRIPTION
Roughly 40 call sites across the codebase each called `Request::createFromGlobals()` (or `HttpRestRequest::createFromGlobals()`) to get at request input. This replaces that with one request object per process, plus constructor injection for the handful of classes deep enough in the stack to deserve it.

## Why this is more than deduplication

`HttpRestRequest::createFromGlobals()` is not a pure read. It rewrites `$_GET['_REWRITE_COMMAND']` into `$_SERVER['PATH_INFO']`, `REQUEST_URI`, and `QUERY_STRING`, and unsets the original key. The second caller in a process is therefore not building from the same input as the first.

That surfaced two real defects:

**The REST and OAuth2 paths were serving the wrong request object.** `apis/dispatch.php` builds an `HttpRestRequest` and hands it to `ApiApplication`, which mutates that instance with the api type, access token scopes, access token id, and session. But `interface/globals.php` is included much later, from `SiteSetupListener::loadApplicationGlobals()`, whose method scope cannot see the dispatcher's `$request`. The `if (empty($restRequest))` guard at `globals.php:258` was therefore *always* true on those paths, so globals.php built a second, bare `HttpRestRequest` — and that is the instance that landed on the globals bag as `restRequest`.

**`interface/smart/admin-client.php` built two requests back to back**, used the first for the session factory, then immediately replaced it with a second and discarded the first.

## What changed

`OpenEMR\Common\Http\CurrentRequest` holds the one request for the process:

- Entry points that own a request — `apis/dispatch.php`, `oauth2/authorize.php` — call `CurrentRequest::set()` with the instance the rest of the stack will mutate.
- Everything downstream, `interface/globals.php` included, calls `CurrentRequest::get()` and receives that same instance.
- On a plain web request nobody has published one, so the first `get()` builds it.
- `reset()` exists for tests that mutate `$_GET`/`$_POST` between cases. `Common::resetRequestCache()` in the CDR code now delegates to it, so the existing CDR tests keep their semantics.

19 scripts converted from `createFromGlobals()` to `CurrentRequest::get()`. The only remaining `createFromGlobals()` calls outside the test suite are the two publishing entry points and `CurrentRequest` itself.

`CurrentRequest` is deliberately **not** on `OEGlobalsBag`. `OEGlobalsBag::set()` mirrors every write back into `$GLOBALS`, so putting a request-scoped service there would re-entrench the pattern that class exists to migrate away from.

## Constructor injection where a constructor exists

The static holder is a transitional seam for procedural entry points that have nowhere to inject. Classes that *can* take a request through their constructor should, and four patient summary cards were reaching out of the call stack for input:

`CareTeamViewCard`, `InsuranceViewCard`, `TreatmentPreferenceViewCard`, and `CareExperiencePreferenceViewCard` now accept a `Request`, passed in by `demographics.php` — the entry point that constructs all four. They only ever used the base `Request` API, so they take Symfony's `Request` rather than `HttpRestRequest`.

> [!IMPORTANT]
> **This is a backwards-incompatible constructor change.** `new InsuranceViewCard($pid, $opts)` becomes `new InsuranceViewCard($pid, $request, $opts)`, and likewise for the other three. Each has exactly one caller in this repository, but a third-party module constructing one of these cards directly will get a `TypeError`. The alternative — an optional `?Request $request = null` that falls back to `createFromGlobals()` — would keep the global reach alive and defeat the point, so the break is deliberate. Happy to drop this commit if maintainers would rather those four cards just read from `CurrentRequest` like everything else.

## Behavioral risk and how it was bounded

A shared request is a snapshot at creation time; a per-call-site `createFromGlobals()` is a live read. There are ~157 assignments and ~40 `unset()`s against `$_GET`/`$_POST`/`$_REQUEST` in the tree, so a script that mutates a superglobal and expects a later `createFromGlobals()` to observe it would change behavior.

This is why the conversion was done per call site rather than as a blanket Rector sweep. For `demographics.php` specifically — the one file where request creation moved meaningfully earlier in the script — I verified it performs no superglobal writes, so hoisting is behavior-preserving.

## Verification

- PHPStan level 10: clean.
- 4,439 isolated tests pass, including 7 new ones for `CurrentRequest` covering instance identity, publish-then-read, visibility of mutations made after publishing, and reset.
- phpcs, Rector, and composer-require-checker clean.

One baseline count changed — `empty()` in `interface/globals.php` from 30 to 29, since the guard is gone. Regenerated with `composer phpstan-baseline` rather than hand-edited. No new baseline entries were added.
