### PR TITLE
fix(demographics): stop passing javascript: hrefs to dashboard cards

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1296,10 +1296,10 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         'card_bg_color' => '',
                         'card_text_color' => '',
                         'forceAlwaysOpen' => !$card->canCollapse(),
+                        // btnLabel/btnLink/linkMethod are owned by the card
+                        // class — it supplies them via getTemplateVariables(),
+                        // which wins the array_merge below.
                         'btnClass'   => 'js-card-toggle-edit',
-                        'btnLabel' => 'Add',
-                        'linkMethod' => 'javascript',
-                        'btnLink' => "void(0);",
                     ];
                     // Merge with ViewCard variables and render CARD template (not form!)
                     echo "<div class='col-12 m-0 p-0 px-2'>";
@@ -1323,10 +1323,10 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         'card_bg_color' => '',
                         'card_text_color' => '',
                         'forceAlwaysOpen' =>  !$card->canCollapse(),
+                        // btnLabel/btnLink/linkMethod are owned by the card
+                        // class — it supplies them via getTemplateVariables(),
+                        // which wins the array_merge below.
                         'btnClass'   => 'js-card-toggle-edit',
-                        'btnLabel' => 'Add',
-                        'linkMethod' => 'javascript',
-                        'btnLink' => "void(0);",
                     ];
 
                     // Merge with ViewCard variables and render CARD template (not form!)
@@ -1660,9 +1660,11 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             'card_text_color' => $card->getTextColorClass(),
                             'forceAlwaysOpen' => !$card->canCollapse(),
                             'btnLabel' => $btnLabel,
-                            // No section card supplies a button target, so this
-                            // is only a fallback. It must stay a safe href:
-                            // `javascript:` URLs are rejected by |safe_href.
+                            // Fallback only: a section card that needs a button
+                            // target supplies its own btnLink via
+                            // getTemplateVariables(), which wins the merge
+                            // below. It must stay a safe href — `javascript:`
+                            // URLs are rejected by |safe_href.
                             'btnLink' => '#',
                         ];
 

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1660,7 +1660,10 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             'card_text_color' => $card->getTextColorClass(),
                             'forceAlwaysOpen' => !$card->canCollapse(),
                             'btnLabel' => $btnLabel,
-                            'btnLink' => "javascript:$('#patient_portal').collapse('toggle')",
+                            // No section card supplies a button target, so this
+                            // is only a fallback. It must stay a safe href:
+                            // `javascript:` URLs are rejected by |safe_href.
+                            'btnLink' => '#',
                         ];
 
                         echo $t->render($card->getTemplateFile(), array_merge($viewArgs, $card->getTemplateVariables()));

--- a/src/Patient/Cards/CareExperiencePreferenceViewCard.php
+++ b/src/Patient/Cards/CareExperiencePreferenceViewCard.php
@@ -64,9 +64,12 @@ class CareExperiencePreferenceViewCard extends CardModel
                 'title' => xl('Care Experience Preferences'),
                 'id' => self::CARD_ID_EXPAND,
                 'btnLabel' => "Edit",
-                // The header pencil is wired up by the delegated
-                // `.js-card-toggle-edit` handler in the card template; the
-                // inline handler only has to suppress the `#` href jump.
+                // card_base emits this as an inline `onclick`; a `javascript:`
+                // href would be stripped by |safe_href. The click itself is
+                // handled by the delegated `.js-card-toggle-edit` listener in
+                // the card template, which already calls preventDefault() —
+                // this only keeps the `#` href from jumping the page if that
+                // listener stops running.
                 'btnLink' => 'event.preventDefault();',
                 'linkMethod' => 'javascript',
                 'initiallyCollapsed' => $initiallyCollapsed,

--- a/src/Patient/Cards/CareExperiencePreferenceViewCard.php
+++ b/src/Patient/Cards/CareExperiencePreferenceViewCard.php
@@ -64,8 +64,11 @@ class CareExperiencePreferenceViewCard extends CardModel
                 'title' => xl('Care Experience Preferences'),
                 'id' => self::CARD_ID_EXPAND,
                 'btnLabel' => "Edit",
