### PR TITLE
fix(ci): pin pcov.directory so web request coverage is collected

### DIFF
--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -347,6 +347,15 @@ setup_e2e_bookends() {
     local prepend_ini_file="${RUNNER_TEMP:-/tmp}/php_prepend.ini"
     {
         echo "auto_prepend_file=${OPENEMR_DIR}/${prepend_file}"
+        # pcov only records files below pcov.directory, which defaults to the
+        # process working directory. CLI PHPUnit runs from the OpenEMR tree and
+        # resolves it correctly, but the web SAPI starts in the image WORKDIR,
+        # so web request coverage silently comes back empty. The flex image
+        # pins this in docker/flex/pcov.sh; dev-php-fpm bakes in pcov without
+        # it, and the image cannot know the path anyway since it differs per
+        # webserver. pcov.directory is PHP_INI_SYSTEM, so ci/auto_prepend.php
+        # cannot set it. Harmless when pcov is not the driver.
+        echo "pcov.directory=${OPENEMR_DIR}"
     } > "${prepend_ini_file}"
     dc cp "${prepend_ini_file}" "openemr:${php_scan_dir}/php_prepend.ini"
 
@@ -359,6 +368,19 @@ setup_e2e_bookends() {
 
     echo "Verifying auto prepend configuration via web server (${webserver} at ${webserver_host})…"
     _exec sh -c "curl -fsSL http://${webserver_host}/ci/phpinfo.php | grep -E auto_prepend_file"
+
+    # A pcov.directory that does not cover the OpenEMR tree collects nothing,
+    # and that only surfaces much later as a missing raw coverage directory.
+    # Assert it here, against the SAPI that actually serves the tests.
+    # shellcheck disable=SC2310  # Intentionally checking exit code in condition
+    if _exec php -r 'exit(function_exists("pcov\\start") ? 0 : 1);'; then
+        echo 'Verifying pcov.directory covers the OpenEMR tree…'
+        if ! _exec sh -c "curl -fsSL http://${webserver_host}/ci/phpinfo.php | grep -E 'pcov.directory.*${OPENEMR_DIR}'"; then
+            echo "Error: pcov is the coverage driver but pcov.directory does not cover ${OPENEMR_DIR}"
+            echo 'Web request coverage would be empty. Check php_prepend.ini.'
+            return 1
+        fi
+    fi
 
     sleep 1  # Give filesystem time to flush
 

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -375,7 +375,17 @@ setup_e2e_bookends() {
     # shellcheck disable=SC2310  # Intentionally checking exit code in condition
     if _exec php -r 'exit(function_exists("pcov\\start") ? 0 : 1);'; then
         echo 'Verifying pcov.directory covers the OpenEMR tree…'
-        if ! _exec sh -c "curl -fsSL http://${webserver_host}/ci/phpinfo.php | grep -E 'pcov.directory.*${OPENEMR_DIR}'"; then
+        # Capture the response before matching it. Piping curl into grep inside
+        # `_exec sh -c` would report only grep's status, because that nested
+        # shell does not inherit pipefail: a failed request would then be
+        # misreported as a bad pcov.directory, or a truncated one could match
+        # and pass.
+        local phpinfo
+        if ! phpinfo=$(_exec sh -c "curl -fsSL http://${webserver_host}/ci/phpinfo.php"); then
+            echo "Error: could not fetch /ci/phpinfo.php from ${webserver_host}"
+            return 1
+        fi
+        if ! grep -qE "pcov.directory.*${OPENEMR_DIR}" <<< "${phpinfo}"; then
             echo "Error: pcov is the coverage driver but pcov.directory does not cover ${OPENEMR_DIR}"
             echo 'Web request coverage would be empty. Check php_prepend.ini.'
             return 1


### PR DESCRIPTION
Since #13085 baked pcov into the `dev-php-fpm` images, `configure_coverage` selects pcov instead of falling through to installing xdebug. That is the right call — pcov is much faster — but it exposes a gap in `setup_e2e_bookends`.

pcov only records files below `pcov.directory`, which defaults to the process working directory. CLI PHPUnit runs from the OpenEMR tree and resolves it correctly, which is why unit and API test coverage look fine. The web SAPI starts in the image `WORKDIR` instead, so coverage collected through `ci/auto_prepend.php` comes back empty, no raw files are written, and `convert_coverage` then fails:

```
[ERROR] Input directory does not exist: /tmp/openemr-coverage/api
```

`docker/flex/pcov.sh` already pins `pcov.directory` to the OpenEMR root, which is why the apache coverage configs (`apache_83_118`, `apache_85_118`) are unaffected — the image sets what the CI library does not. The `dev-php-fpm` images bake pcov in without it, and the image cannot reasonably know the right path anyway, since it differs per webserver (`ci/parse_docker_dir.sh` maps apache to `/var/www/localhost/htdocs/openemr` and nginx to `/usr/share/nginx/html/openemr`). So the CI library is the right place to set it.

## Changes

- Write `pcov.directory=${OPENEMR_DIR}` into the ini that already carries `auto_prepend_file`. That ini is the only place it can go: `pcov.directory` is `PHP_INI_SYSTEM`, so `ci/auto_prepend.php` cannot set it at runtime.
- Assert it through the existing phpinfo request, so a mismatch fails at setup with a clear message instead of surfacing much later as a missing coverage directory.

No behavior change for the apache configs, where the value already matches.

## Verification

This does not reproduce on `master` today, because coverage is enabled only on apache configs and flex already sets the directory. It reproduces immediately with coverage enabled on any nginx config.

Verified on a downstream fork that does exactly that: the `nginx` + `dev-php-fpm:8.5` config failed `Convert API coverage to Clover XML` on every run, and passes with this change. The job log confirms the fix works through the web SAPI rather than just the CLI:

```
Coverage driver: pcov
+ echo pcov.directory=/usr/share/nginx/html/openemr
Verifying pcov.directory covers the OpenEMR tree…
<tr><td class="e">pcov.directory </td><td class="v">/usr/share/nginx/html/openemr </td></tr>
```

Coverage then converted and uploaded normally. On this PR the new assertion runs against `apache_83_118`, which confirms it does not false-positive on the currently covered config.