### PR TITLE
test(acceptance): assert displayed version post-install and post-upgrade

### DIFF
--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -637,16 +637,18 @@ jobs:
         ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
       run: composer acceptance -- --group=version-display
 
-    # api-enable bootstrap fires AFTER post-upgrade so the api-enabled
-    # group (ApiSmokeTest + OAuth2ApiEnabledTest + version-api check)
-    # can assert their contract against the upgraded artifact.
-    # Symmetric with the fresh-install scenario's api-enable ordering:
-    # pre-bootstrap tests verify API-disabled state (OAuth2SmokeTest's
-    # post-upgrade-tagged assertions), post-bootstrap verify enabled
-    # state. Prior to this the api-enabled group only ran in
-    # fresh-install — running it post-upgrade too closes the gap where
-    # a regression to /api/facility, OIDC discovery, or DCR wouldn't
-    # be caught on the upgrade path (see openemr/openemr#13634).
+    # api-enable bootstrap fires AFTER post-upgrade so both the
+    # api-enabled group (ApiSmokeTest + OAuth2ApiEnabledTest) and the
+    # separately-invoked version-api group (VersionApiAcceptanceTest,
+    # its own step below) can assert their contract against the
+    # upgraded artifact. Symmetric with the fresh-install scenario's
+    # api-enable ordering: pre-bootstrap tests verify API-disabled
+    # state (OAuth2SmokeTest's post-upgrade-tagged assertions), post-
+    # bootstrap verify enabled state. Prior to this the api-enabled
+    # group only ran in fresh-install — running it post-upgrade too
+    # closes the gap where a regression to /api/facility, OIDC
+    # discovery, or DCR wouldn't be caught on the upgrade path (see
+    # openemr/openemr#13634).
     - name: Bootstrap API via admin panel (post-upgrade)
       if: matrix.scenario == 'upgrade'
       env:

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -541,6 +541,18 @@ jobs:
       if: matrix.scenario == 'fresh-install'
       run: composer acceptance -- --group=fresh-install
 
+    # Version-display check: About page shows TO_VERSION. Own group
+    # (not piggybacking fresh-install) so this doesn't leak into
+    # acceptance-docker.yml — that workflow uses floating tags
+    # (`latest`, `next`) and doesn't resolve them into X.Y.Z at
+    # runtime, so it can't set ACCEPTANCE_EXPECTED_VERSION. See
+    # openemr/openemr#13634 for the full signal-source rationale.
+    - name: Run version-display check (fresh-install, expect ${{ env.TO_VERSION }})
+      if: matrix.scenario == 'fresh-install'
+      env:
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
+      run: composer acceptance -- --group=version-display
+
     # api-enable bootstrap fires AFTER the fresh-install group. Order
     # matters: OAuth2SmokeTest's fresh-install-tagged assertions verify
     # the API-disabled 404 gate that ships by default; the bootstrap
@@ -555,6 +567,15 @@ jobs:
     - name: Run acceptance suite (api-enabled of to_version)
       if: matrix.scenario == 'fresh-install'
       run: composer acceptance -- --group=api-enabled
+
+    # Version-api check: /api/version returns TO_VERSION. Own group
+    # for the same reason as version-display above (avoid leaking
+    # into acceptance-docker.yml's api-enabled invocation).
+    - name: Run version-api check (fresh-install, expect ${{ env.TO_VERSION }})
+      if: matrix.scenario == 'fresh-install'
+      env:
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
+      run: composer acceptance -- --group=version-api
 
     # ==== wizard-install scenario ====
     # Boots the artifact WITHOUT running install-helper.php so the
@@ -571,6 +592,12 @@ jobs:
       if: matrix.scenario == 'wizard-install'
       run: composer acceptance -- --group=wizard-install
 
+    - name: Run version-display check (wizard-install, expect ${{ env.TO_VERSION }})
+      if: matrix.scenario == 'wizard-install'
+      env:
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
+      run: composer acceptance -- --group=version-display
+
     # ==== upgrade scenario ====
     # from_version is always the shipped GitHub-release tarball (no
     # --local-tarball flag — testing "install the currently-shipped
@@ -586,6 +613,14 @@ jobs:
       if: matrix.scenario == 'upgrade'
       run: composer acceptance -- --group=fresh-install
 
+    # Pre-upgrade the artifact is running FROM_VERSION; the
+    # version-display check at this step asserts against that.
+    - name: Run version-display check (pre-upgrade, expect ${{ env.FROM_VERSION }})
+      if: matrix.scenario == 'upgrade'
+      env:
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.FROM_VERSION }}
+      run: composer acceptance -- --group=version-display
+
     - name: Upgrade from_version -> to_version
       if: matrix.scenario == 'upgrade'
       run: tests/Acceptance/bin/upgrade-package.sh ${{ steps.bootflags.outputs.to_upgrade_local_flag }} "${FROM_VERSION}" "${TO_VERSION}"
@@ -593,6 +628,32 @@ jobs:
     - name: Run post-upgrade suite against to_version
       if: matrix.scenario == 'upgrade'
       run: composer acceptance -- --group=post-upgrade
