### PR TITLE
fix(session): warn before idle timeout

### DIFF
--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -159,7 +159,9 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
         const sessionTimeoutWarningSeconds = 60;
         var sessionTimeoutWarningDeadline = null;
         var sessionTimeoutWarningTimer = null;
+        var sessionTimeoutWarningStartTimer = null;
         var sessionTimeoutCheckPending = false;
+        var sessionTimeoutConfirmRetried = false;
 
         function formatSessionTimeoutRemaining(seconds) {
             const safeSeconds = Math.max(0, parseInt(seconds, 10) || 0);
@@ -178,8 +180,6 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
             warning.id = 'sessionTimeoutWarning';
             warning.className = 'alert alert-warning shadow';
             warning.setAttribute('role', 'alert');
-            warning.setAttribute('aria-live', 'assertive');
-            warning.setAttribute('aria-atomic', 'true');
             warning.style.position = 'fixed';
             warning.style.top = '1rem';
             warning.style.left = '50%';
@@ -194,6 +194,7 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
 
             const countdown = document.createElement('strong');
             countdown.id = 'sessionTimeoutCountdown';
+            countdown.setAttribute('aria-live', 'off');
             countdown.textContent = '1:00';
             warning.appendChild(countdown);
 
@@ -212,6 +213,17 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
             return warning;
         }
 
+        function clearSessionTimeoutWarningTimers() {
+            if (sessionTimeoutWarningTimer !== null) {
+                window.clearInterval(sessionTimeoutWarningTimer);
+                sessionTimeoutWarningTimer = null;
+            }
+            if (sessionTimeoutWarningStartTimer !== null) {
+                window.clearTimeout(sessionTimeoutWarningStartTimer);
+                sessionTimeoutWarningStartTimer = null;
+            }
+        }
+
         function hideSessionTimeoutWarning() {
             const warning = document.getElementById('sessionTimeoutWarning');
             if (warning) {
@@ -219,10 +231,8 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
             }
             sessionTimeoutWarningDeadline = null;
             sessionTimeoutCheckPending = false;
-            if (sessionTimeoutWarningTimer !== null) {
-                window.clearInterval(sessionTimeoutWarningTimer);
-                sessionTimeoutWarningTimer = null;
-            }
+            sessionTimeoutConfirmRetried = false;
+            clearSessionTimeoutWarningTimers();
         }
 
         function requestSessionTimeoutStatus(skipTimeoutReset) {
@@ -256,13 +266,30 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
                     return;
                 }
 
+                if (!Object.prototype.hasOwnProperty.call(data, 'sessionSecondsRemaining')) {
+                    window.setTimeout(confirmSessionTimeout, 5000);
+                    return;
+                }
+
                 const secondsRemaining = parseInt(data.sessionSecondsRemaining, 10);
-                if (isNaN(secondsRemaining) || secondsRemaining <= 0) {
+                if (isNaN(secondsRemaining)) {
+                    window.setTimeout(confirmSessionTimeout, 5000);
+                    return;
+                }
+                if (secondsRemaining <= 0) {
                     timeoutLogout();
                     return;
                 }
+
+                sessionTimeoutConfirmRetried = false;
                 updateSessionTimeoutWarning(secondsRemaining);
             }).catch(() => {
+                sessionTimeoutCheckPending = false;
+                if (!sessionTimeoutConfirmRetried) {
+                    sessionTimeoutConfirmRetried = true;
+                    window.setTimeout(confirmSessionTimeout, 1000);
+                    return;
+                }
                 timeoutLogout();
             });
         }
@@ -288,22 +315,57 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
             }
         }
 
