### PR TITLE
fix(search): validate SQL identifiers in all search field resolvers

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -70138,7 +70138,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$field of class OpenEMR\\\\Services\\\\Search\\\\SearchFieldException constructor expects string, mixed given\\.$#',
-    'count' => 6,
+    'count' => 2,
     'path' => __DIR__ . '/../../src/Services/Search/SearchFieldStatementResolver.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -15997,43 +15997,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/Search/SearchFieldStatementResolver.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between \'\\(\' and mixed results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/Search/SearchFieldStatementResolver.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \' \' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Search/SearchFieldStatementResolver.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \' BETWEEN \\? AND \\? \' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Search/SearchFieldStatementResolver.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \' IN \\(\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Search/SearchFieldStatementResolver.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \' NOT BETWEEN \\? AND …\' results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Search/SearchFieldStatementResolver.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between mixed and \' \\= \\?\' results in an error\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/Search/SearchFieldStatementResolver.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between mixed and \'%%\' results in an error\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Search/SearchFieldStatementResolver.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 2,
     'path' => __DIR__ . '/../../src/Services/Search/SearchFieldStatementResolver.php',
 ];
 $ignoreErrors[] = [

--- a/src/Services/Search/SearchFieldStatementResolver.php
+++ b/src/Services/Search/SearchFieldStatementResolver.php
@@ -53,6 +53,28 @@ class SearchFieldStatementResolver
     }
 
     /**
+     * Search field names are concatenated into the generated SQL as column
+     * identifiers and therefore cannot be parameter bound.  Restrict them to a
+     * simple `column` or `table.column` identifier so a maliciously constructed
+     * field name can never be used to inject SQL.
+     *
+     * @param ISearchField $searchField
+     * @return string The validated field identifier
+     * @throws SearchFieldException if the field name is not a valid identifier
+     */
+    private static function assertValidFieldIdentifier(ISearchField $searchField): string
+    {
+        $field = $searchField->getField();
+        // getField() is untyped on ISearchField; the phpdoc says string but nothing
+        // enforces it at runtime, so keep the defensive check.
+        // @phpstan-ignore function.alreadyNarrowedType
+        if (!is_string($field) || !preg_match('/^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)?$/', $field)) {
+            throw new SearchFieldException('invalid search field', "invalid search field identifier");
+        }
+        return $field;
+    }
+
+    /**
      * Given a DateSearchField with a list of SearchFieldComparableValue objects in the search field a SQL query fragment
      * is generated that handles the date field searching.
      * @param DateSearchField $searchField
@@ -60,8 +82,10 @@ class SearchFieldStatementResolver
      */
     public static function resolveDateField(DateSearchField $searchField)
     {
+        $field = self::assertValidFieldIdentifier($searchField);
+
         if (empty($searchField->getValues())) {
-            throw new SearchFieldException($searchField->getField(), " field does not have a value to search on");
+            throw new SearchFieldException($field, " field does not have a value to search on");
         }
 
         $clauses = [];
@@ -122,17 +146,17 @@ class SearchFieldStatementResolver
             // for equality and also inequality (!=) we have to make sure we deal with the fuzzy ranges since search can
             // specify date ranges of just Year, Year+Month, Year+month+day, Year+month+day+hour&minute, Year+month+day+hour&minute+second
             if ($operator === '=') {
-                array_push($clauses, $searchField->getField() . ' BETWEEN ? AND ? ');
+                array_push($clauses, $field . ' BETWEEN ? AND ? ');
                 $searchFragment->addBoundValue($lowerBoundDateRange->format($dateFormat));
                 $searchFragment->addBoundValue($upperBoundDateRange->format($dateFormat));
             } else if ($operator === '!=') {
                 // we have to make sure we deal with the fuzzy range when we have an = operator since the user
                 // can specify date ranges of just Year, Year+Month, Year+month+day, Year+month+day+hour&minute, Year+month+day+hour&minute+second
-                array_push($clauses, $searchField->getField() . ' NOT BETWEEN ? AND ? ');
+                array_push($clauses, $field . ' NOT BETWEEN ? AND ? ');
                 $searchFragment->addBoundValue($lowerBoundDateRange->format($dateFormat));
                 $searchFragment->addBoundValue($upperBoundDateRange->format($dateFormat));
             } else {
-                array_push($clauses, $searchField->getField() . ' ' . $operator . ' ?');
+                array_push($clauses, $field . ' ' . $operator . ' ?');
                 $searchFragment->addBoundValue($dateSearchString);
             }
         }