+
+    # Post-upgrade the artifact is running TO_VERSION; version-display
+    # check asserts against that.
+    - name: Run version-display check (post-upgrade, expect ${{ env.TO_VERSION }})
+      if: matrix.scenario == 'upgrade'
+      env:
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
+      run: composer acceptance -- --group=version-display
+
+    # api-enable bootstrap fires AFTER post-upgrade so the version-api
+    # check can assert /api/version returns TO_VERSION. Symmetric with
+    # the fresh-install scenario's api-enable ordering (same rationale:
+    # pre-bootstrap tests verify API-disabled state, post-bootstrap
+    # verify enabled state). Added per openemr/openemr#13634 so the
+    # API-side signal covers upgrade paths, not just install paths.
+    - name: Bootstrap API via admin panel (post-upgrade)
+      if: matrix.scenario == 'upgrade'
+      env:
+        OPENEMR_ENABLE_API_BOOTSTRAP: '1'
+      run: php tests/Acceptance/bin/api-enable.php
+
+    - name: Run version-api check (post-upgrade, expect ${{ env.TO_VERSION }})
+      if: matrix.scenario == 'upgrade'
+      env:
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
+      run: composer acceptance -- --group=version-api
 
     # ==== wizard-upgrade scenario ====
     # Boots the from-version normally (install-helper.php runs, DB
@@ -613,6 +674,12 @@ jobs:
     - name: Run acceptance suite (wizard-upgrade)
       if: matrix.scenario == 'wizard-upgrade'
       run: composer acceptance -- --group=wizard-upgrade
+
+    - name: Run version-display check (wizard-upgrade, expect ${{ env.TO_VERSION }})
+      if: matrix.scenario == 'wizard-upgrade'
+      env:
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
+      run: composer acceptance -- --group=version-display
 
     # ==== debug + teardown (all scenarios) ====
     - name: Capture container state (on failure)

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -637,17 +637,25 @@ jobs:
         ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
       run: composer acceptance -- --group=version-display
 
-    # api-enable bootstrap fires AFTER post-upgrade so the version-api
-    # check can assert /api/version returns TO_VERSION. Symmetric with
-    # the fresh-install scenario's api-enable ordering (same rationale:
-    # pre-bootstrap tests verify API-disabled state, post-bootstrap
-    # verify enabled state). Added per openemr/openemr#13634 so the
-    # API-side signal covers upgrade paths, not just install paths.
+    # api-enable bootstrap fires AFTER post-upgrade so the api-enabled
+    # group (ApiSmokeTest + OAuth2ApiEnabledTest + version-api check)
+    # can assert their contract against the upgraded artifact.
+    # Symmetric with the fresh-install scenario's api-enable ordering:
+    # pre-bootstrap tests verify API-disabled state (OAuth2SmokeTest's
+    # post-upgrade-tagged assertions), post-bootstrap verify enabled
+    # state. Prior to this the api-enabled group only ran in
+    # fresh-install — running it post-upgrade too closes the gap where
+    # a regression to /api/facility, OIDC discovery, or DCR wouldn't
+    # be caught on the upgrade path (see openemr/openemr#13634).
     - name: Bootstrap API via admin panel (post-upgrade)
       if: matrix.scenario == 'upgrade'
       env:
         OPENEMR_ENABLE_API_BOOTSTRAP: '1'
       run: php tests/Acceptance/bin/api-enable.php
+
+    - name: Run acceptance suite (api-enabled of to_version, post-upgrade)
+      if: matrix.scenario == 'upgrade'
+      run: composer acceptance -- --group=api-enabled
 
     - name: Run version-api check (post-upgrade, expect ${{ env.TO_VERSION }})
       if: matrix.scenario == 'upgrade'

--- a/docs/artifact-acceptance-testing-plan.md
+++ b/docs/artifact-acceptance-testing-plan.md
@@ -2569,3 +2569,131 @@ install); the rest remain worth periodic re-visit.
   than one idempotent method that runs on both), a dedicated
   pre-upgrade seeding stage would need to land — deferred until
   demand appears.
