### PR TITLE
fix(faxsms): populate Clickatell credentials in constructor

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/ClickatellSMSClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/ClickatellSMSClient.php
@@ -20,6 +20,7 @@ class ClickatellSMSClient extends AppDispatch implements SmsChannelInterface
         if (empty(OEGlobalsBag::getInstance()->get('oefax_enable_sms') ?? null)) {
             throw new \RuntimeException(xlt("Access denied! Module not enabled"));
         }
+        $this->credentials = $this->getCredentials();
         parent::__construct();
     }
 

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/ClickatellSMSClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/ClickatellSMSClient.php
@@ -29,12 +29,6 @@ class ClickatellSMSClient extends AppDispatch implements SmsChannelInterface
      */
     public function sendSMS($toPhone = '', string $subject = '', string $message = '', string $from = ''): string
     {
-        // If this is made as an API call we need to check authorization.
-        $authErrorMsg = $this->authenticate(); // currently default is only admin can send SMS. check with author!
-        if ($authErrorMsg !== 1) {
-            return text(js_escape($authErrorMsg));
-        }
-
         // If this is invoked from the UI via AppDispatch::dispatchAction(), the
         // values won't be parameters, but instead will come from the request.
         $toPhone = $toPhone ?: $this->getRequest('phone');


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:

Clickatell SMS was not working because credentials were no longer populated in the base class constructor.  That logic was commented out in #8603, and then removed in #8657.  

#### Changes proposed in this pull request:

Other subclasses populate the credentials in their own constructor, so this updates Clickatell to do the same.  (E.g. Twilio: https://github.com/openemr/openemr/blob/82cbb89b0e548a31c20ae03bf4259037f154072d/interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php#L51)

#### Was an AI assistant used? Yes / No

No

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
