### PR TITLE
fix(testing): populate NULL form_encounter.date in shared encounter fixture

### DIFF
--- a/tests/Tests/Fixtures/encounters.php
+++ b/tests/Tests/Fixtures/encounters.php
@@ -38,6 +38,7 @@ return [
     ],
     'uuid' => 'uuid(\'form_encounter\')',
     'encounter' => 'generateId()',
+    'date' => '2024-01-01 08:00:00',
     'sensitivity' => 'normal',
     'reason' => 'test-fixture-Complains of nausea, loose stools and weakness.',
     'last_level_billed' => 0,


### PR DESCRIPTION
#### Short description of what this changes or resolves:

  Fixes #13547. The shared test fixture in `tests/Tests/Fixtures/encounters.php` never set a `date` key, so every encounter created by `EncounterFixtureManager` was inserted with`form_encounter.date = NULL`. Since the column is indexed (`KEY encounter_date (date)`), any test that filters or sorts fixture encounters by date silently matched zero rows instead of failing loudly, and code reading the column into a `string`-typed parameter hit a `TypeError`.

  #### Changes proposed in this pull request:

  - Add a fixed literal `date` value (`2024-01-01 08:00:00`) to the fixture row in `tests/Tests/Fixtures/encounters.php`, following the existing convention used by other fixtures (`contact-addresses.php`, `procedure-orders.php`) — a literal keeps the fixture deterministic rather than using wall-clock `date()`.
  - Verified no regression: ran the `services-test` suite (covers `EncounterServiceTest`, the direct consumer of this fixture) both with and without the fix,  identical result both times, 740 tests / 3444 assertions / 0 failures.
  - Manually confirmed via a throwaway script installing the fixture and querying `form_encounter` directly: `date` now returns `2024-01-01 08:00:00` instead of `NULL`.

  #### Was an AI assistant used? Yes