### PR TITLE
feat(api): add search parameters to insurance and employer endpoints

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -59882,11 +59882,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#2 \\$processingResult of static method OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:\\:createProcessingResultResponse\\(\\) expects OpenEMR\\\\Validators\\\\ProcessingResult, Particle\\\\Validator\\\\ValidationResult given\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$processingResult of static method OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:\\:handleProcessingResult\\(\\) expects OpenEMR\\\\Validators\\\\ProcessingResult, mixed given\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',

--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -59487,11 +59487,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/DrugRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$processingResult of static method OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:\\:handleProcessingResult\\(\\) expects OpenEMR\\\\Validators\\\\ProcessingResult, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/EmployerRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/RestControllers/EncounterRestController.php',
@@ -59887,8 +59882,13 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Parameter \\#2 \\$processingResult of static method OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:\\:createProcessingResultResponse\\(\\) expects OpenEMR\\\\Validators\\\\ProcessingResult, Particle\\\\Validator\\\\ValidationResult given\\.$#',
+    'count' => 2,
+    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$processingResult of static method OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:\\:handleProcessingResult\\(\\) expects OpenEMR\\\\Validators\\\\ProcessingResult, mixed given\\.$#',
-    'count' => 7,
+    'count' => 3,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -59882,6 +59882,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Parameter \\#1 \\$insuranceCompanyData of method OpenEMR\\\\Services\\\\InsuranceCompanyService\\:\\:validate\\(\\) expects array\\<string, mixed\\>, mixed given\\.$#',
+    'count' => 2,
+    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$processingResult of static method OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:\\:handleProcessingResult\\(\\) expects OpenEMR\\\\Validators\\\\ProcessingResult, mixed given\\.$#',
     'count' => 7,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
@@ -68522,11 +68527,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/InsuranceCompanyService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$id of method OpenEMR\\\\Services\\\\BaseService\\:\\:getUuidById\\(\\) expects string, mixed given\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/InsuranceService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$row of method OpenEMR\\\\Services\\\\BaseService\\:\\:createResultRecordFromDatabaseResult\\(\\) expects array\\<string, mixed\\>, array given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/InsuranceService.php',
@@ -68534,11 +68534,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$search of method OpenEMR\\\\Services\\\\InsuranceService\\:\\:search\\(\\) expects array\\<string, OpenEMR\\\\Services\\\\Search\\\\ISearchField\\>, array\\<string, mixed\\> given\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/InsuranceService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/InsuranceService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -87,7 +87,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../apis/routes/_rest_routes_fhir_r4_us_core_3_1_0.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$fhirSearchParameters of method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirMediaRestController\\:\\:getAll\\(\\) expects array\\<string\\>, array given\\.$#',
+    'message' => '#^Parameter \\#1 \\$fhirSearchParameters of method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirMediaRestController\\:\\:getAll\\(\\) expects array\\<string\\>, array\\<string, mixed\\> given\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../apis/routes/_rest_routes_fhir_r4_us_core_3_1_0.inc.php',
 ];
@@ -97,7 +97,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../apis/routes/_rest_routes_fhir_r4_us_core_3_1_0.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$searchParams of method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirMedicationDispenseRestController\\:\\:getAll\\(\\) expects array\\<string, int\\|string\\>, array given\\.$#',
+    'message' => '#^Parameter \\#1 \\$searchParams of method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirMedicationDispenseRestController\\:\\:getAll\\(\\) expects array\\<string, int\\|string\\>, array\\<string, mixed\\> given\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../apis/routes/_rest_routes_fhir_r4_us_core_3_1_0.inc.php',
 ];
