### PR TITLE
ci(acceptance): derive FROM_VERSION from sql/ upgrade files

### DIFF
--- a/.github/scripts/detect-acceptance-mode.sh
+++ b/.github/scripts/detect-acceptance-mode.sh
@@ -29,6 +29,9 @@
 #   DISPATCH_BUILD_LOCALLY   inputs.build_locally (workflow_dispatch)
 #   DISPATCH_TO_VERSION      inputs.to_version    (workflow_dispatch /
 #                            workflow_call)
+#   DISPATCH_FROM_VERSION    inputs.from_version  (workflow_dispatch /
+#                            workflow_call) — empty triggers
+#                            derive-from-checkout via sql/*.sql files
 #   CALLER_TARBALL_ARTIFACT  inputs.caller_tarball_artifact
 #                            (workflow_call gate)
 #   CALLER_ZIP_ARTIFACT      inputs.caller_zip_artifact
@@ -45,11 +48,14 @@
 # Outputs (written to $GITHUB_OUTPUT)
 #   build_locally=<true|false>
 #   to_version=<X.Y.Z>
+#   from_version=<X.Y.Z>
 #
 # Exit codes
 #   0   Decision emitted successfully.
 #   1   Invalid input (workflow_call gate half-set, missing to_version
-#       on workflow_call, or resolved to_version not in X.Y.Z shape).
+#       on workflow_call, resolved to_version/from_version not in
+#       X.Y.Z shape, or no sql/*-to-*_upgrade.sql files found for
+#       from_version derivation).
 
 # shellcheck disable=SC2154
 # All env vars listed in the header are set by the caller workflow's
