### PR TITLE
ci: run PHP 8.6 isolated tests nightly instead of on every PR

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -19,20 +19,10 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         running-workflow-name: All Checks Passed
-        # The PHP 8.6 job in isolated-tests.yml already carries continue-on-error
-        # because 8.6 is unreleased and its nightly builds regress from time to
-        # time. That keeps the workflow green, but the individual check run still
-        # concludes "failure", and this action gates on check-run conclusions --
-        # so the pre-release job has to be ignored here too, or every PR in the
-        # repo stays blocked.
-        #
-        # Entries are split on commas, stripped, and compared for exact equality
-        # against the whole check-run name. "PHP 8.6 - Isolated Tests" is the name
-        # isolated-tests.yml renders from its job-level `name:`. If the matrix
-        # moves to a newer pre-release without this entry being updated, the new
-        # job blocks PRs again -- noisy and obvious, not a silent hole in the gate.
-        #
-        # Drop this entry, and the matching continue-on-error, once 8.6 ships.
-        ignore-checks: 'codecov/project,codecov/patch,PHP 8.6 - Isolated Tests'
+        # No pre-release PHP entry here: isolated-tests.yml keeps the unreleased
+        # PHP version off PRs entirely, so there is no flaky check run to ignore.
+        # A PR that opts in via the Test-PHP trailer gets a real check run whose
+        # failure blocks the merge, which is the point of asking for it.
+        ignore-checks: 'codecov/project,codecov/patch'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 30

--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -3,6 +3,24 @@
 # - "Isolated tests": Tests that run without secondary services, a data layer or significant initialization requirements
 # - "Tests": Tests that require a database and initialization before they can run or pass.
 # This workflow runs the kind that does not require initialization.
+#
+# PHP version strategy:
+# - Pull requests and pushes: supported, released PHP versions only.
+# - Scheduled nightly run and workflow_dispatch: supported versions plus the
+#   unreleased pre-release (8.6), which tracks a nightly php-src build.
+# - Pull requests that opt in via a commit trailer: supported versions plus 8.6.
+#
+# 8.6 is built from php-src nightlies and regresses from time to time for
+# reasons that have nothing to do with the PR under test, so it does not run
+# on PRs by default. To check a change against it -- e.g. when the change is
+# about 8.6 compatibility -- add either of these trailers to any commit in the
+# PR:
+#
+#   Test-PHP: 8.6
+#   Test-Mode: full
+#
+# When opted in, the 8.6 job reports honestly and a failure blocks the PR:
+# asking for the version means wanting its answer.
 
 name: Isolated Tests
 
@@ -16,34 +34,86 @@ on:
     branches:
     - master
     - rel-*
+  schedule:
+    # 8:00 UTC = 3:00 AM EST / 4:00 AM EDT
+  - cron: 0 8 * * *
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  collect:
+    name: Collect PHP Versions
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        # For PRs, check out the PR head ref to access commit trailers
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        # Fetch enough history to find the merge base with the target branch
+        fetch-depth: 0
+
+    - name: Collect PHP versions
+      id: php-versions
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      ##
+      # Supported versions always run. The unreleased pre-release runs on the
+      # nightly schedule, on manual dispatch, and on PRs that ask for it by
+      # commit trailer.
+      run: |
+        supported=( '8.3' '8.4' '8.5' )
+        prerelease='8.6'
+        include_prerelease=false
+
+        if [[ "${EVENT_NAME}" = 'schedule' || "${EVENT_NAME}" = 'workflow_dispatch' ]]; then
+          include_prerelease=true
+        elif [[ "${EVENT_NAME}" = 'pull_request' ]]; then
+          # The checkout with fetch-depth=0 already has full history
+          if merge_base=$(git merge-base "origin/${BASE_REF}" HEAD); then
+            echo "::debug::Checking commits ${merge_base}..HEAD for PHP version trailers"
+            # Test-PHP takes a comma- or space-separated list of versions
+            version_pattern="(^|[[:space:],])${prerelease//./\\.}([[:space:],]|$)"
+            if git log --format='%(trailers:key=Test-PHP,valueonly)' "${merge_base}..HEAD" | grep -qE "${version_pattern}"; then
+              include_prerelease=true
+              echo "::notice::PHP ${prerelease} enabled via Test-PHP trailer"
+            elif git log --format='%(trailers:key=Test-Mode,valueonly)' "${merge_base}..HEAD" | grep -qi '^full$'; then
+              include_prerelease=true
+              echo "::notice::PHP ${prerelease} enabled via Test-Mode: full trailer"
+            fi
+          else
+            echo "::warning::Could not find merge base, skipping trailer check"
+          fi
+        fi
+
+        if [[ "${include_prerelease}" = 'true' ]]; then
+          supported+=( "${prerelease}" )
+        fi
+
+        printf '%s\n' "${supported[@]}" |
+          jq -Rrcn '[inputs] | "php-versions=\(.)"' >> "$GITHUB_OUTPUT"
+    outputs:
+      php-versions: ${{ steps.php-versions.outputs.php-versions }}
+
   isolated-tests:
+    needs: collect
     runs-on: ubuntu-24.04
 
     strategy:
