### PR TITLE
fix(patient): stop fetching photos when there is none

### DIFF
--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -1088,7 +1088,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 11,
+    'count' => 12,
     'path' => __DIR__ . '/../../interface/orders/orders_results.php',
 ];
 $ignoreErrors[] = [
@@ -1328,12 +1328,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 15,
+    'count' => 16,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics_full.php',
 ];
 $ignoreErrors[] = [
@@ -1378,12 +1378,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 8,
+    'count' => 9,
     'path' => __DIR__ . '/../../interface/patient_file/summary/pnotes_full.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/patient_file/summary/pnotes_full_add.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -1088,7 +1088,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 12,
+    'count' => 11,
     'path' => __DIR__ . '/../../interface/orders/orders_results.php',
 ];
 $ignoreErrors[] = [
@@ -1328,12 +1328,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 16,
+    'count' => 15,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics_full.php',
 ];
 $ignoreErrors[] = [
@@ -1378,12 +1378,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 9,
+    'count' => 8,
     'path' => __DIR__ . '/../../interface/patient_file/summary/pnotes_full.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 3,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/patient_file/summary/pnotes_full_add.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -4618,7 +4618,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 21,
+    'count' => 19,
     'path' => __DIR__ . '/../../src/Services/PatientService.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -38922,11 +38922,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/PatientService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\PatientService\\:\\:getPatientPictureDocumentId\\(\\) has parameter \\$pid with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/PatientService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\PatientService\\:\\:getPidByUuid\\(\\) has parameter \\$uuid with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/PatientService.php',

--- a/.phpstan/baseline/missingType.property.php
+++ b/.phpstan/baseline/missingType.property.php
@@ -29337,11 +29337,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/PatientAccessOnsiteService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property OpenEMR\\\\Services\\\\PatientService\\:\\:\\$patient_picture_fallback_id has no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/PatientService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property OpenEMR\\\\Services\\\\Qdm\\\\CqmCalculator\\:\\:\\$client has no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/Qdm/CqmCalculator.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -9507,11 +9507,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/PatientService.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Services\\\\PatientService\\:\\:getPatientPictureDocumentId\\(\\) should return float\\|int but returns mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../src/Services/PatientService.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Services\\\\PatientService\\:\\:search\\(\\) should return OpenEMR\\\\Validators\\\\ProcessingResult but returns mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/PatientService.php',

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -640,6 +640,10 @@ class C_Document extends Controller
         switch ($context) {
             case "patient_picture":
                 $document_id = $this->patientService->getPatientPictureDocumentId($patient_id);
+                if ($document_id === null) {
+                    http_response_code(404);
+                    exit;
+                }
                 break;
         }
 

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -25,6 +25,7 @@ use OpenEMR\Common\Crypto\KeyVersion;
 use OpenEMR\Common\Crypto\PasswordBasedCrypto;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Http\RequestTerminator;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
@@ -641,8 +642,10 @@ class C_Document extends Controller
             case "patient_picture":
                 $document_id = $this->patientService->getPatientPictureDocumentId($patient_id);
                 if ($document_id === null) {
-                    http_response_code(404);
-                    exit;
+                    if ($disable_exit == true) {
+                        return null;
+                    }
+                    (new RequestTerminator())->error(404, '');
                 }
                 break;
         }

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -638,6 +638,17 @@ class C_Document extends Controller
             }
         }
 
+        // For patient_picture context, non-portal users may only request the session's active patient.
+        // Runs before the missing-photo branch so 403 vs 404 does not leak whether the patient has a photo.
+        if ($context === 'patient_picture') {
+            if (!($session->has('patient_portal_onsite_two') && $session->has('pid'))) {
+                $allowed_pid = OEGlobalsBag::getInstance()->get('pid') ?? 0;
+                if ($allowed_pid === 0 || $patient_id === null || $patient_id !== (string)$allowed_pid) {
+                    AccessDeniedHelper::deny("Attempt to retrieve patient picture for pid $patient_id");
+                }
+            }
+        }
+
         switch ($context) {
             case "patient_picture":
                 $document_id = $this->patientService->getPatientPictureDocumentId($patient_id);
@@ -648,16 +659,6 @@ class C_Document extends Controller
                     (new RequestTerminator())->error(404, '');
                 }
                 break;
