### PR TITLE
chore(docker): bump flex Dockerfile default ARG ALPINE_VERSION to 3.24

### DIFF
--- a/docker/flex/Dockerfile
+++ b/docker/flex/Dockerfile
@@ -27,7 +27,7 @@
 # BASE IMAGE CONFIGURATION
 # ============================================================================
 # Alpine Linux version - centralized setting for easy updates
-ARG ALPINE_VERSION=3.23
+ARG ALPINE_VERSION=3.24
 FROM alpine:${ALPINE_VERSION} AS base
 
 # PHP version configuration


### PR DESCRIPTION
## Summary

Bump the flex `Dockerfile` \`ARG ALPINE_VERSION\` from 3.23 → 3.24 to match the actually-published default flex image.

## Why

The published \`openemr/openemr:flex\` (bare tag) has been Alpine 3.24 since \`docker-build-324.yml\` set \`is_default_flex: true\`. The build workflows pass \`--build-arg ALPINE_VERSION=3.24\` at build time, so the published image is correct — but tools that read \`docker/flex/Dockerfile\` directly to discover the "default" Alpine version still see 3.23.

## Concrete effect: demo farm auto-reconcile

\`demo_farm_openemr\`'s \`tools/auto-derive/derive.sh\` fetches this Dockerfile as \`MASTER_FLEX_ALPINE\` (algorithm anchors on the ARG value) and uses that to assign Alpine versions to demo clusters. The 07:00 UTC daily cron correctly detected \`3.24=[8.3 8.4 8.5]\` in the flex matrix but declined to promote any demo cluster to 3.24 because \`MASTER_FLEX_ALPINE\` stayed at 3.23.

After this merges, the next demo_farm cron run (or a manual dispatch) will see \`MASTER_FLEX_ALPINE=3.24\`, propagate to \`ip_map_branch.txt\` + \`docker/scripts/demoLibrary.source\`, and auto-open the reconciliation PR to shift demo clusters to Alpine 3.24 flex.

## Second effect: direct-build consistency

Anyone running \`docker build .\` on this Dockerfile locally without passing \`--build-arg ALPINE_VERSION=X\` would get an Alpine 3.23 base. With this change, the local-build default matches the CI/published default.

## Test plan

- [ ] Docker builds continue to pass (all flex-3.22, flex-3.23, flex-3.24, flex-edge workflows override the ARG at build time, so this change only affects the "no build-arg override" case)
- [ ] After merge, verify the next \`demo_farm_openemr\` daily cron opens an auto-derive reconciliation PR promoting clusters to 3.24