### PR TITLE
fix(billing): route misc billing options provider by box 17 qualifier

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -26967,11 +26967,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Billing/Claim.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$userId of method OpenEMR\\\\Services\\\\UserService\\:\\:getUser\\(\\) expects int\\|string, int\\|string\\|null given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/Claim.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$userId of method OpenEMR\\\\Services\\\\UserService\\:\\:getUser\\(\\) expects int\\|string, mixed given\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../src/Billing/Claim.php',

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -3238,7 +3238,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 50,
+    'count' => 49,
     'path' => __DIR__ . '/../../src/Billing/Claim.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -4298,7 +4298,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot call method getOrderingProviderID\\(\\) on mixed\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../src/Billing/Claim.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -16952,11 +16952,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Billing/Claim.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Billing\\\\Claim\\:\\:box17Qualifier\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/Claim.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Billing\\\\Claim\\:\\:claimTypeRaw\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Billing/Claim.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -2452,11 +2452,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Billing/BillingProcessor/BillingClaimBatch.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Billing\\\\Claim\\:\\:getOrdererId\\(\\) should return int\\|string\\|null but returns mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/Claim.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Billing\\\\Claim\\:\\:providerNumberType\\(\\) should return string but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Billing/Claim.php',

--- a/interface/forms/misc_billing_options/report.php
+++ b/interface/forms/misc_billing_options/report.php
@@ -45,13 +45,13 @@ function misc_billing_options_report($pid, $encounter, $cols, $id): void
                 $pqe = $data['provider_qualifier_code'];
                 if (!empty($pqe)) {
                     switch ($pqe) {
-                        case ($pqe == "DN"):
+                        case "DN":
                             $value = "Referring";
                             break;
-                        case ($pqe == "DK"):
+                        case "DK":
                             $value = "Ordering";
                             break;
-                        case ($pqe == "DQ"):
+                        case "DQ":
                             $value = "Supervising";
                             break;
                     }

--- a/src/Billing/Claim.php
+++ b/src/Billing/Claim.php
@@ -185,7 +185,7 @@ class Claim
 
     public function getReferrerId()
     {
-        if ($this->billing_options['provider_id'] ?? '') {
+        if (($this->billing_options['provider_id'] ?? '') && $this->box17Qualifier() !== 'DK') {
             $referrer_id = $this->billing_options['provider_id'];
         } elseif ($this->encounterService->getReferringProviderID($this->pid, $this->encounter_id) ?? '') {
             $referrer_id = $this->encounterService->getReferringProviderID($this->pid, $this->encounter_id);
@@ -197,15 +197,16 @@ class Claim
         return $referrer_id;
     }
 
-    public function getOrdererId(): string|int|null
+    public function getOrdererId(): string|int
     {
-        if ($this->billing_options['provider_id'] ?? '') {
-            $orderer_id = $this->billing_options['provider_id'];
-        } elseif ($this->encounterService->getOrderingProviderID($this->pid, $this->encounter_id) ?? '') {
-            $orderer_id = $this->encounterService->getOrderingProviderID($this->pid, $this->encounter_id);
+        $mboProviderId = $this->billing_options['provider_id'] ?? '';
+        if ($mboProviderId && $this->box17Qualifier() === 'DK') {
+            return is_int($mboProviderId) || is_string($mboProviderId) ? $mboProviderId : '';
         }
 
-        return $orderer_id ?? '';
+        $ordererId = $this->encounterService->getOrderingProviderID($this->pid, $this->encounter_id);
+
+        return is_int($ordererId) || is_string($ordererId) ? $ordererId : '';
     }
 
     /**
@@ -1735,12 +1736,30 @@ class Claim
             $this->billing_options['box_15_date_qual'];
     }
 
-    public function box17Qualifier()
+    /**
+     * CMS-1500 Box 17 qualifier: DN referring, DK ordering, DQ supervising.
+     *
+     * Box 17 holds a single provider whose role is declared by this qualifier.
+     * The 837 expresses role by loop placement instead, so the qualifier decides
+     * which loop the misc billing options provider feeds: DN (or empty) routes it
+     * to Loop 2310A as the referring provider, DK to Loop 2420E as the ordering
+     * provider. Empty is treated as DN to match the provider_qualifier_code list
+     * default and the pre-existing paper fallback in Hcfa1500.
+     *
+     * DQ is accepted for the paper claim but has no 837 equivalent here. The
+     * supervising provider is emitted at Loop 2310D from
+     * form_encounter.supervisor_id, independent of this qualifier; the line-level
+     * Loop 2420D is not generated. A DQ selection therefore feeds neither the
+     * referring nor the ordering loop.
+     *
+     * @return string One of DN, DK, DQ, or '' — values originate as
+     *                provider_qualifier_code option_ids, so callers can compare
+     *                with === against those literals.
+     */
+    public function box17Qualifier(): string
     {
-        //If no box qualifier specified use "DK" for ordering provider
-        //someday might make mbo form the place to set referring instead of demographics under choices
-        return empty($this->billing_options['provider_qualifier_code']) ? '' :
-            $this->billing_options['provider_qualifier_code'];
+        $qual = $this->billing_options['provider_qualifier_code'] ?? '';
+        return is_string($qual) ? $qual : '';
     }
 
   // Returns an array of unique diagnoses.  Periods are stripped by default

--- a/src/Billing/Claim.php
+++ b/src/Billing/Claim.php
@@ -7,7 +7,7 @@
  * @author Rod Roark <rod@sunsetsystems.com>
  * @author Stephen Waite <stephen.waite@cmsvt.com>
  * @copyright Copyright (c) 2009-2020 Rod Roark <rod@sunsetsystems.com>
- * @copyright Copyright (c) 2017-2025 Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2017-2026 Stephen Waite <stephen.waite@cmsvt.com>
  * @link https://github.com/openemr/openemr/tree/master
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */

--- a/src/Billing/Claim.php
+++ b/src/Billing/Claim.php
@@ -185,7 +185,10 @@ class Claim
 
     public function getReferrerId()
     {
-        if (($this->billing_options['provider_id'] ?? '') && $this->box17Qualifier() !== 'DK') {
+        if (
+            ($this->billing_options['provider_id'] ?? '')
+            && in_array($this->box17Qualifier(), ['', 'DN'], true)
+        ) {
             $referrer_id = $this->billing_options['provider_id'];
         } elseif ($this->encounterService->getReferringProviderID($this->pid, $this->encounter_id) ?? '') {
             $referrer_id = $this->encounterService->getReferringProviderID($this->pid, $this->encounter_id);

--- a/src/Billing/Hcfa1500.php
+++ b/src/Billing/Hcfa1500.php
@@ -449,8 +449,8 @@ class Hcfa1500
         // Medicare forbids an entry here and other payers require one.
         // There is still confusion over this.
         if (
-            $claim->referrerLastName() || $claim->billingProviderLastName() &&
-            (!OEGlobalsBag::getInstance()->getBoolean('MedicareReferrerIsRenderer') || $claim->claimType() != 'MB')
+            ($claim->referrerLastName() || $claim->billingProviderLastName())
+            && (!OEGlobalsBag::getInstance()->getBoolean('MedicareReferrerIsRenderer') || $claim->claimType() != 'MB')
         ) {
             // Box 17a. Referring Provider Alternate Identifier
             // Commented this out because UPINs are obsolete, leaving the code as an

--- a/src/Billing/MiscBillingOptions.php
+++ b/src/Billing/MiscBillingOptions.php
@@ -14,7 +14,7 @@
  * @author    Stephen Waite <stephen.waite@cmsvt.com>
  * @copyright Copyright (C) 2013 Kevin Yeh <kevin.y@integralemr.com>
  * @copyright Copyright (C) 2013 OEMR
- * @copyright Copyright (C) 2017-2025 Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (C) 2017-2026 Stephen Waite <stephen.waite@cmsvt.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1613,8 +1613,7 @@ class X125010837P
             $SEFLAG == true
             || !OEGlobalsBag::getInstance()->getBoolean('gen_x12_based_on_ins_co')
         ) {
-            ++$edicount; //todo: This might have to go into the SE flag spot //***MS Modify
-
+            ++$edicount;
             $out .= "SE" .        // SE Trailer
             "*" . $edicount .
             "*" . "0021" .

--- a/tests/Tests/Isolated/Billing/ClaimProviderRoutingTest.php
+++ b/tests/Tests/Isolated/Billing/ClaimProviderRoutingTest.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Billing;
+
+use OpenEMR\Billing\Claim;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * Isolated tests for how the box 17 qualifier routes the misc billing options
+ * provider to the referring (loop 2310A) or ordering (loop 2420E) provider.
+ *
+ * DN or an empty qualifier routes the provider to the referring loop, DK to the
+ * ordering loop, and DQ to neither. When the qualifier does not match, each
+ * getter falls through to its own source.
+ */
+class ClaimProviderRoutingTest extends TestCase
+{
+    private const MBO_PROVIDER_ID = 530;
+    private const ENCOUNTER_REFERRER_ID = 741;
+    private const ENCOUNTER_ORDERER_ID = 852;
+    private const DEMOGRAPHICS_REFERRER_ID = 963;
+
+    /**
+     * A Claim whose real constructor (which hits the database) is bypassed, with
+     * only the properties the provider getters read seeded.
+     *
+     * Claim::$encounterService has no type declaration, so the fallthrough
+     * branches are satisfied by a plain anonymous double. Doubling the real
+     * EncounterService is not an option here: autoloading it pulls in BaseService,
+     * which includes code_types.inc.php and calls sqlStatement() at file scope.
+     */
+    private function makeClaim(string $qualifier, int|string $mboProviderId = self::MBO_PROVIDER_ID): Claim
+    {
+        $stub = new class extends Claim {
+            public function __construct()
+            {
+            }
+        };
+
+        $stub->billing_options = [
+            'provider_id' => $mboProviderId,
+            'provider_qualifier_code' => $qualifier,
+        ];
+        // provider_number_type is anything other than 1C so getReferrerId() takes
+        // the demographics branch rather than the Medicare renderer branch.
+        $stub->insurance_numbers = ['provider_number_type' => '1B'];
+        $stub->patient_data = ['ref_providerID' => self::DEMOGRAPHICS_REFERRER_ID];
+        $stub->encounter = ['provider_id' => 0];
+
+        $encounterService = new class (self::ENCOUNTER_REFERRER_ID, self::ENCOUNTER_ORDERER_ID) {
+            public function __construct(private readonly int $referrerId, private readonly int $ordererId)
+            {
+            }
+
+            public function getReferringProviderID(mixed $pid, mixed $encounterId): int
+            {
+                return $this->referrerId;
+            }
+
+            public function getOrderingProviderID(mixed $pid, mixed $encounterId): int
+            {
+                return $this->ordererId;
+            }
+        };
+
+        $property = new ReflectionProperty(Claim::class, 'encounterService');
+        $property->setValue($stub, $encounterService);
+
+        return $stub;
+    }
+
+    public function testBox17QualifierIsEmptyWhenNotSet(): void
+    {
+        $claim = $this->makeClaim('');
+        $this->assertSame('', $claim->box17Qualifier());
+    }
+
+    public function testBox17QualifierReturnsStoredValue(): void
+    {
+        $claim = $this->makeClaim('DK');
+        $this->assertSame('DK', $claim->box17Qualifier());
+    }
+
+    public function testEmptyQualifierRoutesProviderToReferring(): void
+    {
+        $claim = $this->makeClaim('');
+        $this->assertSame(self::MBO_PROVIDER_ID, $claim->getReferrerId());
+    }
+
+    public function testDnRoutesProviderToReferring(): void
+    {
+        $claim = $this->makeClaim('DN');
+        $this->assertSame(self::MBO_PROVIDER_ID, $claim->getReferrerId());
+    }
+
+    public function testDkDoesNotRouteProviderToReferring(): void
+    {
+        $claim = $this->makeClaim('DK');
+        $this->assertSame(self::ENCOUNTER_REFERRER_ID, $claim->getReferrerId());
+    }
+
+    public function testDqDoesNotRouteProviderToReferring(): void
+    {
+        $claim = $this->makeClaim('DQ');
+        $this->assertSame(self::ENCOUNTER_REFERRER_ID, $claim->getReferrerId());
+    }
+
+    public function testDkRoutesProviderToOrdering(): void
+    {
+        $claim = $this->makeClaim('DK');
+        $this->assertSame(self::MBO_PROVIDER_ID, $claim->getOrdererId());
+    }
+
+    public function testEmptyQualifierDoesNotRouteProviderToOrdering(): void
+    {
+        $claim = $this->makeClaim('');
+        $this->assertSame(self::ENCOUNTER_ORDERER_ID, $claim->getOrdererId());
+    }
+
+    public function testDnDoesNotRouteProviderToOrdering(): void
+    {
+        $claim = $this->makeClaim('DN');
+        $this->assertSame(self::ENCOUNTER_ORDERER_ID, $claim->getOrdererId());
+    }
+
+    public function testDqDoesNotRouteProviderToOrdering(): void
+    {
+        $claim = $this->makeClaim('DQ');
+        $this->assertSame(self::ENCOUNTER_ORDERER_ID, $claim->getOrdererId());
+    }
+
+    public function testUnsetProviderFallsThroughRegardlessOfQualifier(): void
+    {
+        $claim = $this->makeClaim('DN', 0);
+        $this->assertSame(self::ENCOUNTER_REFERRER_ID, $claim->getReferrerId());
+
+        $claim = $this->makeClaim('DK', 0);
+        $this->assertSame(self::ENCOUNTER_ORDERER_ID, $claim->getOrdererId());
+    }
+
+    /**
+     * Provider ids arrive as strings from the data layer and as ints from code
+     * paths that cast, and both getters pass the value through untouched, so the
+     * seeded type is the expected type.
+     *
+     * @return array<string, array{int|string}>
+     */
+    public static function mboProviderIdProvider(): array
+    {
+        return [
+            'int provider id' => [self::MBO_PROVIDER_ID],
+            'string provider id' => [(string) self::MBO_PROVIDER_ID],
+        ];
+    }
+
+    #[DataProvider('mboProviderIdProvider')]
+    public function testDnRoutesProviderToReferringPreservingType(int|string $providerId): void
+    {
+        $claim = $this->makeClaim('DN', $providerId);
+        $this->assertSame($providerId, $claim->getReferrerId());
+    }
+
+    #[DataProvider('mboProviderIdProvider')]
+    public function testDkRoutesProviderToOrderingPreservingType(int|string $providerId): void
+    {
+        $claim = $this->makeClaim('DK', $providerId);
+        $this->assertSame($providerId, $claim->getOrdererId());
+    }
+
+    /**
+     * An unset int column reads back as the string '0', which is falsy in PHP, so
+     * it must fall through rather than being treated as a selected provider.
+     */
+    public function testStringZeroProviderIdFallsThrough(): void
+    {
+        $claim = $this->makeClaim('DN', '0');
+        $this->assertSame(self::ENCOUNTER_REFERRER_ID, $claim->getReferrerId());
+
+        $claim = $this->makeClaim('DK', '0');
+        $this->assertSame(self::ENCOUNTER_ORDERER_ID, $claim->getOrdererId());
+    }
+}


### PR DESCRIPTION
getOrdererId() and getReferrerId() both read
misc_billing_options.provider_id as their first source, so setting the box 17 provider emitted that provider as the referring provider in loop 2310A and as the ordering provider in loop 2420E on every service line. 2420E support was added in #7405 without accounting for the field being box 17 data - a single provider whose role is declared by the box 17 qualifier - rather than a general purpose claim provider.

The qualifier now selects which loop the provider feeds. DN or empty routes it to 2310A, DK to 2420E; empty is treated as DN to match the provider_qualifier_code list default and the existing Hcfa1500 fallback. DQ feeds neither, as loop 2420D is not generated and the supervising provider comes from form_encounter.supervisor_id. Sites that selected DK will see the referring provider fall through to
form_encounter.referring_provider_id or the demographics default.

Also fixes operator precedence in the Hcfa1500 box 17 condition, where && bound tighter than || and made the MedicareReferrerIsRenderer guard unreachable whenever a referring provider was present; corrects switch cases in the misc billing options report that compared boolean expressions rather than values, so every qualifier displayed as Referring; and removes a stale todo on the SE segment count, which is correctly placed.

Nets five phpstan baseline entries removed or reduced.

Assisted-by: Claude.ai
