### PR TITLE
ci(docker): add alpine 3.24 flex build workflow

### DIFF
--- a/.github/workflows/docker-build-324.yml
+++ b/.github/workflows/docker-build-324.yml
@@ -1,0 +1,34 @@
+name: Flex 3.24 Dockers Build
+
+# This workflow builds the OpenEMR Flex Docker images with Alpine 3.24 and PHP versions 8.3, 8.4, and 8.5.
+# And in this configuration will create following dockers (and tags):
+#    PHP 8.3: openemr/openemr:flex-3.24-php-8.3
+#    PHP 8.4: openemr/openemr:flex-3.24-php-8.4
+#    PHP 8.5: openemr/openemr:flex-3.24-php-8.5, openemr/openemr:flex-3.24
+# (The bare openemr/openemr:flex tag is published by docker-build-323.yml, which is the
+#  default flex image; this 3.24 build sets is_default_flex: false in the workflow_call.
+#  A follow-up PR will flip 3.24 to be the default flex image.)
+#
+# php_versions is a JSON array of PHP versions to build.
+#
+# The php_default will determine the default PHP version (ie. above tag without a php version).
+#
+# The is_default_flex environment variable is used to determine if this is the default flex image.
+#
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: '0 2 * * *'   # run at 2 AM UTC
+
+jobs:
+  build:
+    uses: ./.github/workflows/docker-build-flex-core.yml
+    with:
+      is_default_flex: false
+      alpine_version: "3.24"
+      php_versions: '["8.3", "8.4", "8.5"]'
+      php_default: "8.5"
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/docker-build-324.yml\` — a copy of \`docker-build-323.yml\`'s shape, bumped to Alpine 3.24. Daily-scheduled + workflow_dispatch build that publishes:

- \`openemr/openemr:flex-3.24-php-8.3\`
- \`openemr/openemr:flex-3.24-php-8.4\`
- \`openemr/openemr:flex-3.24-php-8.5\`
- \`openemr/openemr:flex-3.24\` (the php-8.5 image, per \`php_default\`)

Verified Alpine 3.24 package repos carry the same PHP set (8.3/8.4/8.5) as 3.23.

\`is_default_flex: false\` — the bare \`openemr/openemr:flex\` tag continues to be published from \`docker-build-323.yml\` for now. A follow-up PR will flip the default over to 3.24 once the 3.24 images are live on Docker Hub.

## Test plan

- [ ] CI green
- [ ] Post-merge: nightly scheduled tick (or manual dispatch) publishes the four 3.24 tags to Docker Hub
- [ ] Follow-up PR: promote 3.24 to \`is_default_flex: true\` + flip 3.23 to false

🤖 Generated with [Claude Code](https://claude.com/claude-code)