@@ -59917,7 +59917,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/PractitionerRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$search of method OpenEMR\\\\Services\\\\PrescriptionService\\:\\:getAll\\(\\) expects array\\<string, OpenEMR\\\\Services\\\\Search\\\\ISearchField\\|string\\>, array\\<mixed, mixed\\> given\\.$#',
+    'message' => '#^Parameter \\#1 \\$search of method OpenEMR\\\\Services\\\\PrescriptionService\\:\\:getAll\\(\\) expects array\\<string, OpenEMR\\\\Services\\\\Search\\\\ISearchField\\|string\\>, array\\<string, mixed\\> given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/PrescriptionRestController.php',
 ];

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -4553,7 +4553,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 8,
+    'count' => 7,
     'path' => __DIR__ . '/../../src/Services/InsuranceService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -6722,11 +6722,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/InsuranceCompanyService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method validateId\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/InsuranceCompanyService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getFirstDataResult\\(\\) on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Services/InsuranceService.php',

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -5157,11 +5157,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/DrugRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method search\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/EmployerRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method createBundle\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirAllergyIntoleranceRestController.php',
@@ -5680,56 +5675,6 @@ $ignoreErrors[] = [
     'message' => '#^Cannot call method hasErrors\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/ImmunizationRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method validate\\(\\) on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method getData\\(\\) on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method getOne\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method hasData\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method hasErrors\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method insert\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method isValid\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method search\\(\\) on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method swapInsurance\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method update\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method delete\\(\\) on mixed\\.$#',

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -5682,33 +5682,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/ImmunizationRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method getAll\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method getInsuranceTypes\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method getOneById\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method insert\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot call method update\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method validate\\(\\) on mixed\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.notFound.php
+++ b/.phpstan/baseline/method.notFound.php
@@ -347,6 +347,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/Operations/FhirOperationExportRestController.php',
 ];
 $ignoreErrors[] = [
+    'message' => '#^Call to an undefined method OpenEMR\\\\Services\\\\InsuranceCompanyService\\:\\:validate\\(\\)\\.$#',
+    'count' => 2,
+    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
+];
+$ignoreErrors[] = [
     'message' => '#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Request\\:\\:getHeader\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/Subscriber/CORSListener.php',

--- a/.phpstan/baseline/method.notFound.php
+++ b/.phpstan/baseline/method.notFound.php
@@ -347,11 +347,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/Operations/FhirOperationExportRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to an undefined method OpenEMR\\\\Services\\\\InsuranceCompanyService\\:\\:validate\\(\\)\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Request\\:\\:getHeader\\(\\)\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/Subscriber/CORSListener.php',

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -4232,11 +4232,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Http/HttpRestRequest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Http\\\\HttpRestRequest\\:\\:getQueryParams\\(\\) return type has no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Http/HttpRestRequest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Common\\\\Http\\\\HttpRestRequest\\:\\:getRequestUser\\(\\) return type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Http/HttpRestRequest.php',
@@ -9080,11 +9075,6 @@ $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\Config\\\\RestConfig\\:\\:parseEndPoint\\(\\) return type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/Config/RestConfig.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\EmployerRestController\\:\\:getAll\\(\\) has parameter \\$searchParams with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/EmployerRestController.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirConditionRestController\\:\\:getAll\\(\\) has parameter \\$searchParams with no value type specified in iterable type array\\.$#',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -38362,11 +38362,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/InsuranceService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\InsuranceService\\:\\:getAll\\(\\) has parameter \\$isAndCondition with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/InsuranceService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\InsuranceService\\:\\:getOneByPid\\(\\) has parameter \\$id with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/InsuranceService.php',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -33062,11 +33062,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\InsuranceRestController\\:\\:getAll\\(\\) has parameter \\$searchParams with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\InsuranceRestController\\:\\:getOne\\(\\) has parameter \\$insuranceUuid with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',

--- a/.phpstan/baseline/missingType.property.php
+++ b/.phpstan/baseline/missingType.property.php
@@ -29362,11 +29362,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/InsuranceCompanyService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\Services\\\\InsuranceCompanyService\\:\\:\\$insuranceCompanyValidator has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/InsuranceCompanyService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Services\\\\InsuranceCompanyService\\:\\:\\$phoneNumberService has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/InsuranceCompanyService.php',

--- a/.phpstan/baseline/missingType.property.php
+++ b/.phpstan/baseline/missingType.property.php
@@ -28997,11 +28997,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/DrugRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\RestControllers\\\\EmployerRestController\\:\\:\\$employerService has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/EmployerRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirAllergyIntoleranceRestController\\:\\:\\$fhirAllergyIntoleranceService has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirAllergyIntoleranceRestController.php',
@@ -29165,16 +29160,6 @@ $ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\RestControllers\\\\ImmunizationRestController\\:\\:\\$immunizationService has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/ImmunizationRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\RestControllers\\\\InsuranceCompanyRestController\\:\\:\\$addressService has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\RestControllers\\\\InsuranceRestController\\:\\:\\$insuranceService has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\RestControllers\\\\ListRestController\\:\\:\\$listService has no type specified\\.$#',

--- a/.phpstan/baseline/missingType.property.php
+++ b/.phpstan/baseline/missingType.property.php
@@ -29172,11 +29172,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\RestControllers\\\\InsuranceCompanyRestController\\:\\:\\$insuranceCompanyService has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\RestControllers\\\\InsuranceRestController\\:\\:\\$insuranceService has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -21222,11 +21222,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/ImmunizationRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\InsuranceCompanyRestController\\:\\:getAll\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\InsuranceCompanyRestController\\:\\:getInsuranceTypes\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -21022,11 +21022,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/DrugRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\EmployerRestController\\:\\:getAll\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/EmployerRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\FHIR\\\\FhirAllergyIntoleranceRestController\\:\\:getOne\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/FHIR/FhirAllergyIntoleranceRestController.php',
@@ -21240,11 +21235,6 @@ $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\InsuranceCompanyRestController\\:\\:put\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\RestControllers\\\\InsuranceRestController\\:\\:getAll\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\RestControllers\\\\InsuranceRestController\\:\\:getOne\\(\\) has no return type specified\\.$#',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -38997,18 +38997,13 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'puuid\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'type\' on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'uuid\' on mixed\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -6953,7 +6953,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/InsuranceService.php',
 ];
 $ignoreErrors[] = [
@@ -6968,7 +6968,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Services/InsuranceService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/staticMethod.deprecated.php
+++ b/.phpstan/baseline/staticMethod.deprecated.php
@@ -132,12 +132,6 @@ use createProcessingResultResponse\\(\\) instead\\.$#',
 $ignoreErrors[] = [
     'message' => '#^Call to deprecated method handleProcessingResult\\(\\) of class OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:
 use createProcessingResultResponse\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/EmployerRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated method handleProcessingResult\\(\\) of class OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:
-use createProcessingResultResponse\\(\\) instead\\.$#',
     'count' => 6,
     'path' => __DIR__ . '/../../src/RestControllers/EncounterRestController.php',
 ];
@@ -150,7 +144,7 @@ use createProcessingResultResponse\\(\\) instead\\.$#',
 $ignoreErrors[] = [
     'message' => '#^Call to deprecated method handleProcessingResult\\(\\) of class OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:
 use createProcessingResultResponse\\(\\) instead\\.$#',
-    'count' => 14,
+    'count' => 13,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/staticMethod.deprecated.php
+++ b/.phpstan/baseline/staticMethod.deprecated.php
@@ -150,6 +150,12 @@ use createProcessingResultResponse\\(\\) instead\\.$#',
 $ignoreErrors[] = [
     'message' => '#^Call to deprecated method handleProcessingResult\\(\\) of class OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:
 use createProcessingResultResponse\\(\\) instead\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Call to deprecated method handleProcessingResult\\(\\) of class OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:
+use createProcessingResultResponse\\(\\) instead\\.$#',
     'count' => 14,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
 ];

--- a/.phpstan/baseline/staticMethod.deprecated.php
+++ b/.phpstan/baseline/staticMethod.deprecated.php
@@ -150,12 +150,6 @@ use createProcessingResultResponse\\(\\) instead\\.$#',
 $ignoreErrors[] = [
     'message' => '#^Call to deprecated method handleProcessingResult\\(\\) of class OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:
 use createProcessingResultResponse\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/RestControllers/InsuranceCompanyRestController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Call to deprecated method handleProcessingResult\\(\\) of class OpenEMR\\\\RestControllers\\\\RestControllerHelper\\:
-use createProcessingResultResponse\\(\\) instead\\.$#',
     'count' => 14,
     'path' => __DIR__ . '/../../src/RestControllers/InsuranceRestController.php',
 ];

--- a/apis/routes/_rest_routes_standard.inc.php
+++ b/apis/routes/_rest_routes_standard.inc.php
@@ -462,7 +462,7 @@ return [
     },
     "GET /api/insurance_company" => function (HttpRestRequest $request) {
         RestConfig::request_authorization_check($request, "acct", "bill");
-        $return = (new InsuranceCompanyRestController())->getAll($request->getQueryParams());
+        $return = (new InsuranceCompanyRestController())->getAll($request);
 
         return $return;
     },

--- a/apis/routes/_rest_routes_standard.inc.php
+++ b/apis/routes/_rest_routes_standard.inc.php
@@ -482,14 +482,14 @@ return [
     "POST /api/insurance_company" => function (HttpRestRequest $request) {
         RestConfig::request_authorization_check($request, "acct", "bill", 'write');
         $data = (array) (json_decode(file_get_contents("php://input")));
-        $return = (new InsuranceCompanyRestController())->post($data);
+        $return = (new InsuranceCompanyRestController())->post($request, $data);
 
         return $return;
     },
     "PUT /api/insurance_company/:iid" => function ($iid, HttpRestRequest $request) {
         RestConfig::request_authorization_check($request, "acct", "bill", 'write');
         $data = (array) (json_decode(file_get_contents("php://input")));
-        $return = (new InsuranceCompanyRestController())->put($iid, $data);
+        $return = (new InsuranceCompanyRestController())->put($request, $iid, $data);
 
         return $return;
     },
@@ -532,7 +532,7 @@ return [
         }
 
         // Try to get the data. The service layer will handle non-existent UUIDs.
-        $return = (new EmployerRestController())->getAll($searchParams);
+        $return = (new EmployerRestController())->getAll($request, $searchParams);
 
         return $return;
     },
@@ -543,7 +543,7 @@ return [
         if ($request->isPatientRequest()) {
             $searchParams['puuid'] = $request->getPatientUUIDString();
         }
-        $return = (new InsuranceRestController())->getAll($searchParams);
+        $return = (new InsuranceRestController())->getAll($request, $searchParams);
 
         return $return;
     },

--- a/apis/routes/_rest_routes_standard.inc.php
+++ b/apis/routes/_rest_routes_standard.inc.php
@@ -462,7 +462,7 @@ return [
     },
     "GET /api/insurance_company" => function (HttpRestRequest $request) {
         RestConfig::request_authorization_check($request, "acct", "bill");
-        $return = (new InsuranceCompanyRestController())->getAll();
+        $return = (new InsuranceCompanyRestController())->getAll($request->getQueryParams());
 
         return $return;
     },

--- a/src/Common/Http/HttpRestRequest.php
+++ b/src/Common/Http/HttpRestRequest.php
@@ -196,6 +196,9 @@ class HttpRestRequest extends Request implements Stringable
         $this->query = new InputBag($queryParams);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getQueryParams(): array
     {
         return $this->query->all();

--- a/src/RestControllers/EmployerRestController.php
+++ b/src/RestControllers/EmployerRestController.php
@@ -19,7 +19,6 @@ use OpenEMR\Services\Search\SearchFieldException;
 use OpenEMR\Services\Search\SearchModifier;
 use OpenEMR\Services\Search\StringSearchField;
 use OpenEMR\Services\Search\TokenSearchField;
-use OpenEMR\Services\Search\TokenSearchValue;
 use OpenEMR\Validators\ProcessingResult;
 
 class EmployerRestController
@@ -47,6 +46,11 @@ class EmployerRestController
                 required: true,
                 schema: new OA\Schema(type: 'string')
             ),
+            new OA\Parameter(name: 'name', in: 'query', description: 'Partial match on the employer name.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'occupation', in: 'query', description: 'The ODH occupation code.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'industry', in: 'query', description: 'The ODH industry code.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'start_date', in: 'query', description: 'The employment start date, supports FHIR prefixes e.g. ge2024-01-01.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'end_date', in: 'query', description: 'The employment end date, supports FHIR prefixes e.g. lt2025-01-01.', required: false, schema: new OA\Schema(type: 'string')),
         ],
         responses: [
             new OA\Response(response: '200', ref: '#/components/responses/standard'),
@@ -65,7 +69,7 @@ class EmployerRestController
                     throw new SearchFieldException('search', 'unsupported search parameter');
                 }
                 $search[$key] = match ($key) {
-                    'id' => new TokenSearchField('id', new TokenSearchValue($value), false),
+                    'id' => new TokenSearchField('id', $value, false),
                     'puuid' => new TokenSearchField('puuid', $value, true),
                     'pid' => new TokenSearchField('pid', $value, true),
                     'name' => new StringSearchField('name', $value, SearchModifier::CONTAINS),

--- a/src/RestControllers/EmployerRestController.php
+++ b/src/RestControllers/EmployerRestController.php
@@ -13,6 +13,7 @@
 namespace OpenEMR\RestControllers;
 
 use OpenApi\Attributes as OA;
+use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Services\EmployerService;
 use OpenEMR\Services\Search\DateSearchField;
 use OpenEMR\Services\Search\SearchFieldException;
@@ -20,10 +21,11 @@ use OpenEMR\Services\Search\SearchModifier;
 use OpenEMR\Services\Search\StringSearchField;
 use OpenEMR\Services\Search\TokenSearchField;
 use OpenEMR\Validators\ProcessingResult;
+use Psr\Http\Message\ResponseInterface;
 
 class EmployerRestController
 {
-    private $employerService;
+    private readonly EmployerService $employerService;
 
     public function __construct()
     {
@@ -59,7 +61,7 @@ class EmployerRestController
         ],
         security: [['openemr_auth' => ['user/employer.read', 'patient/employer.read']]]
     )]
-    public function getAll(array $searchParams)
+    public function getAll(HttpRestRequest $request, array $searchParams): ResponseInterface
     {
         $processingResult = new ProcessingResult();
         try {
@@ -83,6 +85,6 @@ class EmployerRestController
             // do not reflect raw parameter names or values back to the caller
             $processingResult->setValidationMessages(['search' => ['invalid or unsupported search parameter']]);
         }
-        return RestControllerHelper::handleProcessingResult($processingResult, null, 200);
+        return RestControllerHelper::createProcessingResultResponse($request, $processingResult, 200, true);
     }
 }

--- a/src/RestControllers/EmployerRestController.php
+++ b/src/RestControllers/EmployerRestController.php
@@ -14,8 +14,13 @@ namespace OpenEMR\RestControllers;
 
 use OpenApi\Attributes as OA;
 use OpenEMR\Services\EmployerService;
+use OpenEMR\Services\Search\DateSearchField;
+use OpenEMR\Services\Search\SearchFieldException;
+use OpenEMR\Services\Search\SearchModifier;
+use OpenEMR\Services\Search\StringSearchField;
 use OpenEMR\Services\Search\TokenSearchField;
 use OpenEMR\Services\Search\TokenSearchValue;