-        }
-
-        // For patient_picture context, non-portal users may only request the session's active patient.
-        if ($context === 'patient_picture') {
-            if (!($session->has('patient_portal_onsite_two') && $session->has('pid'))) {
-                $allowed_pid = OEGlobalsBag::getInstance()->get('pid') ?? 0;
-                if ($allowed_pid === 0 || $patient_id === null || $patient_id !== (string)$allowed_pid) {
-                    AccessDeniedHelper::deny("Attempt to retrieve patient picture for pid $patient_id");
-                }
-            }
         }
 
         $d = new Document($document_id);

--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -25,6 +25,7 @@ use OpenEMR\PostCalendar\LegacyInputNarrowing;
 use OpenEMR\PostCalendar\ViewModel\CalendarRenderDataBuilder;
 use OpenEMR\PostCalendar\ViewModel\CalendarViewModel;
 use OpenEMR\PostCalendar\ViewModel\ViewType;
+use OpenEMR\Services\PatientService;
 use OpenEMR\Services\UserService;
 
 if (!defined('__POSTCALENDAR__')) {
@@ -1042,6 +1043,8 @@ function &postcalendar_userapi_pcQueryEventsFA($args)
         $i++;
     }
 
+    $events = PatientService::annotateEventsWithPatientHasPicture($events);
+
     return $events;
 }
 
@@ -1465,6 +1468,8 @@ function &postcalendar_userapi_pcQueryEvents($args)
             ? ($counselorsByEvent[(int) $eid] ?? '')
             : '';
     }
+
+    $events = PatientService::annotateEventsWithPatientHasPicture($events);
 
     return $events;
 }

--- a/interface/main/tabs/js/frame_proxies.js
+++ b/interface/main/tabs/js/frame_proxies.js
@@ -24,7 +24,7 @@ var left_nav = {
 
 };
 
-left_nav.setPatient = function(pname, pid, pubpid, frname, str_dob)
+left_nav.setPatient = function(pname, pid, pubpid, frname, str_dob, hasPicture)
 {
     if((app_view_model.application_data.patient()!==null) && (pid===app_view_model.application_data.patient().pid()))
     {
@@ -34,7 +34,7 @@ left_nav.setPatient = function(pname, pid, pubpid, frname, str_dob)
 
         return;
     }
-    var new_patient=new patient_data_view_model(pname,pid,pubpid,str_dob);
+    var new_patient=new patient_data_view_model(pname,pid,pubpid,str_dob,hasPicture);
     app_view_model.application_data.patient(new_patient);
     app_view_model.application_data.therapy_group(null);
 

--- a/interface/main/tabs/js/patient_data_view_model.js
+++ b/interface/main/tabs/js/patient_data_view_model.js
@@ -19,7 +19,7 @@ function encounter_data(id,date,category)
     return this;
 }
 