-      # A failure on one PHP version says nothing about the others, and 8.6 is
-      # still in development — its nightly builds regress from time to time.
-      # Cancelling the production versions on an 8.6 failure hides whether the
-      # supported versions actually pass.
+      # A failure on one PHP version says nothing about the others. Cancelling
+      # the rest of the matrix on the first failure hides whether the remaining
+      # versions actually pass.
       fail-fast: false
       matrix:
-        php-version:
-        - '8.3'
-        - '8.4'
-        - '8.5'
-        - '8.6'
+        php-version: ${{ fromJson(needs.collect.outputs.php-versions) }}
 
     name: PHP ${{ matrix.php-version }} - Isolated Tests
-
-    # PHP 8.6 is not released yet, so it runs against a nightly build that can
-    # regress underneath us. Report those failures as warnings rather than
-    # blocking every PR on an upstream php-src bug. Drop this once 8.6 ships.
-    continue-on-error: ${{ matrix.php-version == '8.6' }}
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -70,31 +70,30 @@ jobs:
       run: |
         supported=( '8.3' '8.4' '8.5' )
         prerelease='8.6'
-        include_prerelease=false
 
-        if [[ "${EVENT_NAME}" = 'schedule' || "${EVENT_NAME}" = 'workflow_dispatch' ]]; then
-          include_prerelease=true
-        elif [[ "${EVENT_NAME}" = 'pull_request' ]]; then
+        case "${EVENT_NAME}" in
+        schedule | workflow_dispatch)
+          supported+=( "${prerelease}" )
+          ;;
+        pull_request)
           # The checkout with fetch-depth=0 already has full history
           if merge_base=$(git merge-base "origin/${BASE_REF}" HEAD); then
-            echo "::debug::Checking commits ${merge_base}..HEAD for PHP version trailers"
-            # Test-PHP takes a comma- or space-separated list of versions
-            version_pattern="(^|[[:space:],])${prerelease//./\\.}([[:space:],]|$)"
-            if git log --format='%(trailers:key=Test-PHP,valueonly)' "${merge_base}..HEAD" | grep -qE "${version_pattern}"; then
-              include_prerelease=true
-              echo "::notice::PHP ${prerelease} enabled via Test-PHP trailer"
-            elif git log --format='%(trailers:key=Test-Mode,valueonly)' "${merge_base}..HEAD" | grep -qi '^full$'; then
-              include_prerelease=true
-              echo "::notice::PHP ${prerelease} enabled via Test-Mode: full trailer"
+            echo "::debug::Checking commits ${merge_base}..HEAD for opt-in trailers"
+            # Test-PHP takes a comma- or space-separated list of versions;
+            # Test-Mode: full opts into everything, as it does in test-all.yml.
+            opt_in=$(git log --extended-regexp --regexp-ignore-case --format='%h' \
+                             --grep="^Test-PHP:([[:space:],]|.*[[:space:],])${prerelease//./\\.}([[:space:],]|\$)" \
+                             --grep='^Test-Mode:[[:space:]]*full[[:space:]]*$' \
+                             "${merge_base}..HEAD")
+            if [[ -n "${opt_in}" ]]; then
+              supported+=( "${prerelease}" )
+              echo "::notice::PHP ${prerelease} requested by commit ${opt_in//$'\n'/, }"
             fi
           else
             echo "::warning::Could not find merge base, skipping trailer check"
           fi
-        fi
-
-        if [[ "${include_prerelease}" = 'true' ]]; then
-          supported+=( "${prerelease}" )
-        fi
+          ;;
+        esac
 
         printf '%s\n' "${supported[@]}" |
           jq -Rrcn '[inputs] | "php-versions=\(.)"' >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Stop running the PHP 8.6 isolated-tests job on pull requests. It now runs on a nightly schedule (08:00 UTC) and on `workflow_dispatch`, plus on any PR that explicitly opts in with a commit trailer:

```
Test-PHP: 8.6
```

`Test-Mode: full` (already understood by `test-all.yml`) opts in as well.

## Why

8.6 is unreleased and runs against a php-src nightly that regresses from time to time for reasons unrelated to the change under test. It was kept non-blocking by a `continue-on-error` on the matrix entry plus a `PHP 8.6 - Isolated Tests` entry in the merge gate's `ignore-checks` list — so every PR carried a red check that everyone was trained to ignore, which is exactly how a real failure gets missed.

Not running it on PRs removes the noise; the nightly run keeps the compatibility signal. Because the job no longer needs to be non-blocking, `continue-on-error` and the `ignore-checks` entry are both gone: when a PR opts in via trailer, the result is reported honestly and a failure blocks the merge. Asking for the version means wanting its answer.

Released versions (8.3, 8.4, 8.5) still run on every PR and push, unchanged.

## Notes

`syntax.yml` already restricts PRs to 8.3, and `test-all.yml` already filters PRs to 8.3 docker configs, so this was the last PR-time 8.6 job. Full-matrix docker coverage for 8.6 continues in `test-scheduled.yml`.


Closes #13681. That issue left the opt-in trailer "tbd"; this PR picks `Test-PHP: 8.6` and also honors the pre-existing `Test-Mode: full`.