+use OpenEMR\Validators\ProcessingResult;
 
 class EmployerRestController
 {
@@ -28,7 +33,7 @@ class EmployerRestController
 
     /**
      * Retrieves all employer data for a patient.
-     * @param array $searchParams - Search parameters including puuid.
+     * @param array<string, mixed> $searchParams - Search parameters including puuid.
      */
     #[OA\Get(
         path: '/api/patient/{puuid}/employer',
@@ -50,18 +55,30 @@ class EmployerRestController
         ],
         security: [['openemr_auth' => ['user/employer.read', 'patient/employer.read']]]
     )]
-    public function getAll($searchParams)
+    public function getAll(array $searchParams)
     {
-        if (isset($searchParams['id'])) {
-            $searchParams['id'] = new TokenSearchField('id', new TokenSearchValue($searchParams['id']), false);
+        $processingResult = new ProcessingResult();
+        try {
+            $search = [];
+            foreach ($searchParams as $key => $value) {
+                if (!is_string($value) && !is_array($value)) {
+                    throw new SearchFieldException('search', 'unsupported search parameter');
+                }
+                $search[$key] = match ($key) {
+                    'id' => new TokenSearchField('id', new TokenSearchValue($value), false),
+                    'puuid' => new TokenSearchField('puuid', $value, true),
+                    'pid' => new TokenSearchField('pid', $value, true),
+                    'name' => new StringSearchField('name', $value, SearchModifier::CONTAINS),
+                    'occupation', 'industry' => new TokenSearchField($key, $value),
+                    'start_date', 'end_date' => new DateSearchField($key, $value, DateSearchField::DATE_TYPE_DATETIME),
+                    default => throw new SearchFieldException('search', 'unsupported search parameter'),
+                };
+            }
+            $processingResult = $this->employerService->search($search);
+        } catch (SearchFieldException | \InvalidArgumentException) {
+            // do not reflect raw parameter names or values back to the caller
+            $processingResult->setValidationMessages(['search' => ['invalid or unsupported search parameter']]);
         }
-        if (isset($searchParams['puuid'])) {
-            $searchParams['puuid'] = new TokenSearchField('puuid', $searchParams['puuid'], true);
-        }
-        if (isset($searchParams['pid'])) {
-            $searchParams['pid'] = new TokenSearchField('pid', $searchParams['pid'], true);
-        }
-        $serviceResult = $this->employerService->search($searchParams);
-        return RestControllerHelper::handleProcessingResult($serviceResult, null, 200);
+        return RestControllerHelper::handleProcessingResult($processingResult, null, 200);
     }
 }

--- a/src/RestControllers/InsuranceCompanyRestController.php
+++ b/src/RestControllers/InsuranceCompanyRestController.php
@@ -17,6 +17,11 @@ use OpenEMR\RestControllers\RestControllerHelper;
 use OpenEMR\Services\Address\AddressData;
 use OpenEMR\Services\AddressService;
 use OpenEMR\Services\InsuranceCompanyService;
+use OpenEMR\Services\Search\SearchFieldException;
+use OpenEMR\Services\Search\SearchModifier;
+use OpenEMR\Services\Search\StringSearchField;
+use OpenEMR\Services\Search\TokenSearchField;
+use OpenEMR\Validators\ProcessingResult;
 
 #[OA\Schema(
     schema: 'api_insurance_company_request',
@@ -55,7 +60,7 @@ use OpenEMR\Services\InsuranceCompanyService;
 )]
 class InsuranceCompanyRestController
 {
-    private $insuranceCompanyService;
+    private readonly InsuranceCompanyService $insuranceCompanyService;
     private $addressService;
 
     public function __construct()
@@ -64,10 +69,21 @@ class InsuranceCompanyRestController
         $this->addressService = new AddressService();
     }
 
+    /**
+     * @param array<string, mixed> $searchParams
+     */
     #[OA\Get(
         path: '/api/insurance_company',
-        description: 'Retrieves all insurance companies',
+        description: 'Retrieves all insurance companies, optionally filtered by search parameters',
         tags: ['standard'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'query', description: 'The uuid of the insurance company.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'name', in: 'query', description: 'Partial match on the insurance company name.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'cms_id', in: 'query', description: 'Exact match on the cms id.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'alt_cms_id', in: 'query', description: 'Exact match on the alternate cms id.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'ins_type_code', in: 'query', description: 'The insurance type code.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'inactive', in: 'query', description: 'Whether the insurance company is inactive (0 or 1).', required: false, schema: new OA\Schema(type: 'string')),
+        ],
         responses: [
             new OA\Response(response: '200', ref: '#/components/responses/standard'),
             new OA\Response(response: '400', ref: '#/components/responses/badrequest'),
@@ -75,10 +91,29 @@ class InsuranceCompanyRestController
         ],
         security: [['openemr_auth' => []]]
     )]
-    public function getAll()
+    public function getAll(array $searchParams = [])
     {
-        $serviceResult = $this->insuranceCompanyService->getAll();
-        return RestControllerHelper::responseHandler($serviceResult, null, 200);
+        $processingResult = new ProcessingResult();
+        try {
+            $search = [];
+            foreach ($searchParams as $key => $value) {
+                if (!is_string($value) && !is_array($value)) {
+                    throw new SearchFieldException('search', 'unsupported search parameter');
+                }
+                $search[$key] = match ($key) {
+                    'uuid' => new TokenSearchField('uuid', $value, true),
+                    'name' => new StringSearchField('name', $value, SearchModifier::CONTAINS),
+                    'cms_id', 'alt_cms_id' => new StringSearchField($key, $value, SearchModifier::EXACT),
+                    'ins_type_code', 'inactive' => new TokenSearchField($key, $value),
+                    default => throw new SearchFieldException('search', 'unsupported search parameter'),
+                };
+            }
+            $processingResult = $this->insuranceCompanyService->search($search);
+        } catch (SearchFieldException | \InvalidArgumentException) {
+            // do not reflect raw parameter names or values back to the caller
+            $processingResult->setValidationMessages(['search' => ['invalid or unsupported search parameter']]);
+        }
+        return RestControllerHelper::handleProcessingResult($processingResult, null, 200);
     }
 
     #[OA\Get(

--- a/src/RestControllers/InsuranceCompanyRestController.php
+++ b/src/RestControllers/InsuranceCompanyRestController.php
@@ -13,6 +13,7 @@
 namespace OpenEMR\RestControllers;
 
 use OpenApi\Attributes as OA;
+use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\RestControllers\RestControllerHelper;
 use OpenEMR\Services\Address\AddressData;
 use OpenEMR\Services\AddressService;
@@ -22,6 +23,7 @@ use OpenEMR\Services\Search\SearchModifier;
 use OpenEMR\Services\Search\StringSearchField;
 use OpenEMR\Services\Search\TokenSearchField;
 use OpenEMR\Validators\ProcessingResult;
+use Psr\Http\Message\ResponseInterface;
 
 #[OA\Schema(
     schema: 'api_insurance_company_request',
@@ -70,7 +72,7 @@ class InsuranceCompanyRestController
     }
 
     /**
-     * @param array<string, mixed> $searchParams
+     * Search parameters are read from the request query string.
      */
     #[OA\Get(
         path: '/api/insurance_company',
@@ -91,12 +93,12 @@ class InsuranceCompanyRestController
         ],
         security: [['openemr_auth' => []]]
     )]
