### PR TITLE
ci: stop duplicate push-event runs on dependabot branches

### DIFF
--- a/.github/workflows/acceptance-docker.yml
+++ b/.github/workflows/acceptance-docker.yml
@@ -107,6 +107,17 @@ on:
     - 'patch-prep/**'
     - 'release-prep/**'
     - 'release-finalize/**'
+    # Same duplicate-run problem, different bot: dependabot pushes the
+    # branch AND opens the PR, so both events fire. Worse, dependabot
+    # force-pushes on every rebase, and a push event's paths: filter is
+    # evaluated over `before..after` — which after a rebase spans every
+    # commit master gained in the interim. A composer.lock bump therefore
+    # matches paths it never touched, and detect-mode's diff of that same
+    # inflated range can resolve build_locally=true, spending an image
+    # build and the full pr-built upgrade suite on a dependency bump.
+    # Keep the pull_request run, which diffs against the PR base and sees
+    # only the bump itself.
+    - 'dependabot/**'
     paths:
     - '.github/workflows/acceptance-docker.yml'
     - '.github/docker/acceptance-docker-compose.yml'

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -108,6 +108,15 @@ on:
     - 'patch-prep/**'
     - 'release-prep/**'
     - 'release-finalize/**'
+    # Same duplicate-run problem, different bot: dependabot pushes the
+    # branch AND opens the PR, so both events fire. Worse, dependabot
+    # force-pushes on every rebase, and a push event's paths: filter is
+    # evaluated over `before..after` — which after a rebase spans every
+    # commit master gained in the interim. A composer.lock bump therefore
+    # matches paths it never touched, and detect-mode diffs that same
+    # inflated range. Keep the pull_request run, which diffs against the
+    # PR base and sees only the bump itself.
+    - 'dependabot/**'
     paths:
     - '.github/workflows/acceptance-package.yml'
     - '.github/docker/acceptance-package-compose.yml'

--- a/.github/workflows/docker-test-bats.yml
+++ b/.github/workflows/docker-test-bats.yml
@@ -5,6 +5,15 @@ name: BATS Tests (release, binary, flex)
 
 on:
   push:
+    # Dependabot pushes the branch AND opens the PR, so both events fire
+    # for the same commit — duplicate runs reporting the same check names.
+    # Worse, a push event's paths: filter is evaluated over
+    # `before..after`, and dependabot force-pushes on every rebase, so
+    # that range spans every commit master gained in the interim. A
+    # dependency bump then matches paths it never touched. Keep the
+    # pull_request run, which diffs against the PR base.
+    branches-ignore:
+    - 'dependabot/**'
     paths:
     - '.github/workflows/docker-test-bats.yml'
     - 'tests/bats/docker/**'

--- a/.github/workflows/docker-test-container-functionality.yml
+++ b/.github/workflows/docker-test-container-functionality.yml
@@ -6,6 +6,15 @@ name: Container Functionality (release, binary, flex)
 
 on:
   push:
+    # Dependabot pushes the branch AND opens the PR, so both events fire
+    # for the same commit — duplicate runs reporting the same check names.
+    # Worse, a push event's paths: filter is evaluated over
+    # `before..after`, and dependabot force-pushes on every rebase, so
+    # that range spans every commit master gained in the interim. A
+    # dependency bump then matches paths it never touched. Keep the
+    # pull_request run, which diffs against the PR base.
+    branches-ignore:
+    - 'dependabot/**'
     paths:
     - '.github/workflows/docker-test-container-functionality.yml'
     - 'docker/container_benchmarking/**'

--- a/.github/workflows/docker-test-release.yml
+++ b/.github/workflows/docker-test-release.yml
@@ -36,6 +36,15 @@ name: Docker release test
 
 on:
   push:
+    # Dependabot pushes the branch AND opens the PR, so both events fire
+    # for the same commit — duplicate runs reporting the same check names.
+    # Worse, a push event's paths: filter is evaluated over
+    # `before..after`, and dependabot force-pushes on every rebase, so
+    # that range spans every commit master gained in the interim. A
+    # dependency bump then matches paths it never touched. Keep the
+    # pull_request run, which diffs against the PR base.
+    branches-ignore:
+    - 'dependabot/**'
     paths:
     - '.github/workflows/docker-test-release.yml'
     - 'docker/release/**'

--- a/.github/workflows/validate-codecov.yml
+++ b/.github/workflows/validate-codecov.yml
@@ -5,6 +5,15 @@ on:
     paths:
     - codecov.yml
   push:
+    # Dependabot pushes the branch AND opens the PR, so both events fire
+    # for the same commit — duplicate runs reporting the same check names.
+    # Worse, a push event's paths: filter is evaluated over
+    # `before..after`, and dependabot force-pushes on every rebase, so
+    # that range spans every commit master gained in the interim. A
+    # dependency bump then matches paths it never touched. Keep the
+    # pull_request run, which diffs against the PR base.
+    branches-ignore:
+    - 'dependabot/**'
     paths:
     - codecov.yml
 


### PR DESCRIPTION
Dependabot pushes its branch and opens the PR in one motion, so every workflow triggering on both `push` and `pull_request` fires twice for the same commit. Both runs report the same check names against the same head SHA, so which result the PR displays is a race.

The push run is also the wrong one to keep. A push event's `paths:` filter is evaluated over `before..after`, and dependabot force-pushes on every rebase — so that range spans every commit master gained since the branch was last pushed. A `composer.lock` bump then matches paths it never touched. In `acceptance-docker.yml` it compounds: `detect-mode` diffs that same inflated range and can resolve `build_locally=true`, spending an image build plus the full `pr-built` upgrade suite on a dependency bump.

## Evidence

Same commits, opposite verdicts, from the current dependabot backlog:

| branch | `pull_request` | `push` |
|---|---|---|
| `justinrainbow/json-schema-6.11.0` | success | **failure** |
| `zircote/swagger-php-6.6.0` | success | **failure** |
| `giggsey/libphonenumber-for-php-9.0.37` | success | **failure** |
| `pear/archive_tar-1.6.1` | success | **failure** |

7 of the 11 open dependabot PRs are currently blocked *solely* by failures from these push runs, with their `pull_request` runs green. Because `All Checks Passed` waits on every check run against the head SHA, one spurious push-run failure blocks the merge — and rebasing re-rolls the dice rather than fixing it.

## Scope

Only six workflows were affected. The other 31 that trigger on both events already scope push to `branches: [master, rel-*]`, so they never fire on a dependabot branch:

- `acceptance-docker.yml`
- `acceptance-package.yml`
- `docker-test-bats.yml`
- `docker-test-container-functionality.yml`
- `docker-test-release.yml`
- `validate-codecov.yml`

`acceptance-docker.yml` and `acceptance-package.yml` already carry a `branches-ignore` list for the release-mechanism bot branches, with a comment describing this exact duplicate-run failure mode. `dependabot/**` belongs there for the same reason; the other four get the key added.

## Note

Push events use the workflow file at the pushed ref, so each existing dependabot branch needs one rebase after this lands before it stops generating push runs.

Unrelated to this change, and tracked separately in #13703: the `Upgrade from_tag -> to_tag` job has a genuine failure when the upgrade target is the run's `pr-built` image.