-function patient_data_view_model(pname,pid,pubpid,str_dob)
+function patient_data_view_model(pname,pid,pubpid,str_dob,hasPicture)
 {
     var self=this;
     self.pname=ko.observable(pname);
@@ -27,6 +27,9 @@ function patient_data_view_model(pname,pid,pubpid,str_dob)
     self.pubpid=ko.observable(pubpid);
     self.str_dob=ko.observable(str_dob);
     self.patient_picture=ko.computed(function(){
+      if (hasPicture === false) {
+          return patient_picture_default_url;
+      }
       return webroot_url + '/controller.php' +
              '?document&retrieve' +
              '&patient_id=' + encodeURIComponent(pid) +

--- a/interface/main/tabs/templates/patient_data_template.php
+++ b/interface/main/tabs/templates/patient_data_template.php
@@ -47,6 +47,9 @@ switch ($search_any_type) {
 }
 
 ?>
+<script>
+    var patient_picture_default_url = <?php echo json_encode(OEGlobalsBag::getInstance()->getKernel()->getImagesRelative() . '/patient-picture-default.png'); ?>;
+</script>
 <script type="text/html" id="patient-data-template">
     <div class="d-lg-inline-flex w-100">
         <div class="flex-fill">

--- a/interface/orders/orders_results.php
+++ b/interface/orders/orders_results.php
@@ -52,7 +52,7 @@ if (!empty($_GET['set_pid']) && $form_review) {
     $result = getPatientData($pid, "*, DATE_FORMAT(DOB,'%Y-%m-%d') as DOB_YMD");
     ?>
     <script>
-        parent.left_nav.setPatient(<?php echo js_escape($result['fname'] . " " . $result['lname']) . "," . js_escape($pid) . "," . js_escape($result['pubpid']) . ",''," . js_escape(" " . xl('DOB') . ": " . oeFormatShortDate($result['DOB_YMD']) . " " . xl('Age') . ": " . getPatientAge($result['DOB_YMD'])) . "," . ((new PatientService())->getPatientPictureDocumentId((string) $pid) !== null ? 'true' : 'false'); ?>);
+        parent.left_nav.setPatient(<?php echo js_escape($result['fname'] . " " . $result['lname']) . "," . js_escape($pid) . "," . js_escape($result['pubpid']) . ",''," . js_escape(" " . xl('DOB') . ": " . oeFormatShortDate($result['DOB_YMD']) . " " . xl('Age') . ": " . getPatientAge($result['DOB_YMD'])) . "," . ((new PatientService())->hasPictureForPid($pid) ? 'true' : 'false'); ?>);
     </script>
     <?php
 }

--- a/interface/orders/orders_results.php
+++ b/interface/orders/orders_results.php
@@ -21,6 +21,7 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Services\PatientService;
 use OpenEMR\Services\PhoneNumberService;
 
 // Indicates if we are entering in batch mode.
@@ -51,7 +52,7 @@ if (!empty($_GET['set_pid']) && $form_review) {
     $result = getPatientData($pid, "*, DATE_FORMAT(DOB,'%Y-%m-%d') as DOB_YMD");
     ?>
     <script>
-        parent.left_nav.setPatient(<?php echo js_escape($result['fname'] . " " . $result['lname']) . "," . js_escape($pid) . "," . js_escape($result['pubpid']) . ",''," . js_escape(" " . xl('DOB') . ": " . oeFormatShortDate($result['DOB_YMD']) . " " . xl('Age') . ": " . getPatientAge($result['DOB_YMD'])); ?>);
+        parent.left_nav.setPatient(<?php echo js_escape($result['fname'] . " " . $result['lname']) . "," . js_escape($pid) . "," . js_escape($result['pubpid']) . ",''," . js_escape(" " . xl('DOB') . ": " . oeFormatShortDate($result['DOB_YMD']) . " " . xl('Age') . ": " . getPatientAge($result['DOB_YMD'])) . "," . ((new PatientService())->getPatientPictureDocumentId((string) $pid) !== null ? 'true' : 'false'); ?>);
     </script>
     <?php
 }

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -936,7 +936,8 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                 echo js_escape(" " . xl('DOB') . ": " . oeFormatShortDate($result['DOB_YMD']) . " " . xl('Age') . ": " . getPatientAgeDisplay($result['DOB_YMD']));
             } else {
                 echo js_escape(" " . xl('DOB') . ": " . oeFormatShortDate($result['DOB_YMD']) . " " . xl('Age at death') . ": " . oeFormatAge($result['DOB_YMD'], $date_of_death));
-            } ?>);
+            }
+            echo "," . ((new PatientService())->getPatientPictureDocumentId((string) $pid) !== null ? 'true' : 'false'); ?>);
             var EncounterDateArray = [];
             var CalendarCategoryArray = [];
             var EncounterIdArray = [];

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -937,7 +937,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
             } else {
                 echo js_escape(" " . xl('DOB') . ": " . oeFormatShortDate($result['DOB_YMD']) . " " . xl('Age at death') . ": " . oeFormatAge($result['DOB_YMD'], $date_of_death));
             }
-            echo "," . ((new PatientService())->getPatientPictureDocumentId((string) $pid) !== null ? 'true' : 'false'); ?>);
+            echo "," . ((new PatientService())->hasPictureForPid($pid) ? 'true' : 'false'); ?>);
             var EncounterDateArray = [];
             var CalendarCategoryArray = [];
             var EncounterIdArray = [];

--- a/interface/patient_file/summary/demographics_full.php
+++ b/interface/patient_file/summary/demographics_full.php
@@ -32,6 +32,7 @@ use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\PatientDemographics\UpdateEvent;
+use OpenEMR\Services\PatientService;
 
 
 /** @var string $date_init */