-    public function getAll(array $searchParams = [])
+    public function getAll(HttpRestRequest $request): ResponseInterface
     {
         $processingResult = new ProcessingResult();
         try {
             $search = [];
-            foreach ($searchParams as $key => $value) {
+            foreach ($request->getQueryParams() as $key => $value) {
                 if (!is_string($value) && !is_array($value)) {
                     throw new SearchFieldException('search', 'unsupported search parameter');
                 }
@@ -113,7 +115,7 @@ class InsuranceCompanyRestController
             // do not reflect raw parameter names or values back to the caller
             $processingResult->setValidationMessages(['search' => ['invalid or unsupported search parameter']]);
         }
-        return RestControllerHelper::handleProcessingResult($processingResult, null, 200);
+        return RestControllerHelper::createProcessingResultResponse($request, $processingResult, 200, true);
     }
 
     #[OA\Get(

--- a/src/RestControllers/InsuranceCompanyRestController.php
+++ b/src/RestControllers/InsuranceCompanyRestController.php
@@ -63,7 +63,7 @@ use Psr\Http\Message\ResponseInterface;
 class InsuranceCompanyRestController
 {
     private readonly InsuranceCompanyService $insuranceCompanyService;
-    private $addressService;
+    private readonly AddressService $addressService;
 
     public function __construct()
     {
@@ -179,18 +179,16 @@ class InsuranceCompanyRestController
         ],
         security: [['openemr_auth' => []]]
     )]
-    public function post($data)
+    public function post(HttpRestRequest $request, $data)
     {
         $insuranceCompanyValidationResult = $this->insuranceCompanyService->validate($data);
-        $insuranceCompanyValidationHandlerResult = RestControllerHelper::validationHandler($insuranceCompanyValidationResult);
-        if (is_array($insuranceCompanyValidationHandlerResult)) {
-            return $insuranceCompanyValidationHandlerResult;
+        if (!$insuranceCompanyValidationResult->isValid()) {
+            return RestControllerHelper::createProcessingResultResponse($request, $insuranceCompanyValidationResult, 400);
         }
 
         $addressValidationResult = $this->addressService->validate(AddressData::fromArray($data));
-        $addressValidationHandlerResult = RestControllerHelper::validationHandler($addressValidationResult);
-        if (is_array($addressValidationHandlerResult)) {
-            return $addressValidationHandlerResult;
+        if (!$addressValidationResult->isValid()) {
+            return RestControllerHelper::createProcessingResultResponse($request, $addressValidationResult, 400);
         }
 
         $serviceResult = $this->insuranceCompanyService->insert($data);
@@ -224,18 +222,16 @@ class InsuranceCompanyRestController
         ],
         security: [['openemr_auth' => []]]
     )]
-    public function put($iid, $data)
+    public function put(HttpRestRequest $request, $iid, $data)
     {
         $insuranceCompanyValidationResult = $this->insuranceCompanyService->validate($data);
-        $insuranceCompanyValidationHandlerResult = RestControllerHelper::validationHandler($insuranceCompanyValidationResult);
-        if (is_array($insuranceCompanyValidationHandlerResult)) {
-            return $insuranceCompanyValidationHandlerResult;
+        if (!$insuranceCompanyValidationResult->isValid()) {
+            return RestControllerHelper::createProcessingResultResponse($request, $insuranceCompanyValidationResult, 400);
         }
 
         $addressValidationResult = $this->addressService->validate(AddressData::fromArray($data));
-        $addressValidationHandlerResult = RestControllerHelper::validationHandler($addressValidationResult);
-        if (is_array($addressValidationHandlerResult)) {
-            return $addressValidationHandlerResult;
+        if (!$addressValidationResult->isValid()) {
+            return RestControllerHelper::createProcessingResultResponse($request, $addressValidationResult, 400);
         }
 
         $serviceResult = $this->insuranceCompanyService->update($data, $iid);

--- a/src/RestControllers/InsuranceCompanyRestController.php
+++ b/src/RestControllers/InsuranceCompanyRestController.php
@@ -188,7 +188,11 @@ class InsuranceCompanyRestController
 
         $addressValidationResult = $this->addressService->validate(AddressData::fromArray($data));
         if (!$addressValidationResult->isValid()) {
-            return RestControllerHelper::createProcessingResultResponse($request, $addressValidationResult, 400);
+            // AddressService::validate() returns a Particle ValidationResult;
+            // convert so the response helper receives a ProcessingResult
+            $addressProcessingResult = new ProcessingResult();
+            $addressProcessingResult->setValidationMessages($addressValidationResult->getMessages());
+            return RestControllerHelper::createProcessingResultResponse($request, $addressProcessingResult, 400);
         }
 
         $serviceResult = $this->insuranceCompanyService->insert($data);
@@ -231,7 +235,11 @@ class InsuranceCompanyRestController
 
         $addressValidationResult = $this->addressService->validate(AddressData::fromArray($data));
         if (!$addressValidationResult->isValid()) {
-            return RestControllerHelper::createProcessingResultResponse($request, $addressValidationResult, 400);
+            // AddressService::validate() returns a Particle ValidationResult;
+            // convert so the response helper receives a ProcessingResult
+            $addressProcessingResult = new ProcessingResult();
+            $addressProcessingResult->setValidationMessages($addressValidationResult->getMessages());
+            return RestControllerHelper::createProcessingResultResponse($request, $addressProcessingResult, 400);
         }
 
         $serviceResult = $this->insuranceCompanyService->update($data, $iid);

--- a/src/RestControllers/InsuranceCompanyRestController.php
+++ b/src/RestControllers/InsuranceCompanyRestController.php
@@ -84,7 +84,13 @@ class InsuranceCompanyRestController
             new OA\Parameter(name: 'cms_id', in: 'query', description: 'Exact match on the cms id.', required: false, schema: new OA\Schema(type: 'string')),
             new OA\Parameter(name: 'alt_cms_id', in: 'query', description: 'Exact match on the alternate cms id.', required: false, schema: new OA\Schema(type: 'string')),
             new OA\Parameter(name: 'ins_type_code', in: 'query', description: 'The insurance type code.', required: false, schema: new OA\Schema(type: 'string')),
-            new OA\Parameter(name: 'inactive', in: 'query', description: 'Whether the insurance company is inactive (0 or 1).', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(
+                name: 'inactive',
+                in: 'query',
+                description: 'Whether the insurance company is inactive (0 or 1).',
+                required: false,
+                schema: new OA\Schema(type: 'string', enum: ['0', '1'])
+            ),
         ],
         responses: [
             new OA\Response(response: '200', ref: '#/components/responses/standard'),

--- a/src/RestControllers/InsuranceRestController.php
+++ b/src/RestControllers/InsuranceRestController.php
@@ -18,6 +18,10 @@ use OpenApi\Attributes as OA;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\InsuranceService;
 use OpenEMR\Services\PatientService;
+use OpenEMR\Services\Search\DateSearchField;
+use OpenEMR\Services\Search\SearchFieldException;
+use OpenEMR\Services\Search\SearchModifier;
+use OpenEMR\Services\Search\StringSearchField;
 use OpenEMR\Services\Search\TokenSearchField;
 use OpenEMR\Validators\ProcessingResult;
 
@@ -98,6 +102,7 @@ class InsuranceRestController
 
     /**
      * Retrieves all insurances for a patient.
+     * @param array<string, mixed> $searchParams
      */
     #[OA\Get(
         path: '/api/patient/{puuid}/insurance',
@@ -111,6 +116,13 @@ class InsuranceRestController
                 required: true,
                 schema: new OA\Schema(type: 'string')
             ),
+            new OA\Parameter(name: 'type', in: 'query', description: 'The insurance type (primary, secondary, tertiary).', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'plan_name', in: 'query', description: 'Partial match on the plan name.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'policy_number', in: 'query', description: 'Exact match on the policy number.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'group_number', in: 'query', description: 'Exact match on the group number.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'policy_type', in: 'query', description: 'The policy type.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'date', in: 'query', description: 'The coverage effective date, supports FHIR prefixes e.g. ge2024-01-01.', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'date_end', in: 'query', description: 'The coverage end date, supports FHIR prefixes e.g. lt2025-01-01.', required: false, schema: new OA\Schema(type: 'string')),
         ],
         responses: [
             new OA\Response(response: '200', ref: '#/components/responses/standard'),
@@ -119,16 +131,31 @@ class InsuranceRestController
         ],
         security: [['openemr_auth' => []]]
     )]
-    public function getAll($searchParams)
+    public function getAll(array $searchParams)
     {
-        if (isset($searchParams['uuid'])) {
-            $searchParams['uuid'] = new TokenSearchField('uuid', $searchParams['uuid'], true);
+        $processingResult = new ProcessingResult();
+        try {
+            $search = [];
+            foreach ($searchParams as $key => $value) {
+                if (!is_string($value) && !is_array($value)) {
+                    throw new SearchFieldException('search', 'unsupported search parameter');
+                }
+                $search[$key] = match ($key) {
+                    'uuid' => new TokenSearchField('uuid', $value, true),
+                    'puuid' => new TokenSearchField('puuid', $value, true),
+                    'type', 'policy_type' => new TokenSearchField($key, $value),
+                    'plan_name' => new StringSearchField('plan_name', $value, SearchModifier::CONTAINS),
+                    'policy_number', 'group_number' => new StringSearchField($key, $value, SearchModifier::EXACT),
+                    'date', 'date_end' => new DateSearchField($key, $value, DateSearchField::DATE_TYPE_DATE),
+                    default => throw new SearchFieldException('search', 'unsupported search parameter'),
+                };
+            }
+            $processingResult = $this->insuranceService->search($search);
+        } catch (SearchFieldException | \InvalidArgumentException) {
+            // do not reflect raw parameter names or values back to the caller
+            $processingResult->setValidationMessages(['search' => ['invalid or unsupported search parameter']]);
         }
-        if (isset($searchParams['puuid'])) {
-            $searchParams['puuid'] = new TokenSearchField('puuid', $searchParams['puuid'], true);
-        }
-        $serviceResult = $this->insuranceService->search($searchParams);
-        return RestControllerHelper::handleProcessingResult($serviceResult, null, 200);
+        return RestControllerHelper::handleProcessingResult($processingResult, null, 200);
     }
 
     /**

--- a/src/RestControllers/InsuranceRestController.php
+++ b/src/RestControllers/InsuranceRestController.php
@@ -15,6 +15,7 @@
 namespace OpenEMR\RestControllers;
 
 use OpenApi\Attributes as OA;
+use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\InsuranceService;
 use OpenEMR\Services\PatientService;
@@ -24,6 +25,7 @@ use OpenEMR\Services\Search\SearchModifier;
 use OpenEMR\Services\Search\StringSearchField;
 use OpenEMR\Services\Search\TokenSearchField;
 use OpenEMR\Validators\ProcessingResult;
+use Psr\Http\Message\ResponseInterface;
 
 #[OA\Schema(
     schema: 'api_insurance_request',
@@ -93,7 +95,7 @@ use OpenEMR\Validators\ProcessingResult;
 )]
 class InsuranceRestController
 {
-    private $insuranceService;
+    private readonly InsuranceService $insuranceService;
 
     public function __construct()
     {
@@ -131,7 +133,7 @@ class InsuranceRestController
         ],
         security: [['openemr_auth' => []]]
     )]
-    public function getAll(array $searchParams)
+    public function getAll(HttpRestRequest $request, array $searchParams): ResponseInterface
     {
         $processingResult = new ProcessingResult();
         try {
@@ -155,7 +157,7 @@ class InsuranceRestController
             // do not reflect raw parameter names or values back to the caller
             $processingResult->setValidationMessages(['search' => ['invalid or unsupported search parameter']]);
         }
-        return RestControllerHelper::handleProcessingResult($processingResult, null, 200);
+        return RestControllerHelper::createProcessingResultResponse($request, $processingResult, 200, true);
     }
 
     /**

--- a/src/RestControllers/InsuranceRestController.php
+++ b/src/RestControllers/InsuranceRestController.php
@@ -118,7 +118,13 @@ class InsuranceRestController
                 required: true,
                 schema: new OA\Schema(type: 'string')
             ),
-            new OA\Parameter(name: 'type', in: 'query', description: 'The insurance type (primary, secondary, tertiary).', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(
+                name: 'type',
+                in: 'query',
+                description: 'The insurance type (primary, secondary, or tertiary).',
+                required: false,
+                schema: new OA\Schema(type: 'string', enum: ['primary', 'secondary', 'tertiary'])
+            ),
             new OA\Parameter(name: 'plan_name', in: 'query', description: 'Partial match on the plan name.', required: false, schema: new OA\Schema(type: 'string')),
             new OA\Parameter(name: 'policy_number', in: 'query', description: 'Exact match on the policy number.', required: false, schema: new OA\Schema(type: 'string')),
             new OA\Parameter(name: 'group_number', in: 'query', description: 'Exact match on the group number.', required: false, schema: new OA\Schema(type: 'string')),

--- a/src/Services/InsuranceCompanyService.php
+++ b/src/Services/InsuranceCompanyService.php
@@ -35,7 +35,7 @@ use OpenEMR\BC\ServiceContainer;
 class InsuranceCompanyService extends BaseService
 {
     private const INSURANCE_TABLE = "insurance_companies";
-    private $insuranceCompanyValidator;
+    private readonly InsuranceCompanyValidator $insuranceCompanyValidator;
     private $addressService = null;
     private $phoneNumberService = null;
 
@@ -426,6 +426,18 @@ class InsuranceCompanyService extends BaseService
             'id' => $id,
             'name' => $this->getInsuranceDisplayName($id),
         ];
+    }
+
+    /**
+     * Validates insurance company data for a database insert or update.
+     *
+     * @param array<string, mixed> $insuranceCompanyData
+     * @param string $context one of InsuranceCompanyValidator::DATABASE_INSERT_CONTEXT
+     *                        or InsuranceCompanyValidator::DATABASE_UPDATE_CONTEXT
+     */
+    public function validate(array $insuranceCompanyData, string $context = InsuranceCompanyValidator::DATABASE_INSERT_CONTEXT): ProcessingResult
+    {
+        return $this->insuranceCompanyValidator->validate($insuranceCompanyData, $context);
     }
 
     public function insert($data): int|string

--- a/src/Services/InsuranceService.php
+++ b/src/Services/InsuranceService.php
@@ -41,21 +41,6 @@ class InsuranceService extends BaseService
     private const COVERAGE_TABLE = "insurance_data";
     private const PATIENT_TABLE = "patient_data";
     private const INSURANCE_TABLE = "insurance_companies";
-    private const SEARCHABLE_FIELDS = [
-        'id',
-        'uuid',
-        'pid',
-        'type',
-        'provider',
-        'plan_name',
-        'policy_number',
-        'group_number',
-        'date',
-        'date_end',
-        'policy_type',
-        'accept_assignment',
-        'copay',
-    ];
     /**
      * @var CoverageValidator $coverageValidator
      */
@@ -145,91 +130,6 @@ class InsuranceService extends BaseService
             $processingResult->addData($sqlResult);
         } else {
             $processingResult->addInternalError("error processing SQL");
-        }
-        return $processingResult;
-    }
-
-    /**
-     * @deprecated use search instead
-     * @param array<string, string> $search
-     * @param $isAndCondition
-     * @return ProcessingResult|true
-     */
-    public function getAll(array $search = [], $isAndCondition = true)
-    {
-
-        // Validating and Converting Patient UUID to PID
-        // Validating and Converting UUID to ID
-        if (isset($search['pid'])) {
-            $isValidcondition = $this->coverageValidator->validateId(
-                'uuid',
-                self::PATIENT_TABLE,
-                $search['pid'],
-                true
-            );
-            if ($isValidcondition !== true) {
-                return $isValidcondition;
-            }
-            $puuidBytes = UuidRegistry::uuidToBytes($search['pid']);
-            $search['pid'] = $this->getIdByUuid($puuidBytes, self::PATIENT_TABLE, "pid");
-        }
-        // Validating and Converting Payor UUID to provider
-        if (isset($search['provider'])) {
-            $isValidcondition = $this->coverageValidator->validateId(
-                'uuid',
-                self::INSURANCE_TABLE,
-                $search['provider'],
-                true
-            );
-            if ($isValidcondition !== true) {
-                return $isValidcondition;
-            }
-            $uuidBytes = UuidRegistry::uuidToBytes($search['provider']);
-            $search['provider'] = $this->getIdByUuid($uuidBytes, self::INSURANCE_TABLE, "provider");
-        }
-
-        // Validating and Converting UUID to ID
-        if (isset($search['id'])) {
-            $isValidcondition = $this->coverageValidator->validateId(
-                'uuid',
-                self::COVERAGE_TABLE,
-                $search['id'],
-                true
-            );
-            if ($isValidcondition !== true) {
-                return $isValidcondition;
-            }
-            $uuidBytes = UuidRegistry::uuidToBytes($search['id']);
-            $search['id'] = $this->getIdByUuid($uuidBytes, self::COVERAGE_TABLE, "id");
-        }
-        $sqlBindArray = [];
-        $sql = "SELECT * FROM insurance_data ";
-        if (!empty($search)) {
-            $sql .= ' WHERE ';
-            $whereClauses = [];
-            foreach ($search as $fieldName => $fieldValue) {
-                if (!in_array($fieldName, self::SEARCHABLE_FIELDS, true)) {
-                    throw new \InvalidArgumentException("Invalid search field: " . $fieldName);
-                }
-                array_push($whereClauses, $fieldName . ' = ?');
-                array_push($sqlBindArray, $fieldValue);
-            }
-            $sqlCondition = ($isAndCondition == true) ? 'AND' : 'OR';
-            $sql .= implode(' ' . $sqlCondition . ' ', $whereClauses);
-        }
-        $statementResults = sqlStatement($sql, $sqlBindArray);
-
-        $processingResult = new ProcessingResult();
-        while ($row = sqlFetchArray($statementResults)) {
-            $row['uuid'] = UuidRegistry::uuidToString($row['uuid']);
-            $patientuuidBytes = $this->getUuidById($row['pid'], self::PATIENT_TABLE, "id");
-            $row['puuid'] = UuidRegistry::uuidToString($patientuuidBytes);
-            $insureruuidBytes = $this->getUuidById($row['provider'], self::INSURANCE_TABLE, "id");
-            //When No provider data is available
-            if (strlen($insureruuidBytes) > 0) {
-                $row['insureruuid'] = UuidRegistry::uuidToString($insureruuidBytes);
-                $processingResult->addData($row);
-            }
         }
         return $processingResult;
     }

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -1076,6 +1076,9 @@ paths:
           required: false
           schema:
             type: string