@@ -179,8 +203,10 @@ class SearchFieldStatementResolver
      */
     public static function resolveReferenceField(ReferenceSearchField $searchField)
     {
+        $field = self::assertValidFieldIdentifier($searchField);
+
         if (empty($searchField->getValues())) {
-            throw new SearchFieldException($searchField->getField(), "field does not have a value to search on");
+            throw new SearchFieldException($field, "field does not have a value to search on");
         }
 
         $searchFragment = new SearchQueryFragment();
@@ -189,7 +215,7 @@ class SearchFieldStatementResolver
 
         foreach ($values as $value) {
             /** @var ReferenceSearchValue $value  */
-            $clauses[] = $searchField->getField() . ' = ?';
+            $clauses[] = $field . ' = ?';
             $searchFragment->addBoundValue($value->getId());
         }
 
@@ -209,8 +235,10 @@ class SearchFieldStatementResolver
      */
     public static function resolveTokenField(TokenSearchField $searchField)
     {
+        $field = self::assertValidFieldIdentifier($searchField);
+
         if (empty($searchField->getValues())) {
-            throw new SearchFieldException($searchField->getField(), "field does not have a value to search on");
+            throw new SearchFieldException($field, "field does not have a value to search on");
         }
 
         $searchFragment = new SearchQueryFragment();
@@ -224,12 +252,12 @@ class SearchFieldStatementResolver
             if ($modifier === SearchModifier::MISSING) {
                 if ($value->getCode() === false) {
                     // often our tokens get treated as string values so we will do this here also
-                    $clauses[] = "(" . $searchField->getField() . " IS NOT NULL AND CAST(" . $searchField->getField() . " AS CHAR) != '') ";
+                    $clauses[] = "(" . $field . " IS NOT NULL AND CAST(" . $field . " AS CHAR) != '') ";
                 } else {
                     // TODO: @adunsulag do we want to compare token values to empty strings... it seems like that would be a missing value but
                     // could we get an inaccurate result here? or will we end up with a case with a number to string conversion on a field
                     // if the value is not a string?
-                    $clauses[] = "(" . $searchField->getField() . " IS NULL OR CAST(" . $searchField->getField() . " AS CHAR) = '') ";
+                    $clauses[] = "(" . $field . " IS NULL OR CAST(" . $field . " AS CHAR) = '') ";
                 }
             // if we have other modifiers we would handle them here
             } else {
@@ -245,10 +273,10 @@ class SearchFieldStatementResolver
                         $value->getCode()
                     );
                     $placeholders = implode(',', array_fill(0, count($codes), '?'));
-                    $clauses[] = $searchField->getField() . ' IN (' . $placeholders . ')';
+                    $clauses[] = $field . ' IN (' . $placeholders . ')';
                 }
                 else {
-                    $clauses[] = $searchField->getField() . ' = ?';
+                    $clauses[] = $field . ' = ?';
                     $code = $codeTypesService->getOpenEMRCodeForSystemAndCode(
                         $value->getSystem(),
                         $value->getCode()
@@ -277,21 +305,16 @@ class SearchFieldStatementResolver
      */
     public static function resolveStringSearchField(StringSearchField $searchField)
     {
+        $field = self::assertValidFieldIdentifier($searchField);
+
         if (empty($searchField->getValues())) {
-            throw new SearchFieldException($searchField->getField(), "does not have a value to search on");
+            throw new SearchFieldException($field, "does not have a value to search on");
         }
 
         $clauses = [];
         $searchFragment = new SearchQueryFragment();
         $modifier = $searchField->getModifier();
         $values = $searchField->getValues();
-
-        // Guard: getField() is concatenated into SQL as a column identifier and
-        // cannot be parameter-bound.
-        $field = $searchField->getField();
-        if (!is_string($field) || !preg_match('/^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)?$/', $field)) {
-            throw new SearchFieldException('invalid search field', "invalid search field identifier");
-        }
 
         foreach ($values as $value) {
             $result = match ($modifier) {

--- a/src/Services/Search/SearchFieldStatementResolver.php
+++ b/src/Services/Search/SearchFieldStatementResolver.php
@@ -68,7 +68,7 @@ class SearchFieldStatementResolver
         // getField() is untyped on ISearchField; the phpdoc says string but nothing
         // enforces it at runtime, so keep the defensive check.
         // @phpstan-ignore function.alreadyNarrowedType
-        if (!is_string($field) || !preg_match('/^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)?$/', $field)) {
+        if (!is_string($field) || !preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $field)) {
             throw new SearchFieldException('invalid search field', "invalid search field identifier");
         }
         return $field;

--- a/tests/Tests/Isolated/Services/Search/SearchFieldStatementResolverTest.php
+++ b/tests/Tests/Isolated/Services/Search/SearchFieldStatementResolverTest.php
@@ -55,6 +55,10 @@ class SearchFieldStatementResolverTest extends TestCase
             'hyphenated fhir param'     => ["questionnaire-code"],
             'wildcard'                  => ["*"],
             'parenthesized function'    => ["LOWER(name)"],
+            'numeric literal'           => ["42"],
+            'decimal numeric literal'   => ["1.2"],
+            'digit-leading identifier'  => ["9col"],
+            'digit-leading dotted part' => ["patient.9col"],
         ];
     }
 
@@ -136,11 +140,18 @@ class SearchFieldStatementResolverTest extends TestCase
             );
             $this->fail('Expected SearchFieldException was not thrown');
         } catch (SearchFieldException $exception) {
-            $this->assertStringNotContainsString(
-                $fieldName === '' ? "\u{0}" : $fieldName,
+            $this->assertSame(
+                'invalid search field',
                 $exception->getField(),
-                'Raw hostile field name must not be reflected in the exception'
+                'Exception field must be the generic label, not the hostile input'
             );
+            if ($fieldName !== '') {
+                $this->assertStringNotContainsString(
+                    $fieldName,
+                    $exception->getMessage(),
+                    'Raw hostile field name must not be reflected in the exception message'
+                );
+            }
         }
     }
 

--- a/tests/Tests/Isolated/Services/Search/SearchFieldStatementResolverTest.php
+++ b/tests/Tests/Isolated/Services/Search/SearchFieldStatementResolverTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * SearchFieldStatementResolver Unit Tests
+ *
+ * Verifies that search field names, which are concatenated into generated SQL
+ * as column identifiers and cannot be parameter bound, are validated across
+ * ALL field types (string, token, date, reference, and composite children) so
+ * a maliciously constructed field name can never inject SQL.  Also pins the
+ * expected SQL fragments and bound values for the happy paths so refactors of
+ * the resolver do not silently change query generation.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Services\Search;
+
+use OpenEMR\Services\Search\CompositeSearchField;
+use OpenEMR\Services\Search\DateSearchField;
+use OpenEMR\Services\Search\ReferenceSearchField;
+use OpenEMR\Services\Search\SearchFieldException;
+use OpenEMR\Services\Search\SearchFieldStatementResolver;
+use OpenEMR\Services\Search\SearchModifier;
+use OpenEMR\Services\Search\StringSearchField;
+use OpenEMR\Services\Search\TokenSearchField;
+use OpenEMR\Services\Search\TokenSearchValue;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class SearchFieldStatementResolverTest extends TestCase
+{
+    /**
+     * Field names that must be rejected because they would otherwise be
+     * concatenated into SQL as identifiers.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function invalidFieldIdentifierProvider(): array
+    {
+        return [
+            'sql injection or clause'   => ["name = '' OR 1=1 -- "],
+            'statement terminator'      => ["name; DROP TABLE patient_data"],
+            'subquery'                  => ["(SELECT password FROM users LIMIT 1)"],
+            'backtick quoted'           => ["`name`"],
+            'double dotted'             => ["a.b.c"],
+            'embedded space'            => ["name OR"],
+            'comment sequence'          => ["name--"],
+            'union keyword with space'  => ["name UNION SELECT"],
+            'empty string'              => [""],
+            'hyphenated fhir param'     => ["questionnaire-code"],
+            'wildcard'                  => ["*"],
+            'parenthesized function'    => ["LOWER(name)"],
+        ];
+    }
+
+    /**
+     * Legitimate identifiers that must continue to resolve.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function validFieldIdentifierProvider(): array
+    {
+        return [
+            'simple column'  => ['name'],
+            'underscored'    => ['policy_number'],
+            'dotted column'  => ['patient.puuid'],
+            'numeric suffix' => ['line1'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('invalidFieldIdentifierProvider')]
+    public function testStringFieldRejectsInvalidIdentifier(string $fieldName): void
+    {
+        $this->expectException(SearchFieldException::class);
+        SearchFieldStatementResolver::resolveStringSearchField(
+            new StringSearchField($fieldName, ['value'], SearchModifier::CONTAINS)
+        );
+    }
+
+    #[Test]
+    #[DataProvider('invalidFieldIdentifierProvider')]
+    public function testTokenFieldRejectsInvalidIdentifier(string $fieldName): void
+    {
+        $searchField = new TokenSearchField($fieldName, [new TokenSearchValue(false)]);
+        $searchField->setModifier(SearchModifier::MISSING);
+        $this->expectException(SearchFieldException::class);
+        SearchFieldStatementResolver::resolveTokenField($searchField);
+    }
+
+    #[Test]
+    #[DataProvider('invalidFieldIdentifierProvider')]
+    public function testDateFieldRejectsInvalidIdentifier(string $fieldName): void
+    {
+        $this->expectException(SearchFieldException::class);
+        SearchFieldStatementResolver::resolveDateField(
+            new DateSearchField($fieldName, ['ge2024-01-01'], DateSearchField::DATE_TYPE_DATE)
+        );
+    }
+
+    #[Test]
+    #[DataProvider('invalidFieldIdentifierProvider')]
+    public function testReferenceFieldRejectsInvalidIdentifier(string $fieldName): void
+    {
+        $this->expectException(SearchFieldException::class);
+        SearchFieldStatementResolver::resolveReferenceField(
+            new ReferenceSearchField($fieldName, ['Patient/123'])
+        );
+    }
+
+    #[Test]
+    #[DataProvider('invalidFieldIdentifierProvider')]
+    public function testCompositeFieldRejectsInvalidChildIdentifier(string $fieldName): void
+    {
+        $composite = new CompositeSearchField('combined', [], true);
+        $composite->addChild(new StringSearchField('name', ['ok'], SearchModifier::EXACT));
+        $composite->addChild(new StringSearchField($fieldName, ['value'], SearchModifier::CONTAINS));
+        $this->expectException(SearchFieldException::class);
+        SearchFieldStatementResolver::getStatementForSearchField($composite);
+    }
+
+    #[Test]
+    #[DataProvider('invalidFieldIdentifierProvider')]
+    public function testGuardRunsBeforeEmptyValueCheck(string $fieldName): void
+    {
+        // The identifier guard must fire before the empty-values check so a
+        // hostile field name is never echoed back through the exception path.
+        try {
+            SearchFieldStatementResolver::resolveStringSearchField(
+                new StringSearchField($fieldName, [], SearchModifier::CONTAINS)
+            );
+            $this->fail('Expected SearchFieldException was not thrown');
+        } catch (SearchFieldException $exception) {
+            $this->assertStringNotContainsString(
+                $fieldName === '' ? "\u{0}" : $fieldName,
+                $exception->getField(),
+                'Raw hostile field name must not be reflected in the exception'
+            );
+        }
+    }
+
+    #[Test]
+    #[DataProvider('validFieldIdentifierProvider')]
+    public function testStringFieldAcceptsValidIdentifier(string $fieldName): void
+    {
+        $fragment = SearchFieldStatementResolver::resolveStringSearchField(
+            new StringSearchField($fieldName, ['bob'], SearchModifier::CONTAINS)
+        );
+        $this->assertEquals($fieldName . ' LIKE ?', $fragment->getFragment());
+        $this->assertEquals(['%bob%'], $fragment->getBoundValues());
+    }
+
+    #[Test]
+    public function testStringFieldModifierFragments(): void
+    {
+        $cases = [
+            [SearchModifier::PREFIX, 'name LIKE ?', ['bob%']],
+            [SearchModifier::SUFFIX, 'name LIKE ?', ['%bob']],
+            [SearchModifier::CONTAINS, 'name LIKE ?', ['%bob%']],
+            [SearchModifier::EXACT, 'BINARY name = ?', ['bob']],
+            [SearchModifier::NOT_EQUALS_EXACT, 'BINARY name != ?', ['bob']],
+        ];
+        foreach ($cases as [$modifier, $expectedSql, $expectedBinds]) {
+            $fragment = SearchFieldStatementResolver::resolveStringSearchField(
+                new StringSearchField('name', ['bob'], $modifier)
+            );
+            $this->assertEquals($expectedSql, $fragment->getFragment(), "modifier: " . $modifier);
+            $this->assertEquals($expectedBinds, $fragment->getBoundValues(), "modifier: " . $modifier);
+        }
+    }
+
+    #[Test]
+    public function testDateFieldEqualityUsesFuzzyBetweenRange(): void
+    {
+        $fragment = SearchFieldStatementResolver::resolveDateField(
+            new DateSearchField('start_date', ['2024-01-01'], DateSearchField::DATE_TYPE_DATE)
+        );
+        $this->assertEquals('start_date BETWEEN ? AND ? ', $fragment->getFragment());
+        $this->assertCount(2, $fragment->getBoundValues());
+    }
+
+    #[Test]
+    public function testDateFieldComparatorOperator(): void
+    {
+        $fragment = SearchFieldStatementResolver::resolveDateField(
+            new DateSearchField('date_end', ['ge2024-01-01'], DateSearchField::DATE_TYPE_DATE)
+        );
+        $this->assertEquals('date_end >= ?', $fragment->getFragment());
+        $this->assertCount(1, $fragment->getBoundValues());
+    }
+
+    #[Test]
+    public function testTokenFieldMissingModifierFragments(): void
+    {
+        // missing=false token value => field must NOT be missing
+        $notMissing = new TokenSearchField('provider', [new TokenSearchValue(false)]);
+        $notMissing->setModifier(SearchModifier::MISSING);
+        $fragment = SearchFieldStatementResolver::resolveTokenField($notMissing);
+        $this->assertEquals(
+            "(provider IS NOT NULL AND CAST(provider AS CHAR) != '') ",
+            $fragment->getFragment()
+        );
+        $this->assertEmpty($fragment->getBoundValues());
+    }
+
+    #[Test]
+    public function testReferenceFieldFragmentAndBinds(): void
+    {
+        $fragment = SearchFieldStatementResolver::resolveReferenceField(
+            new ReferenceSearchField('pid', ['Patient/123'])
+        );
+        $this->assertEquals('pid = ?', $fragment->getFragment());
+        $this->assertEquals(['123'], $fragment->getBoundValues());
+    }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:
Search field names are concatenated into generated SQL as column
identifiers and cannot be parameter bound. Extend the identifier guard
from resolveStringSearchField to the token, date, and reference
resolvers via a shared assertValidFieldIdentifier(), and run it before
the empty-values check so hostile field names are never reflected
through exception messages.


#### Changes proposed in this pull request:
Adds SearchFieldStatementResolverTest (isolated suite) covering hostile
identifiers across all field types, guard ordering, and pinned SQL
fragments for the happy paths.


#### Was an AI assistant used? Yes 

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