@@ -530,7 +531,7 @@ $constraints = LBF_Validation::generate_validate_constraints("DEM");
         <?php }?>
 
         <?php if ($set_pid) { ?>
-        parent.left_nav.setPatient(<?php echo js_escape($result['fname'] . " " . $result['lname']) . "," . js_escape($pid) . "," . js_escape($result['pubpid']) . ",''," . js_escape(" " . xl('DOB') . ": " . oeFormatShortDate($result['DOB_YMD']) . " " . xl('Age') . ": " . getPatientAgeDisplay($result['DOB_YMD'])); ?>);
+        parent.left_nav.setPatient(<?php echo js_escape($result['fname'] . " " . $result['lname']) . "," . js_escape($pid) . "," . js_escape($result['pubpid']) . ",''," . js_escape(" " . xl('DOB') . ": " . oeFormatShortDate($result['DOB_YMD']) . " " . xl('Age') . ": " . getPatientAgeDisplay($result['DOB_YMD'])) . "," . ((new PatientService())->getPatientPictureDocumentId((string) $pid) !== null ? 'true' : 'false'); ?>);
         <?php } ?>
 
         <?php echo $date_init; ?>

--- a/interface/patient_file/summary/demographics_full.php
+++ b/interface/patient_file/summary/demographics_full.php
@@ -531,7 +531,7 @@ $constraints = LBF_Validation::generate_validate_constraints("DEM");
         <?php }?>
 
         <?php if ($set_pid) { ?>
-        parent.left_nav.setPatient(<?php echo js_escape($result['fname'] . " " . $result['lname']) . "," . js_escape($pid) . "," . js_escape($result['pubpid']) . ",''," . js_escape(" " . xl('DOB') . ": " . oeFormatShortDate($result['DOB_YMD']) . " " . xl('Age') . ": " . getPatientAgeDisplay($result['DOB_YMD'])) . "," . ((new PatientService())->getPatientPictureDocumentId((string) $pid) !== null ? 'true' : 'false'); ?>);
+        parent.left_nav.setPatient(<?php echo js_escape($result['fname'] . " " . $result['lname']) . "," . js_escape($pid) . "," . js_escape($result['pubpid']) . ",''," . js_escape(" " . xl('DOB') . ": " . oeFormatShortDate($result['DOB_YMD']) . " " . xl('Age') . ": " . getPatientAgeDisplay($result['DOB_YMD'])) . "," . ((new PatientService())->hasPictureForPid($pid) ? 'true' : 'false'); ?>);
         <?php } ?>
 
         <?php echo $date_init; ?>

--- a/interface/patient_file/summary/pnotes_full.php
+++ b/interface/patient_file/summary/pnotes_full.php
@@ -735,7 +735,7 @@ if (!empty($_GET['set_pid'])) {
     ?>
  parent.left_nav.setPatient(<?php echo js_escape($ndata['fname'] . " " . $ndata['lname']) . "," .
      js_escape($patient_id) . "," . js_escape($ndata['pubpid']) . ",window.name, null, " .
-     ((new PatientService())->getPatientPictureDocumentId((string) $patient_id) !== null ? 'true' : 'false'); ?>);
+     ((new PatientService())->hasPictureForPid($patient_id) ? 'true' : 'false'); ?>);
     <?php
 }
 

--- a/interface/patient_file/summary/pnotes_full.php
+++ b/interface/patient_file/summary/pnotes_full.php
@@ -22,6 +22,7 @@ use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Services\PatientService;
 use OpenEMR\Services\UserService;
 use OpenEMR\Services\Utils\DateFormatterUtils;
 
@@ -733,7 +734,8 @@ if (!empty($_GET['set_pid'])) {
     $ndata = getPatientData($patient_id, "fname, lname, pubpid");
     ?>
  parent.left_nav.setPatient(<?php echo js_escape($ndata['fname'] . " " . $ndata['lname']) . "," .
-     js_escape($patient_id) . "," . js_escape($ndata['pubpid']) . ",window.name"; ?>);
+     js_escape($patient_id) . "," . js_escape($ndata['pubpid']) . ",window.name, null, " .
+     ((new PatientService())->getPatientPictureDocumentId((string) $patient_id) !== null ? 'true' : 'false'); ?>);
     <?php
 }
 

