### PR TITLE
ci(test): bump MariaDB 12 slot to 12.3 LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -179,7 +179,7 @@ updates:
   - ci/apache_85_118_redis_sentinel_tls/
   - ci/apache_85_118_redis_sentinel_mtls/
   - ci/apache_85_118_upgrade/
-  - ci/apache_85_122/
+  - ci/apache_85_123/
   - ci/apache_85_80/
   - ci/apache_85_84/
   - ci/apache_85_93/

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,8 +41,8 @@ jobs:
         - name: MariaDB 11.8 (LTS)
           image: mariadb:11.8
           health-cmd: "healthcheck.sh --connect --innodb_initialized"
-        - name: MariaDB 12
-          image: mariadb:12
+        - name: MariaDB 12.3 (LTS)
+          image: mariadb:12.3
           health-cmd: "healthcheck.sh --connect --innodb_initialized"
           coverage: true
         php:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ on:
         - apache_85_118_redis_sentinel_tls
         - apache_85_118_redis_sentinel_mtls
         - apache_85_118_upgrade
-        - apache_85_122
+        - apache_85_123
         - apache_85_80
         - apache_85_84
         - apache_85_93

--- a/ci/apache_85_123/docker-compose.yml
+++ b/ci/apache_85_123/docker-compose.yml
@@ -7,6 +7,6 @@ x-includes:
 
 services:
   mysql:
-    image: mariadb:12.2.2@sha256:6a4c4bbf0447c2247801309513fcc0dd17c3f35390368139ce419387fdd1144d
+    image: mariadb:12.3.3@sha256:dd9b303aed4f4890ed09f766d8ca9ddfd176c0c6f6267feff53b3192ec65a979
   openemr:
     image: openemr/openemr:flex-3.24-php-8.5@sha256:71f93832be5cf1d0c0d27a66bba6c6c92b9d732a64c31a908372f3845c8746bb


### PR DESCRIPTION
## Summary

MariaDB 12.x follows the yearly LTS cadence (per [mariadb.org/about/maintenance-policy](https://mariadb.org/about/maintenance-policy/) — 11.4 → 11.8 → **12.3**). CI's MariaDB 12 slot was pinned to floating \`mariadb:12\` (currently resolves to 12.3.3-MariaDB) with no LTS marker on the matrix name. Bump to explicit \`mariadb:12.3\` with \`(LTS)\` naming, matching the sibling rows.

## Changes

- \`.github/workflows/integration-tests.yml\` — \`name: MariaDB 12\` → \`MariaDB 12.3 (LTS)\`; \`image: mariadb:12\` → \`mariadb:12.3\`. Coverage cell (\`coverage: true\`) preserved on this row.
- \`ci/apache_85_122/\` → **\`ci/apache_85_123/\`** — directory renamed to match the compose-suite naming convention (\`<php>_<mariadb-short>\`). Image bumped \`mariadb:12.2.2@sha256:6a4c…\` → \`mariadb:12.3.3@sha256:dd9b303aed4f4890ed09f766d8ca9ddfd176c0c6f6267feff53b3192ec65a979\` (current digest pulled fresh from Docker Hub).
- \`.github/workflows/test.yml\` — matrix entry \`apache_85_122\` → \`apache_85_123\`.
- \`.github/dependabot.yml\` — \`ci/apache_85_122/\` → \`ci/apache_85_123/\`.

## MariaDB test surface after this + #13683 + #13688

| Version | LTS | EOL |
|---|---|---|
| 10.11 | ✓ | Feb 2028 |
| 11.4 | ✓ | May 2029 |
| 11.8 | ✓ | May 2028 |
| **12.3** | ✓ (new) | ~2029 |

## Test plan

- [ ] CI green
- [ ] Post-merge: dependabot picks up the renamed dir; no stale PR against the old name

🤖 Generated with [Claude Code](https://claude.com/claude-code)