### PR TITLE
fix(patient): decouple delete refresh from SQL display

### DIFF
--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -433,8 +433,10 @@ function popup_close() {
             }
 
         // Close this window and tell our opener that it's done.
-        // Not sure yet if the callback can be used universally.
+        // If SQL debugging is enabled, preserve the output in the dialog but
+        // still notify the caller immediately so its view can refresh.
             echo "<script>\n";
+            $hideSql = OEGlobalsBag::getInstance()->getBoolean('sql_string_no_show_screen');
             if (!$encounterid) {
                 if ($info_msg) {
                     echo "let message = " . js_escape($info_msg) . ";
@@ -442,21 +444,27 @@ function popup_close() {
                     await asyncAlertMsg(message, time, 'success', 'lg');
                     })(message, 2000)
                     .then(res => {";
-                    // auto close on msg timeout with just enough time to show success or errors.
-                    if (OEGlobalsBag::getInstance()->getBoolean('sql_string_no_show_screen')) {
+                    if ($hideSql) {
                         echo "dlgclose();";
+                    } else {
+                        echo "if (opener && typeof opener.imdeleted === 'function') { opener.imdeleted(false); }";
                     }
-                    echo "});"; // close function.
-                    // any close will call below.
-                    echo " opener.dlgSetCallBack('imdeleted', false);\n";
+                    echo "});";
+                    if ($hideSql) {
+                        echo " opener.dlgSetCallBack('imdeleted', false);\n";
+                    }
                 } else {
-                    echo " dlgclose('imdeleted', false);\n";
+                    if ($hideSql) {
+                        echo " dlgclose('imdeleted', false);\n";
+                    } else {
+                        echo " if (opener && typeof opener.imdeleted === 'function') { opener.imdeleted(false); }\n";
+                    }
                 }
             } else {
-                if (OEGlobalsBag::getInstance()->getBoolean('sql_string_no_show_screen')) {
+                if ($hideSql) {
                     echo " dlgclose('imdeleted', " . js_escape($encounterid) . ");\n";
-                } else { // this allows dialog to stay open then close with button or X.
-                    echo " opener.dlgSetCallBack('imdeleted', " . js_escape($encounterid) . ");\n";
+                } else {
+                    echo " if (opener && typeof opener.imdeleted === 'function') { opener.imdeleted(" . js_escape($encounterid) . "); }\n";
                 }
             }
             echo "</script></body></html>\n";


### PR DESCRIPTION
### Short description of what this changes or resolves:

Refs #13707.

`interface/patient_file/deleter.php` currently ties two separate behaviors to
`sql_string_no_show_screen`:

1. whether SQL strings remain visible in the delete dialog;
2. whether the caller is notified immediately after a successful delete so its
   view can refresh.

When SQL display is enabled, a successful Patient Issues deletion can leave the
caller stale until the dialog is closed.

### Changes proposed in this pull request:

- Keep SQL output visible when `sql_string_no_show_screen` is disabled.
- When SQL output is visible, notify the opener immediately with its existing
  `imdeleted()` callback so Patient Issues refreshes without forcing the dialog
  closed.
- When SQL output is hidden, preserve the existing dialog-close/callback path.
- Preserve deletion queries, authorization, ACLs, CSRF handling, and failure
  behavior.
- Leave the global `sql_string_no_show_screen` default unchanged; changing that
  default is a separate policy decision.

Patient Issues already handles the callback through:

`imdeleted()` → `refreshIssue()` → page reload.

### Testing:

Validated on OpenEMR 8.3.0 staging with synthetic data during development.

Before the workaround:
- deleting a Patient Issues medication succeeded;
- raw DELETE SQL could remain visible;
- the deleted item could remain displayed until the frame was reopened.

Setting `sql_string_no_show_screen = 1` confirmed the coupling:
- SQL disappeared;
- the delete dialog closed normally;
- the existing callback ran;
- Patient Issues refreshed immediately.

The final branch was refreshed onto current `master` while preserving this
functional change.

### Was an AI assistant used? Yes

ChatGPT was used to prepare and review the implementation. The commit includes:

`Generated-By: ChatGPT`