+            enum:
+              - '0'
+              - '1'
       responses:
         200:
           $ref: '#/components/responses/standard'
@@ -3043,10 +3046,14 @@ paths:
         -
           name: type
           in: query
-          description: 'The insurance type (primary, secondary, tertiary).'
+          description: 'The insurance type (primary, secondary, or tertiary).'
           required: false
           schema:
             type: string
+            enum:
+              - primary
+              - secondary
+              - tertiary
         -
           name: plan_name
           in: query

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -1032,7 +1032,50 @@ paths:
     get:
       tags:
         - standard
-      description: 'Retrieves all insurance companies'
+      description: 'Retrieves all insurance companies, optionally filtered by search parameters'
+      parameters:
+        -
+          name: uuid
+          in: query
+          description: 'The uuid of the insurance company.'
+          required: false
+          schema:
+            type: string
+        -
+          name: name
+          in: query
+          description: 'Partial match on the insurance company name.'
+          required: false
+          schema:
+            type: string
+        -
+          name: cms_id
+          in: query
+          description: 'Exact match on the cms id.'
+          required: false
+          schema:
+            type: string
+        -
+          name: alt_cms_id
+          in: query
+          description: 'Exact match on the alternate cms id.'
+          required: false
+          schema:
+            type: string
+        -
+          name: ins_type_code
+          in: query
+          description: 'The insurance type code.'
+          required: false
+          schema:
+            type: string
+        -
+          name: inactive
+          in: query
+          description: 'Whether the insurance company is inactive (0 or 1).'
+          required: false
+          schema:
+            type: string
       responses:
         200:
           $ref: '#/components/responses/standard'
@@ -2786,6 +2829,41 @@ paths:
           required: true
           schema:
             type: string
+        -
+          name: name
+          in: query
+          description: 'Partial match on the employer name.'
+          required: false
+          schema:
+            type: string
+        -
+          name: occupation
+          in: query
+          description: 'The ODH occupation code.'
+          required: false
+          schema:
+            type: string
+        -
+          name: industry
+          in: query
+          description: 'The ODH industry code.'
+          required: false
+          schema:
+            type: string
+        -
+          name: start_date
+          in: query
+          description: 'The employment start date, supports FHIR prefixes e.g. ge2024-01-01.'
+          required: false
+          schema:
+            type: string
+        -
+          name: end_date
+          in: query
+          description: 'The employment end date, supports FHIR prefixes e.g. lt2025-01-01.'
+          required: false
+          schema:
+            type: string
       responses:
         200:
           $ref: '#/components/responses/standard'
@@ -2960,6 +3038,55 @@ paths:
           in: path
           description: 'The uuid for the patient.'
           required: true
