### PR TITLE
fix(release): bump ship-release App token to contents:write for merge API

### DIFF
--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -149,11 +149,15 @@ jobs:
           website-openemr
         # Explicit permission grants (least-privilege). Ship-release
         # needs: read PR state (pull-requests:read via metadata), merge
-        # PRs (pull-requests:write), post commit statuses on PR heads
-        # (statuses:write), read repo contents (contents:read). The
-        # App itself may be installed with broader permissions; scoping
-        # the minted token narrows what a compromised runner can do.
-        permission-contents: read
+        # PRs (contents:write -- GitHub's mergePullRequest mutation
+        # writes to the base branch, so contents:write is the required
+        # grant even though the *trigger* is a PR action; pull-requests:
+        # write alone returns "Resource not accessible by integration
+        # (mergePullRequest)"), post commit statuses on PR heads
+        # (statuses:write). The App itself may be installed with broader
+        # permissions; scoping the minted token narrows what a
+        # compromised runner can do.
+        permission-contents: write
         permission-metadata: read
         permission-pull-requests: write
         permission-statuses: write


### PR DESCRIPTION
## Summary

Semi-auto ship-release on 8.3.0 hit \`GraphQL: Resource not accessible by integration (mergePullRequest)\` when the App tried to squash-merge the Conductor PR. Preflight passed, ruleset bypass was in place, but the API call itself failed at the token-permission layer.

## Root cause

Ship-release mints its App token with least-privilege scope-down via \`generate-app-token\`:

\`\`\`yaml
permission-contents: read      # ← THE BUG
permission-metadata: read
permission-pull-requests: write
permission-statuses: write
\`\`\`

GitHub's GraphQL \`mergePullRequest\` mutation requires **\`contents:write\`**, not \`pull-requests:write\`. Merging a PR technically writes to the base branch's content, even though the trigger is a PR action. The naming is confusing; \`pull-requests:write\` allows opening/updating/commenting on PRs but NOT merging them.

The App installation already has \`contents: Read and write\` on both \`openemr/openemr\` and \`openemr/website-openemr\` (release admin confirmed). The workflow was just requesting the read scope when minting the ephemeral token.

## Fix

One-line change: \`permission-contents: read\` → \`permission-contents: write\`.

Comment block above the permission grants was also expanded to explain the contents-vs-pull-requests distinction so future readers don't fall into the same trap.

## Scope

- **Semi-auto** — fixes Conductor merge (the actual 8.3.0 blocker)
- **Full-auto** — same fix covers Finalize merge on \`openemr/openemr\` + Docs merge on \`openemr/website-openemr\` (all three merges route through the same \`mergePullRequest\` mutation; the App token is scoped to both repos with the same permission set)

No new scopes needed beyond \`contents:write\` — all other ship-release API calls (findByHead, getReadiness, postCommitStatus, releaseExists) work with the existing scope grants.

## Config follow-up for full-auto (not this PR)

Before dispatching full-auto for the first time, verify \`openemr/website-openemr\`'s \`master\` branch doesn't have a \"Restrict updates\" ruleset that would need the release App added to the bypass allowance — same shape as the rel-830 bypass that had to be added for semi-auto today. If it does, Docs merge in full-auto would hit \"base branch policy prohibits the merge\" before this contents:write fix even matters.

## Test plan

- [x] Diff review — 9 insertions, 5 deletions (permission line + expanded comment)
- [x] YAML syntax — actionlint pre-commit hook passed
- [ ] Post-merge: redispatch semi-auto ship-release on rel-830 8.3.0. Expected: Conductor merge succeeds → tag created → build-release-on-tag fires → GitHub Release object created → finalize/docs auto-flip → operator manually merges finalize + docs.

## Related

Ship-release preflight escape-hatch series: #13570, #13574, #13581, #13582, #13590, #13607. Those all fixed preflight-side deadlocks; this fixes the merge-time deadlock that surfaced once preflight cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)