### PR TITLE
fix(rector): hoist a file docblock stranded inside the import block

### DIFF
--- a/tests/Rector/Rules/ConsolidateImportsRector.php
+++ b/tests/Rector/Rules/ConsolidateImportsRector.php
@@ -171,7 +171,9 @@ CODE_SAMPLE
         // the docblock sits at the top already, attached to that declare.
         if ($contiguous && $useIndexes[0] === count($leading)) {
             if ($leading !== []) {
-                return null;
+                // PSR-12 puts the file header above `declare`, so a docblock
+                // left on an import belongs on the declare, not on $uses[0].
+                return $this->hoistDocblockOnto($leading[0], $uses, 0) ? $node : null;
             }
 
             if ($this->hoistDocblockFromLaterImport($uses)) {
@@ -371,12 +373,22 @@ CODE_SAMPLE
      */
     private function hoistDocblockFromLaterImport(array $uses): bool
     {
-        $first = $uses[0];
-        if ($first->getComments() !== []) {
+        return $this->hoistDocblockOnto($uses[0], $uses, 1);
+    }
+
+    /**
+     * Move the first stranded docblock found among `$uses` (from `$offset` on)
+     * onto `$target`, which must not already carry comments of its own.
+     *
+     * @param list<Use_|GroupUse> $uses
+     */
+    private function hoistDocblockOnto(Node\Stmt $target, array $uses, int $offset): bool
+    {
+        if ($target->getComments() !== []) {
             return false;
         }
 
-        foreach (array_slice($uses, 1) as $use) {
+        foreach (array_slice($uses, $offset) as $use) {
             $comments = $use->getComments();
             if ($comments === [] || !$comments[0] instanceof Doc) {
                 continue;
@@ -388,7 +400,7 @@ CODE_SAMPLE
 
             $docblock = array_shift($comments);
             $use->setAttribute('comments', $comments);
-            $first->setAttribute('comments', [$docblock]);
+            $target->setAttribute('comments', [$docblock]);
 
             return true;
         }

--- a/tests/Rector/Rules/ConsolidateImportsRector.php
+++ b/tests/Rector/Rules/ConsolidateImportsRector.php
@@ -174,6 +174,10 @@ CODE_SAMPLE
                 return null;
             }
 
+            if ($this->hoistDocblockFromLaterImport($uses)) {
+                return $node;
+            }
+
             return $this->hoistFileDocblock($rest, $uses[0]) ? $node : null;
         }
 
@@ -213,7 +217,7 @@ CODE_SAMPLE
         //
         // With a leading declare the file docblock already sits at the top of
         // the file, attached to that declare; only hoist when imports lead.
-        if ($leading === []) {
+        if ($leading === [] && !$this->hoistDocblockFromLaterImport($uses)) {
             $this->hoistFileDocblock($rest, $uses[0]);
         }
 
@@ -347,6 +351,56 @@ CODE_SAMPLE
     private function isImport(Node $stmt): bool
     {
         return $stmt instanceof Use_ || $stmt instanceof GroupUse;
+    }
+
+    /**
+     * Move a docblock stranded on a later import up onto the first one.
+     *
+     * Nothing documents a `use` statement, so a docblock attached to one is
+     * the file header that ended up in the wrong place. phpcbf produces this:
+     * once the header is a single block it sorts the imports alphabetically,
+     * and a docblock riding on the import that sorts last lands in the middle
+     * of the block, which `PSR12.Files.FileHeader` then rejects.
+     *
+     * An analyser annotation is the exception -- it is aimed at the import it
+     * sits on and moving it would silently retarget the suppression.
+     *
+     * @param list<Use_|GroupUse> $uses
+     *
+     * @return bool whether a docblock moved
+     */
+    private function hoistDocblockFromLaterImport(array $uses): bool
+    {
+        $first = $uses[0];
+        if ($first->getComments() !== []) {
+            return false;
+        }
+
+        foreach (array_slice($uses, 1) as $use) {
+            $comments = $use->getComments();
+            if ($comments === [] || !$comments[0] instanceof Doc) {
+                continue;
+            }
+
+            if ($this->isAnalyserAnnotation($comments[0])) {
+                continue;
+            }
+
+            $docblock = array_shift($comments);
+            $use->setAttribute('comments', $comments);
+            $first->setAttribute('comments', [$docblock]);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function isAnalyserAnnotation(Doc $docblock): bool
+    {
+        $text = strtolower($docblock->getText());
+
+        return str_contains($text, '@phpstan-') || str_contains($text, '@psalm-');
     }
 
     /**

--- a/tests/Rector/Rules/FixtureConsolidateImports/hoists_docblock_onto_leading_declare.php.inc
+++ b/tests/Rector/Rules/FixtureConsolidateImports/hoists_docblock_onto_leading_declare.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Vendor\Alpha;
+
+/**
+ * File docblock.
+ *
+ * @package Demo
+ */
+
+use Vendor\Beta;
+
+echo Alpha::run() . Beta::run();
+
+?>
+-----
+<?php
+
+/**
+ * File docblock.
+ *
+ * @package Demo
+ */
+declare(strict_types=1);
+
+use Vendor\Alpha;
+
+use Vendor\Beta;
+
+echo Alpha::run() . Beta::run();
+
+?>

--- a/tests/Rector/Rules/FixtureConsolidateImports/hoists_docblock_stranded_inside_import_block.php.inc
+++ b/tests/Rector/Rules/FixtureConsolidateImports/hoists_docblock_stranded_inside_import_block.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+use Vendor\Alpha;
+use Vendor\Beta;
+
+/**
+ * File docblock.
+ *
+ * @package Demo
+ */
+
+use Vendor\Gamma;
+
+require_once __DIR__ . '/globals.php';
+
+echo Alpha::run() . Beta::run() . Gamma::run();
+
+?>
+-----
+<?php
+
+/**
+ * File docblock.
+ *
+ * @package Demo
+ */
+use Vendor\Alpha;
+use Vendor\Beta;
+
+use Vendor\Gamma;
+
+require_once __DIR__ . '/globals.php';
+
+echo Alpha::run() . Beta::run() . Gamma::run();
+
+?>

--- a/tests/Rector/Rules/FixtureConsolidateImports/keeps_analyser_annotation_on_its_import.php.inc
+++ b/tests/Rector/Rules/FixtureConsolidateImports/keeps_analyser_annotation_on_its_import.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+use Vendor\Alpha;
+
+/** @phpstan-ignore-next-line */
+use Vendor\Beta;
+
+require_once __DIR__ . '/globals.php';
+
+echo Alpha::run() . Beta::run();
+
+?>


### PR DESCRIPTION
Nothing documents a `use` statement, so a docblock attached to one is the file header that ended up in the wrong place. `hoistFileDocblock()` only ever inspected the first statement *after* the imports, so a docblock sitting between two imports was invisible to it.

`phpcbf` produces exactly that state. Once #13555 makes the header a single contiguous block, `SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses` sorts it — and a docblock riding on the import that sorts last is carried into the middle of the block:

```php
<?php

use OpenEMR\Common\Csrf\CsrfUtils;
use OpenEMR\Common\Session\SessionWrapperFactory;
use OpenEMR\Common\Twig\TwigContainer;

/**
 * Dash Board Header.
 * ...
 */

use OpenEMR\Core\OEGlobalsBag;

require_once(OEGlobalsBag::getInstance()->getSrcDir() . '/display_help_icon_inc.php');
```

`PSR12.Files.FileHeader` then reports both *"The file-level docblock must follow the opening PHP tag in the file header"* and *"Similar statements must be grouped together inside header blocks"*.

This is the last phpcs failure in the in-flight `withImportNames` slice, on `interface/patient_file/summary/dashboard_header.php`: name importing inserts `OpenEMR\Core\OEGlobalsBag`, which sorts after the three `OpenEMR\Common` imports, so the sort carries the file header down with it.

## The annotation guard

A docblock containing `@phpstan-` or `@psalm-` stays where it is. Those are aimed at the import they sit on, and hoisting one would silently retarget the suppression — a failure that would not surface until some unrelated analysis run started passing or failing for no visible reason. There is a no-change fixture for it.

## Verification

- 16/16 rule tests, including `hoists_docblock_stranded_inside_import_block` and `keeps_analyser_annotation_on_its_import`.
- `composer rector-check` clean across the tree — the new trigger fires on nothing already committed.
- Applied to the real `dashboard_header.php` from the regeneration: header restored, and `phpcbf` + `phpcs` clean afterwards.

Follows #13555, #13562, and #13576 on the same rule.