+          schema:
+            type: string
+        -
+          name: type
+          in: query
+          description: 'The insurance type (primary, secondary, tertiary).'
+          required: false
+          schema:
+            type: string
+        -
+          name: plan_name
+          in: query
+          description: 'Partial match on the plan name.'
+          required: false
+          schema:
+            type: string
+        -
+          name: policy_number
+          in: query
+          description: 'Exact match on the policy number.'
+          required: false
+          schema:
+            type: string
+        -
+          name: group_number
+          in: query
+          description: 'Exact match on the group number.'
+          required: false
+          schema:
+            type: string
+        -
+          name: policy_type
+          in: query
+          description: 'The policy type.'
+          required: false
+          schema:
+            type: string
+        -
+          name: date
+          in: query
+          description: 'The coverage effective date, supports FHIR prefixes e.g. ge2024-01-01.'
+          required: false
+          schema:
+            type: string
+        -
+          name: date_end
+          in: query
+          description: 'The coverage end date, supports FHIR prefixes e.g. lt2025-01-01.'
+          required: false
           schema:
             type: string
       responses:

--- a/tests/Tests/Api/ApiTestClient.php
+++ b/tests/Tests/Api/ApiTestClient.php
@@ -132,6 +132,7 @@ class ApiTestClient
         'user/facility.read',
         'user/facility.write',
         'user/immunization.read',
+        'user/employer.read',
         'user/insurance.read',
         'user/insurance.write',
         'user/insurance_company.read',

--- a/tests/Tests/Api/InsuranceCompanyApiTest.php
+++ b/tests/Tests/Api/InsuranceCompanyApiTest.php
@@ -6,9 +6,11 @@
  * The insurance company REST API has pre-existing bugs:
  * - POST/PUT: InsuranceCompanyService::validate() does not exist
  * - GET one: Binary UUID in raw row causes JSON encoding error
- * - GET all: ProcessingResult is not handled by responseHandler()
+ * (GET all previously did not handle ProcessingResult; fixed by wiring
+ * search parameters through to InsuranceCompanyService::search().
+ * InsuranceEmployerSearchApiTest covers the GET all search behavior.)
  *
- * These tests document the broken state and verify the one working endpoint.
+ * These tests document the remaining broken state.
  * Service-layer tests in InsuranceCompanyServiceTest and AddressServiceTest
  * cover the AddressData DTO integration that this PR introduces.
  *

--- a/tests/Tests/Api/InsuranceCompanyApiTest.php
+++ b/tests/Tests/Api/InsuranceCompanyApiTest.php
@@ -24,12 +24,14 @@
 
 namespace OpenEMR\Tests\Api;
 
+use OpenEMR\Common\Database\QueryUtils;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class InsuranceCompanyApiTest extends TestCase
 {
     private const API_ENDPOINT = "/apis/default/api/insurance_company";
+    private const FIXTURE_NAME_PREFIX = "test-fixture-Validate";
 
     private ApiTestClient $testClient;
 
@@ -38,6 +40,23 @@ class InsuranceCompanyApiTest extends TestCase
         $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
         $this->testClient = new ApiTestClient($baseUrl, false);
         $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+    }
+
+    protected function tearDown(): void
+    {
+        // remove any insurance companies this test class created (the prefix
+        // match also sweeps rows leaked by earlier runs)
+        $rows = QueryUtils::fetchRecords(
+            "SELECT `id` FROM `insurance_companies` WHERE `name` LIKE ?",
+            [self::FIXTURE_NAME_PREFIX . "%"]
+        );
+        foreach ($rows as $row) {
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `addresses` WHERE `foreign_id` = ?", [$row['id']]);
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `phone_numbers` WHERE `foreign_id` = ?", [$row['id']]);
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `insurance_companies` WHERE `id` = ?", [$row['id']]);
+        }
+        $this->testClient->cleanupRevokeAuth();
+        $this->testClient->cleanupClient();
     }
 
     #[Test]
@@ -68,7 +87,7 @@ class InsuranceCompanyApiTest extends TestCase
         // (empty-string optionals are omitted: the validator applies length
         // rules to present-but-empty values)
         $response = $this->testClient->post(self::API_ENDPOINT, [
-            'name' => 'test-fixture-Validate Restored Insurance',
+            'name' => self::FIXTURE_NAME_PREFIX . " Restored Insurance " . uniqid(),
             'ins_type_code' => '1',
         ]);
 

