### PR TITLE
fix(docker): fail loudly when the database upgrade fails

### DIFF
--- a/docker/binary/openemr.sh
+++ b/docker/binary/openemr.sh
@@ -550,7 +550,7 @@ run_upgrade() {
             [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
             if ! sh "/root/fsupgrade-${c}.sh"; then
                 echo "ERROR: fsupgrade-${c}.sh failed; aborting upgrade." >&2
-                echo "Version marker NOT advanced; the upgrade will re-run on next container start (upgrade SQL guards make retry safe)." >&2
+                echo "Version marker NOT advanced; the upgrade will re-run on next container recreation (redeploy from image)." >&2
                 return 1
             fi
             echo "Completed: Processing fsupgrade-${c}.sh upgrade script"

--- a/docker/binary/openemr.sh
+++ b/docker/binary/openemr.sh
@@ -504,6 +504,8 @@ check_upgrade() {
     if [[ "${docker_version_root}" = "${docker_version_code}" ]] &&
        [[ "${docker_version_root}" -gt "${docker_version_sites}" ]]; then
         echo "Upgrade detected: ${docker_version_sites} -> ${docker_version_root}"
+        # run_upgrade failure aborts the entrypoint via set -e -- do not
+        # wrap this call in a conditional or the failure will be swallowed.
         run_upgrade
         return 0
     fi
@@ -546,7 +548,11 @@ run_upgrade() {
             echo "Start: Processing fsupgrade-${c}.sh upgrade script"
             # Update heartbeat before each upgrade script
             [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
-            sh "/root/fsupgrade-${c}.sh"
+            if ! sh "/root/fsupgrade-${c}.sh"; then
+                echo "ERROR: fsupgrade-${c}.sh failed; aborting upgrade." >&2
+                echo "Version marker NOT advanced; the upgrade will re-run on next container start (upgrade SQL guards make retry safe)." >&2
+                return 1
+            fi
             echo "Completed: Processing fsupgrade-${c}.sh upgrade script"
             # Update heartbeat after each upgrade script
             [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat

--- a/docker/binary/openemr.sh
+++ b/docker/binary/openemr.sh
@@ -550,7 +550,10 @@ run_upgrade() {
             [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
             if ! sh "/root/fsupgrade-${c}.sh"; then
                 echo "ERROR: fsupgrade-${c}.sh failed; aborting upgrade." >&2
-                echo "Version marker NOT advanced; the upgrade will re-run on next container recreation (redeploy from image)." >&2
+                echo "The database may be partially upgraded. Review the errors above and either" >&2
+                echo "correct the underlying problem or restore your pre-upgrade backup." >&2
+                echo "Version marker NOT advanced, so the upgrade will be attempted again on the" >&2
+                echo "next container recreation." >&2
                 return 1
             fi
             echo "Completed: Processing fsupgrade-${c}.sh upgrade script"

--- a/docker/binary/upgrade/fsupgrade-1.sh
+++ b/docker/binary/upgrade/fsupgrade-1.sh
@@ -47,12 +47,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-1.sh
+++ b/docker/binary/upgrade/fsupgrade-1.sh
@@ -52,6 +52,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/binary/upgrade/fsupgrade-2.sh
+++ b/docker/binary/upgrade/fsupgrade-2.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/binary/upgrade/fsupgrade-2.sh
+++ b/docker/binary/upgrade/fsupgrade-2.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-3.sh
+++ b/docker/binary/upgrade/fsupgrade-3.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/binary/upgrade/fsupgrade-3.sh
+++ b/docker/binary/upgrade/fsupgrade-3.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-4.sh
+++ b/docker/binary/upgrade/fsupgrade-4.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/binary/upgrade/fsupgrade-4.sh
+++ b/docker/binary/upgrade/fsupgrade-4.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-5.sh
+++ b/docker/binary/upgrade/fsupgrade-5.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/binary/upgrade/fsupgrade-5.sh
+++ b/docker/binary/upgrade/fsupgrade-5.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-6.sh
+++ b/docker/binary/upgrade/fsupgrade-6.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/binary/upgrade/fsupgrade-6.sh
+++ b/docker/binary/upgrade/fsupgrade-6.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-7.sh
+++ b/docker/binary/upgrade/fsupgrade-7.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/binary/upgrade/fsupgrade-7.sh
+++ b/docker/binary/upgrade/fsupgrade-7.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/upgrade/fsupgrade-8.sh
+++ b/docker/binary/upgrade/fsupgrade-8.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/binary/upgrade/fsupgrade-8.sh
+++ b/docker/binary/upgrade/fsupgrade-8.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/binary/utilities/devtoolsLibrary.source
+++ b/docker/binary/utilities/devtoolsLibrary.source
@@ -285,13 +285,16 @@ demoData() {
 # ----------------------------------------------------------------------------
 upgradeOpenEMR() {
     # Inject site context, then run the standard upgrade via its CLI interface
-    {
+    if ! {
         echo "<?php \$_GET['site'] = 'default'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
-    } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php; then
+        echo "ERROR: could not stage sql_upgrade.php (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+        return 1
+    fi
     # Execute the upgrade script with the from-version argument
     # shellcheck disable=SC2310  # set -e behavior in conditionals is intentional
-    if ! run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"; then
     if ! run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"; then
         echo "ERROR: Database upgrade failed (from ${1})" >&2
         rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php

--- a/docker/binary/utilities/devtoolsLibrary.source
+++ b/docker/binary/utilities/devtoolsLibrary.source
@@ -290,6 +290,8 @@ upgradeOpenEMR() {
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
     # Execute the upgrade script with the from-version argument
+    # shellcheck disable=SC2310  # set -e behavior in conditionals is intentional
+    if ! run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"; then
     if ! run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"; then
         echo "ERROR: Database upgrade failed (from ${1})" >&2
         rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php

--- a/docker/binary/utilities/devtoolsLibrary.source
+++ b/docker/binary/utilities/devtoolsLibrary.source
@@ -290,7 +290,11 @@ upgradeOpenEMR() {
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
     # Execute the upgrade script with the from-version argument
-    run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"
+    if ! run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"; then
+        echo "ERROR: Database upgrade failed (from ${1})" >&2
+        rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+        return 1
+    fi
 
     # Clean up temporary file
     rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php

--- a/docker/container_benchmarking/test_suite.sh
+++ b/docker/container_benchmarking/test_suite.sh
@@ -1467,10 +1467,16 @@ EOF
     cd "${test_dir}"
     # shellcheck disable=SC2310  # Stop/rm may no-op if container already exited
     run_docker_compose "${PROJECT_NAME}-upgrade" -f docker-compose.yml stop openemr 2>&1 | tee -a "${LOG_FILE}" || true
-    # shellcheck disable=SC2310 # rm may no-op if container was never created
+    # shellcheck disable=SC2310  # rm may no-op if container was never created
     run_docker_compose "${PROJECT_NAME}-upgrade" -f docker-compose.yml rm -f openemr 2>&1 | tee -a "${LOG_FILE}" || true
-    # shellcheck disable=SC2310  # Error surfaces via wait_for_healthy below
-    run_docker_compose "${PROJECT_NAME}-upgrade" -f docker-compose.yml up -d openemr 2>&1 | tee -a "${LOG_FILE}" || true
+    # shellcheck disable=SC2310  # Error handling is explicit via if/return
+    if ! run_docker_compose "${PROJECT_NAME}-upgrade" -f docker-compose.yml up -d openemr 2>&1 | tee -a "${LOG_FILE}"; then
+        log_test_result "${test_name}" "FAIL" "Failed to recreate container"
+        # shellcheck disable=SC2310  # Cleanup should not fail the test
+        run_docker_compose "${PROJECT_NAME}-upgrade" -f docker-compose.yml down --volumes >/dev/null 2>&1 || true
+        cd - >/dev/null
+        return 1
+    fi
     cd - >/dev/null
 
     # Wait a moment for container to recreate

--- a/docker/container_benchmarking/test_suite.sh
+++ b/docker/container_benchmarking/test_suite.sh
@@ -1455,26 +1455,31 @@ EOF
         return 1
     fi
 
-    # Step 4: Get log position before restart to only check new logs
-    log_info "Step 3: Getting current log position..."
-    local log_size_before
-    # shellcheck disable=SC2034  # log_size_before is captured but not used (reserved for future debugging)
-    log_size_before=$(docker logs "${container_name}" 2>&1 | wc -l) || log_size_before="0"
-
-    # Step 5: Restart container to trigger upgrade check
-    log_info "Step 4: Restarting container to trigger upgrade..."
+    # Step 4: Recreate container to trigger upgrade check.
+    # A real upgrade always ships as a new image -> new container; recreating
+    # (rather than restarting) also restores setup-removed files such as
+    # sql_upgrade.php from the image, which the fsupgrade scripts require.
+    # Note: the sites/default/docker-version marker set above lives on the
+    # upgrade_sites volume and survives recreation; the code-version fix-up
+    # in Step 2 lives in the writable layer and does not (acceptable: images
+    # missing the code version file cannot upgrade in production either).
+    log_info "Step 3: Recreating container to trigger upgrade..."
     cd "${test_dir}"
-    # shellcheck disable=SC2310  # Restart may fail if container is not running, which is acceptable
-    run_docker_compose "${PROJECT_NAME}-upgrade" -f docker-compose.yml restart openemr 2>&1 | tee -a "${LOG_FILE}" || true
+    # shellcheck disable=SC2310  # Stop/rm may no-op if container already exited
+    run_docker_compose "${PROJECT_NAME}-upgrade" -f docker-compose.yml stop openemr 2>&1 | tee -a "${LOG_FILE}" || true
+    # shellcheck disable=SC2310 # rm may no-op if container was never created
+    run_docker_compose "${PROJECT_NAME}-upgrade" -f docker-compose.yml rm -f openemr 2>&1 | tee -a "${LOG_FILE}" || true
+    # shellcheck disable=SC2310  # Error surfaces via wait_for_healthy below
+    run_docker_compose "${PROJECT_NAME}-upgrade" -f docker-compose.yml up -d openemr 2>&1 | tee -a "${LOG_FILE}" || true
     cd - >/dev/null
 
-    # Wait a moment for container to restart
+    # Wait a moment for container to recreate
     sleep 5
 
-    # Wait for container to be healthy again after restart
+    # Wait for container to be healthy again after recreate
     # shellcheck disable=SC2310
     if ! wait_for_healthy "${container_name}" 600; then
-        log_test_result "${test_name}" "FAIL" "Container did not become healthy after restart"
+        log_test_result "${test_name}" "FAIL" "Container did not become healthy after recreate"
         docker logs "${container_name}" --tail 50 2>&1 | tee -a "${LOG_FILE}" || true
         cd "${test_dir}"
         # shellcheck disable=SC2310  # Cleanup should not fail the test
@@ -1486,8 +1491,8 @@ EOF
     # Give upgrade time to complete if it's running
     sleep 10
 
-    # Step 6: Check logs for upgrade messages (only new logs since restart)
-    log_info "Step 5: Checking upgrade logs..."
+    # Step 5: Check logs for upgrade messages (recreated container's logs)
+    log_info "Step 4: Checking upgrade logs..."
     local all_logs
     all_logs=$(docker logs "${container_name}" 2>&1 || echo "")
 
@@ -1501,8 +1506,8 @@ EOF
     local upgrade_scripts_run
     upgrade_scripts_run=$(echo "${all_logs}" | grep -q "Processing fsupgrade-.*\.sh upgrade script" && echo "1" || echo "0")
 
-    # Step 7: Verify version marker was updated
-    log_info "Step 6: Verifying version marker was updated..."
+    # Step 6: Verify version marker was updated
+    log_info "Step 5: Verifying version marker was updated..."
     local new_version
     new_version=$(docker exec "${container_name}" cat /var/www/localhost/htdocs/openemr/sites/default/docker-version 2>/dev/null || echo "0")
     log_info "Version after upgrade: ${new_version} (was ${old_version}, should be ${current_version})"
@@ -1514,7 +1519,7 @@ EOF
     code_version=$(docker exec "${container_name}" cat /var/www/localhost/htdocs/openemr/docker-version 2>/dev/null || echo "0")
     log_info "Root version: ${root_version}, Code version: ${code_version}, Sites version: ${new_version}"
 
-    # Step 8: Verify OpenEMR is still configured and accessible
+    # Step 7: Verify OpenEMR is still configured and accessible
     local config_after_upgrade
     config_after_upgrade=$(check_openemr_configured "${container_name}")
 

--- a/docker/release/openemr.sh
+++ b/docker/release/openemr.sh
@@ -547,7 +547,10 @@ run_upgrade() {
             [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
             if ! sh "/root/fsupgrade-${c}.sh"; then
                 echo "ERROR: fsupgrade-${c}.sh failed; aborting upgrade." >&2
-                echo "Version marker NOT advanced; the upgrade will re-run on next container recreation (redeploy from image)." >&2
+                echo "The database may be partially upgraded. Review the errors above and either" >&2
+                echo "correct the underlying problem or restore your pre-upgrade backup." >&2
+                echo "Version marker NOT advanced, so the upgrade will be attempted again on the" >&2
+                echo "next container recreation." >&2
                 return 1
             fi
             echo "Completed: Processing fsupgrade-${c}.sh upgrade script"

--- a/docker/release/openemr.sh
+++ b/docker/release/openemr.sh
@@ -501,6 +501,8 @@ check_upgrade() {
     if [[ "${docker_version_root}" = "${docker_version_code}" ]] &&
        [[ "${docker_version_root}" -gt "${docker_version_sites}" ]]; then
         echo "Upgrade detected: ${docker_version_sites} -> ${docker_version_root}"
+        # run_upgrade failure aborts the entrypoint via set -e -- do not
+        # wrap this call in a conditional or the failure will be swallowed.
         run_upgrade
         return 0
     fi
@@ -543,7 +545,11 @@ run_upgrade() {
             echo "Start: Processing fsupgrade-${c}.sh upgrade script"
             # Update heartbeat before each upgrade script
             [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
-            sh "/root/fsupgrade-${c}.sh"
+            if ! sh "/root/fsupgrade-${c}.sh"; then
+                echo "ERROR: fsupgrade-${c}.sh failed; aborting upgrade." >&2
+                echo "Version marker NOT advanced; the upgrade will re-run on next container start (upgrade SQL guards make retry safe)." >&2
+                return 1
+            fi
             echo "Completed: Processing fsupgrade-${c}.sh upgrade script"
             # Update heartbeat after each upgrade script
             [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat

--- a/docker/release/openemr.sh
+++ b/docker/release/openemr.sh
@@ -547,7 +547,7 @@ run_upgrade() {
             [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
             if ! sh "/root/fsupgrade-${c}.sh"; then
                 echo "ERROR: fsupgrade-${c}.sh failed; aborting upgrade." >&2
-                echo "Version marker NOT advanced; the upgrade will re-run on next container start (upgrade SQL guards make retry safe)." >&2
+                echo "Version marker NOT advanced; the upgrade will re-run on next container recreation (redeploy from image)." >&2
                 return 1
             fi
             echo "Completed: Processing fsupgrade-${c}.sh upgrade script"

--- a/docker/release/upgrade/fsupgrade-1.sh
+++ b/docker/release/upgrade/fsupgrade-1.sh
@@ -47,12 +47,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-1.sh
+++ b/docker/release/upgrade/fsupgrade-1.sh
@@ -52,6 +52,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-10.sh
+++ b/docker/release/upgrade/fsupgrade-10.sh
@@ -32,6 +32,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-10.sh
+++ b/docker/release/upgrade/fsupgrade-10.sh
@@ -27,12 +27,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     sitename="${sitename##*/}"
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-11.sh
+++ b/docker/release/upgrade/fsupgrade-11.sh
@@ -32,6 +32,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-11.sh
+++ b/docker/release/upgrade/fsupgrade-11.sh
@@ -27,12 +27,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     sitename="${sitename##*/}"
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-12.sh
+++ b/docker/release/upgrade/fsupgrade-12.sh
@@ -32,6 +32,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-12.sh
+++ b/docker/release/upgrade/fsupgrade-12.sh
@@ -27,12 +27,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     sitename="${sitename##*/}"
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-13.sh
+++ b/docker/release/upgrade/fsupgrade-13.sh
@@ -32,6 +32,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-13.sh
+++ b/docker/release/upgrade/fsupgrade-13.sh
@@ -27,12 +27,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     sitename="${sitename##*/}"
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-2.sh
+++ b/docker/release/upgrade/fsupgrade-2.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-2.sh
+++ b/docker/release/upgrade/fsupgrade-2.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-3.sh
+++ b/docker/release/upgrade/fsupgrade-3.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-3.sh
+++ b/docker/release/upgrade/fsupgrade-3.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-4.sh
+++ b/docker/release/upgrade/fsupgrade-4.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-4.sh
+++ b/docker/release/upgrade/fsupgrade-4.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-5.sh
+++ b/docker/release/upgrade/fsupgrade-5.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-5.sh
+++ b/docker/release/upgrade/fsupgrade-5.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-6.sh
+++ b/docker/release/upgrade/fsupgrade-6.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-6.sh
+++ b/docker/release/upgrade/fsupgrade-6.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-7.sh
+++ b/docker/release/upgrade/fsupgrade-7.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-7.sh
+++ b/docker/release/upgrade/fsupgrade-7.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-8.sh
+++ b/docker/release/upgrade/fsupgrade-8.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-8.sh
+++ b/docker/release/upgrade/fsupgrade-8.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/upgrade/fsupgrade-9.sh
+++ b/docker/release/upgrade/fsupgrade-9.sh
@@ -39,6 +39,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/docker/release/upgrade/fsupgrade-9.sh
+++ b/docker/release/upgrade/fsupgrade-9.sh
@@ -34,12 +34,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/docker/release/utilities/devtoolsLibrary.source
+++ b/docker/release/utilities/devtoolsLibrary.source
@@ -285,13 +285,16 @@ demoData() {
 # ----------------------------------------------------------------------------
 upgradeOpenEMR() {
     # Inject site context, then run the standard upgrade via its CLI interface
-    {
+    if ! {
         echo "<?php \$_GET['site'] = 'default'; ?>"
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
-    } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php; then
+        echo "ERROR: could not stage sql_upgrade.php (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+        return 1
+    fi
     # Execute the upgrade script with the from-version argument
     # shellcheck disable=SC2310  # set -e behavior in conditionals is intentional
-    if ! run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"; then
     if ! run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"; then
         echo "ERROR: Database upgrade failed (from ${1})" >&2
         rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php

--- a/docker/release/utilities/devtoolsLibrary.source
+++ b/docker/release/utilities/devtoolsLibrary.source
@@ -290,6 +290,8 @@ upgradeOpenEMR() {
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
     # Execute the upgrade script with the from-version argument
+    # shellcheck disable=SC2310  # set -e behavior in conditionals is intentional
+    if ! run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"; then
     if ! run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"; then
         echo "ERROR: Database upgrade failed (from ${1})" >&2
         rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php

--- a/docker/release/utilities/devtoolsLibrary.source
+++ b/docker/release/utilities/devtoolsLibrary.source
@@ -290,7 +290,11 @@ upgradeOpenEMR() {
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
     # Execute the upgrade script with the from-version argument
-    run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"
+    if ! run_php_as_apache /usr/local/bin/php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php -- --from="${1}"; then
+        echo "ERROR: Database upgrade failed (from ${1})" >&2
+        rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+        return 1
+    fi
 
     # Clean up temporary file
     rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php

--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -44,6 +44,10 @@ if (php_sapi_name() === 'cli') {
 require_once(__DIR__ . "/src/Common/Compatibility/Checker.php");
 $response = OpenEMR\Common\Compatibility\Checker::checkPhpVersion();
 if ($response !== true) {
+    if ($cliFromVersion !== null) {
+        fwrite(STDERR, $response . "\n");
+        exit(1);
+    }
     die(htmlspecialchars($response));
 }
 
@@ -110,7 +114,11 @@ $versions = [];
 $sqldir = "$webserver_root/sql";
 $dh = opendir($sqldir);
 if (!$dh) {
-    die("Cannot read $sqldir");
+    if ($cliFromVersion !== null) {
+        fwrite(STDERR, "Cannot read $sqldir\n");
+        exit(1);
+    }
+    die("Cannot read " . htmlspecialchars($sqldir));
 }
 
 while (false !== ($sfname = readdir($dh))) {

--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -22,7 +22,8 @@
 $GLOBALS['ongoing_sql_upgrade'] = true;
 
 $cliFromVersion = null;
-if (php_sapi_name() === 'cli') {
+$isCli = php_sapi_name() === 'cli';
+if ($isCli) {
     // setting for when running as command line script
     // need this for output to be readable when running as command line
     $GLOBALS['force_simple_sql_upgrade'] = true;
@@ -44,7 +45,7 @@ if (php_sapi_name() === 'cli') {
 require_once(__DIR__ . "/src/Common/Compatibility/Checker.php");
 $response = OpenEMR\Common\Compatibility\Checker::checkPhpVersion();
 if ($response !== true) {
-    if ($cliFromVersion !== null) {
+    if ($isCli) {
         fwrite(STDERR, $response . "\n");
         exit(1);
     }
@@ -114,7 +115,7 @@ $versions = [];
 $sqldir = "$webserver_root/sql";
 $dh = opendir($sqldir);
 if (!$dh) {
-    if ($cliFromVersion !== null) {
+    if ($isCli) {
         fwrite(STDERR, "Cannot read $sqldir\n");
         exit(1);
     }

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-11.sh
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-11.sh
@@ -32,6 +32,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-11.sh
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-11.sh
@@ -27,12 +27,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     sitename="${sitename##*/}"
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
@@ -32,6 +32,7 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
         cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
     } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
         exit 1
     fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.

--- a/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
+++ b/tests/Tests/Isolated/Common/Command/ReleasePrep/fixtures/docker_upgrade/fsupgrade-12.sh.expected
@@ -27,12 +27,19 @@ for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
     sitename="${sitename##*/}"
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
-    {
+    if ! {
         echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php || true
-    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        cat /var/www/localhost/htdocs/openemr/sql_upgrade.php
+    } > /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+        exit 1
+    fi
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"
+    if ! su-exec apache php -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php -- --from="${priorOpenemrVersion}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${priorOpenemrVersion}" >&2
+        rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
+        exit 1
+    fi
     rm -f /var/www/localhost/htdocs/openemr/TEMPsql_upgrade.php
     echo "Completed: Upgrade database for ${sitename} from ${priorOpenemrVersion}"
 done


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Upgrade failures in the docker flow are now loud and recoverable. Previously, a totally failed database migration logged `Completed:` at every layer, printed "OpenEMR upgrade completed successfully," and advanced the version marker — observed in a production 7.0.2 → 8.2.0 Standard-package upgrade where every hop threw a PHP fatal, leaving 8.2.0 code serving a 7.0.2 schema behind a fully green log. Recovery was further blocked because the post-upgrade cleanup had already deleted `sql_upgrade.php`, and re-runs *still* logged `Completed:` while `cat` failed on the missing file (`|| true`).

Root cause: no layer checked any exit status. The fsupgrade scripts discarded the php exit code and echoed `Completed:` unconditionally; the entrypoint's `run_upgrade` loop discarded each script's exit code (a hole in the entrypoint's own `set -euo pipefail` — the failures lived inside child `sh` processes that always exited 0); the version-marker write was unconditional; and two of `sql_upgrade.php`'s own failure paths use `die($string)`, which exits **0**.

#### Changes proposed in this pull request:

**Commit 1 — shell-side enforcement** (all `fsupgrade-N.sh` in both `docker/binary/upgrade/` and `docker/release/upgrade/` including the 8.3.0 scaffold `fsupgrade-13.sh`, both `openemr.sh` runner loops, both `devtoolsLibrary.source` copies, and the ReleasePrep `docker_upgrade` fixtures):

- The `sql_upgrade.php` staging block fails on a missing file (`|| true` removed — previously a missing file produced an empty temp script that "ran" successfully)
- The `php` invocation is checked: non-zero exit → `ERROR` with site and from-version to stderr, temp file cleaned up, exit 1
- The `run_upgrade` loop aborts on a failed hop **before the version-marker write**, so the upgrade re-runs on the next container start — the upgrade SQL's `#IfNotTable`-style guards make retry idempotent
- Aborting before the post-upgrade cleanup also preserves `sql_upgrade.php` for in-place retry after a failure; **removal after successful upgrades is retained** (the file is an unauthenticated web-reachable endpoint, and the next upgrade gets a fresh copy from the new image)
- `check_upgrade`'s call into `run_upgrade` is annotated: failure propagates to a non-zero container exit via `set -e` and must not be wrapped in a conditional
- `devtoolsLibrary.source` `upgradeOpenEMR()` gets the same check (`return 1`, temp file cleaned on both paths)

**Commit 2 — `sql_upgrade.php` CLI exit codes:** the PHP-compatibility failure and the unreadable-sql-dir failure now write to STDERR and `exit(1)` in CLI mode (detected via the `--from` argument); web-mode rendering is unchanged (plus `$sqldir` is now escaped in the web-mode message).

**Failure/recovery story:** failed hop → `ERROR: Database upgrade failed for <site> from <version>` → container exits non-zero, version marker unadvanced, `sql_upgrade.php` intact → operator fixes the cause → next container start re-detects the upgrade and completes. The ReleasePrep isolated tests pass with the updated fixtures.

#### Was an AI assistant used? Yes

<!-- Assisted-by trailers are on the commits. -->