-        function updateSessionTimeoutWarning(secondsRemaining) {
-            const remaining = Math.max(0, parseInt(secondsRemaining, 10) || 0);
-            if (remaining > sessionTimeoutWarningSeconds) {
-                hideSessionTimeoutWarning();
-                return;
-            }
-
+        function showSessionTimeoutWarning() {
             const warning = getSessionTimeoutWarning();
-            sessionTimeoutWarningDeadline = Date.now() + (remaining * 1000);
-            sessionTimeoutCheckPending = false;
             warning.style.display = 'block';
             updateSessionTimeoutCountdown();
-
             if (sessionTimeoutWarningTimer === null && sessionTimeoutWarningDeadline !== null) {
                 sessionTimeoutWarningTimer = window.setInterval(updateSessionTimeoutCountdown, 1000);
             }
+        }
+
+        function updateSessionTimeoutWarning(secondsRemaining) {
+            const parsedRemaining = parseInt(secondsRemaining, 10);
+            if (isNaN(parsedRemaining)) {
+                return;
+            }
+
+            const remaining = Math.max(0, parsedRemaining);
+            clearSessionTimeoutWarningTimers();
+            sessionTimeoutWarningDeadline = Date.now() + (remaining * 1000);
+            sessionTimeoutCheckPending = false;
+            sessionTimeoutConfirmRetried = false;
+
+            if (remaining <= sessionTimeoutWarningSeconds) {
+                showSessionTimeoutWarning();
+                return;
+            }
+
+            const warning = document.getElementById('sessionTimeoutWarning');
+            if (warning) {
+                warning.style.display = 'none';
+            }
+
+            // The normal reminder poll runs every 60 seconds. Schedule locally from
+            // the server-authoritative deadline so the warning starts at one minute,
+            // then confirm passively in case another tab renewed the same session.
+            const delay = Math.max(0, (remaining - sessionTimeoutWarningSeconds) * 1000);
+            sessionTimeoutWarningStartTimer = window.setTimeout(function() {
+                sessionTimeoutWarningStartTimer = null;
+                requestSessionTimeoutStatus(true).then((data) => {
+                    if (data.timeoutMessage && data.timeoutMessage === 'timeout') {
+                        timeoutLogout();
+                        return;
+                    }
+                    if (Object.prototype.hasOwnProperty.call(data, 'sessionSecondsRemaining')) {
+                        updateSessionTimeoutWarning(data.sessionSecondsRemaining);
+                    } else {
+                        showSessionTimeoutWarning();
+                    }
+                }).catch(() => {
+                    showSessionTimeoutWarning();
+                });
+            }, delay);
         }
 
         function stayLoggedInFromSessionWarning() {
@@ -318,9 +380,8 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
                     return;
                 }
 
-                const secondsRemaining = parseInt(data.sessionSecondsRemaining, 10);
-                if (!isNaN(secondsRemaining)) {
-                    updateSessionTimeoutWarning(secondsRemaining);
+                if (Object.prototype.hasOwnProperty.call(data, 'sessionSecondsRemaining')) {
+                    updateSessionTimeoutWarning(data.sessionSecondsRemaining);
                 }
             }).catch((error) => {
                 console.log('Unable to renew session', error);

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -156,6 +156,180 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
         const isServicesOther = (isSms || isFax);
         var telemetryEnabled = <?php echo js_escape((new TelemetryService())->isTelemetryEnabled()); ?>;
         var noBackgroundTasks = <?php echo $noBackgroundTasks ? 'true' : 'false'; ?>;
+        const sessionTimeoutWarningSeconds = 60;
+        var sessionTimeoutWarningDeadline = null;
+        var sessionTimeoutWarningTimer = null;
+        var sessionTimeoutCheckPending = false;
+
+        function formatSessionTimeoutRemaining(seconds) {
+            const safeSeconds = Math.max(0, parseInt(seconds, 10) || 0);
+            const minutes = Math.floor(safeSeconds / 60);
+            const remainder = safeSeconds % 60;
+            return `${minutes}:${String(remainder).padStart(2, '0')}`;
+        }
+
+        function getSessionTimeoutWarning() {
+            let warning = document.getElementById('sessionTimeoutWarning');
+            if (warning) {
+                return warning;
+            }
+
+            warning = document.createElement('div');
+            warning.id = 'sessionTimeoutWarning';
+            warning.className = 'alert alert-warning shadow';
+            warning.setAttribute('role', 'alert');
+            warning.setAttribute('aria-live', 'assertive');
+            warning.setAttribute('aria-atomic', 'true');
+            warning.style.position = 'fixed';
+            warning.style.top = '1rem';
+            warning.style.left = '50%';
+            warning.style.transform = 'translateX(-50%)';
+            warning.style.zIndex = '2000';
+            warning.style.display = 'none';
+            warning.style.maxWidth = 'calc(100% - 2rem)';
+
+            const message = document.createElement('span');
+            message.textContent = <?php echo xlj('Your session will expire due to inactivity in'); ?> + ' ';
+            warning.appendChild(message);
+
+            const countdown = document.createElement('strong');
+            countdown.id = 'sessionTimeoutCountdown';
+            countdown.textContent = '1:00';
+            warning.appendChild(countdown);
+
+            const period = document.createTextNode('. ');
+            warning.appendChild(period);
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.id = 'sessionTimeoutStayLoggedIn';
+            button.className = 'btn btn-sm btn-primary ml-2';
+            button.textContent = <?php echo xlj('Stay Logged In'); ?>;
+            button.addEventListener('click', stayLoggedInFromSessionWarning);
+            warning.appendChild(button);
+
+            document.body.appendChild(warning);
+            return warning;
+        }
+
+        function hideSessionTimeoutWarning() {
+            const warning = document.getElementById('sessionTimeoutWarning');
+            if (warning) {
+                warning.style.display = 'none';
+            }
+            sessionTimeoutWarningDeadline = null;
+            sessionTimeoutCheckPending = false;
+            if (sessionTimeoutWarningTimer !== null) {
+                window.clearInterval(sessionTimeoutWarningTimer);
+                sessionTimeoutWarningTimer = null;
+            }
+        }
+
+        function requestSessionTimeoutStatus(skipTimeoutReset) {
+            restoreSession();
+            const request = new FormData();
+            if (skipTimeoutReset) {
+                request.append('skip_timeout_reset', '1');
+            }
+            request.append('csrf_token_form', csrf_token_js);
+            return fetch(webroot_url + '/library/ajax/dated_reminders_counter.php', {
+                method: 'POST',
+                credentials: 'same-origin',
+                body: request
+            }).then((response) => {
+                if (!response.ok) {
+                    throw new Error('Session status request failed');
+                }
+                return response.json();
+            });
+        }
+
+        function confirmSessionTimeout() {
+            if (sessionTimeoutCheckPending) {
+                return;
+            }
+            sessionTimeoutCheckPending = true;
+            requestSessionTimeoutStatus(true).then((data) => {
+                sessionTimeoutCheckPending = false;
+                if (data.timeoutMessage && data.timeoutMessage === 'timeout') {
+                    timeoutLogout();
+                    return;
+                }
+
+                const secondsRemaining = parseInt(data.sessionSecondsRemaining, 10);
+                if (isNaN(secondsRemaining) || secondsRemaining <= 0) {
+                    timeoutLogout();
+                    return;
+                }
+                updateSessionTimeoutWarning(secondsRemaining);
+            }).catch(() => {
+                timeoutLogout();
+            });
+        }
+
+        function updateSessionTimeoutCountdown() {
+            if (sessionTimeoutWarningDeadline === null) {
+                return;
+            }
+
+            const millisecondsRemaining = sessionTimeoutWarningDeadline - Date.now();
+            const secondsRemaining = Math.max(0, Math.ceil(millisecondsRemaining / 1000));
+            const countdown = document.getElementById('sessionTimeoutCountdown');
+            if (countdown) {
+                countdown.textContent = formatSessionTimeoutRemaining(secondsRemaining);
+            }
+
+            if (secondsRemaining <= 0) {
+                if (sessionTimeoutWarningTimer !== null) {
+                    window.clearInterval(sessionTimeoutWarningTimer);
+                    sessionTimeoutWarningTimer = null;
+                }
+                confirmSessionTimeout();
+            }
+        }
+
+        function updateSessionTimeoutWarning(secondsRemaining) {
+            const remaining = Math.max(0, parseInt(secondsRemaining, 10) || 0);
+            if (remaining > sessionTimeoutWarningSeconds) {
+                hideSessionTimeoutWarning();
+                return;
+            }
+
+            const warning = getSessionTimeoutWarning();
+            sessionTimeoutWarningDeadline = Date.now() + (remaining * 1000);
+            sessionTimeoutCheckPending = false;
+            warning.style.display = 'block';
+            updateSessionTimeoutCountdown();
+
+            if (sessionTimeoutWarningTimer === null && sessionTimeoutWarningDeadline !== null) {
+                sessionTimeoutWarningTimer = window.setInterval(updateSessionTimeoutCountdown, 1000);
+            }
+        }
+
+        function stayLoggedInFromSessionWarning() {
+            const button = document.getElementById('sessionTimeoutStayLoggedIn');
+            if (button) {
+                button.disabled = true;
+            }
+
+            requestSessionTimeoutStatus(false).then((data) => {
+                if (data.timeoutMessage && data.timeoutMessage === 'timeout') {
+                    timeoutLogout();
+                    return;
+                }
+
+                const secondsRemaining = parseInt(data.sessionSecondsRemaining, 10);
+                if (!isNaN(secondsRemaining)) {
+                    updateSessionTimeoutWarning(secondsRemaining);
+                }
+            }).catch((error) => {
+                console.log('Unable to renew session', error);
+            }).finally(() => {
+                if (button) {
+                    button.disabled = false;
+                }
+            });
+        }
 
         /**
          * Async function to get session value from the server
@@ -217,9 +391,16 @@ $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->get
                 }
                 return response.json();
             }).then((data) => {
+                if (!data) {
+                    return;
+                }
                 if (data.timeoutMessage && (data.timeoutMessage == 'timeout')) {
                     // timeout has happened, so logout
                     timeoutLogout();
+                    return;
+                }
+                if (Object.prototype.hasOwnProperty.call(data, 'sessionSecondsRemaining')) {
+                    updateSessionTimeoutWarning(data.sessionSecondsRemaining);
                 }
                 if (isPortalEnabled) {
                     let mail = data.mailCnt;

--- a/library/ajax/dated_reminders_counter.php
+++ b/library/ajax/dated_reminders_counter.php
@@ -20,6 +20,7 @@ require_once("$srcdir/dated_reminder_functions.php");
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionTracker;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\OEGlobalsBag;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
@@ -49,5 +50,18 @@ $activeMessages = getPnotesByUser("1", "no", $session->get('authUser'), true);
 // Below for Message Button count display.
 $totalNumber = $dueReminders + $activeMessages;
 $total_counts['reminderText'] = ($totalNumber > 0 ? text((int)$totalNumber) : '');
+
+// Report the server-authoritative idle-session time remaining. Requests to this
+// endpoint from the background repeater include skip_timeout_reset=1, so reading
+// this value does not extend the session.
+$sessionTracker = sqlQueryNoLog(
+    "SELECT GREATEST(0, ? - TIMESTAMPDIFF(SECOND, `last_updated`, NOW())) AS `seconds_remaining` " .
+    "FROM `session_tracker` WHERE `uuid` = ?",
+    [
+        OEGlobalsBag::getInstance()->getInt('timeout'),
+        $session->get('session_database_uuid'),
+    ]
+);
+$total_counts['sessionSecondsRemaining'] = (int) ($sessionTracker['seconds_remaining'] ?? 0);
 
 echo json_encode($total_counts);

--- a/library/ajax/dated_reminders_counter.php
+++ b/library/ajax/dated_reminders_counter.php
@@ -20,7 +20,6 @@ require_once("$srcdir/dated_reminder_functions.php");
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionTracker;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Core\OEGlobalsBag;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
@@ -51,17 +50,12 @@ $activeMessages = getPnotesByUser("1", "no", $session->get('authUser'), true);
 $totalNumber = $dueReminders + $activeMessages;
 $total_counts['reminderText'] = ($totalNumber > 0 ? text((int)$totalNumber) : '');
 
-// Report the server-authoritative idle-session time remaining. Requests to this
-// endpoint from the background repeater include skip_timeout_reset=1, so reading
-// this value does not extend the session.
-$sessionTracker = sqlQueryNoLog(
-    "SELECT GREATEST(0, ? - TIMESTAMPDIFF(SECOND, `last_updated`, NOW())) AS `seconds_remaining` " .
-    "FROM `session_tracker` WHERE `uuid` = ?",
-    [
-        OEGlobalsBag::getInstance()->getInt('timeout'),
-        $session->get('session_database_uuid'),
-    ]
-);
-$total_counts['sessionSecondsRemaining'] = (int) ($sessionTracker['seconds_remaining'] ?? 0);
+// Background repeater requests include skip_timeout_reset=1, so this read does
+// not extend the session. An unavailable tracker value is deliberately omitted
+// rather than being interpreted as an expired session.
+$sessionSecondsRemaining = SessionTracker::getSessionSecondsRemaining();
+if ($sessionSecondsRemaining !== null) {
+    $total_counts['sessionSecondsRemaining'] = $sessionSecondsRemaining;
+}
 
 echo json_encode($total_counts);

--- a/src/Common/Session/SessionTracker.php
+++ b/src/Common/Session/SessionTracker.php
@@ -11,8 +11,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Brady Miller <brady.g.miller@gmail.com>
- * @copyright Copyright (c) 2020 Brady Miller <brady.g.miller@gmail.com>
+ * @author    Brady Miller <brady.miller@gmail.com>
+ * @copyright Copyright (c) 2020 Brady Miller <brady.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -63,6 +63,34 @@ class SessionTracker
         return false;
     }
 
+    /**
+     * Return the server-authoritative number of seconds before the active session expires.
+     *
+     * A null result means the tracker value is unavailable and must not be interpreted as expiry.
+     */
+    public static function getSessionSecondsRemaining(): ?int
+    {
+        $session = SessionWrapperFactory::getInstance()->getActiveSession();
+        $sessionUuid = $session->get('session_database_uuid');
+        if (empty($sessionUuid)) {
+            return null;
+        }
+
+        $sessionTracker = sqlQueryNoLog(
+            "SELECT GREATEST(0, ? - TIMESTAMPDIFF(SECOND, `last_updated`, NOW())) AS `seconds_remaining` " .
+            "FROM `session_tracker` WHERE `uuid` = ?",
+            [
+                OEGlobalsBag::getInstance()->getInt('timeout'),
+                $sessionUuid,
+            ]
+        );
+        if (!isset($sessionTracker['seconds_remaining']) || !is_numeric($sessionTracker['seconds_remaining'])) {
+            return null;
+        }
+
+        return max(0, (int) $sessionTracker['seconds_remaining']);
+    }
+
     public static function updateSessionExpiration(): void
     {
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
@@ -77,7 +105,7 @@ class SessionTracker
         sqlStatementNoLog("UPDATE `session_tracker` SET `number_scripts` = `number_scripts` + 1 WHERE `uuid` = ?", [$session->get('session_database_uuid')]);
     }
 
-    // Function to throttle down requests when using the online demos to prevent abuse of the demo farm
+    // Function to throttle down requests when using the online demos to prevent abuse of demo farm
     public static function processSessionThrottleDown($throttleDownWaitMilliseconds): void
     {
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
@@ -95,7 +123,7 @@ class SessionTracker
                 die(xlt("These demos are not meant for headless server testing. Please do this on your own servers."));
             }
             // throttle down since the 'THROTTLE_DOWN_WAIT_MILLISECONDS' environment setting has been exceeded
-            error_log("DEBUG: throttling down for script number " . $timeThrottle['number_scripts'] . " for " . $timeThrottle['time_throttle'] . " milliseconds");
+            error_log("DEBUG: throttling down for script number " . $timeThrottle['time_throttle'] . " for " . $timeThrottle['time_throttle'] . " milliseconds");
             usleep($timeThrottle['time_throttle'] * 1000);
         }
     }