--- a/tests/Tests/Api/InsuranceCompanyApiTest.php
+++ b/tests/Tests/Api/InsuranceCompanyApiTest.php
@@ -3,9 +3,10 @@
 /**
  * InsuranceCompany API Endpoint Tests
  *
- * The insurance company REST API has pre-existing bugs:
- * - POST/PUT: InsuranceCompanyService::validate() does not exist
+ * The insurance company REST API has a pre-existing bug:
  * - GET one: Binary UUID in raw row causes JSON encoding error
+ * (POST/PUT previously fataled on a missing InsuranceCompanyService::validate();
+ * restored alongside the search parameter support.)
  * (GET all previously did not handle ProcessingResult; fixed by wiring
  * search parameters through to InsuranceCompanyService::search().
  * InsuranceEmployerSearchApiTest covers the GET all search behavior.)
@@ -60,19 +61,27 @@ class InsuranceCompanyApiTest extends TestCase
     }
 
     #[Test]
-    public function testPostReturns500DueMissingValidateMethod(): void
+    public function testPostWithValidDataCreatesCompany(): void
     {
-        // Pre-existing bug: InsuranceCompanyRestController::post() calls
-        // $this->insuranceCompanyService->validate() which does not exist.
+        // regression test: post() previously fataled because
+        // InsuranceCompanyService::validate() did not exist
+        // (empty-string optionals are omitted: the validator applies length
+        // rules to present-but-empty values)
         $response = $this->testClient->post(self::API_ENDPOINT, [
-            'name' => 'test-fixture-Bug Test Insurance',
-            'attn' => '',
-            'cms_id' => '',
+            'name' => 'test-fixture-Validate Restored Insurance',
             'ins_type_code' => '1',
-            'x12_receiver_id' => '',
-            'alt_cms_id' => '',
         ]);
 
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals(201, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function testPostWithMissingNameReturns400(): void
+    {
+        $response = $this->testClient->post(self::API_ENDPOINT, [
+            'ins_type_code' => '1',
+        ]);
+
+        $this->assertEquals(400, $response->getStatusCode());
     }
 }

--- a/tests/Tests/Api/InsuranceCompanyApiTest.php
+++ b/tests/Tests/Api/InsuranceCompanyApiTest.php
@@ -95,6 +95,21 @@ class InsuranceCompanyApiTest extends TestCase
     }
 
     #[Test]
+    public function testPostWithInvalidAddressReturns400(): void
+    {
+        // company fields valid, address invalid: exercises the second
+        // validation branch, which converts a Particle ValidationResult
+        // into a ProcessingResult for the 400 response
+        $response = $this->testClient->post(self::API_ENDPOINT, [
+            'name' => self::FIXTURE_NAME_PREFIX . " Bad Address " . uniqid(),
+            'ins_type_code' => '1',
+            'line1' => 'X',
+        ]);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
     public function testPostWithMissingNameReturns400(): void
     {
         $response = $this->testClient->post(self::API_ENDPOINT, [

--- a/tests/Tests/Api/InsuranceEmployerSearchApiTest.php
+++ b/tests/Tests/Api/InsuranceEmployerSearchApiTest.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * Insurance and Employer Search API Tests
+ *
+ * Full HTTP tests for the search query parameter support on
+ * GET /api/insurance_company and GET /api/patient/:puuid/employer, including
+ * the 400 responses for unsupported parameters and invalid values that the
+ * controller allowlists and the hardened SearchFieldStatementResolver provide.
+ *
+ * Runs in the api test suite (requires a running OpenEMR instance; set
+ * OPENEMR_BASE_URL_API when the instance is not at https://localhost).
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Api;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\InsuranceCompanyService;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class InsuranceEmployerSearchApiTest extends TestCase
+{
+    private const COMPANY_ENDPOINT = "/apis/default/api/insurance_company";
+    private const PATIENT_ENDPOINT = "/apis/default/api/patient";
+
+    private ApiTestClient $client;
+    private InsuranceCompanyService $companyService;
+    private string $namePrefix;
+
+    /** @var list<int|string> */
+    private array $createdCompanyIds = [];
+
+    protected function setUp(): void
+    {
+        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
+        $this->client = new ApiTestClient($baseUrl, false);
+        $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $this->companyService = new InsuranceCompanyService();
+        // unique per run so searches only match rows this test created
+        $this->namePrefix = "test-fixture-ApiSearch-" . uniqid();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdCompanyIds as $id) {
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `addresses` WHERE `foreign_id` = ?", [$id]);
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `phone_numbers` WHERE `foreign_id` = ?", [$id]);
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `insurance_companies` WHERE `id` = ?", [$id]);
+        }
+        $this->client->cleanupRevokeAuth();
+        $this->client->cleanupClient();
+    }
+
+    /**
+     * Seeds through the service layer because POST /api/insurance_company is
+     * currently broken (missing InsuranceCompanyService::validate(), see
+     * InsuranceCompanyApiTest); the endpoint under test here is GET.
+     */
+    private function createCompany(string $nameSuffix, string $cmsId): void
+    {
+        $id = $this->companyService->insert([
+            "name" => $this->namePrefix . " " . $nameSuffix,
+            "attn" => "Claims",
+            "cms_id" => $cmsId,
+            "ins_type_code" => "2",
+            "x12_receiver_id" => "",
+            "x12_default_partner_id" => "",
+            "alt_cms_id" => "",
+            "line1" => "100 Insurance Blvd",
+            "line2" => "",
+            "city" => "Rutland",
+            "state" => "VT",
+            "zip" => "05701",
+            "country" => "USA",
+        ]);
+        $this->createdCompanyIds[] = $id;
+    }
+
+    #[Test]
+    public function testInsuranceCompanyGetAllWithoutParamsReturns200(): void
+    {
+        // regression test: GET all previously returned a ProcessingResult into
+        // responseHandler(), which does not handle it
+        $this->createCompany("Plain", "88880");
+        $response = $this->client->get(self::COMPANY_ENDPOINT);
+        $this->assertEquals(200, $response->getStatusCode());
+        /** @var array{data: list<array<string, mixed>>} $body */
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertNotEmpty($body["data"]);
+    }
+
+    #[Test]
+    public function testInsuranceCompanySearchByNameContains(): void
+    {
+        $this->createCompany("Alpha", "88881");
+        $this->createCompany("Beta", "88882");
+
+        $response = $this->client->get(self::COMPANY_ENDPOINT, ["name" => $this->namePrefix]);
+        $this->assertEquals(200, $response->getStatusCode());
+        /** @var array{data: list<array{name: string}>} $body */
+        $body = json_decode((string) $response->getBody(), true);
+
+        $this->assertCount(2, $body["data"]);
+        foreach ($body["data"] as $record) {
+            $this->assertStringContainsString($this->namePrefix, $record["name"]);
+        }
+    }
+
+    #[Test]
+    public function testInsuranceCompanySearchByCmsIdExact(): void
+    {
+        $this->createCompany("Gamma", "88883");
+        $this->createCompany("Delta", "88884");
+
+        $response = $this->client->get(self::COMPANY_ENDPOINT, [
+            "name" => $this->namePrefix,
+            "cms_id" => "88883",
+        ]);
+        $this->assertEquals(200, $response->getStatusCode());
+        /** @var array{data: list<array{name: string}>} $body */
+        $body = json_decode((string) $response->getBody(), true);
+
+        $this->assertCount(1, $body["data"]);
+        $this->assertStringContainsString("Gamma", $body["data"][0]["name"]);
+    }
+
+    #[Test]
+    public function testInsuranceCompanyUnsupportedParamReturns400(): void
+    {
+        $response = $this->client->get(self::COMPANY_ENDPOINT, ["not_a_field" => "1"]);
+        $this->assertEquals(400, $response->getStatusCode());
+        /** @var array{validationErrors: array<int|string, mixed>} $body */
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertNotEmpty($body["validationErrors"]);
+    }
+
+    #[Test]
+    public function testInsuranceCompanyHostileParamNameReturns400(): void
+    {
+        // hostile parameter names must produce a clean 400, never a SQL error
+        $response = $this->client->get(self::COMPANY_ENDPOINT, ["name; DROP TABLE x" => "1"]);
+        $this->assertEquals(400, $response->getStatusCode());
+        /** @var array{validationErrors: array<int|string, mixed>} $body */
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertNotEmpty($body["validationErrors"]);
+        // and the hostile name must not be reflected back
+        $this->assertStringNotContainsString("DROP TABLE", (string) $response->getBody());
+    }
+
+    #[Test]
+    public function testEmployerSearchMalformedPatientUuidReturns400(): void
+    {
+        $response = $this->client->get(self::PATIENT_ENDPOINT . "/not-a-uuid/employer");
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function testEmployerSearchUnsupportedParamReturns400(): void
+    {
+        // valid uuid format is all that the route requires before the controller runs
+        $uuid = "11111111-2222-3333-4444-555555555555";
+        $response = $this->client->get(self::PATIENT_ENDPOINT . "/{$uuid}/employer", ["not_a_field" => "1"]);
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function testEmployerSearchInvalidDateValueReturns400(): void
+    {
+        $uuid = "11111111-2222-3333-4444-555555555555";
+        $response = $this->client->get(self::PATIENT_ENDPOINT . "/{$uuid}/employer", ["start_date" => "notadate"]);
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function testEmployerSearchValidUuidNoDataReturnsEmpty200(): void
+    {
+        $uuid = "11111111-2222-3333-4444-555555555555";
+        $response = $this->client->get(self::PATIENT_ENDPOINT . "/{$uuid}/employer");
+        $this->assertEquals(200, $response->getStatusCode());
+        /** @var array{data: list<mixed>} $body */
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertEmpty($body["data"]);
+    }
+}

--- a/tests/Tests/Api/InsuranceEmployerSearchApiTest.php
+++ b/tests/Tests/Api/InsuranceEmployerSearchApiTest.php
@@ -57,9 +57,8 @@ class InsuranceEmployerSearchApiTest extends TestCase
     }
 
     /**
-     * Seeds through the service layer because POST /api/insurance_company is
-     * currently broken (missing InsuranceCompanyService::validate(), see
-     * InsuranceCompanyApiTest); the endpoint under test here is GET.
+     * Seeds through the service layer to keep this test focused on GET
+     * behavior; POST coverage lives in InsuranceCompanyApiTest.
      */
     private function createCompany(string $nameSuffix, string $cmsId): void
     {

--- a/tests/Tests/Isolated/Services/Search/SearchFieldStatementResolverTest.php
+++ b/tests/Tests/Isolated/Services/Search/SearchFieldStatementResolverTest.php
@@ -11,6 +11,8 @@
  * the resolver do not silently change query generation.
  *
  * @package   OpenEMR
+ * @author    Stephen Waite <stephen.waite@open-emr.org>
+ * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@open-emr.org>
  * @link      https://www.open-emr.org
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */

--- a/tests/Tests/Services/EmployerServiceSearchTest.php
+++ b/tests/Tests/Services/EmployerServiceSearchTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * EmployerService Search Tests
+ *
+ * Verifies EmployerService::search() filtering with typed search fields,
+ * backing the query parameter support on GET /api/patient/:puuid/employer.
+ *
+ * Runs in the services test suite (requires a database connection).
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\Services\EmployerService;
+use OpenEMR\Services\Search\DateSearchField;
+use OpenEMR\Services\Search\SearchModifier;
+use OpenEMR\Services\Search\StringSearchField;
+use OpenEMR\Services\Search\TokenSearchField;
+use OpenEMR\Tests\Fixtures\FixtureManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class EmployerServiceSearchTest extends TestCase
+{
+    private const NAME_PREFIX = 'test-fixture-Employer ';
+
+    private EmployerService $service;
+    private FixtureManager $fixtureManager;
+    private int $patientPid;
+    private string $patientUuidString;
+
+    protected function setUp(): void
+    {
+        $this->service = new EmployerService();
+        $this->fixtureManager = new FixtureManager();
+        $this->fixtureManager->installPatientFixtures();
+
+        $patient = QueryUtils::querySingleRow(
+            "SELECT `pid`, `uuid` FROM `patient_data` WHERE `pubpid` LIKE ? LIMIT 1",
+            [FixtureManager::PATIENT_FIXTURE_PUBPID_PREFIX . "%"]
+        );
+        if (!is_array($patient)) {
+            self::fail('patient fixture not found');
+        }
+        /** @var array{pid: int|numeric-string, uuid: string} $patient */
+        $this->patientPid = (int) $patient['pid'];
+        $this->patientUuidString = UuidRegistry::uuidToString($patient['uuid']);
+
+        $this->insertEmployer(self::NAME_PREFIX . 'One', '2020-01-01 00:00:00', null);
+        $this->insertEmployer(self::NAME_PREFIX . 'Two', '2024-06-01 00:00:00', null);
+    }
+
+    protected function tearDown(): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM `employer_data` WHERE `name` LIKE ?",
+            [self::NAME_PREFIX . "%"]
+        );
+        $this->fixtureManager->removePatientFixtures();
+    }
+
+    private function insertEmployer(string $name, string $startDate, ?string $endDate): void
+    {
+        $uuid = (new UuidRegistry(['table_name' => 'employer_data']))->createUuid();
+        QueryUtils::sqlStatementThrowException(
+            "INSERT INTO `employer_data` (`uuid`, `name`, `pid`, `date`, `start_date`, `end_date`)
+             VALUES (?, ?, ?, NOW(), ?, ?)",
+            [$uuid, $name, $this->patientPid, $startDate, $endDate]
+        );
+    }
+
+    #[Test]
+    public function testSearchByPatientUuid(): void
+    {
+        $result = $this->service->search([
+            'puuid' => new TokenSearchField('puuid', $this->patientUuidString, true),
+        ]);
+        $this->assertTrue($result->isValid());
+        /** @var list<array{puuid: string}> $data */
+        $data = $result->getData();
+        $this->assertCount(2, $data);
+        foreach ($data as $record) {
+            $this->assertEquals($this->patientUuidString, $record['puuid']);
+        }
+    }
+
+    #[Test]
+    public function testSearchByPatientUuidAndNameContains(): void
+    {
+        $result = $this->service->search([
+            'puuid' => new TokenSearchField('puuid', $this->patientUuidString, true),
+            'name' => new StringSearchField('name', ['Employer Two'], SearchModifier::CONTAINS),
+        ]);
+        $this->assertTrue($result->isValid());
+        /** @var list<array{name: string}> $data */
+        $data = $result->getData();
+        $this->assertCount(1, $data);
+        $this->assertEquals(self::NAME_PREFIX . 'Two', $data[0]['name']);
+    }
+
+    #[Test]
+    public function testSearchByStartDateRange(): void
+    {
+        $result = $this->service->search([
+            'puuid' => new TokenSearchField('puuid', $this->patientUuidString, true),
+            'start_date' => new DateSearchField('start_date', ['ge2024-01-01'], DateSearchField::DATE_TYPE_DATETIME),
+        ]);
+        $this->assertTrue($result->isValid());
+        /** @var list<array{name: string}> $data */
+        $data = $result->getData();
+        $this->assertCount(1, $data);
+        $this->assertEquals(self::NAME_PREFIX . 'Two', $data[0]['name']);
+    }
+
+    #[Test]
+    public function testSearchByOtherPatientReturnsNothing(): void
+    {
+        // a different fixture patient should have no employer rows
+        $otherPatient = QueryUtils::querySingleRow(
+            "SELECT `uuid` FROM `patient_data` WHERE `pubpid` LIKE ? AND `pid` != ? LIMIT 1",
+            [FixtureManager::PATIENT_FIXTURE_PUBPID_PREFIX . "%", $this->patientPid]
+        );
+        if (!is_array($otherPatient)) {
+            self::fail('second patient fixture not found');
+        }
+        /** @var array{uuid: string} $otherPatient */
+        $result = $this->service->search([
+            'puuid' => new TokenSearchField('puuid', UuidRegistry::uuidToString($otherPatient['uuid']), true),
+        ]);
+        $this->assertTrue($result->isValid());
+        /** @var list<mixed> $data */
+        $data = $result->getData();
+        $this->assertCount(0, $data);
+    }
+}

