### PR TITLE
fix(session): declare write intent in encounter_top and login_screen

### DIFF
--- a/interface/login_screen.php
+++ b/interface/login_screen.php
@@ -6,13 +6,18 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 use OpenEMR\Common\Session\SessionWrapperFactory;
 
 $ignoreAuth = true;
+// Set $sessionAllowWrite to true to prevent session concurrency issues during authorization related code.
+// This lands on a brand new session, so globals.php establishes site_id here.
+$sessionAllowWrite = true;
 require_once("./globals.php");
 $session = SessionWrapperFactory::getInstance()->getCoreSession();
 ?>

--- a/interface/patient_file/encounter/encounter_top.php
+++ b/interface/patient_file/encounter/encounter_top.php
@@ -7,19 +7,36 @@
  * @link      https://www.open-emr.org
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2017 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+// globals.php decides read-only vs writable session before it hands control
+// back, so the request has to be read here. globals.php calls CurrentRequest::get()
+// itself, so this is the same instance, not a second one.
+require_once dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+use OpenEMR\Common\Http\CurrentRequest;
+use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\Header;
+use OpenEMR\Tabs\TabsWrapper;
+
+// When invoked with set_encounter this script writes pid/encounter to the
+// session, so declare the write intent up front and take the session lock once.
+// Without it globals.php opens the session read-only (read_and_close) and each
+// setpid()/setencounter() call has to reopen it mid-request, which logs a
+// "Session reopened for writing after read_and_close" warning per write.
+// Requests without set_encounter (returning from an encounter form) do not
+// write, so they stay lock-free.
+$sessionAllowWrite = CurrentRequest::get()->query->has('set_encounter');
 
 require_once(__DIR__ . '/../../globals.php');
 $srcdir = \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir();
 require_once($srcdir . "/encounter.inc.php");
 require_once($srcdir . "/forms.inc.php");
-
-use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Core\Header;
-use OpenEMR\Tabs\TabsWrapper;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 $encounter = $session->get('encounter', 0);


### PR DESCRIPTION
#### Short description of what this resolves:

Two entry points write to the session but never set `$sessionAllowWrite`, so `interface/globals.php` opens the session with `read_and_close` and the write has to reopen it mid-request. Every reopen logs a warning:

```
OpenEMR.WARNING: Session reopened for writing after read_and_close {"session_name":"OpenEMR","script":"/interface/patient_file/encounter/encounter_top.php"}
OpenEMR.WARNING: Session reopened for writing after read_and_close {"session_name":"OpenEMR","script":"/interface/login_screen.php"}
```

Both are visible in production logs. This is the reopen monitoring added in #10244 correctly flagging two scripts that violate the contract documented at `interface/globals.php:276-282`.

#### Changes proposed in this pull request:

- `interface/patient_file/encounter/encounter_top.php` calls `setpid()` / `setencounter()` when invoked with `set_encounter` — two warnings per encounter open when `set_pid` is also present. The flag is conditional on `set_encounter` so the no-write case (returning from an encounter form with no query parameters) stays lock-free. The parameter is read through `CurrentRequest::get()`, the same instance `globals.php` uses, rather than a second `createFromGlobals()` call. Reading it before the include requires an explicit `vendor/autoload.php` require, because `globals.php` does not load the autoloader until after the value is needed.
- `interface/login_screen.php` is the JS-redirect stub in front of `login.php`, reached with no session, so `globals.php` establishes `site_id` there. `interface/login/login.php:52-53` already declares the flag for the same reason; its stub was missed.

No behavior change — the reopen path was already correct and released the lock immediately. This removes the log noise and takes the lock once instead of once per write.

#### Does your code include anything generated by an AI Engine? Yes