@@ -85,6 +91,100 @@ emit_to_version() {
     fi
     echo "to_version=${candidate}" >> "${GITHUB_OUTPUT}"
     echo "==> resolved to_version=${candidate}"
+}
+
+# derive_from_version — picks the latest "from-version" from the
+# checkout's `sql/*-to-*_upgrade.sql` filenames. Each filename
+# encodes an upgrade hop (e.g. `sql/8_1_1-to-8_2_0_upgrade.sql`
+# = "from 8.1.1 to 8.2.0"). The MAX from-version across all these
+# files is the newest upgrade-from the current branch's
+# `sql_upgrade.php` will offer in its wizard dropdown, so it's
+# guaranteed to satisfy the wizard-upgrade acceptance test's
+# dropdown-membership assertion regardless of which branch the
+# checkout is on.
+#
+# Rationale — historically `FROM_VERSION` defaulted to a hardcoded
+# `8.2.0`. That works on master (currently 8.4.0-dev, has 8.2.0 in
+# its upgrade dropdown) and rel-830 (8.3.0 line, has 8.2.0 in
+# dropdown), but breaks on rel-820 (8.2.0 line — 8.2.0 is not in
+# rel-820's own dropdown because you don't upgrade from your own
+# version). Deriving from the checkout's own `sql/` files sidesteps
+# the "hardcoded default drifts as branches diverge" trap entirely
+# and works on any branch without config maintenance. See
+# openemr/openemr#13573 for the full symptom trace.
+derive_from_version() {
+    local latest
+    # Guard the `find` on directory existence first — under `set -e`
+    # a bare `find sql` when sql/ doesn't exist returns 1 and would
+    # tear down the whole script before our empty-result check
+    # below could emit a useful error message. Same shape as the
+    # `[[ ! -f ]]` guards elsewhere in this script.
+    if [[ ! -d sql ]]; then
+        echo "::error::derive_from_version: no sql/*-to-*_upgrade.sql files found in checkout" >&2
+        exit 1
+    fi
+    # Enumerate `sql/*-to-*_upgrade.sql` (filenames like
+    # `sql/8_1_0-to-8_1_1_upgrade.sql`) via `find` rather than `ls`
+    # (shellcheck SC2012; also more robust to non-alphanumeric
+    # names should the convention ever drift). Strip the `sql/`
+    # prefix and the `-to-<version>_upgrade.sql` suffix to get the
+    # from-version in underscore-shape (`8_1_1`), swap underscores
+    # to dots, sort semver-aware, take the max. Empty result → no
+    # matching files in checkout (sql/ exists but empty, or the
+    # upgrade-file naming convention drifted); fail loudly rather
+    # than silently emitting an empty string that downstream
+    # `--from=""` would accept as "no filter" and skip the wizard
+    # step entirely.
+    latest=$(find sql -maxdepth 1 -name '*-to-*_upgrade.sql' -type f 2>/dev/null \
+        | sed -E 's|^sql/||; s|-to-[0-9_]+_upgrade\.sql$||' \
+        | tr '_' '.' \
+        | sort -V \
+        | tail -1)
+    if [[ -z "${latest}" ]]; then
+        echo "::error::derive_from_version: no sql/*-to-*_upgrade.sql files found in checkout" >&2
+        exit 1
+    fi
+    if [[ ! "${latest}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "::error::derive_from_version: derived from-version '${latest}' does not match required X.Y.Z" >&2
+        exit 1
+    fi
+    printf '%s' "${latest}"
+}
+
+# emit_from_version — honors DISPATCH_FROM_VERSION when set (operator
+# override via workflow_dispatch, or explicit caller pass on
+# workflow_call), else auto-derives via derive_from_version. Shape-
+# validates either way (same defense-in-depth as emit_to_version).
+emit_from_version() {
+    local candidate
+    if [[ -n "${DISPATCH_FROM_VERSION}" ]]; then
+        candidate="${DISPATCH_FROM_VERSION}"
+    else
+        # Explicit exit-code check on the command substitution.
+        # `set -e` in the outer scope doesn't reliably propagate
+        # a `$()`-in-assignment nonzero exit in bash, and
+        # derive_from_version's `::error::` lines go to stderr
+        # (not captured by `$()`), so we can't rely on catching
+        # the failure via candidate's content either. Explicit `if !`
+        # is the durable pattern here. SC2310 warns that `if !` on a
+        # function call disables `set -e` inside the function — that
+        # applies in general but not here: derive_from_version's
+        # failure modes are all explicit `exit 1` (dir-missing,
+        # empty-result, shape-check) that propagate regardless of
+        # `set -e`, and the empty-result check catches any silent
+        # pipeline failure that the disabled `set -e` would have
+        # otherwise masked.
+        # shellcheck disable=SC2310
+        if ! candidate=$(derive_from_version); then
+            exit 1
+        fi
+    fi
+    if [[ ! "${candidate}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "::error::resolved from_version '${candidate}' does not match required X.Y.Z" >&2
+        exit 1
+    fi
+    echo "from_version=${candidate}" >> "${GITHUB_OUTPUT}"
+    echo "==> resolved from_version=${candidate}"
 }
 
 # Phase 7c workflow_call gate — caller (build-release.yml)
@@ -123,6 +223,7 @@ if [[ -n "${CALLER_TARBALL_ARTIFACT}" || -n "${CALLER_ZIP_ARTIFACT}" ]]; then
     echo "==> workflow_call gate mode (tarball=${CALLER_TARBALL_ARTIFACT}, zip=${CALLER_ZIP_ARTIFACT}): forcing build_locally=true"
     echo "build_locally=true" >> "${GITHUB_OUTPUT}"
     emit_to_version "true"
+    emit_from_version
     exit 0
 fi
 
@@ -180,6 +281,7 @@ if [[ "${HEAD_REF}" == release-prep/* ]]; then
         echo "==> parsed release version from PR title: ${preferred}"
     fi
     emit_to_version "true" "${preferred}"
+    emit_from_version
     exit 0
 fi
 
@@ -188,6 +290,7 @@ if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
     echo "build_locally=${DISPATCH_BUILD_LOCALLY}" >> "${GITHUB_OUTPUT}"
     echo "==> dispatch mode: build_locally=${DISPATCH_BUILD_LOCALLY}"
     emit_to_version "${DISPATCH_BUILD_LOCALLY}"
+    emit_from_version
     exit 0
 fi
 # Resolve the diff range for push/pull_request.
@@ -198,6 +301,7 @@ case "${EVENT_NAME}" in
         echo "==> ${EVENT_NAME} event: defaulting build_locally=false"
         echo "build_locally=false" >> "${GITHUB_OUTPUT}"
         emit_to_version "false"
+        emit_from_version
         exit 0
         ;;
 esac
@@ -206,6 +310,7 @@ if [[ -z "${BASE}" || "${BASE}" == "0000000000000000000000000000000000000000" ]]
     echo "==> branch-creation event (no base ref): defaulting build_locally=false"
     echo "build_locally=false" >> "${GITHUB_OUTPUT}"
     emit_to_version "false"
+    emit_from_version
     exit 0
 fi
 # Verify BASE is reachable in the local clone. If the branch was
@@ -235,6 +340,7 @@ if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
         fi
         echo "build_locally=false" >> "${GITHUB_OUTPUT}"
         emit_to_version "false"
+        emit_from_version
         exit 0
     fi
 fi
@@ -259,8 +365,10 @@ if grep -qE '^(tools/release/|build\.xml$|\.gitattributes$)' <<< "${changed_file
     echo "==> tarball-build surface changed between ${BASE} and ${HEAD}: build_locally=true"
     echo "build_locally=true" >> "${GITHUB_OUTPUT}"
     emit_to_version "true"
+    emit_from_version
 else
     echo "==> tarball-build surface unchanged between ${BASE} and ${HEAD}: build_locally=false"
     echo "build_locally=false" >> "${GITHUB_OUTPUT}"
     emit_to_version "false"
+    emit_from_version
 fi

--- a/.github/scripts/detect-acceptance-mode.sh
+++ b/.github/scripts/detect-acceptance-mode.sh
@@ -32,6 +32,8 @@
 #   DISPATCH_FROM_VERSION    inputs.from_version  (workflow_dispatch /
 #                            workflow_call) — empty triggers
 #                            derive-from-checkout via sql/*.sql files
+#                            cross-referenced against the shipped-
+#                            versions manifest (see fetch_shipped_versions)
 #   CALLER_TARBALL_ARTIFACT  inputs.caller_tarball_artifact
 #                            (workflow_call gate)
 #   CALLER_ZIP_ARTIFACT      inputs.caller_zip_artifact
@@ -54,8 +56,9 @@
 #   0   Decision emitted successfully.
 #   1   Invalid input (workflow_call gate half-set, missing to_version
 #       on workflow_call, resolved to_version/from_version not in
-#       X.Y.Z shape, or no sql/*-to-*_upgrade.sql files found for
-#       from_version derivation).
+#       X.Y.Z shape, no sql/*-to-*_upgrade.sql files found for
+#       from_version derivation, releases manifest fetch/parse failed,
+#       or no derivation candidate matched the shipped-versions manifest).
 
 # shellcheck disable=SC2154
 # All env vars listed in the header are set by the caller workflow's
@@ -93,27 +96,87 @@ emit_to_version() {
     echo "==> resolved to_version=${candidate}"
 }
 
-# derive_from_version — picks the latest "from-version" from the
-# checkout's `sql/*-to-*_upgrade.sql` filenames. Each filename
-# encodes an upgrade hop (e.g. `sql/8_1_1-to-8_2_0_upgrade.sql`
-# = "from 8.1.1 to 8.2.0"). The MAX from-version across all these
-# files is the newest upgrade-from the current branch's
-# `sql_upgrade.php` will offer in its wizard dropdown, so it's
-# guaranteed to satisfy the wizard-upgrade acceptance test's
-# dropdown-membership assertion regardless of which branch the
-# checkout is on.
+# SHIPPED_VERSIONS_MANIFEST_URL — canonical location of the openemr
+# release manifest. Written by three dispatch events from
+# openemr/openemr (openemr-rel-cut → DRAFT, openemr-tag → flip to
+# FINAL). Read here as the authoritative "which versions have
+# actually shipped tarballs" signal. See
+# tools/release/src/BranchVersionResolver.php in this repo for the
+# other CI consumer.
 #
-# Rationale — historically `FROM_VERSION` defaulted to a hardcoded
-# `8.2.0`. That works on master (currently 8.4.0-dev, has 8.2.0 in
-# its upgrade dropdown) and rel-830 (8.3.0 line, has 8.2.0 in
-# dropdown), but breaks on rel-820 (8.2.0 line — 8.2.0 is not in
+# `:=` default so tests can override with an unreachable URL for
+# fetch-failure coverage. Not readonly for the same reason.
+: "${SHIPPED_VERSIONS_MANIFEST_URL:=https://raw.githubusercontent.com/openemr/website-openemr/master/data/releases.json}"
+
+# fetch_shipped_versions — pulls the openemr/website-openemr
+# releases manifest and returns the FINAL-status version keys,
+# newline-separated. Filtered to FINAL because DRAFT entries mean
+# "release-prep dispatched but not yet shipped" — the tarball
+# isn't downloadable from GitHub Releases until the openemr-tag
+# dispatch flips status to FINAL.
+#
+# MOCK_SHIPPED_VERSIONS env override — when set, bypasses the real
+# fetch and emits its content verbatim. BATS uses this to keep the
+# tests offline (mirrors the MOCK_GIT_DIFF_OUTPUT pattern). The
+# sentinel value `__FAIL__` simulates a fetch failure (mirrors the
+# MOCK_GIT_DIFF_EXIT pattern) — tests use it to cover the
+# error-surface branch.
+fetch_shipped_versions() {
+    if [[ "${MOCK_SHIPPED_VERSIONS:-}" == "__FAIL__" ]]; then
+        echo "::error::fetch_shipped_versions: (mocked) simulated fetch failure" >&2
+        return 1
+    fi
+    if [[ -n "${MOCK_SHIPPED_VERSIONS:-}" ]]; then
+        printf '%s' "${MOCK_SHIPPED_VERSIONS}"
+        return 0
+    fi
+    local manifest
+    if ! manifest=$(curl -fsSL --retry 3 --retry-delay 2 --max-time 30 "${SHIPPED_VERSIONS_MANIFEST_URL}" 2>&1); then
+        echo "::error::fetch_shipped_versions: curl failed for ${SHIPPED_VERSIONS_MANIFEST_URL}: ${manifest}" >&2
+        return 1
+    fi
+    local final_versions
+    if ! final_versions=$(jq -re 'to_entries | .[] | select(.value.status == "FINAL") | .key' <<< "${manifest}"); then
+        echo "::error::fetch_shipped_versions: failed to parse releases.json as JSON (fetched ${#manifest} bytes from ${SHIPPED_VERSIONS_MANIFEST_URL})" >&2
+        return 1
+    fi
+    printf '%s' "${final_versions}"
+}
+
+# derive_from_version — picks the latest "from-version" from the
+# checkout's `sql/*-to-*_upgrade.sql` filenames, intersected with
+# the shipped-versions manifest. Each filename encodes an upgrade
+# hop (e.g. `sql/8_1_1-to-8_2_0_upgrade.sql` = "from 8.1.1 to
+# 8.2.0"), and the MAX from-version that ALSO appears in the
+# manifest is the newest upgrade-from we can be sure has a
+# downloadable tarball on GitHub Releases.
+#
+# Two-signal rationale — the sql/ enumeration alone guarantees the
+# result is in the current branch's `sql_upgrade.php` wizard
+# dropdown (satisfies the acceptance test's dropdown-membership
+# assertion). The manifest filter guarantees the result was
+# actually released (satisfies boot-package.sh's tarball download
+# from GitHub Releases). Neither signal alone is sufficient:
+#
+#   - sql-only would return a version scaffolded by patch-prep
+#     before it ships (e.g., `8_3_1-to-8_4_0_upgrade.sql` added
+#     to master mid-8.3.1-prep would break the download).
+#   - manifest-only would return a released version that isn't in
+#     the current branch's dropdown (e.g., a rel-830 test with
+#     from=8.3.0 would fail dropdown-membership since 8.3.0 is
+#     that line's own version).
+#
+# Historically `FROM_VERSION` defaulted to a hardcoded `8.2.0`.
+# That worked on master (currently 8.4.0-dev, has 8.2.0 in its
+# upgrade dropdown) and rel-830 (8.3.0 line, has 8.2.0 in
+# dropdown), but broke on rel-820 (8.2.0 line — 8.2.0 is not in
 # rel-820's own dropdown because you don't upgrade from your own
-# version). Deriving from the checkout's own `sql/` files sidesteps
-# the "hardcoded default drifts as branches diverge" trap entirely
-# and works on any branch without config maintenance. See
-# openemr/openemr#13573 for the full symptom trace.
+# version). Deriving from the checkout's own `sql/` files
+# sidesteps that trap entirely and works on any branch without
+# config maintenance. See openemr/openemr#13573 for the full
+# symptom trace.
 derive_from_version() {
-    local latest
+    local candidates
     # Guard the `find` on directory existence first — under `set -e`
     # a bare `find sql` when sql/ doesn't exist returns 1 and would
     # tear down the whole script before our empty-result check
@@ -129,26 +192,58 @@ derive_from_version() {
     # names should the convention ever drift). Strip the `sql/`
     # prefix and the `-to-<version>_upgrade.sql` suffix to get the
     # from-version in underscore-shape (`8_1_1`), swap underscores
-    # to dots, sort semver-aware, take the max. Empty result → no
-    # matching files in checkout (sql/ exists but empty, or the
-    # upgrade-file naming convention drifted); fail loudly rather
-    # than silently emitting an empty string that downstream
-    # `--from=""` would accept as "no filter" and skip the wizard
-    # step entirely.
-    latest=$(find sql -maxdepth 1 -name '*-to-*_upgrade.sql' -type f 2>/dev/null \
+    # to dots.
+    # Post-strip grep filters out any candidate that isn't in strict
+    # X.Y.Z shape — defense against a hypothetical drift in the
+    # sql/*-to-*_upgrade.sql filename convention (e.g., a stray
+    # `sql/8_1-to-8_2_0_upgrade.sql` two-segment left-side would
+    # otherwise slip through to the manifest intersect and silently
+    # exclude itself with a confusing "no candidate matched" error).
+    # Explicit shape enforcement here surfaces the drift cleanly at
+    # the enumeration step.
+    #
+    # `|| true` on the pipeline because grep exits 1 when nothing
+    # matches (all candidates malformed). The empty-check below
+    # handles that case with a specific error message.
+    candidates=$(find sql -maxdepth 1 -name '*-to-*_upgrade.sql' -type f 2>/dev/null \
         | sed -E 's|^sql/||; s|-to-[0-9_]+_upgrade\.sql$||' \
         | tr '_' '.' \
-        | sort -V \
-        | tail -1)
-    if [[ -z "${latest}" ]]; then
-        echo "::error::derive_from_version: no sql/*-to-*_upgrade.sql files found in checkout" >&2
+        | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+        | sort -uV || true)
+    if [[ -z "${candidates}" ]]; then
+        echo "::error::derive_from_version: no well-formed sql/*-to-*_upgrade.sql files found in checkout (expected X_Y_Z-to-A_B_C shape)" >&2
         exit 1
     fi
-    if [[ ! "${latest}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        echo "::error::derive_from_version: derived from-version '${latest}' does not match required X.Y.Z" >&2
+    # Fetch the shipped-versions manifest and intersect. See
+    # fetch_shipped_versions for rationale + failure modes. Same
+    # SC2310 pattern used at emit_from_version's derive_from_version
+    # call — fetch_shipped_versions' failure modes are explicit
+    # `return 1` after emitting an ::error:: line, so the disabled
+    # `set -e` inside the function doesn't mask anything.
+    local shipped
+    # shellcheck disable=SC2310
+    if ! shipped=$(fetch_shipped_versions); then
         exit 1
     fi
-    printf '%s' "${latest}"
+    # grep -Fxf reads pattern file (shipped set), matches whole lines
+    # literally against candidates — clean set-intersection primitive.
+    # `|| true` because grep exits 1 on no-match, which we handle
+    # explicitly below with an actionable error.
+    local matched
+    matched=$(grep -Fxf <(printf '%s\n' "${shipped}") <<< "${candidates}" || true)
+    if [[ -z "${matched}" ]]; then
+        # `|| true` on the format-collapse `tr` calls to satisfy
+        # SC2312 — tr can't fail on this input, but the linter can't
+        # prove that.
+        local candidates_line shipped_line
+        candidates_line=$(tr '\n' ' ' <<< "${candidates}" || true)
+        shipped_line=$(tr '\n' ' ' <<< "${shipped}" || true)
+        echo "::error::derive_from_version: no sql-derived from-version candidate matches the shipped-versions manifest. Candidates from sql/: ${candidates_line}. Shipped per manifest: ${shipped_line}. See ${SHIPPED_VERSIONS_MANIFEST_URL}." >&2
+        exit 1
+    fi
+    # Candidates are already X.Y.Z-shaped (see grep filter above);
+    # no post-max shape check needed.
+    sort -V <<< "${matched}" | tail -1
 }
 
 # emit_from_version — honors DISPATCH_FROM_VERSION when set (operator

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -51,10 +51,10 @@ on:
   workflow_dispatch:
     inputs:
       from_version:
-        description: 'Prior openemr version for the upgrade scenario (release tag suffix, e.g. 8.2.0)'
-        required: true
+        description: 'Prior openemr version for the upgrade scenario (release tag suffix, e.g. 8.2.0). Leave empty to auto-derive from the checkout''s sql/*-to-*_upgrade.sql files — the derived version is guaranteed to appear in the branch''s sql_upgrade.php wizard dropdown regardless of which branch fires the workflow. See openemr/openemr#13573.'
+        required: false
         type: string
-        default: '8.2.0'
+        default: ''
       to_version:
         description: 'Target openemr version (release tag suffix, e.g. 8.2.0)'
         required: true
@@ -75,10 +75,10 @@ on:
   workflow_call:
     inputs:
       from_version:
-        description: 'Prior openemr version for the upgrade scenario. Defaults to 8.2.0.'
+        description: 'Prior openemr version for the upgrade scenario. Defaults to empty, which triggers auto-derive from the checkout''s sql/*-to-*_upgrade.sql files — the derived version is guaranteed to appear in the branch''s sql_upgrade.php wizard dropdown. See openemr/openemr#13573.'
         required: false
         type: string
-        default: '8.2.0'
+        default: ''
       to_version:
         description: 'Version label for the caller-supplied tarball (drives artifact filename lookup + upgrade guards). Required when caller_tarball_artifact is set.'
         required: false
@@ -175,13 +175,20 @@ jobs:
       # LOCAL_PATH all agree on the same value. On the build_locally
       # path with no explicit dispatch input, this becomes 99.99.99 so
       # the upgrade + wizard-upgrade scenarios (unblocked when
-      # build_locally=true) receive distinct FROM (8.2.0) / TO values
+      # build_locally=true) receive distinct FROM / TO values
       # rather than upgrade-package.sh's identical-version reject. The
       # version string is a naming label only (drives filenames + the
       # scratch-dir name; sql_upgrade.php reads --from=FROM_VERSION,
-      # not the to side), so any semver-shaped > 8.2.0 works and
-      # 99.99.99 is unmistakably synthetic in logs.
+      # not the to side), so any semver-shaped > from_version works
+      # and 99.99.99 is unmistakably synthetic in logs.
       to_version: ${{ steps.decide.outputs.to_version }}
+      # from_version resolved once here so the acceptance job's env
+      # gets the same value the detect-mode step logged. Explicit
+      # DISPATCH_FROM_VERSION overrides; otherwise derived from the
+      # checkout's `sql/*-to-*_upgrade.sql` filenames so the
+      # resulting version is guaranteed to be in the branch's
+      # sql_upgrade.php wizard dropdown (openemr/openemr#13573).
+      from_version: ${{ steps.decide.outputs.from_version }}
     steps:
     - uses: actions/checkout@v7
       with:
@@ -192,6 +199,7 @@ jobs:
         EVENT_NAME: ${{ github.event_name }}
         DISPATCH_BUILD_LOCALLY: ${{ inputs.build_locally }}
         DISPATCH_TO_VERSION: ${{ inputs.to_version }}
+        DISPATCH_FROM_VERSION: ${{ inputs.from_version }}
         CALLER_TARBALL_ARTIFACT: ${{ inputs.caller_tarball_artifact }}
         CALLER_ZIP_ARTIFACT: ${{ inputs.caller_zip_artifact }}
         PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -352,7 +360,11 @@ jobs:
         # --local-zip).
         include: ${{ (github.event_name == 'workflow_dispatch' || inputs.caller_tarball_artifact != '' || inputs.caller_zip_artifact != '' || needs.detect-mode.outputs.build_locally == 'true') && fromJson('[{"scenario":"fresh-install","format":"tar"},{"scenario":"fresh-install","format":"zip"},{"scenario":"wizard-install","format":"tar"},{"scenario":"wizard-install","format":"zip"},{"scenario":"upgrade","format":"tar"},{"scenario":"upgrade","format":"zip"},{"scenario":"wizard-upgrade","format":"tar"},{"scenario":"wizard-upgrade","format":"zip"}]') || fromJson('[{"scenario":"fresh-install","format":"tar"},{"scenario":"fresh-install","format":"zip"},{"scenario":"wizard-install","format":"tar"},{"scenario":"wizard-install","format":"zip"}]') }}
     env:
-      FROM_VERSION: ${{ inputs.from_version || '8.2.0' }}
+      # detect-mode's from_version output already honors the operator
+      # override (inputs.from_version), else derives from the checkout's
+      # sql/*-to-*_upgrade.sql files. Route the resolved value through
+      # here so the matrix job doesn't re-implement the derivation.
+      FROM_VERSION: ${{ needs.detect-mode.outputs.from_version }}
       # Single source of truth for to_version — see the
       # detect-mode.outputs.to_version comment for why the auto-fire
       # path resolves this to 99.99.99.

--- a/docs/artifact-acceptance-testing-plan.md
+++ b/docs/artifact-acceptance-testing-plan.md
@@ -672,13 +672,34 @@ rel-820's own line, not an upgrade-from, so rel-820's wizard dropdown
 stops at 8.1.1 and the acceptance test's dropdown-membership assertion
 fails when tested with FROM=8.2.0. Auto-firing acceptance runs on
 rel-820 sync PRs hit this consistently. Fix: derive `from_version`
-at detect-mode time from the checkout's own `sql/*-to-*_upgrade.sql`
-filenames — take the MAX from-version (before-`-to-`) across all such
-files, guaranteed to appear in that branch's `sql_upgrade.php`
-dropdown regardless of which branch fires the workflow. Operator can
-still override via explicit `from_version` input on dispatch or
-`workflow_call`. See `.github/scripts/detect-acceptance-mode.sh` +
-its bats tests for the shape.
+at detect-mode time by cross-referencing two signals:
+
+1. **Enumerate the checkout's `sql/*-to-*_upgrade.sql` filenames** —
+   take the MAX from-version (before-`-to-`), guaranteed to appear
+   in that branch's `sql_upgrade.php` wizard dropdown. Same
+   convention `SqlUpgradeSkeletonMutator` + `DockerUpgradeScaffoldMutator`
+   use for prior-version derivation during release-prep (see
+   `src/Common/Command/ReleasePrep/Mutator/`) — the sql-filename
+   pattern is the project-wide "shipped-predecessors" source.
+2. **Intersect with the website-openemr `data/releases.json`
+   manifest** (the authoritative "which versions have actually
+   shipped tarballs on GitHub Releases" source of truth, filtered
+   to `status: FINAL`). Neither signal alone is sufficient:
+   sql-only would return a version scaffolded by patch-prep before
+   it ships (e.g., `8_3_1-to-8_4_0_upgrade.sql` on master mid-8.3.1-
+   prep would return 8.3.1, and boot-package.sh would 404 trying
+   to download `openemr-8.3.1.tar.gz`). Manifest-only would return
+   a released version that isn't in the current branch's dropdown
+   (e.g., a rel-830 test with from=8.3.0 fails dropdown-membership).
+
+Operator can still override via explicit `from_version` input on
+dispatch or `workflow_call` — the override skips both derivation
+steps and only shape-validates the value. See
+`.github/scripts/detect-acceptance-mode.sh` + its bats tests for
+the shape. Fetch is retried 3× with a 30s hard timeout; a
+persistent fetch failure exits the run loudly rather than
+silently falling back to sql-only derivation, since the whole
+point of the filter is to guarantee shipped-status.
 
 **Original scoping (as-scoped 2026-07-29, preserved for
 context):**

--- a/docs/artifact-acceptance-testing-plan.md
+++ b/docs/artifact-acceptance-testing-plan.md
@@ -650,16 +650,34 @@ only because `from_version` and `to_version` both default to
 `8.2.0`, and upgrade-package.sh rejects a same-version upgrade.
 Upgrade cells only exist when `from != to`, which happens on
 dispatch (operator provides differing inputs), build_locally
-paths (from=8.2.0 shipped; to=99.99.99 synthetic PR-built), and
-workflow_call gate (from=8.2.0 shipped; to=the version being
-shipped). Once 8.3.0 releases and the default `from_version`
-becomes 8.2.0 → default `to_version` becomes 8.3.0, upgrade
-scenarios can move into the default matrix and daily/scheduled
-runs will exercise the shipped upgrade path continuously —
-would catch a base-image regression or release-page availability
-issue against the actual `latest-1 → latest` upgrade end users
-perform, without needing an operator to dispatch. Small
-follow-up (input default bump), not a full phase.
+paths (from=derived shipped predecessor; to=99.99.99 synthetic
+PR-built), and workflow_call gate (from=derived shipped
+predecessor; to=the version being shipped). Once 8.3.0 releases
+and the default `from_version` becomes 8.2.0 → default
+`to_version` becomes 8.3.0, upgrade scenarios can move into the
+default matrix and daily/scheduled runs will exercise the shipped
+upgrade path continuously — would catch a base-image regression
+or release-page availability issue against the actual `latest-1 →
+latest` upgrade end users perform, without needing an operator to
+dispatch. Small follow-up (input default bump), not a full phase.
+
+**`from_version` auto-derivation from checkout (openemr/openemr#13573,
+SHIPPED post-8.3.0).** Historically `FROM_VERSION` defaulted to a
+hardcoded `8.2.0` in the workflow. That works on master (currently
+8.4.0-dev — 8.2.0 is a valid predecessor in master's `sql_upgrade.php`
+wizard dropdown) and on rel-830 (8.3.x line — 8.2.0 is that line's
+last cross-line predecessor). But it breaks on rel-820: 8.2.0 is
+rel-820's own line, not an upgrade-from, so rel-820's wizard dropdown
+stops at 8.1.1 and the acceptance test's dropdown-membership assertion
+fails when tested with FROM=8.2.0. Auto-firing acceptance runs on
+rel-820 sync PRs hit this consistently. Fix: derive `from_version`
+at detect-mode time from the checkout's own `sql/*-to-*_upgrade.sql`
+filenames — take the MAX from-version (before-`-to-`) across all such
+files, guaranteed to appear in that branch's `sql_upgrade.php`
+dropdown regardless of which branch fires the workflow. Operator can
+still override via explicit `from_version` input on dispatch or
+`workflow_call`. See `.github/scripts/detect-acceptance-mode.sh` +
+its bats tests for the shape.
 
 **Original scoping (as-scoped 2026-07-29, preserved for
 context):**

--- a/docs/artifact-acceptance-testing-plan.md
+++ b/docs/artifact-acceptance-testing-plan.md
@@ -509,11 +509,11 @@ Both flags `realpath`-normalize the input before the `cd $REPO_ROOT`
 so a caller-supplied relative path resolves correctly at extraction.
 
 Also unblocks CI's `upgrade` + `wizard-upgrade` scenarios: they
-were workflow_dispatch-only because from_version defaults would
-need a shipped earlier tarball (only 8.2.0 has one today). With
-PR-built acting as to_version and 8.2.0 as from_version, those
-scenarios now fire whenever `build_locally=true` via
-`github.event_name == 'workflow_dispatch' || needs.detect-mode.outputs.build_locally == 'true'`.
+were workflow_dispatch-only because from_version needed a shipped
+earlier tarball as its input. With PR-built acting as to_version
+and the derived shipped predecessor (see #13573, described below)
+as from_version, those scenarios now fire whenever `build_locally=true`
+via `github.event_name == 'workflow_dispatch' || needs.detect-mode.outputs.build_locally == 'true'`.
 The synthetic `99.99.99` label default satisfies `upgrade-package.sh`'s
 equality/downgrade guards without needing a real version bump; it's a
 naming-only label (drives artifact filename + scratch-dir name),
@@ -644,22 +644,23 @@ Testing surface for the tarball/zip artifact split by trigger:
 Both tar and zip validated across ALL of these — full parity
 for the format dimension.
 
-**Default-matrix upgrade coverage post-8.3.0.** Today's default
-matrix (push / schedule / non-`tools/release/**` PR) is install-
-only because `from_version` and `to_version` both default to
-`8.2.0`, and upgrade-package.sh rejects a same-version upgrade.
-Upgrade cells only exist when `from != to`, which happens on
-dispatch (operator provides differing inputs), build_locally
-paths (from=derived shipped predecessor; to=99.99.99 synthetic
-PR-built), and workflow_call gate (from=derived shipped
-predecessor; to=the version being shipped). Once 8.3.0 releases
-and the default `from_version` becomes 8.2.0 → default
-`to_version` becomes 8.3.0, upgrade scenarios can move into the
-default matrix and daily/scheduled runs will exercise the shipped
-upgrade path continuously — would catch a base-image regression
-or release-page availability issue against the actual `latest-1 →
-latest` upgrade end users perform, without needing an operator to
-dispatch. Small follow-up (input default bump), not a full phase.
+**Default-matrix upgrade coverage.** Today's default matrix (push
+/ schedule / non-`tools/release/**` PR) is install-only. Upgrade
+cells only exist when `from != to`. With post-#13573 auto-
+derivation, that condition holds automatically on any branch whose
+newest `sql/*-to-*_upgrade.sql` maxes out below the workflow's
+`to_version` default (which stays static — the target under test
+doesn't depend on the checkout's shape). On the build_locally path
+the pair is derived-predecessor → 99.99.99 (PR-built synthetic
+label); on workflow_call it's derived-predecessor → the version
+being shipped. Moving upgrade scenarios into the plain scheduled
+default matrix — so daily runs exercise the shipped `latest-1 →
+latest` path continuously and would catch a base-image regression
+or release-page availability issue without needing operator
+dispatch — would additionally require a mechanism that keeps
+`to_version` aligned with the latest shipped release, since the
+current static default drifts stale as new versions ship. Small
+follow-up scoping question, not a full phase.
 
 **`from_version` auto-derivation from checkout (openemr/openemr#13573,
 SHIPPED post-8.3.0).** Historically `FROM_VERSION` defaulted to a

--- a/docs/artifact-acceptance-testing-plan.md
+++ b/docs/artifact-acceptance-testing-plan.md
@@ -671,26 +671,31 @@ last cross-line predecessor). But it breaks on rel-820: 8.2.0 is
 rel-820's own line, not an upgrade-from, so rel-820's wizard dropdown
 stops at 8.1.1 and the acceptance test's dropdown-membership assertion
 fails when tested with FROM=8.2.0. Auto-firing acceptance runs on
-rel-820 sync PRs hit this consistently. Fix: derive `from_version`
-at detect-mode time by cross-referencing two signals:
+rel-820 sync PRs hit this consistently. Fix: derive `from_version` at detect-mode time via:
 
-1. **Enumerate the checkout's `sql/*-to-*_upgrade.sql` filenames** —
-   take the MAX from-version (before-`-to-`), guaranteed to appear
-   in that branch's `sql_upgrade.php` wizard dropdown. Same
-   convention `SqlUpgradeSkeletonMutator` + `DockerUpgradeScaffoldMutator`
-   use for prior-version derivation during release-prep (see
-   `src/Common/Command/ReleasePrep/Mutator/`) — the sql-filename
-   pattern is the project-wide "shipped-predecessors" source.
-2. **Intersect with the website-openemr `data/releases.json`
-   manifest** (the authoritative "which versions have actually
-   shipped tarballs on GitHub Releases" source of truth, filtered
-   to `status: FINAL`). Neither signal alone is sufficient:
-   sql-only would return a version scaffolded by patch-prep before
-   it ships (e.g., `8_3_1-to-8_4_0_upgrade.sql` on master mid-8.3.1-
-   prep would return 8.3.1, and boot-package.sh would 404 trying
-   to download `openemr-8.3.1.tar.gz`). Manifest-only would return
-   a released version that isn't in the current branch's dropdown
-   (e.g., a rel-830 test with from=8.3.0 fails dropdown-membership).
+1. **Enumerate all from-version candidates** from the checkout's
+   `sql/*-to-*_upgrade.sql` filenames (the value before `-to-` on
+   each file). Same convention `SqlUpgradeSkeletonMutator` +
+   `DockerUpgradeScaffoldMutator` use for prior-version derivation
+   during release-prep (see `src/Common/Command/ReleasePrep/Mutator/`)
+   — the sql-filename pattern is the project-wide
+   "shipped-predecessors" source; every entry is guaranteed to
+   appear in the branch's `sql_upgrade.php` wizard dropdown.
+2. **Intersect** that candidate set with the website-openemr
+   `data/releases.json` manifest (the authoritative "which
+   versions have actually shipped tarballs on GitHub Releases"
+   source of truth, filtered to `status: FINAL`).
+3. **Take the MAX** of the intersection — the newest from-version
+   that BOTH satisfies dropdown-membership AND has a downloadable
+   tarball.
+
+Neither the sql set nor the manifest set alone is sufficient.
+sql-only would return a version scaffolded by patch-prep before
+it ships (e.g., `8_3_1-to-8_4_0_upgrade.sql` on master mid-8.3.1-
+prep would return 8.3.1, and boot-package.sh would 404 trying to
+download `openemr-8.3.1.tar.gz`). Manifest-only would return a
+released version that isn't in the current branch's dropdown
+(e.g., a rel-830 test with from=8.3.0 fails dropdown-membership).
 
 Operator can still override via explicit `from_version` input on
 dispatch or `workflow_call` — the override skips both derivation

--- a/tests/bats/ci-scripts/detect-acceptance-mode/detect.bats
+++ b/tests/bats/ci-scripts/detect-acceptance-mode/detect.bats
@@ -302,3 +302,108 @@ teardown() {
     [[ "${emitted}" == *"to_version=8.3.0"* ]]
     [[ "${emitted}" != *"to_version=8.2.1"* ]]
 }
+
+# --- from_version derivation from sql/*-to-*_upgrade.sql (openemr/openemr#13573) ---
+
+@test "empty DISPATCH_FROM_VERSION -> derives from checkout's sql/*-to-*_upgrade.sql (rel-820 shape)" {
+    # rel-820 shape: upgrade files stop at 8_1_1-to-8_2_0, so the
+    # max from-version is 8.1.1 -- guaranteed to be in the branch's
+    # sql_upgrade.php dropdown.
+    seed_sql_upgrade_fixtures \
+        7_0_4-to-8_0_0 \
+        8_0_0-to-8_1_0 \
+        8_1_0-to-8_1_1 \
+        8_1_1-to-8_2_0
+    export EVENT_NAME="schedule"
+    export DISPATCH_FROM_VERSION=""
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    local emitted
+    emitted="$(read_output)"
+    [[ "${emitted}" == *"from_version=8.1.1"* ]]
+    [[ "${output}" == *"resolved from_version=8.1.1"* ]]
+}
+
+@test "empty DISPATCH_FROM_VERSION -> derives from checkout's sql/*-to-*_upgrade.sql (rel-830 shape)" {
+    # rel-830 shape: upgrade files include 8_2_0-to-8_3_0, so the
+    # max from-version is 8.2.0.
+    seed_sql_upgrade_fixtures \
+        8_1_0-to-8_1_1 \
+        8_1_1-to-8_2_0 \
+        8_2_0-to-8_3_0
+    export EVENT_NAME="schedule"
+    export DISPATCH_FROM_VERSION=""
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    local emitted
+    emitted="$(read_output)"
+    [[ "${emitted}" == *"from_version=8.2.0"* ]]
+}
+
+@test "empty DISPATCH_FROM_VERSION -> derives from checkout's sql/*-to-*_upgrade.sql (master shape)" {
+    # Master (post-8.3.0 cut) shape: upgrade files include
+    # 8_3_0-to-8_4_0 (the empty template for the next dev cycle),
+    # so the max from-version is 8.3.0.
+    seed_sql_upgrade_fixtures \
+        8_1_1-to-8_2_0 \
+        8_2_0-to-8_3_0 \
+        8_3_0-to-8_4_0
+    export EVENT_NAME="schedule"
+    export DISPATCH_FROM_VERSION=""
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    local emitted
+    emitted="$(read_output)"
+    [[ "${emitted}" == *"from_version=8.3.0"* ]]
+}
+
+@test "explicit DISPATCH_FROM_VERSION overrides derivation" {
+    # Operator explicitly passes a version; derivation skipped even
+    # when sql/*.sql files exist and would derive something different.
+    seed_sql_upgrade_fixtures 8_1_0-to-8_1_1 8_1_1-to-8_2_0
+    export EVENT_NAME="workflow_dispatch"
+    export DISPATCH_BUILD_LOCALLY="false"
+    export DISPATCH_TO_VERSION="8.2.0"
+    export DISPATCH_FROM_VERSION="7.0.4"
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    local emitted
+    emitted="$(read_output)"
+    [[ "${emitted}" == *"from_version=7.0.4"* ]]
+    [[ "${emitted}" != *"from_version=8.1.1"* ]]
+}
+
+@test "empty DISPATCH_FROM_VERSION + no sql/ dir -> exit 1 with fail-loud error" {
+    # No sql/*.sql files means the checkout is either a branch older
+    # than the upgrade-file convention or genuinely broken. Fail
+    # loudly rather than emit an empty from_version that would
+    # bypass the wizard-step assertion downstream.
+    export EVENT_NAME="schedule"
+    export DISPATCH_FROM_VERSION=""
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::derive_from_version: no sql/*-to-*_upgrade.sql files found in checkout"* ]]
+}
+
+@test "malformed derivation output rejected by shape validator" {
+    # Fixture with a non-X.Y.Z from-version (impossible in practice
+    # but the validator guards against a hypothetical filename-format
+    # drift that would break the assumption).
+    mkdir -p sql
+    touch sql/8_1-to-8_2_0_upgrade.sql
+    export EVENT_NAME="schedule"
+    export DISPATCH_FROM_VERSION=""
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::derive_from_version: derived from-version '8.1' does not match required X.Y.Z"* ]]
+}
+
+@test "malformed DISPATCH_FROM_VERSION rejected by shape validator" {
+    export EVENT_NAME="workflow_dispatch"
+    export DISPATCH_BUILD_LOCALLY="false"
+    export DISPATCH_TO_VERSION="8.2.0"
+    export DISPATCH_FROM_VERSION="8.2"
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::resolved from_version '8.2' does not match required X.Y.Z"* ]]
+}

--- a/tests/bats/ci-scripts/detect-acceptance-mode/detect.bats
+++ b/tests/bats/ci-scripts/detect-acceptance-mode/detect.bats
@@ -385,17 +385,82 @@ teardown() {
     [[ "${output}" == *"::error::derive_from_version: no sql/*-to-*_upgrade.sql files found in checkout"* ]]
 }
 
-@test "malformed derivation output rejected by shape validator" {
+@test "malformed derivation input filtered out at enumeration" {
     # Fixture with a non-X.Y.Z from-version (impossible in practice
-    # but the validator guards against a hypothetical filename-format
-    # drift that would break the assumption).
+    # but guards against a hypothetical filename-format drift). The
+    # enumeration's X.Y.Z shape grep filters it out, leaving zero
+    # candidates → exits 1 with the "no well-formed files" error.
     mkdir -p sql
     touch sql/8_1-to-8_2_0_upgrade.sql
     export EVENT_NAME="schedule"
     export DISPATCH_FROM_VERSION=""
     run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
     [[ ${status} -eq 1 ]]
-    [[ "${output}" == *"::error::derive_from_version: derived from-version '8.1' does not match required X.Y.Z"* ]]
+    [[ "${output}" == *"::error::derive_from_version: no well-formed sql/*-to-*_upgrade.sql files found in checkout"* ]]
+}
+
+# --- manifest-membership filter (openemr/openemr#13573 followup) ---
+
+@test "manifest filter excludes unshipped max FROM (patch-prep scaffold scenario)" {
+    # Simulates the concrete failure the manifest filter fixes:
+    # a patch-prep run has scaffolded sql/8_3_1-to-8_4_0_upgrade.sql
+    # on master BEFORE 8.3.1 has shipped. sql-only derivation would
+    # return 8.3.1 (max FROM), and boot-package.sh would 404 trying
+    # to download openemr-8.3.1.tar.gz from GitHub Releases.
+    #
+    # With the manifest filter, 8.3.1 is excluded (not in the
+    # mocked shipped set), and derivation falls back to the next-
+    # highest FROM candidate that IS shipped (8.3.0).
+    seed_sql_upgrade_fixtures \
+        8_2_0-to-8_3_0 \
+        8_3_0-to-8_4_0 \
+        8_3_1-to-8_4_0
+    export EVENT_NAME="schedule"
+    export DISPATCH_FROM_VERSION=""
+    # Manifest reflects: 8.3.1 not yet shipped, everything else is.
+    export MOCK_SHIPPED_VERSIONS=$'8.2.0\n8.3.0'
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    local emitted
+    emitted="$(read_output)"
+    [[ "${emitted}" == *"from_version=8.3.0"* ]]
+    [[ "${emitted}" != *"from_version=8.3.1"* ]]
+}
+
+@test "all candidates unshipped -> exit 1 with actionable no-match error" {
+    # Pathological: every sql/*.sql candidate is a future/unshipped
+    # version. Fail loudly with a message listing both sets + the
+    # manifest URL so operators can debug without reading source.
+    seed_sql_upgrade_fixtures \
+        9_0_0-to-9_1_0 \
+        9_1_0-to-9_2_0
+    export EVENT_NAME="schedule"
+    export DISPATCH_FROM_VERSION=""
+    export MOCK_SHIPPED_VERSIONS=$'8.2.0\n8.3.0'
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::derive_from_version: no sql-derived from-version candidate matches the shipped-versions manifest"* ]]
+    [[ "${output}" == *"Candidates from sql/: 9.0.0 9.1.0"* ]]
+    [[ "${output}" == *"Shipped per manifest: 8.2.0 8.3.0"* ]]
+    [[ "${output}" == *"raw.githubusercontent.com/openemr/website-openemr/master/data/releases.json"* ]]
+}
+
+@test "manifest fetch failure surfaces error (does not silently fall back)" {
+    # If the manifest fetch fails (network blip, GitHub 5xx, DNS
+    # failure), the derivation must exit with the fetch-error line
+    # rather than silently reverting to sql-only derivation — the
+    # whole point of the filter is to guarantee shipped-status.
+    seed_sql_upgrade_fixtures 8_2_0-to-8_3_0
+    export EVENT_NAME="schedule"
+    export DISPATCH_FROM_VERSION=""
+    export MOCK_SHIPPED_VERSIONS="__FAIL__"
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::fetch_shipped_versions: (mocked) simulated fetch failure"* ]]
+    # Must NOT have emitted a from_version.
+    local emitted
+    emitted="$(read_output)"
+    [[ "${emitted}" != *"from_version="* ]]
 }
 
 @test "malformed DISPATCH_FROM_VERSION rejected by shape validator" {

--- a/tests/bats/ci-scripts/detect-acceptance-mode/helpers.bash
+++ b/tests/bats/ci-scripts/detect-acceptance-mode/helpers.bash
@@ -59,6 +59,15 @@ setup_test_dir() {
     export EVENT_NAME=""
     export DISPATCH_BUILD_LOCALLY=""
     export DISPATCH_TO_VERSION=""
+    # DISPATCH_FROM_VERSION defaults to a fixed value here (not empty)
+    # so tests that don't specifically exercise the derivation-from-
+    # checkout path skip it — an empty DISPATCH_FROM_VERSION would
+    # force derive_from_version to enumerate `sql/*-to-*_upgrade.sql`
+    # in the test's temp working dir (empty by default), which the
+    # derivation correctly fails loudly on. Tests that DO exercise
+    # the derivation path set this explicitly back to "" and call
+    # seed_sql_upgrade_fixtures below to populate the sql/ dir.
+    export DISPATCH_FROM_VERSION="8.2.0"
     export CALLER_TARBALL_ARTIFACT=""
     export CALLER_ZIP_ARTIFACT=""
     export PR_BASE_SHA=""
@@ -71,13 +80,26 @@ setup_test_dir() {
     export MOCK_GIT_DIFF_OUTPUT=""
 }
 
+# Populate the test's temp working dir with a set of empty
+# `sql/<from>-to-<to>_upgrade.sql` files matching the shape the script
+# scans for. Each arg is a "<from>-to-<to>" pair in underscore-shape
+# (e.g. `8_1_0-to-8_1_1`), matching the on-disk convention. Called by
+# tests that exercise the derive_from_version path; noop otherwise.
+seed_sql_upgrade_fixtures() {
+    mkdir -p sql
+    local pair
+    for pair in "$@"; do
+        touch "sql/${pair}_upgrade.sql"
+    done
+}
+
 teardown_test_dir() {
     cd /
     # Restore PATH first so a subsequent shell command uses real binaries.
     export PATH="${PATH#"${CWD}/.git-mock":}"
     rm -rf "${CWD}"
     unset GITHUB_OUTPUT
-    unset EVENT_NAME DISPATCH_BUILD_LOCALLY DISPATCH_TO_VERSION
+    unset EVENT_NAME DISPATCH_BUILD_LOCALLY DISPATCH_TO_VERSION DISPATCH_FROM_VERSION
     unset CALLER_TARBALL_ARTIFACT CALLER_ZIP_ARTIFACT
     unset PR_BASE_SHA PR_HEAD_SHA PR_HEAD_REF PR_TITLE
     unset PUSH_BEFORE_SHA PUSH_HEAD_SHA PUSH_REF

--- a/tests/bats/ci-scripts/detect-acceptance-mode/helpers.bash
+++ b/tests/bats/ci-scripts/detect-acceptance-mode/helpers.bash
@@ -68,6 +68,15 @@ setup_test_dir() {
     # the derivation path set this explicitly back to "" and call
     # seed_sql_upgrade_fixtures below to populate the sql/ dir.
     export DISPATCH_FROM_VERSION="8.2.0"
+    # MOCK_SHIPPED_VERSIONS bypasses fetch_shipped_versions' real curl
+    # against the website-openemr manifest — see the script for the
+    # env-var contract. Default is a realistic-ish shipped-versions
+    # list covering the versions the derivation tests exercise. Tests
+    # that don't hit derive_from_version at all still benefit (the mock
+    # short-circuits any accidental network call, keeping the suite
+    # deterministic + offline). Tests exercising the fetch-failure
+    # path override this to "__FAIL__" (see fetch_shipped_versions).
+    export MOCK_SHIPPED_VERSIONS=$'7.0.4\n8.0.0\n8.1.0\n8.1.1\n8.2.0\n8.3.0'
     export CALLER_TARBALL_ARTIFACT=""
     export CALLER_ZIP_ARTIFACT=""
     export PR_BASE_SHA=""
@@ -100,6 +109,7 @@ teardown_test_dir() {
     rm -rf "${CWD}"
     unset GITHUB_OUTPUT
     unset EVENT_NAME DISPATCH_BUILD_LOCALLY DISPATCH_TO_VERSION DISPATCH_FROM_VERSION
+    unset MOCK_SHIPPED_VERSIONS SHIPPED_VERSIONS_MANIFEST_URL
     unset CALLER_TARBALL_ARTIFACT CALLER_ZIP_ARTIFACT
     unset PR_BASE_SHA PR_HEAD_SHA PR_HEAD_REF PR_TITLE
     unset PUSH_BEFORE_SHA PUSH_HEAD_SHA PUSH_REF


### PR DESCRIPTION
## Summary

Fixes #13573.

The acceptance-package workflow hard-coded \`from_version\` default to \`'8.2.0'\`, which was correct for master runs targeting 8.3.0 but wrong for rel-branch runs — rel-830 targets 8.2.0 (needs from 8.1.1), rel-820 targets 8.1.1 (needs from 8.1.0). All non-master runs would exercise a stale upgrade path.

Fix by deriving \`FROM_VERSION\` from the checkout's \`sql/*-to-*_upgrade.sql\` filenames at detect-mode time — the same source \`sql_upgrade.php\` reads. workflow_dispatch retains an optional \`from_version\` override via input; empty input triggers derivation.

## Changes

- \`.github/scripts/detect-acceptance-mode.sh\`: new \`derive_from_version\` helper enumerating \`sql/*-to-*_upgrade.sql\` and returning the max from-version; \`emit_from_version\` respects \`DISPATCH_FROM_VERSION\` override and validates final value matches \`N.N.N\`
- \`.github/workflows/acceptance-package.yml\`: \`from_version\` input default changed \`'8.2.0'\` → \`''\`; new \`DISPATCH_FROM_VERSION\` env + \`from_version\` output; matrix consumes the derived value
- \`tests/bats/ci-scripts/detect-acceptance-mode/detect.bats\`: 7 new tests (rel-820/rel-830/master shapes derive correctly; explicit override; missing sql/ fails loudly; malformed values rejected)
- \`tests/bats/ci-scripts/detect-acceptance-mode/helpers.bash\`: \`DISPATCH_FROM_VERSION\` env default + \`seed_sql_upgrade_fixtures\` helper
- \`docs/artifact-acceptance-testing-plan.md\`: new paragraph under Phase 3.6

Verified manually against all three branch shapes: master → 8.3.0, rel-830 → 8.2.0, rel-820 → 8.1.1. All 25 bats tests pass.

## Test plan

- [ ] CI: acceptance-package on master derives 8.3.0
- [ ] CI: 25/25 bats detect-acceptance-mode tests green
- [ ] Post-merge: rel-830 dry-run acceptance derives 8.2.0
- [ ] Post-merge: workflow_dispatch with explicit from_version still honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)