--- a/tests/Tests/Services/InsuranceCompanyServiceSearchTest.php
+++ b/tests/Tests/Services/InsuranceCompanyServiceSearchTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * InsuranceCompanyService Search Tests
+ *
+ * Verifies InsuranceCompanyService::search() filtering with typed search
+ * fields, backing the query parameter support on GET /api/insurance_company.
+ *
+ * Runs in the services test suite (requires a database connection).
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\InsuranceCompanyService;
+use OpenEMR\Services\Search\SearchModifier;
+use OpenEMR\Services\Search\StringSearchField;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class InsuranceCompanyServiceSearchTest extends TestCase
+{
+    private const NAME_PREFIX = 'test-fixture-Search ';
+
+    private InsuranceCompanyService $service;
+
+    /** @var list<int|string> */
+    private array $createdIds = [];
+
+    protected function setUp(): void
+    {
+        $this->service = new InsuranceCompanyService();
+        $this->insertAndTrack(self::NAME_PREFIX . 'Alpha', '77771');
+        $this->insertAndTrack(self::NAME_PREFIX . 'Beta', '77772');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdIds as $id) {
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `addresses` WHERE `foreign_id` = ?", [$id]);
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `phone_numbers` WHERE `foreign_id` = ?", [$id]);
+            QueryUtils::fetchRecordsNoLog("DELETE FROM `insurance_companies` WHERE `id` = ?", [$id]);
+        }
+    }
+
+    private function insertAndTrack(string $name, string $cmsId): void
+    {
+        $id = $this->service->insert([
+            'name' => $name,
+            'attn' => 'Claims Department',
+            'cms_id' => $cmsId,
+            'ins_type_code' => '1',
+            'x12_receiver_id' => '',
+            'x12_default_partner_id' => '',
+            'alt_cms_id' => '',
+            'line1' => '100 Insurance Blvd',
+            'line2' => '',
+            'city' => 'Rutland',
+            'state' => 'VT',
+            'zip' => '05701',
+            'country' => 'USA',
+        ]);
+        $this->createdIds[] = $id;
+    }
+
+    #[Test]
+    public function testSearchByNameContains(): void
+    {
+        $result = $this->service->search([
+            'name' => new StringSearchField('name', [self::NAME_PREFIX], SearchModifier::CONTAINS),
+        ]);
+        $this->assertTrue($result->isValid());
+        /** @var list<array{name: string}> $data */
+        $data = $result->getData();
+        $this->assertCount(2, $data);
+        foreach ($data as $record) {
+            $this->assertStringContainsString(self::NAME_PREFIX, $record['name']);
+        }
+    }
+
+    #[Test]
+    public function testSearchByCmsIdExact(): void
+    {
+        $result = $this->service->search([
+            'cms_id' => new StringSearchField('cms_id', ['77771'], SearchModifier::EXACT),
+        ]);
+        $this->assertTrue($result->isValid());
+        /** @var list<array{name: string}> $data */
+        $data = $result->getData();
+        $this->assertCount(1, $data);
+        $this->assertEquals(self::NAME_PREFIX . 'Alpha', $data[0]['name']);
+    }
+
+    #[Test]
+    public function testSearchCombinedFieldsAndCondition(): void
+    {
+        $result = $this->service->search([
+            'name' => new StringSearchField('name', [self::NAME_PREFIX], SearchModifier::CONTAINS),
+            'cms_id' => new StringSearchField('cms_id', ['77772'], SearchModifier::EXACT),
+        ]);
+        $this->assertTrue($result->isValid());
+        /** @var list<array{name: string}> $data */
+        $data = $result->getData();
+        $this->assertCount(1, $data);
+        $this->assertEquals(self::NAME_PREFIX . 'Beta', $data[0]['name']);
+    }
+
+    #[Test]
+    public function testSearchNoMatchesReturnsValidEmptyResult(): void
+    {
+        $result = $this->service->search([
+            'name' => new StringSearchField('name', ['test-fixture-NoSuchCompany'], SearchModifier::EXACT),
+        ]);
+        $this->assertTrue($result->isValid());
+        /** @var list<mixed> $data */
+        $data = $result->getData();
+        $this->assertCount(0, $data);
+    }
+}


### PR DESCRIPTION
## Summary

Adds search query parameter support to three standard API endpoints:

- `GET /api/insurance_company` — `uuid`, `name` (partial), `cms_id`, `alt_cms_id`, `ins_type_code`, `inactive`
- `GET /api/patient/:puuid/insurance` — `type`, `policy_type`, `plan_name` (partial), `policy_number`, `group_number`, `date`, `date_end`
- `GET /api/patient/:puuid/employer` — `name` (partial), `occupation`, `industry`, `start_date`, `end_date`

Date parameters accept FHIR prefixes (`ge2024-01-01`, `lt2025-01-01`). Each controller
maps an explicit allowlist of parameters to typed search fields; anything else returns
400. All values are parameter-bound — field names never come from user input.

All new query parameters are documented in the `OA` attributes; constrained parameters
(`inactive`, `type`) declare their value sets as schema enums, not just description
text. `inactive` is `type: string, enum: ['0','1']` rather than an integer enum:
query parameters arrive as strings and the search layer consumes them as strings, so
the schema reflects the actual wire type.

## Bug fixes included

Two of the three pre-existing `/api/insurance_company` bugs documented in
`InsuranceCompanyApiTest` (#10421) are fixed here:

- **GET all returned nothing.** The controller passed a `ProcessingResult` into
  `RestControllerHelper::responseHandler()`, which does not handle it. Switched to
  `InsuranceCompanyService::search()` with `createProcessingResultResponse()`
  (threading `HttpRestRequest` through the route);
  `testInsuranceCompanyGetAllWithoutParamsReturns200` is the regression test. The
  response shape is additive relative to the old `getAll()` (adds x12 default partner
  name, work/fax numbers, and remaining address fields).
- **POST/PUT fataled.** `InsuranceCompanyService::validate()` had been missing since
  before v8.2. Restored it; insert-context validation applies to both post and put
  since the update context requires a uuid the put route does not receive.

The third bug is **not** fixed here — GET one: binary UUID in the raw row breaks JSON
encoding. An issue will be filed to track it.

Restoring `validate()` also surfaced a broader pre-existing bug:
`RestControllerHelper::validationHandler()` guards with `property_exists()` on what is
actually a method, so it can unconditionally return null and silently discard
validation failures on standard-API write endpoints that rely on it. Not fixed here to
keep this PR scoped; an issue will be filed.

## Design notes for reviewers

**Unsupported parameters return 400 rather than being ignored.** This deliberately
diverges from FHIR's ignore-unknown-parameter convention. The standard API has no
`_include`-style meta parameters, and silently misfiltering billing data seemed worse
than failing loudly. Flagging this explicitly since it's the most debatable choice —
happy to switch to ignore-and-proceed if that's preferred.

**Error responses do not reflect raw parameter names or values** (generic
`invalid or unsupported search parameter`), consistent with the non-reflection
approach in #13615.

**Response helper:** the touched `getAll()` methods use
`createProcessingResultResponse()` rather than the deprecated
`handleProcessingResult()`, with `HttpRestRequest` threaded through the routes.
Migrating the rest of the controller family is follow-up work.

## Tests

- `InsuranceCompanyServiceSearchTest`, `EmployerServiceSearchTest` (services suite) —
  service-level filtering: partial/exact string match, token, date-range, AND-combined
  fields, cross-patient isolation
- `InsuranceEmployerSearchApiTest` (api suite) — wire-level behavior: filtered results,
  400 for unsupported and hostile parameter names (asserting no reflection), 400 for
  malformed patient uuid and invalid date values, empty-200 for a valid unknown uuid,
  and the GET-all regression test
- `InsuranceCompanyApiTest` — POST tests now assert real behavior (201 on valid
  payloads, 400 on missing required name) instead of pinning the pre-`validate()` 500s;
  empty-string optionals are omitted since the validator applies length rules to
  present-but-empty values
- `ApiTestClient` gains `user/employer.read` in `ALL_SCOPES` (was registered server-side
  but missing from the test client)

## PHPStan

Baselines regenerated. Net reduction in `src/`; remaining additions are two
mixed-`$data` entries matching the file's existing pattern. Restoring `validate()`
and typing the `$insuranceCompanyValidator` property removed the `method.nonObject`
and `return.type` entries the restoration initially introduced.
`HttpRestRequest::getQueryParams()` gained a `@return array<string, mixed>` annotation,
which sharpened a few existing FHIR-route baseline messages in place.

## Related

- #13615 — search field identifier validation (merged); defense-in-depth beneath this
  feature, not a dependency: the 400s here come from the controller allowlists
- #10421 — documented the insurance company API bugs and established the test patterns
  these tests follow

Assisted-by: Claude (Anthropic)
