### PR TITLE
fix(docker): honor mysql-ca convention in CLI readiness checks

### DIFF
--- a/docker/binary/openemr.sh
+++ b/docker/binary/openemr.sh
@@ -116,12 +116,24 @@ wait_for_mysql() {
     echo "Waiting for MySQL at ${MYSQL_HOST}:${MYSQL_PORT}..."
 
     # Try immediate connection first (MySQL might already be ready)
+    # Honor the same mysql-ca convention as DatabaseConnectionOptions::inferSslPaths():
+    # if the site provides a CA bundle at sites/default/documents/certificates/mysql-ca,
+    # verify the server against it. The MariaDB 11.4+ client verifies certificates by
+    # default and otherwise rejects servers whose CA is not in the system trust store
+    # (e.g. Amazon RDS), which breaks these readiness checks.
+    MYSQL_CA_FILE="/var/www/localhost/htdocs/openemr/sites/default/documents/certificates/mysql-ca"
+    MYSQL_SSL_OPTS=()
+    if [[ -f "${MYSQL_CA_FILE}" ]]; then
+        MYSQL_SSL_OPTS=(--ssl-ca="${MYSQL_CA_FILE}")
+    fi
+
     # Use mysqladmin ping for more efficient health check
     if mysqladmin ping \
         --host="${MYSQL_HOST}" \
         --port="${MYSQL_PORT}" \
         --user="${MYSQL_ROOT_USER}" \
         --password="${MYSQL_ROOT_PASS}" \
+        "${MYSQL_SSL_OPTS[@]}" \
         --silent >/dev/null 2>&1; then
         echo "MySQL is ready!"
         return 0
@@ -134,6 +146,7 @@ wait_for_mysql() {
             --port="${MYSQL_PORT}" \
             --user="${MYSQL_ROOT_USER}" \
             --password="${MYSQL_ROOT_PASS}" \
+            "${MYSQL_SSL_OPTS[@]}" \
             --silent >/dev/null 2>&1; then
             echo "MySQL is ready!"
             return 0

--- a/docker/flex/openemr.sh
+++ b/docker/flex/openemr.sh
@@ -351,12 +351,24 @@ wait_for_mysql() {
     echo "Waiting for MySQL at ${MYSQL_HOST}:${MYSQL_PORT}..."
 
     # Try immediate connection first (MySQL might already be ready)
+    # Honor the same mysql-ca convention as DatabaseConnectionOptions::inferSslPaths():
+    # if the site provides a CA bundle at sites/default/documents/certificates/mysql-ca,
+    # verify the server against it. The MariaDB 11.4+ client verifies certificates by
+    # default and otherwise rejects servers whose CA is not in the system trust store
+    # (e.g. Amazon RDS), which breaks these readiness checks.
+    MYSQL_CA_FILE="/var/www/localhost/htdocs/openemr/sites/default/documents/certificates/mysql-ca"
+    MYSQL_SSL_OPTS=()
+    if [[ -f "${MYSQL_CA_FILE}" ]]; then
+        MYSQL_SSL_OPTS=(--ssl-ca="${MYSQL_CA_FILE}")
+    fi
+
     # Use mysqladmin ping for more efficient health check
     if mysqladmin ping \
         --host="${MYSQL_HOST}" \
         --port="${MYSQL_PORT}" \
         --user="${MYSQL_ROOT_USER}" \
         --password="${MYSQL_ROOT_PASS}" \
+        "${MYSQL_SSL_OPTS[@]}" \
         --silent >/dev/null 2>&1; then
         echo "MySQL is ready!"
         return 0
@@ -369,6 +381,7 @@ wait_for_mysql() {
             --port="${MYSQL_PORT}" \
             --user="${MYSQL_ROOT_USER}" \
             --password="${MYSQL_ROOT_PASS}" \
+            "${MYSQL_SSL_OPTS[@]}" \
             --silent >/dev/null 2>&1; then
             echo "MySQL is ready!"
             return 0

--- a/docker/release/openemr.sh
+++ b/docker/release/openemr.sh
@@ -114,12 +114,24 @@ wait_for_mysql() {
     echo "Waiting for MySQL at ${MYSQL_HOST}:${MYSQL_PORT}..."
 
     # Try immediate connection first (MySQL might already be ready)
+    # Honor the same mysql-ca convention as DatabaseConnectionOptions::inferSslPaths():
+    # if the site provides a CA bundle at sites/default/documents/certificates/mysql-ca,
+    # verify the server against it. The MariaDB 11.4+ client verifies certificates by
+    # default and otherwise rejects servers whose CA is not in the system trust store
+    # (e.g. Amazon RDS), which breaks these readiness checks.
+    MYSQL_CA_FILE="/var/www/localhost/htdocs/openemr/sites/default/documents/certificates/mysql-ca"
+    MYSQL_SSL_OPTS=()
+    if [[ -f "${MYSQL_CA_FILE}" ]]; then
+        MYSQL_SSL_OPTS=(--ssl-ca="${MYSQL_CA_FILE}")
+    fi
+
     # Use mysqladmin ping for more efficient health check
     if mysqladmin ping \
         --host="${MYSQL_HOST}" \
         --port="${MYSQL_PORT}" \
         --user="${MYSQL_ROOT_USER}" \
         --password="${MYSQL_ROOT_PASS}" \
+        "${MYSQL_SSL_OPTS[@]}" \
         --silent >/dev/null 2>&1; then
         echo "MySQL is ready!"
         return 0
@@ -132,6 +144,7 @@ wait_for_mysql() {
             --port="${MYSQL_PORT}" \
             --user="${MYSQL_ROOT_USER}" \
             --password="${MYSQL_ROOT_PASS}" \
+            "${MYSQL_SSL_OPTS[@]}" \
             --silent >/dev/null 2>&1; then
             echo "MySQL is ready!"
             return 0


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

## Summary

The docker entrypoints' MySQL readiness checks (`mysqladmin ping`, two invocations per flavor) run the **MariaDB 11.4+ client, which verifies server certificates by default**. Servers whose CA is not in the container trust store — most notably **Amazon RDS** — fail every ping with:

```
ERROR 2026 (HY000): TLS/SSL error: self-signed certificate in certificate chain
```

The readiness loop exhausts all 60 retries and the upgrade/startup flow proceeds into failure. Every RDS-backed Standard deployment starting or upgrading on current images hits this.

The PHP side already solved this: `DatabaseConnectionOptions::inferSslPaths()` reads a user-supplied CA bundle from `sites/<site>/documents/certificates/mysql-ca` and connects with verified TLS. The CLI side had no equivalent — this PR teaches the readiness checks the same convention.

## Change

In all three entrypoints (`docker/binary/openemr.sh`, `docker/release/openemr.sh`, `docker/flex/openemr.sh`):

```bash
# Honor the same mysql-ca convention as DatabaseConnectionOptions::inferSslPaths():
# if the site provides a CA bundle at sites/default/documents/certificates/mysql-ca,
# verify the server against it. The MariaDB 11.4+ client verifies certificates by
# default and otherwise rejects servers whose CA is not in the system trust store
# (e.g. Amazon RDS), which breaks these readiness checks.
MYSQL_CA_FILE="/var/www/localhost/htdocs/openemr/sites/default/documents/certificates/mysql-ca"
MYSQL_SSL_OPTS=""
if [ -f "${MYSQL_CA_FILE}" ]; then
    MYSQL_SSL_OPTS="--ssl-ca=${MYSQL_CA_FILE}"
fi
```

…and `${MYSQL_SSL_OPTS}` added to both `mysqladmin ping` invocations (with `# shellcheck disable=SC2086` — the variable is intentionally unquoted so it word-splits to nothing when empty).

Design notes:

- **Verification stays ON.** The fix passes `--ssl-ca` so the client verifies against the deployment's CA — it does not disable verification. This supersedes the field workaround of bind-mounting a `[client] ssl-verify-server-cert=0` drop-in into `/etc/my.cnf.d/`, which disabled verification entirely.
- **Deployments without the file are unchanged.** `MYSQL_SSL_OPTS` expands to nothing; current behavior (system trust store) applies.
- **Backend-agnostic.** RDS users stage Amazon's bundle; self-hosted MariaDB/MySQL users stage their own CA. One convention, both client stacks (PHP already honors it).
- **The `default` site hardcode is intentional.** The ping is a connectivity-only check, site-agnostic; per-site CA selection is not meaningful at this stage. flex is included for three-way consistency even though its sidecar-MySQL setups rarely hit the issue.

## Docs one-liner for RDS deployments

For AWS Standard-package (or any RDS-backed) deployments, staging the CA is one command, and it persists on the sitevolume across container recreations:

```bash
curl -o sites/default/documents/certificates/mysql-ca \
  https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
chown apache:apache sites/default/documents/certificates/mysql-ca
```

With this PR, that single file gives verified TLS for **both** PHP (existing behavior) and the CLI readiness checks (new).

## To Reproduce (without the fix)

1. Run the Standard package against an RDS MySQL endpoint on a current image (MariaDB client 11.4.x)
2. Recreate/start the container
3. Observe the readiness loop exhaust all retries: `Timed out waiting for MySQL at <endpoint>:3306`, while `nc` to the same endpoint:3306 succeeds and `mysql ... --ssl-verify-server-cert=0` connects — isolating certificate verification as the cause

## Testing

- Production-derived: on a 7.0.2 → 8.2.0 Standard-package upgrade against RDS MySQL 8.4 (us-east-1), both readiness checks and the PHP-side migrations failed until the CA bundle was staged at the conventional path; with the bundle present, PHP connected with verified TLS via `inferSslPaths()` and (with this change) the CLI checks pass the same way
- Behavior with the file absent verified unchanged (empty `MYSQL_SSL_OPTS`, identical invocation)
- shellcheck clean with the SC2086 directives

## Related

- Follow-up to the `--from` invocation fix (fsupgrade scripts / devtools) merged from the same production upgrade investigation. Remaining findings to be filed separately: fsupgrade/entrypoint do not check the PHP exit status (failed migrations log `Completed:` and advance the version marker), and post-upgrade cleanup removes `sql_upgrade.php`, preventing in-place retry.