--- a/src/Common/Session/SessionTracker.php
+++ b/src/Common/Session/SessionTracker.php
@@ -11,8 +11,8 @@
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
- * @author    Brady Miller <brady.miller@gmail.com>
- * @copyright Copyright (c) 2020 Brady Miller <brady.miller@gmail.com>
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2020 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -123,7 +123,7 @@ class SessionTracker
                 die(xlt("These demos are not meant for headless server testing. Please do this on your own servers."));
             }
             // throttle down since the 'THROTTLE_DOWN_WAIT_MILLISECONDS' environment setting has been exceeded
-            error_log("DEBUG: throttling down for script number " . $timeThrottle['time_throttle'] . " for " . $timeThrottle['time_throttle'] . " milliseconds");
+            error_log("DEBUG: throttling down for script number " . $timeThrottle['number_scripts'] . " for " . $timeThrottle['time_throttle'] . " milliseconds");
             usleep($timeThrottle['time_throttle'] * 1000);
         }
     }

--- a/src/Common/Session/SessionTracker.php
+++ b/src/Common/Session/SessionTracker.php
@@ -105,7 +105,7 @@ class SessionTracker
         sqlStatementNoLog("UPDATE `session_tracker` SET `number_scripts` = `number_scripts` + 1 WHERE `uuid` = ?", [$session->get('session_database_uuid')]);
     }
 
