### PR TITLE
fix(pdf): stop Bootstrap print styles from exploding PDF reports into blank pages

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -2672,11 +2672,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$config of class Mpdf\\\\Mpdf constructor expects array\\<mixed\\>, mixed given\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$date of function fixDate expects string\\|null, mixed given\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/billing/sl_eob_search.php',
@@ -3627,11 +3622,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/LBF/new.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$config of class Mpdf\\\\Mpdf constructor expects array\\<mixed\\>, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/LBF/printable.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$constant of function xl_layout_label expects string, mixed given\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/forms/LBF/printable.php',
@@ -4222,11 +4212,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/taskman_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$config of class Mpdf\\\\Mpdf constructor expects array\\<mixed\\>, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/taskman_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$datetime of class DateTime constructor expects string, mixed given\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/taskman_functions.php',
@@ -4373,11 +4358,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$PMSFH of function show_PMSFH_panel expects array, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/save.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$config of class Mpdf\\\\Mpdf constructor expects array\\<mixed\\>, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/save.php',
 ];
@@ -14742,11 +14722,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/patient_file/reminder/patient_reminders.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$config of class Mpdf\\\\Mpdf constructor expects array\\<mixed\\>, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$constant of function xl_form_title expects string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
@@ -15360,11 +15335,6 @@ $ignoreErrors[] = [
     'message' => '#^Parameter \\#2 \\$value of static method OpenEMR\\\\Common\\\\Acl\\\\AclMain\\:\\:aclCheckCore\\(\\) expects string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics_full.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$config of class Mpdf\\\\Mpdf constructor expects array\\<mixed\\>, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/summary/demographics_print.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$constant of function xl_layout_label expects string, mixed given\\.$#',
@@ -26425,11 +26395,6 @@ $ignoreErrors[] = [
     'message' => '#^Parameter \\#6 \\$year of function mktime expects int\\|null, string given\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../portal/report/pat_ledger.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$config of class Mpdf\\\\Mpdf constructor expects array\\<mixed\\>, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/report/portal_custom_report.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$constant of function xl_form_title expects string, mixed given\\.$#',
@@ -59015,11 +58980,6 @@ $ignoreErrors[] = [
     'message' => '#^Parameter \\#3 \\$length of function substr expects int\\|null, int\\<0, max\\>\\|false given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/PaymentProcessing/Sphere/SphereRevert.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$config of class Mpdf\\\\Mpdf constructor expects array\\<mixed\\>, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Pdf/PatientPortalPDFDocumentCreator.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$html of method HTMLPurifier\\:\\:purify\\(\\) expects string, mixed given\\.$#',

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -20837,11 +20837,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/PaymentProcessing/PaymentProcessing.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Pdf\\\\Config_Mpdf\\:\\:getConfigMpdf\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Pdf/Config_Mpdf.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Pdf\\\\PatientPortalPDFDocumentCreator\\:\\:createPdfObject\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Pdf/PatientPortalPDFDocumentCreator.php',

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -4222,26 +4222,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/LBF/printable.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'margin_bottom\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/LBF/printable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'margin_footer\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/LBF/printable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'margin_header\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/LBF/printable.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'margin_top\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/LBF/printable.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'pid\' on array\\<mixed\\>\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/LBF/printable.php',
@@ -20594,26 +20574,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'form_name\' on mixed\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'margin_bottom\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'margin_footer\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'margin_header\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'margin_top\' on mixed\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/report/custom_report.php',
 ];
 $ignoreErrors[] = [

--- a/interface/themes/style_pdf.scss
+++ b/interface/themes/style_pdf.scss
@@ -1,3 +1,4 @@
+$enable-print-styles: false;
 $compact-theme: false;
 @import "../../public/assets/bootstrap/scss/bootstrap";
 

--- a/src/Pdf/Config_Mpdf.php
+++ b/src/Pdf/Config_Mpdf.php
@@ -17,6 +17,9 @@ use OpenEMR\Services\Storage\CacheDirectory;
 
 class Config_Mpdf
 {
+    /**
+     * @return array<string, mixed>
+     */
     public static function getConfigMpdf()
     {
         return [

--- a/src/Pdf/Config_Mpdf.php
+++ b/src/Pdf/Config_Mpdf.php
@@ -36,6 +36,7 @@ class Config_Mpdf
             'use_kwt' => true,
             'autoScriptToLang' => true,
             'keep_table_proportions' => true,
+            'CSSselectMedia' => 'screen',
         ];
     }
 }

--- a/tests/Tests/Isolated/Pdf/PdfPrintMediaCssTest.php
+++ b/tests/Tests/Isolated/Pdf/PdfPrintMediaCssTest.php
@@ -53,8 +53,12 @@ class PdfPrintMediaCssTest extends TestCase
         'pdf_layout' => 'P',
     ];
 
+    /** @var array<string, mixed> */
+    private array $originalPdfGlobals = [];
+
     protected function setUp(): void
     {
+        $this->originalPdfGlobals = array_intersect_key($GLOBALS, self::PDF_GLOBALS);
         foreach (self::PDF_GLOBALS as $key => $value) {
             $GLOBALS[$key] = $value;
         }
@@ -64,6 +68,9 @@ class PdfPrintMediaCssTest extends TestCase
     {
         foreach (array_keys(self::PDF_GLOBALS) as $key) {
             unset($GLOBALS[$key]);
+        }
+        foreach ($this->originalPdfGlobals as $key => $value) {
+            $GLOBALS[$key] = $value;
         }
     }
 

--- a/tests/Tests/Isolated/Pdf/PdfPrintMediaCssTest.php
+++ b/tests/Tests/Isolated/Pdf/PdfPrintMediaCssTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * Bootstrap 4's @media print block (page-break-inside: avoid on tr/img,
+ * min-width: 992px !important on body, @page { size: a3 }) causes mPDF,
+ * which identifies as print media by default, to emit one mostly-blank
+ * page per block element - a 1-2 page patient report ballooned into
+ * 2,219 blank pages (see mpdf/mpdf#1266).
+ *
+ * Config_Mpdf sets CSSselectMedia => 'screen' so mPDF skips @media print
+ * blocks in any stylesheet it is handed. These tests lock in the mPDF
+ * behavior, the Config_Mpdf configuration, and the rationale.
+ *
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Pdf;
+
+use Mpdf\Mpdf;
+use OpenEMR\Pdf\Config_Mpdf;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('isolated')]
+class PdfPrintMediaCssTest extends TestCase
+{
+    /**
+     * The minimal rule set bisected out of the compiled style_pdf.css
+     * (Bootstrap 4.6 _print.scss) that reproduces the blank-page explosion.
+     */
+    private const GUILTY_CSS = '@media print{blockquote,img,pre,tr{page-break-inside:avoid}'
+        . '@page{size:a3}.container,body{min-width:992px!important}}';
+
+    /**
+     * Globals that Config_Mpdf::getConfigMpdf() reads through OEGlobalsBag,
+     * which sources the singleton's values directly from $GLOBALS.
+     */
+    private const PDF_GLOBALS = [
+        'pdf_language' => 'en',
+        'pdf_size' => 'LETTER',
+        'pdf_font_size' => '10',
+        'pdf_left_margin' => '5',
+        'pdf_right_margin' => '5',
+        'pdf_top_margin' => '5',
+        'pdf_bottom_margin' => '8',
+        'pdf_layout' => 'P',
+    ];
+
+    protected function setUp(): void
+    {
+        foreach (self::PDF_GLOBALS as $key => $value) {
+            $GLOBALS[$key] = $value;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (array_keys(self::PDF_GLOBALS) as $key) {
+            unset($GLOBALS[$key]);
+        }
+    }
+
+    public function testScreenMediaRendersCompactly(): void
+    {
+        $this->assertLessThan(
+            10,
+            $this->renderPages(['CSSselectMedia' => 'screen']),
+            'With CSSselectMedia=screen, the Bootstrap print block must be ignored'
+        );
+    }
+
+    public function testDefaultPrintMediaStillExplodesDocumentingWhyTheOverrideExists(): void
+    {
+        // If mPDF ever fixes mpdf/mpdf#1266 this will start failing, which
+        // is the signal that CSSselectMedia (and this test) can be
+        // reevaluated.
+        $this->assertGreaterThan(
+            50,
+            $this->renderPages([]),
+            'mPDF default (print media) is expected to explode on the Bootstrap print block'
+        );
+    }
+
+    public function testConfigMpdfSelectsScreenMedia(): void
+    {
+        $this->assertSame('screen', Config_Mpdf::getConfigMpdf()['CSSselectMedia']);
+    }
+
+    private function fixtureHtml(): string
+    {
+        $rows = '';
+        for ($i = 0; $i < 300; $i++) {
+            $rows .= "<tr><td>label $i</td><td>value $i</td></tr>";
+        }
+
+        return '<style>' . self::GUILTY_CSS . '</style>'
+            . '<table>' . $rows . '</table>';
+    }
+
+    /**
+     * @param array<string, mixed> $configOverride
+     */
+    private function renderPages(array $configOverride): int
+    {
+        $pdf = new Mpdf(array_merge([
+            'tempDir' => sys_get_temp_dir(),
+            'format' => 'LETTER',
+        ], $configOverride));
+        $pdf->WriteHTML($this->fixtureHtml());
+
+        $pages = $pdf->page;
+        if (!is_int($pages)) {
+            self::fail('mPDF page count is not an int: ' . get_debug_type($pages));
+        }
+        return $pages;
+    }
+}


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes the blank multi-page PDF patient reports described in [community thread: Blank PDF report generated from Demo site and production site 8.3.0](https://community.open-emr.org/t/blank-pdf-report-generated-from-demo-site-and-production-site-8-3-0/26990) — a 1–2 page report rendering as hundreds of blank pages.

**Root cause:** `style_pdf.scss` imports all of Bootstrap 4.6, whose `@media print` block reaches mPDF — and mPDF identifies as print media by default and applies it. Bisecting the compiled stylesheet against a captured report isolated the block: `page-break-inside: avoid` on `tr`/`img`, `min-width: 992px !important` on `body`, and `@page { size: a3 }` make nearly every table row unsplittable and wider than the writable page, so mPDF punts each element to its own mostly-blank page. A 27KB report rendered as **2,219 blank pages**; with the fix, the identical HTML renders as **5**. Prior art: mpdf/mpdf#1266 (open since 2020, minimal repro is a Bootstrap `<link>` plus one word).

**Why it evaded reproduction:** `custom_report.php`'s `getContent()` rewrites `src=` attributes to filesystem paths but not stylesheet `href`s, so mPDF fetches `style_pdf.css` over HTTP(S) at render time. Installs with valid certs (demo farm, reporters' production servers) fetched successfully and exploded; typical dev sandboxes on localhost/self-signed certs silently failed the fetch, got no CSS, and rendered "correctly." Verified end-to-end on the 8.3.0 demo farm: same patient, same select-all report, 2,219 pages → 5 after the `Config_Mpdf` change alone.

#### Changes proposed in this pull request:

- `interface/themes/style_pdf.scss`: set `$enable-print-styles: false;` before the Bootstrap import — this stylesheet is consumed only by mPDF (the `pdf-style` asset), never by a browser, so Bootstrap's print block has no purpose in it. (`rtl_style_pdf.css` is hand-maintained without Bootstrap and was never affected.)
- `src/Pdf/Config_Mpdf.php`: add `'CSSselectMedia' => 'screen'` so mPDF skips `@media print` blocks in any stylesheet it is handed — defense in depth covering already-built assets, every mPDF consumer in the tree, and future dependencies. Also adds a `@return array<string, mixed>` docblock (PHPStan previously inferred `mixed` for all callers).
- `tests/Tests/Isolated/Pdf/PdfPrintMediaCssTest.php`: regression triangle — mPDF with `CSSselectMedia => 'screen'` renders the bisected guilty rule set compactly (<10 pages); mPDF defaults still explode on it (>50 pages, documenting why the override exists and self-signaling if mpdf/mpdf#1266 is ever fixed upstream); and `Config_Mpdf::getConfigMpdf()` requests `'screen'`.

**Backport note:** the `Config_Mpdf.php` change alone is a complete fix requiring no asset rebuild — a clean single-file cherry-pick to `rel-830` for a patch release, and a one-line manual hot-fix for affected 8.3.0 production sites in the meantime.

Follow-ups filed separately (not in this PR): extend `getContent()` to resolve/inline stylesheet `href`s from the filesystem so PDF generation stops depending on TLS reachability, and add a post-`writeHTML` sanity log (`preg_last_error()` + page count vs. content length) so the next silent mPDF pathology is diagnosable from the first report.

#### Was an AI assistant used? Yes