-                'btnLink' => "javascript:toggleEditMode(true);",
-                'linkMethod' => 'html',
+                // The header pencil is wired up by the delegated
+                // `.js-card-toggle-edit` handler in the card template; the
+                // inline handler only has to suppress the `#` href jump.
+                'btnLink' => 'event.preventDefault();',
+                'linkMethod' => 'javascript',
                 'initiallyCollapsed' => $initiallyCollapsed,
                 'auth' => $authCheck
             ]

--- a/src/Patient/Cards/CareTeamViewCard.php
+++ b/src/Patient/Cards/CareTeamViewCard.php
@@ -101,8 +101,11 @@ class CareTeamViewCard extends CardModel
                 'id' => self::CARD_ID_EXPAND,
                 'btnLabel' => "Edit",
                 'btnClass' => 'btn-edit-care-team',
-                'btnLink' => "javascript:void(0);",
-                'linkMethod' => 'html',
+                // The header pencil is wired up by the `.btn-edit-care-team`
+                // listener in the card template; the inline handler only has
+                // to suppress the `#` href jump.
+                'btnLink' => 'event.preventDefault();',
+                'linkMethod' => 'javascript',
                 'initiallyCollapsed' => $initiallyCollapsed,
                 'auth' => $authCheck
             ]

--- a/src/Patient/Cards/CareTeamViewCard.php
+++ b/src/Patient/Cards/CareTeamViewCard.php
@@ -101,9 +101,11 @@ class CareTeamViewCard extends CardModel
                 'id' => self::CARD_ID_EXPAND,
                 'btnLabel' => "Edit",
                 'btnClass' => 'btn-edit-care-team',
-                // The header pencil is wired up by the `.btn-edit-care-team`
-                // listener in the card template; the inline handler only has
-                // to suppress the `#` href jump.
+                // card_base emits this as an inline `onclick`; a `javascript:`
+                // href would be stripped by |safe_href. The click itself is
+                // handled by the `.btn-edit-care-team` listener in the card
+                // template, which does not call preventDefault() — so this
+                // must, or the `#` href jumps the page to the top.
                 'btnLink' => 'event.preventDefault();',
                 'linkMethod' => 'javascript',
                 'initiallyCollapsed' => $initiallyCollapsed,

--- a/src/Patient/Cards/TreatmentPreferenceViewCard.php
+++ b/src/Patient/Cards/TreatmentPreferenceViewCard.php
@@ -64,9 +64,12 @@ class TreatmentPreferenceViewCard extends CardModel
                 'title' => xl('Treatment Intervention Preferences'),
                 'id' => self::CARD_ID_EXPAND,
                 'btnLabel' => "Edit",
-                // The header pencil is wired up by the delegated
-                // `.js-card-toggle-edit` handler in the card template; the
-                // inline handler only has to suppress the `#` href jump.
+                // card_base emits this as an inline `onclick`; a `javascript:`
+                // href would be stripped by |safe_href. The click itself is
+                // handled by the delegated `.js-card-toggle-edit` listener in
+                // the card template, which already calls preventDefault() —
+                // this only keeps the `#` href from jumping the page if that
+                // listener stops running.
                 'btnLink' => 'event.preventDefault();',
                 'linkMethod' => 'javascript',
                 'initiallyCollapsed' => $initiallyCollapsed,

--- a/src/Patient/Cards/TreatmentPreferenceViewCard.php
+++ b/src/Patient/Cards/TreatmentPreferenceViewCard.php
@@ -64,8 +64,11 @@ class TreatmentPreferenceViewCard extends CardModel
                 'title' => xl('Treatment Intervention Preferences'),
                 'id' => self::CARD_ID_EXPAND,
                 'btnLabel' => "Edit",
-                'btnLink' => "javascript:toggleEditMode(true);",
-                'linkMethod' => 'html',
+                // The header pencil is wired up by the delegated
+                // `.js-card-toggle-edit` handler in the card template; the
+                // inline handler only has to suppress the `#` href jump.
+                'btnLink' => 'event.preventDefault();',
+                'linkMethod' => 'javascript',
                 'initiallyCollapsed' => $initiallyCollapsed,
                 'auth' => $authCheck
             ]

--- a/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
+++ b/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
@@ -200,6 +200,34 @@ class TwigTemplateRenderTest extends TestCase
             $fixtureDir . '/appointments-future-empty.html',
         ];
 