--- a/interface/patient_file/summary/pnotes_full_add.php
+++ b/interface/patient_file/summary/pnotes_full_add.php
@@ -24,6 +24,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Services\PatientService;
 
 
 if (!empty($_GET['set_pid'])) {
@@ -359,7 +360,7 @@ function submitform(attr) {
 if (!empty($_GET['set_pid'])) {
     $ndata = getPatientData($patient_id, "fname, lname, pubpid");
     ?>
- parent.left_nav.setPatient(<?php echo js_escape($ndata['fname'] . " " . $ndata['lname']) . "," . js_escape($patient_id) . "," . js_escape($ndata['pubpid']) . ",window.name"; ?>);
+ parent.left_nav.setPatient(<?php echo js_escape($ndata['fname'] . " " . $ndata['lname']) . "," . js_escape($patient_id) . "," . js_escape($ndata['pubpid']) . ",window.name, null, " . ((new PatientService())->getPatientPictureDocumentId((string) $patient_id) !== null ? 'true' : 'false'); ?>);
     <?php
 }
 

--- a/interface/patient_file/summary/pnotes_full_add.php
+++ b/interface/patient_file/summary/pnotes_full_add.php
@@ -360,7 +360,7 @@ function submitform(attr) {
 if (!empty($_GET['set_pid'])) {
     $ndata = getPatientData($patient_id, "fname, lname, pubpid");
     ?>
- parent.left_nav.setPatient(<?php echo js_escape($ndata['fname'] . " " . $ndata['lname']) . "," . js_escape($patient_id) . "," . js_escape($ndata['pubpid']) . ",window.name, null, " . ((new PatientService())->getPatientPictureDocumentId((string) $patient_id) !== null ? 'true' : 'false'); ?>);
+ parent.left_nav.setPatient(<?php echo js_escape($ndata['fname'] . " " . $ndata['lname']) . "," . js_escape($patient_id) . "," . js_escape($ndata['pubpid']) . ",window.name, null, " . ((new PatientService())->hasPictureForPid($patient_id) ? 'true' : 'false'); ?>);
     <?php
 }
 

--- a/src/PostCalendar/ViewModel/CalendarViewModel.php
+++ b/src/PostCalendar/ViewModel/CalendarViewModel.php
@@ -435,6 +435,23 @@ final readonly class CalendarViewModel
      * For those views this predicate is consulted only if a caller
      * explicitly invokes detectEventOverlap, which they shouldn't.
      */
+    /**
+     * URL for the on-hover ShowImage popup. Points at the doc-controller
+     * photo route when the event's `patient_has_picture` flag is true or
+     * missing (unknown → try, preserving legacy behavior). When the flag
+     * is explicitly false, points at the default silhouette so no 404
+     * fires against controller.php.
+     *
+     * @param array<string, mixed> $event
+     */
+    private function patientPhotoHoverHref(array $event, string $patientIdAttr, string $webroot): string
+    {
+        if (($event['patient_has_picture'] ?? null) === false) {
+            return $webroot . '/public/images/patient-picture-default.png';
+        }
+        return $webroot . '/controller.php?document&retrieve&patient_id=' . urlencode($patientIdAttr) . '&document_id=-1&as_file=false&original_file=true&disable_exit=false&show_original=true&context=patient_picture';
+    }
+
     private function shouldSkipForOverlap(int $categoryId): bool
     {
         if ($categoryId === 2) {
@@ -1163,7 +1180,7 @@ final readonly class CalendarViewModel
 
             $content .= "<a class='link_title' data-pid='" . attr($patientIdAttr) . "' href='javascript:goPid(" . attr_js($patientIdAttr) . ")' title='" . $linkTitle . "'>";
 
-            $imageHref = $webroot . '/controller.php?document&retrieve&patient_id=' . urlencode($patientIdAttr) . '&document_id=-1&as_file=false&original_file=true&disable_exit=false&show_original=true&context=patient_picture';
+            $imageHref = $this->patientPhotoHoverHref($event, $patientIdAttr, $webroot);
             $content .= "<img src='" . $tplImagePath . "/user-green.gif' onmouseover=\"javascript:ShowImage(" . attr_js($imageHref) . ");\" onmouseout=\"javascript:HideImage();\" border='0' title='" . $linkTitle . "' alt='View Patient' />";
 
             if ($catid === 1) {
@@ -1410,7 +1427,7 @@ final readonly class CalendarViewModel
 
             $content .= "<a class='link_title' data-pid='" . attr($patientIdAttr) . "' href='javascript:goPid(" . attr_js($patientIdAttr) . ")' title='" . $linkTitle . "'>";
 
-            $imageHref = $webroot . '/controller.php?document&retrieve&patient_id=' . urlencode($patientIdAttr) . '&document_id=-1&as_file=false&original_file=true&disable_exit=false&show_original=true&context=patient_picture';
+            $imageHref = $this->patientPhotoHoverHref($event, $patientIdAttr, $webroot);
             $content .= "<i class='fas fa-user text-success' onmouseover=\"javascript:ShowImage(" . attr_js($imageHref) . ");\" onmouseout=\"javascript:HideImage();\" title='" . $linkTitle . "'></i>";
 
             if ($catid === 1) {
@@ -1640,7 +1657,7 @@ final readonly class CalendarViewModel
 
             $content .= "<a class='link_title' data-pid='" . attr($patientIdAttr) . "' href='javascript:goPid(" . attr_js($patientIdAttr) . ")' title='" . $linkTitle . "'>";
 
-            $imageHref = $webroot . '/controller.php?document&retrieve&patient_id=' . urlencode($patientIdAttr) . '&document_id=-1&as_file=false&original_file=true&disable_exit=false&show_original=true&context=patient_picture';
+            $imageHref = $this->patientPhotoHoverHref($event, $patientIdAttr, $webroot);
             $content .= "<i class='fas fa-user text-success' onmouseover=\"javascript:ShowImage(" . attr_js($imageHref) . ");\" onmouseout=\"javascript:HideImage();\" title='" . $linkTitle . "'></i>";
 
             // Week-specific: the show-appointment toggle anchor between

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -683,6 +683,66 @@ class PatientService extends BaseService
     }
 
     /**
+     * Annotate each event with a `patient_has_picture` bool using one
+     * batched query. The event's patient id is read from `$pidKey`.
+     *
+     * @param  array<int|string, array<string, mixed>> $events
+     * @return array<int|string, array<string, mixed>>
+     */
+    public static function annotateEventsWithPatientHasPicture(array $events, string $pidKey = 'pid'): array
+    {
+        $pids = [];
+        foreach ($events as $event) {
+            $pid = $event[$pidKey] ?? null;
+            if (is_numeric($pid) && (int) $pid > 0) {
+                $pids[(int) $pid] = (int) $pid;
+            }
+        }
+        $withPhoto = $pids === []
+            ? []
+            : array_flip((new self())->getPatientsWithPictures(array_values($pids)));
+        foreach ($events as $index => $event) {
+            $pid = $event[$pidKey] ?? null;
+            $events[$index]['patient_has_picture'] = is_numeric($pid) && isset($withPhoto[(int) $pid]);
+        }
+        return $events;
+    }
+
+    /**
+     * @param  list<int> $pids
+     * @return list<int> subset of $pids that have a photo document
+     */
+    public function getPatientsWithPictures(array $pids): array
+    {
+        if ($pids === []) {
+            return [];
+        }
+        $placeholders = implode(',', array_fill(0, count($pids), '?'));
+        $sql = "SELECT DISTINCT doc.foreign_id AS pid
+                 FROM documents doc
+                 JOIN categories_to_documents cate_to_doc
+                   ON doc.id = cate_to_doc.document_id
+                 JOIN categories cate
+                   ON cate.id = cate_to_doc.category_id
+                WHERE cate.name LIKE ? AND doc.foreign_id IN ($placeholders)";
+
+        $params = array_merge(
+            [OEGlobalsBag::getInstance()->getString('patient_photo_category_name')],
+            $pids,
+        );
+
+        $rows = QueryUtils::fetchRecords($sql, $params);
+        $result = [];
+        foreach ($rows as $row) {
+            $pid = $row['pid'] ?? null;
+            if (is_numeric($pid)) {
+                $result[] = (int) $pid;
+            }
+        }
+        return $result;
+    }
+
+    /**
      * Fetch UUID for the patient id
      *
      * @param string $pid ID of Patient

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -75,13 +75,6 @@ class PatientService extends BaseService
     ];
 
     /**
-     * In the case where a patient doesn't have a picture uploaded,
-     * this value will be returned so that the document controller
-     * can return an empty response.
-     */
-    private $patient_picture_fallback_id = -1;
-
-    /**
      * @var PatientValidator
      */
     private $patientValidator;
@@ -665,10 +658,7 @@ class PatientService extends BaseService
         return $patientRow;
     }
 
-    /**
-     * @return number
-     */
-    public function getPatientPictureDocumentId($pid)
+    public function getPatientPictureDocumentId(string $pid): ?int
     {
         $sql = "SELECT doc.id AS id
                  FROM documents doc
@@ -680,11 +670,16 @@ class PatientService extends BaseService
 
         $result = sqlQuery($sql, [OEGlobalsBag::getInstance()->getString('patient_photo_category_name'), $pid]);
 
-        if (empty($result) || empty($result['id'])) {
-            return $this->patient_picture_fallback_id;
+        if (!is_array($result) || !array_key_exists('id', $result)) {
+            return null;
         }
 
-        return $result['id'];
+        $id = $result['id'];
+        if (!is_numeric($id)) {
+            return null;
+        }
+
+        return (int) $id;
     }
 
     /**

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -658,6 +658,14 @@ class PatientService extends BaseService
         return $patientRow;
     }
 
+    public function hasPictureForPid(mixed $pid): bool
+    {
+        if (!is_numeric($pid)) {
+            return false;
+        }
+        return $this->getPatientPictureDocumentId((string) $pid) !== null;
+    }
+
     public function getPatientPictureDocumentId(string $pid): ?int
     {
         $sql = "SELECT doc.id AS id


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Patients with no uploaded photo currently trigger a doc-controller request on every page load and on every calendar-appointment hover. The controller then either denies with 403 (before) or 404s (after the sentinel fix), and the client falls back via `onError`. This branch removes the round-trip: when the server already knows there is no photo, don't emit the URL at all.

#### Changes proposed in this pull request:

**404 sentinel (baseline fix, was PR-only elsewhere)**
- `PatientService::getPatientPictureDocumentId()` returns `?int` (was `-1` sentinel).
- `C_Document::retrieve_action()` short-circuits with a 404 when the id is `null`, via `RequestTerminator` rather than `exit`. Respects `disable_exit=true` on PHP callers (returns `null` instead of terminating).
- Removed the unused `$patient_picture_fallback_id` property.

**Patient sidebar (top-of-page image)**
- Added an optional `hasPicture` argument to `patient_data_view_model` and `left_nav.setPatient`. When `false`, the computed `patient_picture` URL points directly at `/public/images/patient-picture-default.png`. When `true` or missing, the current controller URL is used (safe fallback on JS-only callers).
- Updated the 5 PHP callers that can cheaply resolve photo state (`demographics.php`, `demographics_full.php`, `orders_results.php`, `pnotes_full.php`, `pnotes_full_add.php`) to pass the flag.
- JS-only call sites (`billing_report`, `linked_documents`, `telehealth`) unchanged — they preserve current behavior.
- New JS global `patient_picture_default_url` emitted from `patient_data_template.php`.

**Calendar hover popup**
- `PatientService::annotateEventsWithPatientHasPicture()` sets `patient_has_picture` on each event via one batched query per fetch.
- Wired into both `postcalendar_userapi_pcQueryEventsFA` and `postcalendar_userapi_pcQueryEvents`.
- New private `CalendarViewModel::patientPhotoHoverHref()` returns the default silhouette when `patient_has_picture === false`, else the controller URL. Applied to all three `ShowImage(...)` hover spots (day/week/month screen views).

**PHPStan baseline**
- Removed 4 obsolete entries covering the old `getPatientPictureDocumentId` signature/property.
- 5 count bumps on the `(string) $pid` casts at the new call sites (session pid is typed `mixed`); no new baseline keys.

#### Was an AI assistant used? Yes

All commits carry an `Assisted-by: Claude Code` trailer.