-    // Function to throttle down requests when using the online demos to prevent abuse of demo farm
+    // Function to throttle down requests when using the online demos to prevent abuse of the demo farm
     public static function processSessionThrottleDown($throttleDownWaitMilliseconds): void
     {
         $session = SessionWrapperFactory::getInstance()->getActiveSession();


### PR DESCRIPTION
### Short description of what this changes or resolves:

OpenEMR currently detects an expired idle session through the existing
database-backed SessionTracker, but users receive no advance warning while
working on unsaved data.

This adds a visible warning during the final 60 seconds of inactivity with
a live countdown and a "Stay Logged In" action.

The existing SessionTracker remains authoritative and the configured
session timeout is not changed or bypassed.

### Changes proposed in this pull request:

- Return the server-authoritative idle-session time remaining from the
  existing reminders endpoint.
- Continue passive reminder polling with `skip_timeout_reset=1`, so polling
  does not extend the user's session.
- Display a localized warning during the final 60 seconds.
- Show a live countdown using an absolute deadline to reduce browser timer drift.
- Add a "Stay Logged In" button that performs a normal authenticated request
  without `skip_timeout_reset`, allowing OpenEMR's existing authentication
  logic to renew SessionTracker.
- At 0:00, perform a final non-renewing server check before invoking the
  existing `timeoutLogout()` path.
- This final check avoids a stale browser countdown forcing logout if another
  tab or legitimate user action has already renewed the same session.
- No parallel session/authentication mechanism is introduced.
- No configured timeout values are changed.

### Testing:

The underlying behavior was validated on an OpenEMR 8.3.0 staging installation
with synthetic data using a temporary 180-second idle timeout.

Confirmed:
- the final-minute warning appeared;
- the countdown reached 0:00 correctly;
- "Stay Logged In" renewed the real OpenEMR SessionTracker timeout;
- passive polling did not renew inactivity;
- ignoring the warning resulted in the normal OpenEMR timeout logout and
  login screen.

The upstream implementation additionally uses an absolute countdown deadline
and a final passive server check to better handle browser timer drift and
multi-tab session renewal.

### Was an AI assistant used? Yes

ChatGPT was used to prepare and review the implementation. The commit includes:

`Generated-By: ChatGPT`