+        // The dashboard preference/care-team cards render the Edit pencil with
+        // linkMethod 'javascript': the href stays '#' and the expression goes
+        // in an onclick. A literal 'javascript:' href would be stripped to '#'
+        // by |safe_href and lose the behavior entirely.
+        yield 'patient/card/appointments edit button via javascript linkMethod' => [
+            'patient/card/appointments.html.twig',
+            [
+                'title'               => 'Appointments',
+                'id'                  => 'appointments_ps_expand',
+                'initiallyCollapsed'  => false,
+                'btnLabel'            => 'Edit',
+                'btnClass'            => 'js-card-toggle-edit',
+                'btnLink'             => 'event.preventDefault();',
+                'linkMethod'          => 'javascript',
+                'appts'               => [],
+                'recurrAppts'         => [],
+                'pastAppts'           => [],
+                'displayAppts'        => false,
+                'displayRecurrAppts'  => false,
+                'displayPastAppts'    => false,
+                'extraApptDate'       => '',
+                'therapyGroupCategories' => [],
+                'auth'                => true,
+                'resNotNull'          => false,
+            ],
+            $fixtureDir . '/appointments-edit-javascript-link.html',
+        ];
+
         // Calendar render cases — see CalendarRenderDataBuilder for the
         // shape each template iterates. Print views are tested with empty
         // events; the per-event content path is unit-covered by

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/appointments-edit-javascript-link.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/appointments-edit-javascript-link.html
@@ -1,0 +1,20 @@
+<section class="card ">
+    <div class="card-body p-1">
+        <h6 class="card-title mb-0 d-flex p-1 justify-content-between">
+            <a class="text-left font-weight-bolder" href="#"  data-toggle="collapse" data-target="#appointments_ps_expand"  aria-expanded="true" aria-controls="appointments_ps_expand">Appointments<i class="ml-1 fa fa-fw  fa-compress " data-target="#appointments_ps_expand"></i></a>
+                            <span>
+                                                    <a class="js-card-toggle-edit" href="#"  onclick="event.preventDefault();"><i class="fa fa-pencil-alt">&nbsp;</i></a>
+                                </span>
+                    </h6>
+        <div id="appointments_ps_expand" class="card-text collapse show">
+            <div class="clearfix pt-2">
+                <div class="list-group list-group-flush appts">
+
+
+
+
+</div>
+            </div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
Fixes #13727.

Four dashboard card call sites passed a literal `javascript:` URL as `btnLink` together with `linkMethod => 'html'` — the branch of `card_base.html.twig` that runs the value through `|safe_href`. `safe_href()` blocks the `javascript:` scheme, so every render of the Medical Record Dashboard logged `safe_href(): blocked disallowed URL scheme` and substituted `#`.

`card_base` already has a `javascript` link method that emits the expression as an `onclick` handler. The three preference/care-team cards now use it with a bare expression. Their buttons are driven by delegated handlers in their own templates (`.js-card-toggle-edit`, `.btn-edit-care-team`), so the inline expression only has to suppress the `#` href jump — which is what the original `javascript:void(0)` was there for.

The fourth call site, the secondary-section loop in `demographics.php`, hardcoded a patient-portal collapse call as `btnLink` for **every** card it renders. Correcting the issue text: `PortalCard` sets `add` and `edit` to `false`, so `card_base` never renders its button and this line cannot log the warning today — only a third-party section card with `add = true` could. Rather than give arbitrary cards portal-specific behavior, this replaces the hardcoded link with a plain `#` fallback. Behavior is unchanged for every card (`safe_href` already collapsed it to `#`).

`demographics.php` also passed its own `btnLabel` / `btnLink` / `linkMethod` for the two preference cards, but the render is `array_merge($viewArgs, $card->getTemplateVariables())` — the card class wins, so those three keys never reached the template. That duplicated, silently-losing config is what let the two values drift apart in the first place; it is removed here, leaving the card class as the single owner.

### Testing

Adds a Twig render case covering the Edit-pencil branch of `card_base` with `linkMethod => 'javascript'`. Existing render coverage only exercised the Add branch. The recorded fixture pins the markup these cards now produce:

```html
<a class="js-card-toggle-edit" href="#"  onclick="event.preventDefault();"><i class="fa fa-pencil-alt">&nbsp;</i></a>
```

Isolated suite passes. `phpcs`, PHPStan, Rector and require-checker pass via pre-commit.
