### PR TITLE
docs(api): replace forbidden $_SESSION reads and the fake role check

### DIFF
--- a/Documentation/api/DEVELOPER_GUIDE.md
+++ b/Documentation/api/DEVELOPER_GUIDE.md
@@ -150,13 +150,24 @@ if (!$hasAccess) {
 ```
 
 #### Get Current User
+
+Read session values through the session wrapper. Direct `$_SESSION` access is
+rejected by the `ForbiddenSessionSuperglobalRule` PHPStan rule.
+
 ```php
 <?php
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Session\SessionWrapperFactory;
+
 // Get current user ID
-$userId = $_SESSION['authUserID'] ?? null;
+$session = SessionWrapperFactory::getInstance()->getActiveSession();
+$userId = $session->get('authUserID');
 
 // Get current user data
-$userData = sqlQuery("SELECT * FROM users WHERE id = ?", [$userId]);
+$userData = QueryUtils::querySingleRow(
+    'SELECT id, username, fname, lname, facility_id FROM users WHERE id = ?',
+    [$userId]
+);
 ```
 
 ## Multisite Support
@@ -233,14 +244,25 @@ The site is determined by:
 2. **Default** - If not specified, uses `default`
 
 **Site Context in Code:**
+
+Neither `$_SESSION` nor `$GLOBALS` may be read directly — the
+`ForbiddenSessionSuperglobalRule` and `ForbiddenGlobalsAccessRule` PHPStan
+rules reject both. Use the session wrapper for session values and
+`OEGlobalsBag` for globals.
+
 ```php
 <?php
+use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\OEGlobalsBag;
+
 // Get current site
-$site = $_SESSION['site_id'] ?? 'default';
+$session = SessionWrapperFactory::getInstance()->getActiveSession();
+$site = $session->get('site_id', 'default');
 
 // Site-specific paths
-$documentPath = $GLOBALS['OE_SITE_DIR'] . '/documents/';
-$sqlConf = $GLOBALS['OE_SITE_DIR'] . '/sqlconf.php';
+$siteDir = OEGlobalsBag::getInstance()->getString('OE_SITE_DIR');
+$documentPath = $siteDir . '/documents/';
+$sqlConf = $siteDir . '/sqlconf.php';
 ```
 
 ## Security Best Practices
@@ -525,7 +547,7 @@ class MyResourceService extends BaseService
     public function getOne($uuid)
     {
         $sql = "SELECT * FROM " . self::TABLE_NAME . " WHERE uuid = ?";
-        $result = QueryUtils::sqlQueryThrowException($sql, [$uuid]);
+        $result = QueryUtils::querySingleRow($sql, [$uuid]);
 
         $processingResult = new ProcessingResult();
         if (!empty($result)) {
@@ -1333,19 +1355,53 @@ return [
 
 ### Authorization Checks
 
-**Scope-based:**
-```php
-RestConfig::authorization_check("patients", "demo");
-```
+Authorization is an ACL check, not a username comparison. Every route closure
+receives an `HttpRestRequest` — pass it to
+`RestConfig::request_authorization_check()`, which resolves the authenticated
+user from the request's session and runs the ACL check for you:
 
-**Role-based:**
 ```php
-// Check user role
-if ($_SESSION['authUser'] !== 'admin') {
-    http_response_code(403);
-    exit;
+"GET /api/patient" => function (HttpRestRequest $request) {
+    RestConfig::request_authorization_check($request, "patients", "demo");
+    // ...
 }
 ```
+
+The second and third arguments are the ACL section and value. Common pairs:
+
+| Section | Value | Grants |
+|---------|-------|--------|
+| `patients` | `demo` | Demographics |
+| `patients` | `med` | Medical records and history |
+| `patients` | `appt` | Appointments |
+| `encounters` | `notes` | Encounter notes — my encounters |
+| `encounters` | `auth_a` | Authorize any encounter |
+| `acct` | `bill` | Billing |
+| `admin` | `users` | User and facility administration |
+| `admin` | `super` | Full administrative access |
+
+The full section/value list is documented in the class docblock of
+`src/Common/Acl/AclMain.php`. An optional fourth argument narrows the
+permission further (`'write'`, `'addonly'`).
+
+Outside a route closure — in a service or a controller that has no request —
+call the ACL layer directly:
+
+```php
+use OpenEMR\Common\Acl\AclMain;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+if (!AclMain::aclCheckCore('admin', 'super')) {
+    throw new AccessDeniedHttpException('Insufficient permissions');
+}
+```
+
+Do **not** authorize by comparing `authUser` against a literal username. The
+`admin` account is an ordinary user whose name happens to be `admin`; the
+comparison grants access to that one account and denies every other
+administrator, while missing the ACL groups that actually carry the
+permission. Reading `$_SESSION` directly is separately rejected by the
+`ForbiddenSessionSuperglobalRule` PHPStan rule.
 
 ## Validation
 

--- a/Documentation/api/DEVELOPER_GUIDE.md
+++ b/Documentation/api/DEVELOPER_GUIDE.md
@@ -1317,7 +1317,7 @@ public function updateWithRelated($id, $data, $related)
 ```php
 <?php
 return [
-    "METHOD /path" => function ($param, HttpRestRequest $request) {
+    "METHOD /path/:param" => function ($param, HttpRestRequest $request) {
         // Authorization — ACL section and value, checked against the
         // authenticated user on the request
         RestConfig::request_authorization_check($request, "patients", "demo");

--- a/Documentation/api/DEVELOPER_GUIDE.md
+++ b/Documentation/api/DEVELOPER_GUIDE.md
@@ -767,33 +767,29 @@ Portal Routes are added to _rest_routes_portal.inc.php
 use OpenEMR\RestControllers\MyResourceRestController;
 
 // Add to existing routes array
-"GET /api/myresource" => function () {
-    RestConfig::authorization_check("admin", "users");
-    $return = (new MyResourceRestController())->getAll($_GET);
-    RestConfig::apiLog($return);
+"GET /api/myresource" => function (HttpRestRequest $request) {
+    RestConfig::request_authorization_check($request, "admin", "users");
+    $return = (new MyResourceRestController())->getAll($request->query->all());
     return $return;
 },
 
-"GET /api/myresource/:uuid" => function ($uuid) {
-    RestConfig::authorization_check("admin", "users");
+"GET /api/myresource/:uuid" => function ($uuid, HttpRestRequest $request) {
+    RestConfig::request_authorization_check($request, "admin", "users");
     $return = (new MyResourceRestController())->getOne($uuid);
-    RestConfig::apiLog($return);
     return $return;
 },
 
-"POST /api/myresource" => function () {
-    RestConfig::authorization_check("admin", "users");
+"POST /api/myresource" => function (HttpRestRequest $request) {
+    RestConfig::request_authorization_check($request, "admin", "users");
     $data = (array)(json_decode(file_get_contents("php://input")));
     $return = (new MyResourceRestController())->post($data);
-    RestConfig::apiLog($return, $data);
     return $return;
 },
 
-"PUT /api/myresource/:uuid" => function ($uuid) {
-    RestConfig::authorization_check("admin", "users");
+"PUT /api/myresource/:uuid" => function ($uuid, HttpRestRequest $request) {
+    RestConfig::request_authorization_check($request, "admin", "users");
     $data = (array)(json_decode(file_get_contents("php://input")));
     $return = (new MyResourceRestController())->put($uuid, $data);
-    RestConfig::apiLog($return, $data);
     return $return;
 }
 ```
@@ -1020,14 +1016,14 @@ use OpenEMR\RestControllers\FHIR\FhirMyResourceRestController;
 
 // Add to FHIR routes
 "GET /fhir/MyResource" => function (HttpRestRequest $request) {
+    RestConfig::request_authorization_check($request, "patients", "demo");
     $return = (new FhirMyResourceRestController())->getAll($request->getQueryParams());
-    RestConfig::apiLog($return);
     return $return;
 },
 
 "GET /fhir/MyResource/:id" => function ($id, HttpRestRequest $request) {
+    RestConfig::request_authorization_check($request, "patients", "demo");
     $return = (new FhirMyResourceRestController())->getOne($id);
-    RestConfig::apiLog($return);
     return $return;
 }
 ```
@@ -1321,20 +1317,22 @@ public function updateWithRelated($id, $data, $related)
 ```php
 <?php
 return [
-    "METHOD /path" => function ($param) {
-        // Authorization
-        RestConfig::authorization_check("scope", "acl");
+    "METHOD /path" => function ($param, HttpRestRequest $request) {
+        // Authorization — ACL section and value, checked against the
+        // authenticated user on the request
+        RestConfig::request_authorization_check($request, "patients", "demo");
 
         // Controller call
-        $return = (new Controller())->method($param);
-
-        // Logging
-        RestConfig::apiLog($return);
+        $return = (new Controller())->method($param, $request);
 
         return $return;
     }
 ];
 ```
+
+Named URL parameters come first in the closure signature; the
+`HttpRestRequest` is appended last. Audit logging is not called from the
+route — it happens automatically for every REST call.
 
 ### Route Parameters
 
@@ -1347,9 +1345,11 @@ return [
 
 **Query parameters:**
 ```php
-"GET /api/patient" => function () {
-    // Access via $_GET
-    $search = $_GET;
+"GET /api/patient" => function (HttpRestRequest $request) {
+    // Read query parameters off the request, never $_GET
+    $search = $request->query->all();
+    $name = $request->query->getString('name');
+    $limit = $request->query->getInt('limit');
 }
 ```
 


### PR DESCRIPTION
Fixes #13593

`Documentation/api/DEVELOPER_GUIDE.md` taught patterns that cannot be merged, and several that fatal outright. `ForbiddenSessionSuperglobalRule` has no baseline file — the codebase carries zero direct `$_SESSION` reads outside tests — so a contributor following the guide fails `composer phpstan` on their first PR with no baseline entry to fall back on.

### Superglobals

- **Get Current User** and **Site Context in Code** now read through `SessionWrapperFactory::getInstance()->getActiveSession()`, and the site directory through `OEGlobalsBag::getInstance()->getString('OE_SITE_DIR')` — matching `AuthorizationController` and `AbstractModuleActionTrait`.
- The **Query parameters** route example read `$_GET` directly; it now uses `$request->query->all()` and the typed `InputBag` getters.

### Authorization

- The **Role-based** example string-compared `authUser` against the literal `'admin'`. That is a username check, not a role check: it grants access to whoever happens to be named `admin` and denies every other administrator. Replaced with `RestConfig::request_authorization_check($request, ...)` — what every route in `_rest_routes_standard.inc.php` already does — plus `AclMain::aclCheckCore()` for call sites with no request, and a table of the section/value pairs the real routes pass (cross-checked against the `AclMain` class docblock).
- The **Structure** route template used `RestConfig::authorization_check("scope", "acl")`. Neither `scope` nor `acl` is a real ACL section/value pair, so the example forwarded something to `AclMain::aclCheckCore()` that can never match. I also dropped the misleading "Scope-based" heading — `authorization_check()` is an ACL check; the actual `scope_check()` has zero callers, so it isn't documented as a recommended path.

### Calls that do not exist

Both verified with `method_exists` under the autoloader, not grep:

- `QueryUtils::sqlQueryThrowException()` in the `BaseService` example — now `QueryUtils::querySingleRow()`.
- `RestConfig::apiLog()`, called in seven route examples across three sections. No route in `apis/routes/` calls it either. Audit logging is handled by the audit sink, which the guide's own Security section already states, so the calls are removed rather than replaced.

The **Get Current User** snippet also used `sqlQuery()` with a double-quoted `SELECT *`; it now names its columns (verified against `sql/database.sql`) and goes through `QueryUtils`.

Documentation only — no runtime changes.