+
+## Post-8.4.0 acceptance-surface refactor plan
+
+**Status:** Deferred until after the next release cut. Captured here so
+the work is pickable-up-cold without relying on session context. Trigger
+that surfaced this: adding version-display coverage in
+openemr/openemr#13635 (three signals: DB via shell, About page via
+Panther, `/apis/default/api/version` via Panther) required workarounds
+whose shape teaches the wrong pattern for future contributors.
+
+### Motivating problem
+
+Group tags on acceptance tests do three unrelated jobs at once:
+1. **Scenario timeline** — "when in the boot→install→upgrade sequence
+   this test is meant to run" (e.g., `post-upgrade`).
+2. **Runtime state** — "what the app must be configured as before this
+   test can run" (e.g., `api-enabled`).
+3. **Workflow isolation** — "which of the two workflows can invoke this
+   test" (implicit; #13635 had to introduce `version-display` /
+   `version-api` groups purely because `acceptance-docker.yml` cannot
+   resolve floating tags to `X.Y.Z` at runtime and so cannot set
+   `ACCEPTANCE_EXPECTED_VERSION`).
+
+The overloading hides real coverage gaps. Two concrete instances that
+surfaced during #13635's design:
+- `api-enabled` group tests (`ApiSmokeTest`, `OAuth2ApiEnabledTest`)
+  historically ran only in the fresh-install scenario, never
+  post-upgrade — because the workflow only invokes `--group=api-enabled`
+  after fresh-install. #13635 partially closed this by adding
+  post-upgrade `api-enable.php` + `--group=api-enabled` steps to the
+  upgrade scenario.
+- `version-display` / `version-api` had to be their own groups (rather
+  than tagging the existing `post-install` / `post-upgrade` /
+  `api-enabled` groups) because `acceptance-docker.yml` would otherwise
+  pick them up and fail without `ACCEPTANCE_EXPECTED_VERSION`.
+
+### Current-state snapshot
+
+**Invocation contexts (`acceptance-package.yml`):**
+
+| # | Trigger | Artifact source | Version signal | Matrix |
+|---|---------|-----------------|----------------|--------|
+| 1 | schedule (daily) | GitHub Releases tarball | `TO_VERSION` default | Default (install-only) |
+| 2 | push (paths filter) | GitHub Releases tarball | Same | Default |
+| 3 | pull_request (paths filter) | GitHub Releases tarball | Same | Default |
+| 4 | push/PR touching `tools/release/**` | PR-built via PackageAssembler | Synthetic `99.99.99` | Expanded |
+| 5 | `release-prep/*` branch | PR-built | Parsed from PR title | Expanded |
+| 6 | workflow_dispatch | GitHub OR PR-built | Operator input | Expanded |
+| 7 | workflow_call (build-release.yml Phase 7c) | Caller artifact | Caller `to_version` | Expanded |
+| 8 | workflow_call (acceptance-only.yml Phase 9) | Same replayed | Same | Expanded |
+
+Plus per-branch `FROM_VERSION` derivation from `sql/*-to-*_upgrade.sql`
+× shipped-versions manifest (#13630).
+
+**Invocation contexts (`acceptance-docker.yml`):**
+
+| # | Trigger | Artifact source | Version signal | Matrix |
+|---|---------|-----------------|----------------|--------|
+| 1 | schedule (daily) | Docker Hub `:latest` + `:next` | Floating tag — no `X.Y.Z` resolution | Default |
+| 2 | push/PR (paths filter) | Docker Hub tags | Same | Default |
+| 3 | workflow_dispatch | Docker Hub OR PR-built image | Operator tag input | Expanded |
+| 4 | workflow_call (docker-build-release.yml) | PR-built image | Caller `to_tag` | Expanded |
+| 5 | workflow_call (docker-acceptance-only.yml) | Same | Same | Expanded |
+
+**Group → tests (as of 2026-08-20):**
+
+| Group | Tests |
+|-------|-------|
+| `fresh-install` | Aa, Appointment, Bb, Dd, Document, E2e, Ff, Fhir, FrontPayment, Gg, Install, Kk, OAuth2Smoke |
+| `post-upgrade` | Same 13 minus `InstallTest`, plus `UpgradeIntegrity` |
+| `wizard-install` | `InstallWizardUiTest` |
+| `wizard-upgrade` | `UpgradeWizardUiTest` |
+| `api-enabled` | `ApiSmokeTest`, `OAuth2ApiEnabledTest` |
+| `version-display` (workaround, #13635) | `VersionDisplayAcceptanceTest` |
+| `version-api` (workaround, #13635) | `VersionApiAcceptanceTest` |
+
+**Group invocation per scenario (package workflow):**
+
+- `fresh-install` scenario → `--group=fresh-install` → `api-enable.php` → `--group=api-enabled` → (post-#13635) `--group=version-display` + `--group=version-api`
+- `wizard-install` scenario → `--group=wizard-install` → (post-#13635) `--group=version-display`
+- `upgrade` scenario → `--group=fresh-install` (against from) → upgrade → `--group=post-upgrade` → (post-#13635) `--group=version-display` + `api-enable.php` + `--group=api-enabled` + `--group=version-api`
+- `wizard-upgrade` scenario → `--group=wizard-upgrade` → (post-#13635) `--group=version-display`
+
+### Friction points captured
+
+1. Same test, different context, no way to know from the test which workflow/scenario invoked it.
+2. Expected-version signal shape differs per context (env `TO_VERSION` vs matrix `image_tag` vs synthetic `99.99.99` vs PR-title parse).
+3. `api-enabled` post-upgrade coverage gap (partially closed in #13635 for package workflow; docker workflow still has the gap).
+4. Group tags overloaded across three concerns (scenario timeline, runtime state, workflow isolation).
+5. Workflow YAML duplication — both workflows walk the same boot→group→api-enable→group shape independently, with drift risk (e.g., #13635 added post-upgrade api-enable to package only).
+6. No mapping-doc reference table for "what runs where" — contributors have to grep both workflows to understand a test's blast radius.
+7. Docker workflow's default matrix excludes wizard-* — a wizard-flow regression on `:latest` wouldn't fire outside dispatch.
+
+### Refactor items (proposed, in priority order)
+
+**Item 1: `AcceptanceContext` support class** *(highest leverage, smallest surface)*
+Central resolver for "what am I running against?" — expected version, base URL, feature-flag state, scenario name — read from a common `ACCEPTANCE_*` env contract. Tests call `AcceptanceContext::expectedVersion()` instead of `getenv('ACCEPTANCE_EXPECTED_VERSION')`. Fail-fast diagnostic if the context isn't ready (rather than tests failing at their business assertions).
+
+Migration path: introduce class, migrate `VersionDisplayAcceptanceTest` + `VersionApiAcceptanceTest` as the first consumers (they're already env-aware), then adopt in future tests. Existing tests can migrate opportunistically.
+
+**Item 2: Split scenario-timeline from runtime-state group tags**
+Rename group tags into two dimensions:
+- Scenario timeline: `post-install`, `post-upgrade`, `wizard-completed`
+- Runtime state: `api-enabled`, `demo-data-seeded`
+
+Tests declare BOTH tags. Workflow steps advance state, then invoke tests via `--group=<scenario> --group=<state>` (PHPUnit's `--group` is OR — need a small custom filter for AND semantics, OR name-combined groups like `api-enabled-post-upgrade` if AND filter turns out to be too invasive).
+
+Once this lands, `version-display` and `version-api` collapse into `#[Group('post-install')] #[Group('post-upgrade')]` (plus `#[Group('api-enabled')]` for the api variant) — the isolation workaround becomes unnecessary.
+
+**Item 3: Shared boot-orchestration composite action**
+Both workflows repeat the boot→group→api-enable→group→teardown shape. Extract to a composite action at `.github/actions/run-acceptance-scenario/` (or a shared shell library at `tests/Acceptance/bin/lib/`). Workflows declare "here's the artifact, here's the expected version, run scenario X." Cuts YAML duplication; makes drift impossible (e.g., item #3 friction, and the `api-enabled` post-upgrade gap in docker workflow).
+
+**Item 4: Docker workflow tag→version resolution**
+So `ACCEPTANCE_EXPECTED_VERSION` can be set in docker context too and the `version-display` / `version-api` isolation isn't needed. Options: query Docker Hub API for the tag→digest→config manifest, OR pull the image and read `version.php`, OR require the caller to pass the version explicitly (already the case for workflow_call gates). Simplest is the last one — scheduled/floating-tag runs can skip version-check by not setting the env.
+
+**Item 5 (hygiene): "Invocation contexts" reference section in this doc**
+Table of ~6 contexts × what each provides. Not covered elsewhere. Cheap; prevents future confusion. (The table above is a starting point.)
+
+**Item 6 (hygiene): Directory structure by concern as suite grows**
+`tests/Acceptance/Version/`, `Upgrade/`, `OAuth/`, `Ui/`. Currently all flat under `tests/Acceptance/`. PHPUnit `<directory>` config handles it naturally.
+
+### Sequencing recommendation
+
+Item 1 first (small standalone refactor PR, highest leverage). Item 2 second (mechanical rename + workflow-invocation update). Item 3 third (biggest structural change; benefits from semantics being settled first). Items 4-6 opportunistic.
+
+### Interim workaround (as of #13635)
+
+`version-display` and `version-api` are dedicated groups purely because `acceptance-docker.yml` can't currently set `ACCEPTANCE_EXPECTED_VERSION`. The workaround is contained (2 test files + additive workflow YAML in package workflow only) and migrates cleanly to standard groups (`post-install`, `post-upgrade`, `api-enabled`) during item #2. No touch to existing tests, so no unwinding needed — just a rename pass.

--- a/tests/Acceptance/VersionApiAcceptanceTest.php
+++ b/tests/Acceptance/VersionApiAcceptanceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance;
+
+use OpenEMR\Tests\Acceptance\Support\ArtifactBrowser;
+use OpenEMR\Tests\Acceptance\Support\ResponseHeaders;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Post-install / post-upgrade assertion that `/api/version` returns
+ * the version the operator expected, in the shape external tooling
+ * relies on.
+ *
+ * `/api/version` is on the SkipAuthorizationStrategy allowlist
+ * (`src/RestControllers/Subscriber/AuthorizationListener.php:98`) so
+ * no Bearer token is required, but the endpoint STILL requires the
+ * REST API to be globally enabled — hence the `api-enabled` group
+ * gate so this only runs after `tests/Acceptance/bin/api-enable.php`
+ * has flipped the `rest_api` global.
+ *
+ * Currently `VersionRestController` reads from the `version` DB row
+ * via `VersionService->fetch()`, so this signal overlaps with the
+ * shell-level DB-version assertion in `boot-package.sh` /
+ * `upgrade-package.sh`. Kept independent because:
+ *
+ *   1. `/api/version` is the operator-facing programmatic-version
+ *      discovery endpoint — a routing/serialization regression here
+ *      is a real customer-facing outage even if the DB row is
+ *      correct.
+ *   2. There's a reasonable future path where `/api/version` shifts
+ *      to reading `version.php` at request-time (matching the model
+ *      About page already uses via `SoftwareVersion::fromGlobals()`).
+ *      Independent coverage now means we catch that shift as a
+ *      signal rather than a coverage gap.
+ *
+ * Companion signals (all part of openemr/openemr#13634):
+ *   - **DB version** — shell-asserted in `boot-package.sh` and
+ *     `upgrade-package.sh` (direct mysql query).
+ *   - **File version** — asserted in `VersionDisplayAcceptanceTest`
+ *     (About page render).
+ *
+ * Tagged `version-api` (a dedicated group, not `api-enabled`) for
+ * the same reason `VersionDisplayAcceptanceTest` uses `version-display`
+ * — piggybacking `api-enabled` would leak this into
+ * `acceptance-docker.yml`, which today does not resolve floating
+ * image tags into X.Y.Z at runtime and so can't set
+ * `ACCEPTANCE_EXPECTED_VERSION`. Docker parity is a bounded
+ * follow-up. Runs only after `api-enable.php` has flipped the
+ * `rest_api` global (workflow ordering).
+ */
+#[Group('version-api')]
+final class VersionApiAcceptanceTest extends TestCase
+{
+    public function testVersionEndpointReturnsExpectedVersion(): void
+    {
+        $expected = getenv('ACCEPTANCE_EXPECTED_VERSION');
+        self::assertNotFalse(
+            $expected,
+            'ACCEPTANCE_EXPECTED_VERSION env is unset — the acceptance-package.yml matrix cell must set this so the test knows which version to assert against. Passing an empty string is not a valid override.',
+        );
+        self::assertMatchesRegularExpression(
+            '/^\d+\.\d+\.\d+$/',
+            $expected,
+            "ACCEPTANCE_EXPECTED_VERSION='{$expected}' does not match required X.Y.Z shape",
+        );
+
+        $browser = ArtifactBrowser::create();
+        $browser->request('GET', ArtifactBrowser::baseUrl() . '/api/version');
+        $response = $browser->getResponse();
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            '/api/version must return 200 on an api-enabled install — a 404 means the REST API bootstrap (api-enable.php) did not flip the rest_api global before this test ran, a 500 means VersionRestController itself is broken, and any 3xx means the auth-skip allowlist regressed',
+        );
+
+        // Assert JSON media type BEFORE json_decode — a JSON-shaped
+        // body served with text/html would still parse but signal a
+        // real content-negotiation regression that machine-readable
+        // clients would break on.
+        self::assertStringStartsWith(
+            'application/json',
+            ResponseHeaders::first($response, 'Content-Type'),
+            '/api/version must be served as application/json — a different media type means RestControllerHelper::responseHandler has regressed',
+        );
+
+        $body = json_decode($response->getContent(), true);
+        self::assertIsArray(
+            $body,
+            '/api/version body must be a JSON object — a non-array decode result means the endpoint returned an empty body, a scalar, or malformed JSON',
+        );
+
+        foreach (['v_major', 'v_minor', 'v_patch'] as $key) {
+            self::assertArrayHasKey(
+                $key,
+                $body,
+                "/api/version payload must include '{$key}' — missing key means VersionService->fetch() shape regressed",
+            );
+            self::assertIsInt(
+                $body[$key],
+                "/api/version payload '{$key}' must be an integer — the DB stores these as ints and VersionService casts to int; a non-int here means the response shape or cast regressed",
+            );
+        }
+
+        $actual = "{$body['v_major']}.{$body['v_minor']}.{$body['v_patch']}";
+        self::assertSame(
+            $expected,
+            $actual,
+            "/api/version returned version '{$actual}' does not match expected '{$expected}'. "
+            . 'Currently this endpoint reads the `version` DB row, so a mismatch here means '
+            . 'either sql_upgrade.php did not bump the version row (silent-no-op class, see '
+            . '#13586/#13587 for the shape) OR install-helper.php seeded the wrong row. See '
+            . 'openemr/openemr#13634 for the full signal-source rationale.',
+        );
+    }
+}

--- a/tests/Acceptance/VersionApiAcceptanceTest.php
+++ b/tests/Acceptance/VersionApiAcceptanceTest.php
@@ -62,6 +62,18 @@ use PHPUnit\Framework\TestCase;
 #[Group('version-api')]
 final class VersionApiAcceptanceTest extends TestCase
 {
+    /**
+     * `/apis/default/api/version` — the REST dispatcher strips the
+     * `/apis/default/` prefix before matching routes, so
+     * `AuthorizationListener`'s `/api/version` skip-list entry
+     * matches on the tail. Same shape ApiSmokeTest uses for
+     * `/apis/default/api/facility`. Single constant so every
+     * assertion diagnostic reports the exact URL actually requested
+     * (single source of truth — avoids CI-triage drift where a
+     * failure message names a different endpoint than the test hit).
+     */
+    private const VERSION_ENDPOINT = '/apis/default/api/version';
+
     public function testVersionEndpointReturnsExpectedVersion(): void
     {
         $expected = getenv('ACCEPTANCE_EXPECTED_VERSION');
@@ -75,19 +87,14 @@ final class VersionApiAcceptanceTest extends TestCase
             "ACCEPTANCE_EXPECTED_VERSION='{$expected}' does not match required X.Y.Z shape",
         );
 
-        // URL is `/apis/default/api/version` — the REST dispatcher
-        // strips the `/apis/default/` prefix before matching routes,
-        // so `AuthorizationListener`'s `/api/version` skip-list entry
-        // matches on the tail. Same shape ApiSmokeTest uses for
-        // `/apis/default/api/facility`.
         $browser = ArtifactBrowser::create();
-        $browser->request('GET', ArtifactBrowser::baseUrl() . '/apis/default/api/version');
+        $browser->request('GET', ArtifactBrowser::baseUrl() . self::VERSION_ENDPOINT);
         $response = $browser->getResponse();
 
         self::assertSame(
             200,
             $response->getStatusCode(),
-            '/apis/default/api/version must return 200 on an api-enabled install — a 404 means the REST API bootstrap (api-enable.php) did not flip the rest_api global before this test ran, a 500 means VersionRestController itself is broken, and any 3xx means the auth-skip allowlist regressed',
+            self::VERSION_ENDPOINT . ' must return 200 on an api-enabled install — a 404 means the REST API bootstrap (api-enable.php) did not flip the rest_api global before this test ran, a 500 means VersionRestController itself is broken, and any 3xx means the auth-skip allowlist regressed',
         );
 
         // Assert JSON media type BEFORE json_decode — a JSON-shaped
@@ -97,24 +104,24 @@ final class VersionApiAcceptanceTest extends TestCase
         self::assertStringStartsWith(
             'application/json',
             ResponseHeaders::first($response, 'Content-Type'),
-            '/api/version must be served as application/json — a different media type means RestControllerHelper::responseHandler has regressed',
+            self::VERSION_ENDPOINT . ' must be served as application/json — a different media type means RestControllerHelper::responseHandler has regressed',
         );
 
         $body = json_decode($response->getContent(), true);
         self::assertIsArray(
             $body,
-            '/apis/default/api/version body must be a JSON object — a non-array decode result means the endpoint returned an empty body, a scalar, or malformed JSON',
+            self::VERSION_ENDPOINT . ' body must be a JSON object — a non-array decode result means the endpoint returned an empty body, a scalar, or malformed JSON',
         );
 
         foreach (['v_major', 'v_minor', 'v_patch'] as $key) {
             self::assertArrayHasKey(
                 $key,
                 $body,
-                "/api/version payload must include '{$key}' — missing key means VersionService->fetch() shape regressed",
+                self::VERSION_ENDPOINT . " payload must include '{$key}' — missing key means VersionService->fetch() shape regressed",
             );
             self::assertIsInt(
                 $body[$key],
-                "/api/version payload '{$key}' must be an integer — the DB stores these as ints and VersionService casts to int; a non-int here means the response shape or cast regressed",
+                self::VERSION_ENDPOINT . " payload '{$key}' must be an integer — the DB stores these as ints and VersionService casts to int; a non-int here means the response shape or cast regressed",
             );
         }
 
@@ -122,7 +129,7 @@ final class VersionApiAcceptanceTest extends TestCase
         self::assertSame(
             $expected,
             $actual,
-            "/api/version returned version '{$actual}' does not match expected '{$expected}'. "
+            self::VERSION_ENDPOINT . " returned version '{$actual}' does not match expected '{$expected}'. "
             . 'Currently this endpoint reads the `version` DB row, so a mismatch here means '
             . 'either sql_upgrade.php did not bump the version row (silent-no-op class, see '
             . '#13586/#13587 for the shape) OR install-helper.php seeded the wrong row. See '

--- a/tests/Acceptance/VersionApiAcceptanceTest.php
+++ b/tests/Acceptance/VersionApiAcceptanceTest.php
@@ -75,14 +75,19 @@ final class VersionApiAcceptanceTest extends TestCase
             "ACCEPTANCE_EXPECTED_VERSION='{$expected}' does not match required X.Y.Z shape",
         );
 
+        // URL is `/apis/default/api/version` — the REST dispatcher
+        // strips the `/apis/default/` prefix before matching routes,
+        // so `AuthorizationListener`'s `/api/version` skip-list entry
+        // matches on the tail. Same shape ApiSmokeTest uses for
+        // `/apis/default/api/facility`.
         $browser = ArtifactBrowser::create();
-        $browser->request('GET', ArtifactBrowser::baseUrl() . '/api/version');
+        $browser->request('GET', ArtifactBrowser::baseUrl() . '/apis/default/api/version');
         $response = $browser->getResponse();
 
         self::assertSame(
             200,
             $response->getStatusCode(),
-            '/api/version must return 200 on an api-enabled install — a 404 means the REST API bootstrap (api-enable.php) did not flip the rest_api global before this test ran, a 500 means VersionRestController itself is broken, and any 3xx means the auth-skip allowlist regressed',
+            '/apis/default/api/version must return 200 on an api-enabled install — a 404 means the REST API bootstrap (api-enable.php) did not flip the rest_api global before this test ran, a 500 means VersionRestController itself is broken, and any 3xx means the auth-skip allowlist regressed',
         );
 
         // Assert JSON media type BEFORE json_decode — a JSON-shaped
@@ -98,7 +103,7 @@ final class VersionApiAcceptanceTest extends TestCase
         $body = json_decode($response->getContent(), true);
         self::assertIsArray(
             $body,
-            '/api/version body must be a JSON object — a non-array decode result means the endpoint returned an empty body, a scalar, or malformed JSON',
+            '/apis/default/api/version body must be a JSON object — a non-array decode result means the endpoint returned an empty body, a scalar, or malformed JSON',
         );
 
         foreach (['v_major', 'v_minor', 'v_patch'] as $key) {

--- a/tests/Acceptance/VersionDisplayAcceptanceTest.php
+++ b/tests/Acceptance/VersionDisplayAcceptanceTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance;
+
+use Facebook\WebDriver\WebDriverBy;
+use OpenEMR\Tests\Acceptance\Support\BrowserSession;
+use OpenEMR\Tests\Acceptance\Support\PantherAcceptanceTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Post-install / post-upgrade UI assertion that the About page reports
+ * the version the operator expected.
+ *
+ * Covers the "file version" pipe end-to-end: `version.php` in the
+ * artifact → `require_once` at `interface/globals.php:408` →
+ * `OEGlobalsBag::set('v_major', ...)` → `VersionService->getSoftwareVersion()`
+ * → `SoftwareVersion::fromGlobals()` → `about_page.php`'s
+ * `versionNumber` Twig variable → `templates/core/about.html.twig`'s
+ * `.version-info strong` render. Any regression along that chain
+ * surfaces here as a mismatch against `ACCEPTANCE_EXPECTED_VERSION`.
+ *
+ * Companion signals (all part of openemr/openemr#13634):
+ *   - **DB version** — asserted at shell level in
+ *     `tests/Acceptance/bin/boot-package.sh` and
+ *     `tests/Acceptance/bin/upgrade-package.sh` (query the `version`
+ *     table directly via `docker compose exec mysql`).
+ *   - **API version** — asserted in `VersionApiAcceptanceTest`
+ *     (tagged `api-enabled`) against `/api/version`.
+ *
+ * Each signal reads a different code path (file / DB / route), so a
+ * future refactor that consolidates any two of them (e.g., /api/version
+ * shifting from DB-read to file-read to match About page) doesn't
+ * leave a coverage gap.
+ *
+ * Tagged with its OWN group `version-display` (not `fresh-install` /
+ * `post-upgrade` / etc.) so `.github/workflows/acceptance-package.yml`
+ * fires it via explicit `--group=version-display` steps at points
+ * where `ACCEPTANCE_EXPECTED_VERSION` is definitively set. Piggy-
+ * backing the existing scenario groups would leak this test into
+ * `acceptance-docker.yml`, which today does not resolve floating
+ * image tags (e.g., `latest`, `next`) into X.Y.Z at runtime — so
+ * `ACCEPTANCE_EXPECTED_VERSION` couldn't be set there without
+ * additional Docker-Hub tag-resolution plumbing. Docker parity is a
+ * bounded follow-up.
+ */
+#[Group('version-display')]
+final class VersionDisplayAcceptanceTest extends PantherAcceptanceTestCase
+{
+    private const ABOUT_URL = '/interface/main/about_page.php';
+
+    /**
+     * Login as admin, GET the About page directly, assert the version
+     * displayed in `.version-info strong` matches
+     * `ACCEPTANCE_EXPECTED_VERSION`.
+     *
+     * Direct navigation (not via the user-menu "About OpenEMR" click)
+     * because the goal is to validate the version-render pipe, not the
+     * menu wiring — the menu wiring is already covered by
+     * `GgUserMenuLinksAcceptanceTest::testUserMenuLink` for the
+     * 'About OpenEMR user menu link' data-provider row.
+     */
+    public function testAboutPageShowsExpectedVersion(): void
+    {
+        $expected = getenv('ACCEPTANCE_EXPECTED_VERSION');
+        self::assertNotFalse(
+            $expected,
+            'ACCEPTANCE_EXPECTED_VERSION env is unset — the acceptance-package.yml matrix cell must set this so the test knows which version to assert against. Passing an empty string is not a valid override.',
+        );
+        self::assertMatchesRegularExpression(
+            '/^\d+\.\d+\.\d+$/',
+            $expected,
+            "ACCEPTANCE_EXPECTED_VERSION='{$expected}' does not match required X.Y.Z shape",
+        );
+
+        $this->client = BrowserSession::create();
+        $this->performLoginAsAdmin();
+
+        $client = $this->requireClient();
+        $client->request('GET', self::ABOUT_URL);
+
+        // `.version-info strong` is the exact element templates/core/
+        // about.html.twig line 14 renders `versionNumber|text` into.
+        // If the selector ever moves, this test breaks loudly with the
+        // observed page title + URL in the assertion diagnostic —
+        // better signal than a silent version-check bypass.
+        $element = $client->findElement(WebDriverBy::cssSelector('.version-info strong'));
+        $actual = trim($element->getText());
+
+        self::assertSame(
+            $expected,
+            $actual,
+            "About page displayed version '{$actual}' does not match expected '{$expected}'. "
+            . 'Landing URL: ' . $client->getCurrentURL() . '. '
+            . 'Title: ' . $client->getTitle() . '. '
+            . 'This most likely means the artifact ships a version.php that does not match '
+            . 'the workflow-declared TO_VERSION (dev-cycle bump missed, backport went to '
+            . 'the wrong branch, tarball built from the wrong ref). See '
+            . 'openemr/openemr#13634 for the full signal-source rationale.',
+        );
+    }
+}

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -285,6 +285,27 @@ for attempt in $(seq 1 60); do
     sleep 5
 done
 
+# Post-install DB version assertion (openemr/openemr#13634).
+# install-helper.php ran install-time SQL population; the `version` row
+# should now match the tarball's shipped version. Catches the class of
+# bug where install "succeeded" (helper exited 0) but the version row
+# wasn't seeded correctly. Same signal /api/version reads later, but
+# available immediately without needing the REST API bootstrap.
+#
+# Root creds `root/root` are the acceptance stack default
+# (`.github/docker/acceptance-package-compose.yml:MYSQL_ROOT_PASSWORD`).
+# `-sN` = silent + no column headers; direct scalar output.
+echo "==> Asserting DB version matches ${VERSION}"
+DB_VERSION="$(docker compose exec -T mysql \
+    mysql -uroot -proot openemr -sN \
+    -e "SELECT CONCAT(v_major,'.',v_minor,'.',v_patch) FROM version" \
+    2>/dev/null || echo "query-failed")"
+if [[ "${DB_VERSION}" != "${VERSION}" ]]; then
+    echo "::error::post-install DB version '${DB_VERSION}' does not match expected '${VERSION}' (see openemr/openemr#13634)" >&2
+    exit 1
+fi
+echo "    DB version=${DB_VERSION}"
+
 echo ""
 echo "==> Boot complete."
 echo "    Artifact URL:  http://localhost:8680"

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -295,9 +295,11 @@ done
 # Root creds `root/root` are the acceptance stack default
 # (`.github/docker/acceptance-package-compose.yml:MYSQL_ROOT_PASSWORD`).
 # `-sN` = silent + no column headers; direct scalar output.
+# `mariadb` (not `mysql`) — the mariadb 11.8 image ships only the
+# `mariadb` client binary; `mysql` is not on $PATH.
 echo "==> Asserting DB version matches ${VERSION}"
 DB_VERSION="$(docker compose exec -T mysql \
-    mysql -uroot -proot openemr -sN \
+    mariadb -uroot -proot openemr -sN \
     -e "SELECT CONCAT(v_major,'.',v_minor,'.',v_patch) FROM version" \
     2>/dev/null || echo "query-failed")"
 if [[ "${DB_VERSION}" != "${VERSION}" ]]; then

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -313,9 +313,11 @@ done
 # upgrade replayed from 2.9.0 on every run). Skipped in
 # --skip-sql-upgrade mode: that path exits before this point (line
 # ~281) because the Panther wizard test runs the upgrade later.
+# `mariadb` (not `mysql`) — the mariadb 11.8 image ships only the
+# `mariadb` client binary; `mysql` is not on $PATH.
 echo "==> Asserting DB version matches ${TO_VERSION}"
 DB_VERSION="$(docker compose exec -T mysql \
-    mysql -uroot -proot openemr -sN \
+    mariadb -uroot -proot openemr -sN \
     -e "SELECT CONCAT(v_major,'.',v_minor,'.',v_patch) FROM version" \
     2>/dev/null || echo "query-failed")"
 if [[ "${DB_VERSION}" != "${TO_VERSION}" ]]; then

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -305,6 +305,25 @@ for attempt in $(seq 1 60); do
     sleep 5
 done
 
+# Post-upgrade DB version assertion (openemr/openemr#13634).
+# sql_upgrade.php bumps the `version` row as its final step, so a
+# successful upgrade leaves DB=TO_VERSION. Catches the exact bug
+# class fixed in #13586/#13587 (fsupgrade sed pattern targeted a
+# refactored-away line → silent no-op → version row never advanced,
+# upgrade replayed from 2.9.0 on every run). Skipped in
+# --skip-sql-upgrade mode: that path exits before this point (line
+# ~281) because the Panther wizard test runs the upgrade later.
+echo "==> Asserting DB version matches ${TO_VERSION}"
+DB_VERSION="$(docker compose exec -T mysql \
+    mysql -uroot -proot openemr -sN \
+    -e "SELECT CONCAT(v_major,'.',v_minor,'.',v_patch) FROM version" \
+    2>/dev/null || echo "query-failed")"
+if [[ "${DB_VERSION}" != "${TO_VERSION}" ]]; then
+    echo "::error::post-upgrade DB version '${DB_VERSION}' does not match expected '${TO_VERSION}' (see openemr/openemr#13634)" >&2
+    exit 1
+fi
+echo "    DB version=${DB_VERSION}"
+
 echo ""
 echo "==> Upgrade complete: ${FROM_VERSION} → ${TO_VERSION}"
 echo "    Artifact URL:  http://localhost:8680  (now serving ${TO_VERSION})"


### PR DESCRIPTION
Closes #13634.

## Summary

Three independent version-check signals wired into the `acceptance-package.yml` matrix for both fresh-install and upgrade paths.

| Signal | Where | Reads | Fires |
|---|---|---|---|
| **DB version** | `boot-package.sh`, `upgrade-package.sh` (shell) | `version` DB row via `docker compose exec mysql` | Post-install of TO_VERSION, post-install of FROM_VERSION in upgrade scenario, post-upgrade to TO_VERSION |
| **File version** | `VersionDisplayAcceptanceTest` (Panther) | About page render — `version.php` → globals → Twig | fresh-install, wizard-install, upgrade (both pre + post), wizard-upgrade |
| **API version** | `VersionApiAcceptanceTest` (Panther) | `/api/version` endpoint | fresh-install (post api-enable), upgrade (post api-enable — new workflow step) |

Neither signal alone is sufficient — sql-only would miss `version.php` drift; file-only would miss silent sql_upgrade no-ops (the fsupgrade sed bug shape fixed in #13586/#13587). API test kept independent because `/api/version` is the operator-facing programmatic discovery endpoint and may plausibly shift to file-version reads in the future (matching what the About page already does).

## Dedicated group naming

Tests use `#[Group('version-display')]` and `#[Group('version-api')]` — deliberately NOT piggybacking existing `fresh-install` / `api-enabled` groups. Piggybacking would leak the tests into `acceptance-docker.yml`, which today uses floating image tags (`latest`, `next`, etc.) and doesn't resolve them into X.Y.Z at runtime, so it couldn't set `ACCEPTANCE_EXPECTED_VERSION`. Package workflow calls `--group=version-display` / `--group=version-api` at explicit points where the expected version is known. Docker parity is a bounded follow-up (needs Docker Hub tag-resolution plumbing).

## Test plan

- [ ] CI: `acceptance-package.yml` matrix all-green on this PR
- [ ] Version-display check fires in all 4 scenarios (fresh-install, wizard-install, upgrade, wizard-upgrade)
- [ ] Version-api check fires in fresh-install + upgrade scenarios
- [ ] Upgrade scenario's pre-upgrade version-display step asserts FROM_VERSION; post-upgrade asserts TO_VERSION
- [ ] Existing acceptance-docker.yml runs unchanged (dedicated groups isolate the new tests)

## Follow-up

- Acceptance-docker.yml parity (needs tag→version resolution — separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)