### PR TITLE
ci(docker): add alpine 3.24 flex test workflow

### DIFF
--- a/.github/workflows/docker-test-flex-324.yml
+++ b/.github/workflows/docker-test-flex-324.yml
@@ -1,7 +1,7 @@
 # This will run the OpenEMR flex dockers with Alpine 3.24 version. It will test the flex docker images in both
 #  development (ie. dev) mode (codebase used from a shared volume) and production (ie. prod) mode (codebase collected via git).
 #  - is_production_docker is required and needs to be false.
-#  - alpine_versions is set to 3.24
+#  - alpine_version is set to 3.24
 #  - php_versions are set to 8.3, 8.4 and 8.5
 #  - flex_timing is set to true to emit TIMING markers in openemr.sh (openemr-devops#797).
 #  - note not using the coverage settings (is_flex_coverage_docker, flex_coverage_php_version) in this workflow. see

--- a/.github/workflows/docker-test-flex-324.yml
+++ b/.github/workflows/docker-test-flex-324.yml
@@ -1,0 +1,39 @@
+# This will run the OpenEMR flex dockers with Alpine 3.24 version. It will test the flex docker images in both
+#  development (ie. dev) mode (codebase used from a shared volume) and production (ie. prod) mode (codebase collected via git).
+#  - is_production_docker is required and needs to be false.
+#  - alpine_versions is set to 3.24
+#  - php_versions are set to 8.3, 8.4 and 8.5
+#  - flex_timing is set to true to emit TIMING markers in openemr.sh (openemr-devops#797).
+#  - note not using the coverage settings (is_flex_coverage_docker, flex_coverage_php_version) in this workflow. see
+#    test-flex-edge.yml for use of these settings.
+
+name: OpenEMR Flex 3.24 Docker Test
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - '.github/workflows/docker-test-flex-324.yml'
+    - 'docker/flex/**'
+    - '.github/actions/test-actions-core/action.yml'
+    - '.github/workflows/docker-test-core.yml'
+    - '.github/docker/compose.yml'
+  pull_request:
+    branches:
+    - master
+    paths:
+    - '.github/workflows/docker-test-flex-324.yml'
+    - 'docker/flex/**'
+    - '.github/actions/test-actions-core/action.yml'
+    - '.github/workflows/docker-test-core.yml'
+    - '.github/docker/compose.yml'
+
+jobs:
+  build:
+    uses: ./.github/workflows/docker-test-core.yml
+    with:
+      is_production_docker: false
+      alpine_version: "3.24"
+      php_versions: '["8.3", "8.4", "8.5"]'
+      flex_timing: true


### PR DESCRIPTION
## Summary

Companion to #13656 (docker-build-324.yml, landed). Adds \`.github/workflows/docker-test-flex-324.yml\` — a copy of \`docker-test-flex-323.yml\`'s shape bumped to Alpine 3.24. Push/PR-triggered on the flex surface (\`docker/flex/**\`, docker-test-core, compose override, this workflow itself), runs \`docker-test-core.yml\` against Alpine 3.24 with PHP 8.3/8.4/8.5 in both dev and prod modes.

## Test plan

- [ ] CI green — the new workflow itself fires on this PR (paths filter matches self-modification) and exercises 3.24
- [ ] Post-merge: flex-surface changes going forward validate against 3.24 alongside 3.22 + 3.23

🤖 Generated with [Claude Code](https://claude.com